### PR TITLE
Expand blob shadows to all entities

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -68,6 +68,7 @@ int		d_lightstylevalue[256];	// 8.8 fraction of base light value
 
 cvar_t	r_norefresh = {"r_norefresh","0",CVAR_NONE};
 cvar_t	r_drawentities = {"r_drawentities","1",CVAR_NONE};
+cvar_t	r_shadows = {"r_shadows", "0", CVAR_ARCHIVE};
 cvar_t	r_drawviewmodel = {"r_drawviewmodel","1",CVAR_NONE};
 cvar_t	r_speeds = {"r_speeds","0",CVAR_NONE};
 cvar_t	r_pos = {"r_pos","0",CVAR_NONE};

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -310,7 +310,8 @@ void R_Init (void)
 	Cvar_RegisterVariable (&r_norefresh);
 	Cvar_RegisterVariable (&r_lightmap);
 	Cvar_RegisterVariable (&r_fullbright);
-	Cvar_RegisterVariable (&r_drawentities);
+        Cvar_RegisterVariable (&r_drawentities);
+        Cvar_RegisterVariable (&r_shadows);
 	Cvar_RegisterVariable (&r_drawviewmodel);
 	Cvar_RegisterVariable (&r_wateralpha);
 	Cvar_SetCallback (&r_wateralpha, R_SetWateralpha_f);

--- a/Quake/gl_shaders.c
+++ b/Quake/gl_shaders.c
@@ -402,12 +402,14 @@ void GL_CreateShaders (void)
         }
         glprogs.skystencil = GL_CreateProgram (GLSL_PATH("skystencil.vert"), NULL, "sky stencil");
 
-	for (oit = 0; oit < 2; oit++)
-		for (mode = 0; mode < 3; mode++)
-			for (alphatest = 0; alphatest < 2; alphatest++)
-				for (md5 = 0; md5 < 2; md5++)
+        for (oit = 0; oit < 2; oit++)
+                for (mode = 0; mode < 3; mode++)
+                        for (alphatest = 0; alphatest < 2; alphatest++)
+                                for (md5 = 0; md5 < 2; md5++)
                                         glprogs.alias[oit][mode][alphatest][md5] =
                                                 GL_CreateProgram (GLSL_PATH("alias.vert"), GLSL_PATH("alias.frag"), "alias|OIT %d; MODE %d; ALPHATEST %d; MD5 %d", oit, mode, alphatest, md5);
+
+        glprogs.blobshadow = GL_CreateProgram (GLSL_PATH("blobshadow.vert"), GLSL_PATH("blobshadow.frag"), "blob shadow");
 
         glprogs.debug3d = GL_CreateProgram (GLSL_PATH("debug3d.vert"), GLSL_PATH("debug3d.frag"), "debug3d");
 

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -463,6 +463,8 @@ void R_DrawAliasModels (entity_t **ents, int count);
 void R_DrawSpriteModels (entity_t **ents, int count);
 void R_DrawBrushModels_ShowTris (entity_t **ents, int count);
 void R_DrawAliasModels_ShowTris (entity_t **ents, int count);
+void R_BlobShadows_Add (const entity_t *e, const vec3_t mins, const vec3_t maxs, float entalpha, float origin_z);
+void R_BlobShadows_Flush (void);
 void R_DrawSpriteModels_ShowTris (entity_t **ents, int count);
 
 entity_t **R_GetVisEntities (modtype_t type, qboolean translucent, int *outcount);
@@ -533,6 +535,7 @@ typedef struct glprogs_s {
 	GLuint		skyboxside[2];		// [dither]
 	GLuint		alias[2][3][2][2];	// [OIT][mode:standard/dithered/noperspective][alpha test][md5]
 	GLuint		sprites[2];			// [dither]
+	GLuint		blobshadow;
 	GLuint		particles[2][2];	// [OIT][dither]
 	GLuint		debug3d;
 

--- a/Quake/menu.c
+++ b/Quake/menu.c
@@ -42,6 +42,7 @@ extern cvar_t cl_rollangle;
 extern cvar_t cl_maxpitch;
 extern cvar_t cl_minpitch;
 extern cvar_t gl_cshiftpercent;
+extern cvar_t r_shadows;
 extern cvar_t sv_autoload;
 extern cvar_t r_particles;
 extern cvar_t gl_texturemode;
@@ -3175,6 +3176,7 @@ void M_Menu_Gamepad_f (void)
 		item (OPT_PARTICLES,			"Particles")					\
 		item (OPT_WATERWARP,			"Underwater FX")				\
 		item (OPT_DLIGHTS,				"Dynamic Lights")				\
+                item (OPT_SHADOWS,                              "Blob Shadows")                                 \
 	end_menu ()															\
 	begin_menu (INTERFACE_OPTIONS, m_interface, TITLE("Interface"))		\
 		item (OPT_UISCALE,				"Scale")						\
@@ -3872,9 +3874,12 @@ void M_AdjustSliders (int dir)
 	case OPT_ALPHAMODE:
 		VID_Menu_ChooseNextAlphaMode (dir);
 		break;
-	case OPT_DLIGHTS:
-		Cbuf_AddText ("toggle r_dynamic\n");
-		break;
+        case OPT_DLIGHTS:
+                Cbuf_AddText ("toggle r_dynamic\n");
+                break;
+        case OPT_SHADOWS:
+                Cbuf_AddText ("toggle r_shadows\n");
+                break;
 	case OPT_SOFTEMU:
 		Cvar_SetValueQuick (&r_softemu, (int)(q_max (r_softemu.value, 0.f) + 4 + dir) % 4);
 		break;
@@ -4489,9 +4494,12 @@ static void M_Options_DrawItem (int y, int item)
 	case OPT_ALPHAMODE:
 		M_Print (x, y, VID_Menu_GetAlphaModeDesc ());
 		break;
-	case OPT_DLIGHTS:
-		M_DrawCheckbox (x, y, r_dynamic.value);
-		break;
+        case OPT_DLIGHTS:
+                M_DrawCheckbox (x, y, r_dynamic.value);
+                break;
+        case OPT_SHADOWS:
+                M_DrawCheckbox (x, y, r_shadows.value);
+                break;
 	case OPT_SOFTEMU:
 		M_Print (x, y, VID_Menu_GetSoftEmuDesc ());
 		break;

--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -27,6 +27,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 extern cvar_t gl_overbright_models, gl_fullbrights, r_lerpmodels, r_lerpmove; //johnfitz
 extern cvar_t scr_fov, cl_gun_fovscale, cl_gun_x, cl_gun_y, cl_gun_z;
 extern cvar_t r_oit;
+extern cvar_t r_shadows;
 
 //up to 16 color translated skins
 gltexture_t *playertextures[MAX_SCOREBOARD]; //johnfitz -- changed to an array of pointers
@@ -75,6 +76,42 @@ struct ibuf_s {
 	} global;
 	aliasinstance_t inst[MAX_ALIAS_INSTANCES];
 } ibuf;
+
+#define BLOB_SHADOW_MIN_RADIUS   8.0f
+#define BLOB_SHADOW_SIZE_SCALE   0.9f
+#define BLOB_SHADOW_LIFT         0.2f
+#define BLOB_SHADOW_ALPHA_SCALE  0.55f
+#define BLOB_SHADOW_FADE_START   24.0f
+#define BLOB_SHADOW_FADE_RANGE   160.0f
+
+typedef struct blobshadowinstance_s
+{
+        float           center_radius[4];
+        float           params[4];
+} blobshadowinstance_t;
+
+static struct
+{
+        int                     count;
+        struct {
+                float   matviewproj[16];
+                vec3_t  eyepos;
+                float   _pad;
+                vec4_t  fog;
+                float   dither;
+                float   _padding[3];
+        } global;
+        blobshadowinstance_t inst[MAX_ALIAS_INSTANCES];
+} shadowbuf;
+
+static const float blobshadow_verts[4][2] = {
+        {-1.f, -1.f},
+        { 1.f, -1.f},
+        { 1.f,  1.f},
+        {-1.f,  1.f},
+};
+
+static const uint16_t blobshadow_idx[6] = {0, 1, 2, 0, 2, 3};
 
 /*
 =================
@@ -283,7 +320,154 @@ void R_SetupAliasLighting (entity_t	*e)
 		lightcolor[2] = 256.0f;
 	}
 
-	VectorScale (lightcolor, 1.0f / 200.0f, lightcolor);
+        VectorScale (lightcolor, 1.0f / 200.0f, lightcolor);
+}
+
+void R_BlobShadows_Flush (void)
+{
+        GLuint  buf, vbuf, ibuf_handle;
+        GLbyte  *ofs, *vofs, *iofs;
+        size_t  bufsize;
+
+        if (!shadowbuf.count)
+                return;
+
+        GL_BeginGroup ("blob shadows");
+
+        memcpy (shadowbuf.global.matviewproj, r_matviewproj, sizeof (r_matviewproj));
+        memcpy (shadowbuf.global.eyepos, r_refdef.vieworg, sizeof (r_refdef.vieworg));
+        memcpy (shadowbuf.global.fog, r_framedata.fogdata, 3 * sizeof (float));
+        shadowbuf.global.fog[3] =
+                gl_overbright_models.value ?
+                        -fabs (r_framedata.fogdata[3]) :
+                         fabs (r_framedata.fogdata[3]);
+        shadowbuf.global.dither = r_framedata.screendither;
+
+        bufsize = sizeof (shadowbuf.global) + sizeof (shadowbuf.inst[0]) * shadowbuf.count;
+        GL_Upload (GL_SHADER_STORAGE_BUFFER, &shadowbuf.global, bufsize, &buf, &ofs);
+
+        GL_Upload (GL_ARRAY_BUFFER, blobshadow_verts, sizeof (blobshadow_verts), &vbuf, &vofs);
+        GL_BindBuffer (GL_ARRAY_BUFFER, vbuf);
+        GL_VertexAttribPointerFunc (0, 2, GL_FLOAT, GL_FALSE, sizeof (blobshadow_verts[0]), vofs);
+
+        GL_Upload (GL_ELEMENT_ARRAY_BUFFER, blobshadow_idx, sizeof (blobshadow_idx), &ibuf_handle, &iofs);
+        GL_BindBuffer (GL_ELEMENT_ARRAY_BUFFER, ibuf_handle);
+
+        GLuint buffers[1] = {buf};
+        GLintptr offsets[1] = {(GLintptr) ofs};
+        GLsizeiptr sizes[1] = {bufsize};
+        GL_BindBuffersRange (GL_SHADER_STORAGE_BUFFER, 1, 1, buffers, offsets, sizes);
+
+        GL_UseProgram (glprogs.blobshadow);
+        GL_SetState (GLS_BLEND_ALPHA | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS(1));
+
+        GL_DrawElementsInstancedFunc (GL_TRIANGLES, 6, GL_UNSIGNED_SHORT, iofs, shadowbuf.count);
+
+        shadowbuf.count = 0;
+
+        GL_EndGroup ();
+}
+
+void R_BlobShadows_Add (const entity_t *e, const vec3_t mins, const vec3_t maxs, float entalpha, float origin_z)
+{
+        if (!r_shadows.value)
+                return;
+
+        if (!e || e == &cl.viewent)
+                return;
+
+        if (!e->model || (e->model->flags & MOD_NOSHADOW))
+                return;
+
+        if (entalpha <= 0.0f)
+                return;
+
+        if (shadowbuf.count == countof (shadowbuf.inst))
+                R_BlobShadows_Flush ();
+
+        float min_x = q_min (mins[0], maxs[0]);
+        float max_x = q_max (mins[0], maxs[0]);
+        float min_y = q_min (mins[1], maxs[1]);
+        float max_y = q_max (mins[1], maxs[1]);
+        float min_z = q_min (mins[2], maxs[2]);
+
+        float radius_x = 0.5f * (max_x - min_x) * BLOB_SHADOW_SIZE_SCALE;
+        float radius_y = 0.5f * (max_y - min_y) * BLOB_SHADOW_SIZE_SCALE;
+        radius_x = q_max (radius_x, BLOB_SHADOW_MIN_RADIUS);
+        radius_y = q_max (radius_y, BLOB_SHADOW_MIN_RADIUS);
+
+        float shadow_z = min_z + BLOB_SHADOW_LIFT;
+
+        vec3_t center;
+        center[0] = 0.5f * (min_x + max_x);
+        center[1] = 0.5f * (min_y + max_y);
+        center[2] = shadow_z;
+
+        float hover = origin_z - shadow_z - BLOB_SHADOW_FADE_START;
+        if (hover < 0.f)
+                hover = 0.f;
+        float fade = 1.f - CLAMP (0.f, hover / BLOB_SHADOW_FADE_RANGE, 1.f);
+
+        float alpha = entalpha * BLOB_SHADOW_ALPHA_SCALE * fade;
+        if (alpha <= 0.0f)
+                return;
+
+        blobshadowinstance_t *inst = &shadowbuf.inst[shadowbuf.count++];
+        inst->center_radius[0] = center[0];
+        inst->center_radius[1] = center[1];
+        inst->center_radius[2] = center[2];
+        inst->center_radius[3] = radius_x;
+        inst->params[0] = radius_y;
+        inst->params[1] = alpha;
+        inst->params[2] = 0.f;
+        inst->params[3] = 0.f;
+}
+
+static void R_Alias_GetBounds (const entity_t *e, vec3_t mins, vec3_t maxs)
+{
+        const vec3_t *minbounds, *maxbounds;
+        float scalefactor = ENTSCALE_DECODE(e->scale);
+        int i;
+
+        if (e->angles[0] || e->angles[2])
+        {
+                minbounds = &e->model->rmins;
+                maxbounds = &e->model->rmaxs;
+        }
+        else if (e->angles[1])
+        {
+                minbounds = &e->model->ymins;
+                maxbounds = &e->model->ymaxs;
+        }
+        else
+        {
+                minbounds = &e->model->mins;
+                maxbounds = &e->model->maxs;
+        }
+
+        if (scalefactor != 1.0f)
+        {
+                for (i = 0; i < 3; i++)
+                {
+                        mins[i] = e->origin[i] + (*minbounds)[i] * scalefactor;
+                        maxs[i] = e->origin[i] + (*maxbounds)[i] * scalefactor;
+                }
+        }
+        else
+        {
+                for (i = 0; i < 3; i++)
+                {
+                        mins[i] = e->origin[i] + (*minbounds)[i];
+                        maxs[i] = e->origin[i] + (*maxbounds)[i];
+                }
+        }
+}
+
+static void R_AddAliasShadow (const entity_t *e, const lerpdata_t *lerpdata, float entalpha)
+{
+        vec3_t mins, maxs;
+        R_Alias_GetBounds (e, mins, maxs);
+        R_BlobShadows_Add (e, mins, maxs, entalpha, lerpdata->origin[2]);
 }
 
 /*
@@ -521,13 +705,16 @@ static void R_DrawAliasModel_Real (entity_t *e, qboolean showtris)
 	//
 	// set up for alpha blending
 	//
-	if (r_lightmap_cheatsafe) //no alpha in drawflat or lightmap mode
-		entalpha = 1;
-	else
-		entalpha = ENTALPHA_DECODE(e->alpha);
+        if (r_lightmap_cheatsafe) //no alpha in drawflat or lightmap mode
+                entalpha = 1;
+        else
+                entalpha = ENTALPHA_DECODE(e->alpha);
 
-	if (entalpha == 0)
-		return;
+        if (entalpha == 0)
+                return;
+
+        if (!showtris)
+                R_AddAliasShadow (e, &lerpdata, entalpha);
 
 	//
 	// set up lighting
@@ -582,10 +769,11 @@ R_DrawAliasModels
 */
 void R_DrawAliasModels (entity_t **ents, int count)
 {
-	int i;
-	for (i = 0; i < count; i++)
-		R_DrawAliasModel_Real (ents[i], false);
-	R_FlushAliasInstances (false);
+        int i;
+        for (i = 0; i < count; i++)
+                R_DrawAliasModel_Real (ents[i], false);
+        R_FlushAliasInstances (false);
+        R_BlobShadows_Flush ();
 }
 
 /*
@@ -595,8 +783,9 @@ R_DrawAliasModels_ShowTris
 */
 void R_DrawAliasModels_ShowTris (entity_t **ents, int count)
 {
-	int i;
-	for (i = 0; i < count; i++)
-		R_DrawAliasModel_Real (ents[i], true);
-	R_FlushAliasInstances (true);
+        int i;
+        for (i = 0; i < count; i++)
+                R_DrawAliasModel_Real (ents[i], true);
+        R_FlushAliasInstances (true);
+        R_BlobShadows_Flush ();
 }

--- a/Quake/r_sprite.c
+++ b/Quake/r_sprite.c
@@ -248,6 +248,38 @@ static void R_DrawSpriteModel_Real (entity_t *e, qboolean showtris)
 		return;
 	}
 
+	if (!showtris)
+	{
+		float entalpha;
+
+		if (r_lightmap_cheatsafe)
+			entalpha = 1.f;
+		else
+			entalpha = ENTALPHA_DECODE (e->alpha);
+
+		if (entalpha > 0.f)
+		{
+			vec3_t mins, maxs;
+			float left = frame->left * scale;
+			float right = frame->right * scale;
+			float up = frame->up * scale;
+			float down = frame->down * scale;
+			float horiz = q_max (fabsf (left), fabsf (right));
+			float vert = q_max (fabsf (up), fabsf (down));
+			float radius = q_max (horiz, vert);
+			mins[0] = e->origin[0] - radius;
+			maxs[0] = e->origin[0] + radius;
+			mins[1] = e->origin[1] - radius;
+			maxs[1] = e->origin[1] + radius;
+			float minz = q_min (down, up);
+			float maxz = q_max (down, up);
+			mins[2] = e->origin[2] + minz;
+			maxs[2] = e->origin[2] + maxz;
+			R_BlobShadows_Add (e, mins, maxs, entalpha, e->origin[2]);
+		}
+	}
+
+
 	if (numbatchquads)
 		if (numbatchquads == countof(batchverts) / 4 || batchmodel != e->model || batchtexture != frame->gltexture)
 			R_FlushSpriteInstances ();
@@ -290,6 +322,7 @@ void R_DrawSpriteModels (entity_t **ents, int count)
 	for (i = 0; i < count; i++)
 		R_DrawSpriteModel_Real (ents[i], false);
 	R_FlushSpriteInstances ();
+	R_BlobShadows_Flush ();
 }
 
 /*
@@ -303,4 +336,5 @@ void R_DrawSpriteModels_ShowTris (entity_t **ents, int count)
 	for (i = 0; i < count; i++)
 		R_DrawSpriteModel_Real (ents[i], true);
 	R_FlushSpriteInstances ();
+	R_BlobShadows_Flush ();
 }

--- a/Quake/shaders/blobshadow.frag
+++ b/Quake/shaders/blobshadow.frag
@@ -1,0 +1,61 @@
+struct ShadowInstance
+{
+        vec4    CenterRadius;
+        vec4    Params;
+};
+
+layout(std430, binding=1) restrict readonly buffer InstanceBuffer
+{
+        mat4    ViewProj;
+        vec3    EyePos;
+        float   _Pad0;
+        vec4    Fog;
+        float   ScreenDither;
+        vec3    _Pad1;
+        ShadowInstance instances[];
+};
+
+float bayer01(ivec2 coord)
+{
+        coord &= 15;
+        coord.y ^= coord.x;
+        uint v = uint(coord.y | (coord.x << 8));
+        v = (v ^ (v << 2)) & 0x3333u;
+        v = (v ^ (v << 1)) & 0x5555u;
+        v |= v >> 7;
+        v = bitfieldReverse(v) >> 24;
+        return float(v) * (1.0 / 256.0);
+}
+
+float bayer(ivec2 coord)
+{
+        return bayer01(coord) - 0.5;
+}
+
+layout(location=0) in vec2 in_uv;
+layout(location=1) in float in_alpha;
+layout(location=2) in vec3 in_pos;
+
+layout(location=0) out vec4 out_fragcolor;
+
+void main()
+{
+        float distSq = dot(in_uv, in_uv);
+        if (distSq > 1.0)
+                discard;
+
+        float falloff = 1.0 - distSq;
+        falloff *= falloff;
+        float alpha = in_alpha * falloff;
+        if (alpha <= 0.0)
+                discard;
+
+        float fog = exp2(abs(Fog.w) * -dot(in_pos, in_pos));
+        fog = clamp(fog, 0.0, 1.0);
+
+        vec3 color = mix(Fog.rgb, vec3(0.0), fog);
+        out_fragcolor = vec4(color, alpha);
+
+        out_fragcolor.rgb += bayer(ivec2(gl_FragCoord.xy)) * ScreenDither;
+        out_fragcolor = clamp(out_fragcolor, 0.0, 1.0);
+}

--- a/Quake/shaders/blobshadow.vert
+++ b/Quake/shaders/blobshadow.vert
@@ -1,0 +1,34 @@
+struct ShadowInstance
+{
+        vec4    CenterRadius;
+        vec4    Params;
+};
+
+layout(std430, binding=1) restrict readonly buffer InstanceBuffer
+{
+        mat4    ViewProj;
+        vec3    EyePos;
+        float   _Pad0;
+        vec4    Fog;
+        float   ScreenDither;
+        vec3    _Pad1;
+        ShadowInstance instances[];
+};
+
+layout(location=0) in vec2 in_pos;
+
+layout(location=0) out vec2 out_uv;
+layout(location=1) out float out_alpha;
+layout(location=2) out vec3 out_pos;
+
+void main()
+{
+        ShadowInstance inst = instances[gl_InstanceID];
+        vec2 radii = vec2(inst.CenterRadius.w, inst.Params.x);
+        vec2 offset = in_pos * radii;
+        vec3 worldPos = inst.CenterRadius.xyz + vec3(offset, 0.0);
+        out_uv = in_pos;
+        out_alpha = inst.Params.y;
+        out_pos = worldPos - EyePos;
+        gl_Position = ViewProj * vec4(worldPos, 1.0);
+}


### PR DESCRIPTION
## Summary
- refactor blob shadow batching into shared helpers that other renderers can call
- hook sprite rendering into the blob shadow system so non-alias pickups also cast shadows

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ea84129f54832eb9a3cda3890b8175