### PR TITLE
Quantize stable shadow cascades

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -939,6 +939,15 @@ static qboolean R_ShadowBuildCascade (int cascade_index, float split_near, float
         {
                 center_light[0] = floorf (center_light[0] / texel_size + 0.5f) * texel_size;
                 center_light[1] = floorf (center_light[1] / texel_size + 0.5f) * texel_size;
+
+                /*
+                ** Snap the cascade extent to texel-sized increments as well when
+                ** running in stable mode. Without quantizing the radius the
+                ** orthographic projection would slightly expand/contract each
+                ** frame which manifests as shimmering or misaligned cascades.
+                */
+                radius = ceilf (radius / texel_size) * texel_size;
+                texel_size = (radius * 2.f) / (float) shadow_state.size;
         }
 
         for (i = 0; i < 3; i++)


### PR DESCRIPTION
## Summary
- snap the stable shadow cascade radius to texel-sized increments to keep projections aligned
- recompute the texel size after quantizing to prevent shimmering and alignment errors

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68eb087c35b8832e87bba0519b8377c5