### PR TITLE
Add configurable rim lighting for alias and world surfaces

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -198,6 +198,9 @@ cvar_t	r_alphasort = { "r_alphasort","1",CVAR_ARCHIVE };
 cvar_t	r_oit = { "r_oit","1",CVAR_ARCHIVE };
 cvar_t	r_dither = { "r_dither", "1.0", CVAR_ARCHIVE };
 cvar_t	r_dof = { "r_dof", "0", CVAR_ARCHIVE };
+cvar_t	r_rim_alias = { "r_rim_alias", "0.25", CVAR_ARCHIVE };
+cvar_t	r_rim_world = { "r_rim_world", "0.15", CVAR_ARCHIVE };
+cvar_t	r_rim_exponent = { "r_rim_exponent", "4.0", CVAR_ARCHIVE };
 cvar_t	r_dof_focus = { "r_dof_focus", "64", CVAR_ARCHIVE };
 cvar_t	r_dof_range = { "r_dof_range", "48", CVAR_ARCHIVE };
 cvar_t	r_dof_strength = { "r_dof_strength", "6", CVAR_ARCHIVE };
@@ -1547,7 +1550,11 @@ void R_SetupView (void)
 
 
 		r_framedata.overbright = overbright;
-		r_framedata._padding0 = 0.f;
+		r_framedata.rim_alias = q_max(0.f, r_rim_alias.value);
+		r_framedata.rim_world = q_max(0.f, r_rim_world.value);
+		r_framedata.rim_exponent = q_max(0.5f, r_rim_exponent.value);
+		r_framedata.rim_pad0 = 0.f;
+		r_framedata.rim_pad1 = 0.f;
 	}
 
 	r_framecount++;

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -356,6 +356,9 @@ void R_Init (void)
 	Cvar_RegisterVariable (&r_oit);
 	Cvar_RegisterVariable (&r_dither);
 	Cvar_RegisterVariable (&r_dof);
+	Cvar_RegisterVariable (&r_rim_alias);
+	Cvar_RegisterVariable (&r_rim_world);
+	Cvar_RegisterVariable (&r_rim_exponent);
         Cvar_RegisterVariable (&r_dof_autofocus);
 	Cvar_RegisterVariable (&r_dof_focus);
 	Cvar_RegisterVariable (&r_dof_range);

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -107,6 +107,9 @@ extern	cvar_t	r_scale;
 
 extern	cvar_t	r_oit;
 extern	cvar_t	r_alphasort;
+extern	cvar_t	r_rim_alias;
+extern	cvar_t	r_rim_world;
+extern	cvar_t	r_rim_exponent;
 
 extern	cvar_t	gl_clear;
 extern	cvar_t	gl_polyblend;
@@ -427,7 +430,11 @@ typedef struct gpuframedata_s {
 	float	screendither;
 	float	texturedither;
 	float	overbright;
-	float	_padding0;
+	float	rim_alias;
+	float	rim_world;
+	float	rim_exponent;
+	float	rim_pad0;
+	float	rim_pad1;
 	vec3_t	eyepos;
 	float	time;
 	vec3_t	prev_eyepos;

--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -33,7 +33,11 @@ layout(std140, binding=0) uniform FrameDataUBO
         float   _FrameScreenDither;
         float   _FrameTextureDither;
         float   _FrameOverbright;
+        float   _FrameRimAlias;
+        float   _FrameRimWorld;
+        float   _FrameRimExponent;
         float   _FramePad0;
+        float   _FramePadRim;
         vec3    _FrameEyePos;
         float   _FrameTime;
         vec3    _FramePrevEyePos;
@@ -249,6 +253,15 @@ void main()
         else
                 worldNormal = vec3(0.0, 0.0, 1.0);
         lighting += ComputeDynamicLights(in_world_pos, worldNormal);
+        if (_FrameRimAlias > 0.0)
+        {
+                vec3 to_eye = EyePos - in_world_pos;
+                float inv_len = inversesqrt(max(dot(to_eye, to_eye), 1e-8));
+                vec3 view_dir = to_eye * inv_len;
+                float ndotv = max(dot(worldNormal, view_dir), 0.0);
+                float fresnel = pow(clamp(1.0 - ndotv, 0.0, 1.0), _FrameRimExponent);
+                lighting += vec3(_FrameRimAlias * fresnel);
+        }
         lighting = max(lighting, vec3(0.0));
 
         uint overbrightFlag = floatBitsToUint(Fog.w) >> 31u;

--- a/Quake/shaders/frame_uniforms.glsl
+++ b/Quake/shaders/frame_uniforms.glsl
@@ -12,7 +12,11 @@ layout(std140, binding=0) uniform FrameDataUBO
         float   ScreenDither;
         float   TextureDither;
         float   Overbright;
+        float   RimAlias;
+        float   RimWorld;
+        float   RimExponent;
         float   _Pad0;
+        float   _PadRim;
         vec3    EyePos;
         float   Time;
         vec3    PrevEyePos;

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -391,6 +391,14 @@ void main()
                 }
         }
 
+        if (RimWorld > 0.0)
+        {
+                float ndotv = max(dot(surface_normal, view_dir), 0.0);
+                float fresnel = pow(clamp(1.0 - ndotv, 0.0, 1.0), RimExponent);
+                vec3 rim_light = vec3(RimWorld * fresnel);
+                total_light += max(min(rim_light, 1. - total_light), 0.);
+        }
+
         vec3 sun_light = ComputeSunLight(in_pos, surface_normal);
         total_light += max(min(sun_light, 1. - total_light), 0.);
 #if DITHER >= 2


### PR DESCRIPTION
## Summary
- add new rim lighting cvars for alias models and world BSP surfaces and expose them in frame data
- update alias and world fragment shaders to apply physically-inspired rim lighting driven by view direction
- extend the shared frame uniform block with rim parameters while keeping alignment padding explicit

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fcfd786df0832eb92feb670a2c2726