### PR TITLE
Store previous frame camera state for motion blur

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -42,6 +42,18 @@ mplane_t	frustum[4];
 float		r_matview[16];
 float		r_matproj[16];
 float		r_matviewproj[16];
+static float r_prev_matviewproj[16];
+static vec3_t r_prev_vieworg;
+static double r_prev_frame_time;
+static qboolean r_prev_frame_valid;
+static qboolean r_frame_rendered_this_update;
+
+static const float r_identity_mat4[16] = {
+        1.f, 0.f, 0.f, 0.f,
+        0.f, 1.f, 0.f, 0.f,
+        0.f, 0.f, 1.f, 0.f,
+        0.f, 0.f, 0.f, 1.f
+};
 
 //johnfitz -- rendering statistics
 int rs_brushpolys, rs_aliaspolys, rs_skypolys;
@@ -1311,6 +1323,30 @@ void R_SetupView (void)
 	r_framedata.eyepos[1] = r_refdef.vieworg[1];
 	r_framedata.eyepos[2] = r_refdef.vieworg[2];
 	r_framedata.time = cl.time;
+
+	double prev_delta = cl.time - r_prev_frame_time;
+	qboolean prev_valid = r_prev_frame_valid && prev_delta > 0.0;
+
+	if (prev_valid)
+	{
+	        memcpy (r_framedata.prevviewproj, r_prev_matviewproj, sizeof (r_prev_matviewproj));
+	        r_framedata.prev_eyepos[0] = r_prev_vieworg[0];
+	        r_framedata.prev_eyepos[1] = r_prev_vieworg[1];
+	        r_framedata.prev_eyepos[2] = r_prev_vieworg[2];
+	        r_framedata.delta_time = (float) prev_delta;
+	        r_framedata.prev_frame_valid = 1;
+	}
+	else
+	{
+	        memcpy (r_framedata.prevviewproj, r_identity_mat4, sizeof (r_identity_mat4));
+	        r_framedata.prev_eyepos[0] = r_refdef.vieworg[0];
+	        r_framedata.prev_eyepos[1] = r_refdef.vieworg[1];
+	        r_framedata.prev_eyepos[2] = r_refdef.vieworg[2];
+	        r_framedata.delta_time = 0.f;
+	        r_framedata.prev_frame_valid = 0;
+	        r_prev_frame_valid = false;
+	}
+
 	if (softemu == SOFTEMU_COARSE)
 	{
 		r_framedata.screendither = NOISESCALE * r_dither.value * r_softemu_dither_screen.value;
@@ -1399,6 +1435,25 @@ void R_SetupView (void)
 	}
 	//johnfitz
 }
+
+void R_StorePrevFrameState (void)
+{
+        if (!r_frame_rendered_this_update)
+        {
+                r_prev_frame_valid = false;
+                return;
+        }
+
+        double prev_time = r_prev_frame_time;
+
+        memcpy (r_prev_matviewproj, r_matviewproj, sizeof (r_prev_matviewproj));
+        VectorCopy (r_refdef.vieworg, r_prev_vieworg);
+
+        r_prev_frame_time = cl.time;
+        r_prev_frame_valid = (cl.time > prev_time);
+        r_frame_rendered_this_update = false;
+}
+
 
 //==============================================================================
 //
@@ -2406,6 +2461,8 @@ void R_RenderView (void)
 	R_SetupView (); //johnfitz -- this does everything that should be done once per frame
 	R_RenderScene ();
 	R_WarpScaleView ();
+
+	r_frame_rendered_this_update = true;
 
 	//johnfitz -- modified r_speeds output
 	time2 = Sys_DoubleTime ();

--- a/Quake/gl_screen.c
+++ b/Quake/gl_screen.c
@@ -2113,6 +2113,8 @@ void SCR_UpdateScreen (void)
 
        GL_PostProcess ();
 
+       R_StorePrevFrameState ();
+
        GL_BeginGroup ("2D");
 
 	GL_Set2D ();

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -419,6 +419,7 @@ typedef struct gpulightbuffer_s {
 
 typedef struct gpuframedata_s {
 	float	viewproj[16];
+	float	prevviewproj[16];
 	float	fogdata[4];
 	float	skyfogdata[4];
 	vec3_t	winddir;
@@ -429,12 +430,14 @@ typedef struct gpuframedata_s {
 	float	_padding1;
 	vec3_t	eyepos;
 	float	time;
+	vec3_t	prev_eyepos;
+	float	delta_time;
 	float	zlogscale;
 	float	zlogbias;
 	int			numlights;
+	int			prev_frame_valid;
 	int			_padding2;
 	int			_padding3;
-	int			_padding4;
 } gpuframedata_t;
 
 extern gpulightbuffer_t r_lightbuffer;
@@ -457,6 +460,7 @@ void R_TranslatePlayerSkin (int playernum);
 void R_TranslateNewPlayerSkin (int playernum); //johnfitz -- this handles cases when the actual texture changes
 
 void R_UploadFrameData (void);
+void R_StorePrevFrameState (void);
 void R_InitShadow (void);
 void R_ShutdownShadow (void);
 void R_ResizeShadowMapIfNeeded (void);

--- a/Quake/shaders/frame_uniforms.glsl
+++ b/Quake/shaders/frame_uniforms.glsl
@@ -4,6 +4,7 @@
 layout(std140, binding=0) uniform FrameDataUBO
 {
         mat4    ViewProj;
+        mat4    PrevViewProj;
         vec4    Fog;
         vec4    SkyFog;
         vec3    WindDir;
@@ -14,12 +15,14 @@ layout(std140, binding=0) uniform FrameDataUBO
         float   _Pad0;
         vec3    EyePos;
         float   Time;
+        vec3    PrevEyePos;
+        float   DeltaTime;
         float   ZLogScale;
         float   ZLogBias;
         uint    NumLights;
+        uint    PrevFrameValid;
         uint    _Pad1;
         uint    _Pad2;
-        uint    _Pad3;
 };
 
 #endif // FRAME_UNIFORMS_GLSL


### PR DESCRIPTION
## Summary
- store the previous frame view-projection matrix, view origin, and frame time so GPU motion blur has valid history
- extend the frame data UBO and struct with PrevViewProj, PrevEyePos, DeltaTime, and PrevFrameValid fields
- capture the current frame state after postprocess to refresh the previous-frame buffers for the next render

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ed31da5cb0832e9180b7f9e972464e