### PR TITLE
Add configurable strength for film grain effect

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -227,6 +227,7 @@ cvar_t	r_vignette_noise = { "r_vignette_noise", "0.0", CVAR_ARCHIVE };
 cvar_t	r_chromatic_aberration = { "r_chromatic_aberration", "0", CVAR_ARCHIVE };
 cvar_t	r_filmgrain = { "r_filmgrain", "0", CVAR_ARCHIVE };
 cvar_t	r_filmgrain_size = { "r_filmgrain_size", "3.0", CVAR_ARCHIVE };
+cvar_t	r_filmgrain_strength = { "r_filmgrain_strength", "1.0", CVAR_ARCHIVE };
 
 cvar_t	r_overbrightbits = { "r_overbrightbits", "1", CVAR_ARCHIVE };
 
@@ -774,9 +775,11 @@ void GL_PostProcess (void)
                 float filmgrain_intensity = q_max (0.f, r_filmgrain.value);
                 filmgrain_intensity = q_min (1.f, filmgrain_intensity);
                 float filmgrain_size = q_max (1.f, r_filmgrain_size.value);
+                float filmgrain_strength = q_max (0.f, r_filmgrain_strength.value);
                 float filmgrain_time = (float)cl.time;
                 float filmgrain_time_alt = (float)(cl.time * 1.37);
-                GL_Uniform4fFunc (11, filmgrain_intensity, filmgrain_size, filmgrain_time, filmgrain_time_alt);
+                GL_Uniform4fFunc (11, filmgrain_intensity, filmgrain_size, filmgrain_strength, 0.f);
+                GL_Uniform4fFunc (12, filmgrain_time, filmgrain_time_alt, 0.f, 0.f);
         }
 
         dof_enabled = R_DoFEnabled ();

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -79,6 +79,7 @@ extern cvar_t r_vignette_noise;
 extern cvar_t r_chromatic_aberration;
 extern cvar_t r_filmgrain;
 extern cvar_t r_filmgrain_size;
+extern cvar_t r_filmgrain_strength;
 
 #if defined(USE_SIMD)
 extern cvar_t r_simd;
@@ -381,6 +382,7 @@ void R_Init (void)
 	Cvar_RegisterVariable (&r_chromatic_aberration);
 	Cvar_RegisterVariable (&r_filmgrain);
 	Cvar_RegisterVariable (&r_filmgrain_size);
+	Cvar_RegisterVariable (&r_filmgrain_strength);
 	Cvar_RegisterVariable (&r_overbrightbits);
 	Cvar_SetCallback (&r_overbrightbits, R_OverbrightBits_f);
 

--- a/Quake/shaders/postprocess.frag
+++ b/Quake/shaders/postprocess.frag
@@ -116,7 +116,8 @@ layout(location=8) uniform vec4 PostFXParams0; // x: vignette strength, y: inner
 layout(location=9) uniform vec4 PostFXParams1; // xyz: vignette color, w: blend mode
 layout(location=10) uniform vec4 PostFXParams2; // x: vignette noise amount, y: chromatic aberration (pixels), zw: reserved
 
-layout(location=11) uniform vec4 FilmGrainParams; // x: intensity, y: grain size (px), zw: temporal offsets
+layout(location=11) uniform vec4 FilmGrainParams; // x: intensity, y: grain size (px), z: strength, w: unused
+layout(location=12) uniform vec4 FilmGrainOffset; // xy: temporal offsets, zw: unused
 
 const int MOTION_MAX_SAMPLES = 64;
 const float OPAQUE_ALPHA_THRESHOLD = 0.999;
@@ -440,12 +441,13 @@ void main()
         if (filmGrainIntensity > 0.0)
         {
                 float grainSize = max(FilmGrainParams.y, 1.0);
-                vec2 grainOffset = vec2(FilmGrainParams.z, FilmGrainParams.w);
+                float filmGrainStrength = max(FilmGrainParams.z, 0.0);
+                vec2 grainOffset = FilmGrainOffset.xy;
                 vec2 grainCoord = (gl_FragCoord.xy + grainOffset) / grainSize;
                 float grain = tri(whitenoise01(grainCoord));
                 float luma = dot(mapped, vec3(0.2126, 0.7152, 0.0722));
                 float response = mix(1.0, clamp(1.0 - luma, 0.0, 1.0), 0.5);
-                mapped = clamp(mapped + grain * (filmGrainIntensity * response), 0.0, 1.0);
+                mapped = clamp(mapped + grain * (filmGrainIntensity * filmGrainStrength * response), 0.0, 1.0);
         }
         out_fragcolor = vec4(pow(mapped, vec3(gamma)), 1.0);
 #endif // PALETTIZE


### PR DESCRIPTION
## Summary
- add the `r_filmgrain_strength` cvar to control film grain intensity
- pass the strength through the renderer and update the shader to use it
- move film grain temporal offsets into a dedicated uniform

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fa2cbab5e0832eb09100b937814d21