### PR TITLE
Fix SSAO normal orientation

### DIFF
--- a/Quake/shaders/ssao.frag
+++ b/Quake/shaders/ssao.frag
@@ -40,6 +40,10 @@ vec3 ComputeNormal(vec3 centerPos, vec2 uv)
     vec3 normal = normalize(cross(tangent, bitangent));
     if (any(isnan(normal)) || length(normal) < 1e-4)
         normal = vec3(0.0, 0.0, 1.0);
+
+    vec3 viewDir = normalize(-centerPos);
+    if (dot(normal, viewDir) < 0.0)
+        normal = -normal;
     return normal;
 }
 


### PR DESCRIPTION
## Summary
- orient reconstructed SSAO normals toward the camera to prevent inverted occlusion
- ensure screen space ambient occlusion sampling no longer forces the final image black when enabled

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ed7427c8c8832ebefb7e74ab2d5fce