### PR TITLE
Fix Windows build warnings for miniz and math helpers

### DIFF
--- a/Quake/common.c
+++ b/Quake/common.c
@@ -29,6 +29,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include <time.h>
 #include <errno.h>
 #include <stdlib.h>
+#include <string.h>
 #include <limits.h>
 #include "miniz.h"
 #include "unicode_translit.h"
@@ -2366,7 +2367,7 @@ static pack_t *COM_LoadPK3File (const char *packfile)
 			continue;
 		if (st.m_uncomp_size > INT_MAX)
 			continue;
-		if ((size_t) q_strlen (st.m_filename) >= sizeof (newfiles[0].name))
+		if (strlen (st.m_filename) >= sizeof (newfiles[0].name))
 			continue;
 		++count;
 	}

--- a/Quake/common.h
+++ b/Quake/common.h
@@ -259,6 +259,7 @@ float Q_atof (const char *str);
 
 
 #include "strl_fn.h"
+#include "miniz.h"
 
 /* locale-insensitive strcasecmp replacement functions: */
 extern int q_strcasecmp (const char * s1, const char * s2);
@@ -378,7 +379,6 @@ typedef struct
 	int		zip_index;
 } packfile_t;
 
-struct mz_zip_archive;
 typedef enum
 {
 	PACKTYPE_PAK,
@@ -392,7 +392,7 @@ typedef struct pack_s
 	int		numfiles;
 	packfile_t	*files;
 	packtype_t	type;
-	struct mz_zip_archive	*zip;
+	mz_zip_archive	*zip;
 } pack_t;
 
 typedef struct searchpath_s

--- a/Quake/mathlib.h
+++ b/Quake/mathlib.h
@@ -59,6 +59,7 @@ static inline int IS_NAN (float x) {
 #define VectorSubtract(a,b,dst)			do {(dst)[0]=(a)[0]-(b)[0];(dst)[1]=(a)[1]-(b)[1];(dst)[2]=(a)[2]-(b)[2];} while (0)
 #define VectorAdd(a,b,dst)				do {(dst)[0]=(a)[0]+(b)[0];(dst)[1]=(a)[1]+(b)[1];(dst)[2]=(a)[2]+(b)[2];} while (0)
 #define VectorCopy(src,dst)				do {(dst)[0]=(src)[0];(dst)[1]=(src)[1];(dst)[2]=(src)[2];} while (0)
+#define VectorNegate(src,dst)				do {(dst)[0]=-(src)[0];(dst)[1]=-(src)[1];(dst)[2]=-(src)[2];} while (0)
 #define VectorSet(v,x,y,z)				do {(v)[0]=(x);(v)[1]=(y);(v)[2]=(z);} while (0)
 #define VectorClear(v)                             do {(v)[0] = (v)[1] = (v)[2] = 0.f;} while (0)
 #define VectorLengthSquared(v)			DotProduct(v,v)

--- a/Quake/miniz.h
+++ b/Quake/miniz.h
@@ -134,7 +134,7 @@
    If all macros here are defined the only functionality remaining will be CRC-32 and adler-32. */
 
 /* Define MINIZ_NO_STDIO to disable all usage and any functions which rely on stdio for file I/O. */
-#define MINIZ_NO_STDIO
+/*#define MINIZ_NO_STDIO */
 
 /* If MINIZ_NO_TIME is specified then the ZIP archive functions will not be able to get the current time, or */
 /* get/set file times, and the C run-time funcs that get/set times won't be called. */


### PR DESCRIPTION
## Summary
- enable miniz's stdio-enabled declarations so pk3 helpers have prototypes and include the header where needed
- replace the lone q_strlen usage with the standard strlen and ensure string.h is included
- add a VectorNegate macro for fallback lighting normal handling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ffaea9ec9c832e9d35415f58ae8526