### PR TITLE
Fix DoF depth sampling for scaled views

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -1296,8 +1296,24 @@ void GL_PostProcess (void)
 		GL_Uniform4fFunc (0, vid_gamma.value, q_min(2.0f, q_max(1.0f, vid_contrast.value)), 1.f/r_refdef.scale, dither);
 
 	dof_enabled = R_DoFEnabled ();
-	if (dof_enabled)
+
 	{
+		float view_min_x = (glx + r_refdef.vrect.x) / (float)vid.width;
+		float view_min_y = (gly + glheight - r_refdef.vrect.y - r_refdef.vrect.height) / (float)vid.height;
+		float view_size_x = r_refdef.vrect.width / (float)vid.width;
+		float view_size_y = r_refdef.vrect.height / (float)vid.height;
+		float inv_scale = r_refdef.scale > 0 ? 1.f / (float)r_refdef.scale : 1.f;
+
+		GL_Uniform4fFunc (3,
+			view_min_x,
+			view_min_y,
+			view_min_x + view_size_x,
+			view_min_y + view_size_y);
+		GL_Uniform4fFunc (4, inv_scale, inv_scale, 0.f, 0.f);
+        }
+
+        if (dof_enabled)
+        {
 		dof_focus = q_max (0.f, r_dof_focus.value);
 		dof_range = q_max (0.f, r_dof_range.value);
 		dof_strength = q_max (0.f, r_dof_strength.value);
@@ -2966,7 +2982,7 @@ void R_WarpScaleView (void)
 				GLbitfield mask = GL_COLOR_BUFFER_BIT;
 				if (fbodest == framebufs.composite.fbo && R_DoFEnabled ())
 					mask |= GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT;
-				GL_BlitFramebufferFunc (0, 0, srcw, srch, srcx, srcy, srcx + srcw, srcy + srch, mask, GL_NEAREST);
+					GL_BlitFramebufferFunc (0, 0, srcw, srch, srcx, srcy, srcx + srcw, srcy + srch, mask, GL_NEAREST);
 			}
 		}
 
@@ -2979,7 +2995,7 @@ void R_WarpScaleView (void)
 		glReadBuffer (GL_COLOR_ATTACHMENT0);
 		GL_BindFramebufferFunc (GL_DRAW_FRAMEBUFFER, framebufs.composite.fbo);
 		glDrawBuffer (GL_COLOR_ATTACHMENT0);
-		GL_BlitFramebufferFunc (0, 0, srcw, srch, srcx, srcy, srcx + r_refdef.vrect.width, srcy + r_refdef.vrect.height, GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT, GL_NEAREST);
+		GL_BlitFramebufferFunc (0, 0, srcw, srch, srcx, srcy, srcx + srcw, srcy + srch, GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT, GL_NEAREST);
 	}
 
 	GL_BindFramebufferFunc (GL_FRAMEBUFFER, fbodest);

--- a/Quake/shaders/postprocess.frag
+++ b/Quake/shaders/postprocess.frag
@@ -63,74 +63,92 @@ float tri(float x)
 layout(location=0) uniform vec4 Params;
 layout(location=1) uniform vec4 DoFParams0; // x: enabled, y: focus distance, z: focus range, w: max blur radius (pixels)
 layout(location=2) uniform vec4 DoFParams1; // x: near plane, y: far plane, z: reversed-Z flag (>0.5 when reversed)
+layout(location=3) uniform vec4 ViewRect;   // xy: view min (normalized), zw: view max (normalized)
+layout(location=4) uniform vec4 DepthParams; // xy: inverse view scale, zw: unused
 
 layout(location=0) out vec4 out_fragcolor;
 
 void main()
 {
-	float gamma = Params.x;
-	float contrast = Params.y;
-	float scale = Params.z;
-	float dither = Params.w;
-		ivec2 pixel = ivec2(gl_FragCoord.xy);
-		vec4 color = texelFetch(GammaTexture, pixel, 0);
-		if (DoFParams0.x > 0.5)
-		{
-				vec2 texSize = vec2(textureSize(GammaTexture, 0));
-				vec2 uv = (vec2(pixel) + 0.5) / texSize;
-				float rawDepth = texture(DepthTexture, uv).r;
-				float nearPlane = DoFParams1.x;
-				float farPlane = DoFParams1.y;
-				float reversed = DoFParams1.z;
-				float linearDepth;
-				if (reversed > 0.5)
-				{
-						float denom = nearPlane + rawDepth * (farPlane - nearPlane);
-						linearDepth = (nearPlane * farPlane) / max(denom, 1e-6);
-				}
-				else
-				{
-						float ndcDepth = rawDepth * 2.0 - 1.0;
-						float denom = farPlane + nearPlane - ndcDepth * (farPlane - nearPlane);
-						linearDepth = (2.0 * nearPlane * farPlane) / max(denom, 1e-6);
-				}
-				float focusDistance = DoFParams0.y;
-				float focusRange = max(DoFParams0.z, 0.0001);
-				float maxBlur = max(DoFParams0.w, 0.0);
-				float coc = abs(linearDepth - focusDistance);
-				float blurFactor = clamp((coc - focusRange) / focusRange, 0.0, 1.0);
-				float blurRadius = blurFactor * maxBlur;
-				if (blurRadius > 0.0001)
-				{
-						vec2 invRes = 1.0 / texSize;
-						const vec2 kernel[8] = vec2[](
-								vec2(1.0, 0.0),
-								vec2(-1.0, 0.0),
-								vec2(0.0, 1.0),
-								vec2(0.0, -1.0),
-								vec2(0.70710678, 0.70710678),
-								vec2(-0.70710678, 0.70710678),
-								vec2(0.70710678, -0.70710678),
-								vec2(-0.70710678, -0.70710678)
-						);
-						float noise = SCREEN_SPACE_NOISE();
-						float angle = noise * 6.28318530718;
-						float sine = sin(angle);
-						float cosine = cos(angle);
-						mat2 rotation = mat2(cosine, -sine, sine, cosine);
-						vec3 accum = color.rgb;
-						float weight = 1.0;
-						for (int i = 0; i < 8; ++i)
-						{
-								vec2 offset = rotation * kernel[i] * blurRadius * invRes;
-								vec3 sampleColor = texture(GammaTexture, uv + offset).rgb;
-								accum += sampleColor;
-								weight += 1.0;
-						}
-						color.rgb = accum / weight;
-				}
-		}
-		out_fragcolor = color;
+        float gamma = Params.x;
+        float contrast = Params.y;
+        float scale = Params.z;
+        float dither = Params.w;
+        ivec2 pixel = ivec2(gl_FragCoord.xy);
+        vec4 color = texelFetch(GammaTexture, pixel, 0);
+        vec2 texSize = vec2(textureSize(GammaTexture, 0));
+        vec2 uv = (vec2(pixel) + 0.5) / texSize;
+        vec2 viewMin = ViewRect.xy;
+        vec2 viewMax = ViewRect.zw;
+        bool inView = all(greaterThanEqual(uv, viewMin)) && all(lessThanEqual(uv, viewMax));
+        if (DoFParams0.x > 0.5 && inView)
+        {
+                vec2 depthTexSize = vec2(textureSize(DepthTexture, 0));
+                vec2 viewMinPx = viewMin * depthTexSize;
+                vec2 viewMaxPx = viewMax * depthTexSize;
+                vec2 viewSizePx = max(viewMaxPx - viewMinPx, vec2(0.0));
+                vec2 invViewScale = max(DepthParams.xy, vec2(1e-4));
+                vec2 depthSizePx = max(vec2(1.0), floor(viewSizePx * invViewScale + vec2(0.0001)));
+                vec2 fragPx = gl_FragCoord.xy;
+                vec2 relPx = clamp(fragPx - viewMinPx, vec2(0.0), max(viewSizePx - vec2(1e-4), vec2(0.0)));
+                vec2 depthIdx = floor(relPx * invViewScale);
+                vec2 maxDepthIdx = max(depthSizePx - vec2(1.0), vec2(0.0));
+                depthIdx = clamp(depthIdx, vec2(0.0), maxDepthIdx);
+                vec2 depthPx = viewMinPx + depthIdx + vec2(0.5);
+                vec2 depthUV = depthPx / depthTexSize;
+                float rawDepth = texture(DepthTexture, depthUV).r;
+                float nearPlane = DoFParams1.x;
+                float farPlane = DoFParams1.y;
+                float reversed = DoFParams1.z;
+                float linearDepth;
+                if (reversed > 0.5)
+                {
+                        float denom = nearPlane + rawDepth * (farPlane - nearPlane);
+                        linearDepth = (nearPlane * farPlane) / max(denom, 1e-6);
+                }
+                else
+                {
+                        float ndcDepth = rawDepth * 2.0 - 1.0;
+                        float denom = farPlane + nearPlane - ndcDepth * (farPlane - nearPlane);
+                        linearDepth = (2.0 * nearPlane * farPlane) / max(denom, 1e-6);
+                }
+                float focusDistance = DoFParams0.y;
+                float focusRange = max(DoFParams0.z, 0.0001);
+                float maxBlur = max(DoFParams0.w, 0.0);
+                float coc = abs(linearDepth - focusDistance);
+                float blurFactor = clamp((coc - focusRange) / focusRange, 0.0, 1.0);
+                float blurRadius = blurFactor * maxBlur;
+                if (blurRadius > 0.0001)
+                {
+                        vec2 invRes = 1.0 / texSize;
+                        const vec2 kernel[8] = vec2[](
+                                vec2(1.0, 0.0),
+                                vec2(-1.0, 0.0),
+                                vec2(0.0, 1.0),
+                                vec2(0.0, -1.0),
+                                vec2(0.70710678, 0.70710678),
+                                vec2(-0.70710678, 0.70710678),
+                                vec2(0.70710678, -0.70710678),
+                                vec2(-0.70710678, -0.70710678)
+                        );
+                        float noise = SCREEN_SPACE_NOISE();
+                        float angle = noise * 6.28318530718;
+                        float sine = sin(angle);
+                        float cosine = cos(angle);
+                        mat2 rotation = mat2(cosine, -sine, sine, cosine);
+                        vec3 accum = color.rgb;
+                        float weight = 1.0;
+                        for (int i = 0; i < 8; ++i)
+                        {
+                                vec2 offset = rotation * kernel[i] * blurRadius * invRes;
+                                vec3 sampleColor = texture(GammaTexture, uv + offset).rgb;
+                                accum += sampleColor;
+                                weight += 1.0;
+                        }
+                        color.rgb = accum / weight;
+                }
+        }
+        out_fragcolor = color;
 #if PALETTIZE == 1
 		vec2 noiseuv = floor(gl_FragCoord.xy * scale) + 0.5;
 		out_fragcolor.rgb = sqrt(out_fragcolor.rgb);


### PR DESCRIPTION
## Summary
- manually remap the depth texture lookups in the DOF pass so scaled 3D views read the correct pixels without relying on invalid depth blits

## Testing
- not run (Linux build directory is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68ec28b2f198832e9d9c59bf0f93cad5