### PR TITLE
Fix r_overbright lightmap scaling

### DIFF
--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -320,9 +320,9 @@ void main()
         }
 #if DITHER >= 2
         vec3 clamped_light = clamp(total_light, 0.0, 1.0);
-        vec3 total_lightmap = clamp(floor(clamped_light * 63. + 0.5) * (Overbright / 63.), 0.0, 1.0);
+        vec3 total_lightmap = clamp(floor(clamped_light * 63. + 0.5) * (Overbright / 63.), 0.0, Overbright);
 #else
-        vec3 total_lightmap = clamp(total_light * Overbright, 0.0, 1.0);
+        vec3 total_lightmap = clamp(total_light * Overbright, 0.0, Overbright);
 #endif
 #if MODE != 1
         result.rgb = mix(result.rgb, result.rgb * total_lightmap, result.a);


### PR DESCRIPTION
## Summary
- allow world lightmap shading to preserve the full r_overbrightbits multiplier so bright surfaces can exceed base albedo before the final clamp

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ea80b4f94c832ead969e3b1b82076b