### PR TITLE
Fix missing renderer symbols for SDL build

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -23,6 +23,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "quakedef.h"
 
+#define NOISESCALE     (1.0f / 127.0f)
+
 qboolean	r_cache_thrash;		// compatability
 
 gpuframedata_t r_framedata;
@@ -32,6 +34,9 @@ vec3_t		*r_pointfile;
 
 int			r_visframecount;	// bumped when going to a new PVS
 int			r_framecount;		// used for dlight push checking
+
+static entity_t *cl_sorted_visedicts[MAX_VISEDICTS + 1];
+static int cl_modtype_ofs[mod_numtypes * 2 + 1];
 
 mplane_t	frustum[4];
 float		r_matview[16];

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -1055,3 +1055,15 @@ void GL_ReserveDeviceMemory (GLenum target, size_t numbytes, GLuint *outbuf, siz
 
 	frameres_device_offset += numbytes;
 }
+
+void R_InitShadow (void)
+{
+}
+
+void R_ShutdownShadow (void)
+{
+}
+
+void R_ResizeShadowMapIfNeeded (void)
+{
+}

--- a/Quake/gl_texmgr.h
+++ b/Quake/gl_texmgr.h
@@ -84,6 +84,9 @@ extern gltexture_t *whitetexture;
 extern gltexture_t *greytexture;
 extern gltexture_t *blacktexture;
 
+extern GLuint gl_palette_lut;
+extern GLuint gl_palette_buffer[2];
+
 extern unsigned int d_8to24table[256];
 extern unsigned int d_8to24table_fbright[256];
 extern unsigned int d_8to24table_nobright[256];

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -457,6 +457,9 @@ void R_TranslatePlayerSkin (int playernum);
 void R_TranslateNewPlayerSkin (int playernum); //johnfitz -- this handles cases when the actual texture changes
 
 void R_UploadFrameData (void);
+void R_InitShadow (void);
+void R_ShutdownShadow (void);
+void R_ResizeShadowMapIfNeeded (void);
 
 void R_DrawBrushModels (entity_t **ents, int count);
 void R_DrawBrushModels_Water (entity_t **ents, int count, qboolean translucent);


### PR DESCRIPTION
## Summary
- define the NOISESCALE constant and persistent sorted entity arrays in `gl_rmain`
- expose palette lookup resources and shadow function prototypes used across the renderer
- add no-op shadow lifecycle helpers so the SDL build links cleanly

## Testing
- `make -C Quake` *(fails: SDL development headers are not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ec3c8810b8832e8300c54d68913c7b