### PR TITLE
Use stored BSP file size for lump validation

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -120,7 +120,9 @@ static mod_lump_info_t Mod_LumpData (const char *context, const char *lumpname, 
 	if (length < 0 || start < 0 || end < start)
 		error_fn ("%s: %s lump overflow in %s", context, lumpname, loadmodel->name);
 
-	if (com_filesize >= 0 && end > com_filesize)
+	const qfileofs_t filesize = loadmodel ? loadmodel->filesize : -1;
+
+	if (filesize >= 0 && end > filesize)
 		error_fn ("%s: %s lump extends past file size in %s", context, lumpname, loadmodel->name);
 
 	info.size = (size_t) length;
@@ -484,6 +486,7 @@ static qmodel_t *Mod_LoadModel (qmodel_t *mod, qboolean crash)
 	COM_FileBase (mod->name, loadname, sizeof(loadname));
 
 	loadmodel = mod;
+	loadmodel->filesize = com_filesize;
 
 //
 // fill it in

--- a/Quake/gl_model.h
+++ b/Quake/gl_model.h
@@ -23,6 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #ifndef GL_MODEL_H
 #define GL_MODEL_H
 
+#include "sys.h"
 #include "modelgen.h"
 #include "spritegn.h"
 
@@ -463,6 +464,7 @@ typedef struct qmodel_s
 	unsigned int	path_id;		// path id of the game directory
 							// that this model came from
 	qboolean	needload;		// bmodels and sprites don't cache normally
+	qfileofs_t	filesize;		// size of the backing file when it was loaded
 
 	modtype_t	type;
 	int			numframes;


### PR DESCRIPTION
## Summary
- cache the size of the loaded model file on qmodel_t
- validate BSP lumps against the cached size instead of the mutable com_filesize
- include sys.h so qfileofs_t is available in gl_model.h

## Testing
- ninja -C Linux *(fails: build.ninja missing)*
- cmake -S . -B build -G Ninja *(fails: SDL2 development files missing)*

------
https://chatgpt.com/codex/tasks/task_e_68f78d0750fc832e9dc2fc7a44aa7d0d