### PR TITLE
Support BSPX decoupled lightmap data

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -73,6 +73,14 @@ typedef struct
 	uint32_t	filelen;
 } bspx_lump_t;
 
+typedef struct
+{
+        uint16_t        lmwidth;
+        uint16_t        lmheight;
+        int32_t         offset;
+        float           world_to_lm[2][4];
+} bspx_decoupled_lm_disk_t;
+
 static mod_lump_info_t Mod_LumpData (const char *context, const char *lumpname, const lump_t *l, mod_lump_error_fn error_fn)
 {
 	mod_lump_info_t info;
@@ -1393,6 +1401,8 @@ static void Mod_LoadFaces (lump_t *l, qboolean bsp2)
 	qboolean	lmstyles_overflow_warned = false;
 	qboolean	lmstyles_range_warned = false;
 	const char      *lmstyle_name = lmstyles_is_16bit ? "LMSTYLE16" : "LMSTYLE";
+	const model_bspx_decoupled_lm_t *decoupled_lm = loadmodel->bspx.decoupled_lm;
+	int             decoupled_lm_count = loadmodel->bspx.decoupled_lm_count;
 
 	if (bsp2)
 	{
@@ -1455,6 +1465,16 @@ static void Mod_LoadFaces (lump_t *l, qboolean bsp2)
 	for (surfnum=0 ; surfnum<(int)count ; surfnum++, out++)
 	{
 		texture_t *texture;
+		const model_bspx_decoupled_lm_t *dlm = NULL;
+		if (decoupled_lm && surfnum < decoupled_lm_count)
+		{
+			const model_bspx_decoupled_lm_t *candidate = &decoupled_lm[surfnum];
+			if (candidate->lmwidth && candidate->lmheight)
+				dlm = candidate;
+		}
+		out->bspx_has_decoupled_lm = false;
+		out->bspx_lmwidth = 0;
+		out->bspx_lmheight = 0;
 		if (bsp2)
 		{
 			out->firstedge = LittleLong(inl->firstedge);
@@ -1487,10 +1507,14 @@ static void Mod_LoadFaces (lump_t *l, qboolean bsp2)
 			if (shift > 7)
 				shift = 7;
 		}
+		if (dlm)
+			shift = 4;
 		out->lightmap_shift = shift;
 
 		if (lmoffsets && surfnum < (int)lmoffset_count)
 			lofs = lmoffsets[surfnum];
+		if (dlm)
+			lofs = dlm->offset;
 
 		if (lmstyles_data)
 		{
@@ -1538,6 +1562,25 @@ static void Mod_LoadFaces (lump_t *l, qboolean bsp2)
 			}
 		}
 
+		if (dlm)
+		{
+			out->bspx_has_decoupled_lm = true;
+			out->bspx_lmwidth = dlm->lmwidth;
+			out->bspx_lmheight = dlm->lmheight;
+			for (int row = 0; row < 2; row++)
+			{
+				for (int col = 0; col < 4; col++)
+					out->bspx_world_to_lm[row][col] = dlm->world_to_lm[row][col];
+			}
+			if (dlm->offset < 0)
+				lofs = -1;
+			else
+				lofs = dlm->offset;
+			out->texturemins[0] = out->texturemins[1] = 0;
+			out->extents[0] = ((int)dlm->lmwidth - 1) << out->lightmap_shift;
+			out->extents[1] = ((int)dlm->lmheight - 1) << out->lightmap_shift;
+		}
+
 		out->flags = 0;
 		if (out->numedges < 3)
 			Con_Warning("surfnum %d: bad numedges %d\n", surfnum, out->numedges);
@@ -1549,7 +1592,8 @@ static void Mod_LoadFaces (lump_t *l, qboolean bsp2)
 
 		out->texinfo = loadmodel->texinfo + texinfon;
 
-		CalcSurfaceExtents (out);
+		if (!out->bspx_has_decoupled_lm)
+			CalcSurfaceExtents (out);
 
 		Mod_CalcSurfaceBounds (out); //johnfitz -- for per-surface frustum culling
 
@@ -3484,6 +3528,40 @@ static void Mod_LoadBSPXLumps (dheader_t *header)
 				loadmodel->bspx.lmoffsets[j] = LittleLong(((const int32_t *)lumpdata)[j]);
 			loadmodel->bspx.lmoffset_count = count;
 		}
+		else if (!strcmp(name, "DECOUPLED_LM"))
+		{
+			if (loadmodel->bspx.decoupled_lm)
+				continue;
+			if ((size_t)filelen % sizeof(bspx_decoupled_lm_disk_t))
+			{
+				Con_Printf("%s: ignoring malformed DECOUPLED_LM BSPX lump\n", loadmodel->name);
+				continue;
+			}
+			size_t count = (size_t)filelen / sizeof(bspx_decoupled_lm_disk_t);
+			if (!count)
+				continue;
+			size_t entry_size = sizeof(model_bspx_decoupled_lm_t);
+			if (count > (size_t)INT_MAX / entry_size)
+			{
+				Con_Printf("%s: ignoring oversized DECOUPLED_LM BSPX lump (%zu entries)\n", loadmodel->name, count);
+				continue;
+			}
+			model_bspx_decoupled_lm_t *entries = (model_bspx_decoupled_lm_t *)Hunk_AllocName((int)(count * entry_size), loadname);
+			const bspx_decoupled_lm_disk_t *src = (const bspx_decoupled_lm_disk_t *)lumpdata;
+			for (size_t j = 0; j < count; j++)
+			{
+				entries[j].lmwidth = LittleShort(src[j].lmwidth);
+				entries[j].lmheight = LittleShort(src[j].lmheight);
+				entries[j].offset = LittleLong(src[j].offset);
+				for (int r = 0; r < 2; r++)
+				{
+					for (int c = 0; c < 4; c++)
+						entries[j].world_to_lm[r][c] = LittleFloat(src[j].world_to_lm[r][c]);
+				}
+			}
+			loadmodel->bspx.decoupled_lm = entries;
+			loadmodel->bspx.decoupled_lm_count = (int)count;
+		}
 		else if (!strcmp(name, "LMSTYLE") || !strcmp(name, "LMSTYLE16"))
 		{
 			qboolean is16 = !strcmp(name, "LMSTYLE16");
@@ -3548,6 +3626,22 @@ static void Mod_LoadBSPXLumps (dheader_t *header)
 			loadmodel->bspx.rgb_lightdata = (byte *)Hunk_AllocName(filelen, loadname);
 			memcpy(loadmodel->bspx.rgb_lightdata, lumpdata, filelen);
 			loadmodel->bspx.rgb_lightdata_size = filelen;
+		}
+		else if (!strcmp(name, "LIGHTINGDIR"))
+		{
+			if (loadmodel->bspx.lightdir_data)
+				continue;
+			loadmodel->bspx.lightdir_data = (byte *)Hunk_AllocName(filelen, loadname);
+			memcpy(loadmodel->bspx.lightdir_data, lumpdata, filelen);
+			loadmodel->bspx.lightdir_data_size = filelen;
+		}
+		else if (!strcmp(name, "LIGHTING_E5BGR9"))
+		{
+			if (loadmodel->bspx.hdr_lightdata)
+				continue;
+			loadmodel->bspx.hdr_lightdata = (byte *)Hunk_AllocName(filelen, loadname);
+			memcpy(loadmodel->bspx.hdr_lightdata, lumpdata, filelen);
+			loadmodel->bspx.hdr_lightdata_size = filelen;
 		}
 	}
 }

--- a/Quake/gl_model.h
+++ b/Quake/gl_model.h
@@ -137,6 +137,14 @@ typedef struct glvert_s {
 	unsigned	styles;
 } glvert_t;
 
+typedef struct model_bspx_decoupled_lm_s
+{
+	uint16_t	lmwidth;
+	uint16_t	lmheight;
+	int32_t	offset;
+	float		world_to_lm[2][4];
+} model_bspx_decoupled_lm_t;
+
 typedef struct model_bspx_s
 {
 	byte		*lmshift;
@@ -148,10 +156,19 @@ typedef struct model_bspx_s
 	byte		*rgb_lightdata;
 	size_t		rgb_lightdata_size;
 
+	byte		*lightdir_data;
+	size_t		lightdir_data_size;
+
+	byte		*hdr_lightdata;
+	size_t		hdr_lightdata_size;
+
 	void		*lmstyles;
 	size_t		lmstyles_size;
 	int		lmstyles_per_face;
 	qboolean	lmstyles_is_16bit;
+
+	model_bspx_decoupled_lm_t *decoupled_lm;
+	int		decoupled_lm_count;
 } model_bspx_t;
 
 typedef struct msurface_s
@@ -175,6 +192,11 @@ typedef struct msurface_s
 
 	int			texturemins[2];
 	mtexinfo_t	*texinfo;
+
+	qboolean	bspx_has_decoupled_lm;
+	uint16_t	bspx_lmwidth;
+	uint16_t	bspx_lmheight;
+	float		bspx_world_to_lm[2][4];
 } msurface_t;
 
 typedef struct mnode_s

--- a/Quake/gl_rlight.c
+++ b/Quake/gl_rlight.c
@@ -348,16 +348,35 @@ loc0:
 		// ericw -- added double casts to force 64-bit precision.
 		// Without them the zombie at the start of jam3_ericw.bsp was
 		// incorrectly being lit up in SSE builds.
-			ds = (int) ((double) DoublePrecisionDotProduct (mid, surf->texinfo->vecs[0]) + surf->texinfo->vecs[0][3]);
-			dt = (int) ((double) DoublePrecisionDotProduct (mid, surf->texinfo->vecs[1]) + surf->texinfo->vecs[1][3]);
+			if (surf->bspx_has_decoupled_lm)
+			{
+				double lux_s = (double)surf->bspx_world_to_lm[0][0] * mid[0] + (double)surf->bspx_world_to_lm[0][1] * mid[1] + (double)surf->bspx_world_to_lm[0][2] * mid[2] + surf->bspx_world_to_lm[0][3];
+				double lux_t = (double)surf->bspx_world_to_lm[1][0] * mid[0] + (double)surf->bspx_world_to_lm[1][1] * mid[1] + (double)surf->bspx_world_to_lm[1][2] * mid[2] + surf->bspx_world_to_lm[1][3];
+				if (lux_s < 0.0 || lux_t < 0.0)
+					continue;
+				double max_s = (double)surf->bspx_lmwidth;
+				double max_t = (double)surf->bspx_lmheight;
+				if (lux_s > max_s || lux_t > max_t)
+					continue;
+				ds = (int)floor(lux_s * (double)(1 << surf->lightmap_shift));
+				dt = (int)floor(lux_t * (double)(1 << surf->lightmap_shift));
+			}
+			else
+			{
+				ds = (int) ((double) DoublePrecisionDotProduct (mid, surf->texinfo->vecs[0]) + surf->texinfo->vecs[0][3]);
+				dt = (int) ((double) DoublePrecisionDotProduct (mid, surf->texinfo->vecs[1]) + surf->texinfo->vecs[1][3]);
 
-			if (ds < surf->texturemins[0] || dt < surf->texturemins[1])
-				continue;
+				if (ds < surf->texturemins[0] || dt < surf->texturemins[1])
+					continue;
 
-			ds -= surf->texturemins[0];
-			dt -= surf->texturemins[1];
+				ds -= surf->texturemins[0];
+				dt -= surf->texturemins[1];
 
-			if (ds > surf->extents[0] || dt > surf->extents[1])
+				if (ds > surf->extents[0] || dt > surf->extents[1])
+					continue;
+			}
+
+			if (ds < 0 || dt < 0 || ds > surf->extents[0] || dt > surf->extents[1])
 				continue;
 
 			if (surf->plane->type < 3)

--- a/Quake/r_brush.c
+++ b/Quake/r_brush.c
@@ -684,9 +684,18 @@ void GL_BuildBModelVertexBuffer (void)
 					useofs = 1.f;
 				}
 				lm = &lightmaps[fa->lightmaptexturenum];
-				lmofs = ((fa->extents[0] >> fa->lightmap_shift) + 1) / (float)lightmap_width;
-				lmscalex = 1.f / ((float)(1 << fa->lightmap_shift) * lightmap_width);
-				lmscaley = 1.f / ((float)(1 << fa->lightmap_shift) * lightmap_height);
+				if (fa->bspx_has_decoupled_lm)
+				{
+					lmofs = fa->bspx_lmwidth / (float)lightmap_width;
+					lmscalex = 1.f / lightmap_width;
+					lmscaley = 1.f / lightmap_height;
+				}
+				else
+				{
+					lmofs = ((fa->extents[0] >> fa->lightmap_shift) + 1) / (float)lightmap_width;
+					lmscalex = 1.f / ((float)(1 << fa->lightmap_shift) * lightmap_width);
+					lmscaley = 1.f / ((float)(1 << fa->lightmap_shift) * lightmap_height);
+				}
 			}
 
 			fa->vbo_firstvert = varray_index;
@@ -734,17 +743,27 @@ void GL_BuildBModelVertexBuffer (void)
 					//
 					// lightmap texture coordinates
 					//
-					s = DotProduct (vec, fa->texinfo->vecs[0]) + fa->texinfo->vecs[0][3];
-					s -= fa->texturemins[0];
-					s += (fa->light_s + lm->xofs) * (1 << fa->lightmap_shift);
-					s += 8;
-					s *= lmscalex;
+					if (fa->bspx_has_decoupled_lm)
+					{
+						float lux_s = vec[0] * fa->bspx_world_to_lm[0][0] + vec[1] * fa->bspx_world_to_lm[0][1] + vec[2] * fa->bspx_world_to_lm[0][2] + fa->bspx_world_to_lm[0][3];
+						float lux_t = vec[0] * fa->bspx_world_to_lm[1][0] + vec[1] * fa->bspx_world_to_lm[1][1] + vec[2] * fa->bspx_world_to_lm[1][2] + fa->bspx_world_to_lm[1][3];
+						s = (lux_s + (fa->light_s + lm->xofs) + 0.5f) / (float)lightmap_width;
+						t = (lux_t + (fa->light_t + lm->yofs) + 0.5f) / (float)lightmap_height;
+					}
+					else
+					{
+						s = DotProduct (vec, fa->texinfo->vecs[0]) + fa->texinfo->vecs[0][3];
+						s -= fa->texturemins[0];
+						s += (fa->light_s + lm->xofs) * (1 << fa->lightmap_shift);
+						s += 8;
+						s *= lmscalex;
 
-					t = DotProduct (vec, fa->texinfo->vecs[1]) + fa->texinfo->vecs[1][3];
-					t -= fa->texturemins[1];
-					t += (fa->light_t + lm->yofs) * (1 << fa->lightmap_shift);
-					t += 8;
-					t *= lmscaley;
+						t = DotProduct (vec, fa->texinfo->vecs[1]) + fa->texinfo->vecs[1][3];
+						t -= fa->texturemins[1];
+						t += (fa->light_t + lm->yofs) * (1 << fa->lightmap_shift);
+						t += 8;
+						t *= lmscaley;
+					}
 
 					vert->st[2] = s;
 					vert->st[3] = t;


### PR DESCRIPTION
## Summary
- add BSPX decoupled lightmap structures and loader logic, including directional/HDR lump handling
- teach face loading, VBO generation, and light sampling to consume BSPX decoupled lightmap metadata

## Testing
- `cmake -S . -B build -G Ninja` *(fails: missing SDL2 development package in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f60122e380832e9df72a70ab32575f