### PR TITLE
Fix blitting path when motion blur is enabled without warp effects

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -2446,9 +2446,23 @@ void R_WarpScaleView (void)
                 GL_BlitFramebufferFunc (0, 0, srcw, srch, srcx, srcy, srcx + srcw, srcy + srch, GL_DEPTH_BUFFER_BIT, GL_NEAREST);
 	}
 
-	GL_BindFramebufferFunc (GL_FRAMEBUFFER, fbodest);
-	if (fbodest)
-	{
+        if (!msaa && !needwarpscale)
+        {
+                GL_BindFramebufferFunc (GL_READ_FRAMEBUFFER, framebufs.scene.fbo);
+                glReadBuffer (GL_COLOR_ATTACHMENT0);
+                GL_BindFramebufferFunc (GL_DRAW_FRAMEBUFFER, fbodest);
+                if (fbodest)
+                        glDrawBuffer (GL_COLOR_ATTACHMENT0);
+                else
+                        glDrawBuffer (GL_BACK);
+                GL_BlitFramebufferFunc (0, 0, srcw, srch,
+                        srcx, srcy, srcx + srcw, srcy + srch,
+                        GL_COLOR_BUFFER_BIT, GL_NEAREST);
+        }
+
+        GL_BindFramebufferFunc (GL_FRAMEBUFFER, fbodest);
+        if (fbodest)
+        {
                 glDrawBuffer (GL_COLOR_ATTACHMENT0);
                 glReadBuffer (GL_COLOR_ATTACHMENT0);
         }
@@ -2459,8 +2473,8 @@ void R_WarpScaleView (void)
         }
         glViewport (srcx, srcy, r_refdef.vrect.width, r_refdef.vrect.height);
 
-	if (!needwarpscale)
-		return;
+        if (!needwarpscale)
+                return;
 
 	GL_BeginGroup ("Warp/scale view");
 


### PR DESCRIPTION
## Summary
- ensure the scene color buffer is blitted to the postprocess target when only motion blur is active
- avoid stale composite frames that caused the screen to freeze with motion blur enabled

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ed54078ce8832ebb89b0e7fff730c3