### PR TITLE
Enhance vignette configuration

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -210,15 +210,20 @@ cvar_t	r_motionblur_maxsamples = { "r_motionblur_maxsamples", "16", CVAR_ARCHIVE
 cvar_t	r_motionblur_minvelocity = { "r_motionblur_minvelocity", "0.0", CVAR_ARCHIVE };
 cvar_t	r_motionblur_depththreshold = { "r_motionblur_depththreshold", "0.1", CVAR_ARCHIVE };
 
-
 cvar_t	r_tonemap = { "r_tonemap", "1", CVAR_ARCHIVE };
 cvar_t	r_tonemap_exposure = { "r_tonemap_exposure", "1.0", CVAR_ARCHIVE };
 cvar_t	r_bloom = { "r_bloom", "0.04", CVAR_ARCHIVE };
 cvar_t	r_bloom_threshold = { "r_bloom_threshold", "1.0", CVAR_ARCHIVE };
 
-cvar_t	r_vignette = { "r_vignette", "0", CVAR_ARCHIVE };
-cvar_t	r_vignette_radius = { "r_vignette_radius", "0.75", CVAR_ARCHIVE };
-cvar_t	r_vignette_softness = { "r_vignette_softness", "0.45", CVAR_ARCHIVE };
+cvar_t	r_vignette = { "r_vignette", "0.75", CVAR_ARCHIVE };
+cvar_t	r_vignette_radius_inner = { "r_vignette_radius_inner", "0.3", CVAR_ARCHIVE };
+cvar_t	r_vignette_radius_outer = { "r_vignette_radius_outer", "0.8", CVAR_ARCHIVE };
+cvar_t	r_vignette_falloff = { "r_vignette_falloff", "2.0", CVAR_ARCHIVE };
+cvar_t	r_vignette_color_r = { "r_vignette_color_r", "0.0", CVAR_ARCHIVE };
+cvar_t	r_vignette_color_g = { "r_vignette_color_g", "0.0", CVAR_ARCHIVE };
+cvar_t	r_vignette_color_b = { "r_vignette_color_b", "0.0", CVAR_ARCHIVE };
+cvar_t	r_vignette_blend_mode = { "r_vignette_blend_mode", "0", CVAR_ARCHIVE };
+cvar_t	r_vignette_noise = { "r_vignette_noise", "0.0", CVAR_ARCHIVE };
 cvar_t	r_chromatic_aberration = { "r_chromatic_aberration", "0", CVAR_ARCHIVE };
 
 cvar_t	r_overbrightbits = { "r_overbrightbits", "1", CVAR_ARCHIVE };
@@ -748,10 +753,20 @@ void GL_PostProcess (void)
         GL_Uniform4fFunc (6, motion_enabled ? 1.f : 0.f, motion_effective_shutter, motion_min_velocity, motion_depth_threshold);
         GL_Uniform4fFunc (7, motion_max_radius, (float)motion_max_samples, velocity_texture ? 1.f : 0.f, 0.f);
         GL_Uniform4fFunc (8,
-                q_max (0.f, r_vignette.value),
-                q_max (0.f, r_vignette_radius.value),
-                q_max (0.f, r_vignette_softness.value),
-                q_max (0.f, r_chromatic_aberration.value));
+                q_min (1.f, q_max (0.f, r_vignette.value)),
+                q_max (0.f, r_vignette_radius_inner.value),
+                q_max (0.f, r_vignette_radius_outer.value),
+                q_max (0.001f, r_vignette_falloff.value));
+        GL_Uniform4fFunc (9,
+                q_min (1.f, q_max (0.f, r_vignette_color_r.value)),
+                q_min (1.f, q_max (0.f, r_vignette_color_g.value)),
+                q_min (1.f, q_max (0.f, r_vignette_color_b.value)),
+                q_min (2.f, q_max (0.f, r_vignette_blend_mode.value)));
+        GL_Uniform4fFunc (10,
+                q_min (0.1f, q_max (0.f, r_vignette_noise.value)),
+                q_max (0.f, r_chromatic_aberration.value),
+                0.f,
+                0.f);
 
         dof_enabled = R_DoFEnabled ();
 

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -68,8 +68,14 @@ extern cvar_t r_tonemap_exposure;
 extern cvar_t r_bloom;
 extern cvar_t r_bloom_threshold;
 extern cvar_t r_vignette;
-extern cvar_t r_vignette_radius;
-extern cvar_t r_vignette_softness;
+extern cvar_t r_vignette_radius_inner;
+extern cvar_t r_vignette_radius_outer;
+extern cvar_t r_vignette_falloff;
+extern cvar_t r_vignette_color_r;
+extern cvar_t r_vignette_color_g;
+extern cvar_t r_vignette_color_b;
+extern cvar_t r_vignette_blend_mode;
+extern cvar_t r_vignette_noise;
 extern cvar_t r_chromatic_aberration;
 
 #if defined(USE_SIMD)
@@ -362,8 +368,14 @@ void R_Init (void)
 	Cvar_RegisterVariable (&r_bloom);
 	Cvar_RegisterVariable (&r_bloom_threshold);
 	Cvar_RegisterVariable (&r_vignette);
-	Cvar_RegisterVariable (&r_vignette_radius);
-	Cvar_RegisterVariable (&r_vignette_softness);
+	Cvar_RegisterVariable (&r_vignette_radius_inner);
+	Cvar_RegisterVariable (&r_vignette_radius_outer);
+	Cvar_RegisterVariable (&r_vignette_falloff);
+	Cvar_RegisterVariable (&r_vignette_color_r);
+	Cvar_RegisterVariable (&r_vignette_color_g);
+	Cvar_RegisterVariable (&r_vignette_color_b);
+	Cvar_RegisterVariable (&r_vignette_blend_mode);
+	Cvar_RegisterVariable (&r_vignette_noise);
 	Cvar_RegisterVariable (&r_chromatic_aberration);
 	Cvar_RegisterVariable (&r_overbrightbits);
 	Cvar_SetCallback (&r_overbrightbits, R_OverbrightBits_f);

--- a/Quake/shaders/postprocess.frag
+++ b/Quake/shaders/postprocess.frag
@@ -86,7 +86,9 @@ layout(location=4) uniform vec4 DepthParams; // xy: inverse view scale, zw: unus
 layout(location=5) uniform vec3 HDRParams; // x: bloom intensity, y: exposure, z: tonemap enabled
 layout(location=6) uniform vec4 MotionParams0; // x: enabled, y: shutter strength, z: min velocity (pixels), w: depth threshold ratio
 layout(location=7) uniform vec4 MotionParams1; // x: max blur radius (pixels), y: max samples, z: velocity texture available, w: reserved
-layout(location=8) uniform vec4 PostFXParams0; // x: vignette strength, y: vignette radius, z: vignette softness, w: chromatic aberration (pixels)
+layout(location=8) uniform vec4 PostFXParams0; // x: vignette strength, y: inner radius, z: outer radius, w: falloff
+layout(location=9) uniform vec4 PostFXParams1; // xyz: vignette color, w: blend mode
+layout(location=10) uniform vec4 PostFXParams2; // x: vignette noise amount, y: chromatic aberration (pixels), zw: reserved
 
 const int MOTION_MAX_SAMPLES = 64;
 const float OPAQUE_ALPHA_THRESHOLD = 0.999;
@@ -305,25 +307,51 @@ void main()
                 vec2 viewUV = clamp((uv - viewMin) / viewSize, vec2(0.0), vec2(1.0));
                 float aspect = texSize.y > 0.0 ? texSize.x / texSize.y : 1.0;
 
-                float vignetteStrength = max(PostFXParams0.x, 0.0);
-                float vignetteRadius = max(PostFXParams0.y, 1e-3);
-                float vignetteSoftness = clamp(PostFXParams0.z, 1e-3, 1.0);
-                if (vignetteStrength > 0.0)
+                float vignetteStrength = clamp(PostFXParams0.x, 0.0, 1.0);
+                float vignetteInner = max(PostFXParams0.y, 0.0);
+                float vignetteOuter = max(PostFXParams0.z, vignetteInner + 1e-3);
+                float vignetteFalloff = max(PostFXParams0.w, 1e-3);
+                vec3 vignetteColor = clamp(PostFXParams1.xyz, vec3(0.0), vec3(1.0));
+                int vignetteBlendMode = clamp(int(PostFXParams1.w + 0.5), 0, 2);
+                float vignetteNoise = clamp(PostFXParams2.x, 0.0, 0.1);
+                if (vignetteStrength > 0.0 && vignetteOuter > vignetteInner)
                 {
                         vec2 vignetteCoord = viewUV * 2.0 - vec2(1.0);
                         vignetteCoord.x *= aspect;
                         float dist = length(vignetteCoord);
-                        float inner = vignetteRadius * (1.0 - vignetteSoftness);
-                        float outer = max(vignetteRadius, inner + 1e-3);
-                        float vignette = smoothstep(inner, outer, dist);
-                        float weight = min(vignetteStrength, 1.0);
-                        float factor = mix(1.0, 1.0 - vignette, weight);
-                        if (vignetteStrength > 1.0)
-                                factor *= pow(max(1.0 - vignette, 1e-3), vignetteStrength - 1.0);
-                        color.rgb *= factor;
+                        float range = max(vignetteOuter - vignetteInner, 1e-3);
+                        float fade = clamp((dist - vignetteInner) / range, 0.0, 1.0);
+                        if (vignetteNoise > 0.0)
+                        {
+                                float noise = whitenoise(gl_FragCoord.xy);
+                                fade = clamp(fade + noise * vignetteNoise * fade, 0.0, 1.0);
+                        }
+                        float vignette = pow(fade, vignetteFalloff);
+                        float intensity = min(vignette * vignetteStrength, 1.0);
+                        if (intensity > 0.0)
+                        {
+                                if (vignetteBlendMode == 1)
+                                {
+                                        vec3 overlayColor = vignetteColor;
+                                        vec3 overlayDark = 2.0 * color.rgb * overlayColor;
+                                        vec3 overlayLight = 1.0 - 2.0 * (1.0 - color.rgb) * (1.0 - overlayColor);
+                                        vec3 overlayResult = mix(overlayDark, overlayLight, step(0.5, color.rgb));
+                                        overlayResult = clamp(overlayResult, vec3(0.0), vec3(1.0));
+                                        color.rgb = mix(color.rgb, overlayResult, intensity);
+                                }
+                                else if (vignetteBlendMode == 2)
+                                {
+                                        color.rgb = clamp(color.rgb + vignetteColor * intensity, vec3(0.0), vec3(1.0));
+                                }
+                                else
+                                {
+                                        vec3 multiplier = mix(vec3(1.0), vignetteColor, intensity);
+                                        color.rgb *= multiplier;
+                                }
+                        }
                 }
 
-                float chromaticAmount = max(PostFXParams0.w, 0.0);
+                float chromaticAmount = max(PostFXParams2.y, 0.0);
                 if (chromaticAmount > 0.0)
                 {
                         vec2 dir = viewUV - vec2(0.5);


### PR DESCRIPTION
## Summary
- add new cvars for vignette radius, falloff, tint, blend mode, and noise so the effect can be tuned from the console
- update the post-process shader to honor the new controls, support multiple blend modes, and drive chromatic aberration from a dedicated uniform block

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f0e73c41b4832ebc79446c7691afa4