### PR TITLE
Improve motion blur coverage and strength

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -171,7 +171,7 @@ cvar_t	r_motionblur = { "r_motionblur", "0", CVAR_ARCHIVE };
 cvar_t	r_motionblur_shutter = { "r_motionblur_shutter", "0.75", CVAR_ARCHIVE };
 cvar_t	r_motionblur_maxradiuspixels = { "r_motionblur_maxradiuspixels", "32", CVAR_ARCHIVE };
 cvar_t	r_motionblur_maxsamples = { "r_motionblur_maxsamples", "16", CVAR_ARCHIVE };
-cvar_t	r_motionblur_minvelocity = { "r_motionblur_minvelocity", "0.5", CVAR_ARCHIVE };
+cvar_t	r_motionblur_minvelocity = { "r_motionblur_minvelocity", "0.0", CVAR_ARCHIVE };
 cvar_t	r_motionblur_depththreshold = { "r_motionblur_depththreshold", "0.1", CVAR_ARCHIVE };
 
 
@@ -649,6 +649,17 @@ void GL_PostProcess (void)
         motion_strength = q_max (0.f, r_motionblur.value);
         motion_shutter = q_max (0.f, r_motionblur_shutter.value);
         motion_effective_shutter = motion_strength * motion_shutter;
+        if (motion_effective_shutter > 0.f && r_prev_frame_valid)
+        {
+                double frame_delta = cl.time - r_prev_frame_time;
+                if (frame_delta > 0.0)
+                {
+                        const double reference_delta = 1.0 / 60.0;
+                        float frame_scale = (float)(reference_delta / frame_delta);
+                        frame_scale = q_min (4.f, q_max (1.f, frame_scale));
+                        motion_effective_shutter *= frame_scale;
+                }
+        }
         motion_max_radius = q_max (0.f, r_motionblur_maxradiuspixels.value);
         motion_min_velocity = q_max (0.f, r_motionblur_minvelocity.value);
         motion_depth_threshold = q_max (0.f, r_motionblur_depththreshold.value);

--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -60,8 +60,11 @@ typedef struct aliasinstance_s {
 	int32_t		pose1;
 	int32_t		pose2;
 	float		blend;
-	int32_t		padding;
+	int32_t		flags;
 } aliasinstance_t;
+
+#define ALIAS_INSTANCE_FLAG_NONE          0
+#define ALIAS_INSTANCE_FLAG_NO_MOTION_BLUR (1 << 0)
 
 struct ibuf_s {
 	int			count;
@@ -757,6 +760,7 @@ static void R_DrawAliasModel_Real (entity_t *e, qboolean showtris)
 		ibuf.ent = e;
 
 	instance = &ibuf.inst[ibuf.count++];
+	instance->flags = ALIAS_INSTANCE_FLAG_NONE;
 
 	{
 		float prev_model_matrix[16];
@@ -801,6 +805,8 @@ static void R_DrawAliasModel_Real (entity_t *e, qboolean showtris)
 	instance->lightcolor[1] = lightcolor[1];
 	instance->lightcolor[2] = lightcolor[2];
 	instance->alpha = entalpha;
+	if (e == &cl.viewent)
+		instance->flags |= ALIAS_INSTANCE_FLAG_NO_MOTION_BLUR;
 	instance->pose1 = lerpdata.pose1;
 	instance->pose2 = lerpdata.pose2;
 	instance->blend = lerpdata.blend;

--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -6,7 +6,7 @@ struct InstanceData
 	int		Pose1;
 	int		Pose2;
 	float	Blend;
-	int		Padding;
+	int		Flags;
 };
 
 layout(std430, binding=1) restrict readonly buffer InstanceBuffer
@@ -80,6 +80,8 @@ vec2 ComputeVelocity(vec4 curr_clip, vec4 prev_clip)
 	return (curr_ndc - prev_ndc) * 0.5;
 }
 
+const int ALIAS_FLAG_NO_MOTION_BLUR = 1;
+
 layout(binding=0) uniform sampler2D Tex;
 layout(binding=1) uniform sampler2D FullbrightTex;
 layout(binding=2) uniform sampler2D EmissiveTex;
@@ -93,6 +95,7 @@ layout(location=1) in vec4 in_color;
 layout(location=2) in vec3 in_pos;
 layout(location=3) noperspective in vec4 in_curr_clip;
 layout(location=4) noperspective in vec4 in_prev_clip;
+layout(location=5) flat in int in_flags;
 
 #define OUT_COLOR out_fragcolor
 #if OIT
@@ -167,7 +170,11 @@ void main()
 	result.rgb = mix(Fog.rgb, result.rgb, fog);
 	out_fragcolor = result;
 #if !OIT
-	out_velocity = ComputeVelocity(in_curr_clip, in_prev_clip) * result.a;
+	vec2 velocity = ComputeVelocity(in_curr_clip, in_prev_clip);
+	if ((in_flags & ALIAS_FLAG_NO_MOTION_BLUR) != 0 || result.a < 0.999)
+		out_velocity = vec2(0.0);
+	else
+		out_velocity = velocity * result.a;
 #endif
 #if MODE == 1 || MODE == 2
 	// Note: sign bit is used as overbright flag

--- a/Quake/shaders/alias.vert
+++ b/Quake/shaders/alias.vert
@@ -6,7 +6,7 @@ struct InstanceData
 	int		Pose1;
 	int		Pose2;
 	float	Blend;
-	int		Padding;
+	int		Flags;
 };
 
 layout(std430, binding=1) restrict readonly buffer InstanceBuffer
@@ -89,6 +89,7 @@ layout(location=1) out vec4 out_color;
 layout(location=2) out vec3 out_pos;
 layout(location=3) noperspective out vec4 out_curr_clip;
 layout(location=4) noperspective out vec4 out_prev_clip;
+layout(location=5) flat out int out_flags;
 
 void main()
 {
@@ -106,6 +107,7 @@ void main()
 	gl_Position = curr_clip;
 	out_curr_clip = curr_clip;
 	out_prev_clip = prev_clip;
+	out_flags = inst.Flags;
 	out_pos = world_vert - EyePos;
 	// transform world X and Z axes to local space
 	mat3 orientation = mat3(normalize(worldmatrix[0].xyz), normalize(worldmatrix[1].xyz), normalize(worldmatrix[2].xyz));

--- a/Quake/shaders/water.frag
+++ b/Quake/shaders/water.frag
@@ -162,7 +162,7 @@ void main()
         result.a *= in_alpha;
         out_fragcolor = result;
 #if !OIT
-        out_velocity = ComputeVelocity(in_curr_clip, in_prev_clip) * result.a;
+        out_velocity = vec2(0.0);
 #endif
 #if DITHER
 	if (Fog.w > 0.)

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -414,7 +414,11 @@ void main()
         result.a = in_alpha; // FIXME: This will make almost transparent things cut holes though heavy fog
         out_fragcolor = result;
 #if !OIT
-        out_velocity = ComputeVelocity(in_curr_clip, in_prev_clip) * result.a;
+        vec2 velocity = ComputeVelocity(in_curr_clip, in_prev_clip);
+        if (result.a < 0.999)
+                out_velocity = vec2(0.0);
+        else
+                out_velocity = velocity * result.a;
 #endif
 #if DITHER == 1
 	vec3 dpos = fwidth(in_pos);


### PR DESCRIPTION
## Summary
- scale the motion blur shutter factor by frame time and lower the activation threshold to make the effect visible during camera motion
- add a per-instance flag and shader changes so the viewmodel and other translucent passes no longer write to the velocity buffer
- zero out velocities for water and translucent world fragments to keep them out of the blur pass

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ee9a2217c8832e9e29e4f02f991fa7