### PR TITLE
Add emissive texture support to world and alias rendering

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -598,7 +598,8 @@ static void Mod_LoadTextures (lump_t *l)
 			pixels = q_max(0L, (long)((mod_base + l->fileofs + l->filelen) - (byte*)(mt+1)));
 		}
 
-		tx->fullbright = NULL; //johnfitz
+			tx->fullbright = NULL; //johnfitz
+			tx->emissive = NULL;
 		tx->shift = 0;	// Q64 only
 		tx->type = Mod_TextureTypeFromName (tx->name);
 
@@ -668,26 +669,34 @@ static void Mod_LoadTextures (lump_t *l)
 				}
 
 				//now load whatever we found
-				if (data) //load external image
-				{
-					char filename2[MAX_OSPATH];
-					tx->gltexture = TexMgr_LoadImage (loadmodel, filename, fwidth, fheight,
-						fmt, data, filename, 0, TEXPREF_MIPMAP | extraflags );
+                               if (data) //load external image
+                               {
+                                       char filename2[MAX_OSPATH];
+                                       tx->gltexture = TexMgr_LoadImage (loadmodel, filename, fwidth, fheight,
+                                               fmt, data, filename, 0, TEXPREF_MIPMAP | extraflags );
 
-					//now try to load glow/luma image from the same place
-					Hunk_FreeToLowMark (mark);
-					q_snprintf (filename2, sizeof(filename2), "%s_glow", filename);
-					data = Image_LoadImage (filename2, &fwidth, &fheight, &fmt);
-					if (!data)
-					{
-						q_snprintf (filename2, sizeof(filename2), "%s_luma", filename);
-						data = Image_LoadImage (filename2, &fwidth, &fheight, &fmt);
-					}
+                                       Hunk_FreeToLowMark (mark);
+                                       mark = Hunk_LowMark ();
+                                       q_snprintf (filename2, sizeof(filename2), "%s_emissive", filename);
+                                       data = Image_LoadImage (filename2, &fwidth, &fheight, &fmt);
+                                       if (data)
+                                               tx->emissive = TexMgr_LoadImage (loadmodel, filename2, fwidth, fheight,
+                                                       fmt, data, filename2, 0, TEXPREF_MIPMAP | extraflags );
 
-					if (data)
-						tx->fullbright = TexMgr_LoadImage (loadmodel, filename2, fwidth, fheight,
-							fmt, data, filename2, 0, TEXPREF_MIPMAP | extraflags );
-				}
+                                       Hunk_FreeToLowMark (mark);
+                                       mark = Hunk_LowMark ();
+                                       q_snprintf (filename2, sizeof(filename2), "%s_glow", filename);
+                                       data = Image_LoadImage (filename2, &fwidth, &fheight, &fmt);
+                                       if (!data)
+                                       {
+                                               q_snprintf (filename2, sizeof(filename2), "%s_luma", filename);
+                                               data = Image_LoadImage (filename2, &fwidth, &fheight, &fmt);
+                                       }
+
+                                       if (data)
+                                               tx->fullbright = TexMgr_LoadImage (loadmodel, filename2, fwidth, fheight,
+                                                       fmt, data, filename2, 0, TEXPREF_MIPMAP | extraflags );
+                               }
 				else //use the texture from the bsp file
 				{
 					q_snprintf (texturename, sizeof(texturename), "%s:%s", loadmodel->name, tx->name);
@@ -3040,8 +3049,10 @@ static void *Mod_LoadAllSkins (int numskins, daliasskintype_t *pskintype)
 				pheader->fbtextures[i][0] = NULL;
 			}
 
-			pheader->gltextures[i][3] = pheader->gltextures[i][2] = pheader->gltextures[i][1] = pheader->gltextures[i][0];
-			pheader->fbtextures[i][3] = pheader->fbtextures[i][2] = pheader->fbtextures[i][1] = pheader->fbtextures[i][0];
+                        pheader->gltextures[i][3] = pheader->gltextures[i][2] = pheader->gltextures[i][1] = pheader->gltextures[i][0];
+                        pheader->fbtextures[i][3] = pheader->fbtextures[i][2] = pheader->fbtextures[i][1] = pheader->fbtextures[i][0];
+			pheader->emissivetextures[i][0] = NULL;
+			pheader->emissivetextures[i][3] = pheader->emissivetextures[i][2] = pheader->emissivetextures[i][1] = pheader->emissivetextures[i][0];
 			//johnfitz
 
 			pskintype = (daliasskintype_t *)((byte *)(pskintype+1) + size);
@@ -3068,7 +3079,8 @@ static void *Mod_LoadAllSkins (int numskins, daliasskintype_t *pskintype)
 				//johnfitz -- rewritten
 				q_snprintf (name, sizeof(name), "%s:frame%i_%i", loadmodel->name, i,j);
 				offset = (src_offset_t)(pskintype) - (src_offset_t)mod_base; //johnfitz
-				if (Mod_CheckFullbrights ((byte *)(pskintype), size))
+				pheader->emissivetextures[i][j&3] = NULL;
+                                if (Mod_CheckFullbrights ((byte *)(pskintype), size))
 				{
 					if (!(texflags & TEXPREF_ALPHA))
 					{
@@ -3086,17 +3098,22 @@ static void *Mod_LoadAllSkins (int numskins, daliasskintype_t *pskintype)
 				}
 				else
 				{
-					pheader->gltextures[i][j&3] = TexMgr_LoadImage (loadmodel, name, pheader->skinwidth, pheader->skinheight,
-						SRC_INDEXED, (byte *)(pskintype), loadmodel->name, offset, texflags);
-					pheader->fbtextures[i][j&3] = NULL;
+                                pheader->gltextures[i][j&3] = TexMgr_LoadImage (loadmodel, name, pheader->skinwidth, pheader->skinheight,
+                                        SRC_INDEXED, (byte *)(pskintype), loadmodel->name, offset, texflags);
+                                pheader->fbtextures[i][j&3] = NULL;
+				pheader->emissivetextures[i][j&3] = NULL;
 				}
 				//johnfitz
 
 				pskintype = (daliasskintype_t *)((byte *)(pskintype) + size);
 			}
 			k = j;
-			for (/**/; j < 4; j++)
-				pheader->gltextures[i][j&3] = pheader->gltextures[i][j - k];
+                        for (/**/; j < 4; j++)
+                        {
+                                pheader->gltextures[i][j&3] = pheader->gltextures[i][j - k];
+                                pheader->fbtextures[i][j&3] = pheader->fbtextures[i][j - k];
+                                pheader->emissivetextures[i][j&3] = pheader->emissivetextures[i][j - k];
+                        }
 		}
 	}
 
@@ -4260,10 +4277,12 @@ static void Mod_LoadMD5MeshModel (qmodel_t *mod, const char *buffer)
 
 				data = Image_LoadImage (texname, (int*)&fwidth, (int*)&fheight, &fmt);
 				//now load whatever we found
-				if (data) //load external image
-				{
-					surf->gltextures[surf->numskins][f] = TexMgr_LoadImage (mod, texname, fwidth, fheight, fmt, data, texname, 0, TEXPREF_ALPHA|TEXPREF_NOBRIGHT|TEXPREF_MIPMAP );
-					surf->fbtextures[surf->numskins][f] = NULL;
+                               if (data) //load external image
+                               {
+                                        char emissivename[MAX_QPATH];
+                                        surf->gltextures[surf->numskins][f] = TexMgr_LoadImage (mod, texname, fwidth, fheight, fmt, data, texname, 0, TEXPREF_ALPHA|TEXPREF_NOBRIGHT|TEXPREF_MIPMAP );
+                                        surf->fbtextures[surf->numskins][f] = NULL;
+                                        surf->emissivetextures[surf->numskins][f] = NULL;
 					if (fmt == SRC_INDEXED)
 					{	//8bit base texture. use it for fullbrights.
 						if (Mod_CheckFullbrights (data, fwidth*fheight))
@@ -4271,16 +4290,18 @@ static void Mod_LoadMD5MeshModel (qmodel_t *mod, const char *buffer)
 					}
 					else
 					{	//we found a 32bit base texture.
-						if (!surf->fbtextures[surf->numskins][f])
-						{
-							q_snprintf(texname, sizeof(texname), "progs/%s_%02u_%02u_glow", com_token, surf->numskins, f);
-							surf->fbtextures[surf->numskins][f] = TexMgr_LoadImage(mod, texname, surf->skinwidth, surf->skinheight, SRC_RGBA, NULL, texname, 0, TEXPREF_MIPMAP);
-						}
-						if (!surf->fbtextures[surf->numskins][f])
-						{
-							q_snprintf(texname, sizeof(texname), "progs/%s_%02u_%02u_luma", com_token, surf->numskins, f);
-							surf->fbtextures[surf->numskins][f] = TexMgr_LoadImage(mod, texname, surf->skinwidth, surf->skinheight, SRC_RGBA, NULL, texname, 0, TEXPREF_MIPMAP);
-						}
+                                                q_snprintf(emissivename, sizeof(emissivename), "progs/%s_%02u_%02u_emissive", com_token, surf->numskins, f);
+                                                surf->emissivetextures[surf->numskins][f] = TexMgr_LoadImage(mod, emissivename, surf->skinwidth, surf->skinheight, SRC_RGBA, NULL, emissivename, 0, TEXPREF_MIPMAP);
+                                                if (!surf->fbtextures[surf->numskins][f])
+                                                {
+                                                        q_snprintf(texname, sizeof(texname), "progs/%s_%02u_%02u_glow", com_token, surf->numskins, f);
+                                                        surf->fbtextures[surf->numskins][f] = TexMgr_LoadImage(mod, texname, surf->skinwidth, surf->skinheight, SRC_RGBA, NULL, texname, 0, TEXPREF_MIPMAP);
+                                                }
+                                                if (!surf->fbtextures[surf->numskins][f])
+                                                {
+                                                        q_snprintf(texname, sizeof(texname), "progs/%s_%02u_%02u_luma", com_token, surf->numskins, f);
+                                                        surf->fbtextures[surf->numskins][f] = TexMgr_LoadImage(mod, texname, surf->skinwidth, surf->skinheight, SRC_RGBA, NULL, texname, 0, TEXPREF_MIPMAP);
+                                                }
 					}
 
 					//now try to load glow/luma image from the same place
@@ -4293,20 +4314,23 @@ static void Mod_LoadMD5MeshModel (qmodel_t *mod, const char *buffer)
 				break;	//no images loaded...
 
 			//this stuff is hideous.
-			if (f < 2)
-			{
-				surf->gltextures[surf->numskins][1] = surf->gltextures[surf->numskins][0];
-				surf->fbtextures[surf->numskins][1] = surf->fbtextures[surf->numskins][0];
-			}
+                        if (f < 2)
+                        {
+                                surf->gltextures[surf->numskins][1] = surf->gltextures[surf->numskins][0];
+                                surf->fbtextures[surf->numskins][1] = surf->fbtextures[surf->numskins][0];
+                                surf->emissivetextures[surf->numskins][1] = surf->emissivetextures[surf->numskins][0];
+                        }
 			if (f == 3)
 				Con_Warning("progs/%s_%02u_##: 3 skinframes found...\n", com_token, surf->numskins);
 			if (f < 4)
 			{
-				surf->gltextures[surf->numskins][3] = surf->gltextures[surf->numskins][1];
-				surf->gltextures[surf->numskins][2] = surf->gltextures[surf->numskins][0];
+                                surf->gltextures[surf->numskins][3] = surf->gltextures[surf->numskins][1];
+                                surf->gltextures[surf->numskins][2] = surf->gltextures[surf->numskins][0];
 
-				surf->fbtextures[surf->numskins][3] = surf->fbtextures[surf->numskins][1];
-				surf->fbtextures[surf->numskins][2] = surf->fbtextures[surf->numskins][0];
+                                surf->fbtextures[surf->numskins][3] = surf->fbtextures[surf->numskins][1];
+                                surf->fbtextures[surf->numskins][2] = surf->fbtextures[surf->numskins][0];
+                                surf->emissivetextures[surf->numskins][3] = surf->emissivetextures[surf->numskins][1];
+                                surf->emissivetextures[surf->numskins][2] = surf->emissivetextures[surf->numskins][0];
 			}
 		}
 		surf->skinwidth = surf->gltextures[0][0]?surf->gltextures[0][0]->width:1;

--- a/Quake/gl_model.h
+++ b/Quake/gl_model.h
@@ -93,6 +93,7 @@ typedef struct texture_s
 	textype_t			type;
 	struct gltexture_s	*gltexture; //johnfitz -- pointer to gltexture
 	struct gltexture_s	*fullbright; //johnfitz -- fullbright mask texture
+	struct gltexture_s	*emissive;   // emissive texture map (Quake 3 style glow)
 	int					anim_total;				// total tenths in sequence ( 0 = no)
 	int					anim_min, anim_max;		// time for this frame min <=time< max
 	struct texture_s	*anim_next;		// in the animation sequence
@@ -340,6 +341,7 @@ typedef struct {
 	} poseverttype;	//spike
 	struct gltexture_s	*gltextures[MAX_SKINS][4]; //johnfitz
 	struct gltexture_s	*fbtextures[MAX_SKINS][4]; //johnfitz
+	struct gltexture_s	*emissivetextures[MAX_SKINS][4];
 	int					texels[MAX_SKINS];	// only for player skins
 	maliasframedesc_t	frames[1];	// variable sized
 } aliashdr_t;

--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -495,7 +495,7 @@ void R_FlushAliasInstances (qboolean showtris)
 	GLuint		buffers[2];
 	GLintptr	offsets[2];
 	GLsizeiptr	sizes[2];
-	gltexture_t	*textures[2];
+	gltexture_t	*textures[3];
 
 	if (!ibuf.count)
 		return;
@@ -595,29 +595,38 @@ void R_FlushAliasInstances (qboolean showtris)
 
 		textures[0] = hdr->gltextures[skinnum][anim];
 		textures[1] = hdr->fbtextures[skinnum][anim];
+		textures[2] = hdr->emissivetextures[skinnum][anim];
 		if (hdr == mainhdr && ibuf.ent->colormap != vid.colormap && !gl_nocolors.value)
 			if (CL_IsPlayerEnt (ibuf.ent)) /* && !strcmp (ibuf.ent->model->name, "progs/player.mdl") */
 				textures[0] = playertextures[ibuf.ent - cl_entities - 1];
 
 		if (!gl_fullbrights.value)
+		{
 			textures[1] = blacktexture;
+			textures[2] = blacktexture;
+		}
 
 		if (r_lightmap_cheatsafe)
 		{
 			textures[0] = greytexture;
 			textures[1] = blacktexture;
+			textures[2] = blacktexture;
 		}
 
 		if (!textures[1])
 			textures[1] = blacktexture;
 
+		if (!textures[2])
+			textures[2] = blacktexture;
+
 		if (showtris)
 		{
 			textures[0] = blacktexture;
 			textures[1] = whitetexture;
+			textures[2] = blacktexture;
 		}
 
-		GL_BindTextures (0, 2, textures);
+		GL_BindTextures (0, 3, textures);
 
 		GL_DrawElementsInstancedFunc (GL_TRIANGLES, hdr->numindexes, GL_UNSIGNED_SHORT, (void *)hdr->eboofs, ibuf.count);
 

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -163,6 +163,7 @@ typedef struct bmodel_bindless_gpu_call_s {
 	GLfloat		alpha;
 	GLuint64	texture;
 	GLuint64	fullbright;
+	GLuint64	emissive;
 } bmodel_bindless_gpu_call_t;
 
 typedef struct bmodel_bound_gpu_call_s {
@@ -184,7 +185,7 @@ static union {
 	} bindless;
 	struct {
 		bmodel_bound_gpu_call_t		params[MAX_BMODEL_DRAWS];
-		gltexture_t					*textures[MAX_BMODEL_DRAWS][2];
+		gltexture_t					*textures[MAX_BMODEL_DRAWS][3];
 	} bound;
 } bmodel_calls;
 static bmodel_gpu_call_remap_t		bmodel_call_remap[MAX_BMODEL_DRAWS];
@@ -273,6 +274,7 @@ static void R_FlushBModelCalls (void)
 		{
 			GL_Uniform1iFunc (0, i);
 			GL_BindTextures (0, 2, bmodel_calls.bound.textures[i]);
+			GL_Bind (GL_TEXTURE4, bmodel_calls.bound.textures[i][2]);
 			GL_DrawElementsIndirectFunc (GL_TRIANGLES, GL_UNSIGNED_INT, (const byte *)(dstcmdofs + i * sizeof (bmodel_draw_indirect_t)));
 		}
 	}
@@ -280,7 +282,8 @@ static void R_FlushBModelCalls (void)
 	num_bmodel_calls = 0;
 }
 
-#define CALLFLAG_ALPHA_TEST      (1u << 3)
+#define CALLFLAG_EMISSIVE        (1u << 3)
+#define CALLFLAG_ALPHA_TEST      (1u << 4)
 
 /*
 =============
@@ -291,7 +294,7 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
 {
 	GLuint		flags;
 	float		alpha;
-	gltexture_t	*tx, *fb;
+	gltexture_t	*tx, *fb, *em;
 
 	if (num_bmodel_calls == MAX_BMODEL_DRAWS)
 		R_FlushBModelCalls ();
@@ -300,20 +303,24 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
 	{
 		tx = t->gltexture;
 		fb = t->fullbright;
+		em = t->emissive;
 		if (r_lightmap_cheatsafe)
-			tx = fb = NULL;
+			tx = fb = em = NULL;
 		if (!gl_fullbrights.value && t->type != TEXTYPE_SKY)
 			fb = NULL;
 	}
 	else
 	{
 		tx = fb = whitetexture;
+		em = NULL;
 	}
 
 	if (!gl_zfix.value || map_checks.value)
 		zfix = 0;
 
         flags = zfix | ((fb != NULL) << 1) | ((r_fullbright_cheatsafe != false) << 2);
+        if (em != NULL)
+                flags |= CALLFLAG_EMISSIVE;
         if (t && t->type == TEXTYPE_CUTOUT)
                 flags |= CALLFLAG_ALPHA_TEST;
         alpha = t ? GL_WaterAlphaForTextureType (t->type) : 1.f;
@@ -325,6 +332,7 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
 		call->alpha = alpha;
 		call->texture = tx ? tx->bindless_handle : greytexture->bindless_handle;
 		call->fullbright = fb ? fb->bindless_handle : blacktexture->bindless_handle;
+		call->emissive = em ? em->bindless_handle : blacktexture->bindless_handle;
 	}
 	else
 	{
@@ -336,6 +344,7 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
 		call->padding = 0;
 		textures[0] = tx ? tx : greytexture;
 		textures[1] = fb ? fb : blacktexture;
+		textures[2] = em ? em : blacktexture;
 	}
 
 	SDL_assert (num_instances > 0);

--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -66,6 +66,7 @@ float tri(float x)
 
 layout(binding=0) uniform sampler2D Tex;
 layout(binding=1) uniform sampler2D FullbrightTex;
+layout(binding=2) uniform sampler2D EmissiveTex;
 
 #if MODE == 2
 	layout(location=0) noperspective in vec2 in_texcoord;
@@ -115,12 +116,13 @@ layout(location=2) in vec3 in_pos;
 
 void main()
 {
-	vec2 uv = in_texcoord;
+        vec2 uv = in_texcoord;
+        vec3 emissive = vec3(0.0);
 #if MODE == 2
-	uv -= 0.5 / vec2(textureSize(Tex, 0).xy);
-	vec4 result = textureLod(Tex, uv, 0.);
+        uv -= 0.5 / vec2(textureSize(Tex, 0).xy);
+        vec4 result = textureLod(Tex, uv, 0.);
 #else
-	vec4 result = texture(Tex, uv);
+        vec4 result = texture(Tex, uv);
 #endif
 #if ALPHATEST
 	if (result.a < 0.666)
@@ -130,13 +132,18 @@ void main()
 	result.rgb = mix(result.rgb, result.rgb * in_color.rgb, result.a);
 #endif
 	result.a = in_color.a; // FIXME: This will make almost transparent things cut holes though heavy fog
+        vec3 fullbright;
 #if MODE == 2
-	result.rgb += textureLod(FullbrightTex, uv, 0.).rgb;
+        fullbright = textureLod(FullbrightTex, uv, 0.).rgb;
+        emissive = textureLod(EmissiveTex, uv, 0.).rgb;
 #else
-	result.rgb += texture(FullbrightTex, uv).rgb;
+        fullbright = texture(FullbrightTex, uv).rgb;
+        emissive = texture(EmissiveTex, uv).rgb;
 #endif
-	result.rgb = clamp(result.rgb, 0.0, 1.0);
-	float fog = exp2(abs(Fog.w) * -dot(in_pos, in_pos));
+        result.rgb += fullbright;
+        result.rgb += emissive;
+        result.rgb = clamp(result.rgb, 0.0, 1.0);
+        float fog = exp2(abs(Fog.w) * -dot(in_pos, in_pos));
 	fog = clamp(fog, 0.0, 1.0);
 	result.rgb = mix(Fog.rgb, result.rgb, fog);
 	out_fragcolor = result;

--- a/Quake/shaders/shadow_depth.fs
+++ b/Quake/shaders/shadow_depth.fs
@@ -10,7 +10,7 @@
         layout(location=0) out vec2 out_moments;
 #endif
 
-const uint CF_ALPHA_TEST = 8u;
+const uint CF_ALPHA_TEST = 16u;
 
 layout(location=0) flat in uint in_flags;
 layout(location=1) in vec2 in_uv;

--- a/Quake/shaders/shadow_depth.vs
+++ b/Quake/shaders/shadow_depth.vs
@@ -15,6 +15,7 @@ struct Call
 #if BINDLESS
         uvec2   txhandle;
         uvec2   fbhandle;
+        uvec2   emhandle;
 #else
         int             baseinstance;
         int             padding;
@@ -24,7 +25,7 @@ const uint
         CF_USE_POLYGON_OFFSET = 1u,
         CF_USE_FULLBRIGHT = 2u,
         CF_NOLIGHTMAP = 4u,
-        CF_ALPHA_TEST = 8u
+        CF_USE_EMISSIVE = 8u
 ;
 
 layout(std430, binding=1) restrict readonly buffer CallBuffer

--- a/Quake/shaders/sky_cubemap.vert
+++ b/Quake/shaders/sky_cubemap.vert
@@ -22,6 +22,7 @@ struct Call
 #if BINDLESS
 	uvec2	txhandle;
 	uvec2	fbhandle;
+	uvec2	emhandle;
 #else
 	int		baseinstance;
 	int		padding;
@@ -30,7 +31,8 @@ struct Call
 const uint
 	CF_USE_POLYGON_OFFSET = 1u,
 	CF_USE_FULLBRIGHT = 2u,
-	CF_NOLIGHTMAP = 4u
+	CF_NOLIGHTMAP = 4u,
+	CF_USE_EMISSIVE = 8u
 ;
 
 layout(std430, binding=1) restrict readonly buffer CallBuffer

--- a/Quake/shaders/sky_layers.vert
+++ b/Quake/shaders/sky_layers.vert
@@ -22,6 +22,7 @@ struct Call
 #if BINDLESS
 	uvec2	txhandle;
 	uvec2	fbhandle;
+	uvec2	emhandle;
 #else
 	int		baseinstance;
 	int		padding;
@@ -30,7 +31,8 @@ struct Call
 const uint
 	CF_USE_POLYGON_OFFSET = 1u,
 	CF_USE_FULLBRIGHT = 2u,
-	CF_NOLIGHTMAP = 4u
+	CF_NOLIGHTMAP = 4u,
+	CF_USE_EMISSIVE = 8u
 ;
 
 layout(std430, binding=1) restrict readonly buffer CallBuffer

--- a/Quake/shaders/skystencil.vert
+++ b/Quake/shaders/skystencil.vert
@@ -22,6 +22,7 @@ struct Call
 #if BINDLESS
 	uvec2	txhandle;
 	uvec2	fbhandle;
+	uvec2	emhandle;
 #else
 	int		baseinstance;
 	int		padding;
@@ -30,7 +31,8 @@ struct Call
 const uint
 	CF_USE_POLYGON_OFFSET = 1u,
 	CF_USE_FULLBRIGHT = 2u,
-	CF_NOLIGHTMAP = 4u
+	CF_NOLIGHTMAP = 4u,
+	CF_USE_EMISSIVE = 8u
 ;
 
 layout(std430, binding=1) restrict readonly buffer CallBuffer

--- a/Quake/shaders/water.frag
+++ b/Quake/shaders/water.frag
@@ -1,17 +1,27 @@
 #if BINDLESS
-	#extension GL_ARB_bindless_texture : require
+        #extension GL_ARB_bindless_texture : require
 #else
-	layout(binding=0) uniform sampler2D Tex;
+        layout(binding=0) uniform sampler2D Tex;
+        layout(binding=1) uniform sampler2D FullbrightTex;
+        layout(binding=4) uniform sampler2D EmissiveTex;
 #endif
 
 #include "shadow_common.glsl"
 
 vec3 ApplyFog(vec3 clr, vec3 p)
 {
-	float fog = exp2(-Fog.w * dot(p, p));
-	fog = clamp(fog, 0.0, 1.0);
-	return mix(Fog.rgb, clr, fog);
+        float fog = exp2(-Fog.w * dot(p, p));
+        fog = clamp(fog, 0.0, 1.0);
+        return mix(Fog.rgb, clr, fog);
 }
+
+const uint
+        CF_USE_POLYGON_OFFSET = 1u,
+        CF_USE_FULLBRIGHT = 2u,
+        CF_NOLIGHTMAP = 4u,
+        CF_USE_EMISSIVE = 8u,
+        CF_ALPHA_TEST = 16u
+;
 
 // ALU-only 16x16 Bayer matrix
 float bayer01(ivec2 coord)
@@ -61,11 +71,13 @@ float tri(float x)
 #define SCREEN_SPACE_NOISE() DITHER_NOISE(floor(gl_FragCoord.xy)+0.5)
 #define SUPPRESS_BANDING() bayer(ivec2(gl_FragCoord.xy))
 
-layout(location=0) flat in float in_alpha;
-layout(location=1) in vec2 in_uv;
-layout(location=2) in vec3 in_pos;
+layout(location=0) flat in uint in_flags;
+layout(location=1) flat in float in_alpha;
+layout(location=2) in vec2 in_uv;
+layout(location=3) in vec3 in_pos;
 #if BINDLESS
-	layout(location=3) flat in uvec2 in_sampler;
+        layout(location=4) flat in uvec4 in_samplers0;
+        layout(location=5) flat in uvec2 in_samplers1;
 #endif
 
 #define OUT_COLOR out_fragcolor
@@ -108,14 +120,34 @@ layout(location=2) in vec3 in_pos;
 
 void main()
 {
-	vec2 uv = in_uv * 2.0 + 0.125 * sin(in_uv.yx * (3.14159265 * 2.0) + Time);
+        vec3 fullbright = vec3(0.0);
+        vec3 emissive = vec3(0.0);
+        vec2 uv = in_uv * 2.0 + 0.125 * sin(in_uv.yx * (3.14159265 * 2.0) + Time);
 #if BINDLESS
-	sampler2D Tex = sampler2D(in_sampler);
+        sampler2D Tex = sampler2D(in_samplers0.xy);
+        if ((in_flags & CF_USE_FULLBRIGHT) != 0u)
+        {
+                sampler2D FullbrightTex = sampler2D(in_samplers0.zw);
+                fullbright = texture(FullbrightTex, uv).rgb;
+        }
+        if ((in_flags & CF_USE_EMISSIVE) != 0u)
+        {
+                sampler2D EmissiveSampler = sampler2D(in_samplers1.xy);
+                emissive = texture(EmissiveSampler, uv).rgb;
+        }
+#else
+        if ((in_flags & CF_USE_FULLBRIGHT) != 0u)
+                fullbright = texture(FullbrightTex, uv).rgb;
+        if ((in_flags & CF_USE_EMISSIVE) != 0u)
+                emissive = texture(EmissiveTex, uv).rgb;
 #endif
-	vec4 result = texture(Tex, uv);
-	result.rgb = ApplyFog(result.rgb, in_pos);
-	result.a *= in_alpha;
-	out_fragcolor = result;
+        vec4 result = texture(Tex, uv);
+        result.rgb += fullbright;
+        result.rgb += emissive;
+        result.rgb = clamp(result.rgb, 0.0, 1.0);
+        result.rgb = ApplyFog(result.rgb, in_pos);
+        result.a *= in_alpha;
+        out_fragcolor = result;
 #if DITHER
 	if (Fog.w > 0.)
 	{

--- a/Quake/shaders/water.vert
+++ b/Quake/shaders/water.vert
@@ -22,6 +22,7 @@ struct Call
 #if BINDLESS
 	uvec2	txhandle;
 	uvec2	fbhandle;
+	uvec2	emhandle;
 #else
 	int		baseinstance;
 	int		padding;
@@ -30,7 +31,9 @@ struct Call
 const uint
 	CF_USE_POLYGON_OFFSET = 1u,
 	CF_USE_FULLBRIGHT = 2u,
-	CF_NOLIGHTMAP = 4u
+	CF_NOLIGHTMAP = 4u,
+	CF_USE_EMISSIVE = 8u,
+	CF_ALPHA_TEST = 16u
 ;
 
 layout(std430, binding=1) restrict readonly buffer CallBuffer
@@ -66,23 +69,32 @@ layout(location=2) in float in_lmofs;
 layout(location=3) in ivec4 in_styles;
 
 
-layout(location=0) flat out float out_alpha;layout(location=1) out vec2 out_uv;
-layout(location=2) out vec3 out_pos;
+layout(location=0) flat out uint out_flags;
+layout(location=1) flat out float out_alpha;
+layout(location=2) out vec2 out_uv;
+layout(location=3) out vec3 out_pos;
 #if BINDLESS
-	layout(location=3) flat out uvec2 out_sampler;
+        layout(location=4) flat out uvec4 out_samplers0;
+        layout(location=5) flat out uvec2 out_samplers1;
 #endif
 
 void main()
 {
-	Call call = call_data[DRAW_ID];
-	int instance_id = GET_INSTANCE_ID(call);
-	Instance instance = instance_data[instance_id];
-	vec3 pos = Transform(in_pos, instance);
-	gl_Position = ViewProj * vec4(pos, 1.0);
-	out_uv = in_uv.xy;
-	out_pos = pos - EyePos;
-	out_alpha = instance.alpha < 0.0 ? call.wateralpha : instance.alpha;
+        Call call = call_data[DRAW_ID];
+        int instance_id = GET_INSTANCE_ID(call);
+        Instance instance = instance_data[instance_id];
+        vec3 pos = Transform(in_pos, instance);
+        gl_Position = ViewProj * vec4(pos, 1.0);
+        out_flags = call.flags;
+        out_uv = in_uv.xy;
+        out_pos = pos - EyePos;
+        out_alpha = instance.alpha < 0.0 ? call.wateralpha : instance.alpha;
 #if BINDLESS
-	out_sampler = call.txhandle;
+        out_samplers0.xy = call.txhandle;
+        if ((call.flags & CF_USE_FULLBRIGHT) != 0u)
+                out_samplers0.zw = call.fbhandle;
+        else
+                out_samplers0.zw = out_samplers0.xy;
+        out_samplers1.xy = call.emhandle;
 #endif
 }

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -3,6 +3,7 @@
 #else
 	layout(binding=0) uniform sampler2D Tex;
 	layout(binding=1) uniform sampler2D FullbrightTex;
+        layout(binding=4) uniform sampler2D EmissiveTex;
 #endif
 layout(binding=2) uniform sampler2D LMTex;
 layout(binding=3) uniform sampler2DArray ShadowMap;
@@ -65,6 +66,7 @@ struct Call
 #if BINDLESS
 	uvec2	txhandle;
 	uvec2	fbhandle;
+	uvec2	emhandle;
 #else
 	int		baseinstance;
 	int		padding;
@@ -74,7 +76,8 @@ const uint
 	CF_USE_POLYGON_OFFSET = 1u,
 	CF_USE_FULLBRIGHT = 2u,
 	CF_NOLIGHTMAP = 4u,
-	CF_ALPHA_TEST = 8u
+	CF_USE_EMISSIVE = 8u,
+	CF_ALPHA_TEST = 16u
 ;
 
 layout(std430, binding=1) restrict readonly buffer CallBuffer
@@ -118,7 +121,8 @@ layout(location=6) noperspective in vec2 in_coord;
 layout(location=7) flat in vec4 in_styles;
 layout(location=8) flat in float in_lmofs;
 #if BINDLESS
-        layout(location=9) flat in uvec4 in_samplers;
+        layout(location=9) flat in uvec4 in_samplers0;
+        layout(location=10) flat in uvec2 in_samplers1;
 #endif
 
 // ALU-only 16x16 Bayer matrix
@@ -410,21 +414,28 @@ void main()
 	return;
 #endif
 	vec3 fullbright = vec3(0.);
+        vec3 emissive = vec3(0.);
 	vec2 uv = in_uv;
 #if MODE == 2
 	uv = uv * 2.0 + 0.125 * sin(uv.yx * (3.14159265 * 2.0) + Time);
 #endif
 #if BINDLESS
-	sampler2D Tex = sampler2D(in_samplers.xy);
-	sampler2D FullbrightTex;
-	if ((in_flags & CF_USE_FULLBRIGHT) != 0u)
-	{
-		FullbrightTex = sampler2D(in_samplers.zw);
-		fullbright = texture(FullbrightTex, uv).rgb;
-	}
+        sampler2D Tex = sampler2D(in_samplers0.xy);
+        if ((in_flags & CF_USE_FULLBRIGHT) != 0u)
+        {
+                sampler2D FullbrightTex = sampler2D(in_samplers0.zw);
+                fullbright = texture(FullbrightTex, uv).rgb;
+        }
+        if ((in_flags & CF_USE_EMISSIVE) != 0u)
+        {
+                sampler2D EmissiveSampler = sampler2D(in_samplers1.xy);
+                emissive = texture(EmissiveSampler, uv).rgb;
+        }
 #else
-	if ((in_flags & CF_USE_FULLBRIGHT) != 0u)
-		fullbright = texture(FullbrightTex, uv).rgb;
+        if ((in_flags & CF_USE_FULLBRIGHT) != 0u)
+                fullbright = texture(FullbrightTex, uv).rgb;
+        if ((in_flags & CF_USE_EMISSIVE) != 0u)
+                emissive = texture(EmissiveTex, uv).rgb;
 #endif
 #if DITHER >= 2
 	vec4 result = texture(Tex, uv, -1.0);
@@ -531,7 +542,8 @@ void main()
 #else
         result.rgb *= total_lightmap;
 #endif
-	result.rgb += fullbright;
+        result.rgb += fullbright;
+        result.rgb += emissive;
 	result = clamp(result, 0.0, 1.0);
         result.rgb = ApplyFog(result.rgb, in_pos - EyePos);
 

--- a/Quake/shaders/world.vert
+++ b/Quake/shaders/world.vert
@@ -51,6 +51,7 @@ struct Call
 #if BINDLESS
 	uvec2	txhandle;
 	uvec2	fbhandle;
+	uvec2	emhandle;
 #else
 	int		baseinstance;
 	int		padding;
@@ -59,7 +60,9 @@ struct Call
 const uint
 	CF_USE_POLYGON_OFFSET = 1u,
 	CF_USE_FULLBRIGHT = 2u,
-	CF_NOLIGHTMAP = 4u
+	CF_NOLIGHTMAP = 4u,
+	CF_USE_EMISSIVE = 8u,
+	CF_ALPHA_TEST = 16u
 ;
 
 layout(std430, binding=1) restrict readonly buffer CallBuffer
@@ -109,7 +112,8 @@ layout(location=6) noperspective out vec2 out_coord;
 layout(location=7) flat out vec4 out_styles;
 layout(location=8) flat out float out_lmofs;
 #if BINDLESS
-	layout(location=9) flat out uvec4 out_samplers;
+	layout(location=9) flat out uvec4 out_samplers0;
+        layout(location=10) flat out uvec2 out_samplers1;
 #endif
 
 void main()
@@ -152,10 +156,11 @@ void main()
 		out_styles.xy = vec2(1., -1.);
 	out_lmofs = in_lmofs;
 #if BINDLESS
-	out_samplers.xy = call.txhandle;
+	out_samplers0.xy = call.txhandle;
 	if ((call.flags & CF_USE_FULLBRIGHT) != 0u)
-		out_samplers.zw = call.fbhandle;
+		out_samplers0.zw = call.fbhandle;
 	else
-		out_samplers.zw = out_samplers.xy;
+		out_samplers0.zw = out_samplers0.xy;
+	out_samplers1.xy = call.emhandle;
 #endif
 }


### PR DESCRIPTION
## Summary
- load optional `_emissive` maps for BSP and alias assets and track them on texture structures
- propagate emissive handles and flags through brushmodel and alias draw calls in both bindless and bound paths
- sample emissive maps in world, water, and alias shaders while aligning alpha-test bit assignments across passes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ec112a8db4832e9c1748f8a1d6cf04