### PR TITLE
Add missing bot and shadow sources to Visual Studio project

### DIFF
--- a/Windows/VisualStudio/ironwail.vcxproj
+++ b/Windows/VisualStudio/ironwail.vcxproj
@@ -244,6 +244,7 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
     <ClCompile Include="..\..\Quake\gl_refrag.c" />
     <ClCompile Include="..\..\Quake\gl_rlight.c" />
     <ClCompile Include="..\..\Quake\gl_rmain.c" />
+    <ClCompile Include="..\..\Quake\gl_shadow.c" />
     <ClCompile Include="..\..\Quake\gl_rmisc.c" />
     <ClCompile Include="..\..\Quake\gl_screen.c" />
     <ClCompile Include="..\..\Quake\gl_shaders.c" />
@@ -333,6 +334,7 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="..\..\Quake\sv_main.c" />
+    <ClCompile Include="..\..\Quake\sv_bot.c" />
     <ClCompile Include="..\..\Quake\sv_move.c" />
     <ClCompile Include="..\..\Quake\sv_phys.c" />
     <ClCompile Include="..\..\Quake\sv_user.c" />

--- a/Windows/VisualStudio/ironwail.vcxproj.filters
+++ b/Windows/VisualStudio/ironwail.vcxproj.filters
@@ -75,6 +75,9 @@
     <ClCompile Include="..\..\Quake\gl_rmain.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Quake\gl_shadow.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\Quake\gl_rmisc.c">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -217,6 +220,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\Quake\sv_main.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Quake\sv_bot.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\Quake\sv_move.c">


### PR DESCRIPTION
## Summary
- add the new sv_bot.c implementation to the Visual Studio project and filters
- include the gl_shadow.c renderer implementation so shadow functions link correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f77d84890c832e84a8676a6d5de336