### PR TITLE
Fix alias shadow bias so projected shadows render correctly

### DIFF
--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -655,10 +655,10 @@ static void R_AddAliasShadowInstance (entity_t *e, aliashdr_t *paliashdr, const 
 	instance->shadow_plane[1] = plane[1];
 	instance->shadow_plane[2] = plane[2];
 	instance->shadow_plane[3] = plane[3];
-	instance->shadow_params[0] = softness;
-	instance->shadow_params[1] = 0.05f;
-	instance->shadow_params[2] = 0.f;
-	instance->shadow_params[3] = 0.f;
+        instance->shadow_params[0] = softness;
+        instance->shadow_params[1] = 0.02f; // view-direction bias to keep the shadow above the receiver
+        instance->shadow_params[2] = 0.f;
+        instance->shadow_params[3] = 0.f;
 
 	if (paliashdr->poseverttype == PV_QUAKE1)
 	{

--- a/Quake/shaders/alias_shadow.vert
+++ b/Quake/shaders/alias_shadow.vert
@@ -89,7 +89,13 @@ void main()
         {
                 projected -= light_dir * (height / denom);
         }
-        projected += plane_normal * inst.ShadowParams.y;
+
+        vec3 view_dir = projected - EyePos;
+        float view_len = length(view_dir);
+        if (view_len > 0.0)
+        {
+                projected += (view_dir / view_len) * inst.ShadowParams.y;
+        }
 
         gl_Position = ViewProj * vec4(projected, 1.0);
         out_color = inst.LightColor;


### PR DESCRIPTION
## Summary
- bias alias shadow projection along the camera view direction so the polygons stay in front of the receiver
- slightly reduce the configurable bias distance used by the CPU side shadow parameters to match the new approach

## Testing
- not run (no automated tests provided)

------
https://chatgpt.com/codex/tasks/task_e_68f14ab010e4832e9f735235c67c0816