### PR TITLE
Render UI after postprocessing pass

### DIFF
--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -618,8 +618,9 @@ void R_TimeRefresh_f (void)
 	{
 		GL_BeginRendering(&glx, &gly, &glwidth, &glheight);
 		r_refdef.viewangles[1] = i*(360.0/128.0);
-		R_RenderView ();
-		GL_EndRendering ();
+               R_RenderView ();
+               GL_PostProcess ();
+               GL_EndRendering ();
 	}
 
 	glFinish ();

--- a/Quake/gl_screen.c
+++ b/Quake/gl_screen.c
@@ -2109,9 +2109,11 @@ void SCR_UpdateScreen (void)
 
 	V_UpdateBlend (); //johnfitz -- V_UpdatePalette cleaned up and renamed
 
-	V_RenderView ();
+       V_RenderView ();
 
-	GL_BeginGroup ("2D");
+       GL_PostProcess ();
+
+       GL_BeginGroup ("2D");
 
 	GL_Set2D ();
 

--- a/Quake/gl_vidsdl.c
+++ b/Quake/gl_vidsdl.c
@@ -1378,8 +1378,7 @@ GL_EndRendering
 */
 void GL_EndRendering (void)
 {
-	GL_PostProcess ();
-	GL_ReleaseFrameResources ();
+       GL_ReleaseFrameResources ();
 
 	if (!scr_skipupdate)
 	{


### PR DESCRIPTION
## Summary
- move the postprocessing pass to run immediately after the 3D scene is rendered
- keep GL_EndRendering focused on resource release and update the time refresh helper to call the postprocess step explicitly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ec3160464c832e8818bfba93d96100