### PR TITLE
Add configurable depth of field post-processing effect

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -105,6 +105,10 @@ cvar_t	r_simd = {"r_simd","1",CVAR_ARCHIVE};
 cvar_t	r_alphasort = {"r_alphasort","1",CVAR_ARCHIVE};
 cvar_t	r_oit = {"r_oit","1",CVAR_ARCHIVE};
 cvar_t	r_dither = {"r_dither", "1.0", CVAR_ARCHIVE};
+cvar_t	r_dof = {"r_dof", "0", CVAR_ARCHIVE};
+cvar_t	r_dof_focus = {"r_dof_focus", "64", CVAR_ARCHIVE};
+cvar_t	r_dof_range = {"r_dof_range", "48", CVAR_ARCHIVE};
+cvar_t	r_dof_strength = {"r_dof_strength", "6", CVAR_ARCHIVE};
 
 cvar_t	r_overbrightbits = {"r_overbrightbits", "1", CVAR_ARCHIVE};
 
@@ -203,6 +207,13 @@ static float shadow_pending_intensity;
 static qboolean shadow_has_intensity;
 static float shadow_view_znear;
 static float shadow_view_zfar;
+static float view_znear;
+static float view_zfar;
+
+static qboolean R_DoFEnabled (void)
+{
+	return r_dof.value > 0.f && r_dof_strength.value > 0.f;
+}
 
 static void ExtractFrustumPlane (float mvp[16], int axis, float ndcval, qboolean flip, mplane_t *out);
 
@@ -1261,6 +1272,9 @@ void GL_PostProcess (void)
 {
 	int palidx, variant;
 	float dither;
+	qboolean dof_enabled;
+	float dof_focus, dof_range, dof_strength;
+	float dof_znear, dof_zfar;
 	if (!GL_NeedsPostprocess ())
 		return;
 
@@ -1281,10 +1295,31 @@ void GL_PostProcess (void)
 	if (variant != 2) // some AMD drivers optimize out the uniform in variant #2
 		GL_Uniform4fFunc (0, vid_gamma.value, q_min(2.0f, q_max(1.0f, vid_contrast.value)), 1.f/r_refdef.scale, dither);
 
+	dof_enabled = R_DoFEnabled ();
+	if (dof_enabled)
+	{
+		dof_focus = q_max (0.f, r_dof_focus.value);
+		dof_range = q_max (0.f, r_dof_range.value);
+		dof_strength = q_max (0.f, r_dof_strength.value);
+		dof_znear = (view_znear > 0.f) ? view_znear : 0.5f;
+		dof_zfar = (view_zfar > dof_znear) ? view_zfar : dof_znear + 1.f;
+		GL_Uniform4fFunc (1, 1.f, dof_focus, dof_range, dof_strength);
+		GL_Uniform4fFunc (2, dof_znear, dof_zfar, gl_clipcontrol_able ? 1.f : 0.f, 0.f);
+		GL_BindNative (GL_TEXTURE2, GL_TEXTURE_2D, framebufs.composite.depth_stencil_tex);
+	}
+	else
+	{
+		dof_znear = (view_znear > 0.f) ? view_znear : 0.5f;
+		dof_zfar = (view_zfar > dof_znear) ? view_zfar : dof_znear + 1.f;
+		GL_Uniform4fFunc (1, 0.f, 0.f, 0.f, 0.f);
+		GL_Uniform4fFunc (2, dof_znear, dof_zfar, gl_clipcontrol_able ? 1.f : 0.f, 0.f);
+	}
+
 	glDrawArrays (GL_TRIANGLES, 0, 3);
 
 	GL_EndGroup ();
 }
+
 
 /*
 =================
@@ -1770,6 +1805,8 @@ void R_SetFrustum (void)
 
         shadow_view_znear = znear;
         shadow_view_zfar = zfar;
+        view_znear = znear;
+        view_zfar = zfar;
 
         GL_FrustumMatrix(r_matproj, DEG2RAD(r_fovx), DEG2RAD(r_fovy), znear, zfar);
 
@@ -1816,7 +1853,7 @@ GL_NeedsPostprocess
 */
 qboolean GL_NeedsPostprocess (void)
 {
-	return vid_gamma.value != 1.f || vid_contrast.value != 1.f || softemu || R_GetEffectiveAlphaMode () == ALPHAMODE_OIT;
+	return vid_gamma.value != 1.f || vid_contrast.value != 1.f || softemu || R_GetEffectiveAlphaMode () == ALPHAMODE_OIT || R_DoFEnabled ();
 }
 
 /*
@@ -2906,34 +2943,48 @@ void R_WarpScaleView (void)
 	needwarpscale = r_refdef.scale != 1 || water_warp || (v_blend[3] && gl_polyblend.value && !softemu);
 	fbodest = GL_NeedsPostprocess () ? framebufs.composite.fbo : 0;
 
-        if (msaa)
-        {
-                GL_BeginGroup ("MSAA resolve");
+	if (msaa)
+	{
+		GL_BeginGroup ("MSAA resolve");
 
-                GL_BindFramebufferFunc (GL_READ_FRAMEBUFFER, framebufs.scene.fbo);
-                glReadBuffer (GL_COLOR_ATTACHMENT0);
-                if (needwarpscale)
-                {
-                        GL_BindFramebufferFunc (GL_DRAW_FRAMEBUFFER, framebufs.resolved_scene.fbo);
-                        glDrawBuffer (GL_COLOR_ATTACHMENT0);
-                        GL_BlitFramebufferFunc (0, 0, srcw, srch, 0, 0, srcw, srch, GL_COLOR_BUFFER_BIT, GL_NEAREST);
-                }
-                else
-                {
-                        GL_BindFramebufferFunc (GL_DRAW_FRAMEBUFFER, fbodest);
-                        if (fbodest)
-                                glDrawBuffer (GL_COLOR_ATTACHMENT0);
-                        else
-                                glDrawBuffer (GL_BACK);
-                        GL_BlitFramebufferFunc (0, 0, srcw, srch, srcx, srcy, srcx + srcw, srcy + srch, GL_COLOR_BUFFER_BIT, GL_NEAREST);
-                }
+		GL_BindFramebufferFunc (GL_READ_FRAMEBUFFER, framebufs.scene.fbo);
+		glReadBuffer (GL_COLOR_ATTACHMENT0);
+		if (needwarpscale)
+		{
+			GL_BindFramebufferFunc (GL_DRAW_FRAMEBUFFER, framebufs.resolved_scene.fbo);
+			glDrawBuffer (GL_COLOR_ATTACHMENT0);
+			GL_BlitFramebufferFunc (0, 0, srcw, srch, 0, 0, srcw, srch, GL_COLOR_BUFFER_BIT, GL_NEAREST);
+		}
+		else
+		{
+			GL_BindFramebufferFunc (GL_DRAW_FRAMEBUFFER, fbodest);
+			if (fbodest)
+				glDrawBuffer (GL_COLOR_ATTACHMENT0);
+			else
+				glDrawBuffer (GL_BACK);
+			{
+				GLbitfield mask = GL_COLOR_BUFFER_BIT;
+				if (fbodest == framebufs.composite.fbo && R_DoFEnabled ())
+					mask |= GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT;
+				GL_BlitFramebufferFunc (0, 0, srcw, srch, srcx, srcy, srcx + srcw, srcy + srch, mask, GL_NEAREST);
+			}
+		}
 
-                GL_EndGroup ();
-        }
+		GL_EndGroup ();
+	}
 
-        GL_BindFramebufferFunc (GL_FRAMEBUFFER, fbodest);
-        if (fbodest)
-        {
+	if (fbodest == framebufs.composite.fbo && R_DoFEnabled () && (!msaa || needwarpscale))
+	{
+		GL_BindFramebufferFunc (GL_READ_FRAMEBUFFER, framebufs.scene.fbo);
+		glReadBuffer (GL_COLOR_ATTACHMENT0);
+		GL_BindFramebufferFunc (GL_DRAW_FRAMEBUFFER, framebufs.composite.fbo);
+		glDrawBuffer (GL_COLOR_ATTACHMENT0);
+		GL_BlitFramebufferFunc (0, 0, srcw, srch, srcx, srcy, srcx + srcw, srcy + srch, GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT, GL_NEAREST);
+	}
+
+	GL_BindFramebufferFunc (GL_FRAMEBUFFER, fbodest);
+	if (fbodest)
+	{
                 glDrawBuffer (GL_COLOR_ATTACHMENT0);
                 glReadBuffer (GL_COLOR_ATTACHMENT0);
         }

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -53,6 +53,10 @@ extern cvar_t gl_zfix; // QuakeSpasm z-fighting fix
 extern cvar_t r_alphasort;
 extern cvar_t r_oit;
 extern cvar_t r_dither;
+extern cvar_t r_dof;
+extern cvar_t r_dof_focus;
+extern cvar_t r_dof_range;
+extern cvar_t r_dof_strength;
 
 #if defined(USE_SIMD)
 extern cvar_t r_simd;
@@ -359,6 +363,10 @@ void R_Init (void)
 	Cvar_RegisterVariable (&r_alphasort);
 	Cvar_RegisterVariable (&r_oit);
 	Cvar_RegisterVariable (&r_dither);
+	Cvar_RegisterVariable (&r_dof);
+	Cvar_RegisterVariable (&r_dof_focus);
+	Cvar_RegisterVariable (&r_dof_range);
+	Cvar_RegisterVariable (&r_dof_strength);
 	Cvar_RegisterVariable (&r_overbrightbits);
 	Cvar_SetCallback (&r_overbrightbits, R_OverbrightBits_f);
 

--- a/Quake/shaders/postprocess.frag
+++ b/Quake/shaders/postprocess.frag
@@ -1,5 +1,6 @@
 layout(binding=0) uniform sampler2D GammaTexture;
 layout(binding=1) uniform usampler3D PaletteLUT;
+layout(binding=2) uniform sampler2D DepthTexture;
 
 layout(std430, binding=0) restrict readonly buffer PaletteBuffer
 {
@@ -60,6 +61,8 @@ float tri(float x)
 #define SUPPRESS_BANDING() bayer(ivec2(gl_FragCoord.xy))
 
 layout(location=0) uniform vec4 Params;
+layout(location=1) uniform vec4 DoFParams0; // x: enabled, y: focus distance, z: focus range, w: max blur radius (pixels)
+layout(location=2) uniform vec4 DoFParams1; // x: near plane, y: far plane, z: reversed-Z flag (>0.5 when reversed)
 
 layout(location=0) out vec4 out_fragcolor;
 
@@ -69,10 +72,68 @@ void main()
 	float contrast = Params.y;
 	float scale = Params.z;
 	float dither = Params.w;
-	out_fragcolor = texelFetch(GammaTexture, ivec2(gl_FragCoord), 0);
+		ivec2 pixel = ivec2(gl_FragCoord.xy);
+		vec4 color = texelFetch(GammaTexture, pixel, 0);
+		if (DoFParams0.x > 0.5)
+		{
+				vec2 texSize = vec2(textureSize(GammaTexture, 0));
+				vec2 uv = (vec2(pixel) + 0.5) / texSize;
+				float rawDepth = texture(DepthTexture, uv).r;
+				float nearPlane = DoFParams1.x;
+				float farPlane = DoFParams1.y;
+				float reversed = DoFParams1.z;
+				float linearDepth;
+				if (reversed > 0.5)
+				{
+						float denom = nearPlane + rawDepth * (farPlane - nearPlane);
+						linearDepth = (nearPlane * farPlane) / max(denom, 1e-6);
+				}
+				else
+				{
+						float ndcDepth = rawDepth * 2.0 - 1.0;
+						float denom = farPlane + nearPlane - ndcDepth * (farPlane - nearPlane);
+						linearDepth = (2.0 * nearPlane * farPlane) / max(denom, 1e-6);
+				}
+				float focusDistance = DoFParams0.y;
+				float focusRange = max(DoFParams0.z, 0.0001);
+				float maxBlur = max(DoFParams0.w, 0.0);
+				float coc = abs(linearDepth - focusDistance);
+				float blurFactor = clamp((coc - focusRange) / focusRange, 0.0, 1.0);
+				float blurRadius = blurFactor * maxBlur;
+				if (blurRadius > 0.0001)
+				{
+						vec2 invRes = 1.0 / texSize;
+						const vec2 kernel[8] = vec2[](
+								vec2(1.0, 0.0),
+								vec2(-1.0, 0.0),
+								vec2(0.0, 1.0),
+								vec2(0.0, -1.0),
+								vec2(0.70710678, 0.70710678),
+								vec2(-0.70710678, 0.70710678),
+								vec2(0.70710678, -0.70710678),
+								vec2(-0.70710678, -0.70710678)
+						);
+						float noise = SCREEN_SPACE_NOISE();
+						float angle = noise * 6.28318530718;
+						float sine = sin(angle);
+						float cosine = cos(angle);
+						mat2 rotation = mat2(cosine, -sine, sine, cosine);
+						vec3 accum = color.rgb;
+						float weight = 1.0;
+						for (int i = 0; i < 8; ++i)
+						{
+								vec2 offset = rotation * kernel[i] * blurRadius * invRes;
+								vec3 sampleColor = texture(GammaTexture, uv + offset).rgb;
+								accum += sampleColor;
+								weight += 1.0;
+						}
+						color.rgb = accum / weight;
+				}
+		}
+		out_fragcolor = color;
 #if PALETTIZE == 1
-	vec2 noiseuv = floor(gl_FragCoord.xy * scale) + 0.5;
-	out_fragcolor.rgb = sqrt(out_fragcolor.rgb);
+		vec2 noiseuv = floor(gl_FragCoord.xy * scale) + 0.5;
+		out_fragcolor.rgb = sqrt(out_fragcolor.rgb);
 	out_fragcolor.rgb += DITHER_NOISE(noiseuv) * dither;
 	out_fragcolor.rgb *= out_fragcolor.rgb;
 #endif // PALETTIZE == 1


### PR DESCRIPTION
## Summary
- add depth of field console controls and tie them into the OpenGL post-process pipeline
- sample the scene depth in the postprocess shader to apply a focus-driven blur with jittered taps
- copy depth data into the composited framebuffer when resolving so the depth of field pass has valid input

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ec1c41bbbc832eb319f290bdcc65d9