### PR TITLE
Improve lightmap atlas and brush batching

### DIFF
--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -386,6 +386,9 @@ void R_Init (void)
 	Cvar_RegisterVariable (&r_showfields_align);
 	Cvar_RegisterVariable (&gl_farclip);
 	Cvar_RegisterVariable (&gl_fullbrights);
+	Cvar_RegisterVariable (&gl_lightmap_atlas_size);
+	Cvar_SetCallback (&gl_lightmap_atlas_size, GL_OnLightmapAtlasSizeChanged);
+	GL_OnLightmapAtlasSizeChanged (&gl_lightmap_atlas_size);
 	Cvar_SetCallback (&gl_fullbrights, GL_Fullbrights_f);
 	Cvar_RegisterVariable (&gl_overbright_models);
 	Cvar_RegisterVariable (&r_lerpmodels);

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -365,9 +365,9 @@ extern overflowtimes_t dev_overflows; //this stores the last time overflow messa
 
 //johnfitz -- moved here from r_brush.c
 extern int gl_lightmap_format, lightmap_bytes;
-
-#define LMBLOCK_WIDTH	256	//FIXME: make dynamic. if we have a decent card there's no real reason not to use 4k or 16k (assuming there's no lightstyles/dynamics that need uploading...)
-#define LMBLOCK_HEIGHT	256 //Alternatively, use texture arrays, which would avoid the need to switch textures as often.
+extern int lightmap_block_width, lightmap_block_height;
+extern cvar_t gl_lightmap_atlas_size;
+void GL_OnLightmapAtlasSizeChanged (cvar_t *var);
 
 typedef struct lightmap_s
 {
@@ -505,7 +505,7 @@ typedef struct bmodel_gpu_surf_s {
 	GLuint		numedges;
 	GLuint		firstvert;
 	vec3_t		mins;
-	GLuint		padding0;
+	GLuint		lightmap;
 	vec3_t		maxs;
 	GLuint		padding1;
 } bmodel_gpu_surf_t;

--- a/Quake/shaders/cull_mark.comp
+++ b/Quake/shaders/cull_mark.comp
@@ -54,7 +54,7 @@ struct Surface
 	uint	numedges;
 	uint	firstvert;
 	vec3	mins;
-	uint	_pad0;
+	uint	lightmap;
 	vec3	maxs;
 	uint	_pad1;
 };
@@ -71,7 +71,8 @@ layout(std430, binding=5) restrict buffer SurfaceBuffer
 #define SURF_TEXNUM(base)			rawsurfaces[base + 1].y
 #define SURF_NUMEDGES(base)		rawsurfaces[base + 1].z
 #define SURF_FIRSTVERT(base)		rawsurfaces[base + 1].w
-#define SURF_MINS(base)			uintBitsToFloat(rawsurfaces[base + 2].xyz)
+#define SURF_MINS(base)		uintBitsToFloat(rawsurfaces[base + 2].xyz)
+#define SURF_LIGHTMAP(base)		rawsurfaces[base + 2].w
 #define SURF_MAXS(base)			uintBitsToFloat(rawsurfaces[base + 3].xyz)
 #define SIZEOF_SURFACE				4 /* uvec4s */
 
@@ -129,12 +130,14 @@ void main()
 	// surface is visible, append its triangles to the index buffer
 	// and update the draw command corresponding to its texture number
 	uint texnum = SURF_TEXNUM(surfbase);
-	uint numedges = SURF_NUMEDGES(surfbase);
-	uint firstvert = SURF_FIRSTVERT(surfbase);
-	uint cmdbase = texnum * uint(SIZEOF_CMD);
+	uint	numedges = SURF_NUMEDGES(surfbase);
+	uint	firstvert_abs = SURF_FIRSTVERT(surfbase);
+	uint	cmdbase = texnum * uint(SIZEOF_CMD);
+	uint	baseVertex = CMD_BASE_VERTEX(cmdbase);
 	// some bsps out there have faces with < 2 edges, which would cause underflow below
 	numedges = max(numedges, 2u);
-	uint ofs = CMD_FIRST_INDEX(cmdbase) + atomicAdd(CMD_COUNT(cmdbase), 3u * (numedges - 2u));
+	uint	ofs = CMD_FIRST_INDEX(cmdbase) + atomicAdd(CMD_COUNT(cmdbase), 3u * (numedges - 2u));
+	uint	firstvert = firstvert_abs - baseVertex;
 	for (uint i = 2u; i < numedges; i++)
 	{
 		indices[ofs++] = firstvert;


### PR DESCRIPTION
## Summary
- add a configurable `gl_lightmap_atlas_size` cvar with sanitisation and register it during renderer init
- apply the requested atlas dimensions when packing lightmaps and propagate lightmap IDs into GPU surface metadata
- track per-bucket base vertices when building brush draw commands and adjust the cull compute shader to emit indices relative to those bases

## Testing
- cmake -S . -B build -G Ninja *(fails: SDL2 package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ee440b4fa0832e929e50e9040a996d