### PR TITLE
Implement cubemap shadow shader interface

### DIFF
--- a/Quake/gl_shaders.c
+++ b/Quake/gl_shaders.c
@@ -519,6 +519,8 @@ void GL_CreateShaders (void)
         for (mode = 0; mode < 2; mode++)
                 glprogs.oit_resolve[mode] = GL_CreateProgram (GLSL_PATH("oit_resolve.vert"), GLSL_PATH("oit_resolve.frag"), "oit resolve|MSAA %d", mode);
 
+        glprogs.shadow_depth_cube = GL_CreateProgram (GLSL_PATH("shadow_depth_cube.vert"), GLSL_PATH("shadow_depth_cube.frag"), "shadow depth cube");
+
 	for (oit = 0; oit < 2; oit++)
 		for (dither = 0; dither < 3; dither++)
 			for (mode = 0; mode < 3; mode++)

--- a/Quake/gl_shadow.c
+++ b/Quake/gl_shadow.c
@@ -1,5 +1,6 @@
 #include "quakedef.h"
 #include "gl_shadow.h"
+#include "gl_texmgr.h"
 
 #define SHADOW_POOL_SIZE 16
 
@@ -20,6 +21,7 @@ static struct shadow_manager_s {
     int max_lights;
     dlight_shadow_t pool[SHADOW_POOL_SIZE];
     int pool_size;
+    GLuint fallback_cube_tex;
 } shadow_manager;
 
 typedef struct shadow_program_uniforms_s {
@@ -43,6 +45,38 @@ typedef struct shadow_program_uniforms_s {
 
 static shadow_program_uniforms_t shadow_uniform_cache[SHADOW_PROGRAM_CACHE_MAX];
 static int shadow_uniform_cache_count;
+
+static qboolean Shadow_CreateFallbackCube(void)
+{
+    GLuint tex = 0;
+    static const GLfloat white = 1.0f;
+    int face;
+
+    glGenTextures(1, &tex);
+    if (!tex)
+        return false;
+
+    GL_BindNative(GL_TEXTURE0 + SHADOW_TEXTURE_UNIT_BASE, GL_TEXTURE_CUBE_MAP, tex);
+    for (face = 0; face < MAX_SHADOW_CUBE_FACES; ++face)
+    {
+        glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + face, 0, GL_R16F, 1, 1, 0,
+            GL_RED, GL_FLOAT, &white);
+    }
+
+    glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
+
+    if (GL_ObjectLabelFunc)
+        GL_ObjectLabelFunc(GL_TEXTURE, tex, -1, "shadow fallback cube");
+
+    GL_BindNative(GL_TEXTURE0 + SHADOW_TEXTURE_UNIT_BASE, GL_TEXTURE_CUBE_MAP, 0);
+
+    shadow_manager.fallback_cube_tex = tex;
+    return true;
+}
 
 static void Shadow_DestroyCube(shadow_cube_t *cube)
 {
@@ -200,7 +234,7 @@ static int Shadow_ClampMapSize(int size)
 static void Shadow_UpdateSettings(void)
 {
     shadow_manager.map_size = Shadow_ClampMapSize((int)gl_shadow_mapsize.value);
-    shadow_manager.max_lights = CLAMP(0, (int)gl_shadow_maxlights.value, SHADOW_POOL_SIZE);
+    shadow_manager.max_lights = CLAMP(0, (int)gl_shadow_maxlights.value, MAX_SHADOW_LIGHTS);
 }
 
 void R_InitShadow(void)
@@ -209,6 +243,12 @@ void R_InitShadow(void)
     Shadow_RegisterCvars();
     Shadow_UpdateSettings();
     Shadow_ClearUniformCache();
+    if (!Shadow_CreateFallbackCube())
+    {
+        Con_Printf("Failed to create fallback shadow cubemap. Point light shadows disabled.\n");
+        shadow_manager.initialized = false;
+        return;
+    }
     shadow_manager.initialized = true;
 }
 
@@ -219,6 +259,11 @@ void R_ShutdownShadow(void)
 
     Shadow_ResetPool();
     Shadow_ClearUniformCache();
+    if (shadow_manager.fallback_cube_tex)
+    {
+        GL_DeleteNativeTexture(shadow_manager.fallback_cube_tex);
+        shadow_manager.fallback_cube_tex = 0;
+    }
     shadow_manager.initialized = false;
 }
 
@@ -235,7 +280,7 @@ void R_ResizeShadowMapIfNeeded(void)
         Shadow_ResetPool();
     }
 
-    shadow_manager.max_lights = CLAMP(0, (int)gl_shadow_maxlights.value, SHADOW_POOL_SIZE);
+    shadow_manager.max_lights = CLAMP(0, (int)gl_shadow_maxlights.value, MAX_SHADOW_LIGHTS);
 }
 
 void R_ShadowBeginFrame(int frame_num)
@@ -252,22 +297,94 @@ void R_ShadowApplyWorldUniforms(GLuint program)
     shadow_program_uniforms_t *uniforms;
     int show = (r_showshadows.value != 0.f) ? 1 : 0;
     int i;
+    int active_lights = 0;
+    int max_upload_lights;
+    float bias = gl_shadow_bias.value;
+    float normal_bias = gl_shadow_normalbias.value;
+    float softness = gl_shadow_softness.value;
+    int pcf_samples = (int)gl_shadow_pcf_samples.value;
+
+    if (!shadow_manager.initialized)
+        return;
+
+    if (pcf_samples < 1)
+        pcf_samples = 1;
 
     uniforms = Shadow_GetProgramUniforms(program);
     if (!uniforms)
         return;
 
+    if (!uniforms->sampler_units_initialized)
+    {
+        for (i = 0; i < MAX_SHADOW_LIGHTS; ++i)
+        {
+            if (uniforms->light_shadow_cube_loc[i] >= 0)
+                GL_Uniform1iFunc(uniforms->light_shadow_cube_loc[i], SHADOW_TEXTURE_UNIT_BASE + i);
+        }
+        uniforms->sampler_units_initialized = true;
+    }
+
     if (uniforms->show_shadows_loc >= 0)
         GL_Uniform1iFunc(uniforms->show_shadows_loc, show);
 
-    if (uniforms->active_lights_loc >= 0)
-        GL_Uniform1iFunc(uniforms->active_lights_loc, 0);
+    max_upload_lights = shadow_manager.max_lights;
+    if (max_upload_lights > MAX_SHADOW_LIGHTS)
+        max_upload_lights = MAX_SHADOW_LIGHTS;
 
-    for (i = 0; i < MAX_SHADOW_LIGHTS; ++i)
+    if (gl_shadows.value && shadow_manager.fallback_cube_tex)
     {
-        if (uniforms->light_shadow_cube_loc[i] >= 0)
-            GL_Uniform1iFunc(uniforms->light_shadow_cube_loc[i], SHADOW_TEXTURE_UNIT_BASE + i);
+        int total = q_min(r_framedata.numlights, max_upload_lights);
+        for (i = 0; i < total && active_lights < max_upload_lights; ++i)
+        {
+            gpulight_t *light = &r_lightbuffer.lights[i];
+            int slot = active_lights;
+
+            if (light->radius <= 0.0f)
+                continue;
+
+            if (uniforms->light_pos_loc[slot] >= 0)
+                GL_Uniform3fFunc(uniforms->light_pos_loc[slot], light->pos[0], light->pos[1], light->pos[2]);
+
+            if (uniforms->light_radius_loc[slot] >= 0)
+                GL_Uniform1fFunc(uniforms->light_radius_loc[slot], light->radius);
+
+            if (uniforms->light_color_loc[slot] >= 0)
+                GL_Uniform3fFunc(uniforms->light_color_loc[slot], light->color[0], light->color[1], light->color[2]);
+
+            if (uniforms->light_intensity_loc[slot] >= 0)
+                GL_Uniform1fFunc(uniforms->light_intensity_loc[slot], 1.0f);
+
+            if (uniforms->light_bias_loc[slot] >= 0)
+                GL_Uniform1fFunc(uniforms->light_bias_loc[slot], bias);
+
+            if (uniforms->light_normal_bias_loc[slot] >= 0)
+                GL_Uniform1fFunc(uniforms->light_normal_bias_loc[slot], normal_bias);
+
+            if (uniforms->light_softness_loc[slot] >= 0)
+                GL_Uniform1fFunc(uniforms->light_softness_loc[slot], softness);
+
+            if (uniforms->light_pcf_samples_loc[slot] >= 0)
+                GL_Uniform1iFunc(uniforms->light_pcf_samples_loc[slot], pcf_samples);
+
+            GL_BindNative(GL_TEXTURE0 + SHADOW_TEXTURE_UNIT_BASE + slot,
+                GL_TEXTURE_CUBE_MAP, shadow_manager.fallback_cube_tex);
+
+            ++active_lights;
+        }
     }
+
+    for (i = active_lights; i < max_upload_lights; ++i)
+    {
+        if (uniforms->light_radius_loc[i] >= 0)
+            GL_Uniform1fFunc(uniforms->light_radius_loc[i], 0.0f);
+        if (uniforms->light_intensity_loc[i] >= 0)
+            GL_Uniform1fFunc(uniforms->light_intensity_loc[i], 0.0f);
+        GL_BindNative(GL_TEXTURE0 + SHADOW_TEXTURE_UNIT_BASE + i,
+            GL_TEXTURE_CUBE_MAP, shadow_manager.fallback_cube_tex);
+    }
+
+    if (uniforms->active_lights_loc >= 0)
+        GL_Uniform1iFunc(uniforms->active_lights_loc, active_lights);
 }
 
 void R_ShadowEndFrame(void)

--- a/Quake/gl_shadow.c
+++ b/Quake/gl_shadow.c
@@ -22,6 +22,28 @@ static struct shadow_manager_s {
     int pool_size;
 } shadow_manager;
 
+typedef struct shadow_program_uniforms_s {
+    GLuint program;
+    GLint active_lights_loc;
+    GLint show_shadows_loc;
+    GLint light_pos_loc[MAX_SHADOW_LIGHTS];
+    GLint light_radius_loc[MAX_SHADOW_LIGHTS];
+    GLint light_color_loc[MAX_SHADOW_LIGHTS];
+    GLint light_intensity_loc[MAX_SHADOW_LIGHTS];
+    GLint light_bias_loc[MAX_SHADOW_LIGHTS];
+    GLint light_normal_bias_loc[MAX_SHADOW_LIGHTS];
+    GLint light_softness_loc[MAX_SHADOW_LIGHTS];
+    GLint light_pcf_samples_loc[MAX_SHADOW_LIGHTS];
+    GLint light_shadow_cube_loc[MAX_SHADOW_LIGHTS];
+    qboolean sampler_units_initialized;
+} shadow_program_uniforms_t;
+
+#define SHADOW_PROGRAM_CACHE_MAX 32
+#define SHADOW_TEXTURE_UNIT_BASE 8
+
+static shadow_program_uniforms_t shadow_uniform_cache[SHADOW_PROGRAM_CACHE_MAX];
+static int shadow_uniform_cache_count;
+
 static void Shadow_DestroyCube(shadow_cube_t *cube)
 {
     if (!cube)
@@ -61,6 +83,82 @@ static void Shadow_ResetPool(void)
         slot->is_static = false;
     }
     shadow_manager.pool_size = 0;
+}
+
+static void Shadow_ClearUniformCache(void)
+{
+    shadow_uniform_cache_count = 0;
+    memset(shadow_uniform_cache, 0, sizeof(shadow_uniform_cache));
+}
+
+static shadow_program_uniforms_t *Shadow_GetProgramUniforms(GLuint program)
+{
+    int i;
+    shadow_program_uniforms_t *entry = NULL;
+
+    for (i = 0; i < shadow_uniform_cache_count; ++i)
+    {
+        if (shadow_uniform_cache[i].program == program)
+            return &shadow_uniform_cache[i];
+    }
+
+    if (shadow_uniform_cache_count >= SHADOW_PROGRAM_CACHE_MAX)
+        return NULL;
+
+    entry = &shadow_uniform_cache[shadow_uniform_cache_count++];
+    memset(entry, 0, sizeof(*entry));
+    entry->program = program;
+    entry->active_lights_loc = -1;
+    entry->show_shadows_loc = -1;
+    for (i = 0; i < MAX_SHADOW_LIGHTS; ++i)
+    {
+        entry->light_pos_loc[i] = -1;
+        entry->light_radius_loc[i] = -1;
+        entry->light_color_loc[i] = -1;
+        entry->light_intensity_loc[i] = -1;
+        entry->light_bias_loc[i] = -1;
+        entry->light_normal_bias_loc[i] = -1;
+        entry->light_softness_loc[i] = -1;
+        entry->light_pcf_samples_loc[i] = -1;
+        entry->light_shadow_cube_loc[i] = -1;
+    }
+
+    entry->active_lights_loc = GL_GetUniformLocationFunc(program, "uActiveLights");
+    entry->show_shadows_loc = GL_GetUniformLocationFunc(program, "uShowShadows");
+
+    for (i = 0; i < MAX_SHADOW_LIGHTS; ++i)
+    {
+        char name[64];
+
+        q_snprintf(name, sizeof(name), "uLights[%d].pos", i);
+        entry->light_pos_loc[i] = GL_GetUniformLocationFunc(program, name);
+
+        q_snprintf(name, sizeof(name), "uLights[%d].radius", i);
+        entry->light_radius_loc[i] = GL_GetUniformLocationFunc(program, name);
+
+        q_snprintf(name, sizeof(name), "uLights[%d].color", i);
+        entry->light_color_loc[i] = GL_GetUniformLocationFunc(program, name);
+
+        q_snprintf(name, sizeof(name), "uLights[%d].intensity", i);
+        entry->light_intensity_loc[i] = GL_GetUniformLocationFunc(program, name);
+
+        q_snprintf(name, sizeof(name), "uLights[%d].bias", i);
+        entry->light_bias_loc[i] = GL_GetUniformLocationFunc(program, name);
+
+        q_snprintf(name, sizeof(name), "uLights[%d].normalBias", i);
+        entry->light_normal_bias_loc[i] = GL_GetUniformLocationFunc(program, name);
+
+        q_snprintf(name, sizeof(name), "uLights[%d].softness", i);
+        entry->light_softness_loc[i] = GL_GetUniformLocationFunc(program, name);
+
+        q_snprintf(name, sizeof(name), "uLights[%d].pcfSamples", i);
+        entry->light_pcf_samples_loc[i] = GL_GetUniformLocationFunc(program, name);
+
+        q_snprintf(name, sizeof(name), "uLights[%d].shadowCube", i);
+        entry->light_shadow_cube_loc[i] = GL_GetUniformLocationFunc(program, name);
+    }
+
+    return entry;
 }
 
 static void Shadow_RegisterCvars(void)
@@ -110,6 +208,7 @@ void R_InitShadow(void)
     memset(&shadow_manager, 0, sizeof(shadow_manager));
     Shadow_RegisterCvars();
     Shadow_UpdateSettings();
+    Shadow_ClearUniformCache();
     shadow_manager.initialized = true;
 }
 
@@ -119,6 +218,7 @@ void R_ShutdownShadow(void)
         return;
 
     Shadow_ResetPool();
+    Shadow_ClearUniformCache();
     shadow_manager.initialized = false;
 }
 
@@ -145,6 +245,29 @@ void R_ShadowBeginFrame(int frame_num)
         return;
 
     Shadow_UpdateSettings();
+}
+
+void R_ShadowApplyWorldUniforms(GLuint program)
+{
+    shadow_program_uniforms_t *uniforms;
+    int show = (r_showshadows.value != 0.f) ? 1 : 0;
+    int i;
+
+    uniforms = Shadow_GetProgramUniforms(program);
+    if (!uniforms)
+        return;
+
+    if (uniforms->show_shadows_loc >= 0)
+        GL_Uniform1iFunc(uniforms->show_shadows_loc, show);
+
+    if (uniforms->active_lights_loc >= 0)
+        GL_Uniform1iFunc(uniforms->active_lights_loc, 0);
+
+    for (i = 0; i < MAX_SHADOW_LIGHTS; ++i)
+    {
+        if (uniforms->light_shadow_cube_loc[i] >= 0)
+            GL_Uniform1iFunc(uniforms->light_shadow_cube_loc[i], SHADOW_TEXTURE_UNIT_BASE + i);
+    }
 }
 
 void R_ShadowEndFrame(void)

--- a/Quake/gl_shadow.h
+++ b/Quake/gl_shadow.h
@@ -8,6 +8,7 @@ extern "C" {
 #endif
 
 #define MAX_SHADOW_CUBE_FACES 6
+#define MAX_SHADOW_LIGHTS 4
 
 typedef struct shadow_cube_s {
     GLuint fbo;
@@ -31,6 +32,7 @@ void R_ShutdownShadow(void);
 void R_ResizeShadowMapIfNeeded(void);
 void R_ShadowBeginFrame(int frame_num);
 void R_ShadowEndFrame(void);
+void R_ShadowApplyWorldUniforms(GLuint program);
 
 extern cvar_t gl_shadows;
 extern cvar_t gl_shadow_mapsize;

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -550,6 +550,7 @@ typedef struct glprogs_s {
 	GLuint		bloom_extract;
 	GLuint		bloom_blur;
 	GLuint		oit_resolve[2];		// [msaa]
+	GLuint		shadow_depth_cube;	// omnidirectional shadow map pass
 
 	/* 3d */
 	GLuint		world[2][3][3];		// [OIT][standard/dithered/banded][solid/alpha test/water]

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -23,6 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // r_world.c: world model rendering
 
 #include "quakedef.h"
+#include "gl_shadow.h"
 
 extern cvar_t gl_fullbrights, r_oldskyleaf, r_showtris; //johnfitz
 extern cvar_t gl_zfix; // QuakeSpasm z-fighting fix
@@ -284,6 +285,7 @@ static void R_FlushBModelCalls (void)
 	GL_MemoryBarrierFunc (GL_COMMAND_BARRIER_BIT);
 
 	GL_UseProgram (bmodel_batch_program);
+	R_ShadowApplyWorldUniforms (bmodel_batch_program);
 	GL_BindBuffer (GL_ELEMENT_ARRAY_BUFFER, gl_bmodel_ibo);
 	GL_BindBuffer (GL_ARRAY_BUFFER, gl_bmodel_vbo);
 	GL_BindBuffer (GL_DRAW_INDIRECT_BUFFER, cmdbuf);

--- a/Quake/shaders/shadow_depth_cube.frag
+++ b/Quake/shaders/shadow_depth_cube.frag
@@ -1,0 +1,15 @@
+#version 430 core
+
+in vec3 vWorldPos;
+
+layout(location = 0) out float outDepth;
+
+uniform vec3  uLightPos;
+uniform float uLightRadius;
+
+void main()
+{
+    float dist = length(vWorldPos - uLightPos);
+    float nd   = clamp(dist / uLightRadius, 0.0, 1.0);
+    outDepth   = nd;
+}

--- a/Quake/shaders/shadow_depth_cube.vert
+++ b/Quake/shaders/shadow_depth_cube.vert
@@ -1,0 +1,13 @@
+#version 430 core
+
+layout(location = 0) in vec3 aPos;
+
+uniform mat4 uVP;
+
+out vec3 vWorldPos;
+
+void main()
+{
+    vWorldPos = aPos;
+    gl_Position = uVP * vec4(aPos, 1.0);
+}

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -8,6 +8,59 @@
 layout(binding=2) uniform sampler2D LMTex;
 #include "frame_uniforms.glsl"
 
+const int SHADOW_MAX_LIGHTS = 4;
+
+struct PointLight
+{
+        vec3 pos;        float radius;
+        vec3 color;      float intensity;
+        samplerCube shadowCube;
+        float bias;      float normalBias;
+        float softness;  int   pcfSamples;
+};
+
+uniform int uActiveLights;
+uniform PointLight uLights[SHADOW_MAX_LIGHTS];
+uniform int uShowShadows;
+
+vec2 SampleDisk(int i, int count)
+{
+        float a = 6.28318530718 * (float(i) + 0.5) / float(count);
+        return vec2(cos(a), sin(a));
+}
+
+float ShadowPointPCF(PointLight L, vec3 P, vec3 N)
+{
+        vec3  Lvec = P - L.pos;
+        float dist = length(Lvec);
+        if (dist >= L.radius)
+                return 1.0;
+        vec3  Ldir = Lvec / max(dist, 1e-5);
+
+        vec3  Poff = P + N * L.normalBias;
+        float current = length(Poff - L.pos) - L.bias;
+
+        vec3 up = (abs(Ldir.y) < 0.999) ? vec3(0.0, 1.0, 0.0) : vec3(1.0, 0.0, 0.0);
+        vec3 T = normalize(cross(up, Ldir));
+        vec3 B = cross(Ldir, T);
+
+        int   count = max(L.pcfSamples, 1);
+        float r_w   = max(L.softness, 0.0);
+        float occluded = 0.0;
+
+        for (int i = 0; i < count; ++i)
+        {
+                vec2 d   = SampleDisk(i, count) * r_w;
+                vec3 dir = normalize(Ldir + d.x * T + d.y * B);
+                float nd = texture(L.shadowCube, dir).r;
+                float depth = nd * L.radius;
+                occluded += (current > depth) ? 1.0 : 0.0;
+        }
+
+        float visibility = 1.0 - (occluded / float(count));
+        return visibility;
+}
+
 vec3 ApplyFog(vec3 clr, vec3 p)
 {
         float fog = exp2(-Fog.w * dot(p, p));
@@ -327,39 +380,83 @@ void main()
         const float SPECULAR_POWER = 16.0;
         const float SPECULAR_SCALE = 0.4;
 
+        vec3 dynamic_light = vec3(0.0);
+        float shadow_debug_value = 1.0;
+        bool shadowDebugMode = (uShowShadows != 0);
+
+
+        if (uActiveLights > 0)
+        {
+                int lightCount = min(uActiveLights, SHADOW_MAX_LIGHTS);
+                for (int li = 0; li < lightCount; ++li)
+                {
+                        PointLight L = uLights[li];
+                        if (L.radius <= 0.0)
+                                continue;
+
+                        float shadow_vis = clamp(ShadowPointPCF(L, in_pos, surface_normal), 0.0, 1.0);
+                        shadow_debug_value = min(shadow_debug_value, shadow_vis);
+                        if (shadow_vis <= 0.0)
+                                continue;
+
+                        vec3 light_vec = L.pos - in_pos;
+                        float dist = length(light_vec);
+                        if (dist <= 0.0 || dist >= L.radius)
+                                continue;
+
+                        vec3 light_dir = light_vec / dist;
+                        float atten = clamp(1.0 - dist / L.radius, 0.0, 1.0);
+                        float ndotl = max(dot(surface_normal, light_dir), 0.0);
+                        if (atten <= 0.0 || ndotl <= 0.0)
+                                continue;
+
+                        vec3 light_color = L.color * L.intensity;
+                        dynamic_light += light_color * ndotl * atten * shadow_vis;
+
+                        vec3 half_vec = light_dir + view_dir;
+                        float half_len = length(half_vec);
+                        if (half_len > 0.0)
+                        {
+                                half_vec /= half_len;
+                                float ndoth = max(dot(surface_normal, half_vec), 0.0);
+                                float spec = pow(ndoth, SPECULAR_POWER) * ndotl;
+                                specular_light += light_color * spec * SPECULAR_SCALE * atten * shadow_vis;
+                        }
+                }
+        }
+
         if (NumLights > 0u)
         {
                 uint i, ofs;
                 ivec3 cluster_coord;
                 cluster_coord.x = int(floor(in_coord.x));
-		cluster_coord.y = int(floor(in_coord.y));
-		cluster_coord.z = int(floor(log2(in_depth) * ZLogScale + ZLogBias));
-		uvec2 clusterdata = imageLoad(LightClusters, cluster_coord).xy;
-		if ((clusterdata.x | clusterdata.y) != 0u)
-		{
+                cluster_coord.y = int(floor(in_coord.y));
+                cluster_coord.z = int(floor(log2(in_depth) * ZLogScale + ZLogBias));
+                uvec2 clusterdata = imageLoad(LightClusters, cluster_coord).xy;
+                if ((clusterdata.x | clusterdata.y) != 0u)
+                {
 #if 0
-			int cluster_idx = cluster_coord.x + cluster_coord.y * LIGHT_TILES_X + cluster_coord.z * LIGHT_TILES_X * LIGHT_TILES_Y;
-			total_light = vec3(ivec3((cluster_idx + 1) * 0x45d9f3b) >> ivec3(0, 8, 16) & 255) / 255.0;
+                        int cluster_idx = cluster_coord.x + cluster_coord.y * LIGHT_TILES_X + cluster_coord.z * LIGHT_TILES_X * LIGHT_TILES_Y;
+                        total_light = vec3(ivec3((cluster_idx + 1) * 0x45d9f3b) >> ivec3(0, 8, 16) & 255) / 255.0;
 #endif // SHOW_ACTIVE_LIGHT_CLUSTERS
-                        vec3 dynamic_light = vec3(0.);
-			vec4 plane;
-			plane.xyz = surface_normal;
-			plane.w = dot(in_pos, plane.xyz);
-			for (i = 0u, ofs = 0u; i < 2u; i++, ofs += 32u)
-			{
-				uint mask = clusterdata[i];
-				while (mask != 0u)
-				{
-					int j = findLSB(mask);
-					mask ^= 1u << j;
-					Light l = Lights[ofs + j];
-					// mimics R_AddDynamicLights, up to a point
-					float rad = l.radius;
-					float dist = dot(l.origin, plane.xyz) - plane.w;
-					rad -= abs(dist);
-					float minlight = l.minlight;
-					if (rad < minlight)
-						continue;
+                        vec3 cluster_light = vec3(0.);
+                        vec4 plane;
+                        plane.xyz = surface_normal;
+                        plane.w = dot(in_pos, plane.xyz);
+                        for (i = 0u, ofs = 0u; i < 2u; i++, ofs += 32u)
+                        {
+                                uint mask = clusterdata[i];
+                                while (mask != 0u)
+                                {
+                                        int j = findLSB(mask);
+                                        mask ^= 1u << j;
+                                        Light l = Lights[ofs + j];
+                                        float rad = l.radius;
+                                        float dist = dot(l.origin, plane.xyz) - plane.w;
+                                        rad -= abs(dist);
+                                        float minlight = l.minlight;
+                                        if (rad < minlight)
+                                                continue;
                                         vec3 local_pos = l.origin - plane.xyz * dist;
                                         minlight = rad - minlight;
                                         vec3 light_vec = local_pos - in_pos;
@@ -367,7 +464,7 @@ void main()
                                         float attenuation = clamp((minlight - surface_dist) / 16.0, 0.0, 1.0);
                                         float falloff = max(0., rad - surface_dist) / 256.;
                                         vec3 light_contrib = attenuation * falloff * l.color;
-                                        dynamic_light += light_contrib;
+                                        cluster_light += light_contrib;
                                         if (attenuation > 0.0 && falloff > 0.0 && surface_dist > 0.0)
                                         {
                                                 vec3 light_dir = light_vec / surface_dist;
@@ -385,10 +482,21 @@ void main()
                                                         }
                                                 }
                                         }
-				}
-			}
-                        total_light += max(min(dynamic_light, 1. - total_light), 0.);
+                                }
+                        }
+                        dynamic_light += cluster_light;
                 }
+        }
+
+        total_light += max(min(dynamic_light, 1. - total_light), 0.);
+
+        if (shadowDebugMode)
+        {
+                OUT_COLOR = vec4(vec3(shadow_debug_value), 1.0);
+#if !OIT
+                out_velocity = vec4(0.0);
+#endif
+                return;
         }
 
         vec3 sun_light = ComputeSunLight(in_pos, surface_normal);


### PR DESCRIPTION
## Summary
- add a dedicated shadow depth cubemap shader pair and register it with the GLSL loader
- expand the world forward shader with point light shadow sampling, PCF softening, and r_showshadows debug output
- provide renderer glue to feed the new shadow uniforms from C, including binding in the world draw path

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f2082a2640832e9c29caa1db547b0a