### PR TITLE
Fix missing r_shadows declaration in GL misc

### DIFF
--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -47,6 +47,7 @@ extern cvar_t r_lerpmodels;
 extern cvar_t r_lerpmove;
 extern cvar_t r_nolerp_list;
 extern cvar_t r_noshadow_list;
+extern cvar_t r_shadows;
 //johnfitz
 extern cvar_t gl_zfix; // QuakeSpasm z-fighting fix
 extern cvar_t r_alphasort;


### PR DESCRIPTION
## Summary
- declare the r_shadows cvar in gl_rmisc.c so it can be registered during initialization

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f1338daa68832ea5d0c64f56f7fe28