### PR TITLE
Add stencil shadow rendering for alias models

### DIFF
--- a/Quake/gl_rlight.c
+++ b/Quake/gl_rlight.c
@@ -334,16 +334,25 @@ loc0:
 				continue;
 			}
 
-			if (dist < *maxdist)
-			{
-				cache->surfidx = surf - cl.worldmodel->surfaces + 1;
-				cache->ds = ds;
-				cache->dt = dt;
-			}
-			else
-			{
-				cache->surfidx = -1;
-			}
+				if (dist < *maxdist)
+				{
+					cache->surfidx = surf - cl.worldmodel->surfaces + 1;
+					cache->ds = ds;
+					cache->dt = dt;
+					VectorCopy (surf->plane->normal, cache->normal);
+					cache->plane_dist = surf->plane->dist;
+					if (surf->flags & SURF_PLANEBACK)
+					{
+						VectorScale (cache->normal, -1.f, cache->normal);
+						cache->plane_dist = -cache->plane_dist;
+					}
+				}
+				else
+				{
+					cache->surfidx = -1;
+					cache->plane_dist = 0.f;
+					VectorClear (cache->normal);
+				}
 
 			return true; // success
 		}
@@ -385,6 +394,8 @@ int R_LightPoint (vec3_t p, float ofs, lightcache_t *cache)
 		|| fabsf (cache->pos[2] - p[2]) >= 1.f)
 	{
 		cache->surfidx = 0;
+		cache->plane_dist = 0.f;
+		VectorClear (cache->normal);
 		VectorCopy (p, cache->pos);
 		RecursiveLightPoint (cache, cl.worldmodel->nodes, start, start, end, &maxdist);
 	}

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -255,6 +255,7 @@ cvar_t	r_lerpmodels = { "r_lerpmodels", "1", CVAR_ARCHIVE };
 cvar_t	r_lerpmove = { "r_lerpmove", "1", CVAR_ARCHIVE };
 cvar_t	r_nolerp_list = { "r_nolerp_list", "progs/flame.mdl,progs/flame2.mdl,progs/braztall.mdl,progs/brazshrt.mdl,progs/longtrch.mdl,progs/flame_pyre.mdl,progs/v_saw.mdl,progs/v_xfist.mdl,progs/h2stuff/newfire.mdl", CVAR_NONE };
 cvar_t	r_noshadow_list = { "r_noshadow_list", "progs/flame2.mdl,progs/flame.mdl,progs/bolt1.mdl,progs/bolt2.mdl,progs/bolt3.mdl,progs/laser.mdl", CVAR_NONE };
+cvar_t	r_shadows = { "r_shadows", "0", CVAR_ARCHIVE };
 
 extern cvar_t	r_vfog;
 extern cvar_t	vid_fsaa;

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -414,6 +414,7 @@ void R_Init (void)
 	Cvar_RegisterVariable (&r_nolerp_list);
 	Cvar_SetCallback (&r_nolerp_list, R_Model_ExtraFlags_List_f);
 	Cvar_RegisterVariable (&r_noshadow_list);
+	Cvar_RegisterVariable (&r_shadows);
 	Cvar_SetCallback (&r_noshadow_list, R_Model_ExtraFlags_List_f);
 	//johnfitz
 

--- a/Quake/gl_shaders.c
+++ b/Quake/gl_shaders.c
@@ -546,6 +546,9 @@ void GL_CreateShaders (void)
                                         glprogs.alias[oit][mode][alphatest][md5] =
                                                 GL_CreateProgram (GLSL_PATH("alias.vert"), GLSL_PATH("alias.frag"), "alias|OIT %d; MODE %d; ALPHATEST %d; MD5 %d", oit, mode, alphatest, md5);
 
+        for (md5 = 0; md5 < 2; md5++)
+                glprogs.alias_shadow[md5] = GL_CreateProgram (GLSL_PATH("alias_shadow.vert"), GLSL_PATH("alias_shadow.frag"), "alias shadow|MD5 %d", md5);
+
         glprogs.debug3d = GL_CreateProgram (GLSL_PATH("debug3d.vert"), GLSL_PATH("debug3d.frag"), "debug3d");
 
         glprogs.clear_indirect = GL_CreateComputeProgram (GLSL_PATH("clear_indirect.comp"), "clear indirect draw params");

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -546,6 +546,7 @@ typedef struct glprogs_s {
 	GLuint		skycubemap[2][2];	// [anim][dither]
 	GLuint		skyboxside[2];		// [dither]
 	GLuint		alias[2][3][2][2];	// [OIT][mode:standard/dithered/noperspective][alpha test][md5]
+	GLuint		alias_shadow[2];		// [md5]
 	GLuint		sprites[2];			// [dither]
 	GLuint		particles[2][2];	// [OIT][dither]
 	GLuint		debug3d;

--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -27,6 +27,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 extern cvar_t gl_overbright_models, gl_fullbrights, r_lerpmodels, r_lerpmove; //johnfitz
 extern cvar_t scr_fov, cl_gun_fovscale, cl_gun_x, cl_gun_y, cl_gun_z;
 extern cvar_t r_oit;
+extern cvar_t r_shadows;
 
 //up to 16 color translated skins
 gltexture_t *playertextures[MAX_SCOREBOARD]; //johnfitz -- changed to an array of pointers
@@ -80,6 +81,7 @@ struct ibuf_s {
 	} global;
 	aliasinstance_t inst[MAX_ALIAS_INSTANCES];
 } ibuf;
+static struct ibuf_s shadowbuf;
 
 /*
 =================
@@ -454,6 +456,210 @@ void R_FlushAliasInstances (qboolean showtris)
 	GL_EndGroup();
 }
 
+
+static void R_FlushAliasShadowInstances (void)
+{
+        qmodel_t        *model;
+        aliashdr_t      *mainhdr, *hdr;
+        qboolean        md5;
+        GLuint          buf;
+        GLbyte          *ofs;
+        size_t          ibuf_size;
+        GLuint          buffers[2];
+        GLintptr        offsets[2];
+        GLsizeiptr      sizes[2];
+        unsigned        state;
+
+        if (!shadowbuf.count)
+                return;
+
+        model = shadowbuf.ent->model;
+        mainhdr = (aliashdr_t *) Mod_Extradata (model);
+        md5 = mainhdr->poseverttype == PV_IQM;
+
+        GL_BeginGroup ("Alias shadows");
+
+        GL_UseProgram (glprogs.alias_shadow[md5]);
+
+        state = GLS_NO_ZWRITE | GLS_BLEND_ALPHA | GLS_CULL_NONE;
+        state |= GLS_ATTRIBS (md5 ? 5 : 1);
+        GL_SetState (state);
+
+        memcpy (shadowbuf.global.matviewproj, r_matviewproj, sizeof (r_matviewproj));
+        memcpy (shadowbuf.global.prev_matviewproj, r_framedata.prev_viewproj, sizeof (r_framedata.prev_viewproj));
+        memcpy (shadowbuf.global.eyepos, r_refdef.vieworg, sizeof (r_refdef.vieworg));
+        memcpy (shadowbuf.global.fog, r_framedata.fogdata, sizeof (shadowbuf.global.fog));
+        shadowbuf.global.dither = r_framedata.screendither;
+
+        ibuf_size = sizeof (shadowbuf.global) + sizeof (shadowbuf.inst[0]) * shadowbuf.count;
+        GL_Upload (GL_SHADER_STORAGE_BUFFER, &shadowbuf.global, ibuf_size, &buf, &ofs);
+
+        buffers[0] = buf;
+        offsets[0] = (GLintptr) ofs;
+        sizes[0] = ibuf_size;
+
+        GL_BindBuffer (GL_ARRAY_BUFFER, model->meshvbo);
+        GL_BindBuffer (GL_ELEMENT_ARRAY_BUFFER, model->meshindexesvbo);
+
+        for (hdr = mainhdr; hdr; hdr = hdr->nextsurface ? (aliashdr_t *) ((byte *) hdr + hdr->nextsurface) : NULL)
+        {
+                if (md5)
+                {
+                        GL_VertexAttribPointerFunc  (0, 3, GL_FLOAT,                    GL_FALSE, sizeof (iqmvert_t), (void *) (hdr->vbovertofs + offsetof (iqmvert_t, xyz)));
+                        GL_VertexAttribPointerFunc  (1, 4, GL_BYTE,                             GL_TRUE,  sizeof (iqmvert_t), (void *) (hdr->vbovertofs + offsetof (iqmvert_t, norm)));
+                        GL_VertexAttribPointerFunc  (2, 2, GL_FLOAT,                    GL_FALSE, sizeof (iqmvert_t), (void *) (hdr->vbovertofs + offsetof (iqmvert_t, st)));
+                        GL_VertexAttribPointerFunc  (3, 4, GL_UNSIGNED_BYTE,    GL_TRUE,  sizeof (iqmvert_t), (void *) (hdr->vbovertofs + offsetof (iqmvert_t, weight)));
+                        GL_VertexAttribIPointerFunc (4, 4, GL_UNSIGNED_BYTE,              sizeof (iqmvert_t), (void *) (hdr->vbovertofs + offsetof (iqmvert_t, idx)));
+
+                        buffers[1] = model->meshvbo;
+                        offsets[1] = hdr->vboposeofs;
+                        sizes[1] = sizeof (bonepose_t) * hdr->numbones * hdr->numboneposes;
+                }
+                else
+                {
+                        GL_VertexAttribPointerFunc (0, 2, GL_FLOAT, GL_FALSE, sizeof (meshst_t), (void *) hdr->vbostofs);
+
+                        buffers[1] = model->meshvbo;
+                        offsets[1] = hdr->vbovertofs;
+                        sizes[1] = sizeof (meshxyz_t) * hdr->numverts_vbo * hdr->numposes;
+                }
+
+                GL_BindBuffersRange (GL_SHADER_STORAGE_BUFFER, 1, 2, buffers, offsets, sizes);
+
+                GL_DrawElementsInstancedFunc (GL_TRIANGLES, hdr->numindexes, GL_UNSIGNED_SHORT, (void *) hdr->eboofs, shadowbuf.count);
+
+                rs_aliaspasses += hdr->numtris * shadowbuf.count;
+        }
+
+        shadowbuf.count = 0;
+
+        GL_EndGroup ();
+}
+
+static qboolean R_AliasShadow_CanAddToBatch (const entity_t *e)
+{
+        if (!shadowbuf.count)
+                return true;
+
+        if (shadowbuf.count == countof (shadowbuf.inst))
+                return false;
+
+        return shadowbuf.ent->model == e->model;
+}
+
+static void R_AddAliasShadowInstance (entity_t *e, aliashdr_t *paliashdr, const lerpdata_t *lerpdata, const float model_matrix[16], float entalpha)
+{
+        vec3_t          normal;
+        float           plane_dist;
+        vec4_t          plane;
+        vec4_t          light;
+        float           dot;
+        float           shadow_proj[16];
+        float           combined[16];
+        float           base_matrix[16];
+        float           height;
+        float           fade;
+        float           alpha;
+        aliasinstance_t *instance;
+
+        if (r_shadows.value <= 0.f)
+                return;
+
+        if (entalpha <= 0.f)
+                return;
+
+        if (e == &cl.viewent)
+                return;
+
+        if (!cl.worldmodel || e->model->flags & MOD_NOSHADOW)
+                return;
+
+        if (e->lightcache.surfidx <= 0)
+                return;
+
+        VectorCopy (e->lightcache.normal, normal);
+        if (DotProduct (normal, normal) < 1e-4f)
+                return;
+
+        plane_dist = e->lightcache.plane_dist;
+
+        plane[0] = normal[0];
+        plane[1] = normal[1];
+        plane[2] = normal[2];
+        plane[3] = -plane_dist;
+
+        light[0] = 0.f;
+        light[1] = 0.f;
+        light[2] = 1.f;
+        light[3] = 0.f;
+
+        dot = plane[0] * light[0] + plane[1] * light[1] + plane[2] * light[2] + plane[3] * light[3];
+        if (fabsf (dot) < 1e-5f)
+                return;
+
+        shadow_proj[0] = dot - light[0] * plane[0];
+        shadow_proj[4] = -light[0] * plane[1];
+        shadow_proj[8] = -light[0] * plane[2];
+        shadow_proj[12] = -light[0] * plane[3];
+
+        shadow_proj[1] = -light[1] * plane[0];
+        shadow_proj[5] = dot - light[1] * plane[1];
+        shadow_proj[9] = -light[1] * plane[2];
+        shadow_proj[13] = -light[1] * plane[3];
+
+        shadow_proj[2] = -light[2] * plane[0];
+        shadow_proj[6] = -light[2] * plane[1];
+        shadow_proj[10] = dot - light[2] * plane[2];
+        shadow_proj[14] = -light[2] * plane[3];
+
+        shadow_proj[3] = -light[3] * plane[0];
+        shadow_proj[7] = -light[3] * plane[1];
+        shadow_proj[11] = -light[3] * plane[2];
+        shadow_proj[15] = dot - light[3] * plane[3];
+
+        memcpy (combined, shadow_proj, sizeof (combined));
+        memcpy (base_matrix, model_matrix, sizeof (base_matrix));
+        MatrixMultiply (combined, base_matrix);
+        ApplyTranslation (combined, normal[0] * 0.05f, normal[1] * 0.05f, normal[2] * 0.05f);
+
+        height = DotProduct (lerpdata->origin, normal) - plane_dist;
+        fade = 1.f - CLAMP (0.f, fabsf (height) / 200.f, 1.f);
+        alpha = CLAMP (0.f, entalpha, 1.f) * 0.5f * fade;
+        if (alpha <= 0.f)
+                return;
+
+        if (!R_AliasShadow_CanAddToBatch (e))
+                R_FlushAliasShadowInstances ();
+
+        if (!shadowbuf.count)
+                shadowbuf.ent = e;
+
+        instance = &shadowbuf.inst[shadowbuf.count++];
+        instance->flags = ALIAS_INSTANCE_FLAG_NO_MOTION_BLUR;
+
+        MatrixTranspose4x3 (combined, instance->worldmatrix);
+        MatrixTranspose4x3 (combined, instance->prev_worldmatrix);
+
+        instance->lightcolor[0] = 0.f;
+        instance->lightcolor[1] = 0.f;
+        instance->lightcolor[2] = 0.f;
+        instance->alpha = alpha;
+        instance->pose1 = lerpdata->pose1;
+        instance->pose2 = lerpdata->pose2;
+        instance->blend = lerpdata->blend;
+
+        if (paliashdr->poseverttype == PV_QUAKE1)
+        {
+                instance->pose1 *= paliashdr->numverts_vbo;
+                instance->pose2 *= paliashdr->numverts_vbo;
+        }
+        else
+        {
+                instance->pose1 *= paliashdr->numbones;
+                instance->pose2 *= paliashdr->numbones;
+        }
+}
+
 /*
 =================
 R_Alias_CanAddToBatch
@@ -561,7 +767,10 @@ static void R_DrawAliasModel_Real (entity_t *e, qboolean showtris)
 		entalpha = 1.f;
 
 	if (!R_Alias_CanAddToBatch (e))
+	{
+		R_FlushAliasShadowInstances ();
 		R_FlushAliasInstances (showtris);
+	}
 
 	if (!ibuf.count)
 		ibuf.ent = e;
@@ -618,6 +827,9 @@ static void R_DrawAliasModel_Real (entity_t *e, qboolean showtris)
 	instance->pose2 = lerpdata.pose2;
 	instance->blend = lerpdata.blend;
 
+	if (!showtris)
+		R_AddAliasShadowInstance (e, paliashdr, &lerpdata, model_matrix, entalpha);
+
 	if (paliashdr->poseverttype == PV_QUAKE1)
 	{
 		instance->pose1 *= paliashdr->numverts_vbo;
@@ -640,7 +852,8 @@ void R_DrawAliasModels (entity_t **ents, int count)
         int i;
         for (i = 0; i < count; i++)
                 R_DrawAliasModel_Real (ents[i], false);
-        R_FlushAliasInstances (false);
+        R_FlushAliasShadowInstances ();
+	R_FlushAliasInstances (false);
 }
 
 /*
@@ -653,5 +866,6 @@ void R_DrawAliasModels_ShowTris (entity_t **ents, int count)
         int i;
         for (i = 0; i < count; i++)
                 R_DrawAliasModel_Real (ents[i], true);
-        R_FlushAliasInstances (true);
+        R_FlushAliasShadowInstances ();
+	R_FlushAliasInstances (true);
 }

--- a/Quake/render.h
+++ b/Quake/render.h
@@ -37,6 +37,8 @@ typedef struct lightcache_s {
 	vec3_t				pos;
 	short				ds;
 	short				dt;
+	vec3_t				normal;
+	float				plane_dist;
 } lightcache_t;
 
 //johnfitz -- for lerping

--- a/Quake/shaders/alias_shadow.frag
+++ b/Quake/shaders/alias_shadow.frag
@@ -1,0 +1,26 @@
+#include "frame_uniforms.glsl"
+
+layout(location=0) in vec4 in_color;
+layout(location=1) in vec3 in_pos;
+
+layout(location=0) out vec4 out_fragcolor;
+
+float ScreenNoise(vec2 p)
+{
+        const vec2 k = vec2(12.9898, 78.233);
+        return fract(sin(dot(p, k)) * 43758.5453);
+}
+
+void main()
+{
+        float fog = exp2(abs(Fog.w) * -dot(in_pos, in_pos));
+        fog = clamp(fog, 0.0, 1.0);
+
+        vec3 base = mix(Fog.rgb, in_color.rgb, fog);
+        float alpha = in_color.a * fog;
+
+        float noise = ScreenNoise(gl_FragCoord.xy);
+        base += (noise - 0.5) * ScreenDither;
+
+        out_fragcolor = clamp(vec4(base, alpha), 0.0, 1.0);
+}

--- a/Quake/shaders/alias_shadow.vert
+++ b/Quake/shaders/alias_shadow.vert
@@ -1,0 +1,83 @@
+#include "frame_uniforms.glsl"
+
+struct InstanceData
+{
+        vec4    WorldMatrix[3];
+        vec4    PrevWorldMatrix[3];
+        vec4    LightColor; // xyz=color, w=alpha
+        int     Pose1;
+        int     Pose2;
+        float   Blend;
+        int     Flags;
+};
+
+layout(std430, binding=1) restrict readonly buffer InstanceBuffer
+{
+        mat4    ViewProj;
+        mat4    PrevViewProj;
+        vec3    EyePos;
+        float   _Pad0;
+        vec4    Fog;
+        float   ScreenDither;
+        float   _Pad1;
+        float   _Pad2;
+        float   _Pad3;
+        InstanceData instances[];
+};
+
+#if MD5
+layout(location=0) in vec3 in_pos;
+layout(location=1) in vec4 in_nor;
+layout(location=2) in vec2 in_uv;
+layout(location=3) in vec4 in_weights;
+layout(location=4) in ivec4 in_indices;
+
+layout(std430, binding=2) restrict readonly buffer PoseBuffer
+{
+        mat3x4 BonePoses[];
+};
+
+vec3 GetPosePosition(uint pose)
+{
+        mat3x4 blendmat = BonePoses[pose + in_indices.x] * in_weights.x;
+        blendmat += BonePoses[pose + in_indices.y] * in_weights.y;
+        if (in_weights.z + in_weights.w > 0.0)
+        {
+                blendmat += BonePoses[pose + in_indices.z] * in_weights.z;
+                blendmat += BonePoses[pose + in_indices.w] * in_weights.w;
+        }
+        mat4x3 anim = transpose(blendmat);
+        return (anim * vec4(in_pos, 1.0)).xyz;
+}
+#else
+layout(location=0) in vec2 in_uv;
+
+layout(std430, binding=2) restrict readonly buffer BlendShapeBuffer
+{
+        uvec2 PackedPosNor[];
+};
+
+vec3 GetPosePosition(uint pose)
+{
+        uvec2 data = PackedPosNor[pose + gl_VertexID];
+        return vec3((data.xxx >> uvec3(0, 8, 16)) & 255u);
+}
+#endif
+
+layout(location=0) out vec4 out_color;
+layout(location=1) out vec3 out_pos;
+
+void main()
+{
+        InstanceData inst = instances[gl_InstanceID];
+        vec3 pos1 = GetPosePosition(inst.Pose1);
+        vec3 pos2 = GetPosePosition(inst.Pose2);
+        vec3 local_pos = mix(pos1, pos2, inst.Blend);
+
+        mat4x3 world = transpose(mat3x4(inst.WorldMatrix[0], inst.WorldMatrix[1], inst.WorldMatrix[2]));
+        vec3 world_pos = (world * vec4(local_pos, 1.0)).xyz;
+
+        gl_Position = ViewProj * vec4(world_pos, 1.0);
+        out_color = inst.LightColor;
+        out_pos = world_pos - EyePos;
+}


### PR DESCRIPTION
## Summary
- add an `r_shadows` cvar and register it to control planar alias-model shadows
- extend the alias rendering pipeline with a shadow instance batch and dedicated shader pair
- cache per-light surface plane data so alias models can project shadows consistently

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f12890b914832e88143dc1a32cb346