### PR TITLE
Implement static directional godray orientation

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -250,6 +250,8 @@ cvar_t	r_godrays_decay = { "r_godrays_decay", "0.95", CVAR_ARCHIVE };
 cvar_t	r_godrays_weight = { "r_godrays_weight", "0.02", CVAR_ARCHIVE };
 cvar_t	r_godrays_samples = { "r_godrays_samples", "64", CVAR_ARCHIVE };
 cvar_t	r_godrays_softness = { "r_godrays_softness", "0.1", CVAR_ARCHIVE };
+cvar_t	r_godrays_mode = { "r_godrays_mode", "0", CVAR_ARCHIVE };
+cvar_t	r_godrays_wall_angle = { "r_godrays_wall_angle", "40", CVAR_ARCHIVE };
 
 cvar_t	r_overbrightbits = { "r_overbrightbits", "1", CVAR_ARCHIVE };
 
@@ -848,6 +850,25 @@ void GL_PostProcess (void)
                 float godrays_light_x = q_min (1.f, q_max (0.f, r_godrays_light_x.value));
                 float godrays_light_y = q_min (1.f, q_max (0.f, r_godrays_light_y.value));
                 float godrays_threshold = q_min (1.f, q_max (0.f, r_godrays_threshold.value));
+                int godrays_mode_value = (int)Q_rint (r_godrays_mode.value);
+                float godrays_dir_x = 0.f;
+                float godrays_dir_y = 0.f;
+                if (godrays_intensity > 0.f && godrays_weight > 0.f && godrays_density > 0.f)
+                {
+                        if (godrays_mode_value == 1)
+                        {
+                                godrays_dir_x = 0.f;
+                                godrays_dir_y = 1.f;
+                        }
+                        else if (godrays_mode_value <= 0)
+                        {
+                                float wall_angle = q_min (85.f, q_max (0.f, r_godrays_wall_angle.value));
+                                float angle_rad = DEG2RAD (wall_angle);
+                                float horizontal_sign = (godrays_light_x <= 0.5f) ? 1.f : -1.f;
+                                godrays_dir_x = horizontal_sign * sinf (angle_rad);
+                                godrays_dir_y = cosf (angle_rad);
+                        }
+                }
 
                 GL_Uniform4fFunc (16,
                         godrays_intensity > 0.f ? 1.f : 0.f,
@@ -862,8 +883,8 @@ void GL_PostProcess (void)
                 GL_Uniform4fFunc (18,
                         godrays_samples,
                         godrays_softness,
-                        0.f,
-                        0.f);
+                        godrays_dir_x,
+                        godrays_dir_y);
         }
 
         dof_enabled = R_DoFEnabled ();

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -96,6 +96,8 @@ extern cvar_t r_godrays_decay;
 extern cvar_t r_godrays_weight;
 extern cvar_t r_godrays_samples;
 extern cvar_t r_godrays_softness;
+extern cvar_t r_godrays_mode;
+extern cvar_t r_godrays_wall_angle;
 
 #if defined(USE_SIMD)
 extern cvar_t r_simd;
@@ -419,6 +421,8 @@ void R_Init (void)
 	Cvar_RegisterVariable (&r_godrays_weight);
 	Cvar_RegisterVariable (&r_godrays_samples);
 	Cvar_RegisterVariable (&r_godrays_softness);
+	Cvar_RegisterVariable (&r_godrays_mode);
+	Cvar_RegisterVariable (&r_godrays_wall_angle);
 	Cvar_RegisterVariable (&r_overbrightbits);
 	Cvar_SetCallback (&r_overbrightbits, R_OverbrightBits_f);
 

--- a/Quake/shaders/postprocess_godrays.glsl
+++ b/Quake/shaders/postprocess_godrays.glsl
@@ -28,14 +28,12 @@ void ApplyGodRays(inout vec3 color,
         vec2 lightUV = clamp(GodRayParams1.xy, vec2(0.0), vec2(1.0));
         lightUV = viewMin + lightUV * viewSize;
 
-        vec2 delta = lightUV - uv;
-        float deltaMag = max(abs(delta.x), abs(delta.y));
-        if (deltaMag <= 1e-6)
-                return;
-
         int samples = int(clamp(GodRayParams2.x + 0.5, 1.0, float(GODRAY_MAX_SAMPLES)));
         float threshold = clamp(GodRayParams1.z, 0.0, 1.0);
         float softness = clamp(GodRayParams2.y, 1e-4, 1.0);
+        vec2 direction = GodRayParams2.zw;
+        float directionLenSq = dot(direction, direction);
+        bool useDirectional = directionLenSq > 1e-6;
 
         bool hasDepth = depthInfo.valid;
         float centerDepth = 0.0;
@@ -48,17 +46,59 @@ void ApplyGodRays(inout vec3 color,
         const float depthBias = 24.0;
         const float depthRange = 96.0;
 
-        vec2 stepUV = delta / float(samples) * density;
         vec2 sampleUV = uv;
-        float illuminationDecay = 1.0;
+        vec2 stepUV = vec2(0.0);
+        float alignment = 1.0;
+        float stepLength = 0.0;
+        float maxTrace = 0.0;
+        float travelled = 0.0;
+
+        if (useDirectional)
+        {
+                vec2 dirNorm = direction / sqrt(directionLenSq);
+                vec2 rayVector = uv - lightUV;
+                float rayDistance = length(rayVector);
+                if (rayDistance <= 1e-6)
+                        return;
+                float along = dot(rayVector, dirNorm);
+                alignment = clamp(along / rayDistance, 0.0, 1.0);
+                if (alignment <= 1e-6)
+                        return;
+                stepLength = density / float(samples);
+                if (stepLength <= 1e-6)
+                        return;
+                stepUV = dirNorm * stepLength;
+                maxTrace = max(along, density);
+        }
+        else
+        {
+                vec2 delta = lightUV - uv;
+                float deltaMag = max(abs(delta.x), abs(delta.y));
+                if (deltaMag <= 1e-6)
+                        return;
+                stepUV = delta / float(samples) * density;
+        }
+
         vec3 scatterAccum = vec3(0.0);
+        float illuminationDecay = 1.0;
 
         for (int i = 0; i < GODRAY_MAX_SAMPLES; ++i)
         {
                 if (i >= samples)
                         break;
 
-                sampleUV += stepUV;
+                if (useDirectional)
+                {
+                        sampleUV -= stepUV;
+                        travelled += stepLength;
+                        if (travelled > maxTrace)
+                                break;
+                }
+                else
+                {
+                        sampleUV += stepUV;
+                }
+
                 if (any(lessThan(sampleUV, viewMin)) || any(greaterThan(sampleUV, viewMax)))
                         break;
 
@@ -81,7 +121,7 @@ void ApplyGodRays(inout vec3 color,
                 illuminationDecay *= decay;
         }
 
-        color += scatterAccum * intensity;
+        color += scatterAccum * intensity * alignment;
 }
 
 #endif // POSTPROCESS_GODRAYS_GLSL


### PR DESCRIPTION
## Summary
- add cvars to control godray orientation mode and default wall angle
- drive the post-process shader with a static direction vector so beams stay fixed
- update CVar registration and uniform packing to feed the shader the new parameters

## Testing
- make -C Quake -j2 *(fails: missing SDL headers in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ffe4b29948832eb25a5e81a16e1904