### PR TITLE
Fix motion blur sampling when r_scale > 1

### DIFF
--- a/Quake/shaders/postprocess.frag
+++ b/Quake/shaders/postprocess.frag
@@ -195,7 +195,12 @@ void main()
                 float effectiveShutter = MotionParams0.y;
                 if (effectiveShutter > 0.0)
                 {
-                        vec2 velocity = texture(VelocityTexture, uv).xy;
+                        vec2 viewMin = ViewRect.xy;
+                        vec2 viewMax = ViewRect.zw;
+                        vec2 viewSize = max(viewMax - viewMin, vec2(1e-6));
+                        vec2 invScale = max(DepthParams.xy, vec2(1e-4));
+                        vec2 velocityUV = clamp((uv - viewMin) * invScale, vec2(0.0), viewSize * invScale);
+                        vec2 velocity = texture(VelocityTexture, velocityUV).xy;
                         vec2 velocityPx = velocity * effectiveShutter * texSize;
                         float speed = length(velocityPx);
                         float minVelocity = max(MotionParams0.z, 0.0);


### PR DESCRIPTION
## Summary
- adjust the postprocess shader to map velocity lookups into the scaled view rectangle
- clamp velocity sampling to the region that actually contains velocity data

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68eeb67ad63c832e9d8fa965c919a3b0