### PR TITLE
Fix SSAO occlusion direction handling

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -588,7 +588,6 @@ static GLuint GL_GenerateSSAOTexture (void)
     static GLint loc_inv_resolution = -1;
     static GLint loc_reverse_z = -1;
     static GLint loc_ndc_zero_to_one = -1;
-    static GLint loc_view_z_sign = -1;
 
     if (cached_program != glprogs.ssao)
     {
@@ -596,7 +595,7 @@ static GLuint GL_GenerateSSAOTexture (void)
         loc_depth = loc_noise = loc_proj = loc_invproj = -1;
         loc_samples = loc_kernel = loc_radius = loc_bias = -1;
         loc_power = loc_intensity = loc_noise_scale = loc_inv_resolution = -1;
-        loc_reverse_z = loc_ndc_zero_to_one = loc_view_z_sign = -1;
+        loc_reverse_z = loc_ndc_zero_to_one = -1;
     }
 
     if (loc_depth < 0)
@@ -615,7 +614,6 @@ static GLuint GL_GenerateSSAOTexture (void)
         loc_inv_resolution = GL_GetUniformLocationFunc (glprogs.ssao, "uInvResolution");
         loc_reverse_z = GL_GetUniformLocationFunc (glprogs.ssao, "uReverseZ");
         loc_ndc_zero_to_one = GL_GetUniformLocationFunc (glprogs.ssao, "uNDCZeroToOne");
-        loc_view_z_sign = GL_GetUniformLocationFunc (glprogs.ssao, "uViewZSign");
     }
 
     int kernel_size = SSAO_MAX_KERNEL;
@@ -665,15 +663,6 @@ static GLuint GL_GenerateSSAOTexture (void)
         GL_Uniform1iFunc (loc_reverse_z, gl_clipcontrol_able ? 1 : 0);
     if (loc_ndc_zero_to_one >= 0)
         GL_Uniform1iFunc (loc_ndc_zero_to_one, gl_clipcontrol_able ? 1 : 0);
-    if (loc_view_z_sign >= 0)
-    {
-        /*
-         * Reverse-Z projections flip the view-space forward axis compared to
-         * the legacy matrix, so expose the actual sign to the shader.
-         */
-        const float view_z_sign = gl_clipcontrol_able ? -1.f : 1.f;
-        GL_Uniform1fFunc (loc_view_z_sign, view_z_sign);
-    }
 
     glDrawArrays (GL_TRIANGLES, 0, 3);
 

--- a/Quake/shaders/ssao.frag
+++ b/Quake/shaders/ssao.frag
@@ -17,7 +17,6 @@ uniform vec2 uNoiseScale;
 uniform vec2 uInvResolution;
 uniform bool  uReverseZ;
 uniform bool  uNDCZeroToOne;
-uniform float uViewZSign;
 
 float DepthToNDC(float depth01)
 {
@@ -37,7 +36,7 @@ vec3 ReconstructPosition(vec2 uv, float depth01)
     return view.xyz / max(view.w, 1e-6);
 }
 
-vec3 ComputeNormal(vec3 centerPos, vec2 uv)
+vec3 ComputeNormal(vec3 centerPos, vec2 uv, vec3 viewDir)
 {
     vec2 offsetX = vec2(uInvResolution.x, 0.0);
     vec2 offsetY = vec2(0.0, uInvResolution.y);
@@ -54,7 +53,6 @@ vec3 ComputeNormal(vec3 centerPos, vec2 uv)
     if (any(isnan(normal)) || length(normal) < 1e-4)
         normal = vec3(0.0, 0.0, 1.0);
 
-    vec3 viewDir = normalize(-centerPos);
     if (dot(normal, viewDir) < 0.0)
         normal = -normal;
     return normal;
@@ -70,7 +68,8 @@ void main()
     }
 
     vec3 position = ReconstructPosition(vUV, depth);
-    vec3 normal = ComputeNormal(position, vUV);
+    vec3 viewDir = normalize(-position);
+    vec3 normal = ComputeNormal(position, vUV, viewDir);
 
     vec3 noise = texture(uNoise, vUV * uNoiseScale).xyz * 2.0 - 1.0;
     noise.z = 0.0;
@@ -99,7 +98,7 @@ void main()
         vec3 depthPos = ReconstructPosition(sampleUV, sampleDepth);
         float range = uRadius / (abs(position.z - depthPos.z) + 1e-4);
         float weight = clamp(range, 0.0, 1.0);
-        float deltaForward = (depthPos.z - samplePos.z) * uViewZSign;
+        float deltaForward = dot(depthPos - samplePos, viewDir);
         const float thickness = 0.05;
         float stepSoft = smoothstep(uBias, uBias + thickness, deltaForward);
         occlusion += stepSoft * weight;


### PR DESCRIPTION
## Summary
- remove the unused SSAO view-space sign uniform and rely on the fragment view direction instead
- adjust the SSAO shader to project occlusion along the reconstructed view ray, avoiding the all-black output when clip control is enabled
- clean up the SSAO uniform handling on the CPU side accordingly

## Testing
- not run (not set up in container)


------
https://chatgpt.com/codex/tasks/task_e_68ed81436094832e8b0c51a22ab365e8