### PR TITLE
Rename Wren runtime integration files to avoid MSVC collisions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ target_include_directories(wren PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/wren_vm/wren/
 target_include_directories(wren PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/wren_vm/wren/vm ${CMAKE_CURRENT_SOURCE_DIR}/wren_vm/wren/optional)
 target_compile_definitions(wren PUBLIC WREN_OPT_META=1 WREN_OPT_RANDOM=1)
 
-list(APPEND IWAIL_SRC ${CMAKE_CURRENT_SOURCE_DIR}/wren_vm/wren_vm.c ${CMAKE_CURRENT_SOURCE_DIR}/wren_vm/wren_bindings.c)
+list(APPEND IWAIL_SRC ${CMAKE_CURRENT_SOURCE_DIR}/wren_vm/wren_runtime.c ${CMAKE_CURRENT_SOURCE_DIR}/wren_vm/wren_bindings.c)
 
 list(REMOVE_ITEM IWAIL_SRC ${CMAKE_CURRENT_SOURCE_DIR}/Quake/lodepng.h)
 list(REMOVE_ITEM IWAIL_SRC ${CMAKE_CURRENT_SOURCE_DIR}/Quake/lodepng.c)

--- a/Quake/host.c
+++ b/Quake/host.c
@@ -25,7 +25,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "quakedef.h"
 #include "bgmusic.h"
 #include "steam.h"
-#include "../wren_vm/wren_vm.h"
+#include "../wren_vm/wren_runtime.h"
 #include <setjmp.h>
 
 /*
@@ -1128,9 +1128,15 @@ static void CL_LoadCSProgs (void)
 		    (PR_LoadProgs ("progs.dat", false) && qcvm->extfuncs.CSQC_DrawHud))
 		{
 			qcvm->max_edicts = CLAMP (MIN_EDICTS, (int)max_edicts.value, MAX_EDICTS);
-			qcvm->edicts = (edict_t *)malloc (qcvm->max_edicts * qcvm->edict_size);
+                        qcvm->edicts = (edict_t *)malloc (qcvm->max_edicts * qcvm->edict_size);
+                        if (!qcvm->edicts)
+                        {
+                                PR_ClearProgs (qcvm);
+                                PR_SwitchQCVM (NULL);
+                                return;
+                        }
 			qcvm->num_edicts = qcvm->reserved_edicts = 1;
-			memset (qcvm->edicts, 0, qcvm->num_edicts * qcvm->edict_size);
+                        memset (qcvm->edicts, 0, qcvm->num_edicts * qcvm->edict_size);
 
 			if (!qcvm->extfuncs.CSQC_DrawHud)
 			{ // no simplecsqc entry points... abort entirely!
@@ -1230,7 +1236,7 @@ void _Host_Frame (double time)
 		return;			// something bad happened, or the server disconnected
 
 // keep the random time dependent
-	rand ();
+        (void)rand ();
 
 // decide the simulation time
 	accumtime += host_netinterval?CLAMP(0.0, time, 0.2):0.0;	//for renderer/server isolation

--- a/Quake/host_cmd.c
+++ b/Quake/host_cmd.c
@@ -24,7 +24,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "quakedef.h"
 #include "q_ctype.h"
 #include "json.h"
-#include "../wren_vm/wren_vm.h"
+#include "../wren_vm/wren_runtime.h"
 #include <time.h>
 #ifndef WITHOUT_CURL
 #include <curl/curl.h>

--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -23,7 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // sv_main.c -- server main program
 
 #include "quakedef.h"
-#include "../wren_vm/wren_vm.h"
+#include "../wren_vm/wren_runtime.h"
 
 server_t	sv;
 server_static_t	svs;

--- a/Quake/sv_phys.c
+++ b/Quake/sv_phys.c
@@ -22,7 +22,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // sv_phys.c
 
 #include "quakedef.h"
-#include "../wren_vm/wren_vm.h"
+#include "../wren_vm/wren_runtime.h"
 
 /*
 

--- a/Windows/VisualStudio/ironwail.vcxproj
+++ b/Windows/VisualStudio/ironwail.vcxproj
@@ -353,7 +353,7 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
     </ClCompile>
-    <ClCompile Include="..\..\wren_vm\wren_vm.c">
+    <ClCompile Include="..\..\wren_vm\wren_runtime.c">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
@@ -487,7 +487,7 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
     <ClInclude Include="..\..\Quake\wsaerror.h" />
     <ClInclude Include="..\..\Quake\zone.h" />
     <ClInclude Include="..\..\wren_vm\wren_bindings.h" />
-    <ClInclude Include="..\..\wren_vm\wren_vm.h" />
+    <ClInclude Include="..\..\wren_vm\wren_runtime.h" />
     <ClInclude Include="..\..\wren_vm\wren\include\wren.h" />
   </ItemGroup>
   <ItemGroup>

--- a/Windows/VisualStudio/ironwail.vcxproj.filters
+++ b/Windows/VisualStudio/ironwail.vcxproj.filters
@@ -273,7 +273,7 @@
     <ClCompile Include="..\..\wren_vm\wren_bindings.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\wren_vm\wren_vm.c">
+    <ClCompile Include="..\..\wren_vm\wren_runtime.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\wren_vm\wren\optional\wren_opt_meta.c">
@@ -521,7 +521,7 @@
     <ClInclude Include="..\..\wren_vm\wren_bindings.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\wren_vm\wren_vm.h">
+    <ClInclude Include="..\..\wren_vm\wren_runtime.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\wren_vm\wren\include\wren.h">

--- a/wren_vm/wren_bindings.c
+++ b/wren_vm/wren_bindings.c
@@ -1,12 +1,11 @@
 #include "quakedef.h"
 #include "common.h"
 #include "cmd.h"
-#include "host.h"
 #include "mathlib.h"
 #include "pr_edict.h"
 #include "server.h"
 #include "world.h"
-#include "wren_vm.h"
+#include "wren_runtime.h"
 #include "wren_bindings.h"
 #include "wren/include/wren.h"
 

--- a/wren_vm/wren_runtime.c
+++ b/wren_vm/wren_runtime.c
@@ -1,9 +1,8 @@
 #include "quakedef.h"
 #include "common.h"
-#include "host.h"
 #include "pr_edict.h"
 #include "server.h"
-#include "wren_vm.h"
+#include "wren_runtime.h"
 #include "wren_bindings.h"
 #include "wren/include/wren.h"
 

--- a/wren_vm/wren_runtime.h
+++ b/wren_vm/wren_runtime.h
@@ -1,5 +1,5 @@
-#ifndef WREN_VM_H
-#define WREN_VM_H
+#ifndef IW_WREN_RUNTIME_H
+#define IW_WREN_RUNTIME_H
 
 #include "q_stdinc.h"
 
@@ -51,4 +51,4 @@ const char *WRENVM_GetCurrentMapName(void);
 }
 #endif
 
-#endif // WREN_VM_H
+#endif // IW_WREN_RUNTIME_H


### PR DESCRIPTION
## Summary
- rename the engine-facing Wren integration files to wren_runtime to avoid clashing with the embedded Wren sources on MSVC
- update the CMake project, Visual Studio project, and all engine includes to use the new header and source names
- harden CSQC allocation error handling and silence the rand() return-value warning reported by MSVC

## Testing
- `cmake -S . -B build -G Ninja` *(fails: missing SDL2 development files in the container)*

------
https://chatgpt.com/codex/tasks/task_e_6901261d6908832e991036fdc8c45979