### PR TITLE
Restore depth of field blur strength

### DIFF
--- a/Quake/shaders/postprocess.frag
+++ b/Quake/shaders/postprocess.frag
@@ -464,7 +464,13 @@ vec3 ApplyDepthOfField(vec3 color, vec2 uv, vec2 invTexSize, DepthSamplingInfo d
         }
 
         vec3 blurred = accum / max(weight, EPSILON);
-        return mix(color, blurred, blurFactor);
+
+        // The blur radius already scales with blurFactor so blending again with the
+        // original color makes the effect almost imperceptible.  Returning the
+        // fully blurred color restores the amount of defocus that the legacy
+        // shader produced while still taking advantage of the bilateral weights
+        // above.
+        return blurred;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- return the fully blurred color from the depth of field pass so the effect is visible again
- document why the blend was removed to keep the bilateral weighting but recover legacy strength

## Testing
- not run (not feasible in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68efeb00d34c832eafe2abcd2b0f5edd