### PR TITLE
Add configurable lightmap overbright control

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -84,6 +84,8 @@ cvar_t	r_alphasort = {"r_alphasort","1",CVAR_ARCHIVE};
 cvar_t	r_oit = {"r_oit","1",CVAR_ARCHIVE};
 cvar_t	r_dither = {"r_dither", "1.0", CVAR_ARCHIVE};
 
+cvar_t	r_overbrightbits = {"r_overbrightbits", "1", CVAR_ARCHIVE};
+
 cvar_t	gl_finish = {"gl_finish","0",CVAR_NONE};
 cvar_t	gl_clear = {"gl_clear","1",CVAR_NONE};
 cvar_t	gl_polyblend = {"gl_polyblend","1",CVAR_NONE};
@@ -964,6 +966,12 @@ R_SetupView -- johnfitz -- this is the stuff that needs to be done once per fram
 void R_SetupView (void)
 {
 	R_AnimateLight ();
+
+	{
+		int overbright_bits = CLAMP (0, (int)Q_rint (r_overbrightbits.value), 3);
+		r_framedata.overbright = (float)(1 << overbright_bits);
+		r_framedata._padding1 = 0.f;
+	}
 
 	r_framecount++;
 	r_framedata.eyepos[0] = r_refdef.vieworg[0];

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -31,6 +31,7 @@ extern cvar_t r_lerplightstyles;
 extern cvar_t gl_fullbrights;
 extern cvar_t gl_farclip;
 extern cvar_t gl_overbright_models;
+extern cvar_t r_overbrightbits;
 extern cvar_t r_waterwarp;
 extern cvar_t r_oldskyleaf;
 extern cvar_t r_drawworld;
@@ -218,8 +219,8 @@ R_SetWateralpha_f -- ericw
 */
 static void R_SetWateralpha_f (cvar_t *var)
 {
-	if (cls.signon == SIGNONS && cl.worldmodel && !(cl.worldmodel->contentstransparent&SURF_DRAWWATER) && var->value < 1)
-		Con_Warning("Map does not appear to be water-vised\n");
+		if (cls.signon == SIGNONS && cl.worldmodel && !(cl.worldmodel->contentstransparent&SURF_DRAWWATER) && var->value < 1)
+				Con_Warning("Map does not appear to be water-vised\n");
 	map_wateralpha = var->value;
 	map_fallbackalpha = var->value;
 }
@@ -231,8 +232,8 @@ R_SetLavaalpha_f -- ericw
 */
 static void R_SetLavaalpha_f (cvar_t *var)
 {
-	if (cls.signon == SIGNONS && cl.worldmodel && !(cl.worldmodel->contentstransparent&SURF_DRAWLAVA) && var->value && var->value < 1)
-		Con_Warning("Map does not appear to be lava-vised\n");
+		if (cls.signon == SIGNONS && cl.worldmodel && !(cl.worldmodel->contentstransparent&SURF_DRAWLAVA) && var->value && var->value < 1)
+				Con_Warning("Map does not appear to be lava-vised\n");
 	map_lavaalpha = var->value;
 }
 
@@ -243,8 +244,8 @@ R_SetTelealpha_f -- ericw
 */
 static void R_SetTelealpha_f (cvar_t *var)
 {
-	if (cls.signon == SIGNONS && cl.worldmodel && !(cl.worldmodel->contentstransparent&SURF_DRAWTELE) && var->value && var->value < 1)
-		Con_Warning("Map does not appear to be tele-vised\n");
+		if (cls.signon == SIGNONS && cl.worldmodel && !(cl.worldmodel->contentstransparent&SURF_DRAWTELE) && var->value && var->value < 1)
+				Con_Warning("Map does not appear to be tele-vised\n");
 	map_telealpha = var->value;
 }
 
@@ -258,6 +259,18 @@ static void R_SetSlimealpha_f (cvar_t *var)
 	if (cls.signon == SIGNONS && cl.worldmodel && !(cl.worldmodel->contentstransparent&SURF_DRAWSLIME) && var->value && var->value < 1)
 		Con_Warning("Map does not appear to be slime-vised\n");
 	map_slimealpha = var->value;
+}
+
+/*
+====================
+R_OverbrightBits_f
+====================
+*/
+static void R_OverbrightBits_f (cvar_t *var)
+{
+	int value = CLAMP (0, (int)Q_rint (var->value), 3);
+	if (value != (int)var->value)
+		Cvar_SetValueQuick (var, (float)value);
 }
 
 /*
@@ -314,6 +327,8 @@ void R_Init (void)
 	Cvar_RegisterVariable (&r_alphasort);
 	Cvar_RegisterVariable (&r_oit);
 	Cvar_RegisterVariable (&r_dither);
+	Cvar_RegisterVariable (&r_overbrightbits);
+	Cvar_SetCallback (&r_overbrightbits, R_OverbrightBits_f);
 
 	Cvar_RegisterVariable (&gl_finish);
 	Cvar_RegisterVariable (&gl_clear);
@@ -458,7 +473,7 @@ static void R_ParseWorldspawn (void)
 	map_wateralpha = (cl.worldmodel->contentstransparent&SURF_DRAWWATER)?r_wateralpha.value:1;
 	map_lavaalpha = (cl.worldmodel->contentstransparent&SURF_DRAWLAVA)?r_lavaalpha.value:1;
 	map_telealpha = (cl.worldmodel->contentstransparent&SURF_DRAWTELE)?r_telealpha.value:1;
-	map_slimealpha = (cl.worldmodel->contentstransparent&SURF_DRAWSLIME)?r_slimealpha.value:1;
+		map_slimealpha = (cl.worldmodel->contentstransparent&SURF_DRAWSLIME)?r_slimealpha.value:1;
 
 	data = COM_Parse(cl.worldmodel->entities);
 	if (!data)
@@ -494,7 +509,7 @@ static void R_ParseWorldspawn (void)
 			map_telealpha = atof(value);
 
 		if (!strcmp("slimealpha", key))
-			map_slimealpha = atof(value);
+				map_slimealpha = atof(value);
 	}
 }
 

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -424,7 +424,8 @@ typedef struct gpuframedata_s {
 	float	windphase;
 	float	screendither;
 	float	texturedither;
-	float	_padding1[2];
+	float	overbright;
+	float	_padding1;
 	vec3_t	eyepos;
 	float	time;
 	float	zlogscale;

--- a/Quake/shaders/cluster_lights.comp
+++ b/Quake/shaders/cluster_lights.comp
@@ -9,6 +9,8 @@ layout(std140, binding=0) uniform FrameDataUBO
 	float	WindPhase;
 	float	ScreenDither;
 	float	TextureDither;
+	float	Overbright;
+	float	_Pad0;
 	vec3	EyePos;
 	float	Time;
 	float	ZLogScale;

--- a/Quake/shaders/debug3d.vert
+++ b/Quake/shaders/debug3d.vert
@@ -7,6 +7,8 @@ layout(std140, binding=0) uniform FrameDataUBO
 	float	WindPhase;
 	float	ScreenDither;
 	float	TextureDither;
+	float	Overbright;
+	float	_Pad0;
 	vec3	EyePos;
 	float	Time;
 	float	ZLogScale;

--- a/Quake/shaders/particles.frag
+++ b/Quake/shaders/particles.frag
@@ -7,6 +7,8 @@ layout(std140, binding=0) uniform FrameDataUBO
 	float	WindPhase;
 	float	ScreenDither;
 	float	TextureDither;
+	float	Overbright;
+	float	_Pad0;
 	vec3	EyePos;
 	float	Time;
 	float	ZLogScale;

--- a/Quake/shaders/particles.vert
+++ b/Quake/shaders/particles.vert
@@ -7,6 +7,8 @@ layout(std140, binding=0) uniform FrameDataUBO
 	float	WindPhase;
 	float	ScreenDither;
 	float	TextureDither;
+	float	Overbright;
+	float	_Pad0;
 	vec3	EyePos;
 	float	Time;
 	float	ZLogScale;

--- a/Quake/shaders/sky_cubemap.frag
+++ b/Quake/shaders/sky_cubemap.frag
@@ -7,6 +7,8 @@ layout(std140, binding=0) uniform FrameDataUBO
 	float	WindPhase;
 	float	ScreenDither;
 	float	TextureDither;
+	float	Overbright;
+	float	_Pad0;
 	vec3	EyePos;
 	float	Time;
 	float	ZLogScale;

--- a/Quake/shaders/sky_cubemap.vert
+++ b/Quake/shaders/sky_cubemap.vert
@@ -15,6 +15,8 @@ layout(std140, binding=0) uniform FrameDataUBO
 	float	WindPhase;
 	float	ScreenDither;
 	float	TextureDither;
+	float	Overbright;
+	float	_Pad0;
 	vec3	EyePos;
 	float	Time;
 	float	ZLogScale;

--- a/Quake/shaders/sky_layers.frag
+++ b/Quake/shaders/sky_layers.frag
@@ -14,6 +14,8 @@ layout(std140, binding=0) uniform FrameDataUBO
 	float	WindPhase;
 	float	ScreenDither;
 	float	TextureDither;
+	float	Overbright;
+	float	_Pad0;
 	vec3	EyePos;
 	float	Time;
 	float	ZLogScale;

--- a/Quake/shaders/sky_layers.vert
+++ b/Quake/shaders/sky_layers.vert
@@ -15,6 +15,8 @@ layout(std140, binding=0) uniform FrameDataUBO
 	float	WindPhase;
 	float	ScreenDither;
 	float	TextureDither;
+	float	Overbright;
+	float	_Pad0;
 	vec3	EyePos;
 	float	Time;
 	float	ZLogScale;

--- a/Quake/shaders/skystencil.vert
+++ b/Quake/shaders/skystencil.vert
@@ -15,6 +15,8 @@ layout(std140, binding=0) uniform FrameDataUBO
 	float	WindPhase;
 	float	ScreenDither;
 	float	TextureDither;
+	float	Overbright;
+	float	_Pad0;
 	vec3	EyePos;
 	float	Time;
 	float	ZLogScale;

--- a/Quake/shaders/sprites.frag
+++ b/Quake/shaders/sprites.frag
@@ -7,6 +7,8 @@ layout(std140, binding=0) uniform FrameDataUBO
 	float	WindPhase;
 	float	ScreenDither;
 	float	TextureDither;
+	float	Overbright;
+	float	_Pad0;
 	vec3	EyePos;
 	float	Time;
 	float	ZLogScale;

--- a/Quake/shaders/sprites.vert
+++ b/Quake/shaders/sprites.vert
@@ -7,6 +7,8 @@ layout(std140, binding=0) uniform FrameDataUBO
 	float	WindPhase;
 	float	ScreenDither;
 	float	TextureDither;
+	float	Overbright;
+	float	_Pad0;
 	vec3	EyePos;
 	float	Time;
 	float	ZLogScale;

--- a/Quake/shaders/water.frag
+++ b/Quake/shaders/water.frag
@@ -13,6 +13,8 @@ layout(std140, binding=0) uniform FrameDataUBO
 	float	WindPhase;
 	float	ScreenDither;
 	float	TextureDither;
+	float	Overbright;
+	float	_Pad0;
 	vec3	EyePos;
 	float	Time;
 	float	ZLogScale;

--- a/Quake/shaders/water.vert
+++ b/Quake/shaders/water.vert
@@ -15,6 +15,8 @@ layout(std140, binding=0) uniform FrameDataUBO
 	float	WindPhase;
 	float	ScreenDither;
 	float	TextureDither;
+	float	Overbright;
+	float	_Pad0;
 	vec3	EyePos;
 	float	Time;
 	float	ZLogScale;

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -274,7 +274,7 @@ void main()
                 }
         }
 
-        vec3 total_light = clamp(static_light * Overbright, 0.0, 1.0);
+        vec3 total_light = clamp(static_light, 0.0, 1.0);
 
         if (NumLights > 0u)
         {
@@ -319,12 +319,15 @@ void main()
                 }
         }
 #if DITHER >= 2
-        total_light = floor(total_light * 63. + 0.5) / 63.;
+        vec3 clamped_light = clamp(total_light, 0.0, 1.0);
+        vec3 total_lightmap = clamp(floor(clamped_light * 63. + 0.5) * (Overbright / 63.), 0.0, 1.0);
+#else
+        vec3 total_lightmap = clamp(total_light * Overbright, 0.0, 1.0);
 #endif
 #if MODE != 1
-	result.rgb = mix(result.rgb, result.rgb * total_light, result.a);
+        result.rgb = mix(result.rgb, result.rgb * total_lightmap, result.a);
 #else
-	result.rgb *= total_light;
+        result.rgb *= total_lightmap;
 #endif
 	result.rgb += fullbright;
 	result = clamp(result, 0.0, 1.0);

--- a/Quake/shaders/world.vert
+++ b/Quake/shaders/world.vert
@@ -15,6 +15,8 @@ layout(std140, binding=0) uniform FrameDataUBO
 	float	WindPhase;
 	float	ScreenDither;
 	float	TextureDither;
+	float	Overbright;
+	float	_Pad0;
 	vec3	EyePos;
 	float	Time;
 	float	ZLogScale;

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ On most maps performance is indeed not much of a concern on a modern system. In 
 - classic underwater warp effect
 - more options exposed in the UI, most of them taking effect instantly (no vid_restart needed)
 - support for lightmapped liquid surfaces
+- configurable Quake 3-style lightmap overbrightening via `r_overbrightbits`
 - lightstyle interpolation (e.g. smoothly pulsating lighting in [ad_tears](https://www.moddb.com/mods/arcane-dimensions))
 - reduced heap usage (e.g. you can play [tershib/shib1_drake](https://www.quaddicted.com/reviews/ter_shibboleth_drake_redux.html) and [peril/tavistock](https://www.quaddicted.com/forum/viewtopic.php?id=1171) without using -heapsize on the command line)
 - reduced loading time for jumbo maps


### PR DESCRIPTION
## Summary
- add an `r_overbrightbits` cvar with clamping so the lightmap overbright multiplier can be adjusted at runtime
- carry the overbright scale through the GPU frame data and world shader so static lighting is boosted and clamped before modulation
- document the new option for users in the README

## Testing
- cmake -S . -B build *(fails: missing SDL2 development files)*

------
https://chatgpt.com/codex/tasks/task_e_68ea7aaeea30832e8711311166446b3c