### PR TITLE
Remove stale pr_edict include from Wren VM

### DIFF
--- a/wren_vm/wren_bindings.c
+++ b/wren_vm/wren_bindings.c
@@ -2,7 +2,6 @@
 #include "common.h"
 #include "cmd.h"
 #include "mathlib.h"
-#include "pr_edict.h"
 #include "server.h"
 #include "world.h"
 #include "wren_runtime.h"

--- a/wren_vm/wren_runtime.c
+++ b/wren_vm/wren_runtime.c
@@ -1,6 +1,5 @@
 #include "quakedef.h"
 #include "common.h"
-#include "pr_edict.h"
 #include "server.h"
 #include "wren_runtime.h"
 #include "wren_bindings.h"


### PR DESCRIPTION
## Summary
- drop the stale pr_edict.h include from the Wren bindings and runtime sources, relying on quakedef.h for the necessary declarations

## Testing
- not run (build not requested)


------
https://chatgpt.com/codex/tasks/task_e_69012838ad04832eab7d2d9266a01eba