### PR TITLE
Add SSAO debug cvar to visualize SSAO depth

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -222,6 +222,7 @@ cvar_t	r_tonemap_exposure = { "r_tonemap_exposure", "1.0", CVAR_ARCHIVE };
 cvar_t	r_bloom = { "r_bloom", "0.04", CVAR_ARCHIVE };
 cvar_t	r_bloom_threshold = { "r_bloom_threshold", "1.0", CVAR_ARCHIVE };
 cvar_t	r_ssao = { "r_ssao", "0", CVAR_ARCHIVE };
+cvar_t	r_ssao_debug = { "r_ssao_debug", "0", CVAR_NONE };
 cvar_t	r_ssao_radius = { "r_ssao_radius", "32", CVAR_ARCHIVE };
 cvar_t	r_ssao_bias = { "r_ssao_bias", "0.01", CVAR_ARCHIVE };
 cvar_t	r_ssao_intensity = { "r_ssao_intensity", "1.0", CVAR_ARCHIVE };
@@ -725,6 +726,7 @@ void GL_PostProcess (void)
         float motion_depth_threshold;
         int motion_max_samples;
         qboolean ssao_enabled;
+        qboolean ssao_debug;
         float ssao_radius;
         float ssao_bias;
         float ssao_intensity;
@@ -794,6 +796,7 @@ void GL_PostProcess (void)
         if (ssao_samples > 64)
                 ssao_samples = 64;
         ssao_enabled = R_SSAOEnabled ();
+        ssao_debug = (r_ssao_debug.value > 0.f);
         if (ssao_samples <= 0 || ssao_radius <= 0.f || ssao_intensity <= 0.f)
                 ssao_enabled = false;
 
@@ -922,10 +925,13 @@ void GL_PostProcess (void)
         }
 
         depth_texture = 0;
-        if (framebufs.composite.depth_stencil_tex && (dof_enabled || (motion_enabled && motion_depth_threshold > 0.f) || ssao_enabled))
+        if (framebufs.composite.depth_stencil_tex && (dof_enabled || (motion_enabled && motion_depth_threshold > 0.f) || ssao_enabled || ssao_debug))
                 depth_texture = framebufs.composite.depth_stencil_tex;
         if (!depth_texture)
+        {
                 ssao_enabled = false;
+                ssao_debug = false;
+        }
         GL_BindNative (GL_TEXTURE2, GL_TEXTURE_2D, depth_texture);
 
         if (dof_enabled)
@@ -959,6 +965,11 @@ void GL_PostProcess (void)
 	GL_Uniform4fFunc (14,
 	        (float)ssao_samples,
 	        ssao_power,
+	        0.f,
+	        0.f);
+	GL_Uniform4fFunc (20,
+	        ssao_debug ? 1.f : 0.f,
+	        0.f,
 	        0.f,
 	        0.f);
 
@@ -1562,7 +1573,7 @@ qboolean GL_NeedsPostprocess (void)
 {
         if (vid_gamma.value != 1.f || vid_contrast.value != 1.f || softemu || R_GetEffectiveAlphaMode () == ALPHAMODE_OIT || R_DoFEnabled ())
                 return true;
-	if (r_tonemap.value > 0.f || r_bloom.value > 0.f || GL_ShouldApplyMotionBlur () || R_SSAOEnabled () || r_godrays.value > 0.f)
+	if (r_tonemap.value > 0.f || r_bloom.value > 0.f || GL_ShouldApplyMotionBlur () || R_SSAOEnabled () || r_godrays.value > 0.f || r_ssao_debug.value > 0.f)
 		return true;
         return false;
 }
@@ -2807,7 +2818,7 @@ void R_WarpScaleView (void)
 
 	needwarpscale = r_refdef.scale != 1 || water_warp || (v_blend[3] && gl_polyblend.value && !softemu);
 	fbodest = GL_NeedsPostprocess () ? framebufs.composite.fbo : 0;
-        need_depth_resolve = (fbodest == framebufs.composite.fbo) && (R_DoFEnabled () || R_SSAOEnabled ());
+        need_depth_resolve = (fbodest == framebufs.composite.fbo) && (R_DoFEnabled () || R_SSAOEnabled () || r_ssao_debug.value > 0.f);
 
 	if (msaa)
 	{

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -80,6 +80,7 @@ extern cvar_t r_chromatic_aberration;
 extern cvar_t r_filmgrain;
 extern cvar_t r_filmgrain_size;
 extern cvar_t r_ssao;
+extern cvar_t r_ssao_debug;
 extern cvar_t r_ssao_radius;
 extern cvar_t r_ssao_bias;
 extern cvar_t r_ssao_intensity;
@@ -394,6 +395,7 @@ void R_Init (void)
 	Cvar_RegisterVariable (&r_bloom);
 	Cvar_RegisterVariable (&r_bloom_threshold);
 	Cvar_RegisterVariable (&r_ssao);
+	Cvar_RegisterVariable (&r_ssao_debug);
 	Cvar_RegisterVariable (&r_ssao_radius);
 	Cvar_RegisterVariable (&r_ssao_bias);
 	Cvar_RegisterVariable (&r_ssao_intensity);

--- a/Quake/shaders/postprocess.frag
+++ b/Quake/shaders/postprocess.frag
@@ -28,6 +28,7 @@ layout(location=16) uniform vec4 GodRayParams0; // x: enabled, y: intensity, z: 
 layout(location=17) uniform vec4 GodRayParams1; // x: light x, y: light y, z: threshold, w: density
 layout(location=18) uniform vec4 GodRayParams2; // x: samples, y: threshold softness, zw: unused
 layout(location=19) uniform mat4 InverseProjectionMatrix;
+layout(location=20) uniform vec4 DebugParams; // x: SSAO debug, yzw: reserved
 
 #include "postprocess_common.glsl"
 #include "postprocess_ssao.glsl"
@@ -46,6 +47,7 @@ void main()
         float contrast = Params.y;
         float scale = Params.z;
         float dither = Params.w;
+        bool ssaoDebug = DebugParams.x > 0.5;
 
         ivec2 pixel = ivec2(gl_FragCoord.xy);
         vec4 color = texelFetch(GammaTexture, pixel, 0);
@@ -60,6 +62,22 @@ void main()
         vec2 invScale = max(DepthParams.xy, vec2(1e-4));
         bool inView = all(greaterThanEqual(uv, viewMin)) && all(lessThanEqual(uv, viewMax));
         DepthSamplingInfo depthInfo = MakeDepthSamplingInfo();
+
+        if (ssaoDebug)
+        {
+                float depth = SampleLinearDepth(gl_FragCoord.xy, depthInfo);
+                float debugValue = 0.0;
+                if (depthInfo.valid && depth > 0.0)
+                {
+                        float nearPlane = min(DoFParams1.x, DoFParams1.y);
+                        float farPlane = max(DoFParams1.x, DoFParams1.y);
+                        float denom = max(farPlane - nearPlane, 1e-6);
+                        float normalized = clamp((depth - nearPlane) / denom, 0.0, 1.0);
+                        debugValue = 1.0 - normalized;
+                }
+                out_fragcolor = vec4(vec3(debugValue), 1.0);
+                return;
+        }
 
         bool hasVelocityTexture = MotionParams1.z > 0.5;
         vec2 velocity = vec2(0.0);


### PR DESCRIPTION
## Summary
- add a new `r_ssao_debug` console variable that forces post-processing to expose the SSAO depth buffer
- ensure depth resolves and uniforms are configured when the debug mode is active
- render the SSAO depth information in the post-process shader when debugging is enabled

## Testing
- ninja -C Linux *(fails: loading 'build.ninja': No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ffea7b6c00832e8c4412d765c2d983