### PR TITLE
Fix map command handling for uppercase BSP extension

### DIFF
--- a/Quake/host_cmd.c
+++ b/Quake/host_cmd.c
@@ -1967,7 +1967,8 @@ command from the console.  Active clients are kicked off.
 static void Host_Map_f (void)
 {
 	int		i;
-	char	name[MAX_QPATH], *p;
+	size_t	len;
+	char	name[MAX_QPATH];
 
 	if (Cmd_Argc() < 2)	//no map name given
 	{
@@ -2005,9 +2006,9 @@ static void Host_Map_f (void)
 	svs.serverflags = 0;			// haven't completed an episode yet
 	q_strlcpy (name, Cmd_Argv(1), sizeof(name));
 	// remove (any) trailing ".bsp" from mapname -- S.A.
-	p = strstr(name, ".bsp");
-	if (p && p[4] == '\0')
-		*p = '\0';
+	len = strlen(name);
+	if (len >= 4 && !q_strcasecmp(name + len - 4, ".bsp"))
+		name[len - 4] = '\0';
 	PR_SwitchQCVM(&sv.qcvm);
 	SV_SpawnServer (name);
 	PR_SwitchQCVM(NULL);


### PR DESCRIPTION
## Summary
- strip the BSP extension from map names in a case-insensitive way when starting a map
- clean up the temporary buffer handling while preparing the map command

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f7a6e336ac832eb35d0614bdba83bf