### PR TITLE
Fix Unix handle search after sys_handle struct change

### DIFF
--- a/Quake/sys_sdl_unix.c
+++ b/Quake/sys_sdl_unix.c
@@ -88,7 +88,7 @@ static int findhandle (void)
 
 	for (i = 1; i < MAX_HANDLES; i++)
 	{
-		if (!sys_handles[i])
+		if (sys_handles[i].type == SYS_HANDLE_NONE)
 			return i;
 	}
 	Sys_Error ("out of handles");


### PR DESCRIPTION
## Summary
- update the Unix SDL backend's handle search to check the new sys_handle type field

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ff9b2b2390832e9105e964a1706537