### PR TITLE
Fix velocity output for water shader under motion blur

### DIFF
--- a/Quake/shaders/water.frag
+++ b/Quake/shaders/water.frag
@@ -162,7 +162,11 @@ void main()
         result.a *= in_alpha;
         out_fragcolor = result;
 #if !OIT
-        out_velocity = vec2(0.0);
+        vec2 velocity = ComputeVelocity(in_curr_clip, in_prev_clip);
+        if (result.a < 0.999)
+                out_velocity = vec2(0.0);
+        else
+                out_velocity = velocity * result.a;
 #endif
 #if DITHER
 	if (Fog.w > 0.)


### PR DESCRIPTION
## Summary
- update the water fragment shader to emit motion vectors consistent with opaque world surfaces when motion blur is enabled

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eedc31a860832e8c5fb76def7a2a22