### PR TITLE
Declare motion blur cvars in gl_rmisc

### DIFF
--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -57,6 +57,8 @@ extern cvar_t r_dof;
 extern cvar_t r_dof_focus;
 extern cvar_t r_dof_range;
 extern cvar_t r_dof_strength;
+extern cvar_t r_motionblur;
+extern cvar_t r_motionblur_samples;
 extern cvar_t r_tonemap;
 extern cvar_t r_tonemap_exposure;
 extern cvar_t r_bloom;


### PR DESCRIPTION
## Summary
- add extern declarations for the motion blur cvars so they can be registered in gl_rmisc

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ed52607f7c832e9be7b2bbd82fa678