### PR TITLE
Fix SSAO depth handling for reverse-Z

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -586,6 +586,9 @@ static GLuint GL_GenerateSSAOTexture (void)
     static GLint loc_intensity = -1;
     static GLint loc_noise_scale = -1;
     static GLint loc_inv_resolution = -1;
+    static GLint loc_reverse_z = -1;
+    static GLint loc_ndc_zero_to_one = -1;
+    static GLint loc_view_z_sign = -1;
 
     if (cached_program != glprogs.ssao)
     {
@@ -593,6 +596,7 @@ static GLuint GL_GenerateSSAOTexture (void)
         loc_depth = loc_noise = loc_proj = loc_invproj = -1;
         loc_samples = loc_kernel = loc_radius = loc_bias = -1;
         loc_power = loc_intensity = loc_noise_scale = loc_inv_resolution = -1;
+        loc_reverse_z = loc_ndc_zero_to_one = loc_view_z_sign = -1;
     }
 
     if (loc_depth < 0)
@@ -609,6 +613,9 @@ static GLuint GL_GenerateSSAOTexture (void)
         loc_intensity = GL_GetUniformLocationFunc (glprogs.ssao, "uIntensity");
         loc_noise_scale = GL_GetUniformLocationFunc (glprogs.ssao, "uNoiseScale");
         loc_inv_resolution = GL_GetUniformLocationFunc (glprogs.ssao, "uInvResolution");
+        loc_reverse_z = GL_GetUniformLocationFunc (glprogs.ssao, "uReverseZ");
+        loc_ndc_zero_to_one = GL_GetUniformLocationFunc (glprogs.ssao, "uNDCZeroToOne");
+        loc_view_z_sign = GL_GetUniformLocationFunc (glprogs.ssao, "uViewZSign");
     }
 
     int kernel_size = SSAO_MAX_KERNEL;
@@ -654,6 +661,12 @@ static GLuint GL_GenerateSSAOTexture (void)
         GL_Uniform2fFunc (loc_noise_scale, noise_scale_x, noise_scale_y);
     if (loc_inv_resolution >= 0)
         GL_Uniform2fFunc (loc_inv_resolution, 1.f / width, 1.f / height);
+    if (loc_reverse_z >= 0)
+        GL_Uniform1iFunc (loc_reverse_z, gl_clipcontrol_able ? 1 : 0);
+    if (loc_ndc_zero_to_one >= 0)
+        GL_Uniform1iFunc (loc_ndc_zero_to_one, gl_clipcontrol_able ? 1 : 0);
+    if (loc_view_z_sign >= 0)
+        GL_Uniform1fFunc (loc_view_z_sign, -1.f);
 
     glDrawArrays (GL_TRIANGLES, 0, 3);
 

--- a/Quake/shaders/ssao.frag
+++ b/Quake/shaders/ssao.frag
@@ -15,13 +15,26 @@ uniform float uPower;
 uniform float uIntensity;
 uniform vec2 uNoiseScale;
 uniform vec2 uInvResolution;
+uniform bool  uReverseZ;
+uniform bool  uNDCZeroToOne;
+uniform float uViewZSign;
 
-vec3 ReconstructPosition(vec2 uv, float depth)
+float DepthToNDC(float depth01)
 {
-    float z = depth * 2.0 - 1.0;
-    vec4 clip = vec4(uv * 2.0 - 1.0, z, 1.0);
+    return uNDCZeroToOne ? depth01 : (depth01 * 2.0 - 1.0);
+}
+
+bool IsSkyDepth(float d)
+{
+    return uReverseZ ? (d <= 0.0005) : (d >= 0.9995);
+}
+
+vec3 ReconstructPosition(vec2 uv, float depth01)
+{
+    float z_ndc = DepthToNDC(depth01);
+    vec4 clip = vec4(uv * 2.0 - 1.0, z_ndc, 1.0);
     vec4 view = uInvProj * clip;
-    return view.xyz / view.w;
+    return view.xyz / max(view.w, 1e-6);
 }
 
 vec3 ComputeNormal(vec3 centerPos, vec2 uv)
@@ -32,8 +45,8 @@ vec3 ComputeNormal(vec3 centerPos, vec2 uv)
     float depthX = texture(uDepth, clamp(uv + offsetX, 0.0, 1.0)).r;
     float depthY = texture(uDepth, clamp(uv + offsetY, 0.0, 1.0)).r;
 
-    vec3 posX = (depthX >= 1.0) ? centerPos : ReconstructPosition(uv + offsetX, depthX);
-    vec3 posY = (depthY >= 1.0) ? centerPos : ReconstructPosition(uv + offsetY, depthY);
+    vec3 posX = IsSkyDepth(depthX) ? centerPos : ReconstructPosition(uv + offsetX, depthX);
+    vec3 posY = IsSkyDepth(depthY) ? centerPos : ReconstructPosition(uv + offsetY, depthY);
 
     vec3 tangent = posX - centerPos;
     vec3 bitangent = posY - centerPos;
@@ -50,7 +63,7 @@ vec3 ComputeNormal(vec3 centerPos, vec2 uv)
 void main()
 {
     float depth = texture(uDepth, vUV).r;
-    if (depth >= 1.0)
+    if (IsSkyDepth(depth))
     {
         FragAO = 1.0;
         return;
@@ -80,14 +93,16 @@ void main()
             continue;
 
         float sampleDepth = texture(uDepth, sampleUV).r;
-        if (sampleDepth >= 1.0)
+        if (IsSkyDepth(sampleDepth))
             continue;
 
         vec3 depthPos = ReconstructPosition(sampleUV, sampleDepth);
         float range = uRadius / (abs(position.z - depthPos.z) + 1e-4);
         float weight = clamp(range, 0.0, 1.0);
-        float delta = depthPos.z - samplePos.z;
-        occlusion += (delta > uBias ? 1.0 : 0.0) * weight;
+        float deltaForward = (depthPos.z - samplePos.z) * uViewZSign;
+        const float thickness = 0.05;
+        float stepSoft = smoothstep(uBias, uBias + thickness, deltaForward);
+        occlusion += stepSoft * weight;
     }
 
     float ao = 1.0 - (samples > 0 ? occlusion / float(samples) : 0.0);


### PR DESCRIPTION
## Summary
- add reverse-Z, depth range, and view axis uniforms to the SSAO shader and use them to reconstruct view-space positions robustly
- replace hard depth thresholds with a helper that handles sky pixels and soften occlusion comparison using the new view-direction sign
- pass the additional uniforms from the renderer so SSAO works with clip-control and reversed depth buffers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ed780f740c832e96d91712f070d366