### PR TITLE
Fix type mismatches in lighting code

### DIFF
--- a/Quake/gl_model.h
+++ b/Quake/gl_model.h
@@ -160,7 +160,7 @@ typedef struct msurface_s
 
 	byte		styles[MAXLIGHTMAPS];
 	byte		*samples;			// [numstyles*surfsize]
-	byte		*bspx_lightdir_samples;
+	const byte	*bspx_lightdir_samples;
 
 	int			texturemins[2];
 	mtexinfo_t	*texinfo;

--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -229,7 +229,7 @@ void R_SetupAliasLighting (entity_t	*e)
 {
 	vec3_t		dist;
 	float		add;
-	int			i;
+	unsigned int	i;
 
 	// if the initial trace is completely black, try again from above
 	// this helps with models whose origin is slightly below ground level


### PR DESCRIPTION
## Summary
- make BSPX light direction samples const-correct to avoid qualifier mismatches
- use an unsigned loop counter when iterating GPU lights to eliminate signed/unsigned comparisons

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f91afeb224832e9fc357929c3877be