### PR TITLE
Fix blob shadow rendering when OIT is enabled

### DIFF
--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -359,7 +359,13 @@ void R_BlobShadows_Flush (void)
         GL_BindBuffersRange (GL_SHADER_STORAGE_BUFFER, 1, 1, buffers, offsets, sizes);
 
         GL_UseProgram (glprogs.blobshadow);
-        GL_SetState (GLS_BLEND_ALPHA | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS(1));
+
+        unsigned int state = GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS(1);
+        if (R_GetEffectiveAlphaMode () == ALPHAMODE_OIT)
+                state |= GLS_BLEND_ALPHA_OIT;
+        else
+                state |= GLS_BLEND_ALPHA;
+        GL_SetState (state);
 
         GL_DrawElementsInstancedFunc (GL_TRIANGLES, 6, GL_UNSIGNED_SHORT, iofs, shadowbuf.count);
 


### PR DESCRIPTION
## Summary
- switch blob shadow rendering to the correct blend path when order-independent transparency is active
- update the blob shadow shader to output to the OIT accumulation and reveal targets so shadows survive the resolve pass

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ea8df4eec0832e80ac89e5ba05c23d