### PR TITLE
Add screen-space god rays postprocess effect

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -237,6 +237,15 @@ cvar_t	r_chromatic_aberration = { "r_chromatic_aberration", "0", CVAR_ARCHIVE };
 cvar_t	r_filmgrain = { "r_filmgrain", "0", CVAR_ARCHIVE };
 cvar_t	r_filmgrain_size = { "r_filmgrain_size", "3.0", CVAR_ARCHIVE };
 cvar_t	r_filmgrain_strength = { "r_filmgrain_strength", "1.0", CVAR_ARCHIVE };
+cvar_t	r_godrays = { "r_godrays", "0", CVAR_ARCHIVE };
+cvar_t	r_godrays_light_x = { "r_godrays_light_x", "0.5", CVAR_ARCHIVE };
+cvar_t	r_godrays_light_y = { "r_godrays_light_y", "0.5", CVAR_ARCHIVE };
+cvar_t	r_godrays_threshold = { "r_godrays_threshold", "0.6", CVAR_ARCHIVE };
+cvar_t	r_godrays_density = { "r_godrays_density", "0.75", CVAR_ARCHIVE };
+cvar_t	r_godrays_decay = { "r_godrays_decay", "0.95", CVAR_ARCHIVE };
+cvar_t	r_godrays_weight = { "r_godrays_weight", "0.02", CVAR_ARCHIVE };
+cvar_t	r_godrays_samples = { "r_godrays_samples", "64", CVAR_ARCHIVE };
+cvar_t	r_godrays_softness = { "r_godrays_softness", "0.1", CVAR_ARCHIVE };
 
 cvar_t	r_overbrightbits = { "r_overbrightbits", "1", CVAR_ARCHIVE };
 
@@ -823,6 +832,34 @@ void GL_PostProcess (void)
                 float filmgrain_time_alt = (float)(cl.time * 1.37);
                 GL_Uniform4fFunc (11, filmgrain_intensity, filmgrain_size, filmgrain_strength, 0.f);
                 GL_Uniform4fFunc (12, filmgrain_time, filmgrain_time_alt, 0.f, 0.f);
+        }
+
+        {
+                float godrays_intensity = q_min (10.f, q_max (0.f, r_godrays.value));
+                float godrays_decay = q_min (0.999f, q_max (0.f, r_godrays_decay.value));
+                float godrays_weight = q_min (1.f, q_max (0.f, r_godrays_weight.value));
+                float godrays_density = q_min (4.f, q_max (0.f, r_godrays_density.value));
+                float godrays_samples = q_min (128.f, q_max (1.f, r_godrays_samples.value));
+                float godrays_softness = q_min (1.f, q_max (0.001f, r_godrays_softness.value));
+                float godrays_light_x = q_min (1.f, q_max (0.f, r_godrays_light_x.value));
+                float godrays_light_y = q_min (1.f, q_max (0.f, r_godrays_light_y.value));
+                float godrays_threshold = q_min (1.f, q_max (0.f, r_godrays_threshold.value));
+
+                GL_Uniform4fFunc (16,
+                        godrays_intensity > 0.f ? 1.f : 0.f,
+                        godrays_intensity,
+                        godrays_decay,
+                        godrays_weight);
+                GL_Uniform4fFunc (17,
+                        godrays_light_x,
+                        godrays_light_y,
+                        godrays_threshold,
+                        godrays_density);
+                GL_Uniform4fFunc (18,
+                        godrays_samples,
+                        godrays_softness,
+                        0.f,
+                        0.f);
         }
 
         dof_enabled = R_DoFEnabled ();
@@ -1500,8 +1537,8 @@ qboolean GL_NeedsPostprocess (void)
 {
         if (vid_gamma.value != 1.f || vid_contrast.value != 1.f || softemu || R_GetEffectiveAlphaMode () == ALPHAMODE_OIT || R_DoFEnabled ())
                 return true;
-        if (r_tonemap.value > 0.f || r_bloom.value > 0.f || GL_ShouldApplyMotionBlur () || R_SSAOEnabled ())
-                return true;
+	if (r_tonemap.value > 0.f || r_bloom.value > 0.f || GL_ShouldApplyMotionBlur () || R_SSAOEnabled () || r_godrays.value > 0.f)
+		return true;
         return false;
 }
 

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -87,6 +87,15 @@ extern cvar_t r_ssao_power;
 extern cvar_t r_ssao_samples;
 
 extern cvar_t r_filmgrain_strength;
+extern cvar_t r_godrays;
+extern cvar_t r_godrays_light_x;
+extern cvar_t r_godrays_light_y;
+extern cvar_t r_godrays_threshold;
+extern cvar_t r_godrays_density;
+extern cvar_t r_godrays_decay;
+extern cvar_t r_godrays_weight;
+extern cvar_t r_godrays_samples;
+extern cvar_t r_godrays_softness;
 
 #if defined(USE_SIMD)
 extern cvar_t r_simd;
@@ -399,6 +408,15 @@ void R_Init (void)
 	Cvar_RegisterVariable (&r_filmgrain);
 	Cvar_RegisterVariable (&r_filmgrain_size);
 	Cvar_RegisterVariable (&r_filmgrain_strength);
+	Cvar_RegisterVariable (&r_godrays);
+	Cvar_RegisterVariable (&r_godrays_light_x);
+	Cvar_RegisterVariable (&r_godrays_light_y);
+	Cvar_RegisterVariable (&r_godrays_threshold);
+	Cvar_RegisterVariable (&r_godrays_density);
+	Cvar_RegisterVariable (&r_godrays_decay);
+	Cvar_RegisterVariable (&r_godrays_weight);
+	Cvar_RegisterVariable (&r_godrays_samples);
+	Cvar_RegisterVariable (&r_godrays_softness);
 	Cvar_RegisterVariable (&r_overbrightbits);
 	Cvar_SetCallback (&r_overbrightbits, R_OverbrightBits_f);
 

--- a/Quake/shaders/postprocess.frag
+++ b/Quake/shaders/postprocess.frag
@@ -24,6 +24,9 @@ layout(location=12) uniform vec4 FilmGrainOffset; // xy: temporal offsets, zw: u
 layout(location=13) uniform vec4 SSAOParams0; // x: enabled, y: radius (px), z: bias, w: intensity
 layout(location=14) uniform vec4 SSAOParams1; // x: samples, y: power, zw: reserved
 layout(location=15) uniform mat4 ProjectionMatrix;
+layout(location=16) uniform vec4 GodRayParams0; // x: enabled, y: intensity, z: decay, w: weight
+layout(location=17) uniform vec4 GodRayParams1; // x: light x, y: light y, z: threshold, w: density
+layout(location=18) uniform vec4 GodRayParams2; // x: samples, y: threshold softness, zw: unused
 layout(location=19) uniform mat4 InverseProjectionMatrix;
 
 #include "postprocess_common.glsl"
@@ -32,6 +35,7 @@ layout(location=19) uniform mat4 InverseProjectionMatrix;
 #include "postprocess_dof.glsl"
 #include "postprocess_vignette.glsl"
 #include "postprocess_chromatic.glsl"
+#include "postprocess_godrays.glsl"
 #include "postprocess_hdr.glsl"
 
 layout(location=0) out vec4 out_fragcolor;
@@ -76,6 +80,7 @@ void main()
         {
                 ApplyVignette(color.rgb, uv, viewMin, viewMax, texSize);
                 ApplyChromaticAberration(color.rgb, uv, invTexSize, viewMin, viewMax);
+                ApplyGodRays(color.rgb, uv, inView, viewMin, viewMax);
         }
 
         out_fragcolor = color;

--- a/Quake/shaders/postprocess_godrays.glsl
+++ b/Quake/shaders/postprocess_godrays.glsl
@@ -1,0 +1,59 @@
+#ifndef POSTPROCESS_GODRAYS_GLSL
+#define POSTPROCESS_GODRAYS_GLSL
+
+const int GODRAY_MAX_SAMPLES = 128;
+
+void ApplyGodRays(inout vec3 color, vec2 uv, bool inView, vec2 viewMin, vec2 viewMax)
+{
+        if (!(GodRayParams0.x > 0.5 && inView))
+                return;
+
+        float intensity = max(GodRayParams0.y, 0.0);
+        if (intensity <= 1e-5)
+                return;
+
+        float decay = clamp(GodRayParams0.z, 0.0, 1.0);
+        float weight = max(GodRayParams0.w, 0.0);
+        float density = max(GodRayParams1.w, 0.0);
+        if (density <= 0.0 || weight <= 0.0)
+                return;
+
+        vec2 viewSize = max(viewMax - viewMin, vec2(1e-6));
+        vec2 lightUV = clamp(GodRayParams1.xy, vec2(0.0), vec2(1.0));
+        lightUV = viewMin + lightUV * viewSize;
+
+        vec2 delta = lightUV - uv;
+        float deltaMag = max(abs(delta.x), abs(delta.y));
+        if (deltaMag <= 1e-6)
+                return;
+
+        int samples = int(clamp(GodRayParams2.x + 0.5, 1.0, float(GODRAY_MAX_SAMPLES)));
+        float threshold = clamp(GodRayParams1.z, 0.0, 1.0);
+        float softness = clamp(GodRayParams2.y, 1e-4, 1.0);
+
+        vec2 stepUV = delta / float(samples) * density;
+        vec2 sampleUV = uv;
+        float illuminationDecay = 1.0;
+        vec3 scatterAccum = vec3(0.0);
+
+        for (int i = 0; i < GODRAY_MAX_SAMPLES; ++i)
+        {
+                if (i >= samples)
+                        break;
+
+                sampleUV += stepUV;
+                if (any(lessThan(sampleUV, viewMin)) || any(greaterThan(sampleUV, viewMax)))
+                        break;
+
+                vec3 sampleColor = texture(GammaTexture, sampleUV).rgb;
+                float luminance = dot(sampleColor, vec3(0.2126, 0.7152, 0.0722));
+                float visibility = smoothstep(threshold, min(threshold + softness, 1.0), luminance);
+
+                scatterAccum += vec3(visibility) * illuminationDecay * weight;
+                illuminationDecay *= decay;
+        }
+
+        color += scatterAccum * intensity;
+}
+
+#endif // POSTPROCESS_GODRAYS_GLSL


### PR DESCRIPTION
## Summary
- add a postprocess god rays shader that generates light shafts from a configurable screen-space light position
- integrate the effect into the postprocessing pass and expose cvars for controlling intensity, falloff, density, samples, and threshold

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ff62dffcf0832ea32c0ac79b1248e9