### PR TITLE
Add soft shadow mapping for alias models

### DIFF
--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -61,6 +61,8 @@ typedef struct aliasinstance_s {
 	int32_t		pose2;
 	float		blend;
 	int32_t		flags;
+	float		shadow_plane[4];
+	float		shadow_params[4];
 } aliasinstance_t;
 
 #define ALIAS_INSTANCE_FLAG_NONE          0
@@ -553,121 +555,121 @@ static qboolean R_AliasShadow_CanAddToBatch (const entity_t *e)
 
 static void R_AddAliasShadowInstance (entity_t *e, aliashdr_t *paliashdr, const lerpdata_t *lerpdata, const float model_matrix[16], float entalpha)
 {
-        vec3_t          normal;
-        float           plane_dist;
-        vec4_t          plane;
-        vec4_t          light;
-        float           dot;
-        float           shadow_proj[16];
-        float           combined[16];
-        float           base_matrix[16];
-        float           height;
-        float           fade;
-        float           alpha;
-        aliasinstance_t *instance;
+	vec3_t		normal;
+	float		plane_dist;
+	vec4_t		plane;
+	float		height;
+	float		fade;
+	float		alpha;
+	aliasinstance_t *instance;
+	vec3_t		axis;
+	float		radius_scale;
+	float		softness;
 
-        if (r_shadows.value <= 0.f)
-                return;
+	if (r_shadows.value <= 0.f)
+		return;
 
-        if (entalpha <= 0.f)
-                return;
+	if (entalpha <= 0.f)
+		return;
 
-        if (e == &cl.viewent)
-                return;
+	if (e == &cl.viewent)
+		return;
 
-        if (!cl.worldmodel || e->model->flags & MOD_NOSHADOW)
-                return;
+	if (!cl.worldmodel || e->model->flags & MOD_NOSHADOW)
+		return;
 
-        if (e->lightcache.surfidx <= 0)
-                return;
+	if (e->lightcache.surfidx <= 0)
+		return;
 
-        VectorCopy (e->lightcache.normal, normal);
-        plane_dist = e->lightcache.plane_dist;
+	VectorCopy (e->lightcache.normal, normal);
+	plane_dist = e->lightcache.plane_dist;
 
-        {
-                float normal_len = VectorNormalize (normal);
+	{
+		float normal_len = VectorNormalize (normal);
 
-                if (normal_len < 1e-4f)
-                        return;
+		if (normal_len < 1e-4f)
+			return;
 
-                plane_dist /= normal_len;
-        }
+		plane_dist /= normal_len;
+	}
 
-        plane[0] = normal[0];
-        plane[1] = normal[1];
-        plane[2] = normal[2];
-        plane[3] = -plane_dist;
+	plane[0] = normal[0];
+	plane[1] = normal[1];
+	plane[2] = normal[2];
+	plane[3] = -plane_dist;
 
-        light[0] = 0.f;
-        light[1] = 0.f;
-        light[2] = 1.f;
-        light[3] = 0.f;
+	if (fabsf (plane[2]) < 1e-5f)
+		return;
 
-        dot = plane[0] * light[0] + plane[1] * light[1] + plane[2] * light[2] + plane[3] * light[3];
-        if (fabsf (dot) < 1e-5f)
-                return;
+	height = DotProduct (lerpdata->origin, normal) - plane_dist;
+	fade = 1.f - CLAMP (0.f, fabsf (height) / 200.f, 1.f);
+	alpha = CLAMP (0.f, entalpha, 1.f) * 0.5f * fade;
+	if (alpha <= 0.f)
+		return;
 
-        shadow_proj[0] = dot - light[0] * plane[0];
-        shadow_proj[4] = -light[0] * plane[1];
-        shadow_proj[8] = -light[0] * plane[2];
-        shadow_proj[12] = -light[0] * plane[3];
+	axis[0] = model_matrix[0];
+	axis[1] = model_matrix[1];
+	axis[2] = model_matrix[2];
+	float axis_x = VectorLength (axis);
+	axis[0] = model_matrix[4];
+	axis[1] = model_matrix[5];
+	axis[2] = model_matrix[6];
+	float axis_y = VectorLength (axis);
+	axis[0] = model_matrix[8];
+	axis[1] = model_matrix[9];
+	axis[2] = model_matrix[10];
+	float axis_z = VectorLength (axis);
+	radius_scale = q_max (axis_x, q_max (axis_y, axis_z));
+	if (radius_scale <= 0.f)
+		radius_scale = 1.f;
 
-        shadow_proj[1] = -light[1] * plane[0];
-        shadow_proj[5] = dot - light[1] * plane[1];
-        shadow_proj[9] = -light[1] * plane[2];
-        shadow_proj[13] = -light[1] * plane[3];
+	softness = 0.f;
+	if (r_shadows.value >= 2.f)
+	{
+		float world_radius = paliashdr->boundingradius * radius_scale;
+		if (world_radius <= 0.f)
+			world_radius = 1.f;
+		softness = 0.5f / world_radius;
+	}
 
-        shadow_proj[2] = -light[2] * plane[0];
-        shadow_proj[6] = -light[2] * plane[1];
-        shadow_proj[10] = dot - light[2] * plane[2];
-        shadow_proj[14] = -light[2] * plane[3];
+	if (!R_AliasShadow_CanAddToBatch (e))
+		R_FlushAliasShadowInstances ();
 
-        shadow_proj[3] = -light[3] * plane[0];
-        shadow_proj[7] = -light[3] * plane[1];
-        shadow_proj[11] = -light[3] * plane[2];
-        shadow_proj[15] = dot - light[3] * plane[3];
+	if (!shadowbuf.count)
+		shadowbuf.ent = e;
 
-        memcpy (combined, shadow_proj, sizeof (combined));
-        memcpy (base_matrix, model_matrix, sizeof (base_matrix));
-        MatrixMultiply (combined, base_matrix);
-        ApplyTranslation (combined, normal[0] * 0.05f, normal[1] * 0.05f, normal[2] * 0.05f);
+	instance = &shadowbuf.inst[shadowbuf.count++];
+	instance->flags = ALIAS_INSTANCE_FLAG_NO_MOTION_BLUR;
 
-        height = DotProduct (lerpdata->origin, normal) - plane_dist;
-        fade = 1.f - CLAMP (0.f, fabsf (height) / 200.f, 1.f);
-        alpha = CLAMP (0.f, entalpha, 1.f) * 0.5f * fade;
-        if (alpha <= 0.f)
-                return;
+	MatrixTranspose4x3 (model_matrix, instance->worldmatrix);
+	MatrixTranspose4x3 (model_matrix, instance->prev_worldmatrix);
 
-        if (!R_AliasShadow_CanAddToBatch (e))
-                R_FlushAliasShadowInstances ();
+	instance->lightcolor[0] = 0.f;
+	instance->lightcolor[1] = 0.f;
+	instance->lightcolor[2] = 0.f;
+	instance->alpha = alpha;
+	instance->pose1 = lerpdata->pose1;
+	instance->pose2 = lerpdata->pose2;
+	instance->blend = lerpdata->blend;
+	instance->shadow_plane[0] = plane[0];
+	instance->shadow_plane[1] = plane[1];
+	instance->shadow_plane[2] = plane[2];
+	instance->shadow_plane[3] = plane[3];
+	instance->shadow_params[0] = softness;
+	instance->shadow_params[1] = 0.05f;
+	instance->shadow_params[2] = 0.f;
+	instance->shadow_params[3] = 0.f;
 
-        if (!shadowbuf.count)
-                shadowbuf.ent = e;
-
-        instance = &shadowbuf.inst[shadowbuf.count++];
-        instance->flags = ALIAS_INSTANCE_FLAG_NO_MOTION_BLUR;
-
-        MatrixTranspose4x3 (combined, instance->worldmatrix);
-        MatrixTranspose4x3 (combined, instance->prev_worldmatrix);
-
-        instance->lightcolor[0] = 0.f;
-        instance->lightcolor[1] = 0.f;
-        instance->lightcolor[2] = 0.f;
-        instance->alpha = alpha;
-        instance->pose1 = lerpdata->pose1;
-        instance->pose2 = lerpdata->pose2;
-        instance->blend = lerpdata->blend;
-
-        if (paliashdr->poseverttype == PV_QUAKE1)
-        {
-                instance->pose1 *= paliashdr->numverts_vbo;
-                instance->pose2 *= paliashdr->numverts_vbo;
-        }
-        else
-        {
-                instance->pose1 *= paliashdr->numbones;
-                instance->pose2 *= paliashdr->numbones;
-        }
+	if (paliashdr->poseverttype == PV_QUAKE1)
+	{
+		instance->pose1 *= paliashdr->numverts_vbo;
+		instance->pose2 *= paliashdr->numverts_vbo;
+	}
+	else
+	{
+		instance->pose1 *= paliashdr->numbones;
+		instance->pose2 *= paliashdr->numbones;
+	}
 }
 
 /*
@@ -836,6 +838,8 @@ static void R_DrawAliasModel_Real (entity_t *e, qboolean showtris)
 	instance->pose1 = lerpdata.pose1;
 	instance->pose2 = lerpdata.pose2;
 	instance->blend = lerpdata.blend;
+	memset (instance->shadow_plane, 0, sizeof (instance->shadow_plane));
+	memset (instance->shadow_params, 0, sizeof (instance->shadow_params));
 
 	if (!showtris)
 		R_AddAliasShadowInstance (e, paliashdr, &lerpdata, model_matrix, entalpha);

--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -7,6 +7,8 @@ struct InstanceData
 	int		Pose2;
 	float	Blend;
 	int		Flags;
+	vec4	ShadowPlane;
+	vec4	ShadowParams;
 };
 
 layout(std430, binding=1) restrict readonly buffer InstanceBuffer

--- a/Quake/shaders/alias.vert
+++ b/Quake/shaders/alias.vert
@@ -7,6 +7,8 @@ struct InstanceData
 	int		Pose2;
 	float	Blend;
 	int		Flags;
+	vec4	ShadowPlane;
+	vec4	ShadowParams;
 };
 
 layout(std430, binding=1) restrict readonly buffer InstanceBuffer

--- a/Quake/shaders/alias_shadow.frag
+++ b/Quake/shaders/alias_shadow.frag
@@ -2,6 +2,8 @@
 
 layout(location=0) in vec4 in_color;
 layout(location=1) in vec3 in_pos;
+layout(location=2) in float in_height;
+layout(location=3) flat in float in_softness;
 
 layout(location=0) out vec4 out_fragcolor;
 
@@ -11,7 +13,17 @@ void main()
         fog = clamp(fog, 0.0, 1.0);
 
         vec3 base = mix(Fog.rgb, in_color.rgb, fog);
-        float alpha = 0.25 * fog;
+        float alpha = 0.5 * fog * in_color.a;
+        float softness = max(in_softness, 0.0);
+        float fade = 1.0;
+        if (softness > 0.0)
+        {
+                float h = max(in_height, 0.0);
+                fade = exp(-h * softness);
+        }
+
+        base *= fade;
+        alpha *= fade;
 
         out_fragcolor = clamp(vec4(base, alpha), 0.0, 1.0);
 }

--- a/Quake/shaders/alias_shadow.vert
+++ b/Quake/shaders/alias_shadow.vert
@@ -7,6 +7,8 @@ struct InstanceData
         int     Pose2;
         float   Blend;
         int     Flags;
+        vec4    ShadowPlane;
+        vec4    ShadowParams;
 };
 
 layout(std430, binding=1) restrict readonly buffer InstanceBuffer
@@ -64,6 +66,8 @@ vec3 GetPosePosition(uint pose)
 
 layout(location=0) out vec4 out_color;
 layout(location=1) out vec3 out_pos;
+layout(location=2) out float out_height;
+layout(location=3) flat out float out_softness;
 
 void main()
 {
@@ -75,7 +79,15 @@ void main()
         mat4x3 world = transpose(mat3x4(inst.WorldMatrix[0], inst.WorldMatrix[1], inst.WorldMatrix[2]));
         vec3 world_pos = (world * vec4(local_pos, 1.0)).xyz;
 
-        gl_Position = ViewProj * vec4(world_pos, 1.0);
+        vec3 plane_normal = inst.ShadowPlane.xyz;
+        float plane_offset = inst.ShadowPlane.w;
+        float height = dot(world_pos, plane_normal) + plane_offset;
+        vec3 projected = world_pos - vec3(0.0, 0.0, 1.0) * height;
+        projected += plane_normal * inst.ShadowParams.y;
+
+        gl_Position = ViewProj * vec4(projected, 1.0);
         out_color = inst.LightColor;
-        out_pos = world_pos - EyePos;
+        out_pos = projected - EyePos;
+        out_height = abs(height);
+        out_softness = inst.ShadowParams.x;
 }


### PR DESCRIPTION
## Summary
- store per-alias shadow plane data and compute a softness factor when `r_shadows` is set to 2
- update the alias shadow shaders to project geometry in-shader and apply an exponential fade for soft shadow edges
- keep existing hard shadows while enabling a new soft shadow option without affecting other alias rendering

## Testing
- ninja -C Linux *(fails: build.ninja missing)*

------
https://chatgpt.com/codex/tasks/task_e_68f1400ff4c0832eace3bdebaf2be166