### PR TITLE
Add BSPX lump support and integrate normals

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -24,6 +24,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // models are the only shared resource between a client and server running
 // on the same machine.
 
+#include <limits.h>
 #include "quakedef.h"
 
 static qmodel_t*	loadmodel;
@@ -36,10 +37,41 @@ static void Mod_LoadMD5MeshModel (qmodel_t *mod, const char *buffer);
 static qmodel_t *Mod_LoadModel (qmodel_t *mod, qboolean crash);
 
 static void Mod_Print (void);
+static void Mod_BspxResetModel (qmodel_t *mod);
+static void Mod_BspxParseLumps (const byte *buffer, size_t filesize);
+static void Mod_BspxIntegrate (const lump_t *lighting_lump);
+static void Bspx_BrushList_f (void);
 
 static cvar_t	external_ents = {"external_ents", "1", CVAR_ARCHIVE};
 static cvar_t	external_vis = {"external_vis", "1", CVAR_ARCHIVE};
 cvar_t			r_md5 = {"r_md5", "1", CVAR_ARCHIVE};
+static cvar_t	r_bspx_enable = {"r_bspx_enable", "1", CVAR_ARCHIVE};
+static cvar_t	r_bspx_normals = {"r_bspx_normals", "1", CVAR_ARCHIVE};
+static cvar_t	r_bspx_lighting = {"r_bspx_lighting", "1", CVAR_ARCHIVE};
+static cvar_t	r_bspx_envmap = {"r_bspx_envmap", "0", CVAR_ARCHIVE};
+
+#define BSPX_SIGNATURE		"BSPX"
+#define BSPX_MAX_LUMP_SIZE	(64 * 1024 * 1024)
+
+typedef struct
+{
+	char	id[4];
+	int		numlumps;
+} bspx_header_disk_t;
+
+typedef struct
+{
+	char	lumpname[24];
+	int		fileofs;
+	int		filelen;
+} bspx_lump_disk_t;
+
+#define BSPX_WARNED_MAX 64
+static char bspx_warned_names[BSPX_WARNED_MAX][24];
+static int  bspx_warned_count;
+
+static void Bspx_WarnUnknown (const char *name);
+static int Bspx_LumpNameCompare (const void *pa, const void *pb);
 
 static byte	*mod_novis;
 static int	mod_novis_capacity;
@@ -93,22 +125,431 @@ Mod_Init
 */
 void Mod_Init (void)
 {
-	Cvar_RegisterVariable (&external_vis);
-	Cvar_RegisterVariable (&external_ents);
-	Cvar_RegisterVariable (&r_md5);
-	Cvar_SetCallback (&r_md5, R_MD5_f);
+        Cvar_RegisterVariable (&external_vis);
+        Cvar_RegisterVariable (&external_ents);
+        Cvar_RegisterVariable (&r_md5);
+        Cvar_RegisterVariable (&r_bspx_enable);
+        Cvar_RegisterVariable (&r_bspx_normals);
+        Cvar_RegisterVariable (&r_bspx_lighting);
+        Cvar_RegisterVariable (&r_bspx_envmap);
+        Cvar_SetCallback (&r_md5, R_MD5_f);
 
-	Cmd_AddCommand ("mcache", Mod_Print);
+        Cmd_AddCommand ("mcache", Mod_Print);
+        Cmd_AddCommand ("bspx_brushlist", Bspx_BrushList_f);
 
-	//johnfitz -- create notexture miptex
-	r_notexture_mip = (texture_t *) Hunk_AllocName (sizeof(texture_t), "r_notexture_mip");
-	strcpy (r_notexture_mip->name, "notexture");
-	r_notexture_mip->height = r_notexture_mip->width = 32;
+        //johnfitz -- create notexture miptex
+        r_notexture_mip = (texture_t *) Hunk_AllocName (sizeof(texture_t), "r_notexture_mip");
+        strcpy (r_notexture_mip->name, "notexture");
+        r_notexture_mip->height = r_notexture_mip->width = 32;
 
-	r_notexture_mip2 = (texture_t *) Hunk_AllocName (sizeof(texture_t), "r_notexture_mip2");
-	strcpy (r_notexture_mip2->name, "notexture2");
-	r_notexture_mip2->height = r_notexture_mip2->width = 32;
-	//johnfitz
+        r_notexture_mip2 = (texture_t *) Hunk_AllocName (sizeof(texture_t), "r_notexture_mip2");
+        strcpy (r_notexture_mip2->name, "notexture2");
+        r_notexture_mip2->height = r_notexture_mip2->width = 32;
+        //johnfitz
+}
+
+static void Bspx_WarnUnknown (const char *name)
+{
+        int i;
+
+        if (!name || !*name)
+                return;
+
+        for (i = 0; i < bspx_warned_count; i++)
+        {
+                if (!q_strcasecmp (bspx_warned_names[i], name))
+                        return;
+        }
+
+        if (bspx_warned_count < BSPX_WARNED_MAX)
+        {
+                q_strlcpy (bspx_warned_names[bspx_warned_count], name, sizeof(bspx_warned_names[0]));
+                bspx_warned_count++;
+        }
+
+        Con_DPrintf ("BSPX: ignoring unknown lump \"%s\"\n", name);
+}
+
+static int Bspx_LumpNameCompare (const void *pa, const void *pb)
+{
+        const bspx_lump_t *a = (const bspx_lump_t *) pa;
+        const bspx_lump_t *b = (const bspx_lump_t *) pb;
+        return q_strcasecmp (a->name, b->name);
+}
+
+static void Mod_BspxResetModel (qmodel_t *mod)
+{
+        if (!mod)
+                return;
+
+        mod->num_bspx_lumps = 0;
+        mod->bspx_lumps = NULL;
+        mod->bspx_vertex_normals = NULL;
+        mod->num_bspx_vertex_normals = 0;
+        mod->bspx_face_normals = NULL;
+        mod->num_bspx_face_normals = 0;
+        mod->bspx_rgb_lighting = NULL;
+        mod->bspx_rgb_lighting_size = 0;
+        mod->bspx_lighting_dir = NULL;
+        mod->bspx_lighting_dir_size = 0;
+        mod->lightdatasize = 0;
+}
+
+static void Mod_BspxParseLumps (const byte *buffer, size_t filesize)
+{
+        int                     i;
+        int                     stored;
+        const bspx_header_disk_t *header;
+        const bspx_lump_disk_t  *disk;
+        size_t                  table_size, table_offset;
+        size_t                  *span_starts = NULL;
+        size_t                  *span_ends = NULL;
+
+        if (!loadmodel)
+                return;
+
+        loadmodel->num_bspx_lumps = 0;
+        loadmodel->bspx_lumps = NULL;
+
+        if (!r_bspx_enable.value)
+                return;
+
+        if (!buffer || filesize < sizeof(*header))
+                return;
+
+        header = (const bspx_header_disk_t *)(buffer + filesize - sizeof(*header));
+        if (memcmp(header->id, BSPX_SIGNATURE, sizeof(header->id)) != 0)
+                return;
+
+        i = LittleLong (header->numlumps);
+        if (i <= 0)
+                return;
+
+        table_size = (size_t)i * sizeof(*disk);
+        if (table_size > filesize || table_size > filesize - sizeof(*header))
+        {
+                Con_DWarning ("BSPX: %s has malformed lump table\n", loadmodel->name);
+                return;
+        }
+
+        table_offset = filesize - sizeof(*header) - table_size;
+        if (table_offset > filesize)
+                return;
+
+        disk = (const bspx_lump_disk_t *)(buffer + table_offset);
+
+        loadmodel->bspx_lumps = (bspx_lump_t *) Hunk_AllocName (i * sizeof(bspx_lump_t), loadname);
+        if (!loadmodel->bspx_lumps)
+        {
+                Con_Warning ("BSPX: unable to allocate registry for %s\n", loadmodel->name);
+                return;
+        }
+
+        if (i > 0)
+        {
+                span_starts = (size_t *) malloc ((size_t)i * sizeof(size_t));
+                span_ends = (size_t *) malloc ((size_t)i * sizeof(size_t));
+                if (!span_starts || !span_ends)
+                {
+                        free (span_starts);
+                        free (span_ends);
+                        Con_Warning ("BSPX: overlap tracking allocation failed for %s\n", loadmodel->name);
+                        return;
+                }
+        }
+
+        stored = 0;
+        for (int lump_index = 0; lump_index < i; ++lump_index)
+        {
+                char            name[25];
+                int             fileofs = LittleLong (disk[lump_index].fileofs);
+                int             filelen = LittleLong (disk[lump_index].filelen);
+                size_t          start, length, end;
+                int             overlap_index = -1;
+
+                memcpy (name, disk[lump_index].lumpname, sizeof(disk[lump_index].lumpname));
+                name[sizeof(name) - 1] = '\0';
+
+                if (fileofs < 0 || filelen < 0)
+                {
+                        Con_DWarning ("BSPX: %s has negative offsets for lump \"%s\"\n", loadmodel->name, name);
+                        continue;
+                }
+
+                length = (size_t)filelen;
+                start = (size_t)fileofs;
+
+                if (length > BSPX_MAX_LUMP_SIZE)
+                {
+                        Con_DWarning ("BSPX: %s lump \"%s\" exceeds %u bytes\n", loadmodel->name, name, (unsigned)BSPX_MAX_LUMP_SIZE);
+                        continue;
+                }
+
+                if (start > filesize || length > filesize - start)
+                {
+                        Con_DWarning ("BSPX: %s lump \"%s\" points outside file\n", loadmodel->name, name);
+                        continue;
+                }
+
+                end = start + length;
+                if (end > table_offset)
+                {
+                        Con_DWarning ("BSPX: %s lump \"%s\" overlaps BSPX table\n", loadmodel->name, name);
+                        continue;
+                }
+
+                for (int test = 0; test < stored; ++test)
+                {
+                        if (!(end <= span_starts[test] || start >= span_ends[test]))
+                        {
+                                overlap_index = test;
+                                break;
+                        }
+                }
+
+                if (overlap_index >= 0)
+                {
+                        Con_DWarning ("BSPX: %s lump \"%s\" overlaps \"%s\"\n", loadmodel->name, name, loadmodel->bspx_lumps[overlap_index].name);
+                        continue;
+                }
+
+                bspx_lump_t *out = &loadmodel->bspx_lumps[stored];
+                memset (out, 0, sizeof(*out));
+                q_strlcpy (out->name, name, sizeof(out->name));
+                out->fileofs = fileofs;
+                out->filelen = filelen;
+
+                if (length > 0)
+                {
+                        out->data = (byte *) Hunk_AllocName (length, loadname);
+                        if (!out->data)
+                        {
+                                Con_Warning ("BSPX: failed to allocate %zu bytes for lump \"%s\" in %s\n", length, name, loadmodel->name);
+                                continue;
+                        }
+                        memcpy (out->data, buffer + start, length);
+                }
+                else
+                        out->data = NULL;
+
+                if (span_starts)
+                {
+                        span_starts[stored] = start;
+                        span_ends[stored] = end;
+                }
+
+                stored++;
+        }
+
+        free (span_starts);
+        free (span_ends);
+
+        loadmodel->num_bspx_lumps = stored;
+        if (stored > 1)
+                qsort (loadmodel->bspx_lumps, stored, sizeof(bspx_lump_t), Bspx_LumpNameCompare);
+        if (stored == 0)
+                loadmodel->bspx_lumps = NULL;
+}
+
+static void Mod_BspxIntegrate (const lump_t *lighting_lump)
+{
+        (void)lighting_lump;
+        const bspx_lump_t *lump;
+        size_t          expected;
+
+        if (!loadmodel || !loadmodel->bspx_lumps || loadmodel->num_bspx_lumps <= 0)
+                return;
+
+        loadmodel->bspx_vertex_normals = NULL;
+        loadmodel->num_bspx_vertex_normals = 0;
+        loadmodel->bspx_face_normals = NULL;
+        loadmodel->num_bspx_face_normals = 0;
+        loadmodel->bspx_rgb_lighting = NULL;
+        loadmodel->bspx_rgb_lighting_size = 0;
+        loadmodel->bspx_lighting_dir = NULL;
+        loadmodel->bspx_lighting_dir_size = 0;
+
+        lump = Mod_BspxFindLump (loadmodel, "VERTEXNORMALS");
+        if (lump && lump->filelen > 0)
+        {
+                expected = (size_t)loadmodel->numvertexes * sizeof(vec3_t);
+                if ((size_t)lump->filelen == expected)
+                {
+                        vec3_t *dst = (vec3_t *) Hunk_AllocName (expected, loadname);
+                        if (dst)
+                        {
+                                const float *src = (const float *) lump->data;
+                                for (int idx = 0; idx < loadmodel->numvertexes; ++idx)
+                                {
+                                        dst[idx][0] = LittleFloat (src[idx * 3 + 0]);
+                                        dst[idx][1] = LittleFloat (src[idx * 3 + 1]);
+                                        dst[idx][2] = LittleFloat (src[idx * 3 + 2]);
+                                }
+                                loadmodel->bspx_vertex_normals = dst;
+                                loadmodel->num_bspx_vertex_normals = loadmodel->numvertexes;
+                        }
+                }
+                else
+                        Con_DWarning ("BSPX: %s VERTEXNORMALS has %d bytes, expected %zu\n", loadmodel->name, lump->filelen, expected);
+        }
+
+        lump = Mod_BspxFindLump (loadmodel, "FACENORMALS");
+        if (lump && lump->filelen > 0)
+        {
+                expected = (size_t)loadmodel->numsurfaces * sizeof(vec3_t);
+                if ((size_t)lump->filelen == expected)
+                {
+                        vec3_t *dst = (vec3_t *) Hunk_AllocName (expected, loadname);
+                        if (dst)
+                        {
+                                const float *src = (const float *) lump->data;
+                                for (int idx = 0; idx < loadmodel->numsurfaces; ++idx)
+                                {
+                                        dst[idx][0] = LittleFloat (src[idx * 3 + 0]);
+                                        dst[idx][1] = LittleFloat (src[idx * 3 + 1]);
+                                        dst[idx][2] = LittleFloat (src[idx * 3 + 2]);
+                                }
+                                loadmodel->bspx_face_normals = dst;
+                                loadmodel->num_bspx_face_normals = loadmodel->numsurfaces;
+                        }
+                }
+                else
+                        Con_DWarning ("BSPX: %s FACENORMALS has %d bytes, expected %zu\n", loadmodel->name, lump->filelen, expected);
+        }
+
+        lump = Mod_BspxFindLump (loadmodel, "RGBLIGHTING");
+        if (lump && lump->filelen > 0)
+        {
+                loadmodel->bspx_rgb_lighting = lump->data;
+                loadmodel->bspx_rgb_lighting_size = lump->filelen;
+                if (!loadmodel->litfile && loadmodel->lightdata && loadmodel->lightdatasize == lump->filelen)
+                {
+                        if (r_bspx_lighting.value)
+                        {
+                                memcpy (loadmodel->lightdata, lump->data, lump->filelen);
+                                loadmodel->litfile = true;
+                        }
+                }
+                else if (loadmodel->lightdatasize && loadmodel->lightdatasize != lump->filelen)
+                        Con_DWarning ("BSPX: %s RGBLIGHTING size mismatch (%d vs %d)\n", loadmodel->name, lump->filelen, loadmodel->lightdatasize);
+        }
+
+        lump = Mod_BspxFindLump (loadmodel, "LIGHTINGDIR");
+        if (lump && lump->filelen > 0)
+        {
+                loadmodel->bspx_lighting_dir = lump->data;
+                loadmodel->bspx_lighting_dir_size = lump->filelen;
+                if (loadmodel->lightdatasize && loadmodel->lightdatasize != lump->filelen)
+                        Con_DWarning ("BSPX: %s LIGHTINGDIR size mismatch (%d vs %d)\n", loadmodel->name, lump->filelen, loadmodel->lightdatasize);
+        }
+
+        qboolean lighting_dir_mismatch = false;
+        if (loadmodel->surfaces && loadmodel->numsurfaces > 0)
+        {
+                const byte *dirbase = loadmodel->bspx_lighting_dir;
+                size_t dirsize = (size_t)loadmodel->bspx_lighting_dir_size;
+                for (int surfidx = 0; surfidx < loadmodel->numsurfaces; ++surfidx)
+                {
+                        msurface_t *surf = loadmodel->surfaces + surfidx;
+                        surf->bspx_lightdir_samples = NULL;
+                        if (!dirbase || dirsize == 0 || !loadmodel->lightdata || !surf->samples)
+                                continue;
+                        if (surf->samples < loadmodel->lightdata)
+                                continue;
+                        size_t offset = (size_t)(surf->samples - loadmodel->lightdata);
+                        if (offset >= dirsize)
+                        {
+                                if (!lighting_dir_mismatch)
+                                {
+                                        Con_DWarning ("BSPX: %s LIGHTINGDIR pointer out of range\n", loadmodel->name);
+                                        lighting_dir_mismatch = true;
+                                }
+                                continue;
+                        }
+                        int smax = (surf->extents[0] >> 4) + 1;
+                        int tmax = (surf->extents[1] >> 4) + 1;
+                        size_t facesize = (size_t)smax * (size_t)tmax * 3u;
+                        int styles = 0;
+                        while (styles < MAXLIGHTMAPS && surf->styles[styles] != 255)
+                                ++styles;
+                        if (styles <= 0)
+                                styles = 1;
+                        size_t span = facesize * (size_t)styles;
+                        if (offset + span > dirsize)
+                        {
+                                if (!lighting_dir_mismatch)
+                                {
+                                        Con_DWarning ("BSPX: %s LIGHTINGDIR block exceeds data size\n", loadmodel->name);
+                                        lighting_dir_mismatch = true;
+                                }
+                                continue;
+                        }
+                        surf->bspx_lightdir_samples = dirbase + offset;
+                }
+        }
+
+        for (int idx = 0; idx < loadmodel->num_bspx_lumps; ++idx)
+        {
+                const char *name = loadmodel->bspx_lumps[idx].name;
+                if (!q_strcasecmp (name, "VERTEXNORMALS") ||
+                        !q_strcasecmp (name, "FACENORMALS") ||
+                        !q_strcasecmp (name, "RGBLIGHTING") ||
+                        !q_strcasecmp (name, "LIGHTINGDIR") ||
+                        !q_strcasecmp (name, "ENVMAP") ||
+                        !q_strcasecmp (name, "SURFENVMAP") ||
+                        !q_strcasecmp (name, "BRUSHLIST") ||
+                        !q_strcasecmp (name, "ZIP_PAKFILE"))
+                        continue;
+
+                Bspx_WarnUnknown (name);
+        }
+}
+
+static void Bspx_BrushList_f (void)
+{
+        const bspx_lump_t *lump;
+        int             count;
+
+        if (!cl.worldmodel)
+        {
+                Con_Printf ("No world model loaded.\n");
+                return;
+        }
+
+        lump = Mod_BspxFindLump (cl.worldmodel, "BRUSHLIST");
+        if (!lump || !lump->data || lump->filelen <= 0)
+        {
+                Con_Printf ("No BSPX BRUSHLIST data available.\n");
+                return;
+        }
+
+        if (lump->filelen % sizeof(int32_t))
+        {
+                Con_Printf ("BRUSHLIST lump has unexpected size (%d bytes).\n", lump->filelen);
+                return;
+        }
+
+        count = lump->filelen / (int)sizeof(int32_t);
+        if (count <= 0)
+        {
+                Con_Printf ("BRUSHLIST is empty.\n");
+                return;
+        }
+
+        Con_Printf ("BRUSHLIST (%d brushes):\n", count);
+
+        const int32_t *values = (const int32_t *) lump->data;
+        int limit = q_min (count, 32);
+        for (int idx = 0; idx < limit; ++idx)
+        {
+                int brush = LittleLong (values[idx]);
+                Con_Printf (" %d", brush);
+                if ((idx & 7) == 7 || idx == limit - 1)
+                        Con_Printf ("\n");
+        }
+
+        if (limit < count)
+                Con_Printf ("... %d additional brushes not shown.\n", count - limit);
 }
 
 /*
@@ -236,20 +677,112 @@ byte *Mod_LeafPVS (mleaf_t *leaf, qmodel_t *model)
 
 byte *Mod_NoVisPVS (qmodel_t *model)
 {
-	int pvsbytes;
- 
-	pvsbytes = (model->numleafs+7)>>3;
-	pvsbytes = (pvsbytes + VIS_ALIGN_MASK) & ~VIS_ALIGN_MASK; // round up
-	if (mod_novis == NULL || pvsbytes > mod_novis_capacity)
-	{
-		mod_novis_capacity = pvsbytes;
-		mod_novis = (byte *) realloc (mod_novis, mod_novis_capacity);
-		if (!mod_novis)
-			Sys_Error ("Mod_NoVisPVS: realloc() failed on %d bytes", mod_novis_capacity);
-		
-		memset(mod_novis, 0xff, mod_novis_capacity);
-	}
-	return mod_novis;
+        int pvsbytes;
+
+        pvsbytes = (model->numleafs+7)>>3;
+        pvsbytes = (pvsbytes + VIS_ALIGN_MASK) & ~VIS_ALIGN_MASK; // round up
+        if (mod_novis == NULL || pvsbytes > mod_novis_capacity)
+        {
+                mod_novis_capacity = pvsbytes;
+                mod_novis = (byte *) realloc (mod_novis, mod_novis_capacity);
+                if (!mod_novis)
+                        Sys_Error ("Mod_NoVisPVS: realloc() failed on %d bytes", mod_novis_capacity);
+
+                memset(mod_novis, 0xff, mod_novis_capacity);
+        }
+        return mod_novis;
+}
+
+const bspx_lump_t *Mod_BspxFindLump (const qmodel_t *model, const char *name)
+{
+        int low, high;
+
+        if (!model || !model->bspx_lumps || model->num_bspx_lumps <= 0 || !name || !*name)
+                return NULL;
+
+        low = 0;
+        high = model->num_bspx_lumps - 1;
+        while (low <= high)
+        {
+                int mid = (low + high) >> 1;
+                int cmp = q_strcasecmp (name, model->bspx_lumps[mid].name);
+                if (cmp == 0)
+                        return &model->bspx_lumps[mid];
+                if (cmp < 0)
+                        high = mid - 1;
+                else
+                        low = mid + 1;
+        }
+
+        return NULL;
+}
+
+qboolean Mod_BspxSurfaceAverageVertexNormal (const qmodel_t *model, const msurface_t *surf, vec3_t out)
+{
+        double sum[3] = {0.0, 0.0, 0.0};
+        int count = 0;
+
+        if (!model || !surf || !out)
+                return false;
+        if (!model->bspx_vertex_normals || model->num_bspx_vertex_normals != model->numvertexes)
+                return false;
+        if (!model->surfedges || !model->edges || !model->vertexes)
+                return false;
+
+        for (int i = 0; i < surf->numedges; ++i)
+        {
+                int edge_index = model->surfedges[surf->firstedge + i];
+                int vert_index;
+
+                if (edge_index >= 0)
+                        vert_index = model->edges[edge_index].v[0];
+                else
+                        vert_index = model->edges[-edge_index].v[1];
+
+                if (vert_index < 0 || vert_index >= model->numvertexes)
+                        continue;
+
+                sum[0] += model->bspx_vertex_normals[vert_index][0];
+                sum[1] += model->bspx_vertex_normals[vert_index][1];
+                sum[2] += model->bspx_vertex_normals[vert_index][2];
+                count++;
+        }
+
+        if (count <= 0)
+                return false;
+
+        out[0] = (float)(sum[0] / count);
+        out[1] = (float)(sum[1] / count);
+        out[2] = (float)(sum[2] / count);
+
+        {
+                float length = VectorLength (out);
+                if (length < 1e-6f)
+                        return false;
+                VectorScale (out, 1.0f / length, out);
+        }
+
+        return true;
+}
+
+const vec3_t *Mod_BspxSurfaceNormal (const qmodel_t *model, int surfindex)
+{
+        if (!model || !model->bspx_face_normals || model->num_bspx_face_normals != model->numsurfaces)
+                return NULL;
+        if (surfindex < 0 || surfindex >= model->numsurfaces)
+                return NULL;
+
+        return &model->bspx_face_normals[surfindex];
+}
+
+qboolean Mod_BspxNormalsEnabled (void)
+{
+        return (r_bspx_enable.value != 0.0f) && (r_bspx_normals.value != 0.0f);
+}
+
+qboolean Mod_BspxLightingEnabled (void)
+{
+        return (r_bspx_enable.value != 0.0f) && (r_bspx_lighting.value != 0.0f);
 }
 
 /*
@@ -391,6 +924,7 @@ static qmodel_t *Mod_LoadModel (qmodel_t *mod, qboolean crash)
 	COM_FileBase (mod->name, loadname, sizeof(loadname));
 
 	loadmodel = mod;
+	Mod_BspxResetModel (loadmodel);
 
 //
 // fill it in
@@ -844,6 +1378,7 @@ static void Mod_LoadLighting (lump_t *l)
 	unsigned int path_id;
 
 	loadmodel->lightdata = NULL;
+	loadmodel->lightdatasize = 0;
 	loadmodel->litfile = false;
 	// LordHavoc: check for a .lit file
 	q_strlcpy(litfilename, loadmodel->name, sizeof(litfilename));
@@ -870,6 +1405,7 @@ static void Mod_LoadLighting (lump_t *l)
 				{
 					Con_DPrintf2("%s loaded\n", litfilename);
 					loadmodel->lightdata = data + 8;
+					loadmodel->lightdatasize = l->filelen * 3;
 					loadmodel->litfile = true;
 					return;
 				}
@@ -899,6 +1435,7 @@ static void Mod_LoadLighting (lump_t *l)
 		// RRRRR GGGGG BBBBBB
 
 		loadmodel->lightdata = (byte *) Hunk_AllocNameNoFill ( (l->filelen / 2)*3, litfilename);
+		loadmodel->lightdatasize = (l->filelen / 2) * 3;
 		in = mod_base + l->fileofs;
 		out = loadmodel->lightdata;
 
@@ -915,6 +1452,7 @@ static void Mod_LoadLighting (lump_t *l)
 	}
 
 	loadmodel->lightdata = (byte *) Hunk_AllocNameNoFill ( l->filelen*3, litfilename);
+	loadmodel->lightdatasize = l->filelen * 3;
 	in = loadmodel->lightdata + l->filelen*2; // place the file at the end, so it will not be overwritten until the very last write
 	out = loadmodel->lightdata;
 	memcpy (in, mod_base + l->fileofs, l->filelen);
@@ -1356,6 +1894,7 @@ static void Mod_LoadFaces (lump_t *l, qboolean bsp2)
 			out->samples = NULL;
 		else
 			out->samples = loadmodel->lightdata + (lofs * 3); //johnfitz -- lit support via lordhavoc (was "+ i")
+		out->bspx_lightdir_samples = NULL;
 
 		texture = loadmodel->textures[out->texinfo->texnum];
 
@@ -2400,6 +2939,11 @@ static void Mod_LoadBrushModel (qmodel_t *mod, void *buffer)
 	dheader_t	*header;
 	dmodel_t 	*bm;
 	float		radius; //johnfitz
+	size_t			bsp_filesize = 0;
+	const byte	*bsp_data = (const byte *)buffer;
+
+	if (com_filesize > 0 && com_filesize <= (qfileofs_t)SIZE_MAX)
+		bsp_filesize = (size_t)com_filesize;
 
 	loadmodel->type = mod_brush;
 
@@ -2428,6 +2972,7 @@ static void Mod_LoadBrushModel (qmodel_t *mod, void *buffer)
 
 // swap all the lumps
 	mod_base = (byte *)header;
+	Mod_BspxParseLumps (bsp_data, bsp_filesize);
 
 	for (i = 0; i < (int) sizeof(dheader_t) / 4; i++)
 		((int *)header)[i] = LittleLong ( ((int *)header)[i]);
@@ -2475,6 +3020,7 @@ visdone:
 	Mod_LoadEntities (&header->lumps[LUMP_ENTITIES]);
 	Mod_LoadSubmodels (&header->lumps[LUMP_MODELS]);
 
+	Mod_BspxIntegrate (&header->lumps[LUMP_LIGHTING]);
 	Mod_MakeHull0 ();
 
 	mod->numframes = 2;		// regular and alternate animation

--- a/Quake/gl_model.h
+++ b/Quake/gl_model.h
@@ -51,6 +51,14 @@ typedef struct
 	vec3_t		position;
 } mvertex_t;
 
+typedef struct bspx_lump_s
+{
+        char            name[24];
+        int             fileofs;
+        int             filelen;
+        byte            *data;
+} bspx_lump_t;
+
 #define	SIDE_FRONT	0
 #define	SIDE_BACK	1
 #define	SIDE_ON		2
@@ -152,6 +160,7 @@ typedef struct msurface_s
 
 	byte		styles[MAXLIGHTMAPS];
 	byte		*samples;			// [numstyles*surfsize]
+	byte		*bspx_lightdir_samples;
 
 	int			texturemins[2];
 	mtexinfo_t	*texinfo;
@@ -490,6 +499,7 @@ typedef struct qmodel_s
 
 	byte		*visdata;
 	byte		*lightdata;
+	int			lightdatasize;
 	char		*entities;
 
 	qboolean	litfile;
@@ -498,6 +508,17 @@ typedef struct qmodel_s
 	int			bspversion;
 	int			contentstransparent;	//spike -- added this so we can disable glitchy wateralpha where its not supported.
 	qboolean	haslitwater;
+
+	int			num_bspx_lumps;
+	bspx_lump_t	*bspx_lumps;
+	vec3_t		*bspx_vertex_normals;
+	int			num_bspx_vertex_normals;
+	vec3_t		*bspx_face_normals;
+	int			num_bspx_face_normals;
+	byte		*bspx_rgb_lighting;
+	int			bspx_rgb_lighting_size;
+	byte		*bspx_lighting_dir;
+	int			bspx_lighting_dir_size;
 
 //
 // alias model
@@ -528,6 +549,11 @@ void	Mod_TouchModel (const char *name);
 mleaf_t *Mod_PointInLeaf (vec3_t p, qmodel_t *model);
 byte	*Mod_LeafPVS (mleaf_t *leaf, qmodel_t *model);
 byte	*Mod_NoVisPVS (qmodel_t *model);
+const bspx_lump_t *Mod_BspxFindLump (const qmodel_t *model, const char *name);
+qboolean Mod_BspxSurfaceAverageVertexNormal (const qmodel_t *model, const msurface_t *surf, vec3_t out);
+const vec3_t *Mod_BspxSurfaceNormal (const qmodel_t *model, int surfindex);
+qboolean Mod_BspxNormalsEnabled (void);
+qboolean Mod_BspxLightingEnabled (void);
 
 void Mod_SetExtraFlags (qmodel_t *mod);
 size_t Mod_SanitizeMapDescription (char *dst, size_t dstsize, const char *src);

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -29,6 +29,8 @@ qboolean	r_cache_thrash;		// compatability
 
 gpuframedata_t r_framedata;
 
+extern gltexture_t *deluxemap_texture;
+
 
 vec3_t* r_pointfile;
 
@@ -227,6 +229,7 @@ cvar_t	r_vignette_noise = { "r_vignette_noise", "0.0", CVAR_ARCHIVE };
 cvar_t	r_chromatic_aberration = { "r_chromatic_aberration", "0", CVAR_ARCHIVE };
 
 cvar_t	r_overbrightbits = { "r_overbrightbits", "1", CVAR_ARCHIVE };
+cvar_t	r_shadingmodel = { "r_shadingmodel", "0", CVAR_ARCHIVE };
 
 cvar_t	gl_finish = { "gl_finish","0",CVAR_NONE };
 cvar_t	gl_clear = { "gl_clear","1",CVAR_NONE };
@@ -1515,6 +1518,21 @@ void R_SetupView (void)
 {
 	R_AnimateLight ();
 
+	memset (r_framedata.lightmapmod, 0, sizeof (r_framedata.lightmapmod));
+	memset (r_framedata.lightmapwave, 0, sizeof (r_framedata.lightmapwave));
+	memset (r_framedata.glowparams, 0, sizeof (r_framedata.glowparams));
+
+	r_framedata.lightmapmod[1] = 1.f;
+	r_framedata.lightmapmod[2] = 1.f;
+
+	unsigned int shading_model = (unsigned int)CLAMP (0, (int)Q_rint (r_shadingmodel.value), 2);
+	r_framedata.shadingmodel = shading_model;
+
+	if (Mod_BspxLightingEnabled () && deluxemap_texture && deluxemap_texture->texnum != 0)
+		r_framedata.has_deluxemap = 1u;
+	else
+		r_framedata.has_deluxemap = 0u;
+
 	{
 		int overbright_bits = CLAMP (0, (int)Q_rint (r_overbrightbits.value), 3);
 		float overbright = (float)(1 << overbright_bits);
@@ -1533,7 +1551,6 @@ void R_SetupView (void)
 
 
 		r_framedata.overbright = overbright;
-		r_framedata._padding0 = 0.f;
 	}
 
 	r_framecount++;

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -32,6 +32,7 @@ extern cvar_t gl_fullbrights;
 extern cvar_t gl_farclip;
 extern cvar_t gl_overbright_models;
 extern cvar_t r_overbrightbits;
+extern cvar_t r_shadingmodel;
 extern cvar_t r_waterwarp;
 extern cvar_t r_oldskyleaf;
 extern cvar_t r_drawworld;
@@ -300,6 +301,18 @@ static void R_OverbrightBits_f (cvar_t *var)
 
 /*
 ====================
+R_ShadingModel_f
+====================
+*/
+static void R_ShadingModel_f (cvar_t *var)
+{
+	int value = CLAMP (0, (int)Q_rint (var->value), 2);
+	if (value != (int)var->value)
+		Cvar_SetValueQuick (var, (float)value);
+}
+
+/*
+====================
 GL_WaterAlphaForTextureType
 ====================
 */
@@ -379,6 +392,9 @@ void R_Init (void)
 	Cvar_RegisterVariable (&r_chromatic_aberration);
 	Cvar_RegisterVariable (&r_overbrightbits);
 	Cvar_SetCallback (&r_overbrightbits, R_OverbrightBits_f);
+	Cvar_RegisterVariable (&r_shadingmodel);
+	Cvar_SetCallback (&r_shadingmodel, R_ShadingModel_f);
+	R_ShadingModel_f (&r_shadingmodel);
 
 	Cvar_RegisterVariable (&gl_finish);
 	Cvar_RegisterVariable (&gl_clear);

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -427,17 +427,20 @@ typedef struct gpuframedata_s {
 	float	screendither;
 	float	texturedither;
 	float	overbright;
-	float	_padding0;
+	unsigned int	shadingmodel;
 	vec3_t	eyepos;
 	float	time;
 	vec3_t	prev_eyepos;
 	float	delta_time;
 	float	zlogscale;
 	float	zlogbias;
-	int			numlights;
-	int			prev_frame_valid;
-	int			_padding1;
-	int			_padding2;
+	float	lightmapmod[4];
+	float	lightmapwave[4];
+	float	glowparams[4];
+	unsigned int	numlights;
+	unsigned int	prev_frame_valid;
+	unsigned int	has_deluxemap;
+	unsigned int	_pad2;
 } gpuframedata_t;
 
 extern gpulightbuffer_t r_lightbuffer;

--- a/Quake/r_brush.c
+++ b/Quake/r_brush.c
@@ -51,7 +51,9 @@ msurface_t		**lit_surfs;
 int				*lit_surf_order[2];
 int				num_lightmap_samples;
 unsigned		*lightmap_data;
+unsigned		*deluxemap_data;
 gltexture_t		*lightmap_texture;
+gltexture_t		*deluxemap_texture;
 int				lightmap_width;
 int				lightmap_height;
 
@@ -320,6 +322,44 @@ static void GL_FillSurfaceLightmap (msurface_t *surf)
 	}
 }
 
+static void GL_FillSurfaceDeluxemap (msurface_t *surf)
+{
+        lightmap_t *lm;
+        int smax, tmax;
+        int xofs, yofs;
+        unsigned *dst;
+        const byte *src;
+        int s, t;
+
+        if (!deluxemap_data || !surf->bspx_lightdir_samples)
+                return;
+        if (surf->lightmaptexturenum < 0 || surf->lightmaptexturenum >= lightmap_count)
+                return;
+
+        lm = &lightmaps[surf->lightmaptexturenum];
+        smax = (surf->extents[0]>>4)+1;
+        tmax = (surf->extents[1]>>4)+1;
+        xofs = lm->xofs + surf->light_s;
+        yofs = lm->yofs + surf->light_t;
+
+        dst = deluxemap_data + yofs * lightmap_width + xofs;
+        src = surf->bspx_lightdir_samples;
+
+        for (t = 0; t < tmax; ++t)
+        {
+                unsigned *row = dst + t * lightmap_width;
+                const byte *srcrow = src + t * smax * 3;
+                for (s = 0; s < smax; ++s)
+                {
+                        int idx = s * 3;
+                        unsigned r = srcrow[idx + 0];
+                        unsigned g = srcrow[idx + 1];
+                        unsigned b = srcrow[idx + 2];
+                        row[s] = r | (g << 8) | (b << 16) | 0xff000000u;
+                }
+        }
+}
+
 /*
 ==================
 GL_FreeLightmapData
@@ -332,6 +372,11 @@ static void GL_FreeLightmapData (void)
 		free (lightmap_data);
 		lightmap_data = NULL;
 	}
+	if (deluxemap_data)
+	{
+		free (deluxemap_data);
+		deluxemap_data = NULL;
+	}
 	if (lightmaps)
 	{
 		free (lightmaps);
@@ -341,6 +386,7 @@ static void GL_FreeLightmapData (void)
 	VEC_CLEAR (lit_surfs);
 
 	lightmap_texture = NULL; // freed by the texture manager
+	deluxemap_texture = NULL;
 	last_lightmap_allocated = 0;
 	lightmap_count = 0;
 	lightmap_width = 0;
@@ -524,6 +570,21 @@ void GL_BuildLightmaps (void)
 	if (!lightmap_data)
 		Sys_Error ("GL_BuildLightmaps: out of memory on %" SDL_PRIu64 " bytes", (uint64_t)(lmsize * sizeof (*lightmap_data)));
 
+	deluxemap_data = NULL;
+	if (cl.worldmodel && cl.worldmodel->bspx_lighting_dir && cl.worldmodel->lightdatasize > 0 && cl.worldmodel->bspx_lighting_dir_size == cl.worldmodel->lightdatasize && Mod_BspxLightingEnabled ())
+	{
+		deluxemap_data = (unsigned *) calloc (lmsize, sizeof (*deluxemap_data));
+		if (!deluxemap_data)
+		{
+			Con_DWarning ("BSPX: unable to allocate deluxemap buffer (%d texels)\n", lmsize);
+		}
+		else
+		{
+			for (i = 0; i < lmsize; ++i)
+				deluxemap_data[i] = 0xffff8080u;
+		}
+	}
+
 	// compute offsets for each lightmap block
 	for (i=0; i<lightmap_count; i++)
 	{
@@ -534,6 +595,8 @@ void GL_BuildLightmaps (void)
 
 	// fill reserved texel
 	lightmap_data[0] = 0xff808080u;
+	if (deluxemap_data)
+		deluxemap_data[0] = 0xffff8080u;
 
 	// unlit map? fill with 50% grey
 	if (!cl.worldmodel->lightdata)
@@ -542,13 +605,29 @@ void GL_BuildLightmaps (void)
 
 	// fill lightmap samples
 	for (i = 0, j = VEC_SIZE (lit_surfs); i < j; i++)
-		GL_FillSurfaceLightmap (lit_surfs[i]);
+	{
+		msurface_t *surf = lit_surfs[i];
+		GL_FillSurfaceLightmap (surf);
+		if (deluxemap_data)
+			GL_FillSurfaceDeluxemap (surf);
+	}
 
 	lightmap_texture =
 		TexMgr_LoadImage (cl.worldmodel, "lightmap", lightmap_width, lightmap_height,
 			SRC_LIGHTMAP, (byte *)lightmap_data, "", (src_offset_t)lightmap_data,
 			TEXPREF_ALPHA | TEXPREF_LINEAR | TEXPREF_NOPICMIP
 		);
+
+	if (deluxemap_data)
+	{
+		deluxemap_texture =
+			TexMgr_LoadImage (cl.worldmodel, "deluxemap", lightmap_width, lightmap_height,
+				SRC_LIGHTMAP, (byte *)deluxemap_data, "", (src_offset_t)deluxemap_data,
+				TEXPREF_LINEAR | TEXPREF_NOPICMIP
+			);
+	}
+	else
+		deluxemap_texture = NULL;
 
 	//johnfitz -- warn about exceeding old limits
 	//GLQuake limit was 64 textures of 128x128. Estimate how many 128x128 textures we would need

--- a/Quake/r_decals.c
+++ b/Quake/r_decals.c
@@ -358,12 +358,55 @@ static qboolean R_DecalProject (const vec3_t point, const vec3_t preferred_norma
                 if (!R_SurfaceIsDecalable (surf))
                         continue;
 
-                VectorCopy (surf->plane->normal, normal);
+                vec3_t plane_normal;
+                qboolean used_bspx_normal = false;
+
+                VectorCopy (surf->plane->normal, plane_normal);
                 plane_dist = surf->plane->dist;
+                VectorCopy (plane_normal, normal);
+
+                if (Mod_BspxNormalsEnabled ())
+                {
+                        int surfindex = (int)(surf - cl.worldmodel->surfaces);
+                        const vec3_t *face_normal = Mod_BspxSurfaceNormal (cl.worldmodel, surfindex);
+                        if (face_normal)
+                        {
+                                VectorCopy (*face_normal, normal);
+                                used_bspx_normal = true;
+                        }
+                        else if (Mod_BspxSurfaceAverageVertexNormal (cl.worldmodel, surf, normal))
+                        {
+                                used_bspx_normal = true;
+                        }
+                        else
+                        {
+                                VectorCopy (plane_normal, normal);
+                        }
+                }
+
                 if (surf->flags & SURF_PLANEBACK)
                 {
-                        VectorScale (normal, -1.f, normal);
+                        VectorScale (plane_normal, -1.f, plane_normal);
                         plane_dist = -plane_dist;
+                        if (used_bspx_normal)
+                                VectorScale (normal, -1.f, normal);
+                        else
+                                VectorCopy (plane_normal, normal);
+                }
+                else if (!used_bspx_normal)
+                {
+                        VectorCopy (plane_normal, normal);
+                }
+
+                if (used_bspx_normal && surf->numedges > 0)
+                {
+                        int edge_index = cl.worldmodel->surfedges[surf->firstedge];
+                        int vert_index = (edge_index >= 0) ? cl.worldmodel->edges[edge_index].v[0] : cl.worldmodel->edges[-edge_index].v[1];
+                        if (vert_index >= 0 && vert_index < cl.worldmodel->numvertexes)
+                        {
+                                const vec3_t v = cl.worldmodel->vertexes[vert_index].position;
+                                plane_dist = DotProduct (normal, v);
+                        }
                 }
 
                 d = DotProduct (point, normal) - plane_dist;

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -29,6 +29,7 @@ extern cvar_t gl_zfix; // QuakeSpasm z-fighting fix
 extern cvar_t r_oit;
 
 extern gltexture_t *lightmap_texture;
+extern gltexture_t *deluxemap_texture;
 
 extern GLuint gl_bmodel_vbo;
 extern size_t gl_bmodel_vbo_size;
@@ -512,6 +513,7 @@ static void R_DrawBrushModels_Real (entity_t **ents, int count, brushpass_t pass
         if (pass <= BP_ALPHATEST)
         {
                 GL_Bind (GL_TEXTURE2, r_fullbright_cheatsafe ? greytexture : lightmap_texture);
+                GL_Bind (GL_TEXTURE3, deluxemap_texture);
         }
         else if (pass == BP_SKYCUBEMAP)
                 GL_Bind (GL_TEXTURE2, skybox->cubemap);
@@ -612,6 +614,7 @@ void R_DrawBrushModels_Water (entity_t **ents, int count, qboolean translucent)
 	R_ResetBModelCalls (program);
 	GL_SetState (state);
 	GL_Bind (GL_TEXTURE2, r_fullbright_cheatsafe ? greytexture : lightmap_texture);
+        GL_Bind (GL_TEXTURE3, deluxemap_texture);
 
 	GL_Upload (GL_SHADER_STORAGE_BUFFER, bmodel_instances, sizeof(bmodel_instances[0]) * totalinst, &buf, &ofs);
 	GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 2, buf, (GLintptr)ofs, sizeof(bmodel_instances[0]) * count);

--- a/docs/bspx.md
+++ b/docs/bspx.md
@@ -1,0 +1,51 @@
+# BSPX Integration
+
+Ironwail can read and cache [BSPX](https://www.quaddicted.com/files/maps/bspx.txt) footer data that is appended to a BSP file. The loader walks the footer table after the vanilla lumps have been parsed and keeps every recognised entry inside the `qmodel_t` so it is available for renderer, tools, and debugging code.
+
+## Recognised lumps
+
+| Lump name      | Purpose | Usage |
+| -------------- | ------- | ----- |
+| `VERTEXNORMALS` | Array of vertex normals stored as little-endian float triples. | Parsed into `qmodel_t::bspx_vertex_normals` for optional shading/decals when `r_bspx_normals` is enabled. |
+| `FACENORMALS`   | Per-surface normals stored as float triples. | Used as the preferred normal in decal projection (`r_decals`), falling back to averaged vertex normals. |
+| `RGBLIGHTING`   | Packed RGB lightmap samples. | Copied into the standard lightmap buffer when `r_bspx_lighting` is enabled and no external `.lit` file overrides the map. |
+| `LIGHTINGDIR`   | Directional lighting samples aligned with the BSP lightmap. | When `r_bspx_lighting` is enabled the samples populate per-surface deluxemaps so shaders can reconstruct smooth normals; otherwise the data remains cached for tooling. |
+| `ENVMAP`, `SURFENVMAP` | Additional material metadata. | Stored as opaque blobs for future renderer features. |
+| `BRUSHLIST`     | List of brush indices. | Available through the `bspx_brushlist` console command for debugging tools. |
+| `ZIP_PAKFILE`   | Embedded archive payload. | Parsed and stored as an opaque blob. |
+
+Unknown lumps are preserved as opaque data and trigger a one-time developer warning so that maps can ship with forward-compatible extensions without breaking the loader.
+
+## Safety checks
+
+* Footer signature (`"BSPX"`) and table size are validated before data is copied from the map buffer.
+* Lump offsets and sizes are clamped to the BSP file boundaries and must not exceed 64&nbsp;MiB per entry.
+* Overlapping lump payloads are rejected to prevent accidental corruption.
+* The loader degrades gracefully if parsing fails – the core BSP path remains untouched.
+
+## CVars
+
+| CVar | Default | Description |
+| ---- | ------- | ----------- |
+| `r_bspx_enable` | `1` | Master switch that enables BSPX parsing. When `0`, only vanilla BSP data is loaded. |
+| `r_bspx_normals` | `1` | Allows renderer subsystems to consume BSPX normals. Decal projection uses them when this cvar is set. |
+| `r_bspx_lighting` | `1` | Allows colour lightmaps supplied by `RGBLIGHTING` to replace the grayscale BSP lump when no `.lit` file is present. |
+| `r_bspx_envmap` | `0` | Reserved flag for future environment mapping support. |
+
+Changes to these CVars take effect on the next map load.
+
+Directional lighting reconstructed from `LIGHTINGDIR` only activates while `r_bspx_lighting` is non-zero; the raw samples are still cached so tools can inspect them when the feature is disabled.
+
+## Developer tooling
+
+* `bspx_brushlist` – prints the indices contained in the `BRUSHLIST` lump (first 32 entries, followed by a summary when more are present). Useful when validating tooling pipelines.
+
+## Opaque data access
+
+Every lump – recognised or not – is retained inside `qmodel_t::bspx_lumps`. Mods or tools can request the raw blob through `Mod_BspxFindLump` and perform their own decoding without touching the loader.
+
+## Failure modes
+
+* If a lump fails validation (e.g. truncated payload or size mismatch) it is ignored and a developer warning is emitted.
+* When `r_bspx_normals` is disabled the renderer falls back to the legacy plane normals.
+* When `r_bspx_lighting` is disabled or a `.lit` file is present, vanilla lightmaps are preserved.


### PR DESCRIPTION
## Summary
- parse BSPX footer data and keep validated lumps with the loaded model
- expose BSPX normals and lighting data to decals and lightmap loaders behind new CVars
- add a developer brushlist command and document supported BSPX extensions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f905b1f408832eb23d8a2507e8484a