### PR TITLE
Add configurable vignette and chromatic aberration post-processing effects

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -216,6 +216,10 @@ cvar_t	r_tonemap_exposure = { "r_tonemap_exposure", "1.0", CVAR_ARCHIVE };
 cvar_t	r_bloom = { "r_bloom", "0.04", CVAR_ARCHIVE };
 cvar_t	r_bloom_threshold = { "r_bloom_threshold", "1.0", CVAR_ARCHIVE };
 
+cvar_t	r_vignette = { "r_vignette", "0", CVAR_ARCHIVE };
+cvar_t	r_vignette_radius = { "r_vignette_radius", "0.75", CVAR_ARCHIVE };
+cvar_t	r_vignette_softness = { "r_vignette_softness", "0.45", CVAR_ARCHIVE };
+cvar_t	r_chromatic_aberration = { "r_chromatic_aberration", "0", CVAR_ARCHIVE };
 
 cvar_t	r_overbrightbits = { "r_overbrightbits", "1", CVAR_ARCHIVE };
 
@@ -743,6 +747,11 @@ void GL_PostProcess (void)
         GL_Uniform3fFunc (5, bloom_intensity, exposure, tonemap_enabled);
         GL_Uniform4fFunc (6, motion_enabled ? 1.f : 0.f, motion_effective_shutter, motion_min_velocity, motion_depth_threshold);
         GL_Uniform4fFunc (7, motion_max_radius, (float)motion_max_samples, velocity_texture ? 1.f : 0.f, 0.f);
+        GL_Uniform4fFunc (8,
+                q_max (0.f, r_vignette.value),
+                q_max (0.f, r_vignette_radius.value),
+                q_max (0.f, r_vignette_softness.value),
+                q_max (0.f, r_chromatic_aberration.value));
 
         dof_enabled = R_DoFEnabled ();
 

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -67,6 +67,10 @@ extern cvar_t r_tonemap;
 extern cvar_t r_tonemap_exposure;
 extern cvar_t r_bloom;
 extern cvar_t r_bloom_threshold;
+extern cvar_t r_vignette;
+extern cvar_t r_vignette_radius;
+extern cvar_t r_vignette_softness;
+extern cvar_t r_chromatic_aberration;
 
 #if defined(USE_SIMD)
 extern cvar_t r_simd;
@@ -357,6 +361,10 @@ void R_Init (void)
 	Cvar_RegisterVariable (&r_tonemap_exposure);
 	Cvar_RegisterVariable (&r_bloom);
 	Cvar_RegisterVariable (&r_bloom_threshold);
+	Cvar_RegisterVariable (&r_vignette);
+	Cvar_RegisterVariable (&r_vignette_radius);
+	Cvar_RegisterVariable (&r_vignette_softness);
+	Cvar_RegisterVariable (&r_chromatic_aberration);
 	Cvar_RegisterVariable (&r_overbrightbits);
 	Cvar_SetCallback (&r_overbrightbits, R_OverbrightBits_f);
 

--- a/Quake/shaders/postprocess.frag
+++ b/Quake/shaders/postprocess.frag
@@ -86,6 +86,7 @@ layout(location=4) uniform vec4 DepthParams; // xy: inverse view scale, zw: unus
 layout(location=5) uniform vec3 HDRParams; // x: bloom intensity, y: exposure, z: tonemap enabled
 layout(location=6) uniform vec4 MotionParams0; // x: enabled, y: shutter strength, z: min velocity (pixels), w: depth threshold ratio
 layout(location=7) uniform vec4 MotionParams1; // x: max blur radius (pixels), y: max samples, z: velocity texture available, w: reserved
+layout(location=8) uniform vec4 PostFXParams0; // x: vignette strength, y: vignette radius, z: vignette softness, w: chromatic aberration (pixels)
 
 const int MOTION_MAX_SAMPLES = 64;
 const float OPAQUE_ALPHA_THRESHOLD = 0.999;
@@ -298,10 +299,55 @@ void main()
                         color.rgb = accum / weight;
                 }
         }
+
+        if (inView)
+        {
+                vec2 viewUV = clamp((uv - viewMin) / viewSize, vec2(0.0), vec2(1.0));
+                float aspect = texSize.y > 0.0 ? texSize.x / texSize.y : 1.0;
+
+                float vignetteStrength = max(PostFXParams0.x, 0.0);
+                float vignetteRadius = max(PostFXParams0.y, 1e-3);
+                float vignetteSoftness = clamp(PostFXParams0.z, 1e-3, 1.0);
+                if (vignetteStrength > 0.0)
+                {
+                        vec2 vignetteCoord = viewUV * 2.0 - vec2(1.0);
+                        vignetteCoord.x *= aspect;
+                        float dist = length(vignetteCoord);
+                        float inner = vignetteRadius * (1.0 - vignetteSoftness);
+                        float outer = max(vignetteRadius, inner + 1e-3);
+                        float vignette = smoothstep(inner, outer, dist);
+                        float weight = min(vignetteStrength, 1.0);
+                        float factor = mix(1.0, 1.0 - vignette, weight);
+                        if (vignetteStrength > 1.0)
+                                factor *= pow(max(1.0 - vignette, 1e-3), vignetteStrength - 1.0);
+                        color.rgb *= factor;
+                }
+
+                float chromaticAmount = max(PostFXParams0.w, 0.0);
+                if (chromaticAmount > 0.0)
+                {
+                        vec2 dir = viewUV - vec2(0.5);
+                        float lenDir = length(dir);
+                        if (lenDir > 1e-4)
+                        {
+                                vec2 normDir = dir / lenDir;
+                                vec2 offsetPx = normDir * (chromaticAmount * lenDir);
+                                vec2 offsetUV = offsetPx * invTexSize;
+                                vec2 uvR = clamp(uv + offsetUV, viewMin, viewMax);
+                                vec2 uvB = clamp(uv - offsetUV, viewMin, viewMax);
+                                vec3 aberrated = color.rgb;
+                                aberrated.r = texture(GammaTexture, uvR).r;
+                                aberrated.b = texture(GammaTexture, uvB).b;
+                                float blend = clamp(chromaticAmount * lenDir, 0.0, 1.0);
+                                color.rgb = mix(color.rgb, aberrated, blend);
+                        }
+                }
+        }
+
         out_fragcolor = color;
 #if PALETTIZE == 1
-		vec2 noiseuv = floor(gl_FragCoord.xy * scale) + 0.5;
-		out_fragcolor.rgb = sqrt(out_fragcolor.rgb);
+                vec2 noiseuv = floor(gl_FragCoord.xy * scale) + 0.5;
+                out_fragcolor.rgb = sqrt(out_fragcolor.rgb);
 	out_fragcolor.rgb += DITHER_NOISE(noiseuv) * dither;
 	out_fragcolor.rgb *= out_fragcolor.rgb;
 #endif // PALETTIZE == 1


### PR DESCRIPTION
## Summary
- add new cvars to control vignette and chromatic aberration post-processing parameters
- extend the postprocess shader to apply vignette darkening and chromatic channel offsets using the new uniform
- pass the configured values from the renderer when running the post-process pass

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f026aa464c832e9561249bbbef2699