### PR TITLE
Implement Hable tonemapping and godrays

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -100,6 +100,17 @@ cvar_t	r_tonemap_exposure = {"r_tonemap_exposure", "1.0", CVAR_ARCHIVE};
 cvar_t	r_bloom = {"r_bloom", "0.04", CVAR_ARCHIVE};
 cvar_t	r_bloom_threshold = {"r_bloom_threshold", "1.0", CVAR_ARCHIVE};
 
+cvar_t	r_godrays = {"r_godrays", "0", CVAR_ARCHIVE};
+cvar_t	r_godrays_intensity = {"r_godrays_intensity", "0.4", CVAR_ARCHIVE};
+cvar_t	r_godrays_decay = {"r_godrays_decay", "0.94", CVAR_ARCHIVE};
+cvar_t	r_godrays_density = {"r_godrays_density", "0.8", CVAR_ARCHIVE};
+cvar_t	r_godrays_weight = {"r_godrays_weight", "0.75", CVAR_ARCHIVE};
+cvar_t	r_godrays_samples = {"r_godrays_samples", "64", CVAR_ARCHIVE};
+cvar_t	r_godrays_depthbias = {"r_godrays_depthbias", "8.0", CVAR_ARCHIVE};
+cvar_t	r_godrays_occlusion = {"r_godrays_occlusion", "96.0", CVAR_ARCHIVE};
+cvar_t	r_sun_pitch = {"r_sun_pitch", "-45", CVAR_ARCHIVE};
+cvar_t	r_sun_yaw = {"r_sun_yaw", "0", CVAR_ARCHIVE};
+
 cvar_t	r_overbrightbits = {"r_overbrightbits", "1", CVAR_ARCHIVE};
 
 cvar_t	gl_finish = {"gl_finish","0",CVAR_NONE};
@@ -296,6 +307,9 @@ void GL_CreateFrameBuffers (void)
 	framebufs.bloom.pingpong_fbo[0] = GL_CreateSimpleFBO (GL_TEXTURE_2D, framebufs.bloom.pingpong_tex[0], 0, 0, "bloom blur fbo 0");
 	framebufs.bloom.pingpong_fbo[1] = GL_CreateSimpleFBO (GL_TEXTURE_2D, framebufs.bloom.pingpong_tex[1], 0, 0, "bloom blur fbo 1");
 
+	framebufs.lightshafts.color_tex = GL_CreateTexture2D (GL_RGBA16F, vid.width, vid.height, GL_LINEAR, "light shafts");
+	framebufs.lightshafts.fbo = GL_CreateSimpleFBO (GL_TEXTURE_2D, framebufs.lightshafts.color_tex, 0, 0, "light shafts fbo");
+
 	/* scene framebuffer (color + depth + stencil, potentially multisampled) */
 	framebufs.scene.samples = Q_nextPow2 ((int) q_max (1.f, vid_fsaa.value));
 	framebufs.scene.samples = CLAMP (1, framebufs.scene.samples, framebufs.max_samples);
@@ -357,6 +371,7 @@ void GL_DeleteFrameBuffers (void)
 	GL_DeleteFramebuffersFunc (1, &framebufs.bloom.extract_fbo);
 	GL_DeleteFramebuffersFunc (1, &framebufs.bloom.pingpong_fbo[0]);
 	GL_DeleteFramebuffersFunc (1, &framebufs.bloom.pingpong_fbo[1]);
+	GL_DeleteFramebuffersFunc (1, &framebufs.lightshafts.fbo);
 	GL_BindFramebufferFunc (GL_FRAMEBUFFER, 0);
 
 	GL_DeleteNativeTexture (framebufs.resolved_scene.color_tex);
@@ -367,6 +382,7 @@ void GL_DeleteFrameBuffers (void)
 	GL_DeleteNativeTexture (framebufs.bloom.pingpong_tex[0]);
 	GL_DeleteNativeTexture (framebufs.bloom.pingpong_tex[1]);
 	GL_DeleteNativeTexture (framebufs.bloom.extract_tex);
+	GL_DeleteNativeTexture (framebufs.lightshafts.color_tex);
 	GL_DeleteNativeTexture (framebufs.composite.depth_stencil_tex);
 	GL_DeleteNativeTexture (framebufs.composite.color_tex);
 
@@ -453,6 +469,111 @@ static GLuint GL_GenerateBloomTexture (void)
 	return input_tex;
 }
 
+static void R_GetSunDirection (vec3_t out_dir)
+{
+	vec3_t angles;
+	angles[0] = r_sun_pitch.value;
+	angles[1] = r_sun_yaw.value;
+	angles[2] = 0.f;
+	AngleVectors (angles, out_dir, NULL, NULL);
+	float len = out_dir[0] * out_dir[0] + out_dir[1] * out_dir[1] + out_dir[2] * out_dir[2];
+	if (len > 0.f)
+	{
+		len = 1.f / sqrtf (len);
+		out_dir[0] *= len;
+		out_dir[1] *= len;
+		out_dir[2] *= len;
+	}
+	else
+	{
+		out_dir[0] = 0.f;
+		out_dir[1] = 0.f;
+		out_dir[2] = -1.f;
+	}
+}
+
+static qboolean R_ProjectSunToScreen (vec2_t out_pos)
+{
+	vec3_t dir;
+	R_GetSunDirection (dir);
+	float distance = (view_zfar > 0.f) ? view_zfar : gl_farclip.value;
+	if (distance <= 0.f)
+		distance = 4096.f;
+	float world[4];
+	world[0] = r_origin[0] + dir[0] * distance;
+	world[1] = r_origin[1] + dir[1] * distance;
+	world[2] = r_origin[2] + dir[2] * distance;
+	world[3] = 1.f;
+
+	const float *m = r_matviewproj;
+	float clip_x = m[0] * world[0] + m[4] * world[1] + m[8] * world[2] + m[12] * world[3];
+	float clip_y = m[1] * world[0] + m[5] * world[1] + m[9] * world[2] + m[13] * world[3];
+	float clip_w = m[3] * world[0] + m[7] * world[1] + m[11] * world[2] + m[15] * world[3];
+	if (clip_w <= 0.f)
+		return false;
+
+	float inv_w = 1.f / clip_w;
+	out_pos[0] = clip_x * inv_w * 0.5f + 0.5f;
+	out_pos[1] = clip_y * inv_w * 0.5f + 0.5f;
+	return true;
+}
+
+static GLuint GL_GenerateGodraysTexture (void)
+{
+	if (r_godrays.value <= 0.f)
+		return 0;
+        if (!glprogs.godrays || framebufs.lightshafts.fbo == 0 || framebufs.lightshafts.color_tex == 0)
+		return 0;
+	if (framebufs.composite.color_tex == 0 || framebufs.composite.depth_stencil_tex == 0)
+		return 0;
+
+	float intensity = q_max (0.f, r_godrays_intensity.value);
+	if (intensity <= 0.f)
+		return 0;
+
+	vec2_t light_pos;
+	if (!R_ProjectSunToScreen (light_pos))
+		return 0;
+
+	GL_BeginGroup ("Light shafts");
+	GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.lightshafts.fbo);
+	glViewport (0, 0, vid.width, vid.height);
+
+	GL_UseProgram (glprogs.godrays);
+	GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS(0));
+
+	GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, framebufs.composite.color_tex);
+	GL_BindNative (GL_TEXTURE1, GL_TEXTURE_2D, framebufs.composite.depth_stencil_tex);
+
+	float decay = q_min (1.f, q_max (0.f, r_godrays_decay.value));
+	float density = q_max (0.f, r_godrays_density.value);
+	float weight = q_max (0.f, r_godrays_weight.value);
+	float samples = q_max (1.f, r_godrays_samples.value);
+	float depth_bias = q_max (0.f, r_godrays_depthbias.value);
+	float occlusion = q_max (0.f, r_godrays_occlusion.value);
+
+	GL_Uniform4fFunc (0, intensity, decay, density, weight);
+
+	float near_plane = (view_znear > 0.f) ? view_znear : 0.5f;
+	float far_plane = (view_zfar > near_plane) ? view_zfar : near_plane + 1.f;
+	GL_Uniform4fFunc (1, near_plane, far_plane, gl_clipcontrol_able ? 1.f : 0.f, samples);
+
+	GL_Uniform4fFunc (2, light_pos[0], light_pos[1], depth_bias, occlusion);
+
+	float view_min_x = (glx + r_refdef.vrect.x) / (float)vid.width;
+	float view_min_y = (gly + glheight - r_refdef.vrect.y - r_refdef.vrect.height) / (float)vid.height;
+	float view_size_x = r_refdef.vrect.width / (float)vid.width;
+	float view_size_y = r_refdef.vrect.height / (float)vid.height;
+	float view_max_x = view_min_x + view_size_x;
+	float view_max_y = view_min_y + view_size_y;
+	GL_Uniform4fFunc (3, view_min_x, view_min_y, view_max_x, view_max_y);
+
+	glDrawArrays (GL_TRIANGLES, 0, 3);
+	GL_EndGroup ();
+
+	return framebufs.lightshafts.color_tex;
+}
+
 
 void GL_PostProcess (void)
 {
@@ -461,6 +582,8 @@ void GL_PostProcess (void)
 	qboolean dof_enabled;
 	float dof_focus, dof_range, dof_strength;
 	float dof_znear, dof_zfar;
+	float godray_enabled;
+	GLuint godray_texture;
 	if (!GL_NeedsPostprocess ())
 		return;
 
@@ -478,6 +601,15 @@ void GL_PostProcess (void)
 	if (bloom_intensity > 0.f)
 		bloom_texture = GL_GenerateBloomTexture ();
 
+	godray_enabled = 0.f;
+	godray_texture = 0;
+	if (r_godrays.value > 0.f)
+	{
+		godray_texture = GL_GenerateGodraysTexture ();
+		if (godray_texture != 0)
+			godray_enabled = 1.f;
+	}
+
 	GL_BindFramebufferFunc (GL_FRAMEBUFFER, 0);
 	glViewport (glx, gly, glwidth, glheight);
 
@@ -487,10 +619,11 @@ void GL_PostProcess (void)
 	GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, framebufs.composite.color_tex);
 	GL_BindNative (GL_TEXTURE1, GL_TEXTURE_3D, gl_palette_lut);
 	GL_BindNative (GL_TEXTURE3, GL_TEXTURE_2D, bloom_texture);
+	GL_BindNative (GL_TEXTURE4, GL_TEXTURE_2D, godray_texture);
 	GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 0, gl_palette_buffer[palidx], 0, 256 * sizeof (GLuint));
 	if (variant != 2) // some AMD drivers optimize out the uniform in variant #2
 		GL_Uniform4fFunc (0, vid_gamma.value, q_min(2.0f, q_max(1.0f, vid_contrast.value)), 1.f/r_refdef.scale, dither);
-	GL_Uniform4fFunc (5, bloom_intensity, exposure, tonemap_enabled, 0.f);
+	GL_Uniform4fFunc (5, bloom_intensity, exposure, tonemap_enabled, godray_enabled);
 
 	dof_enabled = R_DoFEnabled ();
 
@@ -1066,7 +1199,7 @@ qboolean GL_NeedsPostprocess (void)
 {
 	if (vid_gamma.value != 1.f || vid_contrast.value != 1.f || softemu || R_GetEffectiveAlphaMode () == ALPHAMODE_OIT || R_DoFEnabled ())
 		return true;
-	if (r_tonemap.value > 0.f || r_bloom.value > 0.f)
+	if (r_tonemap.value > 0.f || r_bloom.value > 0.f || (r_godrays.value > 0.f && r_godrays_intensity.value > 0.f))
 		return true;
 	return false;
 }

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -62,6 +62,17 @@ extern cvar_t r_tonemap_exposure;
 extern cvar_t r_bloom;
 extern cvar_t r_bloom_threshold;
 
+extern cvar_t r_godrays;
+extern cvar_t r_godrays_intensity;
+extern cvar_t r_godrays_decay;
+extern cvar_t r_godrays_density;
+extern cvar_t r_godrays_weight;
+extern cvar_t r_godrays_samples;
+extern cvar_t r_godrays_depthbias;
+extern cvar_t r_godrays_occlusion;
+extern cvar_t r_sun_pitch;
+extern cvar_t r_sun_yaw;
+
 #if defined(USE_SIMD)
 extern cvar_t r_simd;
 #endif
@@ -345,6 +356,16 @@ void R_Init (void)
 	Cvar_RegisterVariable (&r_tonemap_exposure);
 	Cvar_RegisterVariable (&r_bloom);
 	Cvar_RegisterVariable (&r_bloom_threshold);
+	Cvar_RegisterVariable (&r_godrays);
+	Cvar_RegisterVariable (&r_godrays_intensity);
+	Cvar_RegisterVariable (&r_godrays_decay);
+	Cvar_RegisterVariable (&r_godrays_density);
+	Cvar_RegisterVariable (&r_godrays_weight);
+	Cvar_RegisterVariable (&r_godrays_samples);
+	Cvar_RegisterVariable (&r_godrays_depthbias);
+	Cvar_RegisterVariable (&r_godrays_occlusion);
+	Cvar_RegisterVariable (&r_sun_pitch);
+	Cvar_RegisterVariable (&r_sun_yaw);
 	Cvar_RegisterVariable (&r_overbrightbits);
 	Cvar_SetCallback (&r_overbrightbits, R_OverbrightBits_f);
 

--- a/Quake/gl_shaders.c
+++ b/Quake/gl_shaders.c
@@ -516,6 +516,7 @@ void GL_CreateShaders (void)
 
 	glprogs.bloom_extract = GL_CreateProgram (GLSL_PATH("postprocess.vert"), GLSL_PATH("bloom_extract.frag"), "bloom extract");
 	glprogs.bloom_blur = GL_CreateProgram (GLSL_PATH("postprocess.vert"), GLSL_PATH("bloom_blur.frag"), "bloom blur");
+	glprogs.godrays = GL_CreateProgram (GLSL_PATH("postprocess.vert"), GLSL_PATH("godrays.frag"), "godrays");
         for (mode = 0; mode < 2; mode++)
                 glprogs.oit_resolve[mode] = GL_CreateProgram (GLSL_PATH("oit_resolve.vert"), GLSL_PATH("oit_resolve.frag"), "oit resolve|MSAA %d", mode);
 

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -533,6 +533,7 @@ typedef struct glprogs_s {
 	GLuint		postprocess[3];		// [palettize:off/dithered/direct]
 	GLuint		bloom_extract;
 	GLuint		bloom_blur;
+	GLuint		godrays;
 	GLuint		oit_resolve[2];		// [msaa]
 
 	/* 3d */
@@ -595,6 +596,11 @@ typedef struct glframebufs_s {
 		int			width;
 		int			height;
 	}				bloom;
+
+	struct {
+		GLuint		color_tex;
+		GLuint		fbo;
+	}				lightshafts;
 
 	struct {
 		union {

--- a/Quake/shaders/godrays.frag
+++ b/Quake/shaders/godrays.frag
@@ -1,0 +1,90 @@
+layout(binding=0) uniform sampler2D SceneTexture;
+layout(binding=1) uniform sampler2D DepthTexture;
+
+layout(location=0) uniform vec4 LightShaftParams0; // x: intensity, y: decay, z: density, w: weight
+layout(location=1) uniform vec4 LightShaftParams1; // x: near plane, y: far plane, z: reversed-Z flag, w: sample count (float)
+layout(location=2) uniform vec4 LightShaftParams2; // x: light pos X, y: light pos Y, z: depth bias, w: occlusion range
+layout(location=3) uniform vec4 ViewRect;          // xy: min, zw: max
+
+layout(location=0) out vec4 outColor;
+
+float LinearizeDepth(float rawDepth)
+{
+        float nearPlane = LightShaftParams1.x;
+        float farPlane = LightShaftParams1.y;
+        float reversed = LightShaftParams1.z;
+        if (reversed > 0.5)
+        {
+                float denom = nearPlane + rawDepth * (farPlane - nearPlane);
+                return (nearPlane * farPlane) / max(denom, 1e-6);
+        }
+        else
+        {
+                float ndc = rawDepth * 2.0 - 1.0;
+                float denom = farPlane + nearPlane - ndc * (farPlane - nearPlane);
+                return (2.0 * nearPlane * farPlane) / max(denom, 1e-6);
+        }
+}
+
+void main()
+{
+        float intensity = max(LightShaftParams0.x, 0.0);
+        if (intensity <= 0.0)
+        {
+                outColor = vec4(0.0);
+                return;
+        }
+
+        vec2 texSize = vec2(textureSize(SceneTexture, 0));
+        vec2 uv = (gl_FragCoord.xy + 0.5) / texSize;
+        vec2 viewMin = ViewRect.xy;
+        vec2 viewMax = ViewRect.zw;
+        bool inView = all(greaterThanEqual(uv, viewMin)) && all(lessThanEqual(uv, viewMax));
+        if (!inView)
+        {
+                outColor = vec4(0.0);
+                return;
+        }
+
+        int samples = clamp(int(LightShaftParams1.w + 0.5), 1, 256);
+        float decay = clamp(LightShaftParams0.y, 0.0, 1.0);
+        float density = max(LightShaftParams0.z, 0.0);
+        float weight = max(LightShaftParams0.w, 0.0);
+        float depthBias = max(LightShaftParams2.z, 0.0);
+        float occlusionRange = max(LightShaftParams2.w, 1e-4);
+        vec2 lightPos = LightShaftParams2.xy;
+
+        vec2 stepUV = (lightPos - uv) * (density / float(samples));
+        vec2 sampleUV = uv;
+
+        float currentDepth = LinearizeDepth(texture(DepthTexture, uv).r);
+        if (!(currentDepth > 0.0))
+                currentDepth = LightShaftParams1.y;
+
+        float illuminationDecay = 1.0;
+        float occlusion = 1.0;
+        vec3 shafts = vec3(0.0);
+
+        for (int i = 0; i < samples; ++i)
+        {
+                sampleUV += stepUV;
+                if (any(lessThan(sampleUV, vec2(0.0))) || any(greaterThan(sampleUV, vec2(1.0))))
+                        break;
+
+                float sampleDepth = LinearizeDepth(texture(DepthTexture, sampleUV).r);
+                if (!(sampleDepth > 0.0))
+                        sampleDepth = LightShaftParams1.y;
+
+                float diff = currentDepth - sampleDepth - depthBias;
+                float sampleOcclusion = clamp(1.0 - max(diff, 0.0) / occlusionRange, 0.0, 1.0);
+                occlusion *= sampleOcclusion;
+
+                vec3 sampleColor = texture(SceneTexture, sampleUV).rgb;
+                sampleColor *= illuminationDecay * weight;
+                shafts += sampleColor * occlusion;
+
+                illuminationDecay *= decay;
+        }
+
+        outColor = vec4(shafts * intensity, 1.0);
+}

--- a/Quake/shaders/postprocess.frag
+++ b/Quake/shaders/postprocess.frag
@@ -2,6 +2,7 @@ layout(binding=0) uniform sampler2D GammaTexture;
 layout(binding=1) uniform usampler3D PaletteLUT;
 layout(binding=2) uniform sampler2D DepthTexture;
 layout(binding=3) uniform sampler2D BloomTexture;
+layout(binding=4) uniform sampler2D GodrayTexture;
 
 layout(std430, binding=0) restrict readonly buffer PaletteBuffer
 {
@@ -57,17 +58,21 @@ float tri(float x)
 	return x;
 }
 
-vec3 ACESFilm(vec3 x)
+vec3 HableTonemap(vec3 x)
 {
-	const mat3 A = mat3(0.59719, 0.35458, 0.04823,
-		0.07600, 0.90834, 0.01566,
-		0.02840, 0.13383, 0.83777);
-	const mat3 B = mat3(1.60475, -0.53108, -0.07367,
-		-0.10208, 1.10813, -0.00605,
-		-0.00327, -0.07276, 1.07602);
-	x = A * x;
-	x = (x * (2.51 * x + 0.03)) / (x * (2.43 * x + 0.59) + 0.14);
-	return clamp(B * x, 0.0, 1.0);
+        const float A = 0.15;
+        const float B = 0.50;
+        const float C = 0.10;
+        const float D = 0.20;
+        const float E = 0.02;
+        const float F = 0.30;
+        const float W = 11.2;
+        vec3 numerator = x * (A * x + C * B) + D * E;
+        vec3 denominator = x * (A * x + B) + D * F;
+        vec3 mapped = numerator / denominator - E / F;
+        float white = ((W * (A * W + C * B) + D * E) / (W * (A * W + B) + D * F)) - E / F;
+        mapped /= white;
+        return clamp(mapped, 0.0, 1.0);
 }
 
 #define DITHER_NOISE(uv) tri(bayer01(ivec2(uv)))
@@ -79,7 +84,7 @@ layout(location=1) uniform vec4 DoFParams0; // x: enabled, y: focus distance, z:
 layout(location=2) uniform vec4 DoFParams1; // x: near plane, y: far plane, z: reversed-Z flag (>0.5 when reversed)
 layout(location=3) uniform vec4 ViewRect;   // xy: view min (normalized), zw: view max (normalized)
 layout(location=4) uniform vec4 DepthParams; // xy: inverse view scale, zw: unused
-layout(location=5) uniform vec4 HDRParams; // x: bloom intensity, y: exposure, z: tonemap enabled, w: unused
+layout(location=5) uniform vec4 HDRParams; // x: bloom intensity, y: exposure, z: tonemap enabled, w: godrays enabled
 
 layout(location=0) out vec4 out_fragcolor;
 
@@ -175,18 +180,25 @@ void main()
 	uint remap = Palette[texelFetch(PaletteLUT, clr, 0).x];
 	out_fragcolor.rgb = vec3(UnpackRGB8(remap)) * (1./255.);
 #else
-	vec3 hdrColor = out_fragcolor.rgb;
-	float bloomIntensity = HDRParams.x;
-	vec3 bloomColor = vec3(0.0);
-	if (bloomIntensity > 0.0)
-	{
-		bloomColor = texture(BloomTexture, uv).rgb * bloomIntensity;
-	}
-	float exposure = max(HDRParams.y, 0.0);
-	float tonemapEnabled = HDRParams.z;
-	hdrColor = max((hdrColor + bloomColor) * exposure * contrast, vec3(0.0));
-	vec3 mapped = tonemapEnabled > 0.5 ? ACESFilm(hdrColor) : clamp(hdrColor, 0.0, 1.0);
-	mapped = clamp(mapped, 0.0, 1.0);
-	out_fragcolor = vec4(pow(mapped, vec3(gamma)), 1.0);
+        vec3 hdrColor = out_fragcolor.rgb;
+        float bloomIntensity = HDRParams.x;
+        vec3 bloomColor = vec3(0.0);
+        if (bloomIntensity > 0.0)
+        {
+                bloomColor = texture(BloomTexture, uv).rgb * bloomIntensity;
+        }
+        float godrayEnabled = HDRParams.w;
+        vec3 shaftColor = vec3(0.0);
+        if (godrayEnabled > 0.5)
+        {
+                shaftColor = texture(GodrayTexture, uv).rgb;
+        }
+        float exposure = max(HDRParams.y, 0.0);
+        float tonemapEnabled = HDRParams.z;
+        vec3 combined = (hdrColor + bloomColor + shaftColor) * exposure * contrast;
+        combined = max(combined, vec3(0.0));
+        vec3 mapped = tonemapEnabled > 0.5 ? HableTonemap(combined) : clamp(combined, 0.0, 1.0);
+        mapped = clamp(mapped, 0.0, 1.0);
+        out_fragcolor = vec4(pow(mapped, vec3(gamma)), 1.0);
 #endif // PALETTIZE
 }

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -290,6 +290,15 @@ void main()
         if (surface_normal_len > 0.0)
                 surface_normal = surface_normal_vec / surface_normal_len;
         vec3 total_light = clamp(static_light, 0.0, 1.0);
+        vec3 specular_light = vec3(0.0);
+        vec3 to_eye = EyePos - in_pos;
+        float view_length = length(to_eye);
+        vec3 view_dir = vec3(0.0, 0.0, 1.0);
+        if (view_length > 0.0)
+                view_dir = to_eye / view_length;
+
+        const float SPECULAR_POWER = 16.0;
+        const float SPECULAR_SCALE = 0.4;
 
         if (NumLights > 0u)
         {
@@ -305,7 +314,7 @@ void main()
 			int cluster_idx = cluster_coord.x + cluster_coord.y * LIGHT_TILES_X + cluster_coord.z * LIGHT_TILES_X * LIGHT_TILES_Y;
 			total_light = vec3(ivec3((cluster_idx + 1) * 0x45d9f3b) >> ivec3(0, 8, 16) & 255) / 255.0;
 #endif // SHOW_ACTIVE_LIGHT_CLUSTERS
-			vec3 dynamic_light = vec3(0.);
+                        vec3 dynamic_light = vec3(0.);
 			vec4 plane;
 			plane.xyz = surface_normal;
 			plane.w = dot(in_pos, plane.xyz);
@@ -324,10 +333,31 @@ void main()
 					float minlight = l.minlight;
 					if (rad < minlight)
 						continue;
-					vec3 local_pos = l.origin - plane.xyz * dist;
-					minlight = rad - minlight;
-					dist = length(in_pos - local_pos);
-					dynamic_light += clamp((minlight - dist) / 16.0, 0.0, 1.0) * max(0., rad - dist) / 256. * l.color;
+                                        vec3 local_pos = l.origin - plane.xyz * dist;
+                                        minlight = rad - minlight;
+                                        vec3 light_vec = local_pos - in_pos;
+                                        float surface_dist = length(light_vec);
+                                        float attenuation = clamp((minlight - surface_dist) / 16.0, 0.0, 1.0);
+                                        float falloff = max(0., rad - surface_dist) / 256.;
+                                        vec3 light_contrib = attenuation * falloff * l.color;
+                                        dynamic_light += light_contrib;
+                                        if (attenuation > 0.0 && falloff > 0.0 && surface_dist > 0.0)
+                                        {
+                                                vec3 light_dir = light_vec / surface_dist;
+                                                float ndotl = max(dot(surface_normal, light_dir), 0.0);
+                                                if (ndotl > 0.0)
+                                                {
+                                                        vec3 half_vec = light_dir + view_dir;
+                                                        float half_len = length(half_vec);
+                                                        if (half_len > 0.0)
+                                                        {
+                                                                half_vec /= half_len;
+                                                                float ndoth = max(dot(surface_normal, half_vec), 0.0);
+                                                                float spec = pow(ndoth, SPECULAR_POWER) * ndotl;
+                                                                specular_light += light_contrib * spec * SPECULAR_SCALE;
+                                                        }
+                                                }
+                                        }
 				}
 			}
                         total_light += max(min(dynamic_light, 1. - total_light), 0.);
@@ -349,7 +379,9 @@ void main()
 #endif
         result.rgb += fullbright;
         result.rgb += emissive;
-	result = clamp(result, 0.0, 1.0);
+        vec3 spec_clamped = clamp(specular_light, vec3(0.0), vec3(Overbright));
+        result.rgb += spec_clamped * clamp(result.a, 0.0, 1.0);
+        result = clamp(result, 0.0, 1.0);
         result.rgb = ApplyFog(result.rgb, in_pos - EyePos);
 
         result.a = in_alpha; // FIXME: This will make almost transparent things cut holes though heavy fog


### PR DESCRIPTION
## Summary
- add configurable godray/lightshaft post effect with a dedicated shader, framebuffer, and CVars
- switch the HDR post-process to a Hable tonemap curve and feed the lightshafts through the linear bloom pipeline
- blend dynamic per-pixel specular highlights with existing lightmapped diffuse lighting

## Testing
- cmake -S . -B build -G Ninja *(fails: missing SDL2 package)*

------
https://chatgpt.com/codex/tasks/task_e_68ec4d1a8d74832ebaa492f2aca6ce28