### PR TITLE
Add deluxemap lighting support

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -835,96 +835,226 @@ static void Mod_LoadTextures (lump_t *l)
 Mod_LoadLighting -- johnfitz -- replaced with lit support code via lordhavoc
 =================
 */
+static void Mod_LoadDeluxemap (const char *dlitfilename, int samplecount)
+{
+        int mark;
+        byte *data;
+        unsigned int path_id;
+        size_t expected;
+
+        loadmodel->deluxdata = NULL;
+        loadmodel->deluxfile = false;
+
+        if (samplecount <= 0)
+                return;
+
+        expected = (size_t)samplecount * 3;
+        mark = Hunk_LowMark ();
+        data = (byte *) COM_LoadHunkFile (dlitfilename, &path_id);
+        if (data)
+        {
+                if (path_id < loadmodel->path_id)
+                {
+                        Hunk_FreeToLowMark (mark);
+                        Con_DPrintf ("ignored %s from a gamedir with lower priority\n", dlitfilename);
+                }
+                else if (data[0] == 'Q' && data[1] == 'L' && data[2] == 'I' && data[3] == 'T')
+                {
+                        int version = LittleLong (((int *)data)[1]);
+                        if (version == 2)
+                        {
+                                if ((size_t)(8 + expected) == com_filesize)
+                                {
+                                        Con_DPrintf2 ("%s loaded\n", dlitfilename);
+                                        loadmodel->deluxdata = data + 8;
+                                        loadmodel->deluxfile = true;
+                                        return;
+                                }
+                                Hunk_FreeToLowMark (mark);
+                                Con_Printf ("Mismatched .dlit file (%s should be %u bytes, not %" SDL_PRIs64 ")\n",
+                                        dlitfilename, (unsigned)(8 + expected), com_filesize);
+                        }
+                        else
+                        {
+                                Hunk_FreeToLowMark (mark);
+                                Con_Printf ("Unknown .dlit file version (%d)\n", version);
+                        }
+                }
+                else
+                {
+                        Hunk_FreeToLowMark (mark);
+                        Con_Printf ("Corrupt .dlit file (old version?), ignoring\n");
+                }
+        }
+        else
+        {
+                Con_DPrintf2 ("%s not found, synthesizing deluxemap\n", dlitfilename);
+        }
+
+        Hunk_FreeToLowMark (mark);
+
+        loadmodel->deluxdata = (byte *) Hunk_AllocNameNoFill (samplecount * 3, dlitfilename);
+        memset (loadmodel->deluxdata, 0, samplecount * 3);
+}
+
 static void Mod_LoadLighting (lump_t *l)
 {
-	int i, mark;
-	byte *in, *out, *data;
-	byte d, q64_b0, q64_b1;
-	char litfilename[MAX_OSPATH];
-	unsigned int path_id;
+        int i, mark;
+        byte *in, *out, *data;
+        byte d, q64_b0, q64_b1;
+        char litfilename[MAX_OSPATH];
+        char dlitfilename[MAX_OSPATH];
+        unsigned int path_id;
+        int samplecount = 0;
 
-	loadmodel->lightdata = NULL;
-	loadmodel->litfile = false;
-	// LordHavoc: check for a .lit file
-	q_strlcpy(litfilename, loadmodel->name, sizeof(litfilename));
-	COM_StripExtension(litfilename, litfilename, sizeof(litfilename));
-	q_strlcat(litfilename, ".lit", sizeof(litfilename));
-	mark = Hunk_LowMark();
-	data = (byte*) COM_LoadHunkFile (litfilename, &path_id);
-	if (data)
-	{
-		// use lit file only from the same gamedir as the map
-		// itself or from a searchpath with higher priority.
-		if (path_id < loadmodel->path_id)
-		{
-			Hunk_FreeToLowMark(mark);
-			Con_DPrintf("ignored %s from a gamedir with lower priority\n", litfilename);
-		}
-		else
-		if (data[0] == 'Q' && data[1] == 'L' && data[2] == 'I' && data[3] == 'T')
-		{
-			i = LittleLong(((int *)data)[1]);
-			if (i == 1)
-			{
-				if (8+l->filelen*3 == com_filesize)
-				{
-					Con_DPrintf2("%s loaded\n", litfilename);
-					loadmodel->lightdata = data + 8;
-					loadmodel->litfile = true;
-					return;
-				}
-				Hunk_FreeToLowMark(mark);
-				Con_Printf("Outdated .lit file (%s should be %u bytes, not %" SDL_PRIs64 "\n", litfilename, 8+l->filelen*3, com_filesize);
-			}
-			else
-			{
-				Hunk_FreeToLowMark(mark);
-				Con_Printf("Unknown .lit file version (%d)\n", i);
-			}
-		}
-		else
-		{
-			Hunk_FreeToLowMark(mark);
-			Con_Printf("Corrupt .lit file (old version?), ignoring\n");
-		}
-	}
-	// LordHavoc: no .lit found, expand the white lighting data to color
-	if (!l->filelen)
-		return;
+        loadmodel->lightdata = NULL;
+        loadmodel->deluxdata = NULL;
+        loadmodel->litfile = false;
+        loadmodel->deluxfile = false;
 
-	// Quake64 bsp lighmap data
-	if (loadmodel->bspversion == BSPVERSION_QUAKE64)
-	{
-		// RGB lightmap samples are packed in 16bits.
-		// RRRRR GGGGG BBBBBB
+        q_strlcpy (litfilename, loadmodel->name, sizeof (litfilename));
+        COM_StripExtension (litfilename, litfilename, sizeof (litfilename));
+        q_strlcpy (dlitfilename, litfilename, sizeof (dlitfilename));
+        q_strlcat (litfilename, ".lit", sizeof (litfilename));
+        q_strlcat (dlitfilename, ".dlit", sizeof (dlitfilename));
 
-		loadmodel->lightdata = (byte *) Hunk_AllocNameNoFill ( (l->filelen / 2)*3, litfilename);
-		in = mod_base + l->fileofs;
-		out = loadmodel->lightdata;
+        mark = Hunk_LowMark ();
+        data = (byte *) COM_LoadHunkFile (litfilename, &path_id);
+        if (data)
+        {
+                if (path_id < loadmodel->path_id)
+                {
+                        Hunk_FreeToLowMark (mark);
+                        Con_DPrintf ("ignored %s from a gamedir with lower priority\n", litfilename);
+                }
+                else if (data[0] == 'Q' && data[1] == 'L' && data[2] == 'I' && data[3] == 'T')
+                {
+                        i = LittleLong (((int *)data)[1]);
+                        if (i == 1)
+                        {
+                                if (8 + l->filelen * 3 == com_filesize)
+                                {
+                                        Con_DPrintf2 ("%s loaded\n", litfilename);
+                                        loadmodel->lightdata = data + 8;
+                                        loadmodel->litfile = true;
+                                        samplecount = l->filelen;
+                                        Mod_LoadDeluxemap (dlitfilename, samplecount);
+                                        return;
+                                }
+                                Hunk_FreeToLowMark (mark);
+                                Con_Printf ("Outdated .lit file (%s should be %u bytes, not %" SDL_PRIs64 ")\n",
+                                        litfilename, 8 + l->filelen * 3, com_filesize);
+                        }
+                        else
+                        {
+                                Hunk_FreeToLowMark (mark);
+                                Con_Printf ("Unknown .lit file version (%d)\n", i);
+                        }
+                }
+                else
+                {
+                        Hunk_FreeToLowMark (mark);
+                        Con_Printf ("Corrupt .lit file (old version?), ignoring\n");
+                }
+        }
 
-		for (i = 0;i < (l->filelen / 2) ;i++)
-		{
-			q64_b0 = *in++;
-			q64_b1 = *in++;
+        if (!l->filelen)
+        {
+                Mod_LoadDeluxemap (dlitfilename, 0);
+                return;
+        }
 
-			*out++ = q64_b0 & 0xf8;/* 0b11111000 */
-			*out++ = ((q64_b0 & 0x07) << 5) + ((q64_b1 & 0xc0) >> 5);/* 0b00000111, 0b11000000 */
-			*out++ = (q64_b1 & 0x3f) << 2;/* 0b00111111 */
-		}
-		return;
-	}
+        if (loadmodel->bspversion == BSPVERSION_QUAKE64)
+        {
+                loadmodel->lightdata = (byte *) Hunk_AllocNameNoFill ((l->filelen / 2) * 3, litfilename);
+                in = mod_base + l->fileofs;
+                out = loadmodel->lightdata;
 
-	loadmodel->lightdata = (byte *) Hunk_AllocNameNoFill ( l->filelen*3, litfilename);
-	in = loadmodel->lightdata + l->filelen*2; // place the file at the end, so it will not be overwritten until the very last write
-	out = loadmodel->lightdata;
-	memcpy (in, mod_base + l->fileofs, l->filelen);
-	for (i = 0;i < l->filelen;i++)
-	{
-		d = *in++;
-		*out++ = d;
-		*out++ = d;
-		*out++ = d;
-	}
+                for (i = 0; i < (l->filelen / 2); i++)
+                {
+                        q64_b0 = *in++;
+                        q64_b1 = *in++;
+
+                        *out++ = q64_b0 & 0xf8;
+                        *out++ = ((q64_b0 & 0x07) << 5) + ((q64_b1 & 0xc0) >> 5);
+                        *out++ = (q64_b1 & 0x3f) << 2;
+                }
+
+                samplecount = l->filelen / 2;
+                Mod_LoadDeluxemap (dlitfilename, samplecount);
+                return;
+        }
+
+#ifdef BSP29_VALVE
+        if (loadmodel->bspversion == BSPVERSION_VALVE)
+        {
+                loadmodel->lightdata = (byte *) Hunk_AllocNameNoFill (l->filelen, litfilename);
+                memcpy (loadmodel->lightdata, mod_base + l->fileofs, l->filelen);
+                samplecount = l->filelen / 3;
+                Mod_LoadDeluxemap (dlitfilename, samplecount);
+                return;
+        }
+#endif
+
+        loadmodel->lightdata = (byte *) Hunk_AllocNameNoFill (l->filelen * 3, litfilename);
+        in = loadmodel->lightdata + l->filelen * 2;
+        out = loadmodel->lightdata;
+        memcpy (in, mod_base + l->fileofs, l->filelen);
+        for (i = 0; i < l->filelen; i++)
+        {
+                d = *in++;
+                *out++ = d;
+                *out++ = d;
+                *out++ = d;
+        }
+
+        samplecount = l->filelen;
+        Mod_LoadDeluxemap (dlitfilename, samplecount);
+}
+
+
+static void Mod_InitFallbackDeluxemap (msurface_t *surf)
+{
+        int style_count, i, count;
+        int smax, tmax, facesize;
+        vec3_t normal;
+        byte encoded[3];
+        byte *dst;
+
+        if (!surf->deluxsamples)
+                return;
+
+        style_count = 0;
+        while (style_count < MAXLIGHTMAPS && surf->styles[style_count] != 255)
+                style_count++;
+        if (style_count == 0)
+                style_count = 1;
+
+        smax = (surf->extents[0] >> 4) + 1;
+        tmax = (surf->extents[1] >> 4) + 1;
+        facesize = smax * tmax;
+
+        VectorCopy (surf->plane->normal, normal);
+        if (surf->flags & SURF_PLANEBACK)
+                VectorNegate (normal, normal);
+
+        for (i = 0; i < 3; i++)
+        {
+                float c = CLAMP (-1.0f, normal[i], 1.0f);
+                int v = (int) Q_rint ((c * 0.5f + 0.5f) * 255.0f);
+                encoded[i] = (byte) CLAMP (0, v, 255);
+        }
+
+        for (i = 0; i < style_count; i++)
+        {
+                dst = surf->deluxsamples + i * facesize * 3;
+                for (count = 0; count < facesize; count++, dst += 3)
+                {
+                        dst[0] = encoded[0];
+                        dst[1] = encoded[1];
+                        dst[2] = encoded[2];
+                }
+        }
 }
 
 
@@ -1352,10 +1482,25 @@ static void Mod_LoadFaces (lump_t *l, qboolean bsp2)
 		if (loadmodel->bspversion == BSPVERSION_QUAKE64)
 			lofs /= 2; // Q64 samples are 16bits instead 8 in normal Quake 
 
-		if (lofs == -1)
-			out->samples = NULL;
-		else
-			out->samples = loadmodel->lightdata + (lofs * 3); //johnfitz -- lit support via lordhavoc (was "+ i")
+                if (lofs == -1)
+                {
+                        out->samples = NULL;
+                        out->deluxsamples = NULL;
+                }
+                else
+                {
+                        out->samples = loadmodel->lightdata + (lofs * 3); //johnfitz -- lit support via lordhavoc (was "+ i")
+                        if (loadmodel->deluxdata)
+                        {
+                                out->deluxsamples = loadmodel->deluxdata + (lofs * 3);
+                                if (!loadmodel->deluxfile)
+                                        Mod_InitFallbackDeluxemap (out);
+                        }
+                        else
+                        {
+                                out->deluxsamples = NULL;
+                        }
+                }
 
 		texture = loadmodel->textures[out->texinfo->texnum];
 

--- a/Quake/gl_model.h
+++ b/Quake/gl_model.h
@@ -152,6 +152,7 @@ typedef struct msurface_s
 
 	byte		styles[MAXLIGHTMAPS];
 	byte		*samples;			// [numstyles*surfsize]
+	byte		*deluxsamples;		// [numstyles*surfsize]
 
 	int			texturemins[2];
 	mtexinfo_t	*texinfo;
@@ -490,9 +491,11 @@ typedef struct qmodel_s
 
 	byte		*visdata;
 	byte		*lightdata;
+	byte		*deluxdata;
 	char		*entities;
 
 	qboolean	litfile;
+	qboolean	deluxfile;
 	qboolean	viswarn; // for Mod_DecompressVis()
 
 	int			bspversion;

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -25,6 +25,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #define NOISESCALE     (1.0f / 127.0f)
 
+extern gltexture_t *deluxemap_texture;
+
 qboolean	r_cache_thrash;		// compatability
 
 gpuframedata_t r_framedata;
@@ -189,6 +191,7 @@ cvar_t	r_fullbright = { "r_fullbright","0",CVAR_NONE };
 cvar_t	r_lightmap = { "r_lightmap","0",CVAR_NONE };
 cvar_t	r_wateralpha = { "r_wateralpha","1",CVAR_ARCHIVE };
 cvar_t	r_litwater = { "r_litwater","1",CVAR_NONE };
+cvar_t	r_deluxemaps = { "r_deluxemaps", "1", CVAR_ARCHIVE };
 cvar_t	r_dynamic = { "r_dynamic","1",CVAR_ARCHIVE };
 cvar_t	r_novis = { "r_novis","0",CVAR_ARCHIVE };
 #if defined(USE_SIMD)
@@ -1663,11 +1666,22 @@ void R_SetupView (void)
 		r_framedata.rim_alias = q_max(0.f, r_rim_alias.value);
 		r_framedata.rim_world = q_max(0.f, r_rim_world.value);
 		r_framedata.rim_exponent = q_max(0.5f, r_rim_exponent.value);
-		r_framedata.rim_pad0 = 0.f;
-		r_framedata.rim_pad1 = 0.f;
-	}
+                r_framedata.rim_pad0 = 0.f;
+                r_framedata.rim_pad1 = 0.f;
+        }
 
-	r_framecount++;
+        {
+                qboolean enable_delux =
+                        (r_deluxemaps.value > 0.f) &&
+                        !r_fullbright_cheatsafe && !r_lightmap_cheatsafe &&
+                        cl.worldmodel && cl.worldmodel->deluxdata &&
+                        deluxemap_texture;
+
+                r_framedata.delux_enabled = enable_delux ? 1 : 0;
+                r_framedata._padding1 = 0;
+        }
+
+        r_framecount++;
 	r_framedata.eyepos[0] = r_refdef.vieworg[0];
 	r_framedata.eyepos[1] = r_refdef.vieworg[1];
 	r_framedata.eyepos[2] = r_refdef.vieworg[2];

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -356,10 +356,11 @@ void R_Init (void)
         Cvar_RegisterVariable (&r_fullbright);
         Cvar_RegisterVariable (&r_drawentities);
         Cvar_RegisterVariable (&r_drawviewmodel);
-	Cvar_RegisterVariable (&r_wateralpha);
-	Cvar_SetCallback (&r_wateralpha, R_SetWateralpha_f);
-	Cvar_RegisterVariable (&r_litwater);
-	Cvar_RegisterVariable (&r_dynamic);
+        Cvar_RegisterVariable (&r_wateralpha);
+        Cvar_SetCallback (&r_wateralpha, R_SetWateralpha_f);
+        Cvar_RegisterVariable (&r_litwater);
+        Cvar_RegisterVariable (&r_deluxemaps);
+        Cvar_RegisterVariable (&r_dynamic);
 	Cvar_RegisterVariable (&r_novis);
 #if defined(USE_SIMD)
 	Cvar_RegisterVariable (&r_simd);

--- a/Quake/gl_texmgr.c
+++ b/Quake/gl_texmgr.c
@@ -534,7 +534,7 @@ TexMgr_CanCompress
 */
 static qboolean TexMgr_CanCompress (gltexture_t *glt)
 {
-	return glt->source_format != SRC_LIGHTMAP && (glt->flags & TEXPREF_PERSIST) == 0;
+    return glt->source_format != SRC_LIGHTMAP && glt->source_format != SRC_DELUXMAP && (glt->flags & TEXPREF_PERSIST) == 0;
 }
 
 /*
@@ -1458,13 +1458,22 @@ TexMgr_LoadLightmap -- handles lightmap data
 */
 static void TexMgr_LoadLightmap (gltexture_t *glt, byte *data)
 {
-	// upload it
-	glt->compression = 1;
-	GL_Bind (GL_TEXTURE0, glt);
-	GL_TexImage (glt, 0, GL_RGBA8, glt->width, glt->height, gl_lightmap_format, GL_UNSIGNED_BYTE, data);
+        // upload it
+        glt->compression = 1;
+        GL_Bind (GL_TEXTURE0, glt);
+        GL_TexImage (glt, 0, GL_RGBA8, glt->width, glt->height, gl_lightmap_format, GL_UNSIGNED_BYTE, data);
 
-	// set filter modes
-	TexMgr_SetFilterModes (glt);
+        // set filter modes
+        TexMgr_SetFilterModes (glt);
+}
+
+static void TexMgr_LoadDeluxemap (gltexture_t *glt, byte *data)
+{
+        glt->compression = 1;
+        GL_Bind (GL_TEXTURE0, glt);
+        GL_TexImage (glt, 0, GL_RGB8, glt->width, glt->height, GL_RGB, GL_UNSIGNED_BYTE, data);
+
+        TexMgr_SetFilterModes (glt);
 }
 
 /*
@@ -1494,12 +1503,15 @@ gltexture_t *TexMgr_LoadImageEx (qmodel_t *owner, const char *name, int width, i
 		case SRC_INDEXED:
 			crc = CRC_Block(data, width * height * depth);
 			break;
-		case SRC_LIGHTMAP:
-			crc = CRC_Block(data, width * height * depth * lightmap_bytes);
-			break;
-		case SRC_RGBA:
-			crc = CRC_Block(data, width * height * depth * 4);
-			break;
+                case SRC_LIGHTMAP:
+                        crc = CRC_Block(data, width * height * depth * lightmap_bytes);
+                        break;
+                case SRC_DELUXMAP:
+                        crc = CRC_Block(data, width * height * depth * deluxemap_bytes);
+                        break;
+                case SRC_RGBA:
+                        crc = CRC_Block(data, width * height * depth * 4);
+                        break;
 		default: /* not reachable but avoids compiler warnings */
 			crc = 0;
 			break;
@@ -1543,13 +1555,16 @@ gltexture_t *TexMgr_LoadImageEx (qmodel_t *owner, const char *name, int width, i
 	case SRC_INDEXED:
 		TexMgr_LoadImage8 (glt, data);
 		break;
-	case SRC_LIGHTMAP:
-		TexMgr_LoadLightmap (glt, data);
-		break;
-	case SRC_RGBA:
-		TexMgr_LoadImage32 (glt, (unsigned *)data);
-		break;
-	}
+        case SRC_LIGHTMAP:
+                TexMgr_LoadLightmap (glt, data);
+                break;
+        case SRC_DELUXMAP:
+                TexMgr_LoadDeluxemap (glt, data);
+                break;
+        case SRC_RGBA:
+                TexMgr_LoadImage32 (glt, (unsigned *)data);
+                break;
+        }
 
 	GL_ObjectLabelFunc (GL_TEXTURE, glt->texnum, -1, glt->name);
 	if (flags & TEXPREF_BINDLESS && gl_bindless_able)
@@ -1609,12 +1624,15 @@ void TexMgr_ReloadImage (gltexture_t *glt, int shirt, int pants)
 		fseek (f, glt->source_offset, SEEK_CUR);
 		size = glt->source_width * glt->source_height;
 		/* should be SRC_INDEXED, but no harm being paranoid:  */
-		if (glt->source_format == SRC_RGBA) {
-			size *= 4;
-		}
-		else if (glt->source_format == SRC_LIGHTMAP) {
-			size *= lightmap_bytes;
-		}
+                if (glt->source_format == SRC_RGBA) {
+                        size *= 4;
+                }
+                else if (glt->source_format == SRC_LIGHTMAP) {
+                        size *= lightmap_bytes;
+                }
+                else if (glt->source_format == SRC_DELUXMAP) {
+                        size *= deluxemap_bytes;
+                }
 		data = (byte *) Hunk_AllocNoFill (size);
 		sz = (int) fread (data, 1, size, f);
 		fclose (f);
@@ -1706,13 +1724,16 @@ invalid:	Con_Printf ("TexMgr_ReloadImage: invalid source for %s\n", glt->name);
 	case SRC_INDEXED:
 		TexMgr_LoadImage8 (glt, data);
 		break;
-	case SRC_LIGHTMAP:
-		TexMgr_LoadLightmap (glt, data);
-		break;
-	case SRC_RGBA:
-		TexMgr_LoadImage32 (glt, (unsigned *)data);
-		break;
-	}
+        case SRC_LIGHTMAP:
+                TexMgr_LoadLightmap (glt, data);
+                break;
+        case SRC_DELUXMAP:
+                TexMgr_LoadDeluxemap (glt, data);
+                break;
+        case SRC_RGBA:
+                TexMgr_LoadImage32 (glt, (unsigned *)data);
+                break;
+        }
 
 	GL_ObjectLabelFunc (GL_TEXTURE, glt->texnum, -1, glt->name);
 	if (glt->flags & TEXPREF_BINDLESS && gl_bindless_able)

--- a/Quake/gl_texmgr.h
+++ b/Quake/gl_texmgr.h
@@ -48,7 +48,7 @@ typedef enum
 	TEXPREF_HASALPHA		= (TEXPREF_ALPHA|TEXPREF_ALPHABRIGHT), // texture has alpha channel
 } textureflags_t;
 
-enum srcformat {SRC_INDEXED, SRC_LIGHTMAP, SRC_RGBA};
+enum srcformat {SRC_INDEXED, SRC_LIGHTMAP, SRC_RGBA, SRC_DELUXMAP};
 
 typedef uintptr_t src_offset_t;
 

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -101,6 +101,7 @@ extern	cvar_t	r_lavaalpha;
 extern	cvar_t	r_telealpha;
 extern	cvar_t	r_slimealpha;
 extern	cvar_t	r_litwater;
+extern	cvar_t	r_deluxemaps;
 extern	cvar_t	r_dynamic;
 extern	cvar_t	r_novis;
 extern	cvar_t	r_scale;
@@ -367,7 +368,7 @@ extern overflowtimes_t dev_overflows; //this stores the last time overflow messa
 #define CONSOLE_RESPAM_TIME 3 // seconds between repeated warning messages
 
 //johnfitz -- moved here from r_brush.c
-extern int gl_lightmap_format, lightmap_bytes;
+extern int gl_lightmap_format, lightmap_bytes, deluxemap_bytes;
 extern int lightmap_block_width, lightmap_block_height;
 extern cvar_t gl_lightmap_atlas_size;
 void GL_OnLightmapAtlasSizeChanged (cvar_t *var);
@@ -443,8 +444,8 @@ typedef struct gpuframedata_s {
 	float	zlogbias;
 	int			numlights;
 	int			prev_frame_valid;
+	int			delux_enabled;
 	int			_padding1;
-	int			_padding2;
 } gpuframedata_t;
 
 extern gpulightbuffer_t r_lightbuffer;

--- a/Quake/r_brush.c
+++ b/Quake/r_brush.c
@@ -35,6 +35,7 @@ int     lightmap_block_height = 256;
 
 int		gl_lightmap_format;
 int		lightmap_bytes;
+int		deluxemap_bytes;
 
 typedef struct {
 	qboolean		reverse;
@@ -51,7 +52,9 @@ msurface_t		**lit_surfs;
 int				*lit_surf_order[2];
 int				num_lightmap_samples;
 unsigned		*lightmap_data;
+byte		*deluxemap_data;
 gltexture_t		*lightmap_texture;
+gltexture_t		*deluxemap_texture;
 int				lightmap_width;
 int				lightmap_height;
 
@@ -267,6 +270,12 @@ static void GL_FillSurfaceLightmap (msurface_t *surf)
 	byte		*src;
 	unsigned	*dst;
 	int			s, t, facesize;
+	const byte	*dirsrc;
+	byte		*dstdir;
+	int			tap_count;
+	int			dir_stride;
+	qboolean	use_fallback;
+	byte		fallback[3];
 
 	if (!cl.worldmodel->lightdata || !surf->samples || surf->styles[0] == 255)
 		return;
@@ -318,6 +327,59 @@ static void GL_FillSurfaceLightmap (msurface_t *surf)
 			}
 		}
 	}
+
+	if (!deluxemap_data)
+		return;
+
+	tap_count = GL_NumLightmapTaps (surf);
+	dir_stride = lightmap_width * deluxemap_bytes;
+	dirsrc = surf->deluxsamples;
+	use_fallback = (dirsrc == NULL);
+
+	if (use_fallback)
+	{
+		vec3_t normal;
+		int component;
+
+		VectorCopy (surf->plane->normal, normal);
+		if (surf->flags & SURF_PLANEBACK)
+			VectorNegate (normal, normal);
+
+		for (component = 0; component < 3; component++)
+		{
+			float c = CLAMP (-1.0f, normal[component], 1.0f);
+			int v = (int) Q_rint ((c * 0.5f + 0.5f) * 255.0f);
+			fallback[component] = (byte) CLAMP (0, v, 255);
+		}
+	}
+
+	for (t = 0; t < tmax; t++)
+	{
+		int row_index = yofs + t;
+		dstdir = deluxemap_data + row_index * dir_stride + xofs * deluxemap_bytes;
+
+		for (s = 0; s < smax; s++)
+		{
+			int texel_index = t * smax + s;
+			for (map = 0; map < tap_count; map++)
+			{
+				byte *pixel = dstdir + (s + map * smax) * deluxemap_bytes;
+				if (!use_fallback)
+				{
+					const byte *srcdir = dirsrc + map * facesize + texel_index * 3;
+					pixel[0] = srcdir[0];
+					pixel[1] = srcdir[1];
+					pixel[2] = srcdir[2];
+				}
+				else
+				{
+					pixel[0] = fallback[0];
+					pixel[1] = fallback[1];
+					pixel[2] = fallback[2];
+				}
+			}
+		}
+	}
 }
 
 /*
@@ -332,6 +394,11 @@ static void GL_FreeLightmapData (void)
 		free (lightmap_data);
 		lightmap_data = NULL;
 	}
+	if (deluxemap_data)
+	{
+		free (deluxemap_data);
+		deluxemap_data = NULL;
+	}
 	if (lightmaps)
 	{
 		free (lightmaps);
@@ -341,6 +408,7 @@ static void GL_FreeLightmapData (void)
 	VEC_CLEAR (lit_surfs);
 
 	lightmap_texture = NULL; // freed by the texture manager
+	deluxemap_texture = NULL; // freed by the texture manager
 	last_lightmap_allocated = 0;
 	lightmap_count = 0;
 	lightmap_width = 0;
@@ -493,6 +561,7 @@ void GL_BuildLightmaps (void)
 	default:
 		Sys_Error ("GL_BuildLightmaps: bad lightmap format");
 	}
+	deluxemap_bytes = 3;
 
 	lightmap_block_width = lightmap_block_height = GL_SanitizeAtlasSize ((int)gl_lightmap_atlas_size.value);
 	// allocate lightmap blocks
@@ -524,6 +593,24 @@ void GL_BuildLightmaps (void)
 	if (!lightmap_data)
 		Sys_Error ("GL_BuildLightmaps: out of memory on %" SDL_PRIu64 " bytes", (uint64_t)(lmsize * sizeof (*lightmap_data)));
 
+	if (cl.worldmodel->deluxdata)
+	{
+		deluxemap_data = (byte *) malloc (lmsize * deluxemap_bytes);
+		if (!deluxemap_data)
+			Sys_Error ("GL_BuildLightmaps: out of memory on %" SDL_PRIu64 " bytes", (uint64_t)(lmsize * deluxemap_bytes));
+		for (i = 0; i < lmsize; i++)
+		{
+			byte *dst = deluxemap_data + i * deluxemap_bytes;
+			dst[0] = 128;
+			dst[1] = 128;
+			dst[2] = 255;
+		}
+	}
+	else
+	{
+		deluxemap_data = NULL;
+	}
+
 	// compute offsets for each lightmap block
 	for (i=0; i<lightmap_count; i++)
 	{
@@ -549,6 +636,18 @@ void GL_BuildLightmaps (void)
 			SRC_LIGHTMAP, (byte *)lightmap_data, "", (src_offset_t)lightmap_data,
 			TEXPREF_ALPHA | TEXPREF_LINEAR | TEXPREF_NOPICMIP
 		);
+	if (deluxemap_data)
+	{
+		deluxemap_texture =
+			TexMgr_LoadImage (cl.worldmodel, "deluxemap", lightmap_width, lightmap_height,
+				SRC_DELUXMAP, deluxemap_data, "", (src_offset_t)deluxemap_data,
+				TEXPREF_LINEAR | TEXPREF_NOPICMIP
+			);
+	}
+	else
+	{
+		deluxemap_texture = NULL;
+	}
 
 	//johnfitz -- warn about exceeding old limits
 	//GLQuake limit was 64 textures of 128x128. Estimate how many 128x128 textures we would need

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -29,6 +29,7 @@ extern cvar_t gl_zfix; // QuakeSpasm z-fighting fix
 extern cvar_t r_oit;
 
 extern gltexture_t *lightmap_texture;
+extern gltexture_t *deluxemap_texture;
 
 extern GLuint gl_bmodel_vbo;
 extern size_t gl_bmodel_vbo_size;
@@ -509,12 +510,25 @@ static void R_DrawBrushModels_Real (entity_t **ents, int count, brushpass_t pass
 
         R_ResetBModelCalls (program);
         GL_SetState (state);
-        if (pass <= BP_ALPHATEST)
+
+        if (pass <= BP_ALPHATEST || pass == BP_SHOWTRIS)
         {
+                qboolean use_delux =
+                        (r_deluxemaps.value > 0.f) && !r_fullbright_cheatsafe && !r_lightmap_cheatsafe &&
+                        deluxemap_texture && cl.worldmodel && cl.worldmodel->deluxdata;
+
                 GL_Bind (GL_TEXTURE2, r_fullbright_cheatsafe ? greytexture : lightmap_texture);
+                GL_Bind (GL_TEXTURE3, use_delux ? deluxemap_texture : NULL);
         }
         else if (pass == BP_SKYCUBEMAP)
+        {
                 GL_Bind (GL_TEXTURE2, skybox->cubemap);
+                GL_Bind (GL_TEXTURE3, NULL);
+        }
+        else
+        {
+                GL_Bind (GL_TEXTURE3, NULL);
+        }
 
         GL_Upload (GL_SHADER_STORAGE_BUFFER, bmodel_instances, sizeof(bmodel_instances[0]) * totalinst, &buf, &ofs);
         GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 2, buf, (GLintptr)ofs, sizeof(bmodel_instances[0]) * totalinst);
@@ -610,8 +624,15 @@ void R_DrawBrushModels_Water (entity_t **ents, int count, qboolean translucent)
 		program = glprogs.water[oit][softemu == SOFTEMU_COARSE];
 
 	R_ResetBModelCalls (program);
-	GL_SetState (state);
-	GL_Bind (GL_TEXTURE2, r_fullbright_cheatsafe ? greytexture : lightmap_texture);
+        GL_SetState (state);
+        {
+                qboolean use_delux =
+                        (r_deluxemaps.value > 0.f) && !r_fullbright_cheatsafe && !r_lightmap_cheatsafe &&
+                        deluxemap_texture && cl.worldmodel && cl.worldmodel->deluxdata;
+
+                GL_Bind (GL_TEXTURE2, r_fullbright_cheatsafe ? greytexture : lightmap_texture);
+                GL_Bind (GL_TEXTURE3, use_delux ? deluxemap_texture : NULL);
+        }
 
 	GL_Upload (GL_SHADER_STORAGE_BUFFER, bmodel_instances, sizeof(bmodel_instances[0]) * totalinst, &buf, &ofs);
 	GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 2, buf, (GLintptr)ofs, sizeof(bmodel_instances[0]) * count);

--- a/Quake/shaders/frame_uniforms.glsl
+++ b/Quake/shaders/frame_uniforms.glsl
@@ -25,8 +25,8 @@ layout(std140, binding=0) uniform FrameDataUBO
         float   ZLogBias;
         uint    NumLights;
         uint    PrevFrameValid;
+        uint    DeluxEnabled;
         uint    _Pad1;
-        uint    _Pad2;
 };
 
 #endif // FRAME_UNIFORMS_GLSL

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -1,3 +1,16 @@
+#if BINDLESS
+        #extension GL_ARB_bindless_texture : require
+#else
+        layout(binding=0) uniform sampler2D Tex;
+        layout(binding=1) uniform sampler2D FullbrightTex;
+        layout(binding=4) uniform sampler2D EmissiveTex;
+#endif
+
+layout(binding=2) uniform sampler2D LMTex;
+layout(binding=3) uniform sampler2D DeluxTex;
+
+#include "frame_uniforms.glsl"
+
 // === Performance-Schalter (optional) ===
 #ifndef USE_COARSE_DERIVATIVES
 #define USE_COARSE_DERIVATIVES 1   // 1: dFdxCoarse/dFdyCoarse wenn verfügbar, sonst fallback
@@ -22,6 +35,15 @@ float fastInvLen(vec3 v){
 vec3  fastNorm(vec3 v){
     float inv = fastInvLen(v);
     return (inv>0.0) ? v*inv : vec3(0.0,0.0,1.0);
+}
+
+vec3 DecodeDelux(vec3 encoded, vec3 fallback)
+{
+    vec3 normal = encoded * 2.0 - 1.0;
+    float len2 = dot(normal, normal);
+    if (len2 <= 1.0e-6)
+        return fallback;
+    return normal * inversesqrt(len2);
 }
 
 // schneller Specular für feste Power (hier 16)
@@ -118,7 +140,41 @@ void main()
 
     // schnellere Flächennormalen aus Derivaten
     vec3 dn = cross(DFDX(in_pos), DFDY(in_pos));
-    vec3 surface_normal = fastNorm(dn);
+    vec3 geom_normal = fastNorm(dn);
+    vec3 surface_normal = geom_normal;
+
+    if (DeluxEnabled != 0u)
+    {
+        vec3 accum = vec3(0.0);
+        float weight = 0.0;
+        vec3 dir0 = DecodeDelux(textureLod(DeluxTex, lmuv, 0.0).xyz, geom_normal);
+        float w0 = max(in_styles.x, 0.0);
+        accum += dir0 * w0;
+        weight += w0;
+
+        if (in_styles.y >= 0.0)
+        {
+            vec2 uv1 = vec2(lmuv.x + in_lmofs, lmuv.y);
+            vec3 dir1 = DecodeDelux(textureLod(DeluxTex, uv1, 0.0).xyz, geom_normal);
+            float w1 = max(in_styles.y, 0.0);
+            accum += dir1 * w1;
+            weight += w1;
+
+            if (in_styles.z >= 0.0)
+            {
+                vec2 uv2 = vec2(lmuv.x + in_lmofs * 2.0, lmuv.y);
+                vec3 dir2 = DecodeDelux(textureLod(DeluxTex, uv2, 0.0).xyz, geom_normal);
+                float w2 = max(in_styles.z, 0.0);
+                accum += dir2 * w2;
+                weight += w2;
+            }
+        }
+
+        if (weight > 0.0)
+            surface_normal = fastNorm(accum);
+        else
+            surface_normal = dir0;
+    }
 
     vec3 total_light = saturate(static_light);
     vec3 specular_light = vec3(0.0);

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Ironwail is a high-performance fork of the GLQuake descendant [QuakeSpasm](https
 
 ## Highlights
 - UI upgrades: mouse support, in-game key binding for weapons, extra video and gameplay options that apply instantly.
-- Visual polish: alternative HUD styles (including Q64-inspired layouts), real-time palettization with optional dithering, classic underwater warp, lightmapped liquids, configurable Quake 3-style lightmap overbrightening, lightstyle interpolation, higher color/depth precision, and improved z-fighting workarounds.
+- Visual polish: alternative HUD styles (including Q64-inspired layouts), real-time palettization with optional dithering, classic underwater warp, lightmapped liquids, colored lightmaps with optional directional deluxemaps for smoother shading, configurable Quake 3-style lightmap overbrightening, lightstyle interpolation, higher color/depth precision, and improved z-fighting workarounds.
 - Performance boosts: GPU-driven culling, compute-based lightmap updates, reduced heap usage, faster loading on jumbo maps, and an automatic frame limiter when no map is loaded.
 - Quality-of-life: runs from Unicode paths and plays demanding maps like [Shibboleth](https://www.quaddicted.com/reviews/ter_shibboleth_drake_redux.html), [Raven Keep](https://www.quaddicted.com/reviews/ravenkeep.html), and [ad_tears](https://www.moddb.com/mods/arcane-dimensions) at high frame rates without manual `-heapsize` tuning.
 


### PR DESCRIPTION
## Summary
- load `.dlit` deluxemaps alongside colored lightmaps and synthesize fallback normals when unavailable
- allocate and upload a shared deluxemap texture, expose a `r_deluxemaps` toggle, and pass enable state through the frame UBO
- bind the deluxemap in world and water passes and decode it in the world shader to drive per-pixel lighting

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ff835a2960832ebbbcc30c5e2e63b8