### PR TITLE
Fix signed/unsigned comparison in light halo rendering

### DIFF
--- a/Quake/gl_rlight.c
+++ b/Quake/gl_rlight.c
@@ -269,7 +269,7 @@ void R_DrawLightHalos (void)
 
 	float	scale_base;
 	float	intensity;
-	int		i;
+	unsigned int	i;
 	int		c;
 
 	if (r_flashblend.value <= 0.f)


### PR DESCRIPTION
## Summary
- convert the light halo loop counter to an unsigned type so it matches `r_framedata.numlights`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fa0608bdfc832e96c2766cf343e9be