### PR TITLE
Fix shadow frame data alignment for soft shadows

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -27,6 +27,12 @@ qboolean	r_cache_thrash;		// compatability
 
 gpuframedata_t r_framedata;
 
+COMPILE_TIME_ASSERT (shadowviewproj_alignment, (offsetof (gpuframedata_t, shadowviewproj) & 15) == 0);
+COMPILE_TIME_ASSERT (shadow_params_alignment, (offsetof (gpuframedata_t, shadow_params) & 15) == 0);
+COMPILE_TIME_ASSERT (shadow_filter_alignment, (offsetof (gpuframedata_t, shadow_filter) & 15) == 0);
+COMPILE_TIME_ASSERT (shadow_vsm_alignment, (offsetof (gpuframedata_t, shadow_vsm) & 15) == 0);
+COMPILE_TIME_ASSERT (shadow_block_size_alignment, (sizeof (gpuframedata_t) & 15) == 0);
+
 vec3_t		*r_pointfile;
 
 int			r_visframecount;	// bumped when going to a new PVS

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -435,6 +435,7 @@ typedef struct gpuframedata_s {
 	int		_padding2;
 	int		_padding3;
 	int		_padding4;
+	float	_padding_shadow[2];
 	float	shadowviewproj[4][16];
 	float	shadow_params[4];
 	float	shadow_filter[4];


### PR DESCRIPTION
## Summary
- align the frame data UBO layout with std140 by padding before the shadow matrices so the GPU reads the correct fields
- add compile-time assertions that verify the shadow-related data remains 16-byte aligned in the frame constant buffer

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68eadb0d6cf8832e8efd39f1b3f3b4ae