### PR TITLE
Fix alias shadow vertex shader include

### DIFF
--- a/Quake/shaders/alias_shadow.vert
+++ b/Quake/shaders/alias_shadow.vert
@@ -1,5 +1,3 @@
-#include "frame_uniforms.glsl"
-
 struct InstanceData
 {
         vec4    WorldMatrix[3];


### PR DESCRIPTION
## Summary
- remove the frame_uniforms include from the alias shadow vertex shader to avoid redeclaring uniform buffer members that already exist in the instance buffer

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f13838aac0832e80a62e93b5a35411