### PR TITLE
Fix loading plaque never clearing after signon completes

### DIFF
--- a/Quake/gl_screen.c
+++ b/Quake/gl_screen.c
@@ -2080,7 +2080,18 @@ void SCR_UpdateScreen (void)
 
 	if (scr_disabled_for_loading)
 	{
-		if (realtime - scr_disabled_time > 60)
+		if (cls.state == ca_connected && cls.signon == SIGNONS)
+		{
+			// Fall back to normal rendering if we've finished connecting but
+			// never received the matching SCR_EndLoadingPlaque() call.  This can
+			// happen if an error during the signon sequence interrupts the
+			// loading plaque bookkeeping, leaving the screen permanently
+			// disabled even though the game world continues to run in the
+			// background.  Re-enabling here keeps the visuals in sync with the
+			// simulation instead of presenting a frozen, black screen.
+			scr_disabled_for_loading = false;
+		}
+		else if (realtime - scr_disabled_time > 60)
 		{
 			scr_disabled_for_loading = false;
 			Con_Printf ("load failed.\n");


### PR DESCRIPTION
## Summary
- ensure SCR_UpdateScreen reenables rendering once the client is fully connected even if SCR_EndLoadingPlaque was skipped

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f7cccbf668832e88a37b7430dec27e