### PR TITLE
Fix motion blur state persistence

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -1570,6 +1570,13 @@ void R_StorePrevFrameState (void)
 	r_frame_rendered_this_update = false;
 }
 
+qboolean R_PrevFrameValid (void)
+{
+        return r_prev_frame_valid;
+}
+
+
+
 
 //==============================================================================
 //

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -461,6 +461,7 @@ void R_TranslateNewPlayerSkin (int playernum); //johnfitz -- this handles cases 
 
 void R_UploadFrameData (void);
 void R_StorePrevFrameState (void);
+qboolean R_PrevFrameValid (void);
 void R_InitShadow (void);
 void R_ShutdownShadow (void);
 void R_ResizeShadowMapIfNeeded (void);

--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -760,16 +760,29 @@ static void R_DrawAliasModel_Real (entity_t *e, qboolean showtris)
 
 	{
 		float prev_model_matrix[16];
+		vec3_t prev_origin;
+		vec3_t prev_angles;
+		qboolean have_prev = false;
+
+		if (e != &cl.viewent && e->motion_blur_prev_valid && e->motion_blur_prev_frame == r_framecount - 1 && R_PrevFrameValid ())
+		{
+			VectorCopy (e->motion_blur_prev_origin, prev_origin);
+			VectorCopy (e->motion_blur_prev_angles, prev_angles);
+			have_prev = true;
+		}
+
+		if (!have_prev)
+		{
+			VectorCopy (lerpdata.origin, prev_origin);
+			VectorCopy (lerpdata.angles, prev_angles);
+		}
+
 		if (e == &cl.viewent)
 		{
 			memcpy (prev_model_matrix, model_matrix, sizeof (model_matrix));
 		}
 		else
 		{
-			vec3_t prev_origin;
-			vec3_t prev_angles;
-			VectorCopy (e->previousorigin, prev_origin);
-			VectorCopy (e->previousangles, prev_angles);
 			R_EntityMatrix (prev_model_matrix, prev_origin, prev_angles, e->scale);
 			ApplyTranslation (prev_model_matrix, paliashdr->scale_origin[0], paliashdr->scale_origin[1] * fovscale, paliashdr->scale_origin[2] * fovscale);
 			ApplyScale (prev_model_matrix, paliashdr->scale[0], paliashdr->scale[1] * fovscale, paliashdr->scale[2] * fovscale);
@@ -778,6 +791,11 @@ static void R_DrawAliasModel_Real (entity_t *e, qboolean showtris)
 		MatrixTranspose4x3 (model_matrix, instance->worldmatrix);
 		MatrixTranspose4x3 (prev_model_matrix, instance->prev_worldmatrix);
 	}
+
+	VectorCopy (lerpdata.origin, e->motion_blur_prev_origin);
+	VectorCopy (lerpdata.angles, e->motion_blur_prev_angles);
+	e->motion_blur_prev_frame = r_framecount;
+	e->motion_blur_prev_valid = true;
 
 	instance->lightcolor[0] = lightcolor[0];
 	instance->lightcolor[1] = lightcolor[1];

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -202,28 +202,47 @@ static void R_InitBModelInstance (bmodel_gpu_instance_t *inst, entity_t *ent)
 {
         vec3_t angles;
         vec3_t prev_angles;
+        vec3_t curr_origin;
+        vec3_t prev_origin;
         float mat[16];
         float prev_mat[16];
+        qboolean has_prev = false;
 
-        angles[0] = -ent->angles[0];
-        angles[1] =  ent->angles[1];
-        angles[2] =  ent->angles[2];
-        R_EntityMatrix (mat, ent->origin, angles, ent == &cl_entities[0] ? ENTSCALE_DEFAULT : ent->scale);
+        VectorCopy (ent->origin, curr_origin);
+        VectorCopy (ent->angles, angles);
 
-        if (ent == &cl_entities[0])
+        if (ent->motion_blur_prev_valid && ent->motion_blur_prev_frame == r_framecount - 1 && R_PrevFrameValid ())
         {
-                memcpy (prev_mat, mat, sizeof (mat));
+                VectorCopy (ent->motion_blur_prev_origin, prev_origin);
+                VectorCopy (ent->motion_blur_prev_angles, prev_angles);
+                has_prev = true;
         }
-        else
+
+        if (!has_prev)
         {
-                prev_angles[0] = -ent->previousangles[0];
-                prev_angles[1] =  ent->previousangles[1];
-                prev_angles[2] =  ent->previousangles[2];
-                R_EntityMatrix (prev_mat, ent->previousorigin, prev_angles, ent->scale);
+                VectorCopy (curr_origin, prev_origin);
+                VectorCopy (angles, prev_angles);
         }
+
+        vec3_t matrix_angles;
+        vec3_t prev_matrix_angles;
+        float scale = (ent == &cl_entities[0]) ? ENTSCALE_DEFAULT : ent->scale;
+
+        VectorCopy (angles, matrix_angles);
+        VectorCopy (prev_angles, prev_matrix_angles);
+        matrix_angles[0] = -matrix_angles[0];
+        prev_matrix_angles[0] = -prev_matrix_angles[0];
+
+        R_EntityMatrix (mat, curr_origin, matrix_angles, scale);
+        R_EntityMatrix (prev_mat, prev_origin, prev_matrix_angles, scale);
 
         MatrixTranspose4x3 (mat, inst->world);
         MatrixTranspose4x3 (prev_mat, inst->prev_world);
+
+        VectorCopy (curr_origin, ent->motion_blur_prev_origin);
+        VectorCopy (ent->angles, ent->motion_blur_prev_angles);
+        ent->motion_blur_prev_frame = r_framecount;
+        ent->motion_blur_prev_valid = true;
 
         inst->alpha = ent->alpha == ENTALPHA_DEFAULT ? -1.f : ENTALPHA_DECODE (ent->alpha);
         memset (&inst->padding, 0, sizeof(inst->padding));

--- a/Quake/render.h
+++ b/Quake/render.h
@@ -86,6 +86,12 @@ typedef struct entity_s
 	vec3_t					previousangles;	//johnfitz -- transform lerping
 	vec3_t					currentangles;	//johnfitz -- transform lerping
 
+	// Cached transform from the previous rendered frame for motion blur.
+	vec3_t					motion_blur_prev_origin;
+	vec3_t					motion_blur_prev_angles;
+	int					motion_blur_prev_frame;
+	qboolean			motion_blur_prev_valid;
+
 	lightcache_t			lightcache;		// alias light trace cache
 
 	float					traildelay;		// time left until next particle trail update


### PR DESCRIPTION
## Summary
- cache the previous frame transform per entity so motion blur uses actual frame-to-frame velocities
- expose a helper for checking previous frame validity and reuse it when building motion blur state for brush and alias draws

## Testing
- make -C Quake *(fails: SDL2 headers not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ee8e55853c832ea7fb1ba0dda382c6