### PR TITLE
Fix blob shadow fog tinting

### DIFF
--- a/Quake/shaders/blobshadow.frag
+++ b/Quake/shaders/blobshadow.frag
@@ -92,8 +92,10 @@ void main()
         float fog = exp2(abs(Fog.w) * -dot(in_pos, in_pos));
         fog = clamp(fog, 0.0, 1.0);
 
-        vec3 color = mix(Fog.rgb, vec3(0.0), fog);
-        OUT_COLOR = vec4(color, alpha);
+        // Fade the shadow with distance fog by reducing opacity instead of tinting towards
+        // the fog colour. Tinting made the shadow look like a glowing disc when fog was bright.
+        alpha *= fog;
+        OUT_COLOR = vec4(vec3(0.0), alpha);
 #if !OIT
         out_velocity = vec2(0.0);
 #endif

--- a/Quake/shaders/playershadow.frag
+++ b/Quake/shaders/playershadow.frag
@@ -49,6 +49,10 @@ void main()
                discard;
        float fog = exp2(abs(Fog.w) * -dot(in_viewpos, in_viewpos));
        fog = clamp(fog, 0.0, 1.0);
-       vec3 color = mix(Fog.rgb, vec3(0.0), fog);
-       out_fragcolor = vec4(color, alpha);
+
+       // Fade shadow intensity with fog distance without tinting towards the fog colour.
+       // Using the fog colour here made the shadow appear as a bright disc instead of darkening
+       // the ground beneath the player.
+       alpha *= fog;
+       out_fragcolor = vec4(vec3(0.0), alpha);
 }


### PR DESCRIPTION
## Summary
- stop blob shadow shaders from blending towards the fog colour
- fade the shadow opacity with fog distance instead so it remains dark

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f0130b19a4832ebcd3fcb6939df89d