### PR TITLE
Fix depth of field blur weighting

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -662,6 +662,7 @@ void GL_PostProcess (void)
         float motion_strength;
         float motion_shutter;
         float motion_effective_shutter;
+        double frame_delta;
         float motion_max_radius;
         float motion_min_velocity;
         float motion_depth_threshold;
@@ -689,9 +690,10 @@ void GL_PostProcess (void)
                 motion_strength = 0.f;
         motion_shutter = q_max (0.f, r_motionblur_shutter.value);
         motion_effective_shutter = motion_strength * motion_shutter;
+
+        frame_delta = (r_prev_frame_valid) ? cl.time - r_prev_frame_time : 0.0;
         if (motion_effective_shutter > 0.f && r_prev_frame_valid)
         {
-                double frame_delta = cl.time - r_prev_frame_time;
                 if (frame_delta > 0.0)
                 {
                         const double reference_delta = 1.0 / 60.0;
@@ -729,6 +731,15 @@ void GL_PostProcess (void)
         GL_Uniform3fFunc (5, bloom_intensity, exposure, tonemap_enabled);
         GL_Uniform4fFunc (6, motion_enabled ? 1.f : 0.f, motion_effective_shutter, motion_min_velocity, motion_depth_threshold);
         GL_Uniform4fFunc (7, motion_max_radius, (float)motion_max_samples, 0.f, 0.f);
+
+        float gpu_load = 0.f;
+        if (frame_delta > 0.0)
+        {
+                const double frametime_ms = frame_delta * 1000.0;
+                gpu_load = (frametime_ms > (1000.0 / 60.0)) ? 0.5f : 0.f;
+        }
+        GL_Uniform4fFunc (8, gpu_load, 0.f, 0.f, 0.f);
+        GL_Uniform4fFunc (9, 3.0f, 0.15f, 0.f, 0.f);
 
         dof_enabled = R_DoFEnabled ();
 

--- a/Quake/shaders/postprocess.frag
+++ b/Quake/shaders/postprocess.frag
@@ -370,36 +370,41 @@ vec3 ApplyMotionBlur(vec3 color, vec2 uv, vec2 texSize, DepthSamplingInfo depthI
 // Bilateral weight function: combines spatial and range (depth/color) weights
 float BilateralWeight(float spatialDist, float rangeDist, float sigmaSpatial, float sigmaRange)
 {
-	float spatialWeight = exp(-spatialDist / (2.0 * sigmaSpatial * sigmaSpatial));
-	float rangeWeight = exp(-rangeDist / (2.0 * sigmaRange * sigmaRange));
+	float spatialSigma = max(sigmaSpatial, 1e-4);
+	float rangeSigma = max(sigmaRange, 1e-4);
+	float spatialWeight = exp(-(spatialDist * spatialDist) / (2.0 * spatialSigma * spatialSigma));
+	float rangeWeight = exp(-(rangeDist * rangeDist) / (2.0 * rangeSigma * rangeSigma));
 	return spatialWeight * rangeWeight;
 }
 
 // Apply depth of field with bilateral filtering for better edge preservation
 vec3 ApplyDepthOfField(vec3 color, vec2 uv, vec2 invTexSize, DepthSamplingInfo depthInfo)
 {
-	float linearDepth = SampleLinearDepth(gl_FragCoord.xy, depthInfo);
-	float focusDistance = DoFParams0.y;
-	float focusRange = max(DoFParams0.z, 0.0001);
-	float maxBlur = max(DoFParams0.w, 0.0);
-	
-	// Calculate circle of confusion
-	float coc = abs(linearDepth - focusDistance);
-	float blurFactor = clamp((coc - focusRange) / focusRange, 0.0, 1.0);
-	float blurRadius = blurFactor * maxBlur;
-	
-	// Early exit if no blur needed
-	if (blurRadius < 0.0001)
-		return color;
-	
-	// Bilateral filtering parameters
-	float sigmaSpatial = DoFParams2.x > 0.0 ? DoFParams2.x : BILATERAL_SIGMA_SPATIAL_DEFAULT;
-	float sigmaRange = DoFParams2.y > 0.0 ? DoFParams2.y : BILATERAL_SIGMA_RANGE_DEFAULT;
-	
-	// 8-tap radial blur kernel (optimized pattern)
-	const vec2 kernel[8] = vec2[](
-		vec2(1.0, 0.0),
-		vec2(-1.0, 0.0),
+        float linearDepth = SampleLinearDepth(gl_FragCoord.xy, depthInfo);
+        float focusDistance = DoFParams0.y;
+        float focusRange = max(DoFParams0.z, 0.0001);
+        float maxBlur = max(DoFParams0.w, 0.0);
+
+        // Calculate circle of confusion
+        float coc = abs(linearDepth - focusDistance);
+        float blurFactor = clamp((coc - focusRange) / focusRange, 0.0, 1.0);
+        float blurRadius = blurFactor * maxBlur;
+
+        // Early exit if no blur needed
+        if (blurRadius < 0.0001)
+                return color;
+
+        // Bilateral filtering parameters
+        float sigmaSpatial = DoFParams2.x > 0.0 ? DoFParams2.x : BILATERAL_SIGMA_SPATIAL_DEFAULT;
+        float sigmaRange = DoFParams2.y > 0.0 ? DoFParams2.y : BILATERAL_SIGMA_RANGE_DEFAULT;
+
+        vec2 viewMin = ViewRect.xy;
+        vec2 viewMax = ViewRect.zw;
+
+        // 8-tap radial blur kernel (optimized pattern)
+        const vec2 kernel[8] = vec2[](
+                vec2(1.0, 0.0),
+                vec2(-1.0, 0.0),
 		vec2(0.0, 1.0),
 		vec2(0.0, -1.0),
 		vec2(0.70710678, 0.70710678),
@@ -416,31 +421,50 @@ vec3 ApplyDepthOfField(vec3 color, vec2 uv, vec2 invTexSize, DepthSamplingInfo d
 	mat2 rotation = mat2(cosine, -sine, sine, cosine);
 	
 	// Bilateral filtering accumulation
-	vec3 accum = color;
-	float weight = 1.0;
-	float centerLuma = dot(color, vec3(0.299, 0.587, 0.114));
-	
-	for (int i = 0; i < 8; ++i)
-	{
-		vec2 offset = rotation * kernel[i] * blurRadius * invTexSize;
-		vec2 sampleUV = uv + offset;
-		vec3 sampleColor = texture(GammaTexture, sampleUV).rgb;
-		
-		// Compute spatial distance
-		float spatialDist = length(offset * vec2(textureSize(GammaTexture, 0)));
-		
-		// Compute range distance (luminance-based)
-		float sampleLuma = dot(sampleColor, vec3(0.299, 0.587, 0.114));
-		float rangeDist = abs(sampleLuma - centerLuma);
-		
-		// Bilateral weight
-		float w = BilateralWeight(spatialDist, rangeDist, sigmaSpatial, sigmaRange);
-		
-		accum += sampleColor * w;
-		weight += w;
-	}
-	
-	return accum / max(weight, EPSILON);
+        vec3 accum = color;
+        float weight = 1.0;
+        float centerLuma = dot(color, vec3(0.299, 0.587, 0.114));
+        const float COLOR_SIGMA = 0.35;
+
+        for (int i = 0; i < 8; ++i)
+        {
+                vec2 offsetDir = rotation * kernel[i];
+                vec2 offsetPx = offsetDir * blurRadius;
+                vec2 sampleUV = uv + offsetPx * invTexSize;
+
+                if (!all(greaterThanEqual(sampleUV, viewMin)) || !all(lessThanEqual(sampleUV, viewMax)))
+                        continue;
+
+                vec3 sampleColor = texture(GammaTexture, sampleUV).rgb;
+                vec2 sampleCoord = gl_FragCoord.xy + offsetPx;
+
+                float sampleDepth = SampleLinearDepth(sampleCoord, depthInfo);
+                float sampleCoC = abs(sampleDepth - focusDistance);
+                float sampleBlurFactor = clamp((sampleCoC - focusRange) / focusRange, 0.0, 1.0);
+
+                if (sampleBlurFactor <= 0.0 && blurFactor > 0.0)
+                        continue;
+
+                float spatialDist = length(offsetPx);
+                float blurDelta = sampleBlurFactor - blurFactor;
+                float w = BilateralWeight(spatialDist, blurDelta, sigmaSpatial, sigmaRange);
+
+                float sampleLuma = dot(sampleColor, vec3(0.299, 0.587, 0.114));
+                float colorDiff = sampleLuma - centerLuma;
+                float colorWeight = exp(-(colorDiff * colorDiff) / (2.0 * COLOR_SIGMA * COLOR_SIGMA));
+
+                float defocus = max(sampleBlurFactor, blurFactor);
+                w *= colorWeight * defocus;
+
+                if (w <= 0.0)
+                        continue;
+
+                accum += sampleColor * w;
+                weight += w;
+        }
+
+        vec3 blurred = accum / max(weight, EPSILON);
+        return mix(color, blurred, blurFactor);
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- adjust the depth of field bilateral weight to use squared falloff with safe sigmas
- rework the depth of field gather to gate samples by defocus amount and blend the blurred result back into the source color so the effect is visible again

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68eedeffe454832eb7d4e6debd3d80da