### PR TITLE
Fix Windows build errors

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -199,6 +199,8 @@ static qboolean shadow_has_intensity;
 static float shadow_view_znear;
 static float shadow_view_zfar;
 
+static void ExtractFrustumPlane (float mvp[16], int axis, float ndcval, qboolean flip, mplane_t *out);
+
 //==============================================================================
 //
 // FRAMEBUFFERS
@@ -1702,7 +1704,7 @@ Extracts the normalized frustum plane from the given view-projection matrix
 that corresponds to a value of 'ndcval' on the 'axis' axis in NDC space.
 ===============
 */
-void ExtractFrustumPlane (float mvp[16], int axis, float ndcval, qboolean flip, mplane_t *out)
+static void ExtractFrustumPlane (float mvp[16], int axis, float ndcval, qboolean flip, mplane_t *out)
 {
 	float scale;
 	out->normal[0] =  (mvp[0*4 + axis] - ndcval * mvp[0*4 + 3]);

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -454,6 +454,7 @@ void R_AnimateLight (void);
 void R_MarkSurfaces (void);
 qboolean R_CullBox (vec3_t emins, vec3_t emaxs);
 qboolean R_CullModelForEntity (entity_t *e);
+void R_GetEntityBounds (const entity_t *e, vec3_t mins, vec3_t maxs);
 void R_EntityMatrix (float matrix[16], vec3_t origin, vec3_t angles, unsigned char scale);
 
 void R_InitParticles (void);

--- a/Quake/mathlib.h
+++ b/Quake/mathlib.h
@@ -60,6 +60,7 @@ static inline int IS_NAN (float x) {
 #define VectorAdd(a,b,dst)				do {(dst)[0]=(a)[0]+(b)[0];(dst)[1]=(a)[1]+(b)[1];(dst)[2]=(a)[2]+(b)[2];} while (0)
 #define VectorCopy(src,dst)				do {(dst)[0]=(src)[0];(dst)[1]=(src)[1];(dst)[2]=(src)[2];} while (0)
 #define VectorSet(v,x,y,z)				do {(v)[0]=(x);(v)[1]=(y);(v)[2]=(z);} while (0)
+#define VectorClear(v)                             do {(v)[0] = (v)[1] = (v)[2] = 0.f;} while (0)
 #define VectorLengthSquared(v)			DotProduct(v,v)
 
 //johnfitz -- courtesy of lordhavoc


### PR DESCRIPTION
## Summary
- add a VectorClear helper macro so new shadow code compiles cleanly
- expose R_GetEntityBounds in glquake.h for other translation units
- make ExtractFrustumPlane static with a forward declaration to satisfy MSVC

## Testing
- not run (SDL2 development files are unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68eacb4603b8832ea59edc4b8c6f22b1