### PR TITLE
Adjust godray wall orientation

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -865,11 +865,11 @@ void GL_PostProcess (void)
                         }
                         else if (godrays_mode_value <= 0)
                         {
-                                float wall_angle = q_min (85.f, q_max (0.f, r_godrays_wall_angle.value));
+                                float wall_angle = q_min (90.f, q_max (0.f, r_godrays_wall_angle.value));
                                 float angle_rad = DEG2RAD (wall_angle);
                                 float horizontal_sign = (godrays_light_x <= 0.5f) ? 1.f : -1.f;
-                                godrays_dir_x = horizontal_sign * sinf (angle_rad);
-                                godrays_dir_y = cosf (angle_rad);
+                                godrays_dir_x = horizontal_sign * cosf (angle_rad);
+                                godrays_dir_y = sinf (angle_rad);
                         }
                 }
 

--- a/Quake/shaders/postprocess.frag
+++ b/Quake/shaders/postprocess.frag
@@ -26,7 +26,7 @@ layout(location=14) uniform vec4 SSAOParams1; // x: samples, y: power, zw: reser
 layout(location=15) uniform mat4 ProjectionMatrix;
 layout(location=16) uniform vec4 GodRayParams0; // x: enabled, y: intensity, z: decay, w: weight
 layout(location=17) uniform vec4 GodRayParams1; // x: light x, y: light y, z: threshold, w: density
-layout(location=18) uniform vec4 GodRayParams2; // x: samples, y: threshold softness, zw: unused
+layout(location=18) uniform vec4 GodRayParams2; // x: samples, y: threshold softness, zw: direction
 layout(location=19) uniform mat4 InverseProjectionMatrix;
 layout(location=20) uniform vec4 DebugParams; // x: SSAO debug, yzw: reserved
 


### PR DESCRIPTION
## Summary
- reinterpret the wall godray angle so the beams tilt downwards instead of sideways
- allow a full 0-90° range and document the direction vector uniform

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fffd83fdb4832eb7112556f9e7bad5