### PR TITLE
Fix dynamic light colors for fire effects

### DIFF
--- a/Quake/cl_main.c
+++ b/Quake/cl_main.c
@@ -313,7 +313,42 @@ CL_IsPlayerEnt
 */
 qboolean CL_IsPlayerEnt (const entity_t *ent)
 {
-	return PTR_IN_RANGE (ent, cl_entities + 1, cl_entities + 1 + cl.maxclients);
+        return PTR_IN_RANGE (ent, cl_entities + 1, cl_entities + 1 + cl.maxclients);
+}
+
+static void CL_SetDlightColor (dlight_t *dl, float r, float g, float b)
+{
+        dl->color[0] = r;
+        dl->color[1] = g;
+        dl->color[2] = b;
+}
+
+static void CL_ColorDlightForEntity (const entity_t *ent, dlight_t *dl)
+{
+        const char *modelname;
+
+        if (!ent || !ent->model)
+                return;
+
+        modelname = ent->model->name;
+        if (!modelname || !*modelname)
+                return;
+
+        if (q_strcasestr (modelname, "flame") ||
+            q_strcasestr (modelname, "torch") ||
+            q_strcasestr (modelname, "braz") ||
+            q_strcasestr (modelname, "lava"))
+        {
+                CL_SetDlightColor (dl, 1.0f, 0.38f, 0.12f);
+                return;
+        }
+
+        if (q_strcasestr (modelname, "missile") ||
+            q_strcasestr (modelname, "rocket"))
+        {
+                CL_SetDlightColor (dl, 1.0f, 0.34f, 0.10f);
+                return;
+        }
 }
 
 /*
@@ -624,6 +659,7 @@ void CL_RelinkEntities (void)
 			dl->radius = 200 + (rand()&31);
 			dl->minlight = 32;
 			dl->die = cl.time + 0.1;
+			CL_SetDlightColor (dl, 1.0f, 0.56f, 0.28f);
 
 			//johnfitz -- assume muzzle flash accompanied by muzzle flare, which looks bad when lerped
 			if (r_lerpmodels.value != 2)
@@ -642,6 +678,7 @@ void CL_RelinkEntities (void)
 			dl->origin[2] += 16;
 			dl->radius = 400 + (rand()&31);
 			dl->die = cl.time + 0.001;
+			CL_ColorDlightForEntity (ent, dl);
 		}
 		if (ent->effects & EF_DIMLIGHT)
 		{
@@ -649,6 +686,7 @@ void CL_RelinkEntities (void)
 			VectorCopy (ent->origin,  dl->origin);
 			dl->radius = 200 + (rand()&31);
 			dl->die = cl.time + 0.001;
+			CL_ColorDlightForEntity (ent, dl);
 		}
 		if (ent->effects & EF_QEX_QUADLIGHT)
 		{
@@ -686,6 +724,7 @@ void CL_RelinkEntities (void)
 			VectorCopy (ent->origin, dl->origin);
 			dl->radius = 200;
 			dl->die = cl.time + 0.01;
+			CL_SetDlightColor (dl, 1.0f, 0.34f, 0.10f);
 		}
 		else if (ent->model->flags & EF_GRENADE)
 			CL_RocketTrail (ent, 1);

--- a/Quake/cl_tent.c
+++ b/Quake/cl_tent.c
@@ -23,6 +23,24 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "quakedef.h"
 
+extern unsigned int d_8to24table[256];
+
+static void CL_SetDlightColor (dlight_t *dl, float r, float g, float b)
+{
+	dl->color[0] = r;
+	dl->color[1] = g;
+	dl->color[2] = b;
+}
+
+static void CL_SetDlightColorFromPalette (dlight_t *dl, int index)
+{
+	const byte *rgba;
+
+	index = CLAMP (0, index, 255);
+	rgba = (const byte *) &d_8to24table[index];
+	CL_SetDlightColor (dl, rgba[0] * (1.0f / 255.0f), rgba[1] * (1.0f / 255.0f), rgba[2] * (1.0f / 255.0f));
+}
+
 int			num_temp_entities;
 entity_t	cl_temp_entities[MAX_TEMP_ENTITIES];
 beam_t		cl_beams[MAX_BEAMS];
@@ -197,6 +215,7 @@ void CL_ParseTEnt (void)
 		dl->radius = 350;
 		dl->die = cl.time + 0.5;
 		dl->decay = 300;
+		CL_SetDlightColor (dl, 1.0f, 0.36f, 0.10f);
 		S_StartSound (-1, 0, cl_sfx_r_exp3, pos, 1, 1);
 		break;
 
@@ -253,6 +272,10 @@ void CL_ParseTEnt (void)
 		dl->radius = 350;
 		dl->die = cl.time + 0.5;
 		dl->decay = 300;
+		if (colorLength > 0)
+			CL_SetDlightColorFromPalette (dl, colorStart + (colorLength >> 1));
+		else
+			CL_SetDlightColor (dl, 1.0f, 0.36f, 0.10f);
 		S_StartSound (-1, 0, cl_sfx_r_exp3, pos, 1, 1);
 		break;
 


### PR DESCRIPTION
## Summary
- add helpers to assign warm colors to common fire-based dynamic lights
- color muzzle flashes, bright lights, dim lights, and rockets based on their source entities
- use palette data to tint explosion temporary entity lights, preserving colored temp effects

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ffde8d2298832e851a510a8591ac19