### PR TITLE
Add configurable PCF shadows and optional VSM path

### DIFF
--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -319,6 +319,18 @@ void R_Init (void)
         Cvar_SetCallback (&r_shadow_bias, R_ShadowCvarChanged);
         Cvar_RegisterVariable (&r_shadow_slope_bias);
         Cvar_SetCallback (&r_shadow_slope_bias, R_ShadowCvarChanged);
+        Cvar_RegisterVariable (&r_shadow_soft);
+        Cvar_SetCallback (&r_shadow_soft, R_ShadowCvarChanged);
+        Cvar_RegisterVariable (&r_shadow_pcf_size);
+        Cvar_SetCallback (&r_shadow_pcf_size, R_ShadowCvarChanged);
+        Cvar_RegisterVariable (&r_shadow_soft_dist_scale);
+        Cvar_SetCallback (&r_shadow_soft_dist_scale, R_ShadowCvarChanged);
+        Cvar_RegisterVariable (&r_shadow_normal_offset);
+        Cvar_SetCallback (&r_shadow_normal_offset, R_ShadowCvarChanged);
+        Cvar_RegisterVariable (&r_shadow_vsm);
+        Cvar_SetCallback (&r_shadow_vsm, R_ShadowCvarChanged);
+        Cvar_RegisterVariable (&r_shadow_vsm_bleed_reduce);
+        Cvar_SetCallback (&r_shadow_vsm_bleed_reduce, R_ShadowCvarChanged);
         Cvar_RegisterVariable (&r_drawviewmodel);
 	Cvar_RegisterVariable (&r_wateralpha);
 	Cvar_SetCallback (&r_wateralpha, R_SetWateralpha_f);

--- a/Quake/gl_shaders.c
+++ b/Quake/gl_shaders.c
@@ -545,6 +545,7 @@ void GL_CreateShaders (void)
                                                 GL_CreateProgram (GLSL_PATH("alias.vert"), GLSL_PATH("alias.frag"), "alias|OIT %d; MODE %d; ALPHATEST %d; MD5 %d", oit, mode, alphatest, md5);
 
         glprogs.shadow_depth = GL_CreateProgram (GLSL_PATH("shadow_depth.vs"), GLSL_PATH("shadow_depth.fs"), "shadow depth");
+        glprogs.shadow_depth_vsm = GL_CreateProgram (GLSL_PATH("shadow_depth.vs"), GLSL_PATH("shadow_depth.fs"), "shadow depth (VSM)|SHADOW_VSM 1");
         glprogs.blobshadow = GL_CreateProgram (GLSL_PATH("blobshadow.vert"), GLSL_PATH("blobshadow.frag"), "blob shadow");
 
         glprogs.debug3d = GL_CreateProgram (GLSL_PATH("debug3d.vert"), GLSL_PATH("debug3d.frag"), "debug3d");

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -436,6 +436,8 @@ typedef struct gpuframedata_s {
 	int		_padding4;
 	float	shadowviewproj[16];
 	float	shadow_params[4];
+	float	shadow_filter[4];
+	float	shadow_vsm[4];
 	float	shadow_sundir[4];
 	float	shadow_suncolor[4];
 } gpuframedata_t;
@@ -546,6 +548,7 @@ typedef struct glprogs_s {
 	GLuint		particles[2][2];	// [OIT][dither]
 	GLuint		debug3d;
 	GLuint		shadow_depth;
+	GLuint		shadow_depth_vsm;
 
 	/* compute */
 	GLuint		clear_indirect;
@@ -607,6 +610,12 @@ void GL_DeleteFrameBuffers (void);
 extern cvar_t	r_shadow_map_size;
 extern cvar_t	r_shadow_bias;
 extern cvar_t	r_shadow_slope_bias;
+extern cvar_t	r_shadow_soft;
+extern cvar_t	r_shadow_pcf_size;
+extern cvar_t	r_shadow_soft_dist_scale;
+extern cvar_t	r_shadow_normal_offset;
+extern cvar_t	r_shadow_vsm;
+extern cvar_t	r_shadow_vsm_bleed_reduce;
 
 void R_InitShadow (void);
 void R_ShutdownShadow (void);
@@ -617,6 +626,7 @@ void R_ShadowFinalizeWorldspawn (void);
 void R_ShadowCvarChanged (cvar_t *var);
 void R_BuildShadowMap (void);
 GLuint R_ShadowTexture (void);
+qboolean R_ShadowUsesVSM (void);
 
 void GLLight_CreateResources (void);
 void GLLight_DeleteResources (void);

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -444,7 +444,7 @@ static void R_DrawBrushModels_Real (entity_t **ents, int count, brushpass_t pass
         case BP_SHADOW:
                 texbegin = 0;
                 texend = TEXTYPE_CUTOUT + 1;
-                program = glprogs.shadow_depth;
+                program = R_ShadowUsesVSM () ? glprogs.shadow_depth_vsm : glprogs.shadow_depth;
                 translucent = false;
                 oit = false;
                 break;

--- a/Quake/shaders/shadow_common.glsl
+++ b/Quake/shaders/shadow_common.glsl
@@ -22,6 +22,8 @@ layout(std140, binding=0) uniform FrameDataUBO
         uint    _Pad3;
         mat4    ShadowViewProj;
         vec4    ShadowParams;
+        vec4    ShadowFilter;
+        vec4    ShadowVSM;
         vec4    ShadowSunDir;
         vec4    ShadowSunColor;
 };

--- a/Quake/shaders/shadow_depth.fs
+++ b/Quake/shaders/shadow_depth.fs
@@ -6,6 +6,10 @@
 
 #include "shadow_common.glsl"
 
+#if SHADOW_VSM
+        layout(location=0) out vec2 out_moments;
+#endif
+
 const uint CF_ALPHA_TEST = 8u;
 
 layout(location=0) flat in uint in_flags;
@@ -24,4 +28,8 @@ void main()
                 if (texture(Tex, in_uv).a < 0.666)
                         discard;
         }
+#if SHADOW_VSM
+        float depth = gl_FragCoord.z;
+        out_moments = vec2(depth, depth * depth + 1e-5);
+#endif
 }

--- a/README.md
+++ b/README.md
@@ -23,6 +23,21 @@ On most maps performance is indeed not much of a concern on a modern system. In 
 - capped framerate when no map is loaded
 - ability to run the game from a folder containing Unicode characters
 
+## Tuning & Troubleshooting
+
+Soft shadow quality can be adjusted at runtime using the following console variables:
+
+- `r_shadow_soft` toggles percentage-closer filtering. Set to `0` for hard edges, or `1` to enable the PCF kernel.
+- `r_shadow_pcf_size` selects the PCF radius in texels (1 = 3×3, 2 = 5×5, 3 = 7×7). Larger kernels soften edges at the cost of GPU time.
+- `r_shadow_soft_dist_scale` scales the filter radius with distance to the camera. Keep this low (e.g. `0.001`) for stability, or set to `0` to disable distance-based widening.
+- `r_shadow_normal_offset` applies a receiver offset along the surface normal based on `N·L`. Increase it slightly if shadow acne appears, but lower it if peter-panning becomes visible.
+- `r_shadow_bias` and `r_shadow_slope_bias` remain available for fine-tuning depth bias values.
+- `r_shadow_map_size` can be changed on the fly to recreate the shadow atlas at a different resolution. Consider dropping to `1024` on weaker GPUs.
+
+An optional variance shadow map path is provided via `r_shadow_vsm`. When enabled, the engine switches the shadow pass to a floating-point moment texture (`RG32F`) and the forward shader evaluates a min-variance filter. Use `r_shadow_vsm_bleed_reduce` (range `0`–`0.99`) to clamp light bleeding when VSM is active.
+
+When tuning, start with soft shadows disabled to verify bias settings, then re-enable PCF or VSM once acne and peter-panning are under control.
+
 ## System requirements
 
 | | Minimum GPU | Recommended GPU |


### PR DESCRIPTION
## Summary
- expose soft shadow PCF controls, including kernel size, distance scaling, and normal offset, through new CVars wired into the forward pass
- add an optional variance shadow map pipeline with moment rendering and shader evaluation that can be toggled at runtime
- document shadow tuning options and troubleshooting tips for bias, offsets, and quality settings

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68eab55374d0832e8137c17816f83843