### PR TITLE
Stop rotating explosive barrels

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -3274,6 +3274,10 @@ void Mod_SetExtraFlags (qmodel_t *mod)
 	{
 		mod->flags |= MOD_FBRIGHTHACK;
 	}
+
+	// disable rotation for explosive barrels
+	if (!strcmp (mod->name, "progs/barrel.mdl"))
+		mod->flags &= ~EF_ROTATE;
 }
 
 /*


### PR DESCRIPTION
## Summary
- clear the EF_ROTATE flag for the explosive barrel alias model so barrels no longer spin

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fb5f9075e8832e9b248ef64b4ccb92