### PR TITLE
Add configurable lightmap strength

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -200,6 +200,7 @@ cvar_t	r_simd = { "r_simd","1",CVAR_ARCHIVE };
 cvar_t	r_alphasort = { "r_alphasort","1",CVAR_ARCHIVE };
 cvar_t	r_oit = { "r_oit","1",CVAR_ARCHIVE };
 cvar_t	r_dither = { "r_dither", "1.0", CVAR_ARCHIVE };
+cvar_t	r_lightmap_strength = { "r_lightmap_strength", "0.75", CVAR_ARCHIVE };
 cvar_t	r_dof = { "r_dof", "0", CVAR_ARCHIVE };
 cvar_t	r_rim_alias = { "r_rim_alias", "0.25", CVAR_ARCHIVE };
 cvar_t	r_rim_world = { "r_rim_world", "0.15", CVAR_ARCHIVE };
@@ -1663,11 +1664,11 @@ void R_SetupView (void)
 
 
 		r_framedata.overbright = overbright;
+		r_framedata.lightmap_strength = q_max(0.f, r_lightmap_strength.value);
 		r_framedata.rim_alias = q_max(0.f, r_rim_alias.value);
 		r_framedata.rim_world = q_max(0.f, r_rim_world.value);
 		r_framedata.rim_exponent = q_max(0.5f, r_rim_exponent.value);
                 r_framedata.rim_pad0 = 0.f;
-                r_framedata.rim_pad1 = 0.f;
         }
 
         {

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -372,6 +372,7 @@ void R_Init (void)
 	Cvar_RegisterVariable (&r_alphasort);
 	Cvar_RegisterVariable (&r_oit);
 	Cvar_RegisterVariable (&r_dither);
+	Cvar_RegisterVariable (&r_lightmap_strength);
 	Cvar_RegisterVariable (&r_dof);
 	Cvar_RegisterVariable (&r_rim_alias);
 	Cvar_RegisterVariable (&r_rim_world);

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -107,6 +107,7 @@ extern	cvar_t	r_novis;
 extern	cvar_t	r_scale;
 
 extern	cvar_t	r_oit;
+extern	cvar_t	r_lightmap_strength;
 extern	cvar_t	r_alphasort;
 extern	cvar_t	r_rim_alias;
 extern	cvar_t	r_rim_world;
@@ -431,11 +432,11 @@ typedef struct gpuframedata_s {
 	float	screendither;
 	float	texturedither;
 	float	overbright;
+	float	lightmap_strength;
 	float	rim_alias;
 	float	rim_world;
 	float	rim_exponent;
 	float	rim_pad0;
-	float	rim_pad1;
 	vec3_t	eyepos;
 	float	time;
 	vec3_t	prev_eyepos;

--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -33,10 +33,10 @@ layout(std140, binding=0) uniform FrameDataUBO
         float   _FrameScreenDither;
         float   _FrameTextureDither;
         float   _FrameOverbright;
+        float   _FrameLightmapStrength;
         float   _FrameRimAlias;
         float   _FrameRimWorld;
         float   _FrameRimExponent;
-        float   _FramePad0;
         float   _FramePadRim;
         vec3    _FrameEyePos;
         float   _FrameTime;

--- a/Quake/shaders/frame_uniforms.glsl
+++ b/Quake/shaders/frame_uniforms.glsl
@@ -12,10 +12,10 @@ layout(std140, binding=0) uniform FrameDataUBO
         float   ScreenDither;
         float   TextureDither;
         float   Overbright;
+        float   LightmapStrength;
         float   RimAlias;
         float   RimWorld;
         float   RimExponent;
-        float   _Pad0;
         float   _PadRim;
         vec3    EyePos;
         float   Time;

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -296,6 +296,8 @@ void main()
         }
     }
 
+    static_light *= LightmapStrength;
+
     // schnellere Flächennormalen aus Derivaten
     vec3 dn = cross(DFDX(in_pos), DFDY(in_pos));
     vec3 geom_normal = fastNorm(dn);


### PR DESCRIPTION
## Summary
- add an r_lightmap_strength cvar and feed it through the frame uniform block
- scale static lightmap contributions in the world shader to keep shadows from blowing out under high overbright settings

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ffd6a959f0832eb57477d237722ab0