### PR TITLE
Add server-side multiplayer bot support

### DIFF
--- a/Quake/Makefile
+++ b/Quake/Makefile
@@ -274,6 +274,7 @@ OBJS = strlcat.o \
 	pr_edict.o \
 	pr_exec.o \
 	sv_main.o \
+	sv_bot.o \
 	sv_move.o \
 	sv_phys.o \
 	sv_user.o \

--- a/Quake/host.c
+++ b/Quake/host.c
@@ -505,7 +505,7 @@ void SV_DropClient (qboolean crash)
 	if (!crash)
 	{
 		// send any final messages (don't check for errors)
-		if (NET_CanSendMessage (host_client->netconnection))
+		if (host_client->netconnection && NET_CanSendMessage (host_client->netconnection))
 		{
 			MSG_WriteByte (&host_client->message, svc_disconnect);
 			NET_SendMessage (host_client->netconnection, &host_client->message);
@@ -530,14 +530,18 @@ void SV_DropClient (qboolean crash)
 	}
 
 // break the net connection
-	NET_Close (host_client->netconnection);
-	host_client->netconnection = NULL;
+	if (host_client->netconnection)
+	{
+		NET_Close (host_client->netconnection);
+		host_client->netconnection = NULL;
+		if (net_activeconnections > 0)
+			net_activeconnections--;
+	}
 
 // free the client (the body stays around)
 	host_client->active = false;
 	host_client->name[0] = 0;
 	host_client->old_frags = -999999;
-	net_activeconnections--;
 
 // send notification to all clients
 	for (i = 0, client = svs.clients; i < svs.maxclients; i++, client++)
@@ -589,6 +593,11 @@ void Host_ShutdownServer(qboolean crash)
 		{
 			if (host_client->active && host_client->message.cursize)
 			{
+				if (!host_client->netconnection)
+				{
+					SZ_Clear (&host_client->message);
+					continue;
+				}
 				if (NET_CanSendMessage (host_client->netconnection))
 				{
 					NET_SendMessage(host_client->netconnection, &host_client->message);

--- a/Quake/host_cmd.c
+++ b/Quake/host_cmd.c
@@ -1600,12 +1600,31 @@ static void Host_Status_f (void)
 	if (ipxAvailable)
 		print_fn ("ipx:     %s\n", my_ipx_address);
 	print_fn ("map:     %s\n", sv.name);
-	print_fn ("players: %i active (%i max)\n\n", net_activeconnections, svs.maxclients);
+
+	{
+		int active = 0;
+		int bots = 0;
+		for (j = 0, client = svs.clients; j < svs.maxclients; j++, client++)
+		{
+			if (!client->active)
+				continue;
+			active++;
+			if (client->isbot)
+				bots++;
+		}
+		if (bots)
+			print_fn ("players: %i active (%i max, %i bots)\n\n", active, svs.maxclients, bots);
+		else
+			print_fn ("players: %i active (%i max)\n\n", active, svs.maxclients);
+	}
 	for (j = 0, client = svs.clients; j < svs.maxclients; j++, client++)
 	{
 		if (!client->active)
 			continue;
-		seconds = (int)(net_time - NET_QSocketGetTime(client->netconnection));
+		if (client->netconnection)
+			seconds = (int)(net_time - NET_QSocketGetTime(client->netconnection));
+		else
+			seconds = (int)(realtime - client->last_message);
 		minutes = seconds / 60;
 		if (minutes)
 		{
@@ -1617,7 +1636,10 @@ static void Host_Status_f (void)
 		else
 			hours = 0;
 		print_fn ("#%-2u %-16.16s  %3i  %2i:%02i:%02i\n", j+1, client->name, (int)client->edict->v.frags, hours, minutes, seconds);
-		print_fn ("   %s\n", NET_QSocketGetAddressString(client->netconnection));
+		if (client->netconnection)
+			print_fn ("   %s\n", NET_QSocketGetAddressString(client->netconnection));
+		else
+			print_fn ("   BOT\n");
 	}
 }
 
@@ -3088,7 +3110,7 @@ static void Host_Spawn_f (void)
 		pr_global_struct->self = EDICT_TO_PROG(sv_player);
 		PR_ExecuteProgram (pr_global_struct->ClientConnect);
 
-		if ((Sys_DoubleTime() - NET_QSocketGetTime(host_client->netconnection)) <= qcvm->time)
+		if (!host_client->netconnection || (Sys_DoubleTime() - NET_QSocketGetTime(host_client->netconnection)) <= qcvm->time)
 			Sys_Printf ("%s entered the game\n", host_client->name);
 
 		PR_ExecuteProgram (pr_global_struct->PutClientInServer);

--- a/Quake/server.h
+++ b/Quake/server.h
@@ -126,6 +126,18 @@ enum sendsignon_e
 	PRESPAWN_SIGNONMSG,
 };
 
+typedef struct bot_state_s
+{
+	float			next_repath;
+	float			strafe_change_time;
+	float			strafe_dir;
+	vec3_t			wander_dir;
+	vec3_t			last_origin;
+	float			stuck_check;
+	int			target_ent;
+	qboolean		has_enemy;
+} bot_state_t;
+
 typedef struct client_s
 {
 	qboolean		active;				// false = client is free
@@ -148,6 +160,9 @@ typedef struct client_s
 	edict_t			*edict;				// EDICT_NUM(clientnum+1)
 	char			name[32];			// for printing to other people
 	int				colors;
+
+	qboolean		isbot;
+	bot_state_t	bot;
 
 	float			ping_times[NUM_PING_TIMES];
 	int				num_pings;			// ping_times[num_pings%NUM_PING_TIMES]
@@ -276,8 +291,13 @@ void SV_StartSound (edict_t *entity, int channel, const char *sample, int volume
 void SV_LocalSound (client_t *client, const char *sample); // for 2021 rerelease
 
 void SV_DropClient (qboolean crash);
+void SV_ConnectClient (int clientnum);
 
 void SV_SendClientMessages (void);
+void SV_BotInit (void);
+void SV_BotFrame (client_t *client);
+client_t *SV_BotSpawn (const char *name);
+qboolean SV_ClientIsBot (const client_t *client);
 void SV_ClearDatagram (void);
 void SV_ReserveSignonSpace (int numbytes);
 

--- a/Quake/sv_bot.c
+++ b/Quake/sv_bot.c
@@ -1,0 +1,527 @@
+#include "quakedef.h"
+
+extern cvar_t sv_maxspeed;
+
+#define BOT_ATTACK_RANGE        800.0f
+#define BOT_FIRE_RANGE          600.0f
+#define BOT_REPATH_TIME         1.0f
+#define BOT_STUCK_INTERVAL      1.0f
+#define BOT_WANDER_DISTANCE     256.0f
+#define BOT_RESPAWN_WAIT        0.2f
+
+static const char *bot_default_names[] = {
+        "Atlas", "Blaze", "Cipher", "Dagger", "Echo", "Frost", "Gunner", "Havoc",
+        "Iris", "Jinx", "Knight", "Lancer", "Mara", "Nova", "Onyx", "Phantom",
+        "Quill", "Rogue", "Shade", "Talon", "Vex", "Warden", "Yarrow", "Zeal"
+};
+
+static size_t bot_name_cursor;
+static int bot_name_serial = 1;
+
+static float SV_BotRandomFloat (float min, float max)
+{
+        return min + (max - min) * ((float) rand () / (float) RAND_MAX);
+}
+
+qboolean SV_ClientIsBot (const client_t *client)
+{
+        return client && client->isbot;
+}
+
+static qboolean SV_BotNameInUse (const char *name)
+{
+        size_t i;
+        if (!name || !*name)
+                return false;
+
+        for (i = 0; i < (size_t)svs.maxclients; i++)
+        {
+                const client_t *client = &svs.clients[i];
+                if (!client->active)
+                        continue;
+                if (!Q_strcmp (client->name, name))
+                        return true;
+        }
+
+        return false;
+}
+
+static void SV_BotChooseName (char *buffer, size_t size, const char *requested)
+{
+        size_t attempt;
+
+        if (requested && requested[0])
+        {
+                q_strlcpy (buffer, requested, size);
+                if (!SV_BotNameInUse (buffer))
+                        return;
+
+                for (attempt = 1; attempt < 100; attempt++)
+                {
+                        q_snprintf (buffer, size, "%s%zu", requested, attempt);
+                        if (!SV_BotNameInUse (buffer))
+                                return;
+                }
+        }
+
+        for (attempt = 0; attempt < countof (bot_default_names); attempt++)
+        {
+                const char *base = bot_default_names[bot_name_cursor++ % countof (bot_default_names)];
+                q_snprintf (buffer, size, "%s%d", base, bot_name_serial);
+                bot_name_serial++;
+                if (!SV_BotNameInUse (buffer))
+                        return;
+        }
+
+        for (attempt = 0; attempt < 1024; attempt++)
+        {
+                q_snprintf (buffer, size, "bot%d", bot_name_serial++);
+                if (!SV_BotNameInUse (buffer))
+                        return;
+        }
+
+        q_strlcpy (buffer, "bot", size);
+}
+
+static client_t *SV_BotFindFreeClient (void)
+{
+        int i;
+
+        for (i = 0; i < svs.maxclients; i++)
+        {
+                if (!svs.clients[i].active)
+                        return &svs.clients[i];
+        }
+
+        return NULL;
+}
+
+static void SV_BotBroadcastInfo (client_t *client)
+{
+        int slot = (int)(client - svs.clients);
+
+        MSG_WriteByte (&sv.reliable_datagram, svc_updatename);
+        MSG_WriteByte (&sv.reliable_datagram, slot);
+        MSG_WriteString (&sv.reliable_datagram, client->name);
+
+        MSG_WriteByte (&sv.reliable_datagram, svc_updatefrags);
+        MSG_WriteByte (&sv.reliable_datagram, slot);
+        MSG_WriteShort (&sv.reliable_datagram, (int) client->edict->v.frags);
+
+        MSG_WriteByte (&sv.reliable_datagram, svc_updatecolors);
+        MSG_WriteByte (&sv.reliable_datagram, slot);
+        MSG_WriteByte (&sv.reliable_datagram, client->colors);
+}
+
+static void SV_BotFinalize (client_t *client)
+{
+        qcvm_t *oldqcvm;
+        client_t *old_client = host_client;
+        edict_t *old_player = sv_player;
+        size_t i;
+
+        PR_PushQCVM (&sv.qcvm, &oldqcvm);
+
+        host_client = client;
+        sv_player = client->edict;
+
+        memset (&client->edict->v, 0, qcvm->progs->entityfields * 4);
+        client->edict->v.colormap = NUM_FOR_EDICT (client->edict);
+        client->edict->v.team = (client->colors & 15) + 1;
+        client->edict->v.netname = PR_SetEngineString (client->name);
+
+        for (i = 0; i < NUM_SPAWN_PARMS; i++)
+                (&pr_global_struct->parm1)[i] = client->spawn_parms[i];
+
+        pr_global_struct->time = qcvm->time;
+        pr_global_struct->self = EDICT_TO_PROG (client->edict);
+        PR_ExecuteProgram (pr_global_struct->ClientConnect);
+        PR_ExecuteProgram (pr_global_struct->PutClientInServer);
+
+        client->spawned = true;
+        client->sendsignon = PRESPAWN_DONE;
+        client->last_message = realtime;
+        client->old_frags = (int) client->edict->v.frags;
+
+        SZ_Clear (&client->message);
+        VectorCopy (client->edict->v.origin, client->bot.last_origin);
+        VectorClear (client->bot.wander_dir);
+        client->bot.next_repath = qcvm->time;
+        client->bot.strafe_change_time = 0.0f;
+        client->bot.strafe_dir = 0.0f;
+        client->bot.stuck_check = qcvm->time + BOT_STUCK_INTERVAL;
+        client->bot.target_ent = 0;
+        client->bot.has_enemy = false;
+
+        host_client = old_client;
+        sv_player = old_player;
+        PR_PopQCVM (oldqcvm);
+}
+
+client_t *SV_BotSpawn (const char *requested_name)
+{
+        client_t *client;
+        char name[sizeof (((client_t *)0)->name)];
+        int slot;
+
+        if (!sv.active)
+        {
+                Con_Printf ("Cannot add bot: no active server.\n");
+                return NULL;
+        }
+
+        client = SV_BotFindFreeClient ();
+        if (!client)
+        {
+                Con_Printf ("Cannot add bot: server is full.\n");
+                return NULL;
+        }
+
+        slot = (int)(client - svs.clients);
+        client->netconnection = NULL;
+        SV_ConnectClient (slot);
+
+        client->isbot = true;
+
+        SV_BotChooseName (name, sizeof (name), requested_name);
+        q_strlcpy (client->name, name, sizeof (client->name));
+        client->edict->v.netname = PR_SetEngineString (client->name);
+
+        client->colors = ((rand () & 15) << 4) | (rand () & 15);
+
+        SV_BotFinalize (client);
+        SV_BotBroadcastInfo (client);
+
+        Con_Printf ("Spawned bot %s\n", client->name);
+        return client;
+}
+
+static client_t *SV_BotFindByName (const char *name)
+{
+        size_t i;
+
+        if (!name || !*name)
+                return NULL;
+
+        for (i = 0; i < (size_t)svs.maxclients; i++)
+        {
+                client_t *client = &svs.clients[i];
+                if (!client->active || !client->isbot)
+                        continue;
+                if (!Q_strcmp (client->name, name))
+                        return client;
+        }
+
+        return NULL;
+}
+
+static void SV_BotRemoveClient (client_t *client)
+{
+        client_t *previous = host_client;
+
+        if (!client)
+        {
+                Con_Printf ("No bot to remove.\n");
+                return;
+        }
+
+        host_client = client;
+        SV_DropClient (false);
+        host_client = previous;
+}
+
+static void SV_BotAdd_f (void)
+{
+        const char *name = NULL;
+
+        if (Cmd_Argc () > 1)
+                name = Cmd_Args ();
+
+        SV_BotSpawn (name);
+}
+
+static void SV_BotRemove_f (void)
+{
+        client_t *client = NULL;
+        int i;
+
+        if (Cmd_Argc () > 1)
+                client = SV_BotFindByName (Cmd_Args ());
+
+        if (!client)
+        {
+                for (i = svs.maxclients - 1; i >= 0; i--)
+                {
+                        if (svs.clients[i].active && svs.clients[i].isbot)
+                        {
+                                client = &svs.clients[i];
+                                break;
+                        }
+                }
+        }
+
+        if (!client)
+        {
+                Con_Printf ("No bots are currently active.\n");
+                return;
+        }
+
+        SV_BotRemoveClient (client);
+}
+
+void SV_BotInit (void)
+{
+        Cmd_AddCommand ("bot_add", SV_BotAdd_f);
+        Cmd_AddCommand ("bot_remove", SV_BotRemove_f);
+}
+
+static qboolean SV_BotIsItem (edict_t *ent)
+{
+        const char *classname;
+
+        if (!ent || ent->free)
+                return false;
+        if ((int) ent->v.solid != SOLID_TRIGGER)
+                return false;
+
+        classname = PR_GetString (ent->v.classname);
+        if (!classname || !classname[0])
+                return false;
+
+        if (!Q_strncasecmp (classname, "item_", 5))
+                return true;
+        if (!Q_strncasecmp (classname, "weapon_", 7))
+                return true;
+        if (!Q_strncasecmp (classname, "ammo_", 5))
+                return true;
+
+        return false;
+}
+
+static edict_t *SV_BotFindPickup (client_t *client)
+{
+        edict_t *best = NULL;
+        float best_dist = 0.0f;
+        int i;
+
+        for (i = svs.maxclients + 1; i < qcvm->num_edicts; i++)
+        {
+            edict_t *ent = EDICT_NUM (i);
+            float dist;
+
+            if (!SV_BotIsItem (ent))
+                    continue;
+
+            dist = Distance (client->edict->v.origin, ent->v.origin);
+            if (!best || dist < best_dist)
+            {
+                    best = ent;
+                    best_dist = dist;
+            }
+        }
+
+        return best;
+}
+
+static edict_t *SV_BotFindEnemy (client_t *client)
+{
+        edict_t *best = NULL;
+        float best_dist = 0.0f;
+        int i;
+
+        for (i = 0; i < svs.maxclients; i++)
+        {
+                client_t *other = &svs.clients[i];
+                edict_t *ent;
+                float dist;
+
+                if (!other->active || !other->spawned)
+                        continue;
+                if (other == client)
+                        continue;
+
+                ent = other->edict;
+                if (!ent || ent->free)
+                        continue;
+                if (ent->v.health <= 0)
+                        continue;
+
+                dist = Distance (client->edict->v.origin, ent->v.origin);
+                if (!best || dist < best_dist)
+                {
+                        best = ent;
+                        best_dist = dist;
+                }
+        }
+
+        return best;
+}
+
+static qboolean SV_BotHasLineOfSight (edict_t *self, edict_t *target)
+{
+        vec3_t start, end;
+        trace_t trace;
+
+        VectorAdd (self->v.origin, self->v.view_ofs, start);
+        VectorCopy (target->v.origin, end);
+        if ((int) target->v.flags & FL_CLIENT)
+                VectorAdd (end, target->v.view_ofs, end);
+
+        trace = SV_Move (start, vec3_origin, vec3_origin, end, MOVE_NORMAL, self);
+
+        return trace.ent == target || trace.fraction >= 1.0f;
+}
+
+static void SV_BotSelectGoal (client_t *client)
+{
+        edict_t *enemy = SV_BotFindEnemy (client);
+        bot_state_t *bot = &client->bot;
+
+        if (enemy)
+        {
+                bot->target_ent = NUM_FOR_EDICT (enemy);
+                bot->has_enemy = true;
+        }
+        else
+        {
+                edict_t *pickup = SV_BotFindPickup (client);
+                if (pickup)
+                {
+                        bot->target_ent = NUM_FOR_EDICT (pickup);
+                        bot->has_enemy = false;
+                }
+                else
+                {
+                        float angle = SV_BotRandomFloat (0.f, 360.f);
+                        bot->target_ent = 0;
+                        bot->has_enemy = false;
+                        bot->wander_dir[0] = cos (DEG2RAD (angle));
+                        bot->wander_dir[1] = sin (DEG2RAD (angle));
+                        bot->wander_dir[2] = 0;
+                }
+        }
+
+        bot->next_repath = qcvm->time + BOT_REPATH_TIME;
+}
+
+static edict_t *SV_BotGetTarget (const bot_state_t *bot)
+{
+        if (bot->target_ent <= 0 || bot->target_ent >= qcvm->num_edicts)
+                return NULL;
+        return EDICT_NUM (bot->target_ent);
+}
+
+void SV_BotFrame (client_t *client)
+{
+        bot_state_t *bot;
+        edict_t *self;
+        edict_t *target;
+        usercmd_t *cmd;
+        float maxspeed;
+        vec3_t goal;
+        vec3_t to_goal;
+        float dist;
+
+        if (!SV_ClientIsBot (client))
+                return;
+
+        self = client->edict;
+        if (!self || self->free)
+                return;
+
+        bot = &client->bot;
+        cmd = &client->cmd;
+        memset (cmd, 0, sizeof (*cmd));
+
+        self->v.button0 = 0;
+        self->v.button2 = 0;
+        self->v.impulse = 0;
+
+        if (!client->spawned)
+                return;
+
+        if (self->v.health <= 0)
+        {
+                self->v.button0 = 1;
+                bot->next_repath = qcvm->time + BOT_RESPAWN_WAIT;
+                return;
+        }
+
+        if (bot->stuck_check <= qcvm->time)
+        {
+                float moved = Distance (self->v.origin, bot->last_origin);
+                if (moved < 8.0f)
+                        bot->next_repath = qcvm->time;
+                VectorCopy (self->v.origin, bot->last_origin);
+                bot->stuck_check = qcvm->time + BOT_STUCK_INTERVAL;
+        }
+
+        target = SV_BotGetTarget (bot);
+        if (bot->next_repath <= qcvm->time || !target || target->free)
+                SV_BotSelectGoal (client);
+
+        target = SV_BotGetTarget (bot);
+        VectorClear (goal);
+
+        if (target && !target->free)
+        {
+                VectorCopy (target->v.origin, goal);
+                if (bot->has_enemy)
+                        VectorAdd (goal, target->v.view_ofs, goal);
+        }
+        else
+        {
+                if (VectorLengthSquared (bot->wander_dir) < 0.01f)
+                {
+                        float angle = SV_BotRandomFloat (0.f, 360.f);
+                        bot->wander_dir[0] = cos (DEG2RAD (angle));
+                        bot->wander_dir[1] = sin (DEG2RAD (angle));
+                        bot->wander_dir[2] = 0;
+                }
+                VectorMA (self->v.origin, BOT_WANDER_DISTANCE, bot->wander_dir, goal);
+        }
+
+        VectorSubtract (goal, self->v.origin, to_goal);
+        dist = VectorNormalize (to_goal);
+
+        if (dist > 0.001f)
+        {
+                vec3_t angles;
+                VectorAngles (to_goal, angles);
+                VectorCopy (angles, self->v.v_angle);
+        }
+
+        maxspeed = sv_maxspeed.value > 0 ? sv_maxspeed.value : 320.0f;
+        cmd->upmove = 0;
+
+        if (dist > 24.0f)
+                cmd->forwardmove = q_min (maxspeed, 200.0f);
+        else
+                cmd->forwardmove = 0;
+
+        if (bot->has_enemy)
+        {
+                if (bot->strafe_change_time <= qcvm->time)
+                {
+                        bot->strafe_change_time = qcvm->time + SV_BotRandomFloat (0.75f, 1.25f);
+                        bot->strafe_dir = (rand () & 1 ? 1.0f : -1.0f) * q_min (maxspeed, 150.0f);
+                }
+                cmd->sidemove = bot->strafe_dir;
+        }
+        else
+        {
+                cmd->sidemove = 0;
+        }
+
+        if (bot->has_enemy && target && !target->free)
+        {
+                if (SV_BotHasLineOfSight (self, target) && dist <= BOT_ATTACK_RANGE)
+                        self->v.button0 = 1;
+
+                if (dist > BOT_FIRE_RANGE)
+                        cmd->forwardmove = q_min (maxspeed, 200.0f);
+        }
+
+        if (!bot->has_enemy && dist < 16.0f)
+                bot->next_repath = qcvm->time;
+}

--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -179,6 +179,7 @@ void SV_Init (void)
 	Cvar_RegisterVariable (&sv_autosave_interval);
 
 	Cmd_AddCommand ("sv_protocol", &SV_Protocol_f); //johnfitz
+	SV_BotInit ();
 
 	for (i=0 ; i<MAX_MODELS ; i++)
 		sprintf (localmodels[i], "*%i", i);
@@ -389,7 +390,7 @@ CLIENT SPAWNING
 
 static qboolean SV_IsLocalClient (client_t *client)
 {
-	return Q_strcmp (NET_QSocketGetAddressString (client->netconnection), "LOCAL") == 0;
+	return client->netconnection && Q_strcmp (NET_QSocketGetAddressString (client->netconnection), "LOCAL") == 0;
 }
 
 /*
@@ -475,7 +476,10 @@ void SV_ConnectClient (int clientnum)
 
 	client = svs.clients + clientnum;
 
-	Con_DPrintf ("Client %s connected\n", NET_QSocketGetAddressString(client->netconnection));
+	if (client->netconnection)
+		Con_DPrintf ("Client %s connected\n", NET_QSocketGetAddressString(client->netconnection));
+	else
+		Con_DPrintf ("Bot client connected\n");
 
 	edictnum = clientnum+1;
 
@@ -488,6 +492,7 @@ void SV_ConnectClient (int clientnum)
 		memcpy (spawn_parms, client->spawn_parms, sizeof(spawn_parms));
 	memset (client, 0, sizeof(*client));
 	client->netconnection = netconnection;
+	client->isbot = (client->netconnection == NULL);
 
 	strcpy (client->name, "unconnected");
 	client->active = true;
@@ -1180,6 +1185,9 @@ SV_SendClientDatagram
 */
 qboolean SV_SendClientDatagram (client_t *client)
 {
+	if (!client->netconnection)
+		return true;
+
 	byte		buf[MAX_DATAGRAM];
 	sizebuf_t	msg;
 
@@ -1379,6 +1387,12 @@ void SV_SendClientMessages (void)
 	{
 		if (!host_client->active)
 			continue;
+		if (host_client->isbot)
+		{
+			SZ_Clear (&host_client->message);
+			host_client->sendsignon = PRESPAWN_DONE;
+			continue;
+		}
 
 		if (host_client->spawned)
 		{

--- a/Quake/sv_user.c
+++ b/Quake/sv_user.c
@@ -626,17 +626,25 @@ void SV_RunClients (void)
 
 		sv_player = host_client->edict;
 
-		if (!SV_ReadClientMessage ())
+		if (host_client->isbot)
 		{
-			SV_DropClient (false);	// client misbehaved...
-			continue;
+			if (host_client->spawned)
+				SV_BotFrame (host_client);
 		}
-
-		if (!host_client->spawned)
+		else
 		{
-		// clear client movement until a new packet is received
-			memset (&host_client->cmd, 0, sizeof(host_client->cmd));
-			continue;
+			if (!SV_ReadClientMessage ())
+			{
+				SV_DropClient (false);	// client misbehaved...
+				continue;
+			}
+
+			if (!host_client->spawned)
+			{
+			// clear client movement until a new packet is received
+				memset (&host_client->cmd, 0, sizeof(host_client->cmd));
+				continue;
+			}
 		}
 
 // always pause in single player if in console or menus


### PR DESCRIPTION
## Summary
- add a dedicated server bot module with AI for navigation, combat, and pickup behavior along with console commands to spawn or remove bots
- teach the server, client message loop, and status reporting code to recognize bot clients and avoid network operations when no socket exists
- include the new bot implementation in the build so it is linked with the server

## Testing
- make *(fails: missing sdl2-config/SDL headers in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f4e5223cbc832e880899806818ea80