### PR TITLE
Implement sidebar data manager and wire it into builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ if (WIN32)
 	find_package(BundledCODECS)
 endif()
 
-file(GLOB IWAIL_SRC CONFIGURE_DEPENDS "Quake/*.c" "Quake/*.h")
+file(GLOB IWAIL_SRC CONFIGURE_DEPENDS "Quake/*.c" "Quake/*.h" "Quake/*.cpp" "Quake/*.hpp")
 
 list(REMOVE_ITEM IWAIL_SRC ${CMAKE_CURRENT_SOURCE_DIR}/Quake/lodepng.h)
 list(REMOVE_ITEM IWAIL_SRC ${CMAKE_CURRENT_SOURCE_DIR}/Quake/lodepng.c)
@@ -61,6 +61,7 @@ elseif (PC_MAD_FOUND)
 endif()
 
 add_executable(ironwail ${IWAIL_SRC})
+target_compile_features(ironwail PRIVATE c_std_11 cxx_std_17)
 if (UNIX)
 	target_link_libraries(ironwail PRIVATE m)
 	set(ENABLE_USERDIRS TRUE CACHE STRING "Enable user directories")

--- a/Quake/Makefile
+++ b/Quake/Makefile
@@ -35,6 +35,7 @@ VORBISLIB=vorbis
 # ---------------------------
 
 check_gcc = $(shell if echo | $(CC) $(1) -Werror -S -o /dev/null -xc - > /dev/null 2>&1; then echo "$(1)"; else echo "$(2)"; fi;)
+check_cxx = $(shell if echo | $(CXX) $(1) -Werror -S -o /dev/null -xc++ - > /dev/null 2>&1; then echo "$(1)"; else echo "$(2)"; fi;)
 
 # ---------------------------
 
@@ -46,8 +47,9 @@ DEBUG ?= 0
 # build variables
 # ---------------------------
 
+CXX ?= g++
 CC ?= gcc
-LINKER = $(CC)
+LINKER = $(CXX)
 
 STRIP ?= strip
 PKG_CONFIG ?= pkg-config
@@ -60,6 +62,7 @@ CFLAGS += -D_FILE_OFFSET_BITS=64
 CFLAGS += $(call check_gcc,-std=gnu11,)
 CFLAGS += $(call check_gcc,-Werror=format,)
 CFLAGS += $(CPUFLAGS)
+CXXFLAGS = $(filter-out -std=gnu11,$(CFLAGS)) $(call check_cxx,-std=gnu++17,)
 ifneq ($(DEBUG),0)
 DFLAGS += -DDEBUG
 CFLAGS += -g
@@ -253,6 +256,7 @@ OBJS = strlcat.o \
 	console.o \
 	keys.o \
 	menu.o \
+	sidebar.o \
 	sbar.o \
 	view.o \
         wad.o \
@@ -297,6 +301,13 @@ all: $(DEFAULT_TARGET)
 %.o:	%.c %.d $(MAKEFILE)
 	@echo "Compiling $<" && \
 	$(CC) $(DFLAGS) -c $(CFLAGS) $(SDL_CFLAGS) -o $@ $<
+
+%.d:	%.cpp $(MAKEFILE)
+	@echo "Generating dependencies for $<" && \
+	$(CXX) $(DFLAGS) -c $(CXXFLAGS) $(SDL_CFLAGS) -MM $< -MF $@ -MT $@
+%.o:	%.cpp %.d $(MAKEFILE)
+	@echo "Compiling $<" && \
+	$(CXX) $(DFLAGS) -c $(CXXFLAGS) $(SDL_CFLAGS) -o $@ $<
 
 ironwail:	$(OBJS) $(MAKEFILE)
 	@echo "Linking $@" && \

--- a/Quake/Makefile.w32
+++ b/Quake/Makefile.w32
@@ -33,6 +33,7 @@ VORBISLIB=vorbis
 # ---------------------------
 
 check_gcc = $(shell if echo | $(CC) $(1) -Werror -S -o /dev/null -xc - > /dev/null 2>&1; then echo "$(1)"; else echo "$(2)"; fi;)
+check_cxx = $(shell if echo | $(CXX) $(1) -Werror -S -o /dev/null -xc++ - > /dev/null 2>&1; then echo "$(1)"; else echo "$(2)"; fi;)
 
 # ---------------------------
 
@@ -43,8 +44,9 @@ WINSOCK2 ?= 0
 # build variables
 # ---------------------------
 
+CXX = g++
 CC = gcc
-LINKER = $(CC)
+LINKER = $(CXX)
 WINDRES = windres
 
 STRIP = strip
@@ -57,6 +59,7 @@ CFLAGS += -D_FILE_OFFSET_BITS=64
 CFLAGS += $(call check_gcc,-std=gnu11,)
 CFLAGS += $(call check_gcc,-Werror=format,)
 CFLAGS += $(CPUFLAGS)
+CXXFLAGS = $(filter-out -std=gnu11,$(CFLAGS)) $(call check_cxx,-std=gnu++17,)
 ifneq ($(DEBUG),0)
 DFLAGS += -DDEBUG
 CFLAGS += -g
@@ -259,6 +262,7 @@ OBJS = strlcat.o \
 	console.o \
 	keys.o \
 	menu.o \
+	sidebar.o \
 	sbar.o \
 	view.o \
         wad.o \
@@ -303,6 +307,13 @@ all: $(DEFAULT_TARGET)
 %.o:	%.c %.d $(MAKEFILE)
 	@echo "Compiling $<" && \
 	$(CC) $(DFLAGS) -c $(CFLAGS) $(SDL_CFLAGS) -o $@ $<
+
+%.d:	%.cpp $(MAKEFILE)
+	@echo "Generating dependencies for $<" && \
+	$(CXX) $(DFLAGS) -c $(CXXFLAGS) $(SDL_CFLAGS) -MM $< -MF $@ -MT $@
+%.o:	%.cpp %.d $(MAKEFILE)
+	@echo "Compiling $<" && \
+	$(CXX) $(DFLAGS) -c $(CXXFLAGS) $(SDL_CFLAGS) -o $@ $<
 %.res:	../Windows/%.rc $(MAKEFILE)
 	@echo "Compiling $<" && \
 	$(WINDRES) -I../Windows --output-format=coff --target=pe-i386 -o $@ $<

--- a/Quake/Makefile.w64
+++ b/Quake/Makefile.w64
@@ -32,6 +32,7 @@ VORBISLIB=vorbis
 # ---------------------------
 
 check_gcc = $(shell if echo | $(CC) $(1) -Werror -S -o /dev/null -xc - > /dev/null 2>&1; then echo "$(1)"; else echo "$(2)"; fi;)
+check_cxx = $(shell if echo | $(CXX) $(1) -Werror -S -o /dev/null -xc++ - > /dev/null 2>&1; then echo "$(1)"; else echo "$(2)"; fi;)
 
 # ---------------------------
 
@@ -41,8 +42,9 @@ DEBUG ?= 0
 # build variables
 # ---------------------------
 
+CXX = g++
 CC = gcc
-LINKER = $(CC)
+LINKER = $(CXX)
 WINDRES = windres
 
 STRIP = strip
@@ -55,6 +57,7 @@ CFLAGS += -D_FILE_OFFSET_BITS=64
 CFLAGS += $(call check_gcc,-std=gnu11,)
 CFLAGS += $(call check_gcc,-Werror=format,)
 CFLAGS += $(CPUFLAGS)
+CXXFLAGS = $(filter-out -std=gnu11,$(CFLAGS)) $(call check_cxx,-std=gnu++17,)
 ifneq ($(DEBUG),0)
 DFLAGS += -DDEBUG
 CFLAGS += -g
@@ -252,6 +255,7 @@ OBJS = strlcat.o \
 	console.o \
 	keys.o \
 	menu.o \
+	sidebar.o \
 	sbar.o \
 	view.o \
         wad.o \
@@ -296,6 +300,13 @@ all: $(DEFAULT_TARGET)
 %.o:	%.c %.d $(MAKEFILE)
 	@echo "Compiling $<" && \
 	$(CC) $(DFLAGS) -c $(CFLAGS) $(SDL_CFLAGS) -o $@ $<
+
+%.d:	%.cpp $(MAKEFILE)
+	@echo "Generating dependencies for $<" && \
+	$(CXX) $(DFLAGS) -c $(CXXFLAGS) $(SDL_CFLAGS) -MM $< -MF $@ -MT $@
+%.o:	%.cpp %.d $(MAKEFILE)
+	@echo "Compiling $<" && \
+	$(CXX) $(DFLAGS) -c $(CXXFLAGS) $(SDL_CFLAGS) -o $@ $<
 %.res:	../Windows/%.rc $(MAKEFILE)
 	@echo "Compiling $<" && \
 	$(WINDRES) -I../Windows --output-format=coff --target=pe-x86-64 -o $@ $<

--- a/Quake/quakedef.h
+++ b/Quake/quakedef.h
@@ -288,6 +288,7 @@ typedef struct
 #include "input.h"
 #include "keys.h"
 #include "menu.h"
+#include "sidebar.h"
 #include "cdaudio.h"
 #include "glquake.h"
 

--- a/Quake/sidebar.cpp
+++ b/Quake/sidebar.cpp
@@ -1,0 +1,258 @@
+#include "quakedef.h"
+#include "sidebar.h"
+
+#include <algorithm>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+class CSidebar
+{
+public:
+    CSidebar();
+    ~CSidebar();
+
+    void Setup();
+    void Shutdown();
+    void Clear();
+    void AddCount(const char *path, int count);
+    const char *GetFile(const char *path) const;
+    bool HasItems() const;
+    const sidebar_menu_t *GetMenu() const;
+
+    void Sidebar_Shutdown();
+    void Sidebar_Setup();
+    void Sidebar_Clear();
+    void Sidebar_AddCount(const char *path, int count);
+    const char *Sidebar_GetFile(const char *path) const;
+    bool Sidebar_HasItems() const;
+    const sidebar_menu_t *Sidebar_GetMenu() const;
+
+private:
+    struct entry_t
+    {
+        std::string key;
+        int count = 0;
+    };
+
+    void MarkMenuDirty() const;
+
+    mutable sidebar_menu_t menu_;
+    mutable std::vector<const char *> labels_;
+    mutable std::vector<int> counts_;
+    mutable bool menu_dirty_ = true;
+    mutable bool entries_dirty_ = true;
+
+    std::vector<entry_t> entries_;
+    mutable std::unordered_map<std::string, size_t> index_;
+};
+
+CSidebar::CSidebar()
+{
+    menu_.count = 0;
+    menu_.labels = nullptr;
+    menu_.counts = nullptr;
+}
+
+CSidebar::~CSidebar() = default;
+
+void CSidebar::MarkMenuDirty() const
+{
+    menu_dirty_ = true;
+}
+
+void CSidebar::Setup()
+{
+    if (!entries_dirty_)
+        return;
+
+    if (entries_.empty())
+    {
+        index_.clear();
+        labels_.clear();
+        counts_.clear();
+        menu_.count = 0;
+        menu_.labels = nullptr;
+        menu_.counts = nullptr;
+        menu_dirty_ = false;
+        entries_dirty_ = false;
+        return;
+    }
+
+    std::stable_sort(entries_.begin(), entries_.end(), [](const entry_t &lhs, const entry_t &rhs) {
+        if (lhs.count != rhs.count)
+            return lhs.count > rhs.count;
+        return q_strcasecmp(lhs.key.c_str(), rhs.key.c_str()) < 0;
+    });
+
+    index_.clear();
+    index_.reserve(entries_.size());
+    for (size_t i = 0; i < entries_.size(); ++i)
+        index_[entries_[i].key] = i;
+
+    entries_dirty_ = false;
+    MarkMenuDirty();
+}
+
+void CSidebar::Shutdown()
+{
+    Clear();
+}
+
+void CSidebar::Clear()
+{
+    entries_.clear();
+    index_.clear();
+    labels_.clear();
+    counts_.clear();
+    menu_.count = 0;
+    menu_.labels = nullptr;
+    menu_.counts = nullptr;
+    menu_dirty_ = false;
+    entries_dirty_ = false;
+}
+
+void CSidebar::AddCount(const char *path, int count)
+{
+    if (!path || !*path || count <= 0)
+        return;
+
+    auto it = index_.find(path);
+    if (it != index_.end())
+    {
+        entries_[it->second].count += count;
+    }
+    else
+    {
+        entries_.push_back({std::string(path), count});
+        index_[entries_.back().key] = entries_.size() - 1;
+    }
+
+    entries_dirty_ = true;
+    MarkMenuDirty();
+}
+
+const char *CSidebar::GetFile(const char *path) const
+{
+    if (!path || !*path)
+        return nullptr;
+
+    auto it = index_.find(path);
+    if (it == index_.end())
+        return nullptr;
+
+    const entry_t &entry = entries_[it->second];
+    return entry.key.c_str();
+}
+
+bool CSidebar::HasItems() const
+{
+    return !entries_.empty();
+}
+
+const sidebar_menu_t *CSidebar::GetMenu() const
+{
+    if (entries_dirty_)
+        const_cast<CSidebar *>(this)->Setup();
+
+    if (!menu_dirty_)
+        return &menu_;
+
+    labels_.clear();
+    counts_.clear();
+    labels_.reserve(entries_.size());
+    counts_.reserve(entries_.size());
+
+    for (const entry_t &entry : entries_)
+    {
+        labels_.push_back(entry.key.c_str());
+        counts_.push_back(entry.count);
+    }
+
+    menu_.count = labels_.size();
+    menu_.labels = labels_.empty() ? nullptr : labels_.data();
+    menu_.counts = counts_.empty() ? nullptr : counts_.data();
+    menu_dirty_ = false;
+    return &menu_;
+}
+
+void CSidebar::Sidebar_Shutdown()
+{
+    Shutdown();
+}
+
+void CSidebar::Sidebar_Setup()
+{
+    Setup();
+}
+
+void CSidebar::Sidebar_Clear()
+{
+    Clear();
+}
+
+void CSidebar::Sidebar_AddCount(const char *path, int count)
+{
+    AddCount(path, count);
+}
+
+const char *CSidebar::Sidebar_GetFile(const char *path) const
+{
+    return GetFile(path);
+}
+
+bool CSidebar::Sidebar_HasItems() const
+{
+    return HasItems();
+}
+
+const sidebar_menu_t *CSidebar::Sidebar_GetMenu() const
+{
+    return GetMenu();
+}
+
+static CSidebar g_sidebar;
+
+extern "C" {
+
+void Sidebar_Init(void)
+{
+    g_sidebar.Clear();
+}
+
+void Sidebar_Shutdown(void)
+{
+    g_sidebar.Shutdown();
+}
+
+void Sidebar_Setup(void)
+{
+    g_sidebar.Setup();
+}
+
+void Sidebar_Clear(void)
+{
+    g_sidebar.Clear();
+}
+
+void Sidebar_AddCount(const char *path, int count)
+{
+    g_sidebar.AddCount(path, count);
+}
+
+const char *Sidebar_GetFile(const char *path)
+{
+    return g_sidebar.GetFile(path);
+}
+
+qboolean Sidebar_HasItems(void)
+{
+    return g_sidebar.HasItems() ? 1 : 0;
+}
+
+const sidebar_menu_t *Sidebar_GetMenu(void)
+{
+    return g_sidebar.GetMenu();
+}
+
+}

--- a/Quake/sidebar.h
+++ b/Quake/sidebar.h
@@ -1,0 +1,29 @@
+#ifndef QUAKE_SIDEBAR_H
+#define QUAKE_SIDEBAR_H
+
+#include "q_stdinc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct sidebar_menu_s {
+    size_t count;
+    const char **labels;
+    const int *counts;
+} sidebar_menu_t;
+
+void Sidebar_Init(void);
+void Sidebar_Shutdown(void);
+void Sidebar_Setup(void);
+void Sidebar_Clear(void);
+void Sidebar_AddCount(const char *path, int count);
+const char *Sidebar_GetFile(const char *path);
+qboolean Sidebar_HasItems(void);
+const sidebar_menu_t *Sidebar_GetMenu(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* QUAKE_SIDEBAR_H */

--- a/Windows/VisualStudio/ironwail.vcxproj
+++ b/Windows/VisualStudio/ironwail.vcxproj
@@ -260,6 +260,9 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
     <ClCompile Include="..\..\Quake\main_sdl.c" />
     <ClCompile Include="..\..\Quake\mathlib.c" />
     <ClCompile Include="..\..\Quake\menu.c" />
+    <ClCompile Include="..\..\Quake\sidebar.cpp">
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
     <ClCompile Include="..\..\Quake\miniz.c">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
@@ -397,6 +400,7 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
     <ClInclude Include="..\..\Quake\resource.h" />
     <ClInclude Include="..\..\Quake\sbar.h" />
     <ClInclude Include="..\..\Quake\screen.h" />
+    <ClInclude Include="..\..\Quake\sidebar.h" />
     <ClInclude Include="..\..\Quake\server.h" />
     <ClInclude Include="..\..\Quake\snd_codec.h" />
     <ClInclude Include="..\..\Quake\snd_codeci.h" />

--- a/Windows/VisualStudio/ironwail.vcxproj.filters
+++ b/Windows/VisualStudio/ironwail.vcxproj.filters
@@ -117,6 +117,9 @@
     <ClCompile Include="..\..\Quake\menu.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Quake\sidebar.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\Quake\miniz.c">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -402,6 +405,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Quake\screen.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Quake\sidebar.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Quake\server.h">


### PR DESCRIPTION
## Summary
- add a C++ sidebar module that tracks entry counts and exposes C wrappers for the existing menu system
- include the new header in the engine and add the sidebar sources to every supported build configuration
- enable C++17 compilation support in CMake, GNU makefiles, and the Visual Studio project so the sidebar code is built everywhere

## Testing
- not run (SDL2 dependency unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ebee0c5194832ebc4889c36a9ee018