### PR TITLE
Add sine lightstyle modulation and halo rendering

### DIFF
--- a/Quake/gl_rlight.c
+++ b/Quake/gl_rlight.c
@@ -22,10 +22,20 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // r_light.c
 
 #include "quakedef.h"
+#include <stddef.h>
 
 extern cvar_t r_flatlightstyles; //johnfitz
 extern cvar_t r_lerplightstyles;
 extern cvar_t r_dynamic;
+extern cvar_t r_lightstyle_multiplier;
+extern cvar_t r_lightstyle_sine;
+extern cvar_t r_lightstyle_sine_amplitude;
+extern cvar_t r_lightstyle_sine_frequency;
+extern cvar_t r_lightstyle_sine_phase;
+extern cvar_t r_lightstyle_sine_phase_step;
+extern cvar_t r_flashblend;
+extern cvar_t r_flashblend_scale;
+extern cvar_t r_flashblend_intensity;
 
 gpulightbuffer_t r_lightbuffer;
 
@@ -36,12 +46,20 @@ R_AnimateLight
 */
 void R_AnimateLight (void)
 {
-	int			i,j,k,n;
-	double		f,base;
+	int					i, j, k, n;
+	double				f, base;
+	float				global_multiplier;
+	float				wave_amplitude = 0.f;
+	float				wave_frequency = 0.f;
+	float				wave_phase = 0.f;
+	float				wave_phase_step = 0.f;
+	qboolean			use_wave = false;
+	float				time_value;
+	const float		two_pi = (float)(M_PI * 2.0);
 
-//
-// light animations
-// 'm' is normal light, 'a' is no light, 'z' is double bright
+	//
+	// light animations
+	// 'm' is normal light, 'a' is no light, 'z' is double bright
 	f = cl.time * 10.0;
 	base = floor(f);
 	i = (int)base;
@@ -49,12 +67,42 @@ void R_AnimateLight (void)
 	if (!r_lerplightstyles.value)
 		f = 0.0;
 
-	for (j=0 ; j<MAX_LIGHTSTYLES ; j++)
+	global_multiplier = q_max(r_lightstyle_multiplier.value, 0.f);
+	if (r_lightstyle_sine.value != 0.f)
 	{
+		wave_amplitude = r_lightstyle_sine_amplitude.value;
+		wave_frequency = r_lightstyle_sine_frequency.value;
+		wave_phase = r_lightstyle_sine_phase.value;
+		wave_phase_step = r_lightstyle_sine_phase_step.value;
+		if (wave_amplitude != 0.f && wave_frequency != 0.f)
+			use_wave = true;
+	}
+
+	time_value = (float)cl.time;
+
+	for (j = 0; j < MAX_LIGHTSTYLES; j++)
+	{
+		float style_multiplier = global_multiplier;
+		if (use_wave)
+		{
+			float angle = (wave_frequency * time_value + wave_phase + wave_phase_step * (float)j) * two_pi;
+			float wave = 1.f + wave_amplitude * sinf(angle);
+			if (wave < 0.f)
+				wave = 0.f;
+			style_multiplier *= wave;
+		}
+		style_multiplier = q_max(style_multiplier, 0.f);
+
 		if (!cl_lightstyle[j].length)
 		{
-			d_lightstylevalue[j] = 256;
-			r_lightbuffer.lightstyles[j] = 1.f;
+			float base_light = style_multiplier;
+			float fixed = base_light * 256.f;
+			if (fixed < 0.f)
+				fixed = 0.f;
+			else if (fixed > 65535.f)
+				fixed = 65535.f;
+			d_lightstylevalue[j] = (int)fixed;
+			r_lightbuffer.lightstyles[j] = base_light;
 			continue;
 		}
 		//johnfitz -- r_flatlightstyles
@@ -74,15 +122,26 @@ void R_AnimateLight (void)
 		// only interpolate abrupt changes (e.g. flickering light in e1m1) if r_lerplightstyles >= 2
 		if (r_lerplightstyles.value < 2.f && abs(n - k) >= ('m' - 'a') / 2)
 			n = k;
-		d_lightstylevalue[j] = (int)(k*22 + (n-k)*22*f);
-		r_lightbuffer.lightstyles[j] = (k + (n-k)*f) * (22.f/256.f);
-		//johnfitz
+
+		{
+			float base_fixed = (float)(k * 22 + (n - k) * 22 * f);
+			float scaled_fixed = base_fixed * style_multiplier;
+			if (scaled_fixed < 0.f)
+				scaled_fixed = 0.f;
+			else if (scaled_fixed > 65535.f)
+				scaled_fixed = 65535.f;
+			d_lightstylevalue[j] = (int)scaled_fixed;
+		}
+
+		r_lightbuffer.lightstyles[j] = (k + (n - k) * f) * (22.f / 256.f) * style_multiplier;
 	}
 
 	if (r_fullbright_cheatsafe)
+	{
 		r_lightbuffer.lightstyles[0] = 1.f;
+		d_lightstylevalue[0] = 256;
+	}
 }
-
 /*
 =============================================================================
 
@@ -200,6 +259,83 @@ void R_PushDlights (void)
 
 	GL_EndGroup ();
 }
+void R_DrawLightHalos (void)
+{
+	typedef struct
+	{
+		vec3_t	pos;
+		GLubyte color[4];
+	} halo_vertex_t;
+
+	float	scale_base;
+	float	intensity;
+	int		i;
+	int		c;
+
+	if (r_flashblend.value <= 0.f)
+		return;
+
+	if (r_framedata.numlights <= 0)
+		return;
+
+	scale_base = q_max(r_flashblend_scale.value, 0.f);
+	intensity  = q_max(r_flashblend_intensity.value, 0.f);
+	if (scale_base <= 0.f || intensity <= 0.f)
+		return;
+
+	GL_BeginGroup ("Light halos");
+
+	GL_UseProgram (glprogs.particles[0][0]);
+	GL_SetState (GLS_BLEND_ADDITIVE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE |
+		GLS_ATTRIBS (2) | GLS_INSTANCED_ATTRIBS (2));
+
+	for (i = 0; i < r_framedata.numlights; ++i)
+	{
+		const gpulight_t *light = &r_lightbuffer.lights[i];
+		float radius = light->radius * scale_base;
+		halo_vertex_t vert;
+		float scalex, scaley;
+		float color_scale;
+		GLuint buf;
+		GLbyte *ofs;
+		float alpha;
+
+		if (radius <= 0.f)
+			continue;
+
+		scalex = radius * r_matproj[1 * 4 + 0];
+		scaley = -radius * r_matproj[2 * 4 + 1];
+		GL_Uniform3fFunc (0, scalex, scaley, 1.f);
+
+		VectorCopy (light->pos, vert.pos);
+
+		color_scale = intensity * 255.f;
+		for (c = 0; c < 3; ++c)
+		{
+			float channel = q_max (light->color[c], 0.f) * color_scale;
+			if (channel > 255.f)
+				channel = 255.f;
+			vert.color[c] = (GLubyte) channel;
+		}
+
+		alpha = q_max (q_max (vert.color[0], vert.color[1]), vert.color[2]);
+		if (alpha < 1.f)
+			alpha = q_min (color_scale, 255.f);
+		if (alpha > 255.f)
+			alpha = 255.f;
+		vert.color[3] = (GLubyte) alpha;
+
+		GL_Upload (GL_ARRAY_BUFFER, &vert, sizeof (vert), &buf, &ofs);
+		GL_BindBuffer (GL_ARRAY_BUFFER, buf);
+		GL_VertexAttribPointerFunc (0, 3, GL_FLOAT, GL_FALSE, sizeof (vert), ofs + offsetof (halo_vertex_t, pos));
+		GL_VertexAttribPointerFunc (1, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof (vert), ofs + offsetof (halo_vertex_t, color));
+		GL_DrawArraysInstancedFunc (GL_TRIANGLE_STRIP, 0, 4, 1);
+	}
+
+	GL_EndGroup ();
+}
+
+
 
 
 /*

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -241,6 +241,15 @@ cvar_t	gl_nocolors = { "gl_nocolors","0",CVAR_NONE };
 cvar_t	r_clearcolor = { "r_clearcolor","2",CVAR_ARCHIVE };
 cvar_t	r_flatlightstyles = { "r_flatlightstyles", "0", CVAR_NONE };
 cvar_t	r_lerplightstyles = { "r_lerplightstyles", "1", CVAR_ARCHIVE }; // 0=off; 1=skip abrupt transitions; 2=always lerp
+cvar_t	r_lightstyle_multiplier = { "r_lightstyle_multiplier", "1.0", CVAR_ARCHIVE };
+cvar_t	r_lightstyle_sine = { "r_lightstyle_sine", "0", CVAR_ARCHIVE };
+cvar_t	r_lightstyle_sine_amplitude = { "r_lightstyle_sine_amplitude", "0.25", CVAR_ARCHIVE };
+cvar_t	r_lightstyle_sine_frequency = { "r_lightstyle_sine_frequency", "0.5", CVAR_ARCHIVE };
+cvar_t	r_lightstyle_sine_phase = { "r_lightstyle_sine_phase", "0.0", CVAR_ARCHIVE };
+cvar_t	r_lightstyle_sine_phase_step = { "r_lightstyle_sine_phase_step", "0.0", CVAR_ARCHIVE };
+cvar_t	r_flashblend = { "r_flashblend", "1", CVAR_ARCHIVE };
+cvar_t	r_flashblend_scale = { "r_flashblend_scale", "1.0", CVAR_ARCHIVE };
+cvar_t	r_flashblend_intensity = { "r_flashblend_intensity", "1.0", CVAR_ARCHIVE };
 cvar_t	gl_fullbrights = { "gl_fullbrights", "1", CVAR_ARCHIVE };
 cvar_t	gl_farclip = { "gl_farclip", "65536", CVAR_ARCHIVE };
 cvar_t	gl_overbright_models = { "gl_overbright_models", "1", CVAR_ARCHIVE };
@@ -2605,6 +2614,7 @@ void R_RenderScene (void)
 	R_DrawEntitiesOnList (false); //johnfitz -- false means this is the pass for nonalpha entities
 
 	R_DrawParticles (false);
+	R_DrawLightHalos ();
 
 	Sky_DrawSky (); //johnfitz
 

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -408,6 +408,15 @@ void R_Init (void)
 	Cvar_RegisterVariable (&r_waterwarp);
 	Cvar_RegisterVariable (&r_flatlightstyles);
 	Cvar_RegisterVariable (&r_lerplightstyles);
+	Cvar_RegisterVariable (&r_lightstyle_multiplier);
+	Cvar_RegisterVariable (&r_lightstyle_sine);
+	Cvar_RegisterVariable (&r_lightstyle_sine_amplitude);
+	Cvar_RegisterVariable (&r_lightstyle_sine_frequency);
+	Cvar_RegisterVariable (&r_lightstyle_sine_phase);
+	Cvar_RegisterVariable (&r_lightstyle_sine_phase_step);
+	Cvar_RegisterVariable (&r_flashblend);
+	Cvar_RegisterVariable (&r_flashblend_scale);
+	Cvar_RegisterVariable (&r_flashblend_intensity);
 	Cvar_RegisterVariable (&r_oldskyleaf);
 	Cvar_RegisterVariable (&r_drawworld);
 	Cvar_RegisterVariable (&r_showtris);

--- a/Quake/gl_vidsdl.c
+++ b/Quake/gl_vidsdl.c
@@ -1123,16 +1123,19 @@ static void GL_SetStateEx (unsigned mask, unsigned force)
 					break;
 				}
 				// fallthrough!
-			case GLS_BLEND_ALPHA:
-				glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-				break;
-			case GLS_BLEND_MULTIPLY:
-				glBlendFunc(GL_ZERO, GL_SRC_COLOR);
-				break;
-		}
-	}
+case GLS_BLEND_ALPHA:
+glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+break;
+case GLS_BLEND_MULTIPLY:
+glBlendFunc(GL_ZERO, GL_SRC_COLOR);
+break;
+case GLS_BLEND_ADDITIVE:
+glBlendFunc(GL_ONE, GL_ONE);
+break;
+}
+}
 
-	if (diff & GLS_MASK_CULL)
+if (diff & GLS_MASK_CULL)
 	{
 		unsigned cull = mask & GLS_MASK_CULL;
 		if (cull == GLS_CULL_NONE)

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -44,6 +44,7 @@ extern vec3_t *r_pointfile;
 void R_TimeRefresh_f (void);
 void R_ReadPointFile_f (void);
 texture_t *R_TextureAnimation (texture_t *base, int frame);
+void R_DrawLightHalos (void);
 
 typedef enum {
 	pt_static, pt_grav, pt_slowgrav, pt_fire, pt_explode, pt_explode2, pt_blob, pt_blob2
@@ -104,6 +105,15 @@ extern	cvar_t	r_litwater;
 extern	cvar_t	r_dynamic;
 extern	cvar_t	r_novis;
 extern	cvar_t	r_scale;
+extern	cvar_t	r_lightstyle_multiplier;
+extern	cvar_t	r_lightstyle_sine;
+extern	cvar_t	r_lightstyle_sine_amplitude;
+extern	cvar_t	r_lightstyle_sine_frequency;
+extern	cvar_t	r_lightstyle_sine_phase;
+extern	cvar_t	r_lightstyle_sine_phase_step;
+extern	cvar_t	r_flashblend;
+extern	cvar_t	r_flashblend_scale;
+extern	cvar_t	r_flashblend_intensity;
 
 extern	cvar_t	r_oit;
 extern	cvar_t	r_alphasort;
@@ -275,15 +285,16 @@ typedef enum {
 	GLS_BLEND_ALPHA				= 1 << 2,
 	GLS_BLEND_ALPHA_OIT			= 2 << 2,
 	GLS_BLEND_MULTIPLY			= 3 << 2,
-	GLS_MASK_BLEND				= 3 << 2,
+	GLS_BLEND_ADDITIVE			= 4 << 2,
+	GLS_MASK_BLEND				= 7 << 2,
 
-	GLS_CULL_BACK				= 0 << 4,
-	GLS_CULL_NONE				= 1 << 4,
-	GLS_CULL_FRONT				= 2 << 4,
-	GLS_MASK_CULL				= 3 << 4,
+	GLS_CULL_BACK				= 0 << 5,
+	GLS_CULL_NONE				= 1 << 5,
+	GLS_CULL_FRONT				= 2 << 5,
+	GLS_MASK_CULL				= 3 << 5,
 
 	GLS_ATTRIBS_BITS			= 3,
-	GLS_ATTRIBS_SHIFT			= 6,
+	GLS_ATTRIBS_SHIFT			= 7,
 	GLS_ATTRIBS_MAXCOUNT		= (1 << GLS_ATTRIBS_BITS) - 1,
 	GLS_MASK_ATTRIBS			= GLS_ATTRIBS_MAXCOUNT << GLS_ATTRIBS_SHIFT,
 


### PR DESCRIPTION
## Summary
- add sine-driven lightstyle modulation controls and propagate values into the GPU light buffer
- render additive light halos for dynamic lights using the particle shader
- expose new renderer cvars and additive blending state needed for the halos

## Testing
- `cmake -S . -B build` *(fails: missing SDL2 package in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f91d949f5c832eb7ed6e0623045eac