### PR TITLE
Add BSPX deluxemap support

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -1400,6 +1400,7 @@ static void Mod_LoadFaces (lump_t *l, qboolean bsp2)
 	qboolean	lmstyles_is_16bit = loadmodel->bspx.lmstyles_is_16bit;
 	qboolean	lmstyles_overflow_warned = false;
 	qboolean	lmstyles_range_warned = false;
+	qboolean	lightdir_warned = false;
 	const char      *lmstyle_name = lmstyles_is_16bit ? "LMSTYLE16" : "LMSTYLE";
 	const model_bspx_decoupled_lm_t *decoupled_lm = loadmodel->bspx.decoupled_lm;
 	int             decoupled_lm_count = loadmodel->bspx.decoupled_lm_count;
@@ -1463,18 +1464,19 @@ static void Mod_LoadFaces (lump_t *l, qboolean bsp2)
 	}
 
 	for (surfnum=0 ; surfnum<(int)count ; surfnum++, out++)
-	{
-		texture_t *texture;
-		const model_bspx_decoupled_lm_t *dlm = NULL;
+        {
+                texture_t *texture;
+                const model_bspx_decoupled_lm_t *dlm = NULL;
 		if (decoupled_lm && surfnum < decoupled_lm_count)
 		{
 			const model_bspx_decoupled_lm_t *candidate = &decoupled_lm[surfnum];
 			if (candidate->lmwidth && candidate->lmheight)
 				dlm = candidate;
 		}
-		out->bspx_has_decoupled_lm = false;
-		out->bspx_lmwidth = 0;
-		out->bspx_lmheight = 0;
+                out->bspx_has_decoupled_lm = false;
+                out->bspx_lmwidth = 0;
+                out->bspx_lmheight = 0;
+                out->deluxemap = NULL;
 		if (bsp2)
 		{
 			out->firstedge = LittleLong(inl->firstedge);
@@ -1607,6 +1609,22 @@ static void Mod_LoadFaces (lump_t *l, qboolean bsp2)
 			out->samples = loadmodel->lightdata + (lofs * 3); //johnfitz -- lit support via lordhavoc (was "+ i")
 
 		texture = loadmodel->textures[out->texinfo->texnum];
+		if (loadmodel->bspx.lightdir_data && lofs >= 0)
+		{
+			int smax = (out->extents[0] >> out->lightmap_shift) + 1;
+			int tmax = (out->extents[1] >> out->lightmap_shift) + 1;
+			size_t luxels = (size_t)smax * (size_t)tmax;
+			size_t offset = (size_t)lofs * 3;
+			size_t needed = luxels * 3;
+			if (offset + needed <= loadmodel->bspx.lightdir_data_size)
+				out->deluxemap = loadmodel->bspx.lightdir_data + offset;
+			else if (!lightdir_warned)
+			{
+				Con_Warning("%s: ignoring malformed LIGHTINGDIR BSPX data (surf %d)\n", loadmodel->name, surfnum);
+				lightdir_warned = true;
+			}
+		}
+
 
 		if (texture->type == TEXTYPE_SKY)
 		{

--- a/Quake/gl_model.h
+++ b/Quake/gl_model.h
@@ -189,6 +189,7 @@ typedef struct msurface_s
 
 	byte		styles[MAXLIGHTMAPS];
 	byte		*samples;			// [numstyles*surfsize]
+	byte		*deluxemap;			// optional directional samples
 
 	int			texturemins[2];
 	mtexinfo_t	*texinfo;

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -1574,6 +1574,8 @@ void R_SetupView (void)
         r_framedata.lightmap_wave[2] = r_lightmap_wave_speed.value;
         r_framedata.lightmap_wave[3] = 0.f;
 
+        r_framedata.has_deluxemap = gl_has_deluxemap ? 1 : 0;
+
         r_framedata.glow_params[0] = q_max(0.f, r_screen_glow.value);
         r_framedata.glow_params[1] = q_max(0.f, r_screen_glow_threshold.value);
         r_framedata.glow_params[2] = q_max(0.f, r_screen_glow_radius.value);

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -387,6 +387,9 @@ typedef struct lightmap_s
 } lightmap_t;
 extern lightmap_t *lightmaps;
 extern int lightmap_count;	//allocated lightmaps
+extern gltexture_t *lightmap_texture;
+extern gltexture_t *deluxemap_texture;
+extern qboolean gl_has_deluxemap;
 
 extern qboolean r_fullbright_cheatsafe, r_lightmap_cheatsafe, r_drawworld_cheatsafe; //johnfitz
 
@@ -457,7 +460,7 @@ typedef struct gpuframedata_s {
 	float	glow_params[4];
 	int			numlights;
 	int			prev_frame_valid;
-	int			_padding1;
+	int			has_deluxemap;
 	int			_padding2;
 } gpuframedata_t;
 

--- a/Quake/r_brush.c
+++ b/Quake/r_brush.c
@@ -23,6 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // r_brush.c: brush model rendering. renamed from r_surf.c
 
 #include <limits.h>
+#include <math.h>
 
 #include "quakedef.h"
 
@@ -52,6 +53,9 @@ int				*lit_surf_order[2];
 int				num_lightmap_samples;
 unsigned		*lightmap_data;
 gltexture_t		*lightmap_texture;
+unsigned		*deluxemap_data;
+gltexture_t		*deluxemap_texture;
+qboolean		gl_has_deluxemap;
 int				lightmap_width;
 int				lightmap_height;
 
@@ -246,11 +250,43 @@ GL_NumLightmapTaps
 */
 static int GL_NumLightmapTaps (const msurface_t *surf)
 {
-	if (surf->styles[1] == 255)
-		return 1;
-	if (surf->styles[2] == 255)
-		return 2;
-	return 3;
+        if (surf->styles[1] == 255)
+                return 1;
+        if (surf->styles[2] == 255)
+                return 2;
+        return 3;
+}
+
+static unsigned EncodeDeluxemapBytes (byte x, byte y, byte z)
+{
+	return (unsigned)x | ((unsigned)y << 8) | ((unsigned)z << 16) | 0xff000000u;
+}
+
+static byte EncodeDeluxemapComponent (float c)
+{
+	int val = (int)floorf (c * 127.0f + 128.0f + 0.5f);
+	return (byte)CLAMP (0, val, 255);
+}
+
+static unsigned EncodeDeluxemapFromNormal (const vec3_t normal)
+{
+	vec3_t dir;
+	float len;
+
+	VectorCopy (normal, dir);
+	len = sqrtf (dir[0] * dir[0] + dir[1] * dir[1] + dir[2] * dir[2]);
+	if (len <= 0.0f)
+	        return EncodeDeluxemapBytes (128, 128, 255);
+
+	dir[0] /= len;
+	dir[1] /= len;
+	dir[2] /= len;
+
+	return EncodeDeluxemapBytes (
+	        EncodeDeluxemapComponent (dir[0]),
+	        EncodeDeluxemapComponent (dir[1]),
+	        EncodeDeluxemapComponent (dir[2])
+	);
 }
 
 /*
@@ -260,14 +296,18 @@ GL_FillSurfaceLightmap
 */
 static void GL_FillSurfaceLightmap (msurface_t *surf)
 {
-	lightmap_t	*lm;
-	int			smax, tmax;
-	int			xofs, yofs;
-	int			shift = surf->lightmap_shift;
-	int			map;
+	lightmap_t		*lm;
+	int		smax, tmax;
+	int		xofs, yofs;
+	int		shift = surf->lightmap_shift;
+	int		map;
 	byte		*src;
 	unsigned	*dst;
-	int			s, t, facesize;
+	unsigned	*dst_dir = NULL;
+	const byte	*deluxe_src = NULL;
+	unsigned	fallback_dir = EncodeDeluxemapBytes (128, 128, 255);
+	int		s, t, facesize;
+	int		stylecols = GL_NumLightmapTaps (surf);
 
 	if (!cl.worldmodel->lightdata || !surf->samples || surf->styles[0] == 255)
 		return;
@@ -282,27 +322,68 @@ static void GL_FillSurfaceLightmap (msurface_t *surf)
 	src = surf->samples;
 	dst = lightmap_data + yofs * lightmap_width + xofs;
 
+	if (deluxemap_data)
+	{
+		dst_dir = deluxemap_data + yofs * lightmap_width + xofs;
+		deluxe_src = surf->deluxemap;
+		if (surf->plane)
+			fallback_dir = EncodeDeluxemapFromNormal (surf->plane->normal);
+	}
+
 	if (surf->styles[1] == 255) // single lightstyle
 	{
 		for (t = 0; t < tmax; t++, dst += lightmap_width)
+		{
+			unsigned *row_dir = dst_dir;
 			for (s = 0; s < smax; s++, src += 3)
+			{
+				if (row_dir)
+				{
+					unsigned encoded = fallback_dir;
+					if (deluxe_src)
+					{
+						encoded = EncodeDeluxemapBytes (deluxe_src[0], deluxe_src[1], deluxe_src[2]);
+						deluxe_src += 3;
+					}
+					row_dir[s] = encoded;
+				}
 				dst[s] = src[0] | (src[1] << 8) | (src[2] << 16) | 0xff000000u;
+			}
+			if (dst_dir)
+				dst_dir += lightmap_width;
+		}
 	}
 	else if (surf->styles[2] == 255) // 2 lightstyles
 	{
 		for (t = 0; t < tmax; t++, dst += lightmap_width)
 		{
+			unsigned *row_dir = dst_dir;
 			for (s = 0; s < smax; s++, src += 3)
 			{
+				if (row_dir)
+				{
+					unsigned encoded = fallback_dir;
+					if (deluxe_src)
+					{
+						encoded = EncodeDeluxemapBytes (deluxe_src[0], deluxe_src[1], deluxe_src[2]);
+						deluxe_src += 3;
+					}
+					row_dir[s] = encoded;
+					if (stylecols > 1)
+						row_dir[s + smax] = encoded;
+				}
 				dst[s       ] = src[0           ] | (src[1           ] << 8) | (src[2           ] << 16) | 0xff000000u;
 				dst[s + smax] = src[0 + facesize] | (src[1 + facesize] << 8) | (src[2 + facesize] << 16) | 0xff000000u;
 			}
+			if (dst_dir)
+				dst_dir += lightmap_width;
 		}
 	}
 	else // 3 or 4 lightstyles
 	{
 		for (t = 0; t < tmax; t++, dst += lightmap_width)
 		{
+			unsigned *row_dir = dst_dir;
 			for (s = 0; s < smax; s++, src += 3)
 			{
 				const byte *mapsrc = src;
@@ -316,7 +397,23 @@ static void GL_FillSurfaceLightmap (msurface_t *surf)
 				dst[s           ] = r;
 				dst[s + smax    ] = g;
 				dst[s + smax * 2] = b;
+				if (row_dir)
+				{
+					unsigned encoded = fallback_dir;
+					if (deluxe_src)
+					{
+						encoded = EncodeDeluxemapBytes (deluxe_src[0], deluxe_src[1], deluxe_src[2]);
+						deluxe_src += 3;
+					}
+					row_dir[s] = encoded;
+					if (stylecols > 1)
+						row_dir[s + smax] = encoded;
+					if (stylecols > 2)
+						row_dir[s + smax * 2] = encoded;
+				}
 			}
+			if (dst_dir)
+				dst_dir += lightmap_width;
 		}
 	}
 }
@@ -333,6 +430,11 @@ static void GL_FreeLightmapData (void)
 		free (lightmap_data);
 		lightmap_data = NULL;
 	}
+	if (deluxemap_data)
+	{
+		free (deluxemap_data);
+		deluxemap_data = NULL;
+	}
 	if (lightmaps)
 	{
 		free (lightmaps);
@@ -342,6 +444,8 @@ static void GL_FreeLightmapData (void)
 	VEC_CLEAR (lit_surfs);
 
 	lightmap_texture = NULL; // freed by the texture manager
+	deluxemap_texture = NULL;
+	gl_has_deluxemap = false;
 	last_lightmap_allocated = 0;
 	lightmap_count = 0;
 	lightmap_width = 0;
@@ -525,6 +629,23 @@ void GL_BuildLightmaps (void)
 	if (!lightmap_data)
 		Sys_Error ("GL_BuildLightmaps: out of memory on %" SDL_PRIu64 " bytes", (uint64_t)(lmsize * sizeof (*lightmap_data)));
 
+	gl_has_deluxemap = (cl.worldmodel && cl.worldmodel->bspx.lightdir_data != NULL);
+	if (gl_has_deluxemap)
+	{
+		deluxemap_data = (unsigned *)calloc (lmsize, sizeof (*deluxemap_data));
+		if (!deluxemap_data)
+		{
+			Con_Printf ("GL_BuildLightmaps: out of memory on %" SDL_PRIu64 " bytes for deluxemap, disabling\n", (uint64_t)(lmsize * sizeof (*deluxemap_data)));
+			gl_has_deluxemap = false;
+		}
+		else
+			deluxemap_data[0] = EncodeDeluxemapBytes (128, 128, 255);
+	}
+	else
+	{
+		deluxemap_data = NULL;
+	}
+
 	// compute offsets for each lightmap block
 	for (i=0; i<lightmap_count; i++)
 	{
@@ -550,6 +671,19 @@ void GL_BuildLightmaps (void)
 			SRC_LIGHTMAP, (byte *)lightmap_data, "", (src_offset_t)lightmap_data,
 			TEXPREF_ALPHA | TEXPREF_LINEAR | TEXPREF_NOPICMIP
 		);
+
+	if (gl_has_deluxemap && deluxemap_data)
+	{
+		deluxemap_texture =
+			TexMgr_LoadImage (cl.worldmodel, "deluxemap", lightmap_width, lightmap_height,
+				SRC_LIGHTMAP, (byte *)deluxemap_data, "", (src_offset_t)deluxemap_data,
+				TEXPREF_LINEAR | TEXPREF_NOPICMIP
+			);
+	}
+	else
+	{
+		deluxemap_texture = NULL;
+	}
 
 	//johnfitz -- warn about exceeding old limits
 	//GLQuake limit was 64 textures of 128x128. Estimate how many 128x128 textures we would need

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -30,6 +30,8 @@ extern cvar_t gl_zfix; // QuakeSpasm z-fighting fix
 extern cvar_t r_oit;
 
 extern gltexture_t *lightmap_texture;
+extern gltexture_t *deluxemap_texture;
+extern qboolean gl_has_deluxemap;
 
 extern GLuint gl_bmodel_vbo;
 extern size_t gl_bmodel_vbo_size;
@@ -514,6 +516,7 @@ static void R_DrawBrushModels_Real (entity_t **ents, int count, brushpass_t pass
         if (pass <= BP_ALPHATEST)
         {
                 GL_Bind (GL_TEXTURE2, r_fullbright_cheatsafe ? greytexture : lightmap_texture);
+                GL_Bind (GL_TEXTURE3, gl_has_deluxemap ? deluxemap_texture : blacktexture);
         }
         else if (pass == BP_SKYCUBEMAP)
                 GL_Bind (GL_TEXTURE2, skybox->cubemap);
@@ -614,6 +617,7 @@ void R_DrawBrushModels_Water (entity_t **ents, int count, qboolean translucent)
 	R_ResetBModelCalls (program);
 	GL_SetState (state);
 	GL_Bind (GL_TEXTURE2, r_fullbright_cheatsafe ? greytexture : lightmap_texture);
+	GL_Bind (GL_TEXTURE3, gl_has_deluxemap ? deluxemap_texture : blacktexture);
 
 	GL_Upload (GL_SHADER_STORAGE_BUFFER, bmodel_instances, sizeof(bmodel_instances[0]) * totalinst, &buf, &ofs);
 	GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 2, buf, (GLintptr)ofs, sizeof(bmodel_instances[0]) * count);

--- a/Quake/shaders/frame_uniforms.glsl
+++ b/Quake/shaders/frame_uniforms.glsl
@@ -24,7 +24,7 @@ layout(std140, binding=0) uniform FrameDataUBO
         vec4    GlowParams;
         uint    NumLights;
         uint    PrevFrameValid;
-        uint    _Pad1;
+        uint    HasDeluxemap;
         uint    _Pad2;
 };
 

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -6,6 +6,7 @@
         layout(binding=4) uniform sampler2D EmissiveTex;
 #endif
 layout(binding=2) uniform sampler2D LMTex;
+layout(binding=3) uniform sampler2D DeluxeTex;
 #include "frame_uniforms.glsl"
 
 const int SHADOW_MAX_LIGHTS = 4;
@@ -478,14 +479,32 @@ void main()
         float surface_normal_len = length(surface_normal_vec);
         if (surface_normal_len > 0.0)
                 surface_normal = surface_normal_vec / surface_normal_len;
-        vec3 total_light = clamp(static_light, 0.0, 1.0);
-        vec3 specular_light = vec3(0.0);
         vec3 to_eye = EyePos - in_pos;
         float view_length = length(to_eye);
         vec3 view_dir = vec3(0.0, 0.0, 1.0);
         if (view_length > 0.0)
                 view_dir = to_eye / view_length;
         uint shadingModel = ShadingModel;
+
+        if (HasDeluxemap != 0u)
+        {
+                vec3 encoded_dir = textureLod(DeluxeTex, lmuv, 0.0).xyz * 2.0 - 1.0;
+                float dir_len = length(encoded_dir);
+                vec3 luxel_dir = surface_normal;
+                if (dir_len > 1e-3)
+                        luxel_dir = encoded_dir / dir_len;
+                float ndotl_raw = dot(surface_normal, luxel_dir);
+                float ndotl = max(ndotl_raw, 0.0);
+                if (ndotl > 1e-4)
+                {
+                        vec3 radiance = static_light / ndotl;
+                        float diffuse_term = ComputeDiffuseLighting(shadingModel, surface_normal, luxel_dir, view_dir, ndotl_raw);
+                        static_light = radiance * diffuse_term;
+                }
+        }
+
+        vec3 total_light = clamp(static_light, 0.0, 1.0);
+        vec3 specular_light = vec3(0.0);
 
         const float SPECULAR_POWER = 16.0;
         const float SPECULAR_SCALE = 0.4;


### PR DESCRIPTION
## Summary
- load BSPX LIGHTINGDIR data into surfaces and track deluxemap samples
- build a directional lightmap atlas, bind it alongside lightmaps, and expose availability to the GPU
- update the world shader to decode deluxemap vectors and modulate static lighting when present

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f610fa24a4832eb446cf7b6ae8966e