### PR TITLE
Allow edge shadow samples

### DIFF
--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -246,7 +246,7 @@ bool ComputeCascadeCoord(int cascadeIndex, vec3 offset_pos, float ndotl, out vec
 #endif
         if (projected.x < 0.0 || projected.x > 1.0 || projected.y < 0.0 || projected.y > 1.0)
                 return false;
-        if (projected.z <= 0.0 || projected.z >= 1.0)
+        if (projected.z < 0.0 || projected.z > 1.0)
                 return false;
         out_coord = vec3(projected.xy, float(cascadeIndex));
         out_canonical = DepthToCanonical(clamp(projected.z, 0.0, 1.0));


### PR DESCRIPTION
## Summary
- allow cascade lookups in `ComputeCascadeCoord` to treat depth values of 0 or 1 as valid
- prevent far-plane texels from being discarded so cascaded shadows cover the whole frustum

## Testing
- Not run (shader-only change)


------
https://chatgpt.com/codex/tasks/task_e_68eadfbe7b4c832e933c406ea4680b5f