### PR TITLE
Fix viewmodel muzzleflash lighting

### DIFF
--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -500,6 +500,15 @@ static void R_DrawAliasModel_Real (entity_t *e, qboolean showtris)
 	rs_aliaspolys += paliashdr->numtris;
 	R_SetupAliasLighting (e);
 
+	// Viewmodel muzzle flashes look wrong when shaded using the ambient
+	// lighting at the player's position (typically pitch black in dark
+	// areas).  In the original software renderer the muzzle flash pixels
+	// are effectively fullbright, so replicate that behaviour by forcing a
+	// strong light contribution when the view model is drawing a muzzle
+	// flash frame.
+	if ((e->effects & EF_MUZZLEFLASH) && e == &cl.viewent)
+		lightcolor[0] = lightcolor[1] = lightcolor[2] = 256.0f / 200.0f;
+
 	//
 	// draw it
 	//


### PR DESCRIPTION
## Summary
- force a bright light contribution when the viewmodel is rendering a muzzle flash so it no longer inherits pitch-black ambient lighting

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fe3d786ea8832e8983b6b90a5ad0ec