### PR TITLE
Fix Windows build errors in decals and framebuffer definitions

### DIFF
--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -612,13 +612,9 @@ typedef struct glframebufs_s {
 	}				bloom;
 
 	struct {
-		union {
-			GLuint			mrt[2];
-			struct {
-				GLuint		accum_tex;
-				GLuint		revealage_tex;
-			};
-		};
+		GLuint		accum_tex;
+		GLuint		revealage_tex;
+		GLuint		mrt[2];
 		GLuint		fbo_scene;
 		GLuint		fbo_composite;
 	}				oit;

--- a/Quake/r_decals.c
+++ b/Quake/r_decals.c
@@ -341,7 +341,10 @@ static qboolean R_DecalProject (const vec3_t point, const vec3_t preferred_norma
         if (!cl.worldmodel || !cl.worldmodel->numleafs)
                 return false;
 
-        leaf = Mod_PointInLeaf ((vec3_t) point, cl.worldmodel);
+        vec3_t point_copy;
+        VectorCopy (point, point_copy);
+
+        leaf = Mod_PointInLeaf (point_copy, cl.worldmodel);
         if (!leaf)
                 return false;
 


### PR DESCRIPTION
## Summary
- copy the decal projection point before calling Mod_PointInLeaf so the function signature matches on MSVC
- replace the anonymous union in glframebufs_t with explicit fields to avoid incomplete type errors on Windows

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68efe272cf98832ea01f9fcb215a008e