### PR TITLE
Add per-fragment lighting for alias models

### DIFF
--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -62,8 +62,12 @@ typedef struct aliasinstance_s {
 	int32_t		flags;
 } aliasinstance_t;
 
-#define ALIAS_INSTANCE_FLAG_NONE          0
-#define ALIAS_INSTANCE_FLAG_NO_MOTION_BLUR (1 << 0)
+#define ALIAS_INSTANCE_FLAG_NONE                  0
+#define ALIAS_INSTANCE_FLAG_NO_MOTION_BLUR        (1 << 0)
+#define ALIAS_INSTANCE_FLAG_VIEWMODEL             (1 << 1)
+#define ALIAS_INSTANCE_FLAG_PLAYER                (1 << 2)
+#define ALIAS_INSTANCE_FLAG_FULLBRIGHT_HACK       (1 << 3)
+#define ALIAS_INSTANCE_FLAG_ITEM                  (1 << 4)
 
 struct ibuf_s {
 	int			count;
@@ -225,71 +229,17 @@ void R_SetupEntityTransform (entity_t *e, lerpdata_t *lerpdata)
 R_SetupAliasLighting -- johnfitz -- broken out from R_DrawAliasModel and rewritten
 =================
 */
-void R_SetupAliasLighting (entity_t	*e)
+void R_SetupAliasLighting (entity_t     *e)
 {
-	vec3_t		dist;
-	float		add;
-	int			i;
-
-	// if the initial trace is completely black, try again from above
-	// this helps with models whose origin is slightly below ground level
-	// (e.g. some of the candles in the DOTM start map)
-	if (!R_LightPoint (e->origin, 0.f, &e->lightcache))
-		R_LightPoint (e->origin, e->model->maxs[2] * 0.5f, &e->lightcache);
-
-	//add dlights
-	for (i=0; i<r_framedata.numlights; i++)
-	{
-		gpulight_t *l = &r_lightbuffer.lights[i];
-		VectorSubtract (e->origin, l->pos, dist);
-		add = DotProduct (dist, dist);
-		if (l->radius * l->radius > add)
-			VectorMA (lightcolor, l->radius - sqrtf (add), l->color, lightcolor);
-	}
-
-	// minimum light value on gun (24)
-	if (e == &cl.viewent)
-	{
-		add = 72.0f - (lightcolor[0] + lightcolor[1] + lightcolor[2]);
-		if (add > 0.0f)
-		{
-			add *= 1.0f / 3.0f;
-			lightcolor[0] += add;
-			lightcolor[1] += add;
-			lightcolor[2] += add;
-		}
-	}
-
-	// minimum light value on players (8)
-	if (e > cl_entities && e <= cl_entities + cl.maxclients)
-	{
-		add = 24.0f - (lightcolor[0] + lightcolor[1] + lightcolor[2]);
-		if (add > 0.0f)
-		{
-			add *= 1.0f / 3.0f;
-			lightcolor[0] += add;
-			lightcolor[1] += add;
-			lightcolor[2] += add;
-		}
-	}
-
-	// clamp lighting so it doesn't overbright as much (96)
-	if (gl_overbright_models.value)
-	{
-		add = lightcolor[0] + lightcolor[1] + lightcolor[2];
-		if (add > 288.0f)
-			VectorScale(lightcolor, 288.0f / add, lightcolor);
-	}
-	//hack up the brightness when fullbrights but no overbrights (256)
-	else if (e->model->flags & MOD_FBRIGHTHACK && gl_fullbrights.value)
-	{
-		lightcolor[0] = 256.0f;
-		lightcolor[1] = 256.0f;
-		lightcolor[2] = 256.0f;
-	}
+        // if the initial trace is completely black, try again from above
+        // this helps with models whose origin is slightly below ground level
+        // (e.g. some of the candles in the DOTM start map)
+        if (!R_LightPoint (e->origin, 0.f, &e->lightcache))
+                R_LightPoint (e->origin, e->model->maxs[2] * 0.5f, &e->lightcache);
 
         VectorScale (lightcolor, 1.0f / 200.0f, lightcolor);
 }
+
 
 /*
 =================
@@ -566,8 +516,16 @@ static void R_DrawAliasModel_Real (entity_t *e, qboolean showtris)
 	if (!ibuf.count)
 		ibuf.ent = e;
 
-	instance = &ibuf.inst[ibuf.count++];
-	instance->flags = ALIAS_INSTANCE_FLAG_NONE;
+        instance = &ibuf.inst[ibuf.count++];
+        instance->flags = ALIAS_INSTANCE_FLAG_NONE;
+        if (e == &cl.viewent)
+                instance->flags |= ALIAS_INSTANCE_FLAG_VIEWMODEL;
+        if (e > cl_entities && e <= cl_entities + cl.maxclients)
+                instance->flags |= ALIAS_INSTANCE_FLAG_PLAYER;
+        if ((e->model->flags & MOD_FBRIGHTHACK) && gl_fullbrights.value && !gl_overbright_models.value)
+                instance->flags |= ALIAS_INSTANCE_FLAG_FULLBRIGHT_HACK;
+        if (e->model->flags & EF_ROTATE)
+                instance->flags |= ALIAS_INSTANCE_FLAG_ITEM;
 
 	{
 		float prev_model_matrix[16];

--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -22,6 +22,44 @@ layout(std430, binding=1) restrict readonly buffer InstanceBuffer
 	float	_Pad3;
 	InstanceData instances[];
 };
+layout(std140, binding=0) uniform FrameDataUBO
+{
+        mat4    _FrameViewProj;
+        mat4    _FramePrevViewProj;
+        vec4    _FrameFog;
+        vec4    _FrameSkyFog;
+        vec3    _FrameWindDir;
+        float   _FrameWindPhase;
+        float   _FrameScreenDither;
+        float   _FrameTextureDither;
+        float   _FrameOverbright;
+        float   _FramePad0;
+        vec3    _FrameEyePos;
+        float   _FrameTime;
+        vec3    _FramePrevEyePos;
+        float   _FrameDeltaTime;
+        float   _FrameZLogScale;
+        float   _FrameZLogBias;
+        uint    NumLights;
+        uint    _FramePrevFrameValid;
+        uint    _FramePad1;
+        uint    _FramePad2;
+};
+
+struct Light
+{
+        vec3    origin;
+        float   radius;
+        vec3    color;
+        float   minlight;
+};
+
+layout(std430, binding=0) restrict readonly buffer LightBuffer
+{
+        float   LightStyles[64];
+        Light   Lights[];
+};
+
 // ALU-only 16x16 Bayer matrix
 float bayer01(ivec2 coord)
 {
@@ -59,16 +97,50 @@ float whitenoise(vec2 p)
 // Based on https://www.shadertoy.com/view/4t2SDh 
 float tri(float x)
 {
-	float orig = x * 2.0 - 1.0;
-	uint signbit = floatBitsToUint(orig) & 0x80000000u;
-	x = sqrt(abs(orig)) - 1.;
-	x = uintBitsToFloat(floatBitsToUint(x) ^ signbit);
-	return x;
+        float orig = x * 2.0 - 1.0;
+        uint signbit = floatBitsToUint(orig) & 0x80000000u;
+        x = sqrt(abs(orig)) - 1.;
+        x = uintBitsToFloat(floatBitsToUint(x) ^ signbit);
+        return x;
 }
 
 #define DITHER_NOISE(uv) tri(bayer01(ivec2(uv)))
 #define SCREEN_SPACE_NOISE() DITHER_NOISE(floor(gl_FragCoord.xy)+0.5)
 #define SUPPRESS_BANDING() bayer(ivec2(gl_FragCoord.xy))
+
+float r_avertexnormal_dot(vec3 vertexnormal, vec3 dir)
+{
+        float d = dot(vertexnormal, dir);
+        if (d < 0.0)
+                return 1.0 + d * (13.0 / 44.0);
+        else
+                return 1.0 + d;
+}
+
+vec3 ComputeDynamicLights(vec3 world_pos, vec3 normal)
+{
+        vec3 accum = vec3(0.0);
+        uint count = NumLights;
+        if (count == 0u)
+                return accum;
+        for (uint i = 0u; i < count; ++i)
+        {
+                Light light = Lights[i];
+                vec3 to_light = light.origin - world_pos;
+                float dist_sq = dot(to_light, to_light);
+                float radius = light.radius;
+                float radius_sq = radius * radius;
+                if (dist_sq >= radius_sq)
+                        continue;
+                float dist = sqrt(dist_sq);
+                vec3 L = to_light * inversesqrt(max(dist_sq, 1e-8));
+                float attenuation = radius - dist;
+                float diffuse = max(dot(normal, L), 0.0);
+                float influence = max(diffuse, light.minlight);
+                accum += light.color * (attenuation * influence);
+        }
+        return accum * (1.0 / 200.0);
+}
 
 vec2 ComputeVelocity(vec4 curr_clip, vec4 prev_clip)
 {
@@ -81,6 +153,10 @@ vec2 ComputeVelocity(vec4 curr_clip, vec4 prev_clip)
 }
 
 const int ALIAS_FLAG_NO_MOTION_BLUR = 1;
+const int ALIAS_FLAG_VIEWMODEL = 1 << 1;
+const int ALIAS_FLAG_PLAYER = 1 << 2;
+const int ALIAS_FLAG_FULLBRIGHT_HACK = 1 << 3;
+const int ALIAS_FLAG_ITEM = 1 << 4;
 
 layout(binding=0) uniform sampler2D Tex;
 layout(binding=1) uniform sampler2D FullbrightTex;
@@ -96,6 +172,10 @@ layout(location=2) in vec3 in_pos;
 layout(location=3) noperspective in vec4 in_curr_clip;
 layout(location=4) noperspective in vec4 in_prev_clip;
 layout(location=5) flat in int in_flags;
+layout(location=6) in vec3 in_world_pos;
+layout(location=7) in vec3 in_world_normal;
+layout(location=8) in vec3 in_local_normal;
+layout(location=9) flat in vec3 in_shadevector;
 
 #define OUT_COLOR out_fragcolor
 #if OIT
@@ -142,18 +222,15 @@ void main()
         vec3 emissive = vec3(0.0);
 #if MODE == 2
         uv -= 0.5 / vec2(textureSize(Tex, 0).xy);
-        vec4 result = textureLod(Tex, uv, 0.);
+        vec4 baseSample = textureLod(Tex, uv, 0.);
 #else
-        vec4 result = texture(Tex, uv);
+        vec4 baseSample = texture(Tex, uv);
 #endif
 #if ALPHATEST
-	if (result.a < 0.666)
-		discard;
-	result.rgb *= in_color.rgb;
-#else
-	result.rgb = mix(result.rgb, result.rgb * in_color.rgb, result.a);
+        if (baseSample.a < 0.666)
+                discard;
 #endif
-	result.a = in_color.a; // FIXME: This will make almost transparent things cut holes though heavy fog
+        vec3 baseColor = baseSample.rgb;
         vec3 fullbright;
 #if MODE == 2
         fullbright = textureLod(FullbrightTex, uv, 0.).rgb;
@@ -162,13 +239,78 @@ void main()
         fullbright = texture(FullbrightTex, uv).rgb;
         emissive = texture(EmissiveTex, uv).rgb;
 #endif
-        result.rgb += fullbright;
-        result.rgb += emissive;
-        result.rgb = clamp(result.rgb, 0.0, 1.0);
+        vec3 localNormal = normalize(in_local_normal);
+        vec3 shadevector = normalize(in_shadevector);
+        float shade = r_avertexnormal_dot(localNormal, shadevector);
+        vec3 lighting = in_color.rgb * shade;
+        vec3 worldNormal = in_world_normal;
+        if (dot(worldNormal, worldNormal) > 0.0)
+                worldNormal = normalize(worldNormal);
+        else
+                worldNormal = vec3(0.0, 0.0, 1.0);
+        lighting += ComputeDynamicLights(in_world_pos, worldNormal);
+        lighting = max(lighting, vec3(0.0));
+
+        uint overbrightFlag = floatBitsToUint(Fog.w) >> 31u;
+        bool useFullbrightHack = ((in_flags & ALIAS_FLAG_FULLBRIGHT_HACK) != 0) && overbrightFlag == 0u;
+
+        if (useFullbrightHack)
+        {
+                lighting = vec3(256.0 / 200.0);
+        }
+        else
+        {
+                float sum = lighting.x + lighting.y + lighting.z;
+                if ((in_flags & ALIAS_FLAG_VIEWMODEL) != 0)
+                {
+                        const float minSum = 72.0 / 200.0;
+                        if (sum < minSum)
+                        {
+                                float add = (minSum - sum) / 3.0;
+                                lighting += vec3(add);
+                                sum = minSum;
+                        }
+                }
+                else if ((in_flags & ALIAS_FLAG_PLAYER) != 0)
+                {
+                        const float minSum = 24.0 / 200.0;
+                        if (sum < minSum)
+                        {
+                                float add = (minSum - sum) / 3.0;
+                                lighting += vec3(add);
+                                sum = minSum;
+                        }
+                }
+                if (overbrightFlag != 0u)
+                {
+                        const float maxSum = 288.0 / 200.0;
+                        if (sum > maxSum)
+                        {
+                                float scale = maxSum / sum;
+                                lighting *= scale;
+                                sum = maxSum;
+                        }
+                }
+        }
+
+        lighting = ldexp(lighting, ivec3(int(overbrightFlag)));
+
+#if ALPHATEST
+        vec3 shadedColor = baseColor * lighting;
+#else
+        vec3 shadedColor = mix(baseColor, baseColor * lighting, baseSample.a);
+#endif
+
+        if ((in_flags & ALIAS_FLAG_ITEM) != 0)
+                shadedColor += fullbright;
+        shadedColor += emissive;
+        shadedColor = clamp(shadedColor, 0.0, 1.0);
+
+        vec4 result = vec4(shadedColor, in_color.a);
         float fog = exp2(abs(Fog.w) * -dot(in_pos, in_pos));
-	fog = clamp(fog, 0.0, 1.0);
-	result.rgb = mix(Fog.rgb, result.rgb, fog);
-	out_fragcolor = result;
+        fog = clamp(fog, 0.0, 1.0);
+        result.rgb = mix(Fog.rgb, result.rgb, fog);
+        out_fragcolor = result;
 #if !OIT
         vec2 velocity = ComputeVelocity(in_curr_clip, in_prev_clip);
         float viewModelMask = ((in_flags & ALIAS_FLAG_NO_MOTION_BLUR) != 0) ? 1.0 : 0.0;

--- a/Quake/shaders/alias.vert
+++ b/Quake/shaders/alias.vert
@@ -81,20 +81,24 @@ float r_avertexnormal_dot(vec3 vertexnormal, vec3 dir) // from MH
 }
 
 #if MODE == 2
-	layout(location=0) noperspective out vec2 out_texcoord;
+        layout(location=0) noperspective out vec2 out_texcoord;
 #else
-	layout(location=0) out vec2 out_texcoord;
+        layout(location=0) out vec2 out_texcoord;
 #endif
 layout(location=1) out vec4 out_color;
 layout(location=2) out vec3 out_pos;
 layout(location=3) noperspective out vec4 out_curr_clip;
 layout(location=4) noperspective out vec4 out_prev_clip;
 layout(location=5) flat out int out_flags;
+layout(location=6) out vec3 out_world_pos;
+layout(location=7) out vec3 out_world_normal;
+layout(location=8) out vec3 out_local_normal;
+layout(location=9) flat out vec3 out_shadevector;
 
 void main()
 {
-	InstanceData inst = instances[gl_InstanceID];
-	out_texcoord = in_uv;
+        InstanceData inst = instances[gl_InstanceID];
+        out_texcoord = in_uv;
 	PoseVertex pose1 = GetPoseVertex(inst.Pose1);
 	PoseVertex pose2 = GetPoseVertex(inst.Pose2);
 	vec3 local_vert = mix(pose1.pos, pose2.pos, inst.Blend);
@@ -102,20 +106,29 @@ void main()
 	mat4x3 prev_worldmatrix = transpose(mat3x4(inst.PrevWorldMatrix[0], inst.PrevWorldMatrix[1], inst.PrevWorldMatrix[2]));
 	vec3 world_vert = (worldmatrix * vec4(local_vert, 1.0)).xyz;
 	vec3 prev_world_vert = (prev_worldmatrix * vec4(local_vert, 1.0)).xyz;
-	vec4 curr_clip = ViewProj * vec4(world_vert, 1.0);
-	vec4 prev_clip = PrevViewProj * vec4(prev_world_vert, 1.0);
-	gl_Position = curr_clip;
-	out_curr_clip = curr_clip;
-	out_prev_clip = prev_clip;
-	out_flags = inst.Flags;
-	out_pos = world_vert - EyePos;
-	// transform world X and Z axes to local space
-	mat3 orientation = mat3(normalize(worldmatrix[0].xyz), normalize(worldmatrix[1].xyz), normalize(worldmatrix[2].xyz));
-	orientation = transpose(orientation);
-	vec3 shadevector = (orientation[0] + orientation[2]) / sqrt(2.0);
-	float dot1 = r_avertexnormal_dot(pose1.nor, shadevector);
-	float dot2 = r_avertexnormal_dot(pose2.nor, shadevector);
-	out_color = clamp(inst.LightColor * vec4(vec3(mix(dot1, dot2, inst.Blend)), 1.0), 0.0, 1.0);
-	uint overbright = floatBitsToUint(Fog.w) >> 31;
-	out_color.rgb = ldexp(out_color.rgb, ivec3(overbright));
+        vec4 curr_clip = ViewProj * vec4(world_vert, 1.0);
+        vec4 prev_clip = PrevViewProj * vec4(prev_world_vert, 1.0);
+        gl_Position = curr_clip;
+        out_curr_clip = curr_clip;
+        out_prev_clip = prev_clip;
+        out_flags = inst.Flags;
+        out_pos = world_vert - EyePos;
+        out_world_pos = world_vert;
+        // transform world X and Z axes to local space
+        vec3 basisX = normalize(worldmatrix[0].xyz);
+        vec3 basisY = normalize(worldmatrix[1].xyz);
+        vec3 basisZ = normalize(worldmatrix[2].xyz);
+        mat3 rotation = mat3(basisX, basisY, basisZ);
+        mat3 orientation = transpose(rotation);
+        vec3 shadevector = (orientation[0] + orientation[2]) / sqrt(2.0);
+        vec3 local_normal = normalize(mix(pose1.nor, pose2.nor, inst.Blend));
+        vec3 world_normal = rotation * local_normal;
+        if (dot(world_normal, world_normal) > 0.0)
+                world_normal = normalize(world_normal);
+        else
+                world_normal = basisZ;
+        out_world_normal = world_normal;
+        out_local_normal = local_normal;
+        out_shadevector = shadevector;
+        out_color = vec4(inst.LightColor.rgb, inst.LightColor.w);
 }


### PR DESCRIPTION
## Summary
- compute alias model lighting per fragment using GPU dynamic light data
- add per-instance flags for viewmodels, players, and items to control shader behavior
- restrict fullbright overlays to items so other models respond to dynamic lighting

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fb48f897b0832eb507fb557dfc8e71