### PR TITLE
Fix SSAO depth reconstruction

### DIFF
--- a/Quake/shaders/postprocess.frag
+++ b/Quake/shaders/postprocess.frag
@@ -65,9 +65,11 @@ void main()
 
         if (ssaoDebug)
         {
-                float depth = SampleLinearDepth(gl_FragCoord.xy, depthInfo);
+                vec3 viewPos;
+                float depth = 0.0;
                 float debugValue = 0.0;
-                if (depthInfo.valid && depth > 0.0)
+                if (ReconstructViewPosition(gl_FragCoord.xy, uv, viewMin, viewMax,
+                                depthInfo, viewPos, depth))
                 {
                         float nearPlane = min(DoFParams1.x, DoFParams1.y);
                         float farPlane = max(DoFParams1.x, DoFParams1.y);

--- a/Quake/shaders/postprocess_ssao.glsl
+++ b/Quake/shaders/postprocess_ssao.glsl
@@ -50,7 +50,12 @@ bool ReconstructViewPosition(vec2 fragPx, vec2 uv, vec2 viewMin, vec2 viewMax,
                 return false;
 
         position = viewPos4.xyz / viewPos4.w;
+        if (!IsFiniteVec3(position))
+                return false;
         if (viewPos4.w <= 0.0)
+                return false;
+        linearDepth = -position.z;
+        if (!(linearDepth > SSAO_EPSILON))
                 return false;
         return true;
 }


### PR DESCRIPTION
## Summary
- derive SSAO linear depth values directly from reconstructed view-space positions to avoid bogus occlusion
- reuse the view-position reconstruction in the SSAO debug path so it visualizes real scene depth

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ffef1dc1a4832e960f444f47ae067a