### PR TITLE
Add BSPX lightmap support

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -35,6 +35,7 @@ static void Mod_LoadBrushModel (qmodel_t *mod, void *buffer);
 static void Mod_LoadAliasModel (qmodel_t *mod, void *buffer);
 static void Mod_LoadMD5MeshModel (qmodel_t *mod, const char *buffer);
 static qmodel_t *Mod_LoadModel (qmodel_t *mod, qboolean crash);
+static void Mod_LoadBSPXLumps (dheader_t *header);
 
 static void Mod_Print (void);
 
@@ -55,6 +56,19 @@ typedef struct
 	const byte	*data;
 	size_t		size;
 } mod_lump_info_t;
+
+typedef struct
+{
+	char		id[4];
+	uint32_t	numlumps;
+} bspx_header_t;
+
+typedef struct
+{
+	char		lumpname[24];
+	uint32_t	fileofs;
+	uint32_t	filelen;
+} bspx_lump_t;
 
 static mod_lump_info_t Mod_LumpData (const char *context, const char *lumpname, const lump_t *l, mod_lump_error_fn error_fn)
 {
@@ -900,6 +914,13 @@ static void Mod_LoadLighting (lump_t *l)
 
 	loadmodel->lightdata = NULL;
 	loadmodel->litfile = false;
+
+	if (loadmodel->bspx.rgb_lightdata)
+	{
+		loadmodel->lightdata = loadmodel->bspx.rgb_lightdata;
+		loadmodel->litfile = true;
+		return;
+	}
 	// LordHavoc: check for a .lit file
 	q_strlcpy(litfilename, loadmodel->name, sizeof(litfilename));
 	COM_StripExtension(litfilename, litfilename, sizeof(litfilename));
@@ -1301,8 +1322,10 @@ static void CalcSurfaceExtents (msurface_t *s)
 
 	for (i=0 ; i<2 ; i++)
 	{
-		int bmin = 16 * (int) floor (mins[i]/16);
-		int bmax = 16 * (int) ceil (maxs[i]/16);
+		int scale = 1 << s->lightmap_shift;
+		double scaled = (double)scale;
+		int bmin = scale * (int) floor (mins[i] / scaled);
+		int bmax = scale * (int) ceil (maxs[i] / scaled);
 
 		s->texturemins[i] = bmin;
 		s->extents[i] = bmax - bmin;
@@ -1356,6 +1379,10 @@ static void Mod_LoadFaces (lump_t *l, qboolean bsp2)
 	size_t		count;
 	int		i, surfnum, lofs;
 	int		planenum, side, texinfon;
+	const byte	*lmshift = loadmodel->bspx.lmshift;
+	size_t		lmshift_count = loadmodel->bspx.lmshift_count;
+	const int32_t	*lmoffsets = loadmodel->bspx.lmoffsets;
+	size_t		lmoffset_count = loadmodel->bspx.lmoffset_count;
 
 	if (bsp2)
 	{
@@ -1404,6 +1431,18 @@ static void Mod_LoadFaces (lump_t *l, qboolean bsp2)
 			lofs = LittleLong(ins->lightofs);
 			ins++;
 		}
+
+		byte shift = 4;
+		if (lmshift && surfnum < (int)lmshift_count)
+		{
+			shift = lmshift[surfnum];
+			if (shift > 7)
+				shift = 7;
+		}
+		out->lightmap_shift = shift;
+
+		if (lmoffsets && surfnum < (int)lmoffset_count)
+			lofs = lmoffsets[surfnum];
 
 		out->flags = 0;
 		if (out->numedges < 3)
@@ -2105,6 +2144,7 @@ static void Mod_LoadBrushModel (qmodel_t *mod, void *buffer)
 	float		radius; //johnfitz
 
 	loadmodel->type = mod_brush;
+	memset(&loadmodel->bspx, 0, sizeof(loadmodel->bspx));
 
 	header = (dheader_t *)buffer;
 
@@ -2134,6 +2174,8 @@ static void Mod_LoadBrushModel (qmodel_t *mod, void *buffer)
 
 	for (i = 0; i < (int) sizeof(dheader_t) / 4; i++)
 		((int *)header)[i] = LittleLong ( ((int *)header)[i]);
+
+	Mod_LoadBSPXLumps (header);
 
 // load into heap
 
@@ -3217,6 +3259,96 @@ static void *Mod_LoadSpriteGroup (void * pin, mspriteframe_t **ppframe, int fram
 	return ptemp;
 }
 
+
+static void Mod_LoadBSPXLumps (dheader_t *header)
+{
+	size_t bspxofs = 0;
+	size_t filesize;
+	const byte *base;
+	uint32_t numlumps;
+	const bspx_lump_t *xlump;
+
+	if (com_filesize <= 0)
+		return;
+
+	filesize = (size_t)com_filesize;
+	base = mod_base;
+
+	for (int i = 0; i < HEADER_LUMPS; i++)
+	{
+		int fileofs = header->lumps[i].fileofs;
+		int filelen = header->lumps[i].filelen;
+		if (filelen <= 0)
+			continue;
+
+		size_t end = (size_t)fileofs + (size_t)filelen;
+		if (end > bspxofs)
+			bspxofs = end;
+	}
+
+	bspxofs = (bspxofs + 3) & ~(size_t)3;
+
+	if (bspxofs + sizeof(bspx_header_t) > filesize)
+		return;
+
+	const bspx_header_t *bspx = (const bspx_header_t *)(base + bspxofs);
+	if (memcmp(bspx->id, "BSPX", 4))
+		return;
+
+	numlumps = LittleLong(bspx->numlumps);
+	xlump = (const bspx_lump_t *)(bspx + 1);
+
+	for (uint32_t i = 0; i < numlumps; i++, xlump++)
+	{
+		char name[25];
+		int fileofs = (int)LittleLong(xlump->fileofs);
+		int filelen = (int)LittleLong(xlump->filelen);
+
+		memcpy(name, xlump->lumpname, sizeof(xlump->lumpname));
+		name[sizeof(name) - 1] = '\0';
+
+		if (fileofs < 0 || filelen <= 0)
+			continue;
+
+		size_t end = (size_t)fileofs + (size_t)filelen;
+		if (end > filesize)
+			continue;
+
+		const byte *lumpdata = base + fileofs;
+
+		if (!strcmp(name, "LMSHIFT"))
+		{
+			if (loadmodel->bspx.lmshift)
+				continue;
+			loadmodel->bspx.lmshift = (byte *)Hunk_AllocName(filelen, loadname);
+			memcpy(loadmodel->bspx.lmshift, lumpdata, filelen);
+			loadmodel->bspx.lmshift_count = filelen;
+		}
+		else if (!strcmp(name, "LMOFFSET"))
+		{
+			if (loadmodel->bspx.lmoffsets)
+				continue;
+			if ((size_t)filelen % sizeof(int32_t))
+			{
+				Con_Printf("%s: ignoring malformed LMOFFSET BSPX lump\n", loadmodel->name);
+				continue;
+			}
+			int count = filelen / (int)sizeof(int32_t);
+			loadmodel->bspx.lmoffsets = (int32_t *)Hunk_AllocName(filelen, loadname);
+			for (int j = 0; j < count; j++)
+				loadmodel->bspx.lmoffsets[j] = LittleLong(((const int32_t *)lumpdata)[j]);
+			loadmodel->bspx.lmoffset_count = count;
+		}
+		else if (!strcmp(name, "RGBLIGHTING"))
+		{
+			if (loadmodel->bspx.rgb_lightdata)
+				continue;
+			loadmodel->bspx.rgb_lightdata = (byte *)Hunk_AllocName(filelen, loadname);
+			memcpy(loadmodel->bspx.rgb_lightdata, lumpdata, filelen);
+			loadmodel->bspx.rgb_lightdata_size = filelen;
+		}
+	}
+}
 
 /*
 =================

--- a/Quake/gl_model.h
+++ b/Quake/gl_model.h
@@ -26,6 +26,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "modelgen.h"
 #include "spritegn.h"
 
+#include <stdint.h>
+
 /*
 
 d*_t structures are on-disk representations
@@ -135,6 +137,18 @@ typedef struct glvert_s {
 	unsigned	styles;
 } glvert_t;
 
+typedef struct model_bspx_s
+{
+	byte		*lmshift;
+	int		lmshift_count;
+
+	int32_t	*lmoffsets;
+	int		lmoffset_count;
+
+	byte		*rgb_lightdata;
+	size_t		rgb_lightdata_size;
+} model_bspx_t;
+
 typedef struct msurface_s
 {
 	mplane_t	*plane;
@@ -149,6 +163,7 @@ typedef struct msurface_s
 	short		lightmaptexturenum;
 	short		extents[2];
 	short		light_s, light_t;	// gl lightmap coordinates
+	byte		lightmap_shift;	// lightmap texel scale exponent
 
 	byte		styles[MAXLIGHTMAPS];
 	byte		*samples;			// [numstyles*surfsize]
@@ -498,6 +513,8 @@ typedef struct qmodel_s
 	int			bspversion;
 	int			contentstransparent;	//spike -- added this so we can disable glitchy wateralpha where its not supported.
 	qboolean	haslitwater;
+
+	model_bspx_t	bspx;
 
 //
 // alias model

--- a/Quake/gl_rlight.c
+++ b/Quake/gl_rlight.c
@@ -253,26 +253,38 @@ vec3_t lightcolor; //johnfitz -- lit support via lordhavoc
 
 static void InterpolateLightmap (vec3_t color, msurface_t *surf, int ds, int dt)
 {
-	byte *lightmap;
-	int maps, line3, dsfrac = ds & 15, dtfrac = dt & 15, r00 = 0, g00 = 0, b00 = 0, r01 = 0, g01 = 0, b01 = 0, r10 = 0, g10 = 0, b10 = 0, r11 = 0, g11 = 0, b11 = 0;
-	int scale;
-	line3 = ((surf->extents[0]>>4)+1)*3;
+       byte *lightmap;
+       int maps;
+       int shift = surf->lightmap_shift;
+       int step = 1 << shift;
+       int fracmask = step - 1;
+       int dsfrac = ds & fracmask;
+       int dtfrac = dt & fracmask;
+       int width = (surf->extents[0] >> shift) + 1;
+       int height = (surf->extents[1] >> shift) + 1;
+       int stride = width * 3;
+       int blocksize = width * height * 3;
+       int r00 = 0, g00 = 0, b00 = 0;
+       int r01 = 0, g01 = 0, b01 = 0;
+       int r10 = 0, g10 = 0, b10 = 0;
+       int r11 = 0, g11 = 0, b11 = 0;
+       int scale;
 
-	lightmap = surf->samples + ((dt>>4) * ((surf->extents[0]>>4)+1) + (ds>>4))*3; // LordHavoc: *3 for color
+       lightmap = surf->samples + ((dt >> shift) * width + (ds >> shift)) * 3; // LordHavoc: *3 for color
 
-	for (maps = 0;maps < MAXLIGHTMAPS && surf->styles[maps] != 255;maps++)
-	{
-		scale = d_lightstylevalue[surf->styles[maps]];
-		r00 += lightmap[      0] * scale; g00 += lightmap[      1] * scale; b00 += lightmap[      2] * scale;
-		r01 += lightmap[      3] * scale; g01 += lightmap[      4] * scale; b01 += lightmap[      5] * scale;
-		r10 += lightmap[line3+0] * scale; g10 += lightmap[line3+1] * scale; b10 += lightmap[line3+2] * scale;
-		r11 += lightmap[line3+3] * scale; g11 += lightmap[line3+4] * scale; b11 += lightmap[line3+5] * scale;
-		lightmap += ((surf->extents[0]>>4)+1) * ((surf->extents[1]>>4)+1)*3; // LordHavoc: *3 for colored lighting
-	}
+       for (maps = 0;maps < MAXLIGHTMAPS && surf->styles[maps] != 255;maps++)
+       {
+               scale = d_lightstylevalue[surf->styles[maps]];
+               r00 += lightmap[      0] * scale; g00 += lightmap[      1] * scale; b00 += lightmap[      2] * scale;
+               r01 += lightmap[      3] * scale; g01 += lightmap[      4] * scale; b01 += lightmap[      5] * scale;
+               r10 += lightmap[stride+0] * scale; g10 += lightmap[stride+1] * scale; b10 += lightmap[stride+2] * scale;
+               r11 += lightmap[stride+3] * scale; g11 += lightmap[stride+4] * scale; b11 += lightmap[stride+5] * scale;
+               lightmap += blocksize; // LordHavoc: *3 for colored lighting
+       }
 
-	color[0] = ((((((((r11-r10) * dsfrac) >> 4) + r10)-((((r01-r00) * dsfrac) >> 4) + r00)) * dtfrac) >> 4) + ((((r01-r00) * dsfrac) >> 4) + r00)) * (1.f/256.f);
-	color[1] = ((((((((g11-g10) * dsfrac) >> 4) + g10)-((((g01-g00) * dsfrac) >> 4) + g00)) * dtfrac) >> 4) + ((((g01-g00) * dsfrac) >> 4) + g00)) * (1.f/256.f);
-	color[2] = ((((((((b11-b10) * dsfrac) >> 4) + b10)-((((b01-b00) * dsfrac) >> 4) + b00)) * dtfrac) >> 4) + ((((b01-b00) * dsfrac) >> 4) + b00)) * (1.f/256.f);
+       color[0] = ((((((((r11-r10) * dsfrac) >> shift) + r10)-((((r01-r00) * dsfrac) >> shift) + r00)) * dtfrac) >> shift) + ((((r01-r00) * dsfrac) >> shift) + r00)) * (1.f/256.f);
+       color[1] = ((((((((g11-g10) * dsfrac) >> shift) + g10)-((((g01-g00) * dsfrac) >> shift) + g00)) * dtfrac) >> shift) + ((((g01-g00) * dsfrac) >> shift) + g00)) * (1.f/256.f);
+       color[2] = ((((((((b11-b10) * dsfrac) >> shift) + b10)-((((b01-b00) * dsfrac) >> shift) + b00)) * dtfrac) >> shift) + ((((b01-b00) * dsfrac) >> shift) + b00)) * (1.f/256.f);
 }
 
 /*

--- a/Quake/r_brush.c
+++ b/Quake/r_brush.c
@@ -263,6 +263,7 @@ static void GL_FillSurfaceLightmap (msurface_t *surf)
 	lightmap_t	*lm;
 	int			smax, tmax;
 	int			xofs, yofs;
+	int			shift = surf->lightmap_shift;
 	int			map;
 	byte		*src;
 	unsigned	*dst;
@@ -272,8 +273,8 @@ static void GL_FillSurfaceLightmap (msurface_t *surf)
 		return;
 
 	lm = &lightmaps[surf->lightmaptexturenum];
-	smax = (surf->extents[0]>>4)+1;
-	tmax = (surf->extents[1]>>4)+1;
+	smax = (surf->extents[0] >> shift) + 1;
+	tmax = (surf->extents[1] >> shift) + 1;
 	xofs = lm->xofs + surf->light_s;
 	yofs = lm->yofs + surf->light_t;
 	facesize = smax * tmax * 3;
@@ -375,8 +376,8 @@ static void GL_PackLitSurfaces (void)
 			if (surf->flags & SURF_DRAWTILED)
 				continue;
 
-			w = (surf->extents[0]>>4)+1;
-			h = (surf->extents[1]>>4)+1;
+			w = (surf->extents[0] >> surf->lightmap_shift) + 1;
+			h = (surf->extents[1] >> surf->lightmap_shift) + 1;
 			if (!surf->samples)
 			{
 				maxblack[0] = q_max (maxblack[0], w);
@@ -441,11 +442,11 @@ static void GL_PackLitSurfaces (void)
 	// pack surfaces in sort order
 	for (i = 0, j = VEC_SIZE (lit_surfs); i < j; i++)
 	{
-		int smax, tmax;
+               int smax, tmax;
 
-		surf = lit_surfs[lit_surf_order[0][i]];
-		smax = (surf->extents[0]>>4)+1;
-		tmax = (surf->extents[1]>>4)+1;
+               surf = lit_surfs[lit_surf_order[0][i]];
+               smax = (surf->extents[0] >> surf->lightmap_shift) + 1;
+               tmax = (surf->extents[1] >> surf->lightmap_shift) + 1;
 		smax *= GL_NumLightmapTaps (surf);
 		num_lightmap_samples += smax * tmax;
 
@@ -615,8 +616,8 @@ void GL_BuildBModelVertexBuffer (void)
 	int			i, j, k;
 	qmodel_t	*m;
 	glvert_t	*varray;
-	float		lmscalex = 1.f / 16.f / lightmap_width;
-	float		lmscaley = 1.f / 16.f / lightmap_height;
+	float		lmscalex = 0.f;
+	float		lmscaley = 0.f;
 
 // ask GL for a name for our VBO
 	GL_DeleteBuffer (gl_bmodel_vbo);
@@ -683,7 +684,9 @@ void GL_BuildBModelVertexBuffer (void)
 					useofs = 1.f;
 				}
 				lm = &lightmaps[fa->lightmaptexturenum];
-				lmofs = ((fa->extents[0]>>4)+1) / (float)lightmap_width;
+				lmofs = ((fa->extents[0] >> fa->lightmap_shift) + 1) / (float)lightmap_width;
+				lmscalex = 1.f / ((float)(1 << fa->lightmap_shift) * lightmap_width);
+				lmscaley = 1.f / ((float)(1 << fa->lightmap_shift) * lightmap_height);
 			}
 
 			fa->vbo_firstvert = varray_index;
@@ -733,13 +736,13 @@ void GL_BuildBModelVertexBuffer (void)
 					//
 					s = DotProduct (vec, fa->texinfo->vecs[0]) + fa->texinfo->vecs[0][3];
 					s -= fa->texturemins[0];
-					s += (fa->light_s + lm->xofs) * 16;
+					s += (fa->light_s + lm->xofs) * (1 << fa->lightmap_shift);
 					s += 8;
 					s *= lmscalex;
 
 					t = DotProduct (vec, fa->texinfo->vecs[1]) + fa->texinfo->vecs[1][3];
 					t -= fa->texturemins[1];
-					t += (fa->light_t + lm->yofs) * 16;
+					t += (fa->light_t + lm->yofs) * (1 << fa->lightmap_shift);
 					t += 8;
 					t *= lmscaley;
 


### PR DESCRIPTION
## Summary
- parse BSPX LMSHIFT, LMOFFSET, and RGBLIGHTING data and store it on brush models
- use per-surface lightmap shift values when computing extents, packing lightmaps, and building brush VBO data
- fall back to embedded RGB lightmaps before external .lit files and update light sampling to respect dynamic lightmap scales

## Testing
- cmake -S . -B build *(fails: missing SDL2 development files)*

------
https://chatgpt.com/codex/tasks/task_e_68f52732c418832ea9850e529e8a2b1f