### PR TITLE
Fix alias shadow projection on sloped planes

### DIFF
--- a/Quake/shaders/alias_shadow.vert
+++ b/Quake/shaders/alias_shadow.vert
@@ -82,7 +82,13 @@ void main()
         vec3 plane_normal = inst.ShadowPlane.xyz;
         float plane_offset = inst.ShadowPlane.w;
         float height = dot(world_pos, plane_normal) + plane_offset;
-        vec3 projected = world_pos - vec3(0.0, 0.0, 1.0) * height;
+        const vec3 light_dir = vec3(0.0, 0.0, 1.0);
+        float denom = dot(plane_normal, light_dir);
+        vec3 projected = world_pos;
+        if (abs(denom) > 1e-5)
+        {
+                projected -= light_dir * (height / denom);
+        }
         projected += plane_normal * inst.ShadowParams.y;
 
         gl_Position = ViewProj * vec4(projected, 1.0);


### PR DESCRIPTION
## Summary
- adjust alias shadow projection to account for the shadow plane's tilt
- avoid projecting shadows when the light direction would be parallel to the plane

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f147f5fd80832ebefe171bf8f276dc