### PR TITLE
Add initial shadow manager scaffolding and CVars

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -1516,6 +1516,8 @@ void R_SetupView (void)
 {
 	R_AnimateLight ();
 
+	R_ShadowBeginFrame (r_framecount);
+
 	{
 		int overbright_bits = CLAMP (0, (int)Q_rint (r_overbrightbits.value), 3);
 		float overbright = (float)(1 << overbright_bits);
@@ -2609,6 +2611,8 @@ void R_RenderScene (void)
 	R_ShowBoundingBoxes (); //johnfitz
 
 	R_ShowPointFile ();
+
+	R_ShadowEndFrame ();
 }
 
 /*

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -23,6 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // r_misc.c
 
 #include "quakedef.h"
+#include "gl_shadow.h"
 
 //johnfitz -- new cvars
 extern cvar_t r_clearcolor;
@@ -1101,14 +1102,4 @@ void GL_ReserveDeviceMemory (GLenum target, size_t numbytes, GLuint *outbuf, siz
 	frameres_device_offset += numbytes;
 }
 
-void R_InitShadow (void)
-{
-}
-
-void R_ShutdownShadow (void)
-{
-}
-
-void R_ResizeShadowMapIfNeeded (void)
-{
-}
+/* Shadow management hooks are implemented in gl_shadow.c */

--- a/Quake/gl_shadow.c
+++ b/Quake/gl_shadow.c
@@ -1,0 +1,153 @@
+#include "quakedef.h"
+#include "gl_shadow.h"
+
+#define SHADOW_POOL_SIZE 16
+
+cvar_t gl_shadows = { "gl_shadows", "1", CVAR_ARCHIVE };
+cvar_t gl_shadow_mapsize = { "gl_shadow_mapsize", "512", CVAR_ARCHIVE };
+cvar_t gl_shadow_softness = { "gl_shadow_softness", "0.02", CVAR_ARCHIVE };
+cvar_t gl_shadow_pcf_samples = { "gl_shadow_pcf_samples", "8", CVAR_ARCHIVE };
+cvar_t gl_shadow_maxlights = { "gl_shadow_maxlights", "4", CVAR_ARCHIVE };
+cvar_t gl_shadow_bias = { "gl_shadow_bias", "0.002", CVAR_ARCHIVE };
+cvar_t gl_shadow_normalbias = { "gl_shadow_normalbias", "0.02", CVAR_ARCHIVE };
+cvar_t gl_shadow_update_static_interval = { "gl_shadow_update_static_interval", "2", CVAR_ARCHIVE };
+cvar_t gl_shadow_debug = { "gl_shadow_debug", "0", CVAR_NONE };
+cvar_t r_showshadows = { "r_showshadows", "0", CVAR_NONE };
+
+static struct shadow_manager_s {
+    qboolean initialized;
+    int map_size;
+    int max_lights;
+    dlight_shadow_t pool[SHADOW_POOL_SIZE];
+    int pool_size;
+} shadow_manager;
+
+static void Shadow_DestroyCube(shadow_cube_t *cube)
+{
+    if (!cube)
+        return;
+
+    if (cube->color_cube_tex)
+    {
+        glDeleteTextures(1, &cube->color_cube_tex);
+        cube->color_cube_tex = 0;
+    }
+
+    if (cube->depth_rb)
+    {
+        glDeleteRenderbuffers(1, &cube->depth_rb);
+        cube->depth_rb = 0;
+    }
+
+    if (cube->fbo)
+    {
+        glDeleteFramebuffers(1, &cube->fbo);
+        cube->fbo = 0;
+    }
+
+    cube->size = 0;
+    cube->dirty = true;
+    cube->last_update_frame = -9999;
+}
+
+static void Shadow_ResetPool(void)
+{
+    int i;
+    for (i = 0; i < shadow_manager.pool_size; ++i)
+    {
+        dlight_shadow_t *slot = &shadow_manager.pool[i];
+        Shadow_DestroyCube(&slot->cube);
+        slot->light_id = -1;
+        slot->is_static = false;
+    }
+    shadow_manager.pool_size = 0;
+}
+
+static void Shadow_RegisterCvars(void)
+{
+    static qboolean registered = false;
+    if (registered)
+        return;
+
+    Cvar_RegisterVariable(&gl_shadows);
+    Cvar_RegisterVariable(&gl_shadow_mapsize);
+    Cvar_RegisterVariable(&gl_shadow_softness);
+    Cvar_RegisterVariable(&gl_shadow_pcf_samples);
+    Cvar_RegisterVariable(&gl_shadow_maxlights);
+    Cvar_RegisterVariable(&gl_shadow_bias);
+    Cvar_RegisterVariable(&gl_shadow_normalbias);
+    Cvar_RegisterVariable(&gl_shadow_update_static_interval);
+    Cvar_RegisterVariable(&gl_shadow_debug);
+    Cvar_RegisterVariable(&r_showshadows);
+
+    registered = true;
+}
+
+static int Shadow_ClampMapSize(int size)
+{
+    int clamped = 1;
+    if (size <= 0)
+        size = 1;
+
+    while (clamped < size)
+        clamped <<= 1;
+
+    if (clamped < 16)
+        clamped = 16;
+    if (clamped > 4096)
+        clamped = 4096;
+    return clamped;
+}
+
+static void Shadow_UpdateSettings(void)
+{
+    shadow_manager.map_size = Shadow_ClampMapSize((int)gl_shadow_mapsize.value);
+    shadow_manager.max_lights = CLAMP(0, (int)gl_shadow_maxlights.value, SHADOW_POOL_SIZE);
+}
+
+void R_InitShadow(void)
+{
+    memset(&shadow_manager, 0, sizeof(shadow_manager));
+    Shadow_RegisterCvars();
+    Shadow_UpdateSettings();
+    shadow_manager.initialized = true;
+}
+
+void R_ShutdownShadow(void)
+{
+    if (!shadow_manager.initialized)
+        return;
+
+    Shadow_ResetPool();
+    shadow_manager.initialized = false;
+}
+
+void R_ResizeShadowMapIfNeeded(void)
+{
+    int new_size;
+    if (!shadow_manager.initialized)
+        return;
+
+    new_size = Shadow_ClampMapSize((int)gl_shadow_mapsize.value);
+    if (new_size != shadow_manager.map_size)
+    {
+        shadow_manager.map_size = new_size;
+        Shadow_ResetPool();
+    }
+
+    shadow_manager.max_lights = CLAMP(0, (int)gl_shadow_maxlights.value, SHADOW_POOL_SIZE);
+}
+
+void R_ShadowBeginFrame(int frame_num)
+{
+    (void)frame_num;
+    if (!shadow_manager.initialized)
+        return;
+
+    Shadow_UpdateSettings();
+}
+
+void R_ShadowEndFrame(void)
+{
+    /* Currently a placeholder for future per-frame cleanup. */
+}

--- a/Quake/gl_shadow.h
+++ b/Quake/gl_shadow.h
@@ -1,0 +1,50 @@
+#ifndef GL_SHADOW_H
+#define GL_SHADOW_H
+
+#include "quakedef.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define MAX_SHADOW_CUBE_FACES 6
+
+typedef struct shadow_cube_s {
+    GLuint fbo;
+    GLuint color_cube_tex;
+    GLuint depth_rb;
+    int size;
+    vec3_t light_pos;
+    float radius;
+    qboolean dirty;
+    int last_update_frame;
+} shadow_cube_t;
+
+typedef struct dlight_shadow_s {
+    int light_id;
+    shadow_cube_t cube;
+    qboolean is_static;
+} dlight_shadow_t;
+
+void R_InitShadow(void);
+void R_ShutdownShadow(void);
+void R_ResizeShadowMapIfNeeded(void);
+void R_ShadowBeginFrame(int frame_num);
+void R_ShadowEndFrame(void);
+
+extern cvar_t gl_shadows;
+extern cvar_t gl_shadow_mapsize;
+extern cvar_t gl_shadow_softness;
+extern cvar_t gl_shadow_pcf_samples;
+extern cvar_t gl_shadow_maxlights;
+extern cvar_t gl_shadow_bias;
+extern cvar_t gl_shadow_normalbias;
+extern cvar_t gl_shadow_update_static_interval;
+extern cvar_t gl_shadow_debug;
+extern cvar_t r_showshadows;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GL_SHADOW_H */

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -115,6 +115,17 @@ extern	cvar_t	gl_finish;
 
 extern	cvar_t	gl_playermip;
 
+extern	cvar_t	gl_shadows;
+extern	cvar_t	gl_shadow_mapsize;
+extern	cvar_t	gl_shadow_softness;
+extern	cvar_t	gl_shadow_pcf_samples;
+extern	cvar_t	gl_shadow_maxlights;
+extern	cvar_t	gl_shadow_bias;
+extern	cvar_t	gl_shadow_normalbias;
+extern	cvar_t	gl_shadow_update_static_interval;
+extern	cvar_t	gl_shadow_debug;
+extern	cvar_t	r_showshadows;
+
 extern int		gl_stencilbits;
 extern	qboolean	gl_buffer_storage_able;
 extern	qboolean	gl_multi_bind_able;
@@ -465,6 +476,8 @@ qboolean R_PrevFrameValid (void);
 void R_InitShadow (void);
 void R_ShutdownShadow (void);
 void R_ResizeShadowMapIfNeeded (void);
+void R_ShadowBeginFrame (int frame_num);
+void R_ShadowEndFrame (void);
 
 void R_DrawBrushModels (entity_t **ents, int count);
 void R_DrawBrushModels_Water (entity_t **ents, int count, qboolean translucent);


### PR DESCRIPTION
## Summary
- introduce a shadow manager module with configuration CVars and resource cleanup helpers
- hook the shadow lifecycle into the renderer setup in preparation for future shadow map updates

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f205a8cb64832e94c7c8243a9b241e