### PR TITLE
Fix missing r_shadows declaration

### DIFF
--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -33,6 +33,7 @@ extern cvar_t gl_farclip;
 extern cvar_t gl_overbright_models;
 extern cvar_t r_overbrightbits;
 extern cvar_t r_waterwarp;
+extern cvar_t r_shadows;
 extern cvar_t r_oldskyleaf;
 extern cvar_t r_drawworld;
 extern cvar_t r_showtris;


### PR DESCRIPTION
## Summary
- add the missing extern declaration for r_shadows in gl_rmisc.c so the renderer can register the cvar

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ea8c42c968832e8dc679b11c00fbb9