### PR TITLE
Add PK3 archive support to filesystem

### DIFF
--- a/Quake/common.c
+++ b/Quake/common.c
@@ -28,6 +28,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "steam.h"
 #include <time.h>
 #include <errno.h>
+#include <stdlib.h>
+#include <limits.h>
 #include "miniz.h"
 #include "unicode_translit.h"
 
@@ -1901,6 +1903,46 @@ static int COM_FindFile (const char *filename, int *handle, FILE **file,
 				file_from_pak = 1;
 				if (path_id)
 					*path_id = search->path_id;
+
+				if (pak->type == PACKTYPE_PK3)
+				{
+					size_t extracted = 0;
+					void *data = mz_zip_reader_extract_to_heap (pak->zip, (mz_uint) pak->files[i].zip_index, &extracted, 0);
+					if (!data)
+						return -1;
+
+					if (handle)
+					{
+						*handle = Sys_FileOpenMemory (data, extracted);
+						return com_filesize;
+					}
+					else if (file)
+					{
+						FILE *tmp = Sys_TempFile ();
+						if (!tmp)
+						{
+							mz_free (data);
+							return -1;
+						}
+						if (fwrite (data, 1, extracted, tmp) != extracted)
+						{
+							mz_free (data);
+							fclose (tmp);
+							return -1;
+						}
+						mz_free (data);
+						if (fseek (tmp, 0, SEEK_SET) != 0)
+						{
+							fclose (tmp);
+							return -1;
+						}
+						*file = tmp;
+						return com_filesize;
+					}
+					mz_free (data);
+					return com_filesize;
+				}
+
 				if (handle)
 				{
 					*handle = pak->handle;
@@ -2217,7 +2259,7 @@ Loads the header and directory, adding the files at the beginning
 of the list so they override previous pack files.
 =================
 */
-static pack_t *COM_LoadPackFile (const char *packfile)
+static pack_t *COM_LoadPakArchive (const char *packfile)
 {
 	dpackheader_t	header;
 	int		i;
@@ -2276,6 +2318,7 @@ static pack_t *COM_LoadPackFile (const char *packfile)
 		q_strlcpy (newfiles[i].name, info[i].name, sizeof(newfiles[i].name));
 		newfiles[i].filepos = LittleLong(info[i].filepos);
 		newfiles[i].filelen = LittleLong(info[i].filelen);
+		newfiles[i].zip_index = -1;
 	}
 
 	pack = (pack_t *) Z_Malloc (sizeof (pack_t));
@@ -2283,9 +2326,141 @@ static pack_t *COM_LoadPackFile (const char *packfile)
 	pack->handle = packhandle;
 	pack->numfiles = numpackfiles;
 	pack->files = newfiles;
+	pack->type = PACKTYPE_PAK;
+	pack->zip = NULL;
 
 	//Sys_Printf ("Added packfile %s (%i files)\n", packfile, numpackfiles);
 	return pack;
+}
+
+static int COM_ComparePk3Names (const void *a, const void *b)
+{
+	const char *const *sa = (const char *const *) a;
+	const char *const *sb = (const char *const *) b;
+	return q_strcasecmp (*sa, *sb);
+}
+
+static pack_t *COM_LoadPK3File (const char *packfile)
+{
+	mz_zip_archive   *archive = NULL;
+	packfile_t      *newfiles = NULL;
+	pack_t          *pack = NULL;
+	mz_uint         totalfiles;
+	int             count = 0;
+	int             i;
+
+	archive = (mz_zip_archive *) Z_Malloc (sizeof (*archive));
+	memset (archive, 0, sizeof (*archive));
+	if (!mz_zip_reader_init_file (archive, packfile, 0))
+		goto fail;
+
+	totalfiles = mz_zip_reader_get_num_files (archive);
+	for (i = 0; i < (int) totalfiles; ++i)
+	{
+		mz_zip_archive_file_stat st;
+		if (!mz_zip_reader_file_stat (archive, i, &st))
+			goto fail;
+		if (st.m_is_directory || st.m_is_encrypted || !st.m_is_supported)
+			continue;
+		if (!st.m_filename[0])
+			continue;
+		if (st.m_uncomp_size > INT_MAX)
+			continue;
+		if ((size_t) q_strlen (st.m_filename) >= sizeof (newfiles[0].name))
+			continue;
+		++count;
+	}
+
+	if (!count)
+	{
+		Sys_Printf ("WARNING: %s has no files, ignored\n", packfile);
+		goto fail;
+	}
+
+	newfiles = (packfile_t *) Z_Malloc (count * sizeof (packfile_t));
+	count = 0;
+	for (i = 0; i < (int) totalfiles; ++i)
+	{
+		mz_zip_archive_file_stat st;
+		char normalized[MAX_QPATH];
+		char *p;
+
+		if (!mz_zip_reader_file_stat (archive, i, &st))
+			goto fail;
+		if (st.m_is_directory || st.m_is_encrypted || !st.m_is_supported)
+			continue;
+		if (!st.m_filename[0])
+			continue;
+		if (st.m_uncomp_size > INT_MAX)
+			continue;
+		if ((size_t) q_strlcpy (normalized, st.m_filename, sizeof (normalized)) >= sizeof (normalized))
+			continue;
+		COM_NormalizePath (normalized);
+		for (p = normalized; *p; ++p)
+			*p = q_tolower (*p);
+
+		q_strlcpy (newfiles[count].name, normalized, sizeof (newfiles[count].name));
+		newfiles[count].filepos = -1;
+		newfiles[count].filelen = (int) st.m_uncomp_size;
+		newfiles[count].zip_index = i;
+		++count;
+	}
+
+	if (!count)
+		goto fail;
+
+	pack = (pack_t *) Z_Malloc (sizeof (pack_t));
+	q_strlcpy (pack->filename, packfile, sizeof (pack->filename));
+	pack->handle = -1;
+	pack->numfiles = count;
+	pack->files = newfiles;
+	pack->type = PACKTYPE_PK3;
+	pack->zip = archive;
+
+	com_modified = true;
+	return pack;
+
+fail:
+	if (newfiles)
+		Z_Free (newfiles);
+	if (archive)
+	{
+		mz_zip_reader_end (archive);
+		Z_Free (archive);
+	}
+	return NULL;
+}
+
+static pack_t *COM_LoadPackFile (const char *packfile)
+{
+	const char *ext = COM_FileGetExtension (packfile);
+	if (!q_strcasecmp (ext, "pk3"))
+		return COM_LoadPK3File (packfile);
+	return COM_LoadPakArchive (packfile);
+}
+
+static void COM_FreePack (pack_t *pack)
+{
+	if (!pack)
+		return;
+
+	if (pack->type == PACKTYPE_PAK)
+	{
+		if (pack->handle >= 0)
+			Sys_FileClose (pack->handle);
+	}
+	else if (pack->type == PACKTYPE_PK3)
+	{
+		if (pack->zip)
+		{
+			mz_zip_reader_end (pack->zip);
+			Z_Free (pack->zip);
+		}
+	}
+
+	if (pack->files)
+		Z_Free (pack->files);
+	Z_Free (pack);
 }
 
 const char *COM_GetGameNames(qboolean full)
@@ -2416,6 +2591,53 @@ void COM_AddGameDirectory (const char *dir)
 			if (i == 0 && j == 0 && path_id == 1u && !fitzmode)
 				COM_AddEnginePak ();
 		}
+
+		{
+			int pk3count = 0;
+			findfile_t *find;
+			char **pk3names = NULL;
+
+			for (find = Sys_FindFirst (com_gamedir, "pk3"); find; find = Sys_FindNext (find))
+			{
+				if (!(find->attribs & FA_DIRECTORY))
+					++pk3count;
+			}
+
+			if (pk3count > 0)
+			{
+				int idx;
+				pk3names = (char **) Z_Malloc (pk3count * sizeof (*pk3names));
+
+				idx = 0;
+				for (find = Sys_FindFirst (com_gamedir, "pk3"); find; find = Sys_FindNext (find))
+				{
+					if (find->attribs & FA_DIRECTORY)
+						continue;
+					pk3names[idx] = (char *) Z_Malloc (strlen (find->name) + 1);
+					q_strlcpy (pk3names[idx], find->name, strlen (find->name) + 1);
+					++idx;
+				}
+
+				qsort (pk3names, pk3count, sizeof (*pk3names), COM_ComparePk3Names);
+
+				for (idx = 0; idx < pk3count; ++idx)
+				{
+					q_snprintf (pakfile, sizeof (pakfile), "%s/%s", com_gamedir, pk3names[idx]);
+					pak = COM_LoadPackFile (pakfile);
+					if (pak)
+					{
+						search = (searchpath_t *) Z_Malloc(sizeof(searchpath_t));
+						search->path_id = path_id;
+						search->pack = pak;
+						search->next = com_searchpaths;
+						com_searchpaths = search;
+					}
+					Z_Free (pk3names[idx]);
+				}
+
+				Z_Free (pk3names);
+			}
+		}
 	}
 }
 
@@ -2427,11 +2649,7 @@ void COM_ResetGameDirectories(const char *newgamedirs)
 	while (com_searchpaths != com_base_searchpaths)
 	{
 		if (com_searchpaths->pack)
-		{
-			Sys_FileClose (com_searchpaths->pack->handle);
-			Z_Free (com_searchpaths->pack->files);
-			Z_Free (com_searchpaths->pack);
-		}
+			COM_FreePack (com_searchpaths->pack);
 		search = com_searchpaths->next;
 		Z_Free (com_searchpaths);
 		com_searchpaths = search;

--- a/Quake/common.h
+++ b/Quake/common.h
@@ -375,7 +375,15 @@ typedef struct
 {
 	char	name[MAX_QPATH];
 	int		filepos, filelen;
+	int		zip_index;
 } packfile_t;
+
+struct mz_zip_archive;
+typedef enum
+{
+	PACKTYPE_PAK,
+	PACKTYPE_PK3
+} packtype_t;
 
 typedef struct pack_s
 {
@@ -383,6 +391,8 @@ typedef struct pack_s
 	int		handle;
 	int		numfiles;
 	packfile_t	*files;
+	packtype_t	type;
+	struct mz_zip_archive	*zip;
 } pack_t;
 
 typedef struct searchpath_s

--- a/Quake/sys.h
+++ b/Quake/sys.h
@@ -83,6 +83,7 @@ void Sys_FileClose (int handle);
 void Sys_FileSeek (int handle, int position);
 int Sys_FileRead (int handle, void *dest, int count);
 int Sys_FileWrite (int handle,const void *data, int count);
+int Sys_FileOpenMemory (void *data, size_t length);
 qboolean Sys_FileExists (const char *path);
 qboolean Sys_GetFileTime (const char *path, time_t *out);
 void Sys_mkdir (const char *path);
@@ -91,6 +92,7 @@ int Sys_fseek (FILE *file, qfileofs_t ofs, int origin);
 qfileofs_t Sys_ftell (FILE *file);
 int Sys_remove (const char *path);
 int Sys_rename (const char *oldname, const char *newname);
+FILE *Sys_TempFile (void);
 
 typedef enum {
 	FA_DIRECTORY	= 1 << 0,

--- a/Quake/sys_sdl_unix.c
+++ b/Quake/sys_sdl_unix.c
@@ -54,7 +54,30 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 qboolean		isDedicated;
 
 #define	MAX_HANDLES		32	/* johnfitz -- was 10 */
-static FILE		*sys_handles[MAX_HANDLES];
+
+typedef enum
+{
+	SYS_HANDLE_NONE = 0,
+	SYS_HANDLE_FILE,
+	SYS_HANDLE_MEMORY
+} sys_handle_type_t;
+
+typedef struct
+{
+	sys_handle_type_t		type;
+	union
+	{
+		FILE		*file;
+		struct
+		{
+			byte		*data;
+			size_t	length;
+			size_t	position;
+		} mem;
+	} u;
+} sys_handle_t;
+
+static sys_handle_t		sys_handles[MAX_HANDLES];
 static qboolean		stdinIsATTY;	/* from ioquake3 source */
 
 static double rcp_counter_freq;
@@ -150,7 +173,8 @@ qfileofs_t Sys_FileOpenRead (const char *path, int *hndl)
 	}
 	else
 	{
-		sys_handles[i] = f;
+		sys_handles[i].type = SYS_HANDLE_FILE;
+		sys_handles[i].u.file = f;
 		*hndl = i;
 		retval = Sys_filelength(f);
 	}
@@ -169,29 +193,96 @@ int Sys_FileOpenWrite (const char *path)
 	if (!f)
 		Sys_Error ("Error opening %s: %s", path, strerror(errno));
 
-	sys_handles[i] = f;
+	sys_handles[i].type = SYS_HANDLE_FILE;
+	sys_handles[i].u.file = f;
 	return i;
 }
 
 void Sys_FileClose (int handle)
 {
-	fclose (sys_handles[handle]);
-	sys_handles[handle] = NULL;
+	sys_handle_t *sh = &sys_handles[handle];
+
+	switch (sh->type)
+	{
+	case SYS_HANDLE_FILE:
+		fclose (sh->u.file);
+		break;
+	case SYS_HANDLE_MEMORY:
+		free (sh->u.mem.data);
+		break;
+	case SYS_HANDLE_NONE:
+		break;
+	}
+
+	sh->type = SYS_HANDLE_NONE;
 }
 
 void Sys_FileSeek (int handle, int position)
 {
-	fseek (sys_handles[handle], position, SEEK_SET);
+	sys_handle_t *sh = &sys_handles[handle];
+
+	if (sh->type == SYS_HANDLE_FILE)
+	{
+		fseek (sh->u.file, position, SEEK_SET);
+		return;
+	}
+
+	if (sh->type == SYS_HANDLE_MEMORY)
+	{
+		if (position < 0)
+			position = 0;
+		if ((size_t) position > sh->u.mem.length)
+			sh->u.mem.position = sh->u.mem.length;
+		else
+			sh->u.mem.position = (size_t) position;
+	}
 }
 
 int Sys_FileRead (int handle, void *dest, int count)
 {
-	return fread (dest, 1, count, sys_handles[handle]);
+	sys_handle_t *sh = &sys_handles[handle];
+
+	if (sh->type == SYS_HANDLE_FILE)
+		return fread (dest, 1, count, sh->u.file);
+
+	if (sh->type == SYS_HANDLE_MEMORY)
+	{
+		size_t remaining = sh->u.mem.length - sh->u.mem.position;
+		if ((size_t) count > remaining)
+			count = (int) remaining;
+		memcpy (dest, sh->u.mem.data + sh->u.mem.position, count);
+		sh->u.mem.position += (size_t) count;
+		return count;
+	}
+
+	return 0;
 }
 
 int Sys_FileWrite (int handle, const void *data, int count)
 {
-	return fwrite (data, 1, count, sys_handles[handle]);
+	sys_handle_t *sh = &sys_handles[handle];
+
+	if (sh->type != SYS_HANDLE_FILE)
+		Sys_Error ("Sys_FileWrite: invalid handle type");
+
+	return fwrite (data, 1, count, sh->u.file);
+}
+
+int Sys_FileOpenMemory (void *data, size_t length)
+{
+	int handle = findhandle ();
+
+	sys_handles[handle].type = SYS_HANDLE_MEMORY;
+	sys_handles[handle].u.mem.data = (byte *) data;
+	sys_handles[handle].u.mem.length = length;
+	sys_handles[handle].u.mem.position = 0;
+
+	return handle;
+}
+
+FILE *Sys_TempFile (void)
+{
+	return tmpfile ();
 }
 
 qboolean Sys_FileExists (const char *path)

--- a/Quake/sys_sdl_win.c
+++ b/Quake/sys_sdl_win.c
@@ -53,6 +53,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include <errno.h>
 #include <io.h>
 #include <direct.h>
+#include <stdlib.h>
+#include <string.h>
 
 #if defined(SDL_FRAMEWORK) || defined(NO_SDL_CONFIG)
 #include <SDL2/SDL.h>
@@ -69,7 +71,30 @@ qboolean		isDedicated;
 static HANDLE		hinput, houtput;
 
 #define	MAX_HANDLES		32	/* johnfitz -- was 10 */
-static FILE		*sys_handles[MAX_HANDLES];
+
+typedef enum
+{
+	SYS_HANDLE_NONE = 0,
+	SYS_HANDLE_FILE,
+	SYS_HANDLE_MEMORY
+} sys_handle_type_t;
+
+typedef struct
+{
+	sys_handle_type_t		type;
+	union
+	{
+		FILE		*file;
+		struct
+		{
+			byte		*data;
+			size_t	length;
+			size_t	position;
+		} mem;
+	} u;
+} sys_handle_t;
+
+static sys_handle_t		sys_handles[MAX_HANDLES];
 
 static double rcp_counter_freq;
 
@@ -79,7 +104,7 @@ static int findhandle (void)
 
 	for (i = 1; i < MAX_HANDLES; i++)
 	{
-		if (!sys_handles[i])
+		if (sys_handles[i].type == SYS_HANDLE_NONE)
 			return i;
 	}
 	Sys_Error ("out of handles");
@@ -203,7 +228,8 @@ qfileofs_t Sys_FileOpenRead (const char *path, int *hndl)
 	}
 	else
 	{
-		sys_handles[i] = f;
+		sys_handles[i].type = SYS_HANDLE_FILE;
+		sys_handles[i].u.file = f;
 		*hndl = i;
 		retval = Sys_filelength(f);
 	}
@@ -222,29 +248,96 @@ int Sys_FileOpenWrite (const char *path)
 	if (!f)
 		Sys_Error ("Error opening %s: %s", path, strerror(errno));
 
-	sys_handles[i] = f;
+	sys_handles[i].type = SYS_HANDLE_FILE;
+	sys_handles[i].u.file = f;
 	return i;
 }
 
 void Sys_FileClose (int handle)
 {
-	fclose (sys_handles[handle]);
-	sys_handles[handle] = NULL;
+	sys_handle_t *sh = &sys_handles[handle];
+
+	switch (sh->type)
+	{
+	case SYS_HANDLE_FILE:
+		fclose (sh->u.file);
+		break;
+	case SYS_HANDLE_MEMORY:
+		free (sh->u.mem.data);
+		break;
+	case SYS_HANDLE_NONE:
+		break;
+	}
+
+	sh->type = SYS_HANDLE_NONE;
 }
 
 void Sys_FileSeek (int handle, int position)
 {
-	fseek (sys_handles[handle], position, SEEK_SET);
+	sys_handle_t *sh = &sys_handles[handle];
+
+	if (sh->type == SYS_HANDLE_FILE)
+	{
+		fseek (sh->u.file, position, SEEK_SET);
+		return;
+	}
+
+	if (sh->type == SYS_HANDLE_MEMORY)
+	{
+		if (position < 0)
+			position = 0;
+		if ((size_t) position > sh->u.mem.length)
+			sh->u.mem.position = sh->u.mem.length;
+		else
+			sh->u.mem.position = (size_t) position;
+	}
 }
 
 int Sys_FileRead (int handle, void *dest, int count)
 {
-	return fread (dest, 1, count, sys_handles[handle]);
+	sys_handle_t *sh = &sys_handles[handle];
+
+	if (sh->type == SYS_HANDLE_FILE)
+		return fread (dest, 1, count, sh->u.file);
+
+	if (sh->type == SYS_HANDLE_MEMORY)
+	{
+		size_t remaining = sh->u.mem.length - sh->u.mem.position;
+		if ((size_t) count > remaining)
+			count = (int) remaining;
+		memcpy (dest, sh->u.mem.data + sh->u.mem.position, count);
+		sh->u.mem.position += (size_t) count;
+		return count;
+	}
+
+	return 0;
 }
 
 int Sys_FileWrite (int handle, const void *data, int count)
 {
-	return fwrite (data, 1, count, sys_handles[handle]);
+	sys_handle_t *sh = &sys_handles[handle];
+
+	if (sh->type != SYS_HANDLE_FILE)
+		Sys_Error ("Sys_FileWrite: invalid handle type");
+
+	return fwrite (data, 1, count, sh->u.file);
+}
+
+int Sys_FileOpenMemory (void *data, size_t length)
+{
+	int handle = findhandle ();
+
+	sys_handles[handle].type = SYS_HANDLE_MEMORY;
+	sys_handles[handle].u.mem.data = (byte *) data;
+	sys_handles[handle].u.mem.length = length;
+	sys_handles[handle].u.mem.position = 0;
+
+	return handle;
+}
+
+FILE *Sys_TempFile (void)
+{
+	return tmpfile ();
 }
 
 #ifndef INVALID_FILE_ATTRIBUTES


### PR DESCRIPTION
## Summary
- extend the filesystem pack structures to track archive type information and add a PK3 loader that uses miniz to read zip archives
- update search path handling to discover PK3 files, extract requested files on demand, and ensure packs are cleaned up through a common helper
- add memory-backed file handles and temporary file helpers to the SDL system layers so PK3 contents can be served through the existing file APIs

## Testing
- `cmake -S . -B build -G Ninja` *(fails: missing SDL2 development package in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ff90ae05f4832eb0d440bc69b316b2