### PR TITLE
Fix shadow depth cube shader compilation on Intel drivers

### DIFF
--- a/Quake/shaders/shadow_depth_cube.frag
+++ b/Quake/shaders/shadow_depth_cube.frag
@@ -1,5 +1,3 @@
-#version 430 core
-
 in vec3 vWorldPos;
 
 layout(location = 0) out float outDepth;

--- a/Quake/shaders/shadow_depth_cube.vert
+++ b/Quake/shaders/shadow_depth_cube.vert
@@ -1,5 +1,3 @@
-#version 430 core
-
 layout(location = 0) in vec3 aPos;
 
 uniform mat4 uVP;


### PR DESCRIPTION
## Summary
- remove the extra `#version` directives from the shadow depth cube shaders to avoid duplicate version headers during compilation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f7836a10cc832ea43f221c80716d24