### PR TITLE
Add HDR tonemapping and bloom post-process

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -95,6 +95,11 @@ cvar_t	r_dof_focus = {"r_dof_focus", "64", CVAR_ARCHIVE};
 cvar_t	r_dof_range = {"r_dof_range", "48", CVAR_ARCHIVE};
 cvar_t	r_dof_strength = {"r_dof_strength", "6", CVAR_ARCHIVE};
 
+cvar_t	r_tonemap = {"r_tonemap", "1", CVAR_ARCHIVE};
+cvar_t	r_tonemap_exposure = {"r_tonemap_exposure", "1.0", CVAR_ARCHIVE};
+cvar_t	r_bloom = {"r_bloom", "0.04", CVAR_ARCHIVE};
+cvar_t	r_bloom_threshold = {"r_bloom_threshold", "1.0", CVAR_ARCHIVE};
+
 cvar_t	r_overbrightbits = {"r_overbrightbits", "1", CVAR_ARCHIVE};
 
 cvar_t	gl_finish = {"gl_finish","0",CVAR_NONE};
@@ -196,6 +201,24 @@ static GLuint GL_CreateFBOAttachment (GLenum format, int samples, GLenum filter,
 GL_CreateFBO
 =============
 */
+
+static GLuint GL_CreateTexture2D (GLenum format, int width, int height, GLenum filter, const char *name)
+{
+	GLuint texnum;
+
+	glGenTextures (1, &texnum);
+	GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, texnum);
+	GL_ObjectLabelFunc (GL_TEXTURE, texnum, -1, name);
+	GL_TexStorage2DFunc (GL_TEXTURE_2D, 1, format, width, height);
+	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, filter);
+	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, filter);
+	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0);
+
+	return texnum;
+}
+
 static GLuint GL_CreateFBO (GLenum target, const GLuint *colors, int numcolors, GLuint depth, GLuint stencil, const char *name)
 {
 	GLenum status;
@@ -246,7 +269,7 @@ GL_CreateFrameBuffers
 */
 void GL_CreateFrameBuffers (void)
 {
-	GLenum color_format = GL_RGB10_A2;
+	GLenum color_format = GL_RGBA16F;
 	GLenum depth_format = GL_DEPTH24_STENCIL8;
 
 	/* query MSAA limits */
@@ -263,6 +286,15 @@ void GL_CreateFrameBuffers (void)
 		framebufs.composite.depth_stencil_tex,
 		"composite fbo"
 	);
+
+	framebufs.bloom.width = q_max (1, vid.width / 2);
+	framebufs.bloom.height = q_max (1, vid.height / 2);
+	framebufs.bloom.extract_tex = GL_CreateTexture2D (GL_RGBA16F, framebufs.bloom.width, framebufs.bloom.height, GL_LINEAR, "bloom extract");
+	framebufs.bloom.pingpong_tex[0] = GL_CreateTexture2D (GL_RGBA16F, framebufs.bloom.width, framebufs.bloom.height, GL_LINEAR, "bloom blur 0");
+	framebufs.bloom.pingpong_tex[1] = GL_CreateTexture2D (GL_RGBA16F, framebufs.bloom.width, framebufs.bloom.height, GL_LINEAR, "bloom blur 1");
+	framebufs.bloom.extract_fbo = GL_CreateSimpleFBO (GL_TEXTURE_2D, framebufs.bloom.extract_tex, 0, 0, "bloom extract fbo");
+	framebufs.bloom.pingpong_fbo[0] = GL_CreateSimpleFBO (GL_TEXTURE_2D, framebufs.bloom.pingpong_tex[0], 0, 0, "bloom blur fbo 0");
+	framebufs.bloom.pingpong_fbo[1] = GL_CreateSimpleFBO (GL_TEXTURE_2D, framebufs.bloom.pingpong_tex[1], 0, 0, "bloom blur fbo 1");
 
 	/* scene framebuffer (color + depth + stencil, potentially multisampled) */
 	framebufs.scene.samples = Q_nextPow2 ((int) q_max (1.f, vid_fsaa.value));
@@ -317,22 +349,28 @@ GL_DeleteFrameBuffers
 */
 void GL_DeleteFrameBuffers (void)
 {
-        GL_DeleteFramebuffersFunc (1, &framebufs.resolved_scene.fbo);
-        GL_DeleteFramebuffersFunc (1, &framebufs.oit.fbo_composite);
-        GL_DeleteFramebuffersFunc (1, &framebufs.oit.fbo_scene);
-        GL_DeleteFramebuffersFunc (1, &framebufs.scene.fbo);
-        GL_DeleteFramebuffersFunc (1, &framebufs.composite.fbo);
-        GL_BindFramebufferFunc (GL_FRAMEBUFFER, 0);
+	GL_DeleteFramebuffersFunc (1, &framebufs.resolved_scene.fbo);
+	GL_DeleteFramebuffersFunc (1, &framebufs.oit.fbo_composite);
+	GL_DeleteFramebuffersFunc (1, &framebufs.oit.fbo_scene);
+	GL_DeleteFramebuffersFunc (1, &framebufs.scene.fbo);
+	GL_DeleteFramebuffersFunc (1, &framebufs.composite.fbo);
+	GL_DeleteFramebuffersFunc (1, &framebufs.bloom.extract_fbo);
+	GL_DeleteFramebuffersFunc (1, &framebufs.bloom.pingpong_fbo[0]);
+	GL_DeleteFramebuffersFunc (1, &framebufs.bloom.pingpong_fbo[1]);
+	GL_BindFramebufferFunc (GL_FRAMEBUFFER, 0);
 
-        GL_DeleteNativeTexture (framebufs.resolved_scene.color_tex);
-        GL_DeleteNativeTexture (framebufs.oit.revealage_tex);
-        GL_DeleteNativeTexture (framebufs.oit.accum_tex);
-        GL_DeleteNativeTexture (framebufs.scene.depth_stencil_tex);
-        GL_DeleteNativeTexture (framebufs.scene.color_tex);
-        GL_DeleteNativeTexture (framebufs.composite.depth_stencil_tex);
-        GL_DeleteNativeTexture (framebufs.composite.color_tex);
+	GL_DeleteNativeTexture (framebufs.resolved_scene.color_tex);
+	GL_DeleteNativeTexture (framebufs.oit.revealage_tex);
+	GL_DeleteNativeTexture (framebufs.oit.accum_tex);
+	GL_DeleteNativeTexture (framebufs.scene.depth_stencil_tex);
+	GL_DeleteNativeTexture (framebufs.scene.color_tex);
+	GL_DeleteNativeTexture (framebufs.bloom.pingpong_tex[0]);
+	GL_DeleteNativeTexture (framebufs.bloom.pingpong_tex[1]);
+	GL_DeleteNativeTexture (framebufs.bloom.extract_tex);
+	GL_DeleteNativeTexture (framebufs.composite.depth_stencil_tex);
+	GL_DeleteNativeTexture (framebufs.composite.color_tex);
 
-        memset (&framebufs, 0, sizeof (framebufs));
+	memset (&framebufs, 0, sizeof (framebufs));
 }
 
 static void GL_OrthoMatrix (float matrix[16], float left, float right, float bottom, float top, float n, float f)
@@ -366,6 +404,56 @@ static void GL_OrthoMatrix (float matrix[16], float left, float right, float bot
         matrix[3*4 + 3] = 1.f;
 }
 
+static GLuint GL_GenerateBloomTexture (void)
+{
+	int width = framebufs.bloom.width;
+	int height = framebufs.bloom.height;
+	GLuint fallback = framebufs.bloom.pingpong_tex[0] ? framebufs.bloom.pingpong_tex[0] : framebufs.bloom.extract_tex;
+	if (fallback == 0)
+		fallback = framebufs.bloom.extract_tex;
+	if (width <= 0 || height <= 0)
+		return fallback;
+	if (!glprogs.bloom_extract || !glprogs.bloom_blur)
+		return fallback;
+
+	float threshold = q_max (0.f, r_bloom_threshold.value);
+
+	GL_BeginGroup ("Bloom extract");
+	GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.bloom.extract_fbo);
+	glViewport (0, 0, width, height);
+	GL_UseProgram (glprogs.bloom_extract);
+	GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS(0));
+	GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, framebufs.composite.color_tex);
+	GL_Uniform4fFunc (0, threshold, 0.f, 0.f, 0.f);
+	GL_Uniform4fFunc (1, (float)vid.width, (float)vid.height,
+		(float)vid.width / (float)width,
+		(float)vid.height / (float)height);
+	glDrawArrays (GL_TRIANGLES, 0, 3);
+	GL_EndGroup ();
+
+	GLuint input_tex = framebufs.bloom.extract_tex;
+	const int passes = 4;
+	GL_BeginGroup ("Bloom blur");
+	for (int pass = 0; pass < passes; ++pass)
+	{
+		int target_index = pass & 1;
+		GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.bloom.pingpong_fbo[target_index]);
+		glViewport (0, 0, width, height);
+		GL_UseProgram (glprogs.bloom_blur);
+		GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS(0));
+		GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, input_tex);
+		float dirx = (pass & 1) ? 0.f : 1.f;
+		float diry = (pass & 1) ? 1.f : 0.f;
+		GL_Uniform4fFunc (0, 1.f / (float)width, 1.f / (float)height, dirx, diry);
+		glDrawArrays (GL_TRIANGLES, 0, 3);
+		input_tex = framebufs.bloom.pingpong_tex[target_index];
+	}
+	GL_EndGroup ();
+
+	return input_tex;
+}
+
+
 void GL_PostProcess (void)
 {
 	int palidx, variant;
@@ -381,6 +469,15 @@ void GL_PostProcess (void)
 	palidx =  GLPalette_Postprocess ();
 	dither = (softemu == SOFTEMU_FINE) ? NOISESCALE * r_dither.value * r_softemu_dither_screen.value : 0.f;
 
+	float bloom_intensity = q_max (0.f, r_bloom.value);
+	float exposure = q_max (0.f, r_tonemap_exposure.value);
+	float tonemap_enabled = r_tonemap.value > 0.f ? 1.f : 0.f;
+	GLuint bloom_texture = framebufs.bloom.extract_tex ? framebufs.bloom.extract_tex : 0;
+	if (framebufs.bloom.pingpong_tex[0])
+		bloom_texture = framebufs.bloom.pingpong_tex[0];
+	if (bloom_intensity > 0.f)
+		bloom_texture = GL_GenerateBloomTexture ();
+
 	GL_BindFramebufferFunc (GL_FRAMEBUFFER, 0);
 	glViewport (glx, gly, glwidth, glheight);
 
@@ -389,9 +486,11 @@ void GL_PostProcess (void)
 	GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS(0));
 	GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, framebufs.composite.color_tex);
 	GL_BindNative (GL_TEXTURE1, GL_TEXTURE_3D, gl_palette_lut);
+	GL_BindNative (GL_TEXTURE3, GL_TEXTURE_2D, bloom_texture);
 	GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 0, gl_palette_buffer[palidx], 0, 256 * sizeof (GLuint));
 	if (variant != 2) // some AMD drivers optimize out the uniform in variant #2
 		GL_Uniform4fFunc (0, vid_gamma.value, q_min(2.0f, q_max(1.0f, vid_contrast.value)), 1.f/r_refdef.scale, dither);
+	GL_Uniform4fFunc (5, bloom_intensity, exposure, tonemap_enabled, 0.f);
 
 	dof_enabled = R_DoFEnabled ();
 
@@ -965,7 +1064,11 @@ GL_NeedsPostprocess
 */
 qboolean GL_NeedsPostprocess (void)
 {
-	return vid_gamma.value != 1.f || vid_contrast.value != 1.f || softemu || R_GetEffectiveAlphaMode () == ALPHAMODE_OIT || R_DoFEnabled ();
+	if (vid_gamma.value != 1.f || vid_contrast.value != 1.f || softemu || R_GetEffectiveAlphaMode () == ALPHAMODE_OIT || R_DoFEnabled ())
+		return true;
+	if (r_tonemap.value > 0.f || r_bloom.value > 0.f)
+		return true;
+	return false;
 }
 
 /*

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -57,6 +57,10 @@ extern cvar_t r_dof;
 extern cvar_t r_dof_focus;
 extern cvar_t r_dof_range;
 extern cvar_t r_dof_strength;
+extern cvar_t r_tonemap;
+extern cvar_t r_tonemap_exposure;
+extern cvar_t r_bloom;
+extern cvar_t r_bloom_threshold;
 
 #if defined(USE_SIMD)
 extern cvar_t r_simd;
@@ -337,6 +341,10 @@ void R_Init (void)
 	Cvar_RegisterVariable (&r_dof_focus);
 	Cvar_RegisterVariable (&r_dof_range);
 	Cvar_RegisterVariable (&r_dof_strength);
+	Cvar_RegisterVariable (&r_tonemap);
+	Cvar_RegisterVariable (&r_tonemap_exposure);
+	Cvar_RegisterVariable (&r_bloom);
+	Cvar_RegisterVariable (&r_bloom_threshold);
 	Cvar_RegisterVariable (&r_overbrightbits);
 	Cvar_SetCallback (&r_overbrightbits, R_OverbrightBits_f);
 

--- a/Quake/gl_shaders.c
+++ b/Quake/gl_shaders.c
@@ -514,6 +514,8 @@ void GL_CreateShaders (void)
 	for (palettize = 0; palettize < 3; palettize++)
             glprogs.postprocess[palettize] = GL_CreateProgram (GLSL_PATH("postprocess.vert"), GLSL_PATH("postprocess.frag"), "postprocess|PALETTIZE %d", palettize);
 
+	glprogs.bloom_extract = GL_CreateProgram (GLSL_PATH("postprocess.vert"), GLSL_PATH("bloom_extract.frag"), "bloom extract");
+	glprogs.bloom_blur = GL_CreateProgram (GLSL_PATH("postprocess.vert"), GLSL_PATH("bloom_blur.frag"), "bloom blur");
         for (mode = 0; mode < 2; mode++)
                 glprogs.oit_resolve[mode] = GL_CreateProgram (GLSL_PATH("oit_resolve.vert"), GLSL_PATH("oit_resolve.frag"), "oit resolve|MSAA %d", mode);
 

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -531,6 +531,8 @@ typedef struct glprogs_s {
 	GLuint		viewblend;
 	GLuint		warpscale[2];		// [warp]
 	GLuint		postprocess[3];		// [palettize:off/dithered/direct]
+	GLuint		bloom_extract;
+	GLuint		bloom_blur;
 	GLuint		oit_resolve[2];		// [msaa]
 
 	/* 3d */
@@ -584,6 +586,15 @@ typedef struct glframebufs_s {
 		GLuint		depth_stencil_tex;
 		GLuint		fbo;
 	}				composite;
+
+	struct {
+		GLuint		extract_tex;
+		GLuint		pingpong_tex[2];
+		GLuint		extract_fbo;
+		GLuint		pingpong_fbo[2];
+		int			width;
+		int			height;
+	}				bloom;
 
 	struct {
 		union {

--- a/Quake/shaders/bloom_blur.frag
+++ b/Quake/shaders/bloom_blur.frag
@@ -1,0 +1,21 @@
+layout(binding=0) uniform sampler2D BloomTexture;
+
+layout(location=0) uniform vec4 BlurParams; // xy: texel size, zw: direction
+
+layout(location=0) out vec4 outColor;
+
+void main()
+{
+        vec2 texelSize = BlurParams.xy;
+        vec2 direction = BlurParams.zw;
+        vec2 uv = (gl_FragCoord.xy + 0.5) * texelSize;
+        const float weights[5] = float[](0.227027, 0.1945946, 0.1216216, 0.05405405, 0.016216216);
+        vec3 color = texture(BloomTexture, uv).rgb * weights[0];
+        for (int i = 1; i < 5; ++i)
+        {
+                vec2 offset = direction * texelSize * float(i);
+                color += texture(BloomTexture, uv + offset).rgb * weights[i];
+                color += texture(BloomTexture, uv - offset).rgb * weights[i];
+        }
+        outColor = vec4(color, 1.0);
+}

--- a/Quake/shaders/bloom_extract.frag
+++ b/Quake/shaders/bloom_extract.frag
@@ -1,0 +1,31 @@
+layout(binding=0) uniform sampler2D SceneTexture;
+
+layout(location=0) uniform vec4 ThresholdParams; // x: threshold
+layout(location=1) uniform vec4 DownsampleParams; // xy: source size, zw: scale from target to source
+
+layout(location=0) out vec4 outColor;
+
+void main()
+{
+        float threshold = ThresholdParams.x;
+        vec2 sourceSize = DownsampleParams.xy;
+        vec2 scale = DownsampleParams.zw;
+        vec2 base = (gl_FragCoord.xy + 0.5) * scale - 0.5;
+        vec2 maxCoord = max(sourceSize - vec2(1.0), vec2(0.0));
+        ivec2 baseCoord = ivec2(floor(base));
+        vec3 accum = vec3(0.0);
+        for (int j = 0; j < 2; ++j)
+        {
+                for (int i = 0; i < 2; ++i)
+                {
+                        vec2 sampleCoord = clamp(vec2(baseCoord) + vec2(float(i), float(j)), vec2(0.0), maxCoord);
+                        accum += texelFetch(SceneTexture, ivec2(sampleCoord), 0).rgb;
+                }
+        }
+        vec3 color = accum * 0.25;
+        float brightness = dot(color, vec3(0.2126, 0.7152, 0.0722));
+        float diff = max(brightness - threshold, 0.0);
+        float factor = brightness > 0.0 ? diff / brightness : 0.0;
+        color *= factor;
+        outColor = vec4(color, 1.0);
+}

--- a/Quake/shaders/postprocess.frag
+++ b/Quake/shaders/postprocess.frag
@@ -1,6 +1,7 @@
 layout(binding=0) uniform sampler2D GammaTexture;
 layout(binding=1) uniform usampler3D PaletteLUT;
 layout(binding=2) uniform sampler2D DepthTexture;
+layout(binding=3) uniform sampler2D BloomTexture;
 
 layout(std430, binding=0) restrict readonly buffer PaletteBuffer
 {
@@ -56,6 +57,19 @@ float tri(float x)
 	return x;
 }
 
+vec3 ACESFilm(vec3 x)
+{
+	const mat3 A = mat3(0.59719, 0.35458, 0.04823,
+		0.07600, 0.90834, 0.01566,
+		0.02840, 0.13383, 0.83777);
+	const mat3 B = mat3(1.60475, -0.53108, -0.07367,
+		-0.10208, 1.10813, -0.00605,
+		-0.00327, -0.07276, 1.07602);
+	x = A * x;
+	x = (x * (2.51 * x + 0.03)) / (x * (2.43 * x + 0.59) + 0.14);
+	return clamp(B * x, 0.0, 1.0);
+}
+
 #define DITHER_NOISE(uv) tri(bayer01(ivec2(uv)))
 #define SCREEN_SPACE_NOISE() DITHER_NOISE(floor(gl_FragCoord.xy)+0.5)
 #define SUPPRESS_BANDING() bayer(ivec2(gl_FragCoord.xy))
@@ -65,6 +79,7 @@ layout(location=1) uniform vec4 DoFParams0; // x: enabled, y: focus distance, z:
 layout(location=2) uniform vec4 DoFParams1; // x: near plane, y: far plane, z: reversed-Z flag (>0.5 when reversed)
 layout(location=3) uniform vec4 ViewRect;   // xy: view min (normalized), zw: view max (normalized)
 layout(location=4) uniform vec4 DepthParams; // xy: inverse view scale, zw: unused
+layout(location=5) uniform vec4 HDRParams; // x: bloom intensity, y: exposure, z: tonemap enabled, w: unused
 
 layout(location=0) out vec4 out_fragcolor;
 
@@ -160,7 +175,18 @@ void main()
 	uint remap = Palette[texelFetch(PaletteLUT, clr, 0).x];
 	out_fragcolor.rgb = vec3(UnpackRGB8(remap)) * (1./255.);
 #else
-	out_fragcolor.rgb *= contrast;
-	out_fragcolor = vec4(pow(out_fragcolor.rgb, vec3(gamma)), 1.0);
+	vec3 hdrColor = out_fragcolor.rgb;
+	float bloomIntensity = HDRParams.x;
+	vec3 bloomColor = vec3(0.0);
+	if (bloomIntensity > 0.0)
+	{
+		bloomColor = texture(BloomTexture, uv).rgb * bloomIntensity;
+	}
+	float exposure = max(HDRParams.y, 0.0);
+	float tonemapEnabled = HDRParams.z;
+	hdrColor = max((hdrColor + bloomColor) * exposure * contrast, vec3(0.0));
+	vec3 mapped = tonemapEnabled > 0.5 ? ACESFilm(hdrColor) : clamp(hdrColor, 0.0, 1.0);
+	mapped = clamp(mapped, 0.0, 1.0);
+	out_fragcolor = vec4(pow(mapped, vec3(gamma)), 1.0);
 #endif // PALETTIZE
 }


### PR DESCRIPTION
## Summary
- render the scene into HDR RGBA16F buffers and allocate bloom ping-pong framebuffers
- add bloom extraction/blur passes and ACES filmic tonemapping with exposure and bloom controls
- wire up new GLSL programs, shaders, and cvars for configurable bloom and tonemap output

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ec43872520832eb8205677a26320b4