### PR TITLE
Ensure per-object motion blur persists without camera movement

### DIFF
--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -768,7 +768,7 @@ static void R_DrawAliasModel_Real (entity_t *e, qboolean showtris)
 		vec3_t prev_angles;
 		qboolean have_prev = false;
 
-		if (e != &cl.viewent && e->motion_blur_prev_valid && e->motion_blur_prev_frame == r_framecount - 1 && R_PrevFrameValid ())
+		if (e != &cl.viewent && e->motion_blur_prev_valid && e->motion_blur_prev_frame == r_framecount - 1)
 		{
 			VectorCopy (e->motion_blur_prev_origin, prev_origin);
 			VectorCopy (e->motion_blur_prev_angles, prev_angles);

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -211,7 +211,7 @@ static void R_InitBModelInstance (bmodel_gpu_instance_t *inst, entity_t *ent)
         VectorCopy (ent->origin, curr_origin);
         VectorCopy (ent->angles, angles);
 
-        if (ent->motion_blur_prev_valid && ent->motion_blur_prev_frame == r_framecount - 1 && R_PrevFrameValid ())
+        if (ent->motion_blur_prev_valid && ent->motion_blur_prev_frame == r_framecount - 1)
         {
                 VectorCopy (ent->motion_blur_prev_origin, prev_origin);
                 VectorCopy (ent->motion_blur_prev_angles, prev_angles);


### PR DESCRIPTION
## Summary
- remove the dependency on R_PrevFrameValid when restoring alias model motion blur history
- always reuse stored brush model transforms for motion blur regardless of camera state

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eeaf1afabc832e8e56a33b2ec6f496