### PR TITLE
Add configurable SSAO postprocess pass

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -217,6 +217,12 @@ cvar_t	r_tonemap = { "r_tonemap", "1", CVAR_ARCHIVE };
 cvar_t	r_tonemap_exposure = { "r_tonemap_exposure", "1.0", CVAR_ARCHIVE };
 cvar_t	r_bloom = { "r_bloom", "0.04", CVAR_ARCHIVE };
 cvar_t	r_bloom_threshold = { "r_bloom_threshold", "1.0", CVAR_ARCHIVE };
+cvar_t	r_ssao = { "r_ssao", "0", CVAR_ARCHIVE };
+cvar_t	r_ssao_radius = { "r_ssao_radius", "32", CVAR_ARCHIVE };
+cvar_t	r_ssao_bias = { "r_ssao_bias", "0.01", CVAR_ARCHIVE };
+cvar_t	r_ssao_intensity = { "r_ssao_intensity", "1.0", CVAR_ARCHIVE };
+cvar_t	r_ssao_power = { "r_ssao_power", "1.5", CVAR_ARCHIVE };
+cvar_t	r_ssao_samples = { "r_ssao_samples", "16", CVAR_ARCHIVE };
 
 cvar_t	r_vignette = { "r_vignette", "0.75", CVAR_ARCHIVE };
 cvar_t	r_vignette_radius_inner = { "r_vignette_radius_inner", "0.3", CVAR_ARCHIVE };
@@ -287,6 +293,21 @@ static float view_zfar;
 static qboolean R_DoFEnabled (void)
 {
 	return r_dof.value > 0.f && r_dof_strength.value > 0.f;
+}
+
+static qboolean R_SSAOEnabled (void)
+{
+	if (r_ssao.value <= 0.f)
+		return false;
+	if (r_ssao_intensity.value <= 0.f)
+		return false;
+	if (r_ssao_samples.value <= 0.f)
+		return false;
+	if (r_ssao_radius.value <= 0.f)
+		return false;
+	if (!framebufs.composite.depth_stencil_tex)
+		return false;
+	return true;
 }
 
 static qboolean r_dof_autofocus_initialized = false;
@@ -688,6 +709,12 @@ void GL_PostProcess (void)
         float motion_min_velocity;
         float motion_depth_threshold;
         int motion_max_samples;
+        qboolean ssao_enabled;
+        float ssao_radius;
+        float ssao_bias;
+        float ssao_intensity;
+        float ssao_power;
+        int ssao_samples;
         if (!GL_NeedsPostprocess ())
                 return;
 
@@ -741,6 +768,19 @@ void GL_PostProcess (void)
                 }
         }
         motion_enabled = (motion_effective_shutter > 0.f && motion_max_samples > 0 && velocity_texture != 0);
+
+        ssao_radius = q_max (0.f, r_ssao_radius.value);
+        ssao_bias = q_max (0.f, r_ssao_bias.value);
+        ssao_intensity = q_max (0.f, r_ssao_intensity.value);
+        ssao_power = q_max (0.f, r_ssao_power.value);
+        ssao_samples = (int)Q_rint (r_ssao_samples.value);
+        if (ssao_samples < 0)
+                ssao_samples = 0;
+        if (ssao_samples > 64)
+                ssao_samples = 64;
+        ssao_enabled = R_SSAOEnabled ();
+        if (ssao_samples <= 0 || ssao_radius <= 0.f || ssao_intensity <= 0.f)
+                ssao_enabled = false;
 
 	GL_BindFramebufferFunc (GL_FRAMEBUFFER, 0);
 	glViewport (glx, gly, glwidth, glheight);
@@ -803,8 +843,10 @@ void GL_PostProcess (void)
         }
 
         depth_texture = 0;
-        if (framebufs.composite.depth_stencil_tex && (dof_enabled || (motion_enabled && motion_depth_threshold > 0.f)))
+        if (framebufs.composite.depth_stencil_tex && (dof_enabled || (motion_enabled && motion_depth_threshold > 0.f) || ssao_enabled))
                 depth_texture = framebufs.composite.depth_stencil_tex;
+        if (!depth_texture)
+                ssao_enabled = false;
         GL_BindNative (GL_TEXTURE2, GL_TEXTURE_2D, depth_texture);
 
         if (dof_enabled)
@@ -826,6 +868,17 @@ void GL_PostProcess (void)
                 GL_Uniform4fFunc (1, 0.f, 0.f, 0.f, 0.f);
                 GL_Uniform4fFunc (2, dof_znear, dof_zfar, gl_clipcontrol_able ? 1.f : 0.f, 0.f);
         }
+
+	GL_Uniform4fFunc (13,
+	        ssao_enabled ? 1.f : 0.f,
+	        ssao_radius,
+	        ssao_bias,
+	        ssao_intensity);
+	GL_Uniform4fFunc (14,
+	        (float)ssao_samples,
+	        ssao_power,
+	        0.f,
+	        0.f);
 
 	glDrawArrays (GL_TRIANGLES, 0, 3);
 
@@ -1427,7 +1480,7 @@ qboolean GL_NeedsPostprocess (void)
 {
         if (vid_gamma.value != 1.f || vid_contrast.value != 1.f || softemu || R_GetEffectiveAlphaMode () == ALPHAMODE_OIT || R_DoFEnabled ())
                 return true;
-        if (r_tonemap.value > 0.f || r_bloom.value > 0.f || GL_ShouldApplyMotionBlur ())
+        if (r_tonemap.value > 0.f || r_bloom.value > 0.f || GL_ShouldApplyMotionBlur () || R_SSAOEnabled ())
                 return true;
         return false;
 }
@@ -2661,7 +2714,7 @@ void R_WarpScaleView (void)
 
 	needwarpscale = r_refdef.scale != 1 || water_warp || (v_blend[3] && gl_polyblend.value && !softemu);
 	fbodest = GL_NeedsPostprocess () ? framebufs.composite.fbo : 0;
-        need_depth_resolve = (fbodest == framebufs.composite.fbo) && R_DoFEnabled ();
+        need_depth_resolve = (fbodest == framebufs.composite.fbo) && (R_DoFEnabled () || R_SSAOEnabled ());
 
 	if (msaa)
 	{

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -79,6 +79,13 @@ extern cvar_t r_vignette_noise;
 extern cvar_t r_chromatic_aberration;
 extern cvar_t r_filmgrain;
 extern cvar_t r_filmgrain_size;
+extern cvar_t r_ssao;
+extern cvar_t r_ssao_radius;
+extern cvar_t r_ssao_bias;
+extern cvar_t r_ssao_intensity;
+extern cvar_t r_ssao_power;
+extern cvar_t r_ssao_samples;
+
 extern cvar_t r_filmgrain_strength;
 
 #if defined(USE_SIMD)
@@ -373,6 +380,12 @@ void R_Init (void)
 	Cvar_RegisterVariable (&r_tonemap_exposure);
 	Cvar_RegisterVariable (&r_bloom);
 	Cvar_RegisterVariable (&r_bloom_threshold);
+	Cvar_RegisterVariable (&r_ssao);
+	Cvar_RegisterVariable (&r_ssao_radius);
+	Cvar_RegisterVariable (&r_ssao_bias);
+	Cvar_RegisterVariable (&r_ssao_intensity);
+	Cvar_RegisterVariable (&r_ssao_power);
+	Cvar_RegisterVariable (&r_ssao_samples);
 	Cvar_RegisterVariable (&r_vignette);
 	Cvar_RegisterVariable (&r_vignette_radius_inner);
 	Cvar_RegisterVariable (&r_vignette_radius_outer);

--- a/Quake/shaders/postprocess.frag
+++ b/Quake/shaders/postprocess.frag
@@ -119,7 +119,11 @@ layout(location=10) uniform vec4 PostFXParams2; // x: vignette noise amount, y: 
 layout(location=11) uniform vec4 FilmGrainParams; // x: intensity, y: grain size (px), z: strength, w: unused
 layout(location=12) uniform vec4 FilmGrainOffset; // xy: temporal offsets, zw: unused
 
+layout(location=13) uniform vec4 SSAOParams0; // x: enabled, y: radius (px), z: bias, w: intensity
+layout(location=14) uniform vec4 SSAOParams1; // x: samples, y: power, zw: reserved
+
 const int MOTION_MAX_SAMPLES = 64;
+const int SSAO_MAX_SAMPLES = 64;
 const float OPAQUE_ALPHA_THRESHOLD = 0.999;
 
 struct DepthSamplingInfo
@@ -237,6 +241,57 @@ void main()
                 vec4 velocitySample = texture(VelocityTexture, velocityUV);
                 velocity = velocitySample.xy;
                 viewModelMask = velocitySample.z;
+        }
+
+        if (SSAOParams0.x > 0.5 && inView && depthInfo.valid && centerOpaque && viewModelMask < 0.5)
+        {
+                float radiusPx = max(SSAOParams0.y, 0.0);
+                float bias = max(SSAOParams0.z, 0.0);
+                float intensity = max(SSAOParams0.w, 0.0);
+                int sampleCount = clamp(int(SSAOParams1.x + 0.5), 1, SSAO_MAX_SAMPLES);
+                float power = max(SSAOParams1.y, 0.0);
+                if (radiusPx > 0.5 && intensity > 0.0 && sampleCount > 0)
+                {
+                        float centerDepth = SampleLinearDepth(gl_FragCoord.xy, depthInfo);
+                        if (centerDepth > 0.0)
+                        {
+                                float goldenAngle = 2.39996322972865332;
+                                float rotationNoise = SCREEN_SPACE_NOISE();
+                                float occlusionAccum = 0.0;
+                                float weightAccum = 0.0;
+                                for (int i = 0; i < SSAO_MAX_SAMPLES; ++i)
+                                {
+                                        if (i >= sampleCount)
+                                                break;
+                                        float fi = float(i);
+                                        float t = (fi + 0.5) / float(sampleCount);
+                                        float angle = (fi + rotationNoise) * goldenAngle;
+                                        float radius = radiusPx * t;
+                                        vec2 offset = vec2(cos(angle), sin(angle)) * radius;
+                                        vec2 sampleUV = uv + offset * invTexSize;
+                                        if (!all(greaterThanEqual(sampleUV, viewMin)) || !all(lessThanEqual(sampleUV, viewMax)))
+                                                continue;
+                                        float sampleDepth = SampleLinearDepth(gl_FragCoord.xy + offset, depthInfo);
+                                        if (sampleDepth <= 0.0)
+                                                continue;
+                                        float depthDelta = centerDepth - sampleDepth;
+                                        if (depthDelta <= bias)
+                                                continue;
+                                        float rangeWeight = 1.0 - t;
+                                        float occlusionSample = clamp((depthDelta - bias) / (depthDelta + centerDepth + 1e-4), 0.0, 1.0);
+                                        occlusionAccum += occlusionSample * rangeWeight;
+                                        weightAccum += rangeWeight;
+                                }
+                                if (weightAccum > 0.0)
+                                {
+                                        float occlusion = occlusionAccum / weightAccum;
+                                        float ao = clamp(1.0 - occlusion * intensity, 0.0, 1.0);
+                                        if (power > 0.0)
+                                                ao = pow(ao, power);
+                                        color.rgb *= ao;
+                                }
+                        }
+                }
         }
 
         if (MotionParams0.x > 0.5 && inView && hasVelocityTexture && viewModelMask < 0.5 && centerOpaque)


### PR DESCRIPTION
## Summary
- add runtime-configurable SSAO cvars and resolve pipeline support
- feed SSAO uniforms through the postprocess pass and compute occlusion in the shader

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fd156b15bc832ea9cd83e423ea2724