### PR TITLE
Fix Wren VM header includes for Quake sources

### DIFF
--- a/Quake/host.c
+++ b/Quake/host.c
@@ -25,7 +25,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "quakedef.h"
 #include "bgmusic.h"
 #include "steam.h"
-#include "wren_vm.h"
+#include "../wren_vm/wren_vm.h"
 #include <setjmp.h>
 
 /*

--- a/Quake/host_cmd.c
+++ b/Quake/host_cmd.c
@@ -24,7 +24,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "quakedef.h"
 #include "q_ctype.h"
 #include "json.h"
-#include "wren_vm.h"
+#include "../wren_vm/wren_vm.h"
 #include <time.h>
 #ifndef WITHOUT_CURL
 #include <curl/curl.h>

--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -23,7 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // sv_main.c -- server main program
 
 #include "quakedef.h"
-#include "wren_vm.h"
+#include "../wren_vm/wren_vm.h"
 
 server_t	sv;
 server_static_t	svs;

--- a/Quake/sv_phys.c
+++ b/Quake/sv_phys.c
@@ -22,7 +22,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // sv_phys.c
 
 #include "quakedef.h"
-#include "wren_vm.h"
+#include "../wren_vm/wren_vm.h"
 
 /*
 


### PR DESCRIPTION
## Summary
- update Quake sources to include the Wren VM header via a relative path so it resolves in Visual Studio builds

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690123fc049c832e8f84afd236b94308