### PR TITLE
Fix engine time binding for Wren

### DIFF
--- a/wren_vm/wren_bindings.c
+++ b/wren_vm/wren_bindings.c
@@ -251,7 +251,7 @@ static void entity_link(WrenVM *vm)
 
 static void engine_time(WrenVM *vm)
 {
-    wrenSetSlotDouble(vm, 0, sv.time);
+    wrenSetSlotDouble(vm, 0, sv.qcvm.time);
 }
 
 static void engine_set_skill(WrenVM *vm)


### PR DESCRIPTION
## Summary
- adjust the engine time binding to use the QCVM time field

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69012a820f00832ebfc7e99886224094