### PR TITLE
Add configurable film grain post effect

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -225,6 +225,8 @@ cvar_t	r_vignette_color_b = { "r_vignette_color_b", "0.0", CVAR_ARCHIVE };
 cvar_t	r_vignette_blend_mode = { "r_vignette_blend_mode", "0", CVAR_ARCHIVE };
 cvar_t	r_vignette_noise = { "r_vignette_noise", "0.0", CVAR_ARCHIVE };
 cvar_t	r_chromatic_aberration = { "r_chromatic_aberration", "0", CVAR_ARCHIVE };
+cvar_t	r_filmgrain = { "r_filmgrain", "0", CVAR_ARCHIVE };
+cvar_t	r_filmgrain_size = { "r_filmgrain_size", "3.0", CVAR_ARCHIVE };
 
 cvar_t	r_overbrightbits = { "r_overbrightbits", "1", CVAR_ARCHIVE };
 
@@ -767,6 +769,15 @@ void GL_PostProcess (void)
                 q_max (0.f, r_chromatic_aberration.value),
                 0.f,
                 0.f);
+
+        {
+                float filmgrain_intensity = q_max (0.f, r_filmgrain.value);
+                filmgrain_intensity = q_min (1.f, filmgrain_intensity);
+                float filmgrain_size = q_max (1.f, r_filmgrain_size.value);
+                float filmgrain_time = (float)cl.time;
+                float filmgrain_time_alt = (float)(cl.time * 1.37);
+                GL_Uniform4fFunc (11, filmgrain_intensity, filmgrain_size, filmgrain_time, filmgrain_time_alt);
+        }
 
         dof_enabled = R_DoFEnabled ();
 

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -77,6 +77,8 @@ extern cvar_t r_vignette_color_b;
 extern cvar_t r_vignette_blend_mode;
 extern cvar_t r_vignette_noise;
 extern cvar_t r_chromatic_aberration;
+extern cvar_t r_filmgrain;
+extern cvar_t r_filmgrain_size;
 
 #if defined(USE_SIMD)
 extern cvar_t r_simd;
@@ -377,6 +379,8 @@ void R_Init (void)
 	Cvar_RegisterVariable (&r_vignette_blend_mode);
 	Cvar_RegisterVariable (&r_vignette_noise);
 	Cvar_RegisterVariable (&r_chromatic_aberration);
+	Cvar_RegisterVariable (&r_filmgrain);
+	Cvar_RegisterVariable (&r_filmgrain_size);
 	Cvar_RegisterVariable (&r_overbrightbits);
 	Cvar_SetCallback (&r_overbrightbits, R_OverbrightBits_f);
 

--- a/Quake/shaders/postprocess.frag
+++ b/Quake/shaders/postprocess.frag
@@ -116,6 +116,8 @@ layout(location=8) uniform vec4 PostFXParams0; // x: vignette strength, y: inner
 layout(location=9) uniform vec4 PostFXParams1; // xyz: vignette color, w: blend mode
 layout(location=10) uniform vec4 PostFXParams2; // x: vignette noise amount, y: chromatic aberration (pixels), zw: reserved
 
+layout(location=11) uniform vec4 FilmGrainParams; // x: intensity, y: grain size (px), zw: temporal offsets
+
 const int MOTION_MAX_SAMPLES = 64;
 const float OPAQUE_ALPHA_THRESHOLD = 0.999;
 
@@ -434,6 +436,17 @@ void main()
                 mapped = clamp(combined, 0.0, 1.0);
         }
         mapped = clamp(mapped, 0.0, 1.0);
+        float filmGrainIntensity = max(FilmGrainParams.x, 0.0);
+        if (filmGrainIntensity > 0.0)
+        {
+                float grainSize = max(FilmGrainParams.y, 1.0);
+                vec2 grainOffset = vec2(FilmGrainParams.z, FilmGrainParams.w);
+                vec2 grainCoord = (gl_FragCoord.xy + grainOffset) / grainSize;
+                float grain = tri(whitenoise01(grainCoord));
+                float luma = dot(mapped, vec3(0.2126, 0.7152, 0.0722));
+                float response = mix(1.0, clamp(1.0 - luma, 0.0, 1.0), 0.5);
+                mapped = clamp(mapped + grain * (filmGrainIntensity * response), 0.0, 1.0);
+        }
         out_fragcolor = vec4(pow(mapped, vec3(gamma)), 1.0);
 #endif // PALETTIZE
 }


### PR DESCRIPTION
## Summary
- add r_filmgrain and r_filmgrain_size CVars and plumb them through the post-processing pipeline
- introduce a large-grain noise pass in the postprocess shader that applies subtle luminance-dependent film grain

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fa1eef5f80832ebcf3de4ac91bb885