### PR TITLE
Increase alias shadow opacity

### DIFF
--- a/Quake/shaders/alias_shadow.frag
+++ b/Quake/shaders/alias_shadow.frag
@@ -13,7 +13,7 @@ void main()
         fog = clamp(fog, 0.0, 1.0);
 
         vec3 base = mix(Fog.rgb, in_color.rgb, fog);
-        float alpha = 0.5 * fog * in_color.a;
+        float alpha = fog * in_color.a;
         float softness = max(in_softness, 0.0);
         float fade = 1.0;
         if (softness > 0.0)


### PR DESCRIPTION
## Summary
- increase the fragment output alpha for alias shadows so their projected silhouettes remain visible

## Testing
- not run (reason: renderer changes require in-game validation)

------
https://chatgpt.com/codex/tasks/task_e_68f148f71bb8832ea36360676e7ae366