### PR TITLE
Add selectable shading models and update world lighting

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -196,6 +196,7 @@ cvar_t	r_simd = { "r_simd","1",CVAR_ARCHIVE };
 #endif
 cvar_t	r_alphasort = { "r_alphasort","1",CVAR_ARCHIVE };
 cvar_t	r_oit = { "r_oit","1",CVAR_ARCHIVE };
+cvar_t	r_shading_model = { "r_shading_model", "0", CVAR_ARCHIVE };
 cvar_t	r_dither = { "r_dither", "1.0", CVAR_ARCHIVE };
 cvar_t	r_dof = { "r_dof", "0", CVAR_ARCHIVE };
 cvar_t	r_dof_focus = { "r_dof_focus", "64", CVAR_ARCHIVE };
@@ -1536,7 +1537,8 @@ void R_SetupView (void)
 
 
 		r_framedata.overbright = overbright;
-		r_framedata._padding0 = 0.f;
+		int shading_model = CLAMP (0, (int)Q_rint (r_shading_model.value), SHADING_MODEL_COUNT - 1);
+		r_framedata.shading_model = (unsigned int)shading_model;
 	}
 
 	r_framecount++;

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -53,6 +53,7 @@ extern cvar_t r_shadows;
 extern cvar_t gl_zfix; // QuakeSpasm z-fighting fix
 extern cvar_t r_alphasort;
 extern cvar_t r_oit;
+extern cvar_t r_shading_model;
 extern cvar_t r_dither;
 extern cvar_t r_dof;
 extern cvar_t r_dof_autofocus;
@@ -290,6 +291,18 @@ static void R_SetSlimealpha_f (cvar_t *var)
 
 /*
 ====================
+R_ShadingModel_f
+====================
+*/
+static void R_ShadingModel_f (cvar_t *var)
+{
+	int value = CLAMP (0, (int)Q_rint (var->value), SHADING_MODEL_COUNT - 1);
+	if (value != (int)var->value)
+		Cvar_SetValueQuick (var, (float)value);
+}
+
+/*
+====================
 R_OverbrightBits_f
 ====================
 */
@@ -353,6 +366,8 @@ void R_Init (void)
 	Cvar_RegisterVariable (&r_pos);
 	Cvar_RegisterVariable (&r_alphasort);
 	Cvar_RegisterVariable (&r_oit);
+	Cvar_RegisterVariable (&r_shading_model);
+	Cvar_SetCallback (&r_shading_model, R_ShadingModel_f);
 	Cvar_RegisterVariable (&r_dither);
 	Cvar_RegisterVariable (&r_dof);
         Cvar_RegisterVariable (&r_dof_autofocus);

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -428,6 +428,13 @@ typedef struct gpulightbuffer_s {
 	gpulight_t	lights[MAX_DLIGHTS];
 } gpulightbuffer_t;
 
+typedef enum shading_model_e {
+	SHADING_MODEL_LAMBERT = 0,
+	SHADING_MODEL_HALF_LAMBERT = 1,
+	SHADING_MODEL_OREN_NAYAR = 2,
+	SHADING_MODEL_COUNT
+} shading_model_t;
+
 typedef struct gpuframedata_s {
 	float	viewproj[16];
 	float	prev_viewproj[16];
@@ -438,7 +445,7 @@ typedef struct gpuframedata_s {
 	float	screendither;
 	float	texturedither;
 	float	overbright;
-	float	_padding0;
+	unsigned int	shading_model;
 	vec3_t	eyepos;
 	float	time;
 	vec3_t	prev_eyepos;

--- a/Quake/shaders/frame_uniforms.glsl
+++ b/Quake/shaders/frame_uniforms.glsl
@@ -12,7 +12,7 @@ layout(std140, binding=0) uniform FrameDataUBO
         float   ScreenDither;
         float   TextureDither;
         float   Overbright;
-        float   _Pad0;
+        uint    ShadingModel;
         vec3    EyePos;
         float   Time;
         vec3    PrevEyePos;

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -94,6 +94,66 @@ vec3 ApplyFog(vec3 clr, vec3 p)
         return mix(Fog.rgb, clr, fog);
 }
 
+const uint SHADING_MODEL_LAMBERT = 0u;
+const uint SHADING_MODEL_HALF_LAMBERT = 1u;
+const uint SHADING_MODEL_OREN_NAYAR = 2u;
+
+float EvaluateHalfLambert(float ndotlRaw)
+{
+        float result = ndotlRaw * 0.5 + 0.5;
+        result = clamp(result, 0.0, 1.0);
+        return result * result;
+}
+
+float EvaluateOrenNayar(vec3 normal, vec3 light_dir, vec3 view_dir)
+{
+        float ndotl = max(dot(normal, light_dir), 0.0);
+        float ndotv = max(dot(normal, view_dir), 0.0);
+        if (ndotl <= 0.0 || ndotv <= 0.0)
+                return 0.0;
+
+        const float sigma = 0.5;
+        const float sigma2 = sigma * sigma;
+        float A = 1.0 - (0.5 * sigma2 / (sigma2 + 0.33));
+        float B = 0.45 * (sigma2 / (sigma2 + 0.09));
+
+        float sinThetaL = sqrt(max(1.0 - ndotl * ndotl, 0.0));
+        float sinThetaV = sqrt(max(1.0 - ndotv * ndotv, 0.0));
+
+        float cosPhiDiff = 0.0;
+        if (sinThetaL > 1e-4 && sinThetaV > 1e-4)
+        {
+                vec3 projL = normalize(light_dir - normal * ndotl);
+                vec3 projV = normalize(view_dir - normal * ndotv);
+                cosPhiDiff = clamp(dot(projL, projV), -1.0, 1.0);
+        }
+
+        float sinAlpha;
+        float tanBeta;
+        if (ndotv > ndotl)
+        {
+                sinAlpha = sinThetaV;
+                tanBeta = sinThetaL / max(ndotl, 1e-4);
+        }
+        else
+        {
+                sinAlpha = sinThetaL;
+                tanBeta = sinThetaV / max(ndotv, 1e-4);
+        }
+
+        float oren = ndotl * (A + B * max(0.0, cosPhiDiff) * sinAlpha * tanBeta);
+        return clamp(oren, 0.0, 1.0);
+}
+
+float ComputeDiffuseLighting(uint shadingModel, vec3 normal, vec3 light_dir, vec3 view_dir, float ndotlRaw)
+{
+        if (shadingModel == SHADING_MODEL_HALF_LAMBERT)
+                return EvaluateHalfLambert(ndotlRaw);
+        if (shadingModel == SHADING_MODEL_OREN_NAYAR)
+                return EvaluateOrenNayar(normal, light_dir, view_dir);
+        return max(ndotlRaw, 0.0);
+}
+
 #define LIGHT_TILES_X 32
 #define LIGHT_TILES_Y 16
 #define LIGHT_TILES_Z 32
@@ -402,6 +462,7 @@ void main()
         vec3 view_dir = vec3(0.0, 0.0, 1.0);
         if (view_length > 0.0)
                 view_dir = to_eye / view_length;
+        uint shadingModel = ShadingModel;
 
         const float SPECULAR_POWER = 16.0;
         const float SPECULAR_SCALE = 0.4;
@@ -431,8 +492,10 @@ void main()
                                 continue;
 
                         vec3 light_dir = light_vec / dist;
-                        float ndotl = max(dot(surface_normal, light_dir), 0.0);
-                        if (ndotl <= 0.0)
+                        float ndotl_raw = dot(surface_normal, light_dir);
+                        float lambert = max(ndotl_raw, 0.0);
+                        float diffuse_term = ComputeDiffuseLighting(shadingModel, surface_normal, light_dir, view_dir, ndotl_raw);
+                        if (diffuse_term <= 0.0)
                                 continue;
 
                         float contribution = ComputeDynamicLightContribution(L.radius, 0.0, dist);
@@ -441,15 +504,15 @@ void main()
 
                         float normalizedIntensity = contribution / max(L.radius, 1e-5);
                         vec3 light_color = L.color * (L.intensity * normalizedIntensity);
-                        dynamic_light += light_color * ndotl * shadow_vis;
+                        dynamic_light += light_color * diffuse_term * shadow_vis;
 
                         vec3 half_vec = light_dir + view_dir;
                         float half_len = length(half_vec);
-                        if (half_len > 0.0)
+                        if (half_len > 0.0 && lambert > 0.0)
                         {
                                 half_vec /= half_len;
                                 float ndoth = max(dot(surface_normal, half_vec), 0.0);
-                                float spec = pow(ndoth, SPECULAR_POWER) * ndotl;
+                                float spec = pow(ndoth, SPECULAR_POWER) * lambert;
                                 specular_light += light_color * spec * SPECULAR_SCALE * shadow_vis;
                         }
                 }
@@ -494,18 +557,20 @@ void main()
                                         if (contribution <= 0.0 || surface_dist <= 0.0)
                                                 continue;
                                         vec3 light_dir = light_vec / surface_dist;
-                                        float ndotl = max(dot(surface_normal, light_dir), 0.0);
-                                        if (ndotl <= 0.0)
+                                        float ndotl_raw = dot(surface_normal, light_dir);
+                                        float lambert = max(ndotl_raw, 0.0);
+                                        float diffuse_term = ComputeDiffuseLighting(shadingModel, surface_normal, light_dir, view_dir, ndotl_raw);
+                                        if (diffuse_term <= 0.0)
                                                 continue;
                                         vec3 light_color = l.color * (contribution / 256.0);
-                                        cluster_light += light_color * ndotl;
+                                        cluster_light += light_color * diffuse_term;
                                         vec3 half_vec = light_dir + view_dir;
                                         float half_len = length(half_vec);
-                                        if (half_len > 0.0)
+                                        if (half_len > 0.0 && lambert > 0.0)
                                         {
                                                 half_vec /= half_len;
                                                 float ndoth = max(dot(surface_normal, half_vec), 0.0);
-                                                float spec = pow(ndoth, SPECULAR_POWER) * ndotl;
+                                                float spec = pow(ndoth, SPECULAR_POWER) * lambert;
                                                 specular_light += light_color * spec * SPECULAR_SCALE;
                                         }
                                 }


### PR DESCRIPTION
## Summary
- add a new `r_shading_model` console variable and send the selected mode to GPU frame data
- implement half-Lambert and Oren–Nayar diffuse evaluations in the world shader while keeping Blinn-Phong specular highlights
- allow clustered and shadowed lights to use the selected shading model when accumulating lighting

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f50a65f07c832e95c486491be4a697