### PR TITLE
Fix SSAO depth sampling precision

### DIFF
--- a/Quake/shaders/postprocess.frag
+++ b/Quake/shaders/postprocess.frag
@@ -164,10 +164,13 @@ vec2 ComputeDepthUV(vec2 fragPx, DepthSamplingInfo info)
 {
         if (!info.valid)
                 return vec2(-1.0);
-        vec2 viewSizePx = max(info.viewMaxPx - info.viewMinPx, vec2(0.0));
-        vec2 relPx = clamp(fragPx - info.viewMinPx, vec2(0.0), max(viewSizePx - vec2(1e-4), vec2(0.0)));
-        vec2 depthIdx = clamp(floor(relPx * info.invViewScale), vec2(0.0), info.maxDepthIdx);
-        vec2 depthPx = info.viewMinPx + depthIdx + vec2(0.5);
+        vec2 viewMinPx = info.viewMinPx + vec2(0.5);
+        vec2 viewMaxPx = max(info.viewMaxPx - vec2(0.5), viewMinPx);
+        vec2 clampedFragPx = clamp(fragPx, viewMinPx, viewMaxPx);
+        vec2 depthPx = info.viewMinPx + (clampedFragPx - info.viewMinPx - vec2(0.5)) * info.invViewScale + vec2(0.5);
+        vec2 depthMinPx = info.viewMinPx + vec2(0.5);
+        vec2 depthMaxPx = depthMinPx + info.maxDepthIdx;
+        depthPx = clamp(depthPx, depthMinPx, max(depthMaxPx, depthMinPx));
         return depthPx / info.depthTexSize;
 }
 


### PR DESCRIPTION
## Summary
- keep depth sampling in the post-process shader in continuous space instead of flooring to texel centers
- clamp sampling coordinates safely within the valid depth range to avoid artifacts near the view edges

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68fe0a843950832e8641337e4919c94e