### PR TITLE
Make stencil shadows render as solid silhouettes

### DIFF
--- a/Quake/shaders/alias_shadow.frag
+++ b/Quake/shaders/alias_shadow.frag
@@ -5,22 +5,13 @@ layout(location=1) in vec3 in_pos;
 
 layout(location=0) out vec4 out_fragcolor;
 
-float ScreenNoise(vec2 p)
-{
-        const vec2 k = vec2(12.9898, 78.233);
-        return fract(sin(dot(p, k)) * 43758.5453);
-}
-
 void main()
 {
         float fog = exp2(abs(Fog.w) * -dot(in_pos, in_pos));
         fog = clamp(fog, 0.0, 1.0);
 
         vec3 base = mix(Fog.rgb, in_color.rgb, fog);
-        float alpha = in_color.a * fog;
-
-        float noise = ScreenNoise(gl_FragCoord.xy);
-        base += (noise - 0.5) * ScreenDither;
+        float alpha = 0.25 * fog;
 
         out_fragcolor = clamp(vec4(base, alpha), 0.0, 1.0);
 }


### PR DESCRIPTION
## Summary
- remove per-pixel dithering noise from the alias shadow fragment shader
- render alias shadows with a fixed 25% opacity to create a solid silhouette

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f13b5fdce4832ea519d23fcb46d54a