### PR TITLE
Enhance atmospheric lighting across episode one maps

### DIFF
--- a/Quake/maps/E1M1.MAP
+++ b/Quake/maps/E1M1.MAP
@@ -4,6 +4,12 @@
 "classname"	"worldspawn"
 "sounds"	"6"
 "worldtype"	"2"
+	"_ambient"	"18"
+	"_minlight"	"6"
+	"_sunlight"	"70"
+	"_sunlight_color"	"0.85 0.72 0.58"
+	"_sun_mangle"	"45 120 0"
+	"fog"	"0.03 0.08 0.11 0.18"
 {
 ( 448 -320 64 ) ( 448 -384 64 ) ( 448 -384 0 ) SLIPBOTSD 0 0 90 -1.000000 1.000000
 ( 512 -320 64 ) ( 448 -320 64 ) ( 448 -320 0 ) SLIPBOTSD 0 0 90 -1.000000 1.000000
@@ -9288,68 +9294,94 @@
 ( 1040 2512 -160 ) ( 1024 2512 -160 ) ( 1024 2480 -160 ) ECOP1_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "angle"	"90"
 "origin"	"480 -352 88"
 "classname"	"info_player_start"
 }
+
 {
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"480 96 168"
 "classname"	"light"
 }
+
 {
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"480 288 168"
 "classname"	"light"
 }
+
 {
 "origin"	"272 96 80"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"272 288 80"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"272 192 80"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "style"	"10"
 "classname"	"light_fluorospark"
 "origin"	"688 192 80"
+	"_color"	"0.60 0.78 1.00"
 }
+
 {
 "origin"	"688 288 80"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 "style"	"10"
 }
+
 {
 "style"	"10"
 "classname"	"light"
 "origin"	"688 96 80"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"480 -280 168"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 "origin"	"480 -144 168"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"480 -376 120"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"480 -40 168"
 "light"	"160"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"func_door"
 "angle"	"270"
@@ -9380,6 +9412,7 @@
 ( 208 538 48 ) ( 256 538 48 ) ( 256 556 76 ) DOOR02_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"func_door"
 "angle"	"90"
@@ -9409,70 +9442,95 @@
 ( 256 538 48 ) ( 208 538 48 ) ( 208 556 76 ) DOOR02_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light_fluoro"
 "origin"	"592 544 88"
 "light"	"250"
+	"_color"	"0.60 0.78 1.00"
 }
+
 {
 "classname"	"light"
 "origin"	"456 600 104"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"688 648 136"
 "light"	"180"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"180"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"688 520 136"
 "classname"	"light"
 }
+
 {
 "classname"	"item_armor1"
 "origin"	"688 480 80"
 }
+
 {
 "classname"	"monster_army"
 "origin"	"616 72 40"
 "spawnflags"	"768"
 "angle"	"180"
 }
+
 {
 "classname"	"light"
 "origin"	"0 576 120"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"160 576 72"
 "light"	"180"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"560 -32 72"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"400 -32 72"
 "classname"	"light"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"0 712 72"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"0 728 -136"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"0 592 -136"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "dmg"	"10"
 "classname"	"func_door"
@@ -9505,6 +9563,7 @@
 ( 64 640 -240 ) ( -64 640 -240 ) ( -64 512 -240 ) CLIP 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"func_button"
 "angle"	"180"
@@ -9519,80 +9578,111 @@
 ( -60 592 32 ) ( -68 592 32 ) ( -68 560 32 ) DOOR02_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"412 780 136"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"328 904 72"
 "classname"	"light"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"168 800 72"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"-72 864 72"
 "classname"	"light"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"264 888 -136"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-8 992 -136"
 "classname"	"light"
 }
+
 {
 "origin"	"272 1064 -136"
 "classname"	"light"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-8 1232 -136"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"256 1272 -136"
 "classname"	"light"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"312 1464 -136"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"128 968 72"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"-48 1168 72"
 "classname"	"light"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"312 1168 72"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"128 1504 -120"
 "classname"	"light"
 "light"	"220"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"-56 1464 -136"
 "classname"	"light"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "speed"	"400"
 "angle"	"180"
@@ -9623,6 +9713,7 @@
 ( 108 1824 -132 ) ( 90 1824 -160 ) ( 90 1776 -160 ) DOOR02_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "speed"	"400"
 "angle"	"0"
@@ -9652,111 +9743,156 @@
 ( 108 1776 -132 ) ( 90 1776 -160 ) ( 90 1824 -160 ) DOOR02_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "origin"	"176 1744 -152"
+	"_color"	"0.60 0.78 1.00"
 "classname"	"light_fluoro"
 }
+
 {
 "classname"	"light_fluoro"
 "origin"	"80 1744 -152"
+	"_color"	"0.60 0.78 1.00"
 }
+
 {
 "classname"	"light"
 "origin"	"-232 1600 -136"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"488 1600 -136"
 "classname"	"light"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 "origin"	"-56 1448 72"
 }
+
 {
 "origin"	"312 1448 72"
 "classname"	"light"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"416 2064 -112"
 "classname"	"light_fluoro"
 "light"	"260"
+	"_color"	"0.60 0.78 1.00"
 }
+
 {
 "classname"	"light_fluoro"
 "origin"	"416 1968 -112"
 "light"	"260"
+	"_color"	"0.60 0.78 1.00"
 }
+
 {
 "classname"	"light"
 "origin"	"128 1880 -112"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"616 1944 -88"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"344 2216 -88"
+	"_color"	"0.60 0.78 1.00"
 "classname"	"light_fluorospark"
 "style"	"10"
 }
+
 {
 "classname"	"light"
 "origin"	"352 2016 -112"
 "light"	"180"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"128 2056 -112"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-112 1984 -112"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light_fluoro"
 "origin"	"-472 2064 -88"
 "light"	"350"
+	"_color"	"0.60 0.78 1.00"
 }
+
 {
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-192 2208 8"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-424 2208 8"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-248 2088 -96"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-200 2384 -72"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"-424 2384 -72"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-448 2408 -128"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-176 2408 -128"
 "classname"	"light"
 }
+
 {
 "classname"	"func_plat"
 "sounds"	"1"
@@ -9785,62 +9921,87 @@
 ( -496 2688 -128 ) ( -592 2688 -128 ) ( -592 2624 -128 ) CLIP 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"-352 2656 184"
 "light"	"350"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"-352 2464 184"
 "classname"	"light"
 "light"	"350"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-576 2800 -40"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"160 2920 232"
 "light"	"500"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"500"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"160 2720 232"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-288 2992 8"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"-168 2776 -40"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"160 2824 104"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-64 2760 136"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"16 2832 -152"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"304 2832 -152"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"504 2816 16"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"func_door"
 "angle"	"270"
@@ -9858,26 +10019,35 @@
 ( 320 2992 -96 ) ( 0 2992 -96 ) ( 0 2640 -96 ) TECH04_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"160 2840 -152"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"16 2904 -88"
 "light"	"80"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"80"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"304 2904 -88"
 "classname"	"light"
 }
+
 {
 "light"	"80"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"160 2904 -88"
 "classname"	"light"
 }
+
 {
 "classname"	"func_button"
 "angle"	"270"
@@ -9894,47 +10064,63 @@
 ( -40 2664 -48 ) ( -64 2664 -48 ) ( -64 2656 -48 ) DOOR02_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"0 1800 -32"
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"248 1800 -32"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"8 2352 200"
+	"_color"	"0.88 0.74 0.58"
 "targetname"	"t3"
 }
+
 {
 "origin"	"32 2392 200"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 "targetname"	"t3"
 }
+
 {
 "classname"	"light"
 "origin"	"56 2352 200"
+	"_color"	"0.88 0.74 0.58"
 "targetname"	"t3"
 }
+
 {
 "origin"	"32 2312 200"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 "targetname"	"t3"
 }
+
 {
 "classname"	"light"
 "origin"	"32 2352 88"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "targetname"	"t3"
 }
+
 {
 "classname"	"weapon_nailgun"
 "origin"	"112 2352 16"
 "spawnflags"	"2048"
 }
+
 {
 "classname"	"func_door_secret"
 "angle"	"270"
@@ -9950,6 +10136,7 @@
 ( 208 2384 16 ) ( 192 2384 16 ) ( 192 2312 16 ) TECH04_3 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_once"
 "target"	"t3"
@@ -9963,19 +10150,24 @@
 ( 136 2384 48 ) ( 80 2384 48 ) ( 80 2320 48 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"304 2368 96"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"monster_army"
 "origin"	"248 2392 40"
 "angle"	"180"
 }
+
 {
 "classname"	"item_spikes"
 "origin"	"272 2352 64"
 }
+
 {
 "classname"	"trigger_once"
 "target"	"t3"
@@ -9989,153 +10181,212 @@
 ( 256 2432 48 ) ( 240 2432 48 ) ( 240 2304 48 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "light"	"220"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 "origin"	"832 2608 16"
 }
+
 {
 "origin"	"832 2480 0"
 "classname"	"light"
 "light"	"220"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"800 2816 24"
 "light"	"240"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"400"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"752 2000 -88"
 "classname"	"light"
 "spawnflags"	"1"
 "targetname"	"t11"
 }
+
 {
 "light"	"400"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 "origin"	"1280 2000 -152"
 "targetname"	"t12"
 "spawnflags"	"1"
 }
+
 {
 "light"	"400"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1280 2496 -216"
 "classname"	"light"
 "targetname"	"t13"
 "spawnflags"	"1"
 }
+
 {
 "classname"	"light"
 "origin"	"784 2496 -280"
+	"_color"	"0.88 0.74 0.58"
 "targetname"	"t14"
 "spawnflags"	"1"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1368 2584 -488"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 "origin"	"1368 1944 -488"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"696 2584 -488"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 "origin"	"1016 2584 -488"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1016 1944 -488"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 "origin"	"1368 2272 -488"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"696 2272 -488"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"960 2296 -488"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1032 2352 -488"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"888 2352 -488"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"960 2408 -488"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"984 2448 -304"
 "classname"	"light"
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"400"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"832 2360 112"
 "classname"	"light"
 }
+
 {
 "origin"	"1144 2448 -488"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1232 2360 -488"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1320 2448 -488"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1232 2536 -488"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"1232 2136 -488"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1144 2048 -488"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1232 1960 -488"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1320 2048 -488"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"832 2336 -200"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "sounds"	"3"
 "spawnflags"	"2"
@@ -10190,6 +10441,7 @@
 ( 760 2496 -80 ) ( 752 2496 -80 ) ( 752 2464 -80 ) BASEBUTN3 0 16 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"3"
 "angle"	"180"
@@ -10259,21 +10511,28 @@
 ( 560 2248 -96 ) ( 528 2248 -96 ) ( 528 2240 -96 ) +0PLANET 16 0 0 1.000000 1.000000
 }
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"552 2480 -56"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"544 2296 -56"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"664 2480 -56"
 "classname"	"light"
 }
+
 {
 "sounds"	"2"
 "spawnflags"	"1"
@@ -10297,6 +10556,7 @@
 ( 576 2176 -144 ) ( 512 2176 -144 ) ( 512 2112 -144 ) SFLOOR4_2 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "health"	"1"
 "target"	"t4"
@@ -10310,6 +10570,7 @@
 ( 456 2040 -104 ) ( 448 2040 -104 ) ( 448 1984 -104 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"2"
 "wait"	"-1"
@@ -10326,6 +10587,7 @@
 ( 592 2528 -128 ) ( 576 2528 -128 ) ( 576 2432 -128 ) TECH08_1 208 0 0 1.000000 1.000000
 }
 }
+
 {
 "target"	"t5"
 "classname"	"trigger_once"
@@ -10339,36 +10601,50 @@
 ( 896 2616 -80 ) ( 768 2616 -80 ) ( 768 2600 -80 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "origin"	"544 2480 -88"
 "classname"	"item_artifact_super_damage"
 }
+
 {
 "origin"	"832 2104 -208"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"832 2048 -368"
 "classname"	"light"
 }
+
 {
 "origin"	"1120 2464 112"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1120 2080 112"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"752 2080 112"
 "classname"	"light"
 }
+
 {
 "origin"	"1048 2280 -72"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "target"	"t1"
 "angle"	"270"
@@ -10382,148 +10658,207 @@
 ( 112 712 -192 ) ( 80 712 -192 ) ( 80 704 -192 ) DOOR02_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "light"	"220"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1136 1848 -504"
 "classname"	"light"
 }
+
 {
 "light"	"220"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 "origin"	"1136 1672 -504"
 }
+
 {
 "light"	"220"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1008 1672 -504"
 "classname"	"light"
 }
+
 {
 "light"	"220"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 "origin"	"1008 1848 -504"
 }
+
 {
 "light"	"220"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1288 1848 -504"
 "classname"	"light"
 }
+
 {
 "light"	"220"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 "origin"	"1400 1584 -504"
 }
+
 {
 "light"	"220"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1224 1584 -504"
 "classname"	"light"
 }
+
 {
 "light"	"220"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 "origin"	"1400 1736 -504"
 }
+
 {
 "light"	"220"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 "origin"	"880 1672 -504"
 }
+
 {
 "light"	"220"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"744 1672 -504"
 "classname"	"light"
 }
+
 {
 "light"	"220"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1312 1648 -392"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1312 1520 -392"
 "light"	"170"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"220"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1200 1760 -392"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1072 1760 -392"
 "light"	"170"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"170"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"944 1760 -392"
 "classname"	"light"
 }
+
 {
 "light"	"220"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 "origin"	"832 1992 -208"
 }
+
 {
 "classname"	"light"
 "origin"	"744 1832 -504"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"832 1760 -392"
 "light"	"170"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"680 1936 -504"
 "light"	"220"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"170"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1312 1392 -352"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1312 1264 -288"
 "light"	"170"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"1312 1136 -232"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "light"	"220"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 "origin"	"1224 1456 -504"
 }
+
 {
 "light"	"220"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1400 1456 -504"
 "classname"	"light"
 }
+
 {
 "light"	"220"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 "origin"	"1400 1328 -504"
 }
+
 {
 "light"	"220"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1224 1328 -504"
 "classname"	"light"
 }
+
 {
 "light"	"220"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 "origin"	"1224 1200 -504"
 }
+
 {
 "light"	"220"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1400 1200 -504"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1312 960 -208"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "target"	"t6"
 "classname"	"trigger_teleport"
@@ -10536,39 +10871,54 @@
 ( 1344 1096 -408 ) ( 1280 1096 -408 ) ( 1280 1080 -408 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "origin"	"1312 912 -472"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "origin"	"1312 1080 -368"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "light"	"170"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1128 1064 -504"
 "classname"	"light"
 }
+
 {
 "light"	"170"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 "origin"	"1128 856 -504"
 }
+
 {
 "light"	"170"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1496 856 -504"
 "classname"	"light"
 }
+
 {
 "light"	"170"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 "origin"	"1496 1064 -504"
 }
+
 {
 "light"	"170"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1312 776 -504"
 "classname"	"light"
 }
+
 {
 "classname"	"func_door_secret"
 "angle"	"90"
@@ -10582,10 +10932,13 @@
 ( 1120 1056 -272 ) ( 1104 1056 -272 ) ( 1104 992 -272 ) TECH04_3 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"1072 1024 -168"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"func_plat"
 "sounds"	"1"
@@ -10603,6 +10956,7 @@
 ( 832 496 64 ) ( 816 480 64 ) ( 832 496 80 ) PLAT_SIDE1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"func_door_secret"
 "angle"	"90"
@@ -10617,6 +10971,7 @@
 ( 752 544 80 ) ( 736 544 80 ) ( 736 480 80 ) TECH04_3 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_multiple"
 "target"	"t8"
@@ -10629,103 +10984,133 @@
 ( 832 544 0 ) ( 752 544 0 ) ( 752 480 0 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"792 888 -248"
 "light"	"220"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"944 608 -248"
 "classname"	"light"
 "light"	"180"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"792 512 -248"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"792 512 -56"
 "classname"	"light"
 }
+
 {
 "light"	"220"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"624 928 -240"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"504 1200 -248"
 "light"	"220"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"180"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 "origin"	"936 800 -248"
 }
+
 {
 "origin"	"960 984 -208"
 "classname"	"light"
 "light"	"180"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"792 512 128"
 "classname"	"light"
 }
+
 {
 "classname"	"item_health"
 "origin"	"944 1008 -272"
 "spawnflags"	"2"
 }
+
 {
 "classname"	"weapon_rocketlauncher"
 "origin"	"144 2352 16"
 "spawnflags"	"1792"
 }
+
 {
 "classname"	"weapon_grenadelauncher"
 "origin"	"1216 1040 -432"
 "spawnflags"	"1792"
 }
+
 {
 "classname"	"item_rockets"
 "origin"	"1392 1024 -432"
 "spawnflags"	"1793"
 }
+
 {
 "classname"	"info_teleport_destination"
 "origin"	"-32 1800 -56"
 "targetname"	"t6"
 }
+
 {
 "classname"	"weapon_supernailgun"
 "origin"	"832 2448 -368"
 "spawnflags"	"1792"
 }
+
 {
 "classname"	"weapon_supershotgun"
 "origin"	"128 1216 -208"
 "spawnflags"	"1792"
 }
+
 {
 "classname"	"item_shells"
 "origin"	"296 2136 -192"
 }
+
 {
 "classname"	"item_health"
 "origin"	"1424 904 -432"
 "spawnflags"	"1"
 }
+
 {
 "origin"	"1376 808 -432"
 "classname"	"item_health"
 }
+
 {
 "classname"	"item_health"
 "origin"	"1176 936 -432"
 }
+
 {
 "classname"	"func_button"
 "angle"	"0"
@@ -10741,6 +11126,7 @@
 ( 1296 2064 -208 ) ( 1288 2064 -208 ) ( 1288 2016 -208 ) DOOR02_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"func_button"
 "angle"	"90"
@@ -10756,6 +11142,7 @@
 ( 1200 2504 -272 ) ( 1248 2504 -272 ) ( 1248 2512 -272 ) DOOR02_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"func_button"
 "angle"	"270"
@@ -10771,6 +11158,7 @@
 ( 832 1992 -144 ) ( 784 1992 -144 ) ( 784 1984 -144 ) DOOR02_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_counter"
 "count"	"3"
@@ -10785,6 +11173,7 @@
 ( 816 1952 -144 ) ( 792 1952 -144 ) ( 792 1936 -144 ) +0BASEBTN 16 16 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"func_door"
 "angle"	"180"
@@ -10842,11 +11231,14 @@
 ( 864 1888 -416 ) ( 800 1888 -416 ) ( 800 1880 -416 ) KEY01_3 32 32 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"832 1928 -384"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"trigger_once"
 "target"	"t11"
@@ -10860,6 +11252,7 @@
 ( 896 2384 -104 ) ( 784 2384 -104 ) ( 784 2368 -104 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_once"
 "target"	"t12"
@@ -10873,6 +11266,7 @@
 ( 912 2104 -168 ) ( 896 2104 -168 ) ( 896 1992 -168 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_once"
 "target"	"t13"
@@ -10886,6 +11280,7 @@
 ( 1296 2128 -232 ) ( 1168 2128 -232 ) ( 1168 2112 -232 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_once"
 "target"	"t14"
@@ -10899,6 +11294,7 @@
 ( 1168 2512 -296 ) ( 1152 2512 -296 ) ( 1152 2384 -296 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"func_door"
 "angle"	"-2"
@@ -10915,6 +11311,7 @@
 ( 728 1992 -136 ) ( 712 2000 -136 ) ( 712 1992 -136 ) TLIGHT11 0 16 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"1"
 "wait"	"-1"
@@ -10931,6 +11328,7 @@
 ( 1264 1992 -200 ) ( 1248 2000 -200 ) ( 1248 1992 -200 ) TLIGHT11 0 16 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"func_door"
 "angle"	"-2"
@@ -10947,6 +11345,7 @@
 ( 1264 2496 -264 ) ( 1248 2504 -264 ) ( 1248 2496 -264 ) TLIGHT11 0 16 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"1"
 "wait"	"-1"
@@ -10963,50 +11362,60 @@
 ( 760 2496 -328 ) ( 744 2504 -328 ) ( 744 2496 -328 ) TLIGHT11 0 16 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"info_player_deathmatch"
 "origin"	"1312 880 -248"
 "angle"	"90"
 }
+
 {
 "classname"	"item_spikes"
 "origin"	"1376 1024 -272"
 "spawnflags"	"1"
 }
+
 {
 "classname"	"item_health"
 "origin"	"1184 992 -272"
 }
+
 {
 "classname"	"item_health"
 "origin"	"1376 856 -272"
 "spawnflags"	"1"
 }
+
 {
 "classname"	"item_health"
 "origin"	"1256 1704 -432"
 "spawnflags"	"1"
 }
+
 {
 "classname"	"info_player_deathmatch"
 "origin"	"480 48 24"
 "angle"	"90"
 }
+
 {
 "classname"	"info_player_deathmatch"
 "origin"	"528 1888 -168"
 "angle"	"180"
 }
+
 {
 "classname"	"info_player_deathmatch"
 "origin"	"-272 2928 -56"
 "angle"	"0"
 }
+
 {
 "classname"	"info_player_deathmatch"
 "origin"	"832 2048 -152"
 "angle"	"0"
 }
+
 {
 "wait"	"-1"
 "classname"	"func_door"
@@ -11064,6 +11473,7 @@
 ( 1096 1040 -256 ) ( 1088 1040 -256 ) ( 1088 1008 -256 ) KEY01_3 32 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_once"
 "target"	"t15"
@@ -11077,191 +11487,227 @@
 ( 1384 1136 -264 ) ( 1248 1136 -264 ) ( 1248 1120 -264 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"weapon_nailgun"
 "origin"	"480 576 0"
 "spawnflags"	"1792"
 }
+
 {
 "classname"	"item_spikes"
 "origin"	"464 728 64"
 "spawnflags"	"1793"
 }
+
 {
 "classname"	"item_health"
 "origin"	"328 848 -224"
 }
+
 {
 "origin"	"344 920 -224"
 "classname"	"item_health"
 }
+
 {
 "classname"	"item_health"
 "origin"	"-16 2064 -208"
 "spawnflags"	"1"
 }
+
 {
 "classname"	"item_rockets"
 "origin"	"-480 2240 -160"
 "spawnflags"	"1792"
 }
+
 {
 "classname"	"item_shells"
 "origin"	"-96 2456 16"
 "spawnflags"	"1793"
 }
+
 {
 "spawnflags"	"1793"
 "origin"	"-104 2216 16"
 "classname"	"item_rockets"
 }
+
 {
 "spawnflags"	"1792"
 "origin"	"256 1808 -40"
 "classname"	"item_artifact_invulnerability"
 }
+
 {
 "spawnflags"	"256"
 "angle"	"0"
 "origin"	"0 576 24"
 "classname"	"monster_army"
 }
+
 {
 "angle"	"270"
 "origin"	"8 1520 -200"
 "classname"	"monster_army"
 }
+
 {
 "angle"	"270"
 "origin"	"88 1520 -200"
 "classname"	"monster_dog"
 }
+
 {
 "spawnflags"	"768"
 "angle"	"270"
 "origin"	"224 1552 -200"
 "classname"	"monster_army"
 }
+
 {
 "classname"	"monster_army"
 "origin"	"-8 936 -200"
 "angle"	"270"
 "spawnflags"	"768"
 }
+
 {
 "angle"	"180"
 "spawnflags"	"768"
 "origin"	"648 736 104"
 "classname"	"monster_army"
 }
+
 {
 "angle"	"90"
 "origin"	"712 2040 -408"
 "classname"	"item_artifact_envirosuit"
 }
+
 {
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"712 2040 -360"
 "classname"	"light"
 }
+
 {
 "spawnflags"	"1793"
 "origin"	"1328 2536 -528"
 "classname"	"item_rockets"
 }
+
 {
 "spawnflags"	"2"
 "origin"	"916 2416 -136"
 "classname"	"item_health"
 }
+
 {
 "angle"	"90"
 "origin"	"1312 936 -248"
 "classname"	"monster_army"
 "spawnflags"	"1"
 }
+
 {
 "spawnflags"	"257"
 "angle"	"180"
 "origin"	"1336 1784 -408"
 "classname"	"monster_dog"
 }
+
 {
 "classname"	"monster_army"
 "origin"	"1392 928 -248"
 "angle"	"90"
 "spawnflags"	"257"
 }
+
 {
 "spawnflags"	"768"
 "angle"	"90"
 "origin"	"1384 1008 -248"
 "classname"	"monster_army"
 }
+
 {
 "classname"	"monster_army"
 "origin"	"1240 1008 -248"
 "angle"	"90"
 "spawnflags"	"768"
 }
+
 {
 "spawnflags"	"257"
 "angle"	"180"
 "origin"	"1256 1760 -408"
 "classname"	"monster_army"
 }
+
 {
 "angle"	"90"
 "spawnflags"	"257"
 "origin"	"824 1784 -408"
 "classname"	"monster_army"
 }
+
 {
 "spawnflags"	"769"
 "angle"	"180"
 "origin"	"1128 1760 -408"
 "classname"	"monster_dog"
 }
+
 {
 "targetname"	"t17"
 "target"	"t16"
 "origin"	"880 2048 -168"
 "classname"	"path_corner"
 }
+
 {
 "target"	"t17"
 "targetname"	"t16"
 "classname"	"path_corner"
 "origin"	"1232 2048 -232"
 }
+
 {
 "target"	"t16"
 "origin"	"1232 2088 -216"
 "classname"	"monster_army"
 }
+
 {
 "spawnflags"	"256"
 "angle"	"270"
 "origin"	"1232 2448 -280"
 "classname"	"monster_army"
 }
+
 {
 "spawnflags"	"256"
 "angle"	"0"
 "origin"	"832 2464 -344"
 "classname"	"monster_army"
 }
+
 {
 "angle"	"90"
 "origin"	"832 2072 -408"
 "classname"	"monster_army"
 }
+
 {
 "spawnflags"	"768"
 "angle"	"90"
 "origin"	"840 1960 -408"
 "classname"	"monster_dog"
 }
+
 {
 "health"	"1"
 "target"	"t18"
@@ -11275,6 +11721,7 @@
 ( 176 3064 -16 ) ( 144 3064 -16 ) ( 144 3056 -16 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "targetname"	"t18"
 "spawnflags"	"2"
@@ -11289,10 +11736,12 @@
 ( -304 2944 -80 ) ( -320 2944 -80 ) ( -320 2880 -80 ) TECH04_3 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "origin"	"-360 2912 -80"
 "classname"	"weapon_supershotgun"
 }
+
 {
 "target"	"t18"
 "classname"	"trigger_multiple"
@@ -11305,213 +11754,253 @@
 ( -328 2944 -48 ) ( -384 2944 -48 ) ( -384 2880 -48 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "light"	"120"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-352 2912 -24"
 "classname"	"light"
 }
+
 {
 "light"	"120"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"160 3024 0"
 "classname"	"light"
 }
+
 {
 "origin"	"528 720 80"
 "classname"	"item_shells"
 }
+
 {
 "spawnflags"	"768"
 "angle"	"180"
 "origin"	"416 1912 -168"
 "classname"	"monster_army"
 }
+
 {
 "spawnflags"	"256"
 "angle"	"180"
 "origin"	"432 2120 -168"
 "classname"	"monster_dog"
 }
+
 {
 "target"	"t20"
 "targetname"	"t19"
 "origin"	"248 1992 -200"
 "classname"	"path_corner"
 }
+
 {
 "target"	"t21"
 "targetname"	"t20"
 "classname"	"path_corner"
 "origin"	"-200 1992 -200"
 }
+
 {
 "target"	"t22"
 "targetname"	"t21"
 "origin"	"-136 1912 -200"
 "classname"	"path_corner"
 }
+
 {
 "targetname"	"t22"
 "target"	"t19"
 "classname"	"path_corner"
 "origin"	"248 1912 -200"
 }
+
 {
 "target"	"t20"
 "origin"	"80 2024 -184"
 "classname"	"monster_army"
 }
+
 {
 "target"	"t22"
 "spawnflags"	"256"
 "origin"	"-16 1888 -184"
 "classname"	"monster_army"
 }
+
 {
 "angle"	"315"
 "spawnflags"	"768"
 "origin"	"-248 2144 -136"
 "classname"	"monster_dog"
 }
+
 {
 "target"	"t24"
 "targetname"	"t23"
 "origin"	"-560 2352 40"
 "classname"	"path_corner"
 }
+
 {
 "targetname"	"t24"
 "target"	"t23"
 "classname"	"path_corner"
 "origin"	"-104 2352 40"
 }
+
 {
 "target"	"t23"
 "spawnflags"	"768"
 "origin"	"-432 2352 56"
 "classname"	"monster_army"
 }
+
 {
 "spawnflags"	"256"
 "origin"	"-544 2584 56"
 "classname"	"monster_dog"
 "angle"	"0"
 }
+
 {
 "angle"	"270"
 "origin"	"-344 2656 -104"
 "classname"	"monster_army"
 }
+
 {
 "angle"	"225"
 "spawnflags"	"256"
 "origin"	"-72 2896 -56"
 "classname"	"monster_dog"
 }
+
 {
 "target"	"t25"
 "origin"	"432 2920 -56"
 "classname"	"monster_army"
 }
+
 {
 "angle"	"180"
 "spawnflags"	"256"
 "origin"	"424 2832 -56"
 "classname"	"monster_army"
 }
+
 {
 "target"	"t26"
 "targetname"	"t25"
 "origin"	"368 2936 -72"
 "classname"	"path_corner"
 }
+
 {
 "target"	"t27"
 "targetname"	"t26"
 "classname"	"path_corner"
 "origin"	"368 2696 -72"
 }
+
 {
 "target"	"t28"
 "targetname"	"t27"
 "origin"	"480 2696 -72"
 "classname"	"path_corner"
 }
+
 {
 "targetname"	"t28"
 "target"	"t25"
 "classname"	"path_corner"
 "origin"	"480 2936 -72"
 }
+
 {
 "target"	"t27"
 "origin"	"424 2672 -56"
 "classname"	"monster_army"
 }
+
 {
 "spawnflags"	"768"
 "angle"	"180"
 "origin"	"424 2880 -56"
 "classname"	"monster_army"
 }
+
 {
 "angle"	"180"
 "spawnflags"	"768"
 "origin"	"424 2760 -56"
 "classname"	"monster_army"
 }
+
 {
 "target"	"t30"
 "targetname"	"t29"
 "origin"	"832 2712 -88"
 "classname"	"path_corner"
 }
+
 {
 "targetname"	"t30"
 "target"	"t29"
 "classname"	"path_corner"
 "origin"	"832 2416 -104"
 }
+
 {
 "target"	"t29"
 "spawnflags"	"257"
 "origin"	"848 2584 -72"
 "classname"	"monster_army"
 }
+
 {
 "spawnflags"	"768"
 "angle"	"90"
 "origin"	"824 2008 -152"
 "classname"	"monster_army"
 }
+
 {
 "spawnflags"	"1"
 "origin"	"-376 1704 -224"
 "classname"	"item_health"
 }
+
 {
 "classname"	"monster_army"
 "origin"	"248 2352 40"
 "spawnflags"	"768"
 "angle"	"180"
 }
+
 {
 "classname"	"monster_army"
 "origin"	"-72 2464 40"
 "angle"	"270"
 "spawnflags"	"768"
 }
+
 {
 "classname"	"monster_army"
 "origin"	"904 1024 -248"
 "angle"	"225"
 "spawnflags"	"768"
 }
+
 {
 "origin"	"688 0 80"
 "classname"	"light"
 "style"	"10"
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"func_door_secret"
 "angle"	"0"
@@ -11526,10 +12015,12 @@
 ( 720 64 48 ) ( 656 64 48 ) ( 656 48 48 ) COMP1_6 240 240 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"item_shells"
 "origin"	"672 -40 48"
 }
+
 {
 "classname"	"trigger_secret"
 {
@@ -11541,6 +12032,7 @@
 ( 720 48 48 ) ( 656 48 48 ) ( 656 32 48 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_secret"
 {
@@ -11552,6 +12044,7 @@
 ( 1080 1088 -344 ) ( 752 1088 -344 ) ( 752 776 -344 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_secret"
 {
@@ -11563,6 +12056,7 @@
 ( 1368 960 -400 ) ( 1256 960 -400 ) ( 1256 848 -400 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_secret"
 {
@@ -11574,6 +12068,7 @@
 ( 992 2472 -128 ) ( 976 2472 -128 ) ( 976 2392 -128 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_secret"
 {
@@ -11585,6 +12080,7 @@
 ( 640 2528 -80 ) ( 512 2528 -80 ) ( 512 2336 -80 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_secret"
 {
@@ -11596,105 +12092,144 @@
 ( -320 2944 -48 ) ( -336 2944 -48 ) ( -336 2880 -48 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"0 632 -88"
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "spawnflags"	"1"
 "origin"	"600 2200 -128"
 "classname"	"item_health"
 }
+
 {
 "origin"	"832 1880 -504"
 "classname"	"light"
 "light"	"220"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"misc_explobox"
 "origin"	"72 2056 -208"
 }
+
 {
 "classname"	"light"
 "origin"	"-128 584 72"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-128 568 -136"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-56 632 -168"
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-56 864 -136"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"40 1672 -40"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"216 1672 -40"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"128 1080 -152"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"128 1096 72"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"-352 1656 72"
 "classname"	"light"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 "origin"	"608 1640 72"
 }
+
 {
 "light"	"170"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 "origin"	"-48 1144 -320"
 }
+
 {
 "origin"	"-48 1256 -320"
 "classname"	"light"
 "light"	"170"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"170"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 "origin"	"320 1256 -320"
 }
+
 {
 "origin"	"312 1128 -320"
 "classname"	"light"
 "light"	"170"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"170"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 "origin"	"136 1128 -320"
 }
+
 {
 "origin"	"136 1272 -320"
 "classname"	"light"
 "light"	"170"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "targetname"	"t32"
 "classname"	"trigger_multiple"
@@ -11711,6 +12246,7 @@
 ( 384 496 32 ) ( 320 496 32 ) ( 320 480 32 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "targetname"	"t31"
 "classname"	"trigger_multiple"
@@ -11727,31 +12263,42 @@
 ( 640 320 16 ) ( 624 320 16 ) ( 624 296 16 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"1008 2128 -408"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1312 544 -184"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"1208 456 -184"
 "classname"	"light"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 "origin"	"1416 456 -184"
 }
+
 {
 "classname"	"light"
 "origin"	"1312 728 -56"
 "light"	"170"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"trigger_changelevel"
 "map"	"e1m2"
@@ -11764,32 +12311,40 @@
 ( 1336 576 -280 ) ( 1288 576 -280 ) ( 1288 520 -280 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "spawnflags"	"1"
 "origin"	"1224 2464 -304"
 "classname"	"item_health"
 }
+
 {
 "light"	"160"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"688 1680 -160"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-392 1688 -160"
 "light"	"160"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"monster_army"
 "origin"	"288 1536 -200"
 "angle"	"270"
 "spawnflags"	"768"
 }
+
 {
 "classname"	"monster_army"
 "origin"	"968 2432 -112"
 "spawnflags"	"768"
 }
+
 {
 "angle"	"270"
 "sounds"	"2"
@@ -11805,6 +12360,7 @@
 ( 1408 768 -280 ) ( 1216 768 -280 ) ( 1216 752 -280 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "spawnflags"	"3072"
 "target"	"t31"
@@ -11819,6 +12375,7 @@
 ( 704 320 56 ) ( 672 320 56 ) ( 672 64 56 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "killtarget"	"t32"
 "target"	"t32"
@@ -11833,61 +12390,74 @@
 ( 376 688 48 ) ( 320 688 48 ) ( 320 656 48 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "origin"	"1312 1048 -432"
 "classname"	"item_armor2"
 }
+
 {
 "origin"	"250 194 72"
 "classname"	"ambient_comp_hum"
 }
+
 {
 "classname"	"ambient_comp_hum"
 "origin"	"714 194 72"
 }
+
 {
 "origin"	"626 2058 -104"
 "classname"	"ambient_comp_hum"
 }
+
 {
 "classname"	"ambient_comp_hum"
 "origin"	"466 2226 -104"
 }
+
 {
 "mangle"	"20 45 0"
 "origin"	"-112 704 56"
 "classname"	"info_intermission"
 }
+
 {
 "mangle"	"20 225 0"
 "origin"	"-208 2736 192"
 "classname"	"info_intermission"
 }
+
 {
 "mangle"	"20 120 0"
 "origin"	"240 2664 104"
 "classname"	"info_intermission"
 }
+
 {
 "mangle"	"20 135 0"
 "origin"	"1376 1936 64"
 "classname"	"info_intermission"
 }
+
 {
 "classname"	"info_player_coop"
 "origin"	"528 -296 72"
 "angle"	"90"
 }
+
 {
 "angle"	"90"
 "origin"	"432 -296 72"
 "classname"	"info_player_coop"
 }
+
 {
 "classname"	"info_player_coop"
 "origin"	"480 -240 72"
 "angle"	"90"
 }
+
 {
 "spawnflags"	"1792"
 "classname"	"func_wall"
@@ -11916,6 +12486,7 @@
 ( 1376 592 -280 ) ( 1248 592 -280 ) ( 1248 576 -280 ) TECH04_1 0 8 0 1.000000 1.000000
 }
 }
+
 {
 "spawnflags"	"1792"
 "classname"	"func_wall"
@@ -11928,7 +12499,15 @@
 ( 1328 600 -280 ) ( 1296 600 -280 ) ( 1296 592 -280 ) TECH04_1 0 8 0 1.000000 1.000000
 }
 }
+
 {
 "origin"	"1314 450 -200"
 "classname"	"ambient_drone"
+}
+
+{
+	"classname"	"light_environment"
+	"_color"	"0.85 0.72 0.58"
+	"light"	"220"
+	"angles"	"45 120 0"
 }

--- a/Quake/maps/E1M2.MAP
+++ b/Quake/maps/E1M2.MAP
@@ -4,6 +4,12 @@
 "classname"	"worldspawn"
 "worldtype"	"0"
 "sounds"	"8"
+	"_ambient"	"18"
+	"_minlight"	"6"
+	"_sunlight"	"70"
+	"_sunlight_color"	"0.85 0.72 0.58"
+	"_sun_mangle"	"45 120 0"
+	"fog"	"0.03 0.08 0.11 0.18"
 {
 ( 1464 1632 264 ) ( 1544 1632 264 ) ( 1544 1632 248 ) SLIPBOTSD 8 0 90 -1.000000 1.000000
 ( 1464 1696 264 ) ( 1464 1624 264 ) ( 1464 1624 248 ) SLIPBOTSD 8 0 90 -1.000000 1.000000
@@ -7956,394 +7962,550 @@
 ( 64 112 0 ) ( -96 112 0 ) ( -96 -112 0 ) SKY1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "angle"	"270"
 "origin"	"1496 1664 296"
 "classname"	"info_player_start"
 }
+
 {
 "origin"	"1432 672 336"
 "classname"	"light"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1496 888 272"
 "classname"	"light"
 }
+
 {
 "classname"	"light_torch_small_walltorch"
 "origin"	"932 640 340"
+	"_color"	"1.00 0.55 0.24"
+	"style"	"1"
 }
+
 {
 "classname"	"light_torch_small_walltorch"
 "origin"	"1104 812 340"
+	"_color"	"1.00 0.55 0.24"
+	"style"	"1"
 }
+
 {
 "classname"	"light"
 "origin"	"1104 640 544"
 "light"	"300"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1216 536 353"
 "classname"	"light"
 }
+
 {
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1816 328 448"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1632 472 208"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1792 -392 240"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1452 -124 508"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1196 -124 508"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1044 -124 508"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"756 -124 508"
 "classname"	"light"
 }
+
 {
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"744 336 145"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1176 -912 672"
 "classname"	"light"
 }
+
 {
 "origin"	"1328 -544 552"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1528 -912 640"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 "origin"	"880 -648 672"
 }
+
 {
 "origin"	"240 -264 392"
 "classname"	"light"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-352 -504 464"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"-448 -608 804"
 "classname"	"light"
 "light"	"450"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"776 -912 472"
 "classname"	"light"
 }
+
 {
 "light"	"300"
+	"style"	"1"
+	"_color"	"1.00 0.55 0.24"
 "origin"	"1630 -806 428"
 "classname"	"light_torch_small_walltorch"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1528 -912 464"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1180 -484 560"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1184 -612 560"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1016 -368 472"
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1016 -464 472"
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1020 -560 472"
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1208 -776 472"
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1288 -776 472"
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1360 -776 472"
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1792 120 376"
 "classname"	"light"
 }
+
 {
 "origin"	"1538 182 356"
+	"_color"	"1.00 0.55 0.24"
+	"style"	"1"
 "classname"	"light_torch_small_walltorch"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1640 80 360"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1928 80 360"
 "classname"	"light"
 }
+
 {
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1792 296 208"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1800 40 160"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1776 -392 160"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1304 -392 152"
 "classname"	"light"
 }
+
 {
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1632 112 136"
 "classname"	"light"
 }
+
 {
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1432 312 136"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1136 -656 160"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1136 -416 160"
 "classname"	"light"
 }
+
 {
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1448 -552 160"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1920 440 136"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"968 88 177"
 "classname"	"light"
 }
+
 {
 "light"	"300"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1088 312 129"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1376 168 129"
 "classname"	"light"
 }
+
 {
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"112 -384 392"
 "classname"	"light"
 }
+
 {
 "origin"	"300 -1004 508"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "origin"	"296 -812 505"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "origin"	"300 -1204 505"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"style"	"1"
+	"_color"	"1.00 0.55 0.24"
 "origin"	"470 -1006 468"
 "classname"	"light_torch_small_walltorch"
 }
+
 {
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"984 -1216 496"
 "classname"	"light"
 }
+
 {
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"888 -1128 552"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"800 -1216 592"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"664 -1216 592"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"584 -1136 592"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"584 -968 592"
 "classname"	"light"
 }
+
 {
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"584 -744 592"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"528 -1144 464"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"528 -856 464"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 "origin"	"1496 1544 440"
 }
+
 {
 "origin"	"1384 1392 440"
 "classname"	"light"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"1496 1104 520"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "origin"	"1608 1400 440"
 "classname"	"light"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1240 1712 360"
 "classname"	"light"
 }
+
 {
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1744 1696 360"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1384 1136 440"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1608 1144 440"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"1168 736 296"
 "targetname"	"t5"
 "target"	"t6"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"992 744 296"
 "targetname"	"t6"
 "target"	"t7"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"1000 544 296"
 "targetname"	"t7"
 "target"	"t34"
 }
+
 {
 "classname"	"item_health"
 "origin"	"960 704 288"
 }
+
 {
 "classname"	"item_shells"
 "origin"	"952 512 288"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"1344 -128 304"
 "targetname"	"t9"
 "target"	"t8"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"898 -128 304"
 "targetname"	"t8"
 "target"	"t9"
 }
+
 {
 "spawnflags"	"1"
 "classname"	"monster_ogre"
@@ -8351,41 +8513,49 @@
 "angle"	"0"
 "target"	"t8"
 }
+
 {
 "classname"	"item_health"
 "origin"	"1344 -224 296"
 "spawnflags"	"1"
 }
+
 {
 "classname"	"item_health"
 "origin"	"1400 -224 296"
 "spawnflags"	"1"
 }
+
 {
 "origin"	"1528 192 296"
 "classname"	"item_shells"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"1496 1040 184"
 "targetname"	"t22"
 "target"	"t23"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"1496 840 248"
 "targetname"	"t23"
 "target"	"t33"
 }
+
 {
 "spawnflags"	"1"
 "classname"	"item_shells"
 "origin"	"1056 -648 288"
 }
+
 {
 "classname"	"item_health"
 "origin"	"1184 -736 288"
 }
+
 {
 "spawnflags"	"257"
 "classname"	"monster_army"
@@ -8393,38 +8563,45 @@
 "angle"	"180"
 "targetname"	"t89"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"1400 640 272"
 "targetname"	"t30"
 "target"	"t79"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"1496 752 232"
 "targetname"	"t33"
 "target"	"t77"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"1192 560 296"
 "targetname"	"t34"
 "target"	"t80"
 }
+
 {
 "classname"	"item_shells"
 "origin"	"1616 1280 176"
 }
+
 {
 "classname"	"item_health"
 "origin"	"1056 -840 416"
 "spawnflags"	"1"
 }
+
 {
 "classname"	"item_health"
 "origin"	"1104 -840 416"
 "spawnflags"	"1"
 }
+
 {
 "spawnflags"	"1"
 "classname"	"monster_army"
@@ -8432,68 +8609,84 @@
 "angle"	"0"
 "target"	"t96"
 }
+
 {
 "spawnflags"	"1024"
 "classname"	"item_health"
 "origin"	"136 -296 296"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"-536 -704 472"
 "targetname"	"t42"
 "target"	"t41"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"-576 -416 472"
 "targetname"	"t41"
 "target"	"t42"
 }
+
 {
 "classname"	"monster_knight"
 "origin"	"-578 -654 480"
 "target"	"t41"
 "spawnflags"	"1"
 }
+
 {
 "classname"	"item_shells"
 "origin"	"-368 -752 456"
 }
+
 {
 "classname"	"item_health"
 "origin"	"-16 -520 360"
 "spawnflags"	"1"
 }
+
 {
 "classname"	"item_health"
 "origin"	"-16 -576 360"
 "spawnflags"	"1"
 }
+
 {
 "classname"	"light"
 "origin"	"1848 -568 320"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1760 -560 408"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1624 -560 352"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "targetname"	"t43"
 "angle"	"270"
 "origin"	"800 368 312"
 "classname"	"info_teleport_destination"
 }
+
 {
 "origin"	"752 168 296"
 "classname"	"item_health"
 }
+
 {
 "target"	"t43"
 "classname"	"trigger_teleport"
@@ -8506,30 +8699,39 @@
 ( 1880 -520 272 ) ( 1848 -520 272 ) ( 1848 -608 272 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "origin"	"1712 -568 256"
 "classname"	"item_health"
 }
+
 {
 "classname"	"monster_ogre"
 "origin"	"1494 1134 208"
 "angle"	"270"
 "target"	"t22"
 }
+
 {
 "light"	"300"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1856 1288 384"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1136 1288 384"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1920 328 380"
 "classname"	"light"
 }
+
 {
 "target"	"t122"
 "spawnflags"	"2048"
@@ -8537,89 +8739,129 @@
 "classname"	"item_key1"
 "origin"	"880 -300 464"
 }
+
 {
 "light"	"300"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 "origin"	"648 -384 430"
 "classname"	"light_flame_small_yellow"
 }
+
 {
 "light"	"250"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 "classname"	"light_flame_small_yellow"
 "origin"	"1104 -224 406"
 }
+
 {
 "light"	"250"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 "origin"	"1456 -128 406"
 "classname"	"light_flame_small_yellow"
 }
+
 {
 "classname"	"light"
 "origin"	"988 532 353"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1100 648 328"
 "classname"	"light"
 }
+
 {
 "origin"	"1616 936 310"
 "classname"	"light_flame_small_yellow"
 "light"	"300"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 }
+
 {
 "light"	"300"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 "classname"	"light_flame_small_yellow"
 "origin"	"1360 936 310"
 }
+
 {
 "origin"	"1792 504 390"
 "classname"	"light_flame_small_yellow"
 "light"	"300"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 }
+
 {
 "origin"	"1972 -252 332"
 "classname"	"info_null"
 "targetname"	"t47"
 }
+
 {
 "light"	"800"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1992 -252 336"
 "classname"	"light"
 "target"	"t47"
 }
+
 {
 "classname"	"info_null"
 "origin"	"1948 -292 332"
 "targetname"	"t48"
 }
+
 {
 "light"	"800"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 "origin"	"1948 -312 336"
 "target"	"t48"
 }
+
 {
 "origin"	"880 -328 562"
 "classname"	"light_flame_small_yellow"
 "light"	"300"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 }
+
 {
 "classname"	"light"
 "origin"	"1056 -1288 504"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"1184 -1288 504"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1312 -1288 504"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"1440 -1288 504"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "sounds"	"1"
 "classname"	"func_door"
@@ -8635,6 +8877,7 @@
 ( 1440 -1048 416 ) ( 1280 -1048 416 ) ( 1280 -1072 416 ) WMET4_3 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"1"
 "classname"	"func_door"
@@ -8650,6 +8893,7 @@
 ( 1216 -1048 416 ) ( 1056 -1048 416 ) ( 1056 -1072 416 ) WMET4_3 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_once"
 "target"	"t50"
@@ -8662,65 +8906,93 @@
 ( 1464 -832 416 ) ( 1440 -832 416 ) ( 1440 -1064 416 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"1368 -1016 504"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1120 -1024 504"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1248 -1184 464"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"776 -480 480"
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1904 -144 168"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light_torch_small_walltorch"
 "origin"	"1706 -206 316"
 "light"	"300"
+	"style"	"1"
+	"_color"	"1.00 0.55 0.24"
 }
+
 {
 "light"	"300"
+	"style"	"1"
+	"_color"	"1.00 0.55 0.24"
 "origin"	"2134 -34 316"
 "classname"	"light_torch_small_walltorch"
 }
+
 {
 "origin"	"1152 -296 422"
 "classname"	"light_flame_small_yellow"
 "light"	"250"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 }
+
 {
 "light"	"250"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 "classname"	"light_flame_small_yellow"
 "origin"	"1152 -760 422"
 }
+
 {
 "origin"	"1528 -556 478"
 "classname"	"light_flame_small_yellow"
 "light"	"250"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 }
+
 {
 "targetname"	"t52"
 "origin"	"1532 -552 328"
 "classname"	"info_null"
 }
+
 {
 "origin"	"1340 -544 384"
 "classname"	"item_armor2"
 }
+
 {
 "sounds"	"1"
 "targetname"	"t53"
@@ -8753,6 +9025,7 @@
 ( 1364 -584 376 ) ( 1320 -584 376 ) ( 1320 -592 376 ) WIZMET1_2 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"1"
 "targetname"	"t53"
@@ -8785,6 +9058,7 @@
 ( 1316 -504 376 ) ( 1360 -504 376 ) ( 1360 -496 376 ) WIZMET1_2 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "targetname"	"t53"
 "target"	"t54"
@@ -8799,12 +9073,14 @@
 ( 1888 -896 169 ) ( 1864 -896 169 ) ( 1864 -976 169 ) WBRICK1_5 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "targetname"	"t54"
 "angle"	"180"
 "origin"	"1408 -688 449"
 "classname"	"info_teleport_destination"
 }
+
 {
 "targetname"	"t53"
 "target"	"t57"
@@ -8819,12 +9095,14 @@
 ( 1888 -808 169 ) ( 1864 -808 169 ) ( 1864 -888 169 ) WBRICK1_5 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "targetname"	"t57"
 "angle"	"180"
 "origin"	"1408 -400 361"
 "classname"	"info_teleport_destination"
 }
+
 {
 "spawnflags"	"768"
 "targetname"	"t53"
@@ -8832,6 +9110,7 @@
 "origin"	"1912 -856 217"
 "classname"	"monster_wizard"
 }
+
 {
 "spawnflags"	"768"
 "targetname"	"t53"
@@ -8839,12 +9118,14 @@
 "origin"	"1912 -936 217"
 "angle"	"180"
 }
+
 {
 "targetname"	"t50"
 "angle"	"90"
 "origin"	"1320 -1112 441"
 "classname"	"monster_knight"
 }
+
 {
 "spawnflags"	"256"
 "targetname"	"t50"
@@ -8852,6 +9133,7 @@
 "origin"	"1056 -1144 441"
 "classname"	"monster_knight"
 }
+
 {
 "sounds"	"1"
 "targetname"	"t61"
@@ -8883,6 +9165,7 @@
 ( 992 -568 232 ) ( 992 -536 248 ) ( 1008 -568 232 ) WBRICK1_5 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"3"
 "lip"	"64"
@@ -8900,6 +9183,7 @@
 ( 928 -320 392 ) ( 840 -320 392 ) ( 840 -696 392 ) WIZWOOD1_5 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"1"
 "wait"	"-1"
@@ -8915,6 +9199,7 @@
 ( 1264 -1200 440 ) ( 1232 -1200 440 ) ( 1232 -1208 440 ) DOOR05_3 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "target"	"t61"
 "classname"	"trigger_once"
@@ -8927,40 +9212,55 @@
 ( 992 -344 321 ) ( 768 -344 321 ) ( 768 -696 321 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"984 -480 480"
 "classname"	"light"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"880 -368 176"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"880 -592 240"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"880 -488 184"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"880 -304 472"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-96 308 864"
 "light"	"850"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"-32 -440 624"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "sounds"	"1"
 "targetname"	"t73"
@@ -8985,16 +9285,21 @@
 ( 320 368 296 ) ( 232 368 296 ) ( 232 272 296 ) WBRICK1_5 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "light"	"300"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"104 144 688"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-264 144 688"
 "light"	"300"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "sounds"	"1"
 "targetname"	"t73"
@@ -9019,11 +9324,15 @@
 ( -480 368 296 ) ( -480 280 296 ) ( -384 280 296 ) WBRICK1_5 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light_flame_small_yellow"
 "origin"	"-24 -232 414"
 "light"	"250"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 }
+
 {
 "lip"	"-2"
 "sounds"	"3"
@@ -9041,18 +9350,21 @@
 ( -24 480 296 ) ( -152 480 296 ) ( -152 464 296 ) DOOR04_1 32 112 0 1.000000 1.000000
 }
 }
+
 {
 "target"	"t63"
 "targetname"	"t62"
 "origin"	"-12 312 264"
 "classname"	"path_corner"
 }
+
 {
 "target"	"t64"
 "targetname"	"t63"
 "origin"	"-12 312 356"
 "classname"	"path_corner"
 }
+
 {
 "wait"	"-1"
 "target"	"t66"
@@ -9060,6 +9372,7 @@
 "classname"	"path_corner"
 "origin"	"-13 440 355"
 }
+
 {
 "sounds"	"1"
 "targetname"	"t71"
@@ -9076,34 +9389,42 @@
 ( -48 272 292 ) ( -112 272 292 ) ( -112 240 292 ) +1FLOORSW 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "target"	"t64"
 "targetname"	"t66"
 "origin"	"-13 440 355"
 "classname"	"path_corner"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-96 440 376"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"8 456 376"
 "classname"	"light"
 }
+
 {
 "targetname"	"t70"
 "target"	"t67"
 "classname"	"path_corner"
 "origin"	"-220 312 264"
 }
+
 {
 "target"	"t68"
 "targetname"	"t67"
 "classname"	"path_corner"
 "origin"	"-220 312 356"
 }
+
 {
 "wait"	"-1"
 "target"	"t69"
@@ -9111,17 +9432,21 @@
 "origin"	"-221 440 355"
 "classname"	"path_corner"
 }
+
 {
 "target"	"t68"
 "targetname"	"t69"
 "classname"	"path_corner"
 "origin"	"-221 440 355"
 }
+
 {
 "classname"	"light"
 "origin"	"-200 456 376"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "targetname"	"t65"
 "target"	"t62"
@@ -9137,22 +9462,29 @@
 ( 24 200 436 ) ( 0 200 436 ) ( 0 176 436 ) WMET4_5 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "light"	"250"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 "origin"	"-96 632 406"
 "classname"	"light_flame_small_yellow"
 }
+
 {
 "targetname"	"t72"
 "origin"	"-96 288 304"
 "classname"	"info_null"
 }
+
 {
 "light"	"450"
+	"_color"	"0.88 0.74 0.58"
 "target"	"t72"
 "origin"	"-96 288 368"
 "classname"	"light"
 }
+
 {
 "target"	"t70"
 "targetname"	"t65"
@@ -9168,6 +9500,7 @@
 ( -168 200 436 ) ( -192 200 436 ) ( -192 176 436 ) WMET4_5 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "lip"	"-2"
 "sounds"	"0"
@@ -9184,6 +9517,7 @@
 ( 48 480 296 ) ( -80 480 296 ) ( -80 464 296 ) DOOR04_1 32 112 0 1.000000 1.000000
 }
 }
+
 {
 "targetname"	"t65"
 "delay"	"4.7"
@@ -9198,6 +9532,7 @@
 ( -64 444 536 ) ( -128 444 536 ) ( -128 428 536 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "targetname"	"t73"
 "angle"	"270"
@@ -9205,18 +9540,21 @@
 "classname"	"monster_demon1"
 "spawnflags"	"1024"
 }
+
 {
 "targetname"	"t74"
 "angle"	"90"
 "origin"	"132 -192 476"
 "classname"	"info_teleport_destination"
 }
+
 {
 "targetname"	"t75"
 "classname"	"info_teleport_destination"
 "origin"	"-328 -196 476"
 "angle"	"90"
 }
+
 {
 "target"	"t75"
 "classname"	"trigger_teleport"
@@ -9230,6 +9568,7 @@
 ( 296 280 308 ) ( 300 284 308 ) ( 264 320 308 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "target"	"t74"
 "classname"	"trigger_teleport"
@@ -9243,16 +9582,21 @@
 ( -460 280 308 ) ( -456 276 308 ) ( -420 312 308 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-418 306 356"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"260 308 356"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "sounds"	"0"
 "targetname"	"t73"
@@ -9268,6 +9612,7 @@
 ( -32 28 312 ) ( -160 28 312 ) ( -160 12 312 ) WMET2_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"0"
 "targetname"	"t73"
@@ -9283,6 +9628,7 @@
 ( -32 -16 312 ) ( -160 -16 312 ) ( -160 -32 312 ) WMET2_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"0"
 "wait"	"-1"
@@ -9298,6 +9644,7 @@
 ( -32 28 384 ) ( -160 28 384 ) ( -160 12 384 ) WMET2_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"0"
 "targetname"	"t73"
@@ -9313,6 +9660,7 @@
 ( -32 -16 384 ) ( -160 -16 384 ) ( -160 -32 384 ) WMET2_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"3"
 "wait"	"-1"
@@ -9328,92 +9676,123 @@
 ( -88 8 296 ) ( -104 8 296 ) ( -104 -8 296 ) WMET2_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"-96 24 360"
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-96 -40 360"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-160 -568 624"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"-160 -440 624"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-32 -568 624"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-96 -88 484"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-440 -408 804"
 "light"	"450"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"600 -128 352"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"576 -608 504"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"384 -504 392"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1264 240 295"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"944 240 295"
 "classname"	"light"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"1480 704 264"
 "targetname"	"t77"
 "target"	"t78"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"1448 656 264"
 "targetname"	"t78"
 "target"	"t30"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"1264 640 304"
 "targetname"	"t80"
 "target"	"t5"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"1328 640 304"
 "targetname"	"t79"
 "target"	"t80"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1488 -392 216"
 "classname"	"light"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"816 80 304"
@@ -9421,6 +9800,7 @@
 "target"	"t82"
 "spawnflags"	"256"
 }
+
 {
 "origin"	"816 312 304"
 "classname"	"path_corner"
@@ -9428,6 +9808,7 @@
 "target"	"t83"
 "spawnflags"	"256"
 }
+
 {
 "classname"	"monster_army"
 "origin"	"806 206 320"
@@ -9435,6 +9816,7 @@
 "target"	"t82"
 "spawnflags"	"256"
 }
+
 {
 "classname"	"trigger_once"
 "target"	"t84"
@@ -9447,36 +9829,42 @@
 ( 1488 448 288 ) ( 1472 448 288 ) ( 1472 336 288 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"monster_ogre"
 "origin"	"1790 -146 312"
 "angle"	"90"
 "targetname"	"t84"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"1088 -672 296"
 "target"	"t85"
 "targetname"	"t88"
 }
+
 {
 "origin"	"1088 -376 296"
 "classname"	"path_corner"
 "targetname"	"t85"
 "target"	"t86"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"1088 -376 296"
 "targetname"	"t87"
 "target"	"t88"
 }
+
 {
 "origin"	"1448 -376 296"
 "classname"	"path_corner"
 "targetname"	"t86"
 "target"	"t87"
 }
+
 {
 "spawnflags"	"1"
 "classname"	"monster_ogre"
@@ -9484,6 +9872,7 @@
 "angle"	"270"
 "target"	"t88"
 }
+
 {
 "spawnflags"	"256"
 "classname"	"trigger_once"
@@ -9497,69 +9886,81 @@
 ( 1216 -496 288 ) ( 1080 -496 288 ) ( 1080 -512 288 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"item_health"
 "origin"	"352 -752 408"
 "spawnflags"	"1025"
 }
+
 {
 "spawnflags"	"1025"
 "origin"	"352 -792 408"
 "classname"	"item_health"
 }
+
 {
 "classname"	"item_health"
 "origin"	"352 -832 408"
 "spawnflags"	"1"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"408 -776 416"
 "targetname"	"t94"
 "target"	"t95"
 }
+
 {
 "origin"	"400 -1088 416"
 "classname"	"path_corner"
 "targetname"	"t95"
 "target"	"t94"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"584 -1096 416"
 "targetname"	"t92"
 "target"	"t93"
 }
+
 {
 "origin"	"584 -792 416"
 "classname"	"path_corner"
 "targetname"	"t93"
 "target"	"t92"
 }
+
 {
 "classname"	"monster_army"
 "origin"	"390 -970 432"
 "angle"	"0"
 "target"	"t94"
 }
+
 {
 "classname"	"monster_army"
 "origin"	"566 -970 432"
 "angle"	"270"
 "target"	"t92"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"208 -304 304"
 "targetname"	"t97"
 "target"	"t96"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"208 -464 304"
 "targetname"	"t96"
 "target"	"t97"
 }
+
 {
 "spawnflags"	"1280"
 "classname"	"path_corner"
@@ -9567,6 +9968,7 @@
 "targetname"	"t100"
 "target"	"t99"
 }
+
 {
 "spawnflags"	"1280"
 "origin"	"168 152 304"
@@ -9574,6 +9976,7 @@
 "targetname"	"t99"
 "target"	"t100"
 }
+
 {
 "spawnflags"	"1280"
 "classname"	"monster_ogre"
@@ -9581,6 +9984,7 @@
 "angle"	"180"
 "target"	"t99"
 }
+
 {
 "spawnflags"	"768"
 "classname"	"monster_ogre"
@@ -9588,6 +9992,7 @@
 "angle"	"0"
 "targetname"	"t101"
 }
+
 {
 "spawnflags"	"768"
 "classname"	"trigger_once"
@@ -9601,160 +10006,207 @@
 ( 304 -16 296 ) ( 104 -16 296 ) ( 104 -24 296 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"item_health"
 "origin"	"40 -16 464"
 }
+
 {
 "origin"	"80 -48 464"
 "classname"	"item_health"
 }
+
 {
 "origin"	"520 -72 296"
 "classname"	"item_shells"
 }
+
 {
 "spawnflags"	"1"
 "origin"	"-424 -216 296"
 "classname"	"item_shells"
 }
+
 {
 "spawnflags"	"769"
 "angle"	"270"
 "origin"	"880 -400 568"
 "classname"	"monster_wizard"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"432 176 152"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"432 -56 256"
 "classname"	"light"
 }
+
 {
 "origin"	"264 -96 300"
 "classname"	"item_health"
 }
+
 {
 "classname"	"item_health"
 "origin"	"264 -140 300"
 }
+
 {
 "spawnflags"	"1"
 "origin"	"1184 1568 240"
 "classname"	"item_health"
 }
+
 {
 "classname"	"item_health"
 "origin"	"1184 1616 240"
 "spawnflags"	"1"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1496 1112 108"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1120 1152 96"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1080 692 184"
 "classname"	"light"
 }
+
 {
 "light"	"300"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 "classname"	"light_flame_small_yellow"
 "origin"	"832 1184 294"
 }
+
 {
 "origin"	"464 536 358"
 "classname"	"light_flame_small_yellow"
 "light"	"300"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 }
+
 {
 "light"	"300"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 "classname"	"light_flame_small_yellow"
 "origin"	"600 704 334"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1736 1096 110"
 "classname"	"light"
 }
+
 {
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"832 1056 134"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"784 704 294"
 "classname"	"light"
 }
+
 {
 "origin"	"856 592 182"
 "classname"	"item_health"
 }
+
 {
 "classname"	"item_health"
 "origin"	"824 552 182"
 }
+
 {
 "classname"	"info_player_deathmatch"
 "origin"	"-416 -144 320"
 "angle"	"90"
 }
+
 {
 "classname"	"info_player_deathmatch"
 "origin"	"168 -480 320"
 "angle"	"45"
 }
+
 {
 "classname"	"info_player_deathmatch"
 "origin"	"1496 1328 200"
 "angle"	"270"
 }
+
 {
 "classname"	"info_player_deathmatch"
 "origin"	"1936 -136 312"
 "angle"	"180"
 }
+
 {
 "classname"	"info_player_deathmatch"
 "origin"	"936 -1216 432"
 "angle"	"180"
 }
+
 {
 "classname"	"info_player_deathmatch"
 "origin"	"792 -992 440"
 "angle"	"45"
 }
+
 {
 "classname"	"info_player_deathmatch"
 "origin"	"1080 -720 312"
 "angle"	"0"
 }
+
 {
 "classname"	"info_player_deathmatch"
 "origin"	"408 -752 432"
 "angle"	"270"
 }
+
 {
 "classname"	"info_player_deathmatch"
 "origin"	"792 -208 320"
 "angle"	"45"
 }
+
 {
 "classname"	"info_player_deathmatch"
 "origin"	"784 808 206"
 "angle"	"225"
 }
+
 {
 "sounds"	"3"
 "wait"	"3"
@@ -9769,6 +10221,7 @@
 ( 736 -64 304 ) ( 720 -64 304 ) ( 720 -128 304 ) DOOR04_1 64 112 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"0"
 "wait"	"3"
@@ -9783,31 +10236,38 @@
 ( 736 -128 304 ) ( 720 -128 304 ) ( 720 -192 304 ) DOOR04_1 64 112 0 1.000000 1.000000
 }
 }
+
 {
 "spawnflags"	"1"
 "origin"	"680 832 182"
 "classname"	"item_shells"
 }
+
 {
 "origin"	"1392 240 300"
 "classname"	"weapon_supershotgun"
 }
+
 {
 "spawnflags"	"769"
 "angle"	"270"
 "origin"	"954 -754 444"
 "classname"	"monster_ogre"
 }
+
 {
 "spawnflags"	"1"
 "origin"	"520 -1280 408"
 "classname"	"item_shells"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-612 -500 548"
 "classname"	"light"
 }
+
 {
 "classname"	"func_door"
 "angle"	"90"
@@ -9822,6 +10282,7 @@
 ( -640 -376 456 ) ( -656 -376 456 ) ( -656 -488 456 ) METAL5_6 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"3"
 "classname"	"func_door"
@@ -9836,6 +10297,7 @@
 ( -640 -488 456 ) ( -656 -488 456 ) ( -656 -600 456 ) METAL5_6 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_once"
 "target"	"t110"
@@ -9848,6 +10310,7 @@
 ( -632 -400 464 ) ( -640 -400 464 ) ( -640 -560 464 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_changelevel"
 "map"	"e1m3"
@@ -9860,47 +10323,56 @@
 ( -664 -376 464 ) ( -672 -376 464 ) ( -672 -624 464 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "spawnflags"	"1792"
 "origin"	"680 728 184"
 "classname"	"weapon_rocketlauncher"
 }
+
 {
 "spawnflags"	"1792"
 "origin"	"1496 1256 176"
 "classname"	"weapon_nailgun"
 }
+
 {
 "angle"	"180"
 "spawnflags"	"1792"
 "origin"	"-96 -496 360"
 "classname"	"weapon_supernailgun"
 }
+
 {
 "spawnflags"	"1794"
 "origin"	"-112 -8 464"
 "classname"	"item_health"
 }
+
 {
 "spawnflags"	"1793"
 "origin"	"-112 -568 360"
 "classname"	"item_spikes"
 }
+
 {
 "spawnflags"	"1792"
 "origin"	"1616 1424 176"
 "classname"	"item_spikes"
 }
+
 {
 "spawnflags"	"1792"
 "classname"	"item_spikes"
 "origin"	"1656 1424 176"
 }
+
 {
 "spawnflags"	"1792"
 "origin"	"1696 1424 176"
 "classname"	"item_spikes"
 }
+
 {
 "spawnflags"	"768"
 "target"	"t34"
@@ -9908,6 +10380,7 @@
 "origin"	"1070 646 312"
 "classname"	"monster_ogre"
 }
+
 {
 "spawnflags"	"768"
 "targetname"	"t84"
@@ -9915,6 +10388,7 @@
 "origin"	"1624 88 376"
 "classname"	"monster_wizard"
 }
+
 {
 "spawnflags"	"768"
 "angle"	"90"
@@ -9922,12 +10396,14 @@
 "origin"	"1866 -378 312"
 "classname"	"monster_ogre"
 }
+
 {
 "angle"	"45"
 "origin"	"1088 -1096 440"
 "classname"	"monster_knight"
 "targetname"	"t50"
 }
+
 {
 "spawnflags"	"768"
 "classname"	"monster_knight"
@@ -9935,6 +10411,7 @@
 "angle"	"90"
 "targetname"	"t50"
 }
+
 {
 "spawnflags"	"256"
 "target"	"t111"
@@ -9942,6 +10419,7 @@
 "origin"	"896 -1216 416"
 "classname"	"path_corner"
 }
+
 {
 "spawnflags"	"256"
 "target"	"t112"
@@ -9949,6 +10427,7 @@
 "classname"	"path_corner"
 "origin"	"704 -1216 416"
 }
+
 {
 "spawnflags"	"257"
 "target"	"t111"
@@ -9956,6 +10435,7 @@
 "origin"	"758 -1218 432"
 "classname"	"monster_army"
 }
+
 {
 "spawnflags"	"768"
 "target"	"t114"
@@ -9963,6 +10443,7 @@
 "origin"	"-96 -520 368"
 "classname"	"path_corner"
 }
+
 {
 "spawnflags"	"768"
 "target"	"t113"
@@ -9970,6 +10451,7 @@
 "origin"	"-96 -152 304"
 "classname"	"path_corner"
 }
+
 {
 "targetname"	"t116"
 "spawnflags"	"769"
@@ -9978,16 +10460,19 @@
 "origin"	"-98 -194 320"
 "classname"	"monster_ogre"
 }
+
 {
 "spawnflags"	"1536"
 "origin"	"1936 -96 289"
 "classname"	"item_health"
 }
+
 {
 "spawnflags"	"1025"
 "origin"	"1040 -1200 417"
 "classname"	"item_health"
 }
+
 {
 "spawnflags"	"769"
 "target"	"t117"
@@ -9995,6 +10480,7 @@
 "origin"	"-560 -312 592"
 "classname"	"monster_wizard"
 }
+
 {
 "spawnflags"	"768"
 "target"	"t118"
@@ -10002,6 +10488,7 @@
 "origin"	"-528 -344 576"
 "classname"	"path_corner"
 }
+
 {
 "spawnflags"	"768"
 "target"	"t117"
@@ -10009,475 +10496,666 @@
 "origin"	"-352 -656 576"
 "classname"	"path_corner"
 }
+
 {
 "classname"	"light"
 "origin"	"1360 976 224"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1616 976 224"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1208 1296 368"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"1784 1288 368"
 "classname"	"light"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1496 1664 336"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1752 1176 112"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1776 976 112"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1216 976 112"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1224 1176 112"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1496 1432 520"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1496 1304 264"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1496 1432 288"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1608 1120 88"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1384 1120 88"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1496 864 368"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"980 764 353"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1228 764 353"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1104 464 353"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1104 -40 423"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1416 -128 367"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1104 -184 367"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1184 56 423"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1024 56 423"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1272 -64 399"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"888 -64 399"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1104 152 129"
 "light"	"300"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"976 392 129"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1104 656 120"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"896 712 144"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"640 704 280"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"464 496 296"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"888 1152 96"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"840 880 240"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"848 584 240"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"784 160 144"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"440 336 144"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"584 336 144"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"432 24 136"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"656 328 224"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"432 -128 312"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"600 -384 360"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"520 -128 406"
 "classname"	"light_flame_small_yellow"
 "light"	"250"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 }
+
 {
 "classname"	"light"
 "origin"	"424 -320 352"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"664 -1216 472"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"336 -1208 504"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"336 -1008 504"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"336 -816 504"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"880 -1000 496"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"880 -792 496"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"880 -376 304"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1048 -912 480"
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1120 -1192 468"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1376 -1192 468"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1472 -912 464"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"880 -304 480"
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"880 -680 480"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1600 -704 484"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1504 -704 348"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1336 -704 348"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1152 -640 332"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1096 -552 348"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1160 -456 332"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1216 -384 348"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1344 -384 348"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1544 392 156"
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1848 248 156"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1936 136 156"
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"2096 -80 156"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"2048 -408 156"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1456 -392 444"
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1640 -384 352"
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light_torch_small_walltorch"
 "origin"	"2134 -474 316"
 "light"	"250"
+	"style"	"1"
+	"_color"	"1.00 0.55 0.24"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"168 216 496"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-328 208 496"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-96 360 432"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-96 144 432"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-376 32 432"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"208 -72 432"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-96 72 360"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-64 -232 368"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-96 -320 560"
 "classname"	"light"
 }
+
 {
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-96 -496 448"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-416 -104 392"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-344 -152 528"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"160 -152 528"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-96 8 528"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-560 -504 688"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-440 -368 688"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-440 -656 688"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-336 -504 688"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"2084 -208 336"
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"2012 -252 332"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1948 -328 332"
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1892 -452 332"
 "classname"	"light"
 }
+
 {
 "sounds"	"1"
 "targetname"	"t120"
@@ -10494,6 +11172,7 @@
 ( 472 -240 296 ) ( 392 -240 296 ) ( 392 -256 296 ) WBRICK1_5 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "target"	"t120"
 "classname"	"trigger_once"
@@ -10506,11 +11185,14 @@
 ( 488 -152 240 ) ( 376 -152 240 ) ( 376 -160 240 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"2076 -312 336"
 "classname"	"light"
 }
+
 {
 "sounds"	"3"
 "spawnflags"	"2064"
@@ -10550,6 +11232,7 @@
 ( 304 -248 304 ) ( 304 -232 304 ) ( 240 -232 304 ) DOOR04_1 80 112 0 1.000000 1.000000
 }
 }
+
 {
 "spawnflags"	"2064"
 "wait"	"-1"
@@ -10588,21 +11271,28 @@
 ( 240 -232 304 ) ( 176 -232 304 ) ( 176 -248 304 ) DOOR04_1 80 112 0 1.000000 1.000000
 }
 }
+
 {
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"332 -264 356"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"144 -264 356"
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1104 572 316"
 "classname"	"light"
 }
+
 {
 "target"	"t121"
 "wait"	".8"
@@ -10616,6 +11306,7 @@
 ( 2112 -56 326 ) ( 1888 -56 326 ) ( 1888 -480 326 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "targetname"	"t121"
 "angle"	"180"
@@ -10623,6 +11314,7 @@
 "classname"	"trap_spikeshooter"
 "spawnflags"	"1024"
 }
+
 {
 "targetname"	"t121"
 "angle"	"90"
@@ -10630,21 +11322,28 @@
 "classname"	"trap_spikeshooter"
 "spawnflags"	"1024"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1312 -856 472"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1184 -856 472"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1560 -568 224"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"func_door"
 "angle"	"-2"
@@ -10662,6 +11361,7 @@
 ( 1568 -512 144 ) ( 1536 -512 144 ) ( 1536 -616 144 ) WBRICK1_5 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_once"
 "target"	"t123"
@@ -10674,36 +11374,48 @@
 ( 1536 -448 192 ) ( 1152 -448 192 ) ( 1152 -640 192 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"1496 -552 330"
 "light"	"700"
+	"_color"	"0.88 0.74 0.58"
 "target"	"t52"
 }
+
 {
 "classname"	"light"
 "origin"	"1288 80 140"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1288 400 80"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1328 -664 160"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"item_armor1"
 "origin"	"784 56 304"
 }
+
 {
 "classname"	"light"
 "origin"	"1544 464 352"
 "light"	"75"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"func_plat"
 {
@@ -10739,126 +11451,168 @@
 ( 1336 96 272 ) ( 1216 96 272 ) ( 1216 16 272 ) WMET4_5 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"1496 1192 280"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1608 1192 136"
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1384 1184 136"
 "classname"	"light"
 }
+
 {
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1608 1048 136"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1384 1048 136"
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1200 1148 92"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"876 -184 367"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"768 -128 384"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1104 388 552"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1392 240 384"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1392 80 368"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1272 400 367"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"920 400 367"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"816 208 368"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"800 24 368"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"800 376 385"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1400 400 385"
 "classname"	"light"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"1104 336 300"
 "target"	"t126"
 "targetname"	"t127"
 }
+
 {
 "origin"	"1104 24 300"
 "classname"	"path_corner"
 "targetname"	"t126"
 "target"	"t127"
 }
+
 {
 "classname"	"monster_army"
 "origin"	"1104 424 316"
 "angle"	"270"
 "target"	"t127"
 }
+
 {
 "targetname"	"t128"
 "origin"	"1392 240 308"
 "classname"	"info_null"
 }
+
 {
 "light"	"300"
+	"_color"	"0.88 0.74 0.58"
 "target"	"t128"
 "origin"	"1392 240 376"
 "classname"	"light"
 }
+
 {
 "targetname"	"t129"
 "angle"	"0"
 "origin"	"552 -128 320"
 "classname"	"monster_army"
 }
+
 {
 "target"	"t129"
 "classname"	"trigger_once"
@@ -10871,6 +11625,7 @@
 ( 656 -1000 416 ) ( 344 -1000 416 ) ( 344 -1008 416 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"1"
 "classname"	"trigger_secret"
@@ -10883,6 +11638,7 @@
 ( 880 896 184 ) ( 584 896 184 ) ( 584 672 184 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"1"
 "classname"	"trigger_secret"
@@ -10895,11 +11651,14 @@
 ( 1576 -528 184 ) ( 1568 -528 184 ) ( 1568 -600 184 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"1104 24 536"
 "light"	"350"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "spawnflags"	"1"
 "classname"	"func_door_secret"
@@ -10913,30 +11672,38 @@
 ( 1176 1192 48 ) ( 1160 1192 48 ) ( 1160 1112 48 ) WSWAMP2_2 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1680 1552 320"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1312 1552 320"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"item_spikes"
 "origin"	"1480 1104 68"
 "spawnflags"	"1"
 }
+
 {
 "classname"	"item_spikes"
 "origin"	"1760 -568 256"
 "spawnflags"	"1"
 }
+
 {
 "classname"	"item_spikes"
 "origin"	"1232 -1200 416"
 }
+
 {
 "message"	"This door is opened elsewhere..."
 "classname"	"func_door"
@@ -10955,6 +11722,7 @@
 ( 880 -1048 416 ) ( 880 -1032 416 ) ( 808 -1032 416 ) ADOOR09_2 80 32 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"func_door"
 "angle"	"0"
@@ -10970,36 +11738,48 @@
 ( 952 -1032 416 ) ( 880 -1032 416 ) ( 880 -1048 416 ) ADOOR09_2 80 32 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"1496 1600 296"
 "light"	"150 "
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1568 1664 296"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1424 1664 296"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1328 1424 296"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1696 1416 296"
 "classname"	"light"
 }
+
 {
 "classname"	"monster_army"
 "origin"	"1592 1296 200"
 "angle"	"270"
 }
+
 {
 "spawnflags"	"768"
 "classname"	"monster_demon1"
@@ -11008,6 +11788,7 @@
 "targetname"	"t73"
 "target"	"t143"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"1392 416 304"
@@ -11015,6 +11796,7 @@
 "target"	"t130"
 "spawnflags"	"768"
 }
+
 {
 "origin"	"1392 296 304"
 "classname"	"path_corner"
@@ -11022,6 +11804,7 @@
 "target"	"t131"
 "spawnflags"	"768"
 }
+
 {
 "classname"	"monster_army"
 "origin"	"1392 352 320"
@@ -11029,18 +11812,21 @@
 "target"	"t130"
 "spawnflags"	"768"
 }
+
 {
 "target"	"t132"
 "targetname"	"t133"
 "origin"	"296 -328 304"
 "classname"	"path_corner"
 }
+
 {
 "target"	"t133"
 "targetname"	"t132"
 "classname"	"path_corner"
 "origin"	"472 -416 304"
 }
+
 {
 "spawnflags"	"1"
 "target"	"t132"
@@ -11048,6 +11834,7 @@
 "origin"	"472 -456 320"
 "classname"	"monster_army"
 }
+
 {
 "spawnflags"	"1"
 "targetname"	"t89"
@@ -11055,6 +11842,7 @@
 "origin"	"1712 -784 376"
 "classname"	"monster_army"
 }
+
 {
 "target"	"t135"
 "spawnflags"	"256"
@@ -11062,6 +11850,7 @@
 "origin"	"400 -1128 416"
 "classname"	"path_corner"
 }
+
 {
 "target"	"t134"
 "spawnflags"	"256"
@@ -11069,6 +11858,7 @@
 "classname"	"path_corner"
 "origin"	"400 -1248 416"
 }
+
 {
 "target"	"t134"
 "spawnflags"	"257"
@@ -11076,6 +11866,7 @@
 "origin"	"408 -1208 432"
 "classname"	"monster_army"
 }
+
 {
 "targetname"	"t101"
 "angle"	"90"
@@ -11083,6 +11874,7 @@
 "classname"	"monster_army"
 "spawnflags"	"768"
 }
+
 {
 "spawnflags"	"768"
 "targetname"	"t101"
@@ -11090,22 +11882,26 @@
 "origin"	"136 -128 488"
 "angle"	"90"
 }
+
 {
 "spawnflags"	"1792"
 "origin"	"-264 -24 464"
 "classname"	"item_rockets"
 }
+
 {
 "spawnflags"	"2048"
 "origin"	"-240 -8 464"
 "classname"	"item_spikes"
 }
+
 {
 "classname"	"monster_ogre"
 "origin"	"-304 -304 488"
 "angle"	"225"
 "spawnflags"	"769"
 }
+
 {
 "classname"	"func_wall"
 "spawnflags"	"768"
@@ -11150,6 +11946,7 @@
 ( 2040 -32 354 ) ( 2048 -32 354 ) ( 2048 -32 301 ) BLACK 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trap_spikeshooter"
 "origin"	"2048 -48 332"
@@ -11157,19 +11954,23 @@
 "spawnflags"	"769"
 "targetname"	"t121"
 }
+
 {
 "origin"	"2048 -476 332"
 "classname"	"info_null"
 "targetname"	"t136"
 }
+
 {
 "origin"	"2048 -456 336"
 "classname"	"light"
 "light"	"800"
+	"_color"	"0.88 0.74 0.58"
 "spawnflags"	"1"
 "target"	"t136"
 "targetname"	"t137"
 }
+
 {
 "classname"	"trigger_once"
 "spawnflags"	"768"
@@ -11183,6 +11984,7 @@
 ( 1520 1576 238 ) ( 1384 1576 238 ) ( 1384 1568 238 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"monster_wizard"
 "origin"	"672 328 384"
@@ -11190,6 +11992,7 @@
 "spawnflags"	"768"
 "targetname"	"t138"
 }
+
 {
 "classname"	"trigger_once"
 "target"	"t138"
@@ -11202,18 +12005,22 @@
 ( 632 536 80 ) ( 608 536 80 ) ( 608 288 80 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"2004 -52 332"
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 "spawnflags"	"1"
 "targetname"	"t137"
 }
+
 {
 "classname"	"item_shells"
 "origin"	"1416 224 300"
 "spawnflags"	"768"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"-344 136 304"
@@ -11221,6 +12028,7 @@
 "target"	"t140"
 "spawnflags"	"768"
 }
+
 {
 "origin"	"168 128 304"
 "classname"	"path_corner"
@@ -11228,12 +12036,14 @@
 "targetname"	"t140"
 "spawnflags"	"768"
 }
+
 {
 "classname"	"monster_ogre"
 "origin"	"-400 168 320"
 "spawnflags"	"768"
 "target"	"t139"
 }
+
 {
 "classname"	"trap_spikeshooter"
 "origin"	"2120 -256 332"
@@ -11241,6 +12051,7 @@
 "spawnflags"	"769"
 "targetname"	"t121"
 }
+
 {
 "classname"	"trap_spikeshooter"
 "origin"	"1944 -456 332"
@@ -11248,11 +12059,13 @@
 "angle"	"90"
 "spawnflags"	"769"
 }
+
 {
 "classname"	"item_spikes"
 "origin"	"-336 -80 470"
 "spawnflags"	"768"
 }
+
 {
 "targetname"	"t143"
 "classname"	"trigger_teleport"
@@ -11267,6 +12080,7 @@
 ( -128 776 335 ) ( -128 784 335 ) ( -256 784 335 ) WBRICK1_5 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "targetname"	"t143"
 "classname"	"trigger_teleport"
@@ -11281,6 +12095,7 @@
 ( 96 776 335 ) ( 96 784 335 ) ( -32 784 335 ) WBRICK1_5 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"monster_demon1"
 "origin"	"32 840 359"
@@ -11288,6 +12103,7 @@
 "targetname"	"t143"
 "spawnflags"	"768"
 }
+
 {
 "angle"	"270"
 "origin"	"-192 840 359"
@@ -11295,18 +12111,21 @@
 "targetname"	"t143"
 "spawnflags"	"768"
 }
+
 {
 "classname"	"info_teleport_destination"
 "origin"	"80 216 303"
 "angle"	"270"
 "targetname"	"t141"
 }
+
 {
 "angle"	"270"
 "origin"	"-264 224 303"
 "classname"	"info_teleport_destination"
 "targetname"	"t142"
 }
+
 {
 "wait"	"-1"
 "target"	"t53"
@@ -11321,27 +12140,32 @@
 ( 1536 -520 304 ) ( 1528 -520 304 ) ( 1528 -568 304 ) +0SHOOT 0 16 0 1.000000 1.000000
 }
 }
+
 {
 "spawnflags"	"768"
 "angle"	"270"
 "origin"	"1408 1296 200"
 "classname"	"monster_army"
 }
+
 {
 "classname"	"item_shells"
 "origin"	"772 -856 420"
 "spawnflags"	"768"
 }
+
 {
 "spawnflags"	"1792"
 "origin"	"1248 -1128 420"
 "classname"	"weapon_grenadelauncher"
 }
+
 {
 "spawnflags"	"1793"
 "origin"	"864 -312 440"
 "classname"	"item_rockets"
 }
+
 {
 "classname"	"trigger_once"
 "message"	"Pass through the arch to exit..."
@@ -11354,26 +12178,31 @@
 ( -392 -440 424 ) ( -400 -440 424 ) ( -400 -568 424 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "mangle"	"20 300 0"
 "classname"	"info_intermission"
 "origin"	"-224 424 512"
 }
+
 {
 "mangle"	"20 45 0"
 "origin"	"1048 -744 488"
 "classname"	"info_intermission"
 }
+
 {
 "mangle"	"20 270 0"
 "origin"	"1104 424 528"
 "classname"	"info_intermission"
 }
+
 {
 "mangle"	"20 45 0"
 "origin"	"1240 984 416"
 "classname"	"info_intermission"
 }
+
 {
 "sounds"	"1"
 "speed"	"20"
@@ -11390,11 +12219,14 @@
 ( 480 -960 416 ) ( 472 -960 416 ) ( 472 -1032 416 ) WBRICK1_5 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"400 -1392 480"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"func_door"
 "angle"	"-2"
@@ -11411,6 +12243,7 @@
 ( 448 -1288 408 ) ( 352 -1288 408 ) ( 352 -1312 408 ) WBRICK1_5 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_secret"
 {
@@ -11422,60 +12255,72 @@
 ( 448 -1320 408 ) ( 352 -1320 408 ) ( 352 -1328 408 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"item_artifact_super_damage"
 "origin"	"400 -1360 432"
 }
+
 {
 "classname"	"item_spikes"
 "origin"	"808 -632 192"
 "spawnflags"	"2049"
 }
+
 {
 "classname"	"item_health"
 "origin"	"924 -632 192"
 "spawnflags"	"2048"
 }
+
 {
 "classname"	"weapon_supernailgun"
 "origin"	"880 -616 192"
 "spawnflags"	"1792"
 }
+
 {
 "classname"	"ambient_drip"
 "origin"	"842 978 344"
 }
+
 {
 "classname"	"ambient_drip"
 "origin"	"546 330 400"
 }
+
 {
 "classname"	"info_player_coop"
 "origin"	"1608 1664 264"
 "angle"	"270"
 }
+
 {
 "angle"	"270"
 "origin"	"1392 1664 264"
 "classname"	"info_player_coop"
 }
+
 {
 "classname"	"info_player_coop"
 "origin"	"1496 1560 264"
 "angle"	"270"
 }
+
 {
 "spawnflags"	"256"
 "angle"	"270"
 "origin"	"232 -176 320"
 "classname"	"monster_ogre"
 }
+
 {
 "spawnflags"	"1280"
 "angle"	"225"
 "origin"	"-368 -312 480"
 "classname"	"monster_knight"
 }
+
 {
 "spawnflags"	"1792"
 "classname"	"func_wall"
@@ -11496,75 +12341,100 @@
 ( -616 -400 456 ) ( -632 -400 456 ) ( -632 -592 456 ) WMET4_5 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "origin"	"1810 274 200"
 "classname"	"ambient_drip"
 }
+
 {
 "classname"	"ambient_drip"
 "origin"	"1802 -102 200"
 }
+
 {
 "origin"	"2050 -214 200"
 "classname"	"ambient_drip"
 }
+
 {
 "classname"	"ambient_drip"
 "origin"	"2002 -390 200"
 }
+
 {
 "origin"	"1738 -398 200"
 "classname"	"ambient_drip"
 }
+
 {
 "classname"	"ambient_drip"
 "origin"	"1346 -398 200"
 }
+
 {
 "origin"	"1138 -542 200"
 "classname"	"ambient_drip"
 }
+
 {
 "classname"	"ambient_drip"
 "origin"	"882 -494 200"
 }
+
 {
 "classname"	"ambient_swamp1"
 "origin"	"1722 1090 176"
 }
+
 {
 "origin"	"1242 1090 176"
 "classname"	"ambient_swamp1"
 }
+
 {
 "classname"	"ambient_swamp2"
 "origin"	"1106 642 192"
 }
+
 {
 "origin"	"1346 242 192"
 "classname"	"ambient_swamp2"
 }
+
 {
 "classname"	"ambient_swamp1"
 "origin"	"866 210 192"
 }
+
 {
 "classname"	"ambient_swamp1"
 "origin"	"1802 90 192"
 }
+
 {
 "origin"	"1546 -398 192"
 "classname"	"ambient_swamp1"
 }
+
 {
 "classname"	"ambient_swamp2"
 "origin"	"2042 -310 192"
 }
+
 {
 "origin"	"1178 -398 192"
 "classname"	"ambient_swamp2"
 }
+
 {
 "classname"	"ambient_swamp2"
 "origin"	"1202 -678 192"
+}
+
+{
+	"classname"	"light_environment"
+	"_color"	"0.85 0.72 0.58"
+	"light"	"220"
+	"angles"	"45 120 0"
 }

--- a/Quake/maps/E1M3.MAP
+++ b/Quake/maps/E1M3.MAP
@@ -4,6 +4,12 @@
 "worldtype"	"0"
 "wad"	"gfx/wizard.wad"
 "classname"	"worldspawn"
+	"_ambient"	"18"
+	"_minlight"	"6"
+	"_sunlight"	"70"
+	"_sunlight_color"	"0.85 0.72 0.58"
+	"_sun_mangle"	"45 120 0"
+	"fog"	"0.03 0.08 0.11 0.18"
 {
 ( 1424 272 52 ) ( 1424 272 0 ) ( 1424 240 0 ) WSWAMP2_1 0 0 0 1.000000 1.000000
 ( 1412 272 52 ) ( 1424 272 52 ) ( 1424 240 52 ) WSWAMP2_1 0 0 0 1.000000 1.000000
@@ -8169,6 +8175,7 @@
 ( 592 -1240 -208 ) ( 584 -1240 -208 ) ( 584 -1344 -208 ) WSWAMP2_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "wait"	"-1"
 "sounds"	"3"
@@ -8183,6 +8190,7 @@
 ( 1360 264 -160 ) ( 1272 264 -160 ) ( 1272 248 -160 ) DOOR04_2 112 32 0 1.000000 1.000000
 }
 }
+
 {
 "wait"	"-1"
 "sounds"	"0"
@@ -8197,14 +8205,19 @@
 ( 1448 264 -160 ) ( 1360 264 -160 ) ( 1360 248 -160 ) DOOR04_2 112 32 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"1360 336 48"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"1360 440 476"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "speed"	"35"
 "targetname"	"t5"
@@ -8255,6 +8268,7 @@
 ( 1496 520 128 ) ( 1360 520 128 ) ( 1360 504 128 ) WIZMET1_2 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "speed"	"35"
 "targetname"	"t5"
@@ -8305,18 +8319,21 @@
 ( 1360 504 128 ) ( 1360 520 128 ) ( 1224 520 128 ) WIZMET1_2 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "target"	"t2"
 "targetname"	"t1"
 "origin"	"1360 296 136"
 "classname"	"path_corner"
 }
+
 {
 "target"	"t3"
 "targetname"	"t2"
 "origin"	"1360 296 -88"
 "classname"	"path_corner"
 }
+
 {
 "target"	"t4"
 "targetname"	"t3"
@@ -8324,24 +8341,28 @@
 "origin"	"1496 296 -88"
 "classname"	"path_corner"
 }
+
 {
 "target"	"t3"
 "targetname"	"t4"
 "classname"	"path_corner"
 "origin"	"1496 292 -80"
 }
+
 {
 "target"	"t8"
 "targetname"	"t6"
 "classname"	"path_corner"
 "origin"	"1224 296 136"
 }
+
 {
 "target"	"t7"
 "targetname"	"t8"
 "classname"	"path_corner"
 "origin"	"1224 296 -88"
 }
+
 {
 "target"	"t9"
 "targetname"	"t7"
@@ -8349,11 +8370,13 @@
 "origin"	"1084 296 -88"
 "wait"	"-1"
 }
+
 {
 "targetname"	"t9"
 "origin"	"1084 276 -80"
 "classname"	"path_corner"
 }
+
 {
 "sounds"	"2"
 "target"	"t5"
@@ -8369,11 +8392,14 @@
 ( 1400 572 -128 ) ( 1352 572 -128 ) ( 1352 568 -128 ) +0BUTTON 8 8 0 1.000000 1.000000
 }
 }
+
 {
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1360 552 -112"
 "classname"	"light"
 }
+
 {
 "sounds"	"0"
 "targetname"	"t5"
@@ -8392,6 +8418,7 @@
 ( 1448 288 -72 ) ( 1440 288 -72 ) ( 1440 280 -72 ) WMET2_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"1"
 "targetname"	"t5"
@@ -8411,6 +8438,7 @@
 ( 1448 296 -160 ) ( 1440 296 -160 ) ( 1440 288 -160 ) WMET2_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "delay"	"10.5"
 "target"	"t10"
@@ -8425,6 +8453,7 @@
 ( 1496 568 -56 ) ( 1480 568 -56 ) ( 1480 552 -56 ) WMET2_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"1"
 "targetname"	"t10"
@@ -8446,6 +8475,7 @@
 ( 1272 296 12 ) ( 1224 344 12 ) ( 1272 296 28 ) WIZMET1_7 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "targetname"	"t5"
 "dmg"	"1000"
@@ -8463,45 +8493,61 @@
 ( 1424 288 -20 ) ( 1296 288 -20 ) ( 1296 272 -20 ) WMET2_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-752 -1576 176"
 "classname"	"light"
 }
+
 {
 "angle"	"270"
 "origin"	"-736 -1592 88"
 "classname"	"info_player_start"
 }
+
 {
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-584 -1800 312"
 "classname"	"light"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-488 -1800 320"
 "classname"	"light"
 }
+
 {
 "origin"	"-288 -1800 308"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-176 -1616 320"
 "classname"	"light"
 }
+
 {
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 "origin"	"-184 -1248 280"
 }
+
 {
 "classname"	"light"
 "origin"	"-184 -1416 280"
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "sounds"	"0"
 "angle"	"90"
@@ -8515,6 +8561,7 @@
 ( -464 -1248 48 ) ( -464 -1160 48 ) ( -480 -1160 48 ) DOOR04_2 32 48 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"3"
 "angle"	"270"
@@ -8528,30 +8575,42 @@
 ( -464 -1336 48 ) ( -464 -1248 48 ) ( -480 -1248 48 ) DOOR04_2 32 48 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"-424 -1256 160"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light_flame_small_yellow"
 "origin"	"-312 -1000 158"
+	"_color"	"1.00 0.58 0.22"
+	"style"	"1"
 }
+
 {
 "origin"	"-400 -1096 158"
+	"_color"	"1.00 0.58 0.22"
+	"style"	"1"
 "classname"	"light_flame_small_yellow"
 }
+
 {
 "classname"	"info_null"
 "origin"	"-720 -1244 52"
 "targetname"	"t11"
 }
+
 {
 "light"	"400"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 "origin"	"-712 -1240 164"
 "target"	"t11"
 }
+
 {
 "sounds"	"0"
 "classname"	"func_door"
@@ -8569,6 +8628,7 @@
 ( -776 -1160 -32 ) ( -808 -1160 -32 ) ( -808 -1336 -32 ) WMET4_7 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"1"
 "classname"	"func_door"
@@ -8586,6 +8646,7 @@
 ( -736 -1160 -32 ) ( -768 -1160 -32 ) ( -768 -1336 -32 ) WMET4_7 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"0"
 "classname"	"func_door"
@@ -8603,6 +8664,7 @@
 ( -696 -1160 -32 ) ( -728 -1160 -32 ) ( -728 -1336 -32 ) WMET4_7 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"0"
 "classname"	"func_door"
@@ -8620,6 +8682,7 @@
 ( -656 -1160 -32 ) ( -688 -1160 -32 ) ( -688 -1336 -32 ) WMET4_7 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"1"
 "targetname"	"t12"
@@ -8636,6 +8699,7 @@
 ( -608 -1160 -32 ) ( -648 -1160 -32 ) ( -648 -1336 -32 ) WMET4_7 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "target"	"t13"
 "classname"	"trigger_once"
@@ -8648,24 +8712,29 @@
 ( -708 -1224 60 ) ( -736 -1224 60 ) ( -736 -1240 60 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "spawnflags"	"1"
 "targetname"	"t13"
 "origin"	"-628 -1252 380"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "target"	"t15"
 "targetname"	"t14"
 "origin"	"-816 -1384 504"
 "classname"	"path_corner"
 }
+
 {
 "target"	"t16"
 "targetname"	"t15"
 "origin"	"-816 -1384 60"
 "classname"	"path_corner"
 }
+
 {
 "target"	"t14"
 "targetname"	"t16"
@@ -8673,43 +8742,57 @@
 "origin"	"-816 -1384 232"
 "classname"	"path_corner"
 }
+
 {
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-908 -1248 12"
 "classname"	"light"
 }
+
 {
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-568 -1176 240"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-760 -1172 240"
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-756 -1332 240"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-564 -1336 240"
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "targetname"	"t12"
 "target"	"t18"
 "light"	"500"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-776 -1240 104"
 "classname"	"light"
 }
+
 {
 "targetname"	"t18"
 "origin"	"-818 -1240 104"
 "classname"	"info_null"
 }
+
 {
 "sounds"	"3"
 "wait"	"20"
@@ -8728,6 +8811,7 @@
 ( -488 -1184 72 ) ( -500 -1184 72 ) ( -500 -1312 72 ) WMET2_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "wait"	"20"
 "targetname"	"t13"
@@ -8745,25 +8829,34 @@
 ( -488 -1184 120 ) ( -500 -1184 120 ) ( -500 -1312 120 ) WMET2_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"-1224 -800 0"
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-952 -936 8"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-1216 -960 8"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-776 -160 128"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "sounds"	"0"
 "classname"	"func_door"
@@ -8779,6 +8872,7 @@
 ( -488 -160 -96 ) ( -488 -72 -96 ) ( -504 -72 -96 ) DOOR04_2 96 96 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"3"
 "classname"	"func_door"
@@ -8794,227 +8888,331 @@
 ( -488 -248 -96 ) ( -488 -160 -96 ) ( -504 -160 -96 ) DOOR04_2 96 96 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"-264 -160 124"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light_torch_small_walltorch"
 "origin"	"-544 -82 -4"
 "light"	"225"
+	"style"	"1"
+	"_color"	"1.00 0.55 0.24"
 }
+
 {
 "origin"	"-544 -238 -4"
 "classname"	"light_torch_small_walltorch"
 "light"	"225"
+	"style"	"1"
+	"_color"	"1.00 0.55 0.24"
 }
+
 {
 "classname"	"light_flame_small_yellow"
 "origin"	"-1144 48 38"
+	"_color"	"1.00 0.58 0.22"
+	"style"	"1"
 }
+
 {
 "origin"	"-1432 -256 38"
+	"_color"	"1.00 0.58 0.22"
+	"style"	"1"
 "classname"	"light_flame_small_yellow"
 }
+
 {
 "classname"	"light"
 "origin"	"1352 440 600"
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"-1040 -272 38"
+	"_color"	"1.00 0.58 0.22"
+	"style"	"1"
 "classname"	"light_flame_small_yellow"
 }
+
 {
 "classname"	"light_flame_small_yellow"
 "origin"	"-1352 -432 14"
+	"_color"	"1.00 0.58 0.22"
+	"style"	"1"
 }
+
 {
 "origin"	"-960 -48 14"
+	"_color"	"1.00 0.58 0.22"
+	"style"	"1"
 "classname"	"light_flame_small_yellow"
 }
+
 {
 "classname"	"light"
 "origin"	"-1408 -624 20"
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-1072 -512 20"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-1016 64 20"
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-1048 -712 20"
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-632 32 64"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-632 -168 -32"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-952 -432 16"
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-952 0 -312"
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-944 -248 -312"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-824 -72 -312"
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-800 -344 -312"
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-648 -176 -312"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-528 -320 -360"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-960 -448 -312"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-1232 -448 -312"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-1232 -608 -312"
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-1432 -696 -312"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-1464 -376 -312"
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-1056 -736 -312"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-992 -560 -312"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"-620 -1958 256"
+	"_color"	"1.00 0.64 0.30"
+	"style"	"1"
 "classname"	"light_flame_large_yellow"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-624 -1912 176"
 "classname"	"light"
 }
+
 {
 "classname"	"light_flame_large_yellow"
 "origin"	"-966 -1750 256"
+	"_color"	"1.00 0.64 0.30"
+	"style"	"1"
 }
+
 {
 "classname"	"light"
 "origin"	"-920 -1744 176"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-768 -1760 200"
 "classname"	"light"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-616 -1600 248"
 "classname"	"light"
 }
+
 {
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-288 -1632 144"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-352 -1696 144"
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-584 -1640 136"
 "classname"	"light"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-184 -1488 144"
 "classname"	"light"
 }
+
 {
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-152 -1832 144"
 "classname"	"light"
 }
+
 {
 "classname"	"light_flame_small_yellow"
 "origin"	"72 -1312 158"
+	"_color"	"1.00 0.58 0.22"
+	"style"	"1"
 }
+
 {
 "light"	"300"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 "classname"	"light_flame_small_yellow"
 "origin"	"120 -464 -98"
 }
+
 {
 "origin"	"-264 -520 30"
+	"_color"	"1.00 0.58 0.22"
+	"style"	"1"
 "classname"	"light_flame_small_yellow"
 }
+
 {
 "origin"	"64 -480 -256"
 "classname"	"light"
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"68 -548 -156"
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"48 -128 -172"
 "targetname"	"t72"
 "target"	"t73"
 }
+
 {
 "origin"	"48 -672 -172"
 "classname"	"path_corner"
@@ -9022,6 +9220,7 @@
 "target"	"t77"
 "wait"	"-1"
 }
+
 {
 "sounds"	"1"
 "classname"	"func_train"
@@ -9052,6 +9251,7 @@
 ( -608 -384 -148 ) ( -608 -360 -164 ) ( -624 -384 -148 ) WIZMET1_2 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"func_door_secret"
 "angle"	"0"
@@ -9066,6 +9266,7 @@
 ( 96 -120 -176 ) ( 64 -120 -176 ) ( 64 -128 -176 ) WIZMET1_2 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"1"
 "spawnflags"	"3"
@@ -9081,6 +9282,7 @@
 ( 64 -120 -176 ) ( 32 -120 -176 ) ( 32 -128 -176 ) WIZMET1_2 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_once"
 "target"	"t76"
@@ -9093,6 +9295,7 @@
 ( 112 -324 -208 ) ( 16 -324 -208 ) ( 16 -336 -208 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_once"
 "delay"	"2.4"
@@ -9107,6 +9310,7 @@
 ( 124 -108 -160 ) ( 112 -108 -160 ) ( 112 -120 -160 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "wait"	"-1"
 "classname"	"path_corner"
@@ -9114,13 +9318,16 @@
 "targetname"	"t77"
 "target"	"t73"
 }
+
 {
 "classname"	"light"
 "origin"	"64 -160 -152"
 "spawnflags"	"1"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 "targetname"	"t76"
 }
+
 {
 "sounds"	"3"
 "classname"	"func_door"
@@ -9138,6 +9345,7 @@
 ( 112 -136 -224 ) ( 16 -136 -224 ) ( 16 -216 -224 ) DOOR05_2 0 96 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"0"
 "classname"	"func_door"
@@ -9154,6 +9362,7 @@
 ( 64 -128 -224 ) ( -32 -128 -224 ) ( -32 -208 -224 ) DOOR05_2 0 96 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_once"
 "delay"	"3"
@@ -9168,6 +9377,7 @@
 ( 8 -112 -160 ) ( 0 -112 -160 ) ( 0 -120 -160 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "spawnflags"	"256"
 "classname"	"monster_zombie"
@@ -9175,6 +9385,7 @@
 "angle"	"90"
 "targetname"	"t79"
 }
+
 {
 "classname"	"trigger_once"
 "target"	"t79"
@@ -9187,6 +9398,7 @@
 ( 104 -184 -232 ) ( 24 -184 -232 ) ( 24 -208 -232 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "spawnflags"	"256"
 "angle"	"90"
@@ -9194,6 +9406,7 @@
 "classname"	"monster_zombie"
 "targetname"	"t79"
 }
+
 {
 "sounds"	"0"
 "classname"	"func_door"
@@ -9211,49 +9424,70 @@
 ( 128 -416 -400 ) ( 0 -416 -400 ) ( 0 -528 -400 ) WSWAMP1_2 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"136 -604 -260"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"384 -48 -168"
 "classname"	"light"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"776 -248 -256"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"768 -464 -256"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"216 136 -104"
 "classname"	"light"
 }
+
 {
 "origin"	"228 -168 -98"
+	"_color"	"1.00 0.58 0.22"
+	"style"	"1"
 "classname"	"light_flame_small_yellow"
 }
+
 {
 "classname"	"light_flame_small_yellow"
 "origin"	"8 148 -98"
+	"_color"	"1.00 0.58 0.22"
+	"style"	"1"
 }
+
 {
 "classname"	"light"
 "origin"	"976 -352 -168"
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1368 -336 -112"
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "sounds"	"0"
 "angle"	"90"
@@ -9267,6 +9501,7 @@
 ( 1480 -352 -160 ) ( 1480 -264 -160 ) ( 1464 -264 -160 ) DOOR04_2 32 32 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"3"
 "angle"	"270"
@@ -9280,150 +9515,218 @@
 ( 1480 -440 -160 ) ( 1480 -352 -160 ) ( 1464 -352 -160 ) DOOR04_2 32 32 0 1.000000 1.000000
 }
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1488 -360 72"
 "classname"	"light"
 }
+
 {
 "light"	"225"
+	"style"	"1"
+	"_color"	"1.00 0.55 0.24"
 "origin"	"1426 -274 -68"
 "classname"	"light_torch_small_walltorch"
 }
+
 {
 "light"	"225"
+	"style"	"1"
+	"_color"	"1.00 0.55 0.24"
 "classname"	"light_torch_small_walltorch"
 "origin"	"1426 -430 -68"
 }
+
 {
 "light"	"250"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 "classname"	"light_flame_small_yellow"
 "origin"	"1120 -136 -18"
 }
+
 {
 "classname"	"light"
 "origin"	"1608 -344 -8"
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1608 -96 -8"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1168 -352 120"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"896 -216 -16"
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"896 -488 -16"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1336 -224 88"
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1336 -488 88"
 "classname"	"light"
 }
+
 {
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1728 -360 -80"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1500 -96 -80"
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light_torch_small_walltorch"
 "origin"	"1608 10 116"
 "light"	"225"
+	"style"	"1"
+	"_color"	"1.00 0.55 0.24"
 }
+
 {
 "light"	"225"
+	"style"	"1"
+	"_color"	"1.00 0.55 0.24"
 "origin"	"1608 -458 116"
 "classname"	"light_torch_small_walltorch"
 }
+
 {
 "light"	"225"
+	"style"	"1"
+	"_color"	"1.00 0.64 0.30"
 "origin"	"1686 396 672"
 "classname"	"light_flame_large_yellow"
 }
+
 {
 "light"	"225"
+	"style"	"1"
+	"_color"	"1.00 0.64 0.30"
 "classname"	"light_flame_large_yellow"
 "origin"	"1686 652 672"
 }
+
 {
 "classname"	"light_flame_large_yellow"
 "origin"	"1008 396 672"
 "light"	"225"
+	"style"	"1"
+	"_color"	"1.00 0.64 0.30"
 }
+
 {
 "origin"	"1008 652 672"
 "classname"	"light_flame_large_yellow"
 "light"	"225"
+	"style"	"1"
+	"_color"	"1.00 0.64 0.30"
 }
+
 {
 "classname"	"light"
 "origin"	"1360 800 736"
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1360 752 592"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1360 392 864"
 "light"	"450"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"450"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1360 648 864"
 "classname"	"light"
 }
+
 {
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1632 496 672"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1064 488 672"
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1600 968 672"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1104 968 672"
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1200 240 648"
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1520 240 648"
 "classname"	"light"
 }
+
 {
 "sounds"	"3"
 "classname"	"func_door"
@@ -9439,6 +9742,7 @@
 ( 1592 1040 536 ) ( 1336 1040 536 ) ( 1336 1024 536 ) METAL5_6 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"3"
 "classname"	"func_door"
@@ -9453,6 +9757,7 @@
 ( 1464 1040 536 ) ( 1208 1040 536 ) ( 1208 1024 536 ) METAL5_6 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_once"
 "target"	"t80"
@@ -9465,69 +9770,100 @@
 ( 1464 1024 536 ) ( 1216 1024 536 ) ( 1216 1016 536 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1344 160 -32"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1608 152 -32"
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-520 -448 -288"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-520 -640 -288"
 "classname"	"light"
 }
+
 {
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"208 -1152 32"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"style"	"1"
+	"_color"	"1.00 0.55 0.24"
 "origin"	"150 -1466 -4"
 "classname"	"light_torch_small_walltorch"
 }
+
 {
 "origin"	"518 -890 120"
+	"_color"	"1.00 0.64 0.30"
+	"style"	"1"
 "classname"	"light_flame_large_yellow"
 }
+
 {
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"520 -888 36"
 "classname"	"light"
 }
+
 {
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"516 -764 -48"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"520 -1028 4"
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"-144 -728 -256"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "light"	"250"
+	"style"	"1"
+	"_color"	"1.00 0.55 0.24"
 "origin"	"-186 -822 -292"
 "classname"	"light_torch_small_walltorch"
 }
+
 {
 "light"	"250"
+	"style"	"1"
+	"_color"	"1.00 0.55 0.24"
 "classname"	"light_torch_small_walltorch"
 "origin"	"306 -810 -292"
 }
+
 {
 "sounds"	"2"
 "targetname"	"t82"
@@ -9561,36 +9897,51 @@
 ( 560 -704 -144 ) ( 624 -768 -144 ) ( 560 -704 -128 ) PLAT_TOP2 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "light"	"250"
+	"style"	"1"
+	"_color"	"1.00 0.55 0.24"
 "origin"	"698 -886 -292"
 "classname"	"light_torch_small_walltorch"
 }
+
 {
 "light"	"250"
+	"style"	"1"
+	"_color"	"1.00 0.55 0.24"
 "classname"	"light_torch_small_walltorch"
 "origin"	"522 -1066 -292"
 }
+
 {
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"520 -776 -280"
 "classname"	"light"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"368 -888 -280"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"384 -248 -256"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"384 -456 -256"
 "classname"	"light"
 }
+
 {
 "sounds"	"2"
 "classname"	"func_plat"
@@ -9619,80 +9970,115 @@
 ( 144 -944 32 ) ( 48 -944 32 ) ( 48 -1056 32 ) PLAT_TOP2 16 80 0 1.000000 1.000000
 }
 }
+
 {
 "origin"	"280 -1000 102"
+	"_color"	"1.00 0.58 0.22"
+	"style"	"1"
 "classname"	"light_flame_small_yellow"
 }
+
 {
 "light"	"250"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 "classname"	"light_flame_small_yellow"
 "origin"	"728 -1128 78"
 }
+
 {
 "light"	"250"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 "origin"	"312 -1128 78"
 "classname"	"light_flame_small_yellow"
 }
+
 {
 "light"	"225"
+	"style"	"1"
+	"_color"	"1.00 0.55 0.24"
 "origin"	"150 -1210 -108"
 "classname"	"light_torch_small_walltorch"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"400 -1160 -10"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"632 -1160 -10"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"456 -1160 -118"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"576 -1160 -118"
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"344 -1264 -118"
 "classname"	"light"
 }
+
 {
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"344 -1096 -118"
 "classname"	"light"
 }
+
 {
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"712 -1064 -118"
 "classname"	"light"
 }
+
 {
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"216 -1000 -118"
 "classname"	"light"
 }
+
 {
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"200 -1000 -6"
 "classname"	"light"
 }
+
 {
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"96 -1000 -78"
 "classname"	"light"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"72 -1000 122"
 "classname"	"light"
 }
+
 {
 "sounds"	"0"
 "target"	"t81"
@@ -9708,6 +10094,7 @@
 ( -190 -960 48 ) ( -254 -960 48 ) ( -254 -1024 48 ) +0FLOORSW 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"3"
 "targetname"	"t81"
@@ -9724,36 +10111,49 @@
 ( -272 -1064 64 ) ( -288 -1064 64 ) ( -288 -1080 64 ) WMET4_6 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-272 -1000 120"
 "classname"	"light"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"368 -1408 8"
 "classname"	"light"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"608 -808 -20"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"440 -808 -20"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"672 -880 -60"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"368 -888 -60"
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "target"	"t82"
 "classname"	"trigger_once"
@@ -9766,6 +10166,7 @@
 ( 568 -712 -148 ) ( 472 -712 -148 ) ( 472 -752 -148 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "target"	"t82"
 "classname"	"trigger_once"
@@ -9778,6 +10179,7 @@
 ( 328 -856 -352 ) ( 320 -856 -352 ) ( 320 -920 -352 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "target"	"t83"
 "classname"	"trigger_once"
@@ -9790,6 +10192,7 @@
 ( -728 -320 -368 ) ( -744 -320 -368 ) ( -744 -456 -368 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "lip"	"-4"
 "sounds"	"0"
@@ -9808,18 +10211,21 @@
 ( -1176 -472 -464 ) ( -1232 -472 -464 ) ( -1232 -536 -464 ) WGRND1_5 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"monster_zombie"
 "origin"	"-1218 -532 -438"
 "angle"	"0"
 "targetname"	"t83"
 }
+
 {
 "origin"	"-1270 -558 -438"
 "classname"	"monster_zombie"
 "angle"	"0"
 "targetname"	"t83"
 }
+
 {
 "sounds"	"0"
 "targetname"	"t83"
@@ -9838,22 +10244,28 @@
 ( -840 -8 -398 ) ( -960 -8 -398 ) ( -960 -120 -398 ) WGRND1_5 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "spawnflags"	"2048"
 "sounds"	"1"
 "classname"	"item_key2"
 "origin"	"-976 -360 -336"
 }
+
 {
 "classname"	"light"
 "origin"	"80 -1144 24"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-72 -1136 80"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "lip"	"-4"
 "sounds"	"0"
@@ -9872,6 +10284,7 @@
 ( -840 -8 -496 ) ( -960 -8 -496 ) ( -960 -120 -496 ) WGRND1_5 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"0"
 "classname"	"func_door"
@@ -9888,57 +10301,79 @@
 ( -1176 -472 -396 ) ( -1296 -472 -396 ) ( -1296 -584 -396 ) WGRND1_5 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "angle"	"315"
 "origin"	"-866 -44 -448"
 "classname"	"monster_zombie"
 "targetname"	"t83"
 }
+
 {
 "classname"	"light"
 "origin"	"-892 -64 -450"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-1236 -528 -450"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"912 -208 -160"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"920 -504 -160"
 "classname"	"light"
 }
+
 {
 "classname"	"light_torch_small_walltorch"
 "origin"	"726 -206 -4"
 "light"	"225"
+	"style"	"1"
+	"_color"	"1.00 0.55 0.24"
 }
+
 {
 "origin"	"726 -506 -4"
 "classname"	"light_torch_small_walltorch"
 "light"	"225"
+	"style"	"1"
+	"_color"	"1.00 0.55 0.24"
 }
+
 {
 "classname"	"light"
 "origin"	"740 -360 -8"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1344 -192 -112"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1344 -520 -112"
 "classname"	"light"
 }
+
 {
 "sounds"	"1"
 "classname"	"func_door"
@@ -9954,6 +10389,7 @@
 ( 1248 -112 -208 ) ( 1192 -112 -208 ) ( 1192 -120 -208 ) WMET2_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"1"
 "wait"	"-1"
@@ -9969,11 +10405,15 @@
 ( 1056 -112 -208 ) ( 1000 -112 -208 ) ( 1000 -120 -208 ) WMET2_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "origin"	"1120 -560 -18"
 "classname"	"light_flame_small_yellow"
 "light"	"250"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 }
+
 {
 "sounds"	"1"
 "wait"	"-1"
@@ -9989,6 +10429,7 @@
 ( 1192 -576 -208 ) ( 1192 -584 -208 ) ( 1248 -584 -208 ) ALTARB_2 32 64 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"1"
 "classname"	"func_door"
@@ -10004,46 +10445,63 @@
 ( 1000 -576 -208 ) ( 1000 -584 -208 ) ( 1056 -584 -208 ) ALTARB_2 32 64 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"1216 -136 -136"
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1024 -136 -136"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1216 -568 -136"
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1024 -568 -136"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1024 -40 -136"
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1216 -40 -136"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1216 -656 -136"
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1024 -656 -136"
 "classname"	"light"
 }
+
 {
 "sounds"	"2"
 "classname"	"func_button"
@@ -10059,21 +10517,28 @@
 ( 728 -336 -32 ) ( 720 -336 -32 ) ( 720 -368 -32 ) DOOR05_3 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"1120 -192 -104"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1120 -504 -104"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1760 128 -96"
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "sounds"	"1"
 "classname"	"func_door_secret"
@@ -10089,12 +10554,14 @@
 ( 1752 160 -160 ) ( 1744 160 -160 ) ( 1744 96 -160 ) WSWAMP2_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"info_teleport_destination"
 "origin"	"1360 704 552"
 "angle"	"90"
 "targetname"	"t86"
 }
+
 {
 "classname"	"trigger_teleport"
 "target"	"t86"
@@ -10107,47 +10574,56 @@
 ( 1768 160 -132 ) ( 1764 160 -132 ) ( 1764 96 -132 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1724 -96 -80"
 "classname"	"light"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"-216 -1504 96"
 "targetname"	"t87"
 "target"	"t88"
 }
+
 {
 "origin"	"-216 -1768 96"
 "classname"	"path_corner"
 "targetname"	"t90"
 "target"	"t87"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"-216 -1768 96"
 "targetname"	"t88"
 "target"	"t89"
 }
+
 {
 "origin"	"-376 -1768 96"
 "classname"	"path_corner"
 "targetname"	"t89"
 "target"	"t90"
 }
+
 {
 "classname"	"monster_zombie"
 "origin"	"-194 -1466 112"
 "angle"	"270"
 "target"	"t87"
 }
+
 {
 "spawnflags"	"1"
 "angle"	"270"
 "origin"	"-154 -1002 72"
 "classname"	"monster_ogre"
 }
+
 {
 "classname"	"monster_ogre"
 "origin"	"358 -1274 -40"
@@ -10155,6 +10631,7 @@
 "targetname"	"t93"
 "spawnflags"	"768"
 }
+
 {
 "spawnflags"	"768"
 "classname"	"monster_wizard"
@@ -10162,6 +10639,7 @@
 "angle"	"270"
 "target"	"t91"
 }
+
 {
 "spawnflags"	"768"
 "classname"	"path_corner"
@@ -10169,6 +10647,7 @@
 "targetname"	"t91"
 "target"	"t92"
 }
+
 {
 "spawnflags"	"768"
 "origin"	"392 -1160 8"
@@ -10176,6 +10655,7 @@
 "targetname"	"t92"
 "target"	"t91"
 }
+
 {
 "classname"	"monster_zombie"
 "origin"	"704 -1192 -120"
@@ -10183,6 +10663,7 @@
 "targetname"	"t93"
 "spawnflags"	"256"
 }
+
 {
 "spawnflags"	"256"
 "classname"	"trigger_once"
@@ -10196,6 +10677,7 @@
 ( 592 -1296 -64 ) ( 448 -1296 -64 ) ( 448 -1304 -64 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "spawnflags"	"768"
 "classname"	"trigger_once"
@@ -10209,36 +10691,42 @@
 ( 624 -968 -64 ) ( 432 -968 -64 ) ( 432 -976 -64 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"path_corner"
 "origin"	"232 -864 -344"
 "targetname"	"t94"
 "target"	"t95"
 }
+
 {
 "origin"	"8 -824 -344"
 "classname"	"path_corner"
 "targetname"	"t95"
 "target"	"t94"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"-96 -816 -344"
 "targetname"	"t96"
 "target"	"t97"
 }
+
 {
 "origin"	"-168 -744 -344"
 "classname"	"path_corner"
 "targetname"	"t97"
 "target"	"t96"
 }
+
 {
 "classname"	"monster_zombie"
 "origin"	"184 -856 -328"
 "angle"	"180"
 "target"	"t94"
 }
+
 {
 "angle"	"180"
 "origin"	"-48 -856 -328"
@@ -10246,18 +10734,21 @@
 "target"	"t96"
 "spawnflags"	"256"
 }
+
 {
 "classname"	"monster_zombie"
 "origin"	"-556 -12 -336"
 "angle"	"0"
 "targetname"	"t83"
 }
+
 {
 "classname"	"monster_zombie"
 "origin"	"-1384 -856 -336"
 "targetname"	"t83"
 "angle"	"270"
 }
+
 {
 "spawnflags"	"768"
 "classname"	"monster_ogre"
@@ -10265,78 +10756,91 @@
 "angle"	"90"
 "targetname"	"t111"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"384 -256 -296"
 "target"	"t100"
 "targetname"	"t103"
 }
+
 {
 "origin"	"768 -256 -296"
 "classname"	"path_corner"
 "targetname"	"t100"
 "target"	"t101"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"768 -448 -296"
 "targetname"	"t101"
 "target"	"t102"
 }
+
 {
 "origin"	"384 -456 -296"
 "classname"	"path_corner"
 "targetname"	"t102"
 "target"	"t103"
 }
+
 {
 "classname"	"monster_zombie"
 "origin"	"384 -352 -280"
 "angle"	"90"
 "target"	"t103"
 }
+
 {
 "classname"	"monster_zombie"
 "origin"	"776 -360 -280"
 "angle"	"270"
 "target"	"t101"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"384 -616 -296"
 "targetname"	"t105"
 "target"	"t104"
 }
+
 {
 "origin"	"192 -616 -296"
 "classname"	"path_corner"
 "targetname"	"t104"
 "target"	"t105"
 }
+
 {
 "classname"	"monster_zombie"
 "origin"	"320 -616 -280"
 "angle"	"180"
 "target"	"t104"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"-216 -688 -344"
 "targetname"	"t106"
 "target"	"t107"
 }
+
 {
 "origin"	"-336 -656 -344"
 "classname"	"path_corner"
 "targetname"	"t107"
 "target"	"t106"
 }
+
 {
 "classname"	"monster_zombie"
 "origin"	"-224 -656 -328"
 "angle"	"315"
 "target"	"t106"
 }
+
 {
 "spawnflags"	"1280"
 "classname"	"path_corner"
@@ -10344,6 +10848,7 @@
 "targetname"	"t108"
 "target"	"t109"
 }
+
 {
 "spawnflags"	"1280"
 "origin"	"232 -104 -200"
@@ -10351,6 +10856,7 @@
 "targetname"	"t109"
 "target"	"t108"
 }
+
 {
 "spawnflags"	"1280"
 "classname"	"monster_zombie"
@@ -10358,6 +10864,7 @@
 "angle"	"90"
 "target"	"t108"
 }
+
 {
 "classname"	"trigger_once"
 "target"	"t110"
@@ -10370,6 +10877,7 @@
 ( 264 -544 -312 ) ( 248 -544 -312 ) ( 248 -672 -312 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"monster_zombie"
 "origin"	"552 -216 -280"
@@ -10377,12 +10885,14 @@
 "targetname"	"t110"
 "spawnflags"	"256"
 }
+
 {
 "angle"	"270"
 "origin"	"800 -216 -280"
 "classname"	"monster_zombie"
 "targetname"	"t110"
 }
+
 {
 "classname"	"monster_zombie"
 "origin"	"656 -480 -280"
@@ -10390,12 +10900,14 @@
 "targetname"	"t110"
 "spawnflags"	"256"
 }
+
 {
 "classname"	"monster_wizard"
 "origin"	"8 -472 -32"
 "angle"	"180"
 "targetname"	"t111"
 }
+
 {
 "classname"	"trigger_once"
 "target"	"t111"
@@ -10408,30 +10920,35 @@
 ( -464 -72 -96 ) ( -472 -72 -96 ) ( -472 -248 -96 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"monster_zombie"
 "origin"	"1024 -88 -184"
 "angle"	"270"
 "targetname"	"t84"
 }
+
 {
 "angle"	"270"
 "origin"	"1216 -72 -184"
 "classname"	"monster_zombie"
 "targetname"	"t84"
 }
+
 {
 "classname"	"monster_zombie"
 "origin"	"1216 -608 -184"
 "angle"	"90"
 "targetname"	"t84"
 }
+
 {
 "angle"	"90"
 "origin"	"1024 -604 -184"
 "classname"	"monster_zombie"
 "targetname"	"t84"
 }
+
 {
 "classname"	"trigger_once"
 "target"	"t112"
@@ -10444,6 +10961,7 @@
 ( 1488 -264 -160 ) ( 1480 -264 -160 ) ( 1480 -440 -160 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "spawnflags"	"1280"
 "classname"	"path_corner"
@@ -10451,6 +10969,7 @@
 "targetname"	"t116"
 "target"	"t115"
 }
+
 {
 "spawnflags"	"1280"
 "origin"	"1528 752 544"
@@ -10458,6 +10977,7 @@
 "targetname"	"t115"
 "target"	"t116"
 }
+
 {
 "spawnflags"	"1280"
 "classname"	"monster_demon1"
@@ -10465,18 +10985,21 @@
 "angle"	"0"
 "target"	"t115"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"392 -1408 -48"
 "targetname"	"t118"
 "target"	"t122"
 }
+
 {
 "origin"	"216 -1408 -48"
 "classname"	"path_corner"
 "targetname"	"t117"
 "target"	"t118"
 }
+
 {
 "spawnflags"	"1"
 "classname"	"monster_ogre"
@@ -10484,22 +11007,28 @@
 "angle"	"180"
 "target"	"t117"
 }
+
 {
 "classname"	"weapon_nailgun"
 "origin"	"-712 -1240 60"
 "angle"	"90"
 }
+
 {
 "spawnflags"	"256"
 "classname"	"monster_ogre"
 "origin"	"790 -346 -40"
 "angle"	"0"
 }
+
 {
 "classname"	"light_torch_small_walltorch"
 "origin"	"1658 -574 -92"
 "light"	"225"
+	"style"	"1"
+	"_color"	"1.00 0.55 0.24"
 }
+
 {
 "sounds"	"0"
 "classname"	"func_door"
@@ -10515,6 +11044,7 @@
 ( 1644 -468 -152 ) ( 1628 -468 -152 ) ( 1628 -484 -152 ) WIZMET1_2 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"0"
 "classname"	"func_door"
@@ -10530,6 +11060,7 @@
 ( 1596 -468 -152 ) ( 1580 -468 -152 ) ( 1580 -484 -152 ) WIZMET1_2 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"3"
 "classname"	"func_door"
@@ -10545,6 +11076,7 @@
 ( 1560 -544 -80 ) ( 1560 -528 -80 ) ( 1560 -528 -64 ) WIZMET1_2 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"0"
 "classname"	"func_door"
@@ -10560,11 +11092,13 @@
 ( 1560 -544 -124 ) ( 1560 -528 -124 ) ( 1560 -528 -108 ) WIZMET1_2 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"item_shells"
 "origin"	"1592 -524 -152"
 "spawnflags"	"1"
 }
+
 {
 "classname"	"trigger_once"
 "spawnflags"	"1792"
@@ -10578,6 +11112,7 @@
 ( 1660 -452 -152 ) ( 1560 -452 -152 ) ( 1560 -460 -152 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "spawnflags"	"1792"
 "classname"	"trigger_once"
@@ -10591,97 +11126,118 @@
 ( 1660 -440 -152 ) ( 1560 -440 -152 ) ( 1560 -448 -152 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"item_health"
 "origin"	"-960 -1616 64"
 }
+
 {
 "spawnflags"	"1"
 "origin"	"-960 -1664 64"
 "classname"	"item_health"
 }
+
 {
 "classname"	"weapon_supershotgun"
 "origin"	"184 -1432 -56"
 "spawnflags"	"2048"
 }
+
 {
 "spawnflags"	"1024"
 "classname"	"item_shells"
 "origin"	"-688 -1944 88"
 }
+
 {
 "classname"	"item_rockets"
 "origin"	"-352 -1128 48"
 }
+
 {
 "classname"	"item_spikes"
 "origin"	"-1000 -1320 -32"
 "spawnflags"	"1"
 }
+
 {
 "classname"	"item_armor1"
 "origin"	"-288 -992 48"
 }
+
 {
 "classname"	"item_health"
 "origin"	"-24 -1272 80"
 "spawnflags"	"2048"
 }
+
 {
 "classname"	"item_spikes"
 "origin"	"344 -1288 -152"
 }
+
 {
 "classname"	"item_health"
 "origin"	"656 -904 -112"
 "spawnflags"	"1"
 }
+
 {
 "classname"	"item_health"
 "origin"	"616 -856 -112"
 "spawnflags"	"1"
 }
+
 {
 "classname"	"item_rockets"
 "origin"	"504 -1064 -352"
 }
+
 {
 "classname"	"item_health"
 "origin"	"-144 -840 -348"
 }
+
 {
 "origin"	"-464 -684 -348"
 "classname"	"item_health"
 }
+
 {
 "classname"	"item_spikes"
 "origin"	"1008 -70 -208"
 "spawnflags"	"1"
 }
+
 {
 "classname"	"item_shells"
 "origin"	"1008 -656 -208"
 }
+
 {
 "classname"	"item_rockets"
 "origin"	"792 -264 -64"
 "spawnflags"	"1"
 }
+
 {
 "classname"	"item_health"
 "origin"	"1200 -660 -208"
 }
+
 {
 "classname"	"item_health"
 "origin"	"1344 -200 -208"
 "spawnflags"	"1"
 }
+
 {
 "spawnflags"	"1"
 "origin"	"1288 -200 -208"
 "classname"	"item_health"
 }
+
 {
 "classname"	"trigger_once"
 "target"	"t171"
@@ -10695,100 +11251,125 @@
 ( -88 -1560 88 ) ( -280 -1560 88 ) ( -280 -1576 88 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"32 -1312 112"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-400 -1136 112"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-1144 0 -20"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-1088 -272 -20"
 "classname"	"light"
 }
+
 {
 "classname"	"item_shells"
 "origin"	"536 -1464 -64"
 }
+
 {
 "classname"	"item_spikes"
 "origin"	"-1192 16 -92"
 }
+
 {
 "origin"	"-1128 16 -92"
 "classname"	"item_spikes"
 }
+
 {
 "classname"	"item_shells"
 "origin"	"344 -904 -112"
 }
+
 {
 "classname"	"item_spikes"
 "origin"	"-200 -176 -96"
 }
+
 {
 "classname"	"item_health"
 "origin"	"176 -152 -208"
 "spawnflags"	"1"
 }
+
 {
 "spawnflags"	"1"
 "origin"	"272 -152 -208"
 "classname"	"item_health"
 }
+
 {
 "classname"	"item_health"
 "origin"	"24 152 -208"
 }
+
 {
 "classname"	"item_rockets"
 "origin"	"48 -112 -96"
 "spawnflags"	"1"
 }
+
 {
 "classname"	"item_shells"
 "origin"	"-576 -24 -96"
 "spawnflags"	"2048"
 }
+
 {
 "classname"	"item_shells"
 "origin"	"64 152 -208"
 }
+
 {
 "spawnflags"	"1"
 "origin"	"-936 -936 -32"
 "classname"	"item_spikes"
 }
+
 {
 "classname"	"item_rockets"
 "origin"	"-1048 -752 -96"
 }
+
 {
 "origin"	"216 -1408 -48"
 "classname"	"path_corner"
 "targetname"	"t122"
 "target"	"t123"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"216 -1264 -48"
 "targetname"	"t123"
 "target"	"t117"
 }
+
 {
 "classname"	"item_health"
 "origin"	"152 -1144 -150"
 "spawnflags"	"1"
 }
+
 {
 "sounds"	"1"
 "classname"	"func_door"
@@ -10805,6 +11386,7 @@
 ( 96 -1416 48 ) ( -8 -1416 48 ) ( -8 -1432 48 ) WSWAMP2_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"monster_ogre"
 "origin"	"34 -1466 72"
@@ -10812,6 +11394,7 @@
 "target"	"t124"
 "spawnflags"	"257"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"32 -1280 56"
@@ -10819,6 +11402,7 @@
 "target"	"t125"
 "spawnflags"	"256"
 }
+
 {
 "origin"	"-320 -1280 56"
 "classname"	"path_corner"
@@ -10826,108 +11410,145 @@
 "target"	"t124"
 "spawnflags"	"256"
 }
+
 {
 "classname"	"light"
 "origin"	"40 -1488 120"
 "light"	"75"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-264 -472 -32"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"80 -464 -136"
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"232 -136 -144"
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"48 144 -144"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"64 -96 -32"
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"item_health"
 "origin"	"1288 104 -160"
 }
+
 {
 "spawnflags"	"1"
 "origin"	"1336 104 -160"
 "classname"	"item_health"
 }
+
 {
 "classname"	"item_shells"
 "origin"	"1600 968 536"
 }
+
 {
 "classname"	"light"
 "origin"	"584 -448 -256"
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"568 -248 -256"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"400 -624 -256"
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-928 -48 -40"
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"item_health"
 "origin"	"-1256 -1000 -30"
 "spawnflags"	"3584"
 }
+
 {
 "spawnflags"	"3584"
 "origin"	"-1208 -1000 -30"
 "classname"	"item_health"
 }
+
 {
 "classname"	"light"
 "origin"	"-1376 -104 26"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"-1320 -56 -94"
 "classname"	"item_health"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-448 -160 136"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-416 -216 -24"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-288 -64 -32"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-448 -88 -32"
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"monster_wizard"
 "origin"	"-528 -304 -64"
@@ -10935,82 +11556,114 @@
 "spawnflags"	"256"
 "targetname"	"t148"
 }
+
 {
 "classname"	"light"
 "origin"	"-648 16 -48"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-600 -320 40"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"monster_wizard"
 "origin"	"-1196 100 0"
 "angle"	"90"
 "targetname"	"t147"
 }
+
 {
 "classname"	"light"
 "origin"	"-704 -384 -152"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-40 -992 152"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"1686 884 672"
 "classname"	"light_flame_large_yellow"
 "light"	"225"
+	"style"	"1"
+	"_color"	"1.00 0.64 0.30"
 }
+
 {
 "light"	"225"
+	"style"	"1"
+	"_color"	"1.00 0.64 0.30"
 "classname"	"light_flame_large_yellow"
 "origin"	"1008 884 672"
 }
+
 {
 "classname"	"light"
 "origin"	"1360 880 864"
 "light"	"450"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1344 960 576"
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1096 632 592"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1600 632 592"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1080 396 592"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1620 396 592"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1084 884 592"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1604 884 592"
 "classname"	"light"
 }
+
 {
 "classname"	"monster_demon1"
 "origin"	"1584 816 560"
@@ -11018,6 +11671,7 @@
 "target"	"t130"
 "spawnflags"	"1024"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"1536 880 544"
@@ -11025,6 +11679,7 @@
 "target"	"t131"
 "spawnflags"	"1024"
 }
+
 {
 "origin"	"1120 880 544"
 "classname"	"path_corner"
@@ -11032,6 +11687,7 @@
 "target"	"t130"
 "spawnflags"	"1024"
 }
+
 {
 "classname"	"trigger_changelevel"
 "map"	"e1m4"
@@ -11044,20 +11700,26 @@
 ( 1464 1056 536 ) ( 1216 1056 536 ) ( 1216 1040 536 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-136 -1568 144"
 "classname"	"light"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-192 -1304 144"
 "classname"	"light"
 }
+
 {
 "classname"	"item_health"
 "origin"	"-200 -96 -96"
 }
+
 {
 "targetname"	"t13"
 "target"	"t14"
@@ -11142,33 +11804,39 @@
 ( -760 -1384 536 ) ( -808 -1336 536 ) ( -760 -1384 552 ) WIZWOOD1_7 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"item_health"
 "origin"	"-1208 -1000 -24"
 "spawnflags"	"1281"
 }
+
 {
 "spawnflags"	"1281"
 "origin"	"-1256 -1000 -24"
 "classname"	"item_health"
 }
+
 {
 "classname"	"item_shells"
 "origin"	"-200 -216 -96"
 "spawnflags"	"2048"
 }
+
 {
 "classname"	"monster_zombie"
 "origin"	"-912 -88 -448"
 "angle"	"315"
 "spawnflags"	"256"
 }
+
 {
 "spawnflags"	"1025"
 "classname"	"monster_ogre"
 "origin"	"-1400 -256 -72"
 "angle"	"0"
 }
+
 {
 "targetname"	"t112"
 "target"	"t135"
@@ -11176,6 +11844,7 @@
 "origin"	"1608 -96 80"
 "classname"	"monster_ogre"
 }
+
 {
 "targetname"	"t112"
 "target"	"t135"
@@ -11183,6 +11852,7 @@
 "origin"	"1608 -344 104"
 "angle"	"90"
 }
+
 {
 "target"	"t119"
 "targetname"	"t135"
@@ -11198,6 +11868,7 @@
 ( 1776 -264 56 ) ( 1752 -264 56 ) ( 1752 -296 56 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "target"	"t120"
 "targetname"	"t135"
@@ -11213,23 +11884,27 @@
 ( 1776 -304 56 ) ( 1752 -304 56 ) ( 1752 -336 56 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"monster_zombie"
 "origin"	"368 -1136 -120"
 "angle"	"0"
 "targetname"	"t93"
 }
+
 {
 "classname"	"monster_zombie"
 "origin"	"-16 -904 -328"
 "angle"	"45"
 }
+
 {
 "classname"	"monster_zombie"
 "origin"	"808 -488 -280"
 "angle"	"135"
 "spawnflags"	"256"
 }
+
 {
 "classname"	"monster_ogre"
 "origin"	"1384 -344 -136"
@@ -11237,36 +11912,42 @@
 "spawnflags"	"768"
 "targetname"	"t140"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"-272 -1824 96"
 "targetname"	"t138"
 "target"	"t137"
 }
+
 {
 "origin"	"-176 -1800 96"
 "classname"	"path_corner"
 "targetname"	"t136"
 "target"	"t138"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"-176 -1800 96"
 "targetname"	"t137"
 "target"	"t139"
 }
+
 {
 "origin"	"-144 -1496 96"
 "classname"	"path_corner"
 "target"	"t136"
 "targetname"	"t139"
 }
+
 {
 "classname"	"monster_zombie"
 "origin"	"-136 -1416 112"
 "angle"	"270"
 "target"	"t139"
 }
+
 {
 "classname"	"func_door"
 "angle"	"-1"
@@ -11283,16 +11964,21 @@
 ( -224 -1064 64 ) ( -240 -1064 64 ) ( -240 -1080 64 ) WMET4_6 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"64 -160 -296"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"64 -280 -296"
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"trigger_once"
 "spawnflags"	"768"
@@ -11306,6 +11992,7 @@
 ( 840 -296 -312 ) ( 832 -296 -312 ) ( 832 -416 -312 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"monster_zombie"
 "origin"	"1536 104 -136"
@@ -11313,6 +12000,7 @@
 "targetname"	"t112"
 "spawnflags"	"1024"
 }
+
 {
 "angle"	"315"
 "origin"	"1440 168 -136"
@@ -11320,6 +12008,7 @@
 "targetname"	"t112"
 "spawnflags"	"1024"
 }
+
 {
 "classname"	"monster_zombie"
 "origin"	"1592 112 -136"
@@ -11327,6 +12016,7 @@
 "targetname"	"t112"
 "spawnflags"	"1280"
 }
+
 {
 "targetname"	"t140"
 "spawnflags"	"1536"
@@ -11334,6 +12024,7 @@
 "origin"	"1384 -344 -136"
 "classname"	"monster_zombie"
 }
+
 {
 "angle"	"0"
 "classname"	"func_door_secret"
@@ -11346,6 +12037,7 @@
 ( 1688 -624 -160 ) ( 1536 -624 -160 ) ( 1536 -632 -160 ) WBRICK1_5 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "target"	"t141"
 "classname"	"trigger_teleport"
@@ -11358,17 +12050,21 @@
 ( 1640 -672 -132 ) ( 1640 -668 -132 ) ( 1576 -668 -132 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1608 -688 -88"
 "classname"	"light"
 }
+
 {
 "targetname"	"t141"
 "angle"	"90"
 "origin"	"1612 -372 72"
 "classname"	"info_teleport_destination"
 }
+
 {
 "classname"	"trigger_secret"
 {
@@ -11380,70 +12076,87 @@
 ( 1660 -304 64 ) ( 1564 -304 64 ) ( 1564 -392 64 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "spawnflags"	"2049"
 "origin"	"1592 -164 56"
 "classname"	"item_rockets"
 }
+
 {
 "classname"	"monster_zombie"
 "origin"	"116 132 -184"
 "angle"	"315"
 "spawnflags"	"768"
 }
+
 {
 "spawnflags"	"768"
 "angle"	"315"
 "origin"	"264 152 -184"
 "classname"	"monster_zombie"
 }
+
 {
 "origin"	"1608 -584 -152"
 "classname"	"item_armor2"
 }
+
 {
 "targetname"	"t144"
 "origin"	"-404 -1804 92"
 "classname"	"info_null"
 }
+
 {
 "target"	"t144"
 "light"	"350"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-392 -1804 160"
 "classname"	"light"
 }
+
 {
 "origin"	"-408 -1800 88"
 "classname"	"weapon_grenadelauncher"
 }
+
 {
 "target"	"t146"
 "targetname"	"t145"
 "classname"	"path_corner"
 "origin"	"-112 -1536 96"
 }
+
 {
 "target"	"t145"
 "targetname"	"t146"
 "origin"	"-112 -1608 96"
 "classname"	"path_corner"
 }
+
 {
 "target"	"t145"
 "angle"	"270"
 "origin"	"-104 -1480 112"
 "classname"	"monster_zombie"
 }
+
 {
 "classname"	"light"
 "origin"	"-584 8 -288"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light_torch_small_walltorch"
 "origin"	"-494 -334 -300"
 "light"	"250"
+	"style"	"1"
+	"_color"	"1.00 0.55 0.24"
 }
+
 {
 "classname"	"trigger_once"
 "target"	"t147"
@@ -11456,6 +12169,7 @@
 ( -1164 -824 -28 ) ( -1164 -816 -28 ) ( -1260 -816 -28 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_once"
 "target"	"t148"
@@ -11469,11 +12183,13 @@
 ( -1152 -468 -104 ) ( -1320 -468 -104 ) ( -1320 -476 -104 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "origin"	"-200 -136 -96"
 "classname"	"item_health"
 "spawnflags"	"3072"
 }
+
 {
 "speed"	"50"
 "sounds"	"1"
@@ -11490,6 +12206,7 @@
 ( -880 -896 -44 ) ( -896 -896 -44 ) ( -896 -1024 -44 ) WSWAMP2_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "targetname"	"t149"
 "spawnflags"	"768"
@@ -11497,6 +12214,7 @@
 "origin"	"-848 -928 -4"
 "classname"	"monster_zombie"
 }
+
 {
 "targetname"	"t149"
 "classname"	"monster_zombie"
@@ -11504,6 +12222,7 @@
 "angle"	"180"
 "spawnflags"	"768"
 }
+
 {
 "targetname"	"t149"
 "spawnflags"	"768"
@@ -11511,6 +12230,7 @@
 "origin"	"-856 -992 -4"
 "classname"	"monster_zombie"
 }
+
 {
 "target"	"t149"
 "spawnflags"	"768"
@@ -11524,6 +12244,7 @@
 ( -1048 -896 -28 ) ( -1056 -896 -28 ) ( -1056 -1008 -28 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "target"	"t169"
 "spawnflags"	"769"
@@ -11531,11 +12252,13 @@
 "origin"	"-1384 -256 -72"
 "classname"	"monster_shambler"
 }
+
 {
 "spawnflags"	"769"
 "origin"	"-808 -936 -32"
 "classname"	"item_rockets"
 }
+
 {
 "spawnflags"	"2"
 "target"	"t150"
@@ -11550,6 +12273,7 @@
 ( -1160 232 -88 ) ( -1288 232 -88 ) ( -1288 224 -88 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "targetname"	"t151"
 "spawnflags"	"768"
@@ -11557,17 +12281,21 @@
 "origin"	"-1224 272 -64"
 "classname"	"monster_shambler"
 }
+
 {
 "targetname"	"t150"
 "angle"	"270"
 "origin"	"-1232 -136 -88"
 "classname"	"info_teleport_destination"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-800 -968 28"
 "classname"	"light"
 }
+
 {
 "spawnflags"	"768"
 "targetname"	"t155"
@@ -11575,6 +12303,7 @@
 "origin"	"600 -856 -344"
 "classname"	"path_corner"
 }
+
 {
 "spawnflags"	"768"
 "target"	"t153"
@@ -11582,6 +12311,7 @@
 "classname"	"path_corner"
 "origin"	"440 -848 -344"
 }
+
 {
 "spawnflags"	"768"
 "target"	"t154"
@@ -11589,6 +12319,7 @@
 "origin"	"440 -968 -344"
 "classname"	"path_corner"
 }
+
 {
 "spawnflags"	"768"
 "target"	"t155"
@@ -11596,18 +12327,21 @@
 "classname"	"path_corner"
 "origin"	"608 -968 -344"
 }
+
 {
 "spawnflags"	"768"
 "target"	"t152"
 "origin"	"536 -848 -328"
 "classname"	"monster_zombie"
 }
+
 {
 "spawnflags"	"768"
 "target"	"t154"
 "origin"	"520 -960 -328"
 "classname"	"monster_zombie"
 }
+
 {
 "classname"	"func_wall"
 "spawnflags"	"1024"
@@ -11620,11 +12354,15 @@
 ( 592 -1328 80 ) ( 288 -1328 80 ) ( 288 -1480 80 ) WSWAMP2_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light_torch_small_walltorch"
 "origin"	"586 -1466 -4"
 "light"	"200"
+	"style"	"1"
+	"_color"	"1.00 0.55 0.24"
 }
+
 {
 "target"	"t157"
 "classname"	"monster_ogre"
@@ -11633,6 +12371,7 @@
 "targetname"	"t156"
 "spawnflags"	"768"
 }
+
 {
 "classname"	"trigger_once"
 "spawnflags"	"768"
@@ -11646,6 +12385,7 @@
 ( 288 -1296 -56 ) ( 144 -1296 -56 ) ( 144 -1304 -56 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_once"
 "target"	"t156"
@@ -11659,11 +12399,14 @@
 ( 592 -1240 -64 ) ( 448 -1240 -64 ) ( 448 -1248 -64 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"672 -1400 -16"
 "classname"	"light"
 }
+
 {
 "sounds"	"1"
 "targetname"	"t157"
@@ -11679,6 +12422,7 @@
 ( 608 -1344 -74 ) ( 592 -1344 -74 ) ( 592 -1456 -74 ) WSWAMP2_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "targetname"	"t157"
 "spawnflags"	"768"
@@ -11686,16 +12430,20 @@
 "origin"	"648 -1400 -40"
 "classname"	"monster_ogre"
 }
+
 {
 "target"	"t157"
 "origin"	"676 -1336 -28"
 "classname"	"info_null"
 }
+
 {
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"520 -1296 16"
 "classname"	"light"
 }
+
 {
 "target"	"t12"
 "wait"	"-1"
@@ -11711,11 +12459,13 @@
 ( -824 -1216 80 ) ( -832 -1216 80 ) ( -832 -1264 80 ) +1SHOOT 16 -16 0 1.000000 1.000000
 }
 }
+
 {
 "spawnflags"	"2561"
 "classname"	"item_shells"
 "origin"	"672 -1144 -152"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"248 88 -200"
@@ -11723,6 +12473,7 @@
 "targetname"	"t159"
 "target"	"t160"
 }
+
 {
 "spawnflags"	"768"
 "origin"	"216 -104 -200"
@@ -11730,6 +12481,7 @@
 "targetname"	"t160"
 "target"	"t159"
 }
+
 {
 "classname"	"monster_ogre"
 "origin"	"216 24 -184"
@@ -11737,12 +12489,14 @@
 "angle"	"90"
 "target"	"t159"
 }
+
 {
 "angle"	"0"
 "origin"	"782 -434 -40"
 "classname"	"monster_ogre"
 "spawnflags"	"768"
 }
+
 {
 "classname"	"monster_demon1"
 "origin"	"1600 184 -136"
@@ -11750,6 +12504,7 @@
 "targetname"	"t112"
 "spawnflags"	"769"
 }
+
 {
 "classname"	"monster_demon1"
 "origin"	"1496 1272 560"
@@ -11758,6 +12513,7 @@
 "targetname"	"t173"
 "target"	"t175"
 }
+
 {
 "angle"	"270"
 "origin"	"1392 1272 560"
@@ -11766,6 +12522,7 @@
 "targetname"	"t174"
 "target"	"t175"
 }
+
 {
 "classname"	"monster_shambler"
 "origin"	"1288 1288 560"
@@ -11773,6 +12530,7 @@
 "spawnflags"	"768"
 "targetname"	"t176"
 }
+
 {
 "classname"	"monster_demon1"
 "origin"	"1288 920 560"
@@ -11780,6 +12538,7 @@
 "spawnflags"	"768"
 "target"	"t174"
 }
+
 {
 "classname"	"monster_demon1"
 "origin"	"1408 920 560"
@@ -11787,6 +12546,7 @@
 "target"	"t173"
 "spawnflags"	"768"
 }
+
 {
 "classname"	"trigger_teleport"
 "spawnflags"	"770"
@@ -11801,6 +12561,7 @@
 ( 1504 1232 536 ) ( 1256 1232 536 ) ( 1256 1224 536 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_teleport"
 "spawnflags"	"770"
@@ -11815,6 +12576,7 @@
 ( 1600 1232 536 ) ( 1352 1232 536 ) ( 1352 1224 536 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_teleport"
 "spawnflags"	"770"
@@ -11829,6 +12591,7 @@
 ( 1704 1232 536 ) ( 1456 1232 536 ) ( 1456 1224 536 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"info_teleport_destination"
 "origin"	"1352 912 544"
@@ -11836,6 +12599,7 @@
 "spawnflags"	"768"
 "targetname"	"t165"
 }
+
 {
 "spawnflags"	"768"
 "angle"	"270"
@@ -11843,6 +12607,7 @@
 "classname"	"info_teleport_destination"
 "targetname"	"t167"
 }
+
 {
 "classname"	"info_teleport_destination"
 "origin"	"1176 912 544"
@@ -11850,21 +12615,25 @@
 "spawnflags"	"768"
 "targetname"	"t166"
 }
+
 {
 "spawnflags"	"2816"
 "origin"	"552 -1024 -352"
 "classname"	"item_rockets"
 }
+
 {
 "spawnflags"	"768"
 "origin"	"-1072 -256 -96"
 "classname"	"item_shells"
 }
+
 {
 "spawnflags"	"2817"
 "origin"	"-680 -1944 88"
 "classname"	"item_shells"
 }
+
 {
 "classname"	"trigger_once"
 "delay"	"3"
@@ -11880,6 +12649,7 @@
 ( -1104 272 -54 ) ( -1136 272 -54 ) ( -1136 248 -54 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"monster_wizard"
 "origin"	"-1400 -856 -40"
@@ -11887,6 +12657,7 @@
 "spawnflags"	"768"
 "targetname"	"t147"
 }
+
 {
 "classname"	"monster_wizard"
 "origin"	"-1480 -312 112"
@@ -11894,6 +12665,7 @@
 "spawnflags"	"256"
 "targetname"	"t147"
 }
+
 {
 "classname"	"monster_wizard"
 "origin"	"-792 -452 152"
@@ -11901,6 +12673,7 @@
 "spawnflags"	"257"
 "targetname"	"t170"
 }
+
 {
 "classname"	"trigger_once"
 "spawnflags"	"256"
@@ -11914,6 +12687,7 @@
 ( -928 -72 -104 ) ( -936 -72 -104 ) ( -936 -256 -104 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "targetname"	"t171"
 "spawnflags"	"1281"
@@ -11921,6 +12695,7 @@
 "origin"	"28 -1352 72"
 "classname"	"monster_ogre"
 }
+
 {
 "targetname"	"t171"
 "spawnflags"	"769"
@@ -11928,46 +12703,55 @@
 "origin"	"28 -1344 72"
 "classname"	"monster_demon1"
 }
+
 {
 "angle"	"315"
 "origin"	"-864 -1696 92"
 "classname"	"info_player_deathmatch"
 }
+
 {
 "angle"	"90"
 "origin"	"-1216 -928 -8"
 "classname"	"info_player_deathmatch"
 }
+
 {
 "angle"	"180"
 "origin"	"1128 -352 -184"
 "classname"	"info_player_deathmatch"
 }
+
 {
 "angle"	"225"
 "origin"	"384 136 -184"
 "classname"	"info_player_deathmatch"
 }
+
 {
 "angle"	"180"
 "origin"	"-816 -152 -80"
 "classname"	"info_player_deathmatch"
 }
+
 {
 "angle"	"180"
 "origin"	"-200 -368 -72"
 "classname"	"info_player_deathmatch"
 }
+
 {
 "spawnflags"	"1792"
 "origin"	"-976 -360 -360"
 "classname"	"weapon_rocketlauncher"
 }
+
 {
 "classname"	"weapon_supershotgun"
 "origin"	"784 -360 -64"
 "spawnflags"	"1792"
 }
+
 {
 "classname"	"trigger_teleport"
 "spawnflags"	"1792"
@@ -11981,6 +12765,7 @@
 ( 1088 832 556 ) ( 1084 832 556 ) ( 1084 768 556 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"func_wall"
 "spawnflags"	"1792"
@@ -11993,6 +12778,7 @@
 ( 1100 820 640 ) ( 1088 820 640 ) ( 1088 780 640 ) WIZMET1_2 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"func_wall"
 "spawnflags"	"1792"
@@ -12005,6 +12791,7 @@
 ( 1100 832 544 ) ( 1084 832 544 ) ( 1084 816 544 ) WIZMET1_2 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"func_wall"
 "spawnflags"	"1792"
@@ -12017,6 +12804,7 @@
 ( 1100 780 544 ) ( 1084 780 544 ) ( 1084 764 544 ) WIZMET1_2 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"func_wall"
 "spawnflags"	"1792"
@@ -12029,6 +12817,7 @@
 ( 1100 820 544 ) ( 1088 820 544 ) ( 1088 780 544 ) WIZMET1_2 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"func_wall"
 "spawnflags"	"1792"
@@ -12041,6 +12830,7 @@
 ( 1096 820 556 ) ( 1088 820 556 ) ( 1088 780 556 ) *TELEPORT 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"info_teleport_destination"
 "origin"	"-864 -1696 76"
@@ -12048,6 +12838,7 @@
 "spawnflags"	"1792"
 "targetname"	"t172"
 }
+
 {
 "classname"	"func_wall"
 "spawnflags"	"1792"
@@ -12060,41 +12851,49 @@
 ( -832 -1664 64 ) ( -896 -1664 64 ) ( -896 -1728 64 ) COP3_4 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"item_health"
 "origin"	"1328 816 540"
 "spawnflags"	"1794"
 }
+
 {
 "classname"	"weapon_supernailgun"
 "origin"	"1648 -96 56"
 "spawnflags"	"1792"
 }
+
 {
 "classname"	"item_spikes"
 "origin"	"1560 -112 56"
 "spawnflags"	"1793"
 }
+
 {
 "classname"	"weapon_nailgun"
 "origin"	"232 24 -208"
 "spawnflags"	"1792"
 }
+
 {
 "classname"	"info_player_deathmatch"
 "origin"	"72 -864 -328"
 "angle"	"180"
 }
+
 {
 "classname"	"item_health"
 "origin"	"1064 504 540"
 "spawnflags"	"1536"
 }
+
 {
 "classname"	"item_health"
 "origin"	"1064 464 540"
 "spawnflags"	"2048"
 }
+
 {
 "targetname"	"t171"
 "classname"	"monster_demon1"
@@ -12102,6 +12901,7 @@
 "angle"	"0"
 "spawnflags"	"769"
 }
+
 {
 "classname"	"trigger_once"
 "message"	"Shoot the button!"
@@ -12116,51 +12916,67 @@
 ( -808 -1104 -216 ) ( -824 -1104 -216 ) ( -824 -1120 -216 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "mangle"	"20 225 0"
 "origin"	"-544 24 176"
 "classname"	"info_intermission"
 }
+
 {
 "mangle"	"20 305 0"
 "origin"	"904 -216 56"
 "classname"	"info_intermission"
 }
+
 {
 "mangle"	"12 65 0"
 "origin"	"1112 288 680"
 "classname"	"info_intermission"
 }
+
 {
 "mangle"	"15 45 0"
 "origin"	"-1448 -744 64"
 "classname"	"info_intermission"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-1552 -560 -464"
 "classname"	"light"
 }
+
 {
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-1448 -560 -424"
 "classname"	"light"
 }
+
 {
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-1672 -568 -424"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"style"	"1"
+	"_color"	"1.00 0.55 0.24"
 "origin"	"-1774 -550 -300"
 "classname"	"light_torch_small_walltorch"
 }
+
 {
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-1584 -560 -328"
 "classname"	"light"
 }
+
 {
 "classname"	"trigger_secret"
 {
@@ -12172,10 +12988,12 @@
 ( -1600 -496 -360 ) ( -1688 -496 -360 ) ( -1688 -616 -360 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "origin"	"-1736 -552 -336"
 "classname"	"item_artifact_invisibility"
 }
+
 {
 "angle"	"180"
 "spawnflags"	"3"
@@ -12189,21 +13007,28 @@
 ( 416 -1296 -152 ) ( 304 -1296 -152 ) ( 304 -1312 -152 ) WMET4_6 0 -24 0 1.000000 1.000000
 }
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"368 -1400 -120"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"520 -1320 -120"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"512 -1408 -120"
 "classname"	"light"
 }
+
 {
 "classname"	"trigger_secret"
 {
@@ -12215,44 +13040,53 @@
 ( 416 -1344 -144 ) ( 304 -1344 -144 ) ( 304 -1352 -144 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "origin"	"544 -1424 -152"
 "classname"	"item_health"
 }
+
 {
 "spawnflags"	"1"
 "origin"	"504 -1304 -152"
 "classname"	"item_rockets"
 }
+
 {
 "spawnflags"	"2817"
 "origin"	"1072 968 544"
 "classname"	"item_shells"
 }
+
 {
 "classname"	"item_shells"
 "origin"	"1112 968 544"
 "spawnflags"	"2817"
 }
+
 {
 "angle"	"270"
 "origin"	"-648 -1592 88"
 "classname"	"info_player_coop"
 }
+
 {
 "classname"	"info_player_coop"
 "origin"	"-824 -1584 88"
 "angle"	"270"
 }
+
 {
 "angle"	"270"
 "origin"	"-888 -1584 88"
 "classname"	"info_player_coop"
 }
+
 {
 "classname"	"item_health"
 "origin"	"32 -1544 56"
 }
+
 {
 "spawnflags"	"1792"
 "classname"	"func_wall"
@@ -12273,6 +13107,7 @@
 ( 1440 1008 536 ) ( 1252 1008 536 ) ( 1252 996 536 ) WMET2_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_counter"
 "count"	"2"
@@ -12288,83 +13123,110 @@
 ( 1584 1312 544 ) ( 1568 1312 544 ) ( 1568 1296 544 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "origin"	"162 -878 -208"
 "classname"	"ambient_drip"
 }
+
 {
 "origin"	"-150 -758 -248"
 "classname"	"ambient_drip"
 }
+
 {
 "origin"	"-518 -606 -256"
 "classname"	"ambient_drip"
 }
+
 {
 "origin"	"-742 -166 -256"
 "classname"	"ambient_drip"
 }
+
 {
 "classname"	"ambient_drip"
 "origin"	"-958 -374 -256"
 }
+
 {
 "origin"	"-1070 -670 -256"
 "classname"	"ambient_drip"
 }
+
 {
 "classname"	"ambient_drip"
 "origin"	"-1438 -694 -256"
 }
+
 {
 "origin"	"394 -102 -152"
 "classname"	"ambient_drip"
 }
+
 {
 "origin"	"50 98 -96"
 "classname"	"ambient_drip"
 }
+
 {
 "origin"	"386 -262 -256"
 "classname"	"ambient_drip"
 }
+
 {
 "classname"	"ambient_drip"
 "origin"	"602 -470 -256"
 }
+
 {
 "origin"	"762 -246 -256"
 "classname"	"ambient_drip"
 }
+
 {
 "origin"	"978 -358 -192"
 "classname"	"ambient_drip"
 }
+
 {
 "classname"	"ambient_drip"
 "origin"	"-1686 -558 -288"
 }
+
 {
 "classname"	"ambient_drip"
 "origin"	"58 -214 -248"
 }
+
 {
 "origin"	"-822 -374 -304"
 "classname"	"ambient_swamp2"
 }
+
 {
 "classname"	"ambient_swamp2"
 "origin"	"-1150 -646 -304"
 }
+
 {
 "origin"	"-1470 -438 -304"
 "classname"	"ambient_swamp1"
 }
+
 {
 "classname"	"ambient_swamp1"
 "origin"	"-854 50 -304"
 }
+
 {
 "origin"	"-526 -526 -304"
 "classname"	"ambient_swamp1"
+}
+
+{
+	"classname"	"light_environment"
+	"_color"	"0.85 0.72 0.58"
+	"light"	"220"
+	"angles"	"45 120 0"
 }

--- a/Quake/maps/E1M4.MAP
+++ b/Quake/maps/E1M4.MAP
@@ -4,6 +4,12 @@
 "classname"	"worldspawn"
 "wad"	"gfx/wizard.wad"
 "sounds"	"5"
+	"_ambient"	"18"
+	"_minlight"	"6"
+	"_sunlight"	"70"
+	"_sunlight_color"	"0.85 0.72 0.58"
+	"_sun_mangle"	"45 120 0"
+	"fog"	"0.03 0.08 0.11 0.18"
 {
 ( 784 648 872 ) ( 784 144 872 ) ( 784 144 864 ) WGRND1_6 0 0 0 1.000000 1.000000
 ( 1056 320 872 ) ( 928 320 872 ) ( 928 320 864 ) WGRND1_6 0 0 0 1.000000 1.000000
@@ -9872,16 +9878,21 @@
 ( -152 1760 834 ) ( -376 1760 834 ) ( -376 1520 834 ) WGRND1_6 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"464 480 1656"
 "light"	"300"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"400"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"712 296 1512"
 "classname"	"light"
 }
+
 {
 "sounds"	"3"
 "angle"	"180"
@@ -9895,6 +9906,7 @@
 ( 704 -136 1248 ) ( 616 -136 1248 ) ( 616 -152 1248 ) DOOR02_2 0 80 0 1.000000 1.000000
 }
 }
+
 {
 "angle"	"0"
 "classname"	"func_door"
@@ -9907,119 +9919,178 @@
 ( 792 -136 1248 ) ( 704 -136 1248 ) ( 704 -152 1248 ) DOOR02_2 0 80 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light_flame_small_yellow"
 "origin"	"560 -112 1374"
+	"_color"	"1.00 0.58 0.22"
+	"style"	"1"
 }
+
 {
 "origin"	"848 -112 1374"
+	"_color"	"1.00 0.58 0.22"
+	"style"	"1"
 "classname"	"light_flame_small_yellow"
 }
+
 {
 "origin"	"760 656 1536"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "light"	"400"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"834 498 1040"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 "origin"	"944 728 1456"
 }
+
 {
 "classname"	"light_flame_small_yellow"
 "origin"	"1016 80 998"
+	"_color"	"1.00 0.58 0.22"
+	"style"	"1"
 }
+
 {
 "origin"	"392 80 998"
+	"_color"	"1.00 0.58 0.22"
+	"style"	"1"
 "classname"	"light_flame_small_yellow"
 }
+
 {
 "classname"	"light"
 "origin"	"680 1224 516"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"704 992 516"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"696 1608 628"
 "classname"	"light"
 }
+
 {
 "origin"	"704 1368 588"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "origin"	"816 1616 444"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"712 1728 444"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"592 1608 444"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"624 1096 444"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"300"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"432 1328 816"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"696 1112 816"
 "light"	"300"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"704 -80 960"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light_torch_small_walltorch"
 "origin"	"818 18 948"
 "light"	"200"
+	"style"	"1"
+	"_color"	"1.00 0.55 0.24"
 }
+
 {
 "origin"	"586 18 948"
 "classname"	"light_torch_small_walltorch"
 "light"	"200"
+	"style"	"1"
+	"_color"	"1.00 0.55 0.24"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"688 496 880"
 "classname"	"light"
 }
+
 {
 "origin"	"489 483 1356"
+	"_color"	"1.00 0.64 0.30"
+	"style"	"1"
 "classname"	"light_flame_large_yellow"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"704 -120 1360"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1216 936 1560"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"1294 826 1576"
+	"_color"	"1.00 0.64 0.30"
+	"style"	"1"
 "classname"	"light_flame_large_yellow"
 }
+
 {
 "sounds"	"1"
 "targetname"	"t1"
@@ -10035,6 +10106,7 @@
 ( 1224 1008 1384 ) ( 1112 1008 1384 ) ( 1112 992 1384 ) METAL5_6 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "angle"	"0"
 "wait"	"-1"
@@ -10048,6 +10120,7 @@
 ( 1336 1008 1384 ) ( 1224 1008 1384 ) ( 1224 992 1384 ) METAL5_6 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "target"	"t1"
 "classname"	"trigger_once"
@@ -10060,6 +10133,7 @@
 ( 1328 992 1384 ) ( 1120 992 1384 ) ( 1120 984 1384 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "map"	"e1m5"
 "classname"	"trigger_changelevel"
@@ -10072,6 +10146,7 @@
 ( 1336 1016 1384 ) ( 1112 1016 1384 ) ( 1112 1008 1384 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "wait"	"-1"
 "angle"	"0"
@@ -10086,11 +10161,13 @@
 ( -256 2001 1224 ) ( -192 2001 1224 ) ( -192 2025 1224 ) METAL5_6 0 16 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"info_player_start"
 "origin"	"-256 2272 1240"
 "angle"	"270"
 }
+
 {
 "targetname"	"t23"
 "classname"	"func_door"
@@ -10107,81 +10184,118 @@
 ( -320 2001 1224 ) ( -256 2001 1224 ) ( -256 2025 1224 ) METAL5_6 0 16 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"696 704 820"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"704 776 672"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"360 904 520"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"704 856 400"
 "classname"	"light"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"944 880 416"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"1056 1176 424"
 "classname"	"light"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1096 1408 360"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"416 1696 360"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"328 1368 360"
 "classname"	"light"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200 "
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 "origin"	"696 752 896"
 }
+
 {
 "light"	"250"
+	"style"	"1"
+	"_color"	"1.00 0.55 0.24"
 "origin"	"798 1850 1024"
 "classname"	"light_torch_small_walltorch"
 }
+
 {
 "classname"	"light_torch_small_walltorch"
 "origin"	"642 1850 1024"
 "light"	"250"
+	"style"	"1"
+	"_color"	"1.00 0.55 0.24"
 }
+
 {
 "light"	"200 "
+	"_color"	"0.88 0.74 0.58"
 "origin"	"700 1364 952"
 "classname"	"light"
 }
+
 {
 "classname"	"light_flame_large_yellow"
 "origin"	"1094 1494 1064"
+	"_color"	"1.00 0.64 0.30"
+	"style"	"1"
 }
+
 {
 "origin"	"324 1104 1064"
+	"_color"	"1.00 0.64 0.30"
+	"style"	"1"
 "classname"	"light_flame_large_yellow"
 }
+
 {
 "light"	"200 "
+	"_color"	"0.88 0.74 0.58"
 "origin"	"704 1660 952"
 "classname"	"light"
 }
+
 {
 "sounds"	"3"
 "classname"	"func_door"
@@ -10201,6 +10315,7 @@
 ( -352 1652 1336 ) ( -352 1644 1344 ) ( -368 1652 1336 ) WMET4_5 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"3"
 "classname"	"func_door"
@@ -10220,6 +10335,7 @@
 ( -160 1632 1336 ) ( -160 1640 1344 ) ( -144 1632 1336 ) WMET4_5 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_once"
 "targetname"	"t4"
@@ -10233,6 +10349,7 @@
 ( -40 1632 1234 ) ( -16 1632 1234 ) ( -16 1656 1234 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_once"
 "targetname"	"t2"
@@ -10246,6 +10363,7 @@
 ( -448 1496 1234 ) ( -424 1496 1234 ) ( -424 1520 1234 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "dmg"	"90"
 "speed"	"200"
@@ -10265,12 +10383,14 @@
 ( -184 1744 1336 ) ( -152 1712 1336 ) ( -184 1744 1352 ) WIZWOOD1_8 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"path_corner"
 "origin"	"-359 1528 1316"
 "targetname"	"t5"
 "target"	"t6"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"-359 1528 880"
@@ -10278,6 +10398,7 @@
 "target"	"t5"
 "wait"	"-1"
 }
+
 {
 "classname"	"trigger_counter"
 "targetname"	"t7"
@@ -10292,366 +10413,516 @@
 ( -56 1464 1234 ) ( -24 1464 1234 ) ( -24 1488 1234 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "targetname"	"t11"
 "origin"	"-96 1640 1256"
 "classname"	"info_null"
 }
+
 {
 "targetname"	"t9"
 "origin"	"-416 1640 1256"
 "classname"	"info_null"
 }
+
 {
 "light"	"400"
+	"_color"	"0.88 0.74 0.58"
 "target"	"t9"
 "origin"	"-396 1640 1256"
 "classname"	"light"
 }
+
 {
 "light"	"400"
+	"_color"	"0.88 0.74 0.58"
 "target"	"t11"
 "origin"	"-116 1640 1256"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-328 1564 1532"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light_flame_small_yellow"
 "origin"	"-88 1640 1514"
+	"_color"	"1.00 0.58 0.22"
+	"style"	"1"
 }
+
 {
 "origin"	"-424 1640 1514"
+	"_color"	"1.00 0.58 0.22"
+	"style"	"1"
 "classname"	"light_flame_small_yellow"
 }
+
 {
 "origin"	"-248 1464 1154"
+	"_color"	"1.00 0.58 0.22"
+	"style"	"1"
 "classname"	"light_flame_small_yellow"
 }
+
 {
 "classname"	"light_flame_small_yellow"
 "origin"	"-256 1808 1046"
+	"_color"	"1.00 0.58 0.22"
+	"style"	"1"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-164 1732 1268"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-348 1732 1268"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-248 1500 1056"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-256 1772 956"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-128 1636 920"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-124 1640 920"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-172 1524 920"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-284 1516 920"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-360 1580 920"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"75"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-360 1700 920"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"72 1632 928"
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"80 1488 928"
 "classname"	"light"
 }
+
 {
 "classname"	"light_flame_large_yellow"
 "origin"	"158 1308 1064"
+	"_color"	"1.00 0.64 0.30"
+	"style"	"1"
 }
+
 {
 "classname"	"light"
 "origin"	"-192 1688 1380"
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-192 1592 1380"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-320 1592 1380"
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-320 1688 1380"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-384 1640 1452"
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-112 1640 1452"
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-248 1504 1336"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-128 1640 1336"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-384 1640 1336"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"696 1608 816"
 "light"	"300"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 "origin"	"888 1328 424"
 }
+
 {
 "classname"	"light"
 "origin"	"160 1352 960"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"368 1104 1000"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1048 1504 1000"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"992 992 1048"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"48 1384 1008"
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1080 1144 1048"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"968 824 976"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"896 1328 1000"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"368 1616 1000"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"256 1496 824"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"256 1352 824"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"856 1368 536"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"552 1360 536"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"872 1552 1056"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1032 1056 904"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1080 1184 904"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"864 848 904"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"312 1496 1016"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"704 1368 808"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"464 816 904"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"944 888 800"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"888 1112 728"
 "classname"	"light"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1008 1504 728"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"720 1848 1200"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"704 888 672"
 "classname"	"light"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"512 1456 1040"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"440 840 380"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"720 1848 1028"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"720 1936 1024"
 "classname"	"light"
 }
+
 {
 "origin"	"544 2128 984"
 "classname"	"light"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"712 1912 576"
 "classname"	"light"
 }
+
 {
 "light"	"300"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"720 2544 856"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"888 2048 592"
 "classname"	"light"
 }
+
 {
 "origin"	"704 2496 1128"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "origin"	"512 2048 976"
 "classname"	"light"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"952 2328 528"
 "classname"	"light"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"700 2760 808"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"700 2800 616"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"584 2780 584"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"808 2780 584"
 "classname"	"light"
 }
+
 {
 "sounds"	"3"
 "wait"	"-1"
@@ -10667,6 +10938,7 @@
 ( 392 2304 920 ) ( 376 2304 920 ) ( 376 2176 920 ) DOOR01_2 64 144 0 1.000000 1.000000
 }
 }
+
 {
 "message"	"This door is opened elsewhere..."
 "wait"	"-1"
@@ -10681,51 +10953,72 @@
 ( 392 2368 920 ) ( 376 2368 920 ) ( 376 2240 920 ) DOOR01_2 64 144 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"424 2304 1000"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"300"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 "origin"	"696 2880 1062"
 "classname"	"light_flame_small_yellow"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 "origin"	"864 2128 984"
 }
+
 {
 "classname"	"light_flame_large_yellow"
 "origin"	"702 2154 1228"
 "light"	"0"
+	"style"	"1"
+	"_color"	"1.00 0.64 0.30"
 }
+
 {
 "classname"	"light"
 "origin"	"832 2008 1136"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"584 2008 1136"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"272 2016 1136"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"272 2320 1136"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1104 2408 984"
 "classname"	"light"
 }
+
 {
 "sounds"	"2"
 "classname"	"func_plat"
@@ -10763,400 +11056,573 @@
 ( 744 2880 904 ) ( 656 2880 904 ) ( 656 2800 904 ) WMET4_5 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"700 2844 996"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"704 2216 1252"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"936 2304 1252"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"936 2536 1252"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"300"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 "origin"	"488 2536 1252"
 }
+
 {
 "origin"	"488 2304 1252"
 "classname"	"light"
 "light"	"300"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"0"
+	"style"	"1"
+	"_color"	"1.00 0.64 0.30"
 "origin"	"998 2306 1228"
 "classname"	"light_flame_large_yellow"
 }
+
 {
 "classname"	"light_flame_large_yellow"
 "origin"	"998 2534 1228"
 "light"	"0"
+	"style"	"1"
+	"_color"	"1.00 0.64 0.30"
 }
+
 {
 "light"	"0"
+	"style"	"1"
+	"_color"	"1.00 0.64 0.30"
 "origin"	"426 2534 1228"
 "classname"	"light_flame_large_yellow"
 }
+
 {
 "classname"	"light_flame_large_yellow"
 "origin"	"426 2306 1228"
 "light"	"0"
+	"style"	"1"
+	"_color"	"1.00 0.64 0.30"
 }
+
 {
 "classname"	"light"
 "origin"	"704 2152 984"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light_flame_small_yellow"
 "origin"	"1160 2400 1038"
 "light"	"250"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 }
+
 {
 "origin"	"840 2536 630"
 "classname"	"light_flame_small_yellow"
 "light"	"250"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 }
+
 {
 "classname"	"light_flame_small_yellow"
 "origin"	"584 2544 630"
 "light"	"250"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 }
+
 {
 "light"	"250"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 "origin"	"408 2304 694"
 "classname"	"light_flame_small_yellow"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 "origin"	"960 2632 528"
 }
+
 {
 "classname"	"light"
 "origin"	"960 2480 528"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"456 2304 624"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"704 2416 576"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"728 2184 528"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"512 2176 528"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"832 2336 656"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"592 2336 656"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"808 2584 576"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"616 2576 576"
 "classname"	"light"
 }
+
 {
 "classname"	"light_flame_small_yellow"
 "origin"	"488 2712 694"
 "light"	"250"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 }
+
 {
 "classname"	"light"
 "origin"	"488 2624 608"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"480 2464 608"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"250"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 "origin"	"184 2184 1038"
 "classname"	"light_flame_small_yellow"
 }
+
 {
 "classname"	"light_flame_small_yellow"
 "origin"	"512 2096 1038"
 "light"	"250"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 }
+
 {
 "classname"	"light"
 "origin"	"224 2184 976"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"848 2024 992"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"256 1992 1000"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"272 2376 1000"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1112 2208 1032"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"0"
+	"style"	"1"
+	"_color"	"1.00 0.64 0.30"
 "origin"	"698 2860 1228"
 "classname"	"light_flame_large_yellow"
 }
+
 {
 "origin"	"700 2808 1252"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"472 2632 1062"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"952 2632 1062"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"952 2424 894"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"480 2424 894"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"896 2296 966"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"704 2304 966"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"552 2304 966"
 "classname"	"light"
 }
+
 {
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"704 2184 406"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"712 2000 406"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"504 2224 400"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"960 2576 400"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"960 2400 400"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"808 1112 592"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"600 1112 592"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1016 128 936"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"392 128 936"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"848 -64 1304"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"560 -64 1304"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1248 832 1496"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1096 872 1496"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"896 2208 976"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1096 200 1512"
 "light"	"350"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"350"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"264 192 1512"
 "classname"	"light"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"488 448 1264"
 "classname"	"light"
 }
+
 {
 "origin"	"1048 728 1456"
 "classname"	"light"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1328 928 1448"
 "classname"	"light"
 }
+
 {
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"696 672 1320"
 "classname"	"light"
 }
+
 {
 "origin"	"816 -56 1640"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"584 -56 1640"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"880 96 1376"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"528 96 1376"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"960 344 1072"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1120 264 1072"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1208 96 1016"
 "classname"	"light"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1024 360 968"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"328 336 968"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"416 424 1072"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"296 256 1072"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"704 48 1040"
 "classname"	"light"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"384 464 976"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"224 264 976"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"952 2192 416"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1040 -464 1016"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "sounds"	"2"
 "spawnflags"	"1"
@@ -11194,103 +11660,148 @@
 ( 576 -512 1080 ) ( 448 -512 1080 ) ( 448 -640 1080 ) WMET4_5 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "light"	"250"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 "origin"	"1072 -272 1262"
 "classname"	"light_flame_small_yellow"
 }
+
 {
 "classname"	"light"
 "origin"	"1024 -272 1200"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"624 -240 1328"
 "classname"	"light"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1080 -624 1168"
 "classname"	"light"
 }
+
 {
 "origin"	"456 -576 1230"
+	"_color"	"1.00 0.58 0.22"
+	"style"	"1"
 "classname"	"light_flame_small_yellow"
 }
+
 {
 "classname"	"light"
 "origin"	"504 -576 1168"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"624 -448 924"
+	"_color"	"1.00 0.64 0.30"
+	"style"	"1"
 "classname"	"light_flame_large_yellow"
 }
+
 {
 "classname"	"light_flame_large_yellow"
 "origin"	"624 -704 924"
+	"_color"	"1.00 0.64 0.30"
+	"style"	"1"
 }
+
 {
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"664 -448 880"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"624 -488 880"
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"584 -448 880"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"624 -408 880"
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"624 -664 880"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"664 -704 880"
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"624 -744 880"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"584 -704 880"
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"296 -96 968"
 "classname"	"light"
 }
+
 {
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1112 -96 968"
 "classname"	"light"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1056 -224 968"
 "classname"	"light"
 }
+
 {
 "light"	"500"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-264 2120 1504"
 "classname"	"light"
 }
+
 {
 "spawnflags"	"2064"
 "angle"	"0"
@@ -11329,6 +11840,7 @@
 ( 768 6 976 ) ( 704 6 976 ) ( 704 -10 976 ) DOOR05_3 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"3"
 "classname"	"func_door"
@@ -11368,11 +11880,14 @@
 ( 704 -10 976 ) ( 704 6 976 ) ( 640 6 976 ) DOOR02_2 0 112 0 1.000000 1.000000
 }
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"704 32 952"
 "classname"	"light"
 }
+
 {
 "target"	"t101"
 "spawnflags"	"256"
@@ -11381,6 +11896,7 @@
 "origin"	"-248 1560 1224"
 "classname"	"monster_wizard"
 }
+
 {
 "target"	"t23"
 "classname"	"trigger_once"
@@ -11393,23 +11909,28 @@
 ( -24 2160 1216 ) ( -480 2160 1216 ) ( -480 2144 1216 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "origin"	"-280 1560 1348"
 "classname"	"item_armor2"
 }
+
 {
 "origin"	"-488 2112 1220"
 "classname"	"item_health"
 }
+
 {
 "classname"	"item_health"
 "origin"	"-488 2064 1220"
 }
+
 {
 "spawnflags"	"1536"
 "origin"	"-272 1784 1156"
 "classname"	"item_shells"
 }
+
 {
 "spawnflags"	"256"
 "target"	"t25"
@@ -11417,6 +11938,7 @@
 "origin"	"888 1640 1028"
 "classname"	"path_corner"
 }
+
 {
 "spawnflags"	"256"
 "target"	"t24"
@@ -11424,12 +11946,14 @@
 "classname"	"path_corner"
 "origin"	"624 1264 1028"
 }
+
 {
 "spawnflags"	"256"
 "target"	"t24"
 "origin"	"928 1672 1028"
 "classname"	"monster_wizard"
 }
+
 {
 "spawnflags"	"2304"
 "target"	"t26"
@@ -11443,24 +11967,28 @@
 ( 192 1592 804 ) ( 176 1592 804 ) ( 176 1264 804 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "target"	"t27"
 "targetname"	"t28"
 "origin"	"568 2040 928"
 "classname"	"path_corner"
 }
+
 {
 "target"	"t28"
 "targetname"	"t27"
 "classname"	"path_corner"
 "origin"	"368 2044 928"
 }
+
 {
 "target"	"t27"
 "origin"	"472 2040 944"
 "classname"	"monster_ogre"
 "spawnflags"	"1"
 }
+
 {
 "sounds"	"2"
 "target"	"t29"
@@ -11476,6 +12004,7 @@
 ( 1128 2552 944 ) ( 1096 2552 944 ) ( 1096 2544 944 ) DOOR05_3 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"3"
 "angle"	"180"
@@ -11489,6 +12018,7 @@
 ( 720 1904 920 ) ( 632 1904 920 ) ( 632 1888 920 ) DOOR03_2 112 160 0 1.000000 1.000000
 }
 }
+
 {
 "angle"	"0"
 "classname"	"func_door"
@@ -11501,21 +12031,26 @@
 ( 808 1904 920 ) ( 720 1904 920 ) ( 720 1888 920 ) DOOR03_2 112 160 0 1.000000 1.000000
 }
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1112 2520 964"
 "classname"	"light"
 }
+
 {
 "origin"	"104 1308 892"
 "classname"	"item_health"
 }
+
 {
 "spawnflags"	"2048"
 "origin"	"704 1344 936"
 "classname"	"item_key1"
 "sounds"	"1"
 }
+
 {
 "target"	"t34"
 "angle"	"180"
@@ -11523,36 +12058,42 @@
 "classname"	"monster_ogre"
 "spawnflags"	"1"
 }
+
 {
 "target"	"t35"
 "targetname"	"t34"
 "origin"	"864 2044 528"
 "classname"	"path_corner"
 }
+
 {
 "target"	"t37"
 "targetname"	"t35"
 "classname"	"path_corner"
 "origin"	"704 2048 528"
 }
+
 {
 "target"	"t34"
 "targetname"	"t36"
 "origin"	"704 2048 528"
 "classname"	"path_corner"
 }
+
 {
 "target"	"t36"
 "targetname"	"t37"
 "classname"	"path_corner"
 "origin"	"704 1808 528"
 }
+
 {
 "targetname"	"t38"
 "angle"	"270"
 "origin"	"456 2476 544"
 "classname"	"monster_ogre"
 }
+
 {
 "target"	"t38"
 "classname"	"trigger_once"
@@ -11565,6 +12106,7 @@
 ( 960 2132 520 ) ( 960 2144 520 ) ( 824 2144 520 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "targetname"	"t29"
 "angle"	"0"
@@ -11572,6 +12114,7 @@
 "classname"	"monster_knight"
 "spawnflags"	"768"
 }
+
 {
 "targetname"	"t39"
 "spawnflags"	"1"
@@ -11588,12 +12131,14 @@
 ( 776 2608 416 ) ( 648 2608 416 ) ( 648 2480 416 ) WMET2_3 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "targetname"	"t39"
 "angle"	"270"
 "origin"	"712 2540 448"
 "classname"	"monster_ogre"
 }
+
 {
 "target"	"t39"
 "classname"	"trigger_once"
@@ -11606,29 +12151,36 @@
 ( 768 2404 512 ) ( 640 2404 512 ) ( 640 2396 512 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"712 2544 440"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"item_health"
 "origin"	"1064 2184 920"
 "spawnflags"	"1024"
 }
+
 {
 "spawnflags"	"1"
 "origin"	"1128 2184 920"
 "classname"	"item_health"
 }
+
 {
 "classname"	"item_spikes"
 "origin"	"816 2840 920"
 }
+
 {
 "origin"	"816 2800 920"
 "classname"	"item_spikes"
 }
+
 {
 "spawnflags"	"256"
 "classname"	"monster_wizard"
@@ -11636,6 +12188,7 @@
 "angle"	"180"
 "target"	"t41"
 }
+
 {
 "spawnflags"	"2"
 "classname"	"trigger_teleport"
@@ -11650,12 +12203,14 @@
 ( 1600 1528 944 ) ( 1592 1528 944 ) ( 1592 1464 944 ) WSWAMP1_4 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"info_teleport_destination"
 "origin"	"984 1496 1000"
 "angle"	"180"
 "targetname"	"t40"
 }
+
 {
 "spawnflags"	"256"
 "classname"	"path_corner"
@@ -11663,6 +12218,7 @@
 "targetname"	"t41"
 "target"	"t42"
 }
+
 {
 "spawnflags"	"256"
 "origin"	"528 1368 1000"
@@ -11670,21 +12226,25 @@
 "targetname"	"t42"
 "target"	"t41"
 }
+
 {
 "classname"	"item_health"
 "origin"	"408 2640 520"
 }
+
 {
 "classname"	"item_shells"
 "origin"	"456 2672 520"
 "spawnflags"	"1"
 }
+
 {
 "angle"	"0"
 "origin"	"80 864 968"
 "classname"	"monster_wizard"
 "target"	"t44"
 }
+
 {
 "targetname"	"t119"
 "spawnflags"	"2"
@@ -11699,24 +12259,28 @@
 ( 128 832 944 ) ( 128 896 944 ) ( 120 896 944 ) WSWAMP1_4 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"info_teleport_destination"
 "origin"	"432 856 952"
 "angle"	"45"
 "targetname"	"t45"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"496 872 952"
 "target"	"t43"
 "targetname"	"t44"
 }
+
 {
 "origin"	"872 1056 952"
 "classname"	"path_corner"
 "targetname"	"t43"
 "target"	"t44"
 }
+
 {
 "classname"	"trigger_once"
 "spawnflags"	"1792"
@@ -11730,6 +12294,7 @@
 ( 760 2720 512 ) ( 648 2720 512 ) ( 648 2712 512 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "spawnflags"	"1024"
 "classname"	"monster_knight"
@@ -11738,6 +12303,7 @@
 "target"	"t49"
 "targetname"	"t67"
 }
+
 {
 "classname"	"monster_ogre"
 "origin"	"1800 224 920"
@@ -11745,6 +12311,7 @@
 "target"	"t116"
 "spawnflags"	"256"
 }
+
 {
 "classname"	"func_door"
 "angle"	"-1"
@@ -11760,6 +12327,7 @@
 ( 1752 264 888 ) ( 1744 264 888 ) ( 1744 168 888 ) WBRICK1_5 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "wait"	"-1"
 "angle"	"-1"
@@ -11776,6 +12344,7 @@
 ( 1736 264 888 ) ( 1728 264 888 ) ( 1728 168 888 ) WBRICK1_5 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"func_door"
 "angle"	"-1"
@@ -11791,6 +12360,7 @@
 ( 1520 264 888 ) ( 1512 264 888 ) ( 1512 168 888 ) WBRICK1_5 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "spawnflags"	"2"
 "classname"	"trigger_teleport"
@@ -11804,12 +12374,14 @@
 ( 1432 264 888 ) ( 1424 264 888 ) ( 1424 168 888 ) WBRICK1_5 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"info_teleport_destination"
 "origin"	"1104 232 880"
 "angle"	"180"
 "targetname"	"t46"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"1064 256 880"
@@ -11817,6 +12389,7 @@
 "targetname"	"t48"
 "spawnflags"	"256"
 }
+
 {
 "origin"	"312 232 880"
 "classname"	"path_corner"
@@ -11824,12 +12397,14 @@
 "target"	"t48"
 "spawnflags"	"256"
 }
+
 {
 "classname"	"info_teleport_destination"
 "origin"	"704 -40 1256"
 "angle"	"90"
 "targetname"	"t50"
 }
+
 {
 "classname"	"trigger_once"
 "target"	"t52"
@@ -11842,6 +12417,7 @@
 ( 784 248 1248 ) ( 624 248 1248 ) ( 624 240 1248 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "spawnflags"	"2"
 "classname"	"trigger_teleport"
@@ -11856,40 +12432,48 @@
 ( 560 -856 1264 ) ( 512 -856 1264 ) ( 512 -864 1264 ) WBRICK1_5 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "angle"	"90"
 "origin"	"570 -898 1300"
 "classname"	"monster_wizard"
 "targetname"	"t52"
 }
+
 {
 "classname"	"item_shells"
 "origin"	"216 120 880"
 "spawnflags"	"1"
 }
+
 {
 "classname"	"item_health"
 "origin"	"192 232 880"
 }
+
 {
 "origin"	"192 192 880"
 "classname"	"item_health"
 "spawnflags"	"1024"
 }
+
 {
 "classname"	"item_shells"
 "origin"	"-216 1464 888"
 }
+
 {
 "classname"	"item_health"
 "origin"	"816 1160 512"
 "spawnflags"	"1024"
 }
+
 {
 "spawnflags"	"1"
 "origin"	"816 1120 512"
 "classname"	"item_health"
 }
+
 {
 "classname"	"monster_wizard"
 "origin"	"944 840 956"
@@ -11897,6 +12481,7 @@
 "target"	"t53"
 "targetname"	"t64"
 }
+
 {
 "classname"	"trigger_once"
 "target"	"t64"
@@ -11909,6 +12494,7 @@
 ( 96 1552 888 ) ( 48 1552 888 ) ( 48 1544 888 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"monster_knight"
 "origin"	"704 392 1280"
@@ -11916,18 +12502,21 @@
 "target"	"t65"
 "spawnflags"	"1"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"704 208 1264"
 "targetname"	"t65"
 "target"	"t66"
 }
+
 {
 "origin"	"704 496 1264"
 "classname"	"path_corner"
 "targetname"	"t66"
 "target"	"t65"
 }
+
 {
 "classname"	"trigger_once"
 "target"	"t67"
@@ -11940,6 +12529,7 @@
 ( 888 440 848 ) ( 544 440 848 ) ( 544 320 848 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"1"
 "classname"	"func_door"
@@ -11955,6 +12545,7 @@
 ( 896 -320 928 ) ( 640 -320 928 ) ( 640 -336 928 ) WIZMET1_2 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"1"
 "classname"	"func_door"
@@ -11970,6 +12561,7 @@
 ( 896 -816 928 ) ( 640 -816 928 ) ( 640 -832 928 ) WIZMET1_2 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_once"
 "target"	"t72"
@@ -11982,65 +12574,84 @@
 ( 912 -512 816 ) ( 904 -512 816 ) ( 904 -640 816 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"info_null"
 "origin"	"852 -580 820"
 "targetname"	"t73"
 }
+
 {
 "classname"	"light"
 "origin"	"856 -584 936"
 "light"	"400"
+	"_color"	"0.88 0.74 0.58"
 "target"	"t73"
 }
+
 {
 "classname"	"light"
 "origin"	"920 -448 744"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"760 -448 744"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"552 -424 744"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"560 -728 744"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"776 -712 744"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"936 -712 744"
 "classname"	"light"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"652 -576 952"
 "targetname"	"t75"
 "target"	"t74"
 }
+
 {
 "origin"	"908 -576 952"
 "classname"	"path_corner"
 "targetname"	"t74"
 "target"	"t75"
 }
+
 {
 "classname"	"monster_ogre"
 "origin"	"816 -260 952"
 "angle"	"270"
 "targetname"	"t72"
 }
+
 {
 "classname"	"monster_ogre"
 "origin"	"724 -260 952"
@@ -12048,15 +12659,18 @@
 "targetname"	"t72"
 "spawnflags"	"256"
 }
+
 {
 "classname"	"item_health"
 "origin"	"632 -548 820"
 "spawnflags"	"3072"
 }
+
 {
 "origin"	"672 -548 820"
 "classname"	"item_health"
 }
+
 {
 "classname"	"func_button"
 "angle"	"-2"
@@ -12071,6 +12685,7 @@
 ( 384 -64 872 ) ( 320 -64 872 ) ( 320 -128 872 ) +0FLOORSW 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"1"
 "classname"	"func_door"
@@ -12086,34 +12701,47 @@
 ( 1144 -64 912 ) ( 1128 -64 912 ) ( 1128 -128 912 ) DEM5_3 0 16 0 1.000000 1.000000
 }
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1040 -712 1016"
 "classname"	"light"
 }
+
 {
 "origin"	"1112 -576 942"
+	"_color"	"1.00 0.58 0.22"
+	"style"	"1"
 "classname"	"light_flame_small_yellow"
 }
+
 {
 "classname"	"light"
 "origin"	"1064 -576 896"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"888 -80 968"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"512 -80 968"
 "classname"	"light"
 }
+
 {
 "classname"	"item_armor2"
 "origin"	"1184 -96 920"
 }
+
 {
 "classname"	"monster_ogre"
 "origin"	"392 8 912"
@@ -12121,6 +12749,7 @@
 "targetname"	"t77"
 "spawnflags"	"256"
 }
+
 {
 "classname"	"trigger_once"
 "target"	"t77"
@@ -12133,21 +12762,25 @@
 ( 792 -16 888 ) ( 624 -16 888 ) ( 624 -24 888 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"item_health"
 "origin"	"336 -224 888"
 "spawnflags"	"1"
 }
+
 {
 "classname"	"item_spikes"
 "origin"	"968 16 888"
 "spawnflags"	"1"
 }
+
 {
 "classname"	"item_health"
 "origin"	"560 2808 516"
 "spawnflags"	"1"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"1056 -384 824"
@@ -12155,6 +12788,7 @@
 "target"	"t79"
 "spawnflags"	"256"
 }
+
 {
 "origin"	"1056 -736 824"
 "classname"	"path_corner"
@@ -12162,6 +12796,7 @@
 "target"	"t78"
 "spawnflags"	"256"
 }
+
 {
 "classname"	"monster_ogre"
 "origin"	"1064 -656 840"
@@ -12169,37 +12804,47 @@
 "target"	"t78"
 "spawnflags"	"257"
 }
+
 {
 "angle"	"90"
 "origin"	"848 -880 952"
 "classname"	"monster_ogre"
 "targetname"	"t72"
 }
+
 {
 "classname"	"item_shells"
 "origin"	"1160 16 1248"
 }
+
 {
 "classname"	"item_health"
 "origin"	"280 64 1248"
 }
+
 {
 "classname"	"item_rockets"
 "origin"	"648 -256 928"
 "spawnflags"	"1025"
 }
+
 {
 "classname"	"item_spikes"
 "origin"	"648 -304 1248"
 }
+
 {
 "origin"	"696 -304 1248"
 "classname"	"item_spikes"
 }
+
 {
 "classname"	"light_flame_small_yellow"
 "origin"	"768 -352 1230"
+	"_color"	"1.00 0.58 0.22"
+	"style"	"1"
 }
+
 {
 "target"	"t83"
 "wait"	".8"
@@ -12213,6 +12858,7 @@
 ( 800 -560 1108 ) ( 736 -560 1108 ) ( 736 -624 1108 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "target"	"t83"
 "classname"	"trigger_multiple"
@@ -12226,6 +12872,7 @@
 ( 800 -448 1108 ) ( 736 -448 1108 ) ( 736 -512 1108 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "target"	"t83"
 "wait"	".8"
@@ -12239,6 +12886,7 @@
 ( 928 -560 1108 ) ( 864 -560 1108 ) ( 864 -624 1108 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "target"	"t83"
 "classname"	"trigger_multiple"
@@ -12252,6 +12900,7 @@
 ( 800 -672 1108 ) ( 736 -672 1108 ) ( 736 -736 1108 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "target"	"t83"
 "wait"	".8"
@@ -12265,6 +12914,7 @@
 ( 672 -560 1108 ) ( 608 -560 1108 ) ( 608 -624 1108 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "targetname"	"t83"
 "classname"	"trap_spikeshooter"
@@ -12272,6 +12922,7 @@
 "spawnflags"	"1"
 "angle"	"180"
 }
+
 {
 "targetname"	"t83"
 "angle"	"90"
@@ -12279,46 +12930,64 @@
 "origin"	"768 -796 1140"
 "classname"	"trap_spikeshooter"
 }
+
 {
 "origin"	"1112 -576 1230"
+	"_color"	"1.00 0.58 0.22"
+	"style"	"1"
 "classname"	"light_flame_small_yellow"
 }
+
 {
 "classname"	"light_flame_small_yellow"
 "origin"	"768 -800 1230"
+	"_color"	"1.00 0.58 0.22"
+	"style"	"1"
 }
+
 {
 "classname"	"light"
 "origin"	"712 -756 1168"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"768 -424 1168"
 "classname"	"light"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"888 -744 956"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"888 -408 956"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"384 -224 888"
 "classname"	"item_shells"
 }
+
 {
 "origin"	"584 1784 920"
 "classname"	"item_health"
 }
+
 {
 "origin"	"832 2064 920"
 "classname"	"item_shells"
 }
+
 {
 "target"	"t72"
 "classname"	"trigger_once"
@@ -12331,37 +13000,44 @@
 ( 544 -528 968 ) ( 448 -528 968 ) ( 448 -616 968 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "target"	"t85"
 "targetname"	"t84"
 "origin"	"1560 216 896"
 "classname"	"path_corner"
 }
+
 {
 "target"	"t48"
 "targetname"	"t85"
 "classname"	"path_corner"
 "origin"	"1456 216 896"
 }
+
 {
 "origin"	"704 1368 516"
 "classname"	"weapon_supernailgun"
 }
+
 {
 "spawnflags"	"1"
 "origin"	"184 1928 920"
 "classname"	"item_spikes"
 }
+
 {
 "classname"	"item_spikes"
 "origin"	"656 1816 528"
 "spawnflags"	"768"
 }
+
 {
 "classname"	"item_shells"
 "origin"	"1072 -800 820"
 "spawnflags"	"1024"
 }
+
 {
 "classname"	"monster_ogre"
 "origin"	"840 -40 1276"
@@ -12369,6 +13045,7 @@
 "targetname"	"t86"
 "spawnflags"	"768"
 }
+
 {
 "classname"	"trigger_once"
 "target"	"t86"
@@ -12381,28 +13058,34 @@
 ( 792 -152 1252 ) ( 616 -152 1252 ) ( 616 -160 1252 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"472 -576 876"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"item_shells"
 "origin"	"656 680 1256"
 "spawnflags"	"1536"
 }
+
 {
 "angle"	"270"
 "origin"	"880 2224 536"
 "classname"	"monster_knight"
 "spawnflags"	"256"
 }
+
 {
 "angle"	"180"
 "origin"	"1112 2424 944"
 "classname"	"monster_ogre"
 "spawnflags"	"1281"
 }
+
 {
 "targetname"	"t88"
 "target"	"t87"
@@ -12410,6 +13093,7 @@
 "classname"	"path_corner"
 "spawnflags"	"1280"
 }
+
 {
 "target"	"t88"
 "targetname"	"t87"
@@ -12417,6 +13101,7 @@
 "origin"	"504 160 880"
 "spawnflags"	"1280"
 }
+
 {
 "target"	"t87"
 "angle"	"315"
@@ -12424,6 +13109,7 @@
 "classname"	"monster_knight"
 "spawnflags"	"1280"
 }
+
 {
 "spawnflags"	"257"
 "targetname"	"t86"
@@ -12431,27 +13117,32 @@
 "origin"	"376 120 1272"
 "classname"	"monster_ogre"
 }
+
 {
 "origin"	"776 1368 916"
 "classname"	"item_shells"
 "spawnflags"	"1024"
 }
+
 {
 "classname"	"item_spikes"
 "origin"	"184 1968 920"
 "spawnflags"	"1"
 }
+
 {
 "classname"	"monster_wizard"
 "origin"	"312 936 944"
 "angle"	"45"
 "spawnflags"	"769"
 }
+
 {
 "classname"	"monster_knight"
 "origin"	"704 -80 908"
 "angle"	"90"
 }
+
 {
 "angle"	"0"
 "origin"	"568 -56 1276"
@@ -12459,6 +13150,7 @@
 "targetname"	"t86"
 "spawnflags"	"768"
 }
+
 {
 "spawnflags"	"1536"
 "targetname"	"t90"
@@ -12466,6 +13158,7 @@
 "origin"	"720 1696 924"
 "classname"	"path_corner"
 }
+
 {
 "spawnflags"	"1536"
 "target"	"t90"
@@ -12473,12 +13166,14 @@
 "classname"	"path_corner"
 "origin"	"720 1416 924"
 }
+
 {
 "spawnflags"	"1537"
 "target"	"t90"
 "origin"	"704 1784 948"
 "classname"	"monster_ogre"
 }
+
 {
 "classname"	"func_door_secret"
 "angle"	"0"
@@ -12493,6 +13188,7 @@
 ( 720 -808 1104 ) ( 648 -808 1104 ) ( 648 -824 1104 ) WBRICK1_5 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"func_button"
 "angle"	"-2"
@@ -12507,6 +13203,7 @@
 ( 672 -560 1096 ) ( 608 -560 1096 ) ( 608 -624 1096 ) SWTCH1_1 16 32 90 -1.000000 -1.000000
 }
 }
+
 {
 "classname"	"func_button"
 "angle"	"-2"
@@ -12521,6 +13218,7 @@
 ( 800 -560 1096 ) ( 736 -560 1096 ) ( 736 -624 1096 ) SWTCH1_1 16 32 90 -1.000000 -1.000000
 }
 }
+
 {
 "classname"	"func_button"
 "wait"	"-1"
@@ -12535,6 +13233,7 @@
 ( 928 -560 1096 ) ( 864 -560 1096 ) ( 864 -624 1096 ) SWTCH1_1 80 32 90 -1.000000 -1.000000
 }
 }
+
 {
 "classname"	"func_button"
 "angle"	"-2"
@@ -12549,6 +13248,7 @@
 ( 800 -448 1096 ) ( 736 -448 1096 ) ( 736 -512 1096 ) SWTCH1_1 0 32 90 -1.000000 -1.000000
 }
 }
+
 {
 "classname"	"func_button"
 "wait"	"-1"
@@ -12563,6 +13263,7 @@
 ( 800 -672 1096 ) ( 736 -672 1096 ) ( 736 -736 1096 ) SWTCH1_1 32 32 90 -1.000000 -1.000000
 }
 }
+
 {
 "classname"	"trigger_counter"
 "count"	"5"
@@ -12577,16 +13278,20 @@
 ( 376 -824 1096 ) ( 352 -824 1096 ) ( 352 -848 1096 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"680 -920 1144"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"item_spikes"
 "origin"	"752 -876 928"
 "spawnflags"	"1"
 }
+
 {
 "spawnflags"	"3"
 "angle"	"0"
@@ -12601,11 +13306,14 @@
 ( 720 -328 1112 ) ( 648 -328 1112 ) ( 648 -344 1112 ) WBRICK1_5 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"680 -256 1144"
 "classname"	"light"
 }
+
 {
 "classname"	"trigger_once"
 "spawnflags"	"1792"
@@ -12619,6 +13327,7 @@
 ( 1120 -336 1108 ) ( 992 -336 1108 ) ( 992 -344 1108 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_secret"
 "sounds"	"1"
@@ -12632,28 +13341,33 @@
 ( -112 1432 1234 ) ( -136 1432 1234 ) ( -136 1408 1234 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "angle"	"270"
 "origin"	"704 624 1280"
 "classname"	"monster_knight"
 "spawnflags"	"1"
 }
+
 {
 "angle"	"225"
 "origin"	"1016 -440 1128"
 "classname"	"monster_knight"
 }
+
 {
 "angle"	"180"
 "origin"	"1024 -728 1128"
 "classname"	"monster_knight"
 }
+
 {
 "spawnflags"	"256"
 "angle"	"180"
 "origin"	"1008 -568 1128"
 "classname"	"monster_knight"
 }
+
 {
 "spawnflags"	"256"
 "classname"	"monster_knight"
@@ -12661,12 +13375,14 @@
 "angle"	"0"
 "targetname"	"t29"
 }
+
 {
 "spawnflags"	"1025"
 "classname"	"monster_knight"
 "origin"	"272 136 896"
 "angle"	"45"
 }
+
 {
 "classname"	"monster_wizard"
 "origin"	"784 -576 960"
@@ -12674,20 +13390,24 @@
 "target"	"t74"
 "spawnflags"	"1"
 }
+
 {
 "classname"	"item_health"
 "origin"	"732 -936 928"
 }
+
 {
 "origin"	"772 -936 928"
 "classname"	"item_health"
 }
+
 {
 "spawnflags"	"256"
 "classname"	"monster_knight"
 "origin"	"704 -248 1272"
 "angle"	"0"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"1328 928 1396"
@@ -12695,6 +13415,7 @@
 "target"	"t94"
 "spawnflags"	"512"
 }
+
 {
 "origin"	"1176 928 1396"
 "classname"	"path_corner"
@@ -12702,6 +13423,7 @@
 "targetname"	"t94"
 "spawnflags"	"512"
 }
+
 {
 "classname"	"monster_knight"
 "origin"	"1192 884 1412"
@@ -12709,17 +13431,20 @@
 "target"	"t93"
 "spawnflags"	"513"
 }
+
 {
 "classname"	"monster_knight"
 "origin"	"704 2376 944"
 "angle"	"90"
 }
+
 {
 "classname"	"monster_knight"
 "origin"	"888 2312 944"
 "angle"	"180"
 "targetname"	"t95"
 }
+
 {
 "angle"	"0"
 "origin"	"512 2304 944"
@@ -12727,6 +13452,7 @@
 "targetname"	"t95"
 "spawnflags"	"768"
 }
+
 {
 "classname"	"trigger_once"
 "target"	"t95"
@@ -12739,32 +13465,43 @@
 ( 752 2880 880 ) ( 648 2880 880 ) ( 648 2784 880 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "spawnflags"	"256"
 "angle"	"315"
 "origin"	"728 2312 536"
 "classname"	"monster_knight"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1296 1528 936"
 "classname"	"light"
 }
+
 {
 "light"	"250"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 "origin"	"1432 1360 982"
 "classname"	"light_flame_small_yellow"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1400 1360 920"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1248 1344 680"
 "classname"	"light"
 }
+
 {
 "lip"	"-384"
 "wait"	"-1"
@@ -12782,15 +13519,19 @@
 ( 1648 1216 632 ) ( 1648 1272 544 ) ( 1632 1216 632 ) ROCK1_2 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1152 1328 584"
 "classname"	"light"
 }
+
 {
 "origin"	"1376 1480 864"
 "classname"	"item_health"
 }
+
 {
 "sounds"	"1"
 "classname"	"trigger_secret"
@@ -12803,6 +13544,7 @@
 ( 1312 1440 864 ) ( 1160 1440 864 ) ( 1160 1248 864 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"func_button"
 "sounds"	"1"
@@ -12818,6 +13560,7 @@
 ( 896 -872 952 ) ( 888 -872 952 ) ( 888 -904 952 ) METAL6_3 40 24 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"func_button"
 "wait"	"-1"
@@ -12833,6 +13576,7 @@
 ( 896 -248 952 ) ( 888 -248 952 ) ( 888 -280 952 ) METAL6_3 24 24 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_counter"
 "targetname"	"t97"
@@ -12846,28 +13590,35 @@
 ( 944 -880 952 ) ( 920 -880 952 ) ( 920 -904 952 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"880 -888 968"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"880 -264 968"
 "classname"	"light"
 }
+
 {
 "angle"	"180"
 "origin"	"1112 2344 944"
 "classname"	"monster_ogre"
 "spawnflags"	"769"
 }
+
 {
 "angle"	"270"
 "origin"	"1120 880 1412"
 "classname"	"monster_ogre"
 "spawnflags"	"257"
 }
+
 {
 "map"	"e1m8"
 "classname"	"trigger_changelevel"
@@ -12880,36 +13631,45 @@
 ( 1324 1592 904 ) ( 1260 1592 904 ) ( 1260 1584 904 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"824 -756 1168"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1080 -528 1168"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"monster_wizard"
 "origin"	"672 -392 1024"
 "angle"	"315"
 "spawnflags"	"257"
 }
+
 {
 "classname"	"monster_knight"
 "origin"	"1008 -656 1128"
 "angle"	"180"
 "spawnflags"	"768"
 }
+
 {
 "origin"	"520 1064 440"
 "classname"	"air_bubbles"
 }
+
 {
 "classname"	"item_spikes"
 "origin"	"16 1432 892"
 }
+
 {
 "classname"	"trigger_once"
 "message"	"A secret cave has opened..."
@@ -12923,6 +13683,7 @@
 ( 944 -912 952 ) ( 920 -912 952 ) ( 920 -936 952 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "target"	"t4"
 "health"	"1"
@@ -12938,6 +13699,7 @@
 ( -80 1648 1232 ) ( -80 1616 1232 ) ( -72 1616 1232 ) +1SHOOT 16 -16 0 1.000000 1.000000
 }
 }
+
 {
 "target"	"t2"
 "health"	"1"
@@ -12953,6 +13715,7 @@
 ( -440 1648 1232 ) ( -440 1616 1232 ) ( -432 1616 1232 ) +1SHOOT 16 -16 0 1.000000 1.000000
 }
 }
+
 {
 "target"	"t49"
 "spawnflags"	"769"
@@ -12960,18 +13723,21 @@
 "origin"	"1208 128 904"
 "classname"	"monster_demon1"
 }
+
 {
 "spawnflags"	"769"
 "angle"	"45"
 "origin"	"288 160 896"
 "classname"	"monster_demon1"
 }
+
 {
 "spawnflags"	"768"
 "classname"	"monster_ogre"
 "origin"	"692 -884 952"
 "angle"	"90"
 }
+
 {
 "classname"	"monster_ogre"
 "origin"	"-312 1648 1372"
@@ -12979,6 +13745,7 @@
 "targetname"	"t23"
 "spawnflags"	"768"
 }
+
 {
 "angle"	"90"
 "origin"	"-192 1648 1372"
@@ -12986,12 +13753,14 @@
 "targetname"	"t23"
 "spawnflags"	"768"
 }
+
 {
 "classname"	"monster_ogre"
 "origin"	"704 1288 540"
 "angle"	"270"
 "spawnflags"	"768"
 }
+
 {
 "targetname"	"t101"
 "target"	"t106"
@@ -13006,6 +13775,7 @@
 ( -224 2400 1248 ) ( -344 2400 1248 ) ( -344 2392 1248 ) WBRICK1_5 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "spawnflags"	"768"
 "targetname"	"t101"
@@ -13013,11 +13783,13 @@
 "origin"	"-256 2424 1288"
 "classname"	"monster_wizard"
 }
+
 {
 "targetname"	"t101"
 "origin"	"-248 2440 1280"
 "classname"	"trigger_relay"
 }
+
 {
 "targetname"	"t29"
 "spawnflags"	"256"
@@ -13025,6 +13797,7 @@
 "origin"	"144 2648 1024"
 "classname"	"monster_wizard"
 }
+
 {
 "targetname"	"t29"
 "spawnflags"	"768"
@@ -13032,6 +13805,7 @@
 "origin"	"144 2592 1024"
 "angle"	"0"
 }
+
 {
 "targetname"	"t29"
 "spawnflags"	"768"
@@ -13039,6 +13813,7 @@
 "origin"	"144 2536 1024"
 "classname"	"monster_wizard"
 }
+
 {
 "targetname"	"t29"
 "target"	"t102"
@@ -13053,6 +13828,7 @@
 ( 176 2680 1000 ) ( 168 2680 1000 ) ( 168 2504 1000 ) WBRICK1_5 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "targetname"	"t29"
 "target"	"t103"
@@ -13067,6 +13843,7 @@
 ( 176 2624 1000 ) ( 168 2624 1000 ) ( 168 2448 1000 ) WBRICK1_5 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "targetname"	"t29"
 "target"	"t104"
@@ -13081,6 +13858,7 @@
 ( 176 2560 1000 ) ( 168 2560 1000 ) ( 168 2384 1000 ) WBRICK1_5 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "angle"	"270"
 "targetname"	"t102"
@@ -13088,6 +13866,7 @@
 "origin"	"704 2656 1008"
 "classname"	"info_teleport_destination"
 }
+
 {
 "angle"	"270"
 "targetname"	"t103"
@@ -13095,6 +13874,7 @@
 "classname"	"info_teleport_destination"
 "origin"	"920 2520 1008"
 }
+
 {
 "angle"	"0"
 "targetname"	"t104"
@@ -13102,6 +13882,7 @@
 "origin"	"592 2192 1008"
 "classname"	"info_teleport_destination"
 }
+
 {
 "sounds"	"1"
 "classname"	"func_door"
@@ -13118,6 +13899,7 @@
 ( 1120 -808 1104 ) ( 984 -808 1104 ) ( 984 -824 1104 ) WBRICK1_5 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"monster_demon1"
 "origin"	"1056 -880 1128"
@@ -13125,6 +13907,7 @@
 "spawnflags"	"768"
 "targetname"	"t105"
 }
+
 {
 "classname"	"trigger_once"
 "spawnflags"	"768"
@@ -13138,26 +13921,32 @@
 ( 992 -344 1104 ) ( 984 -344 1104 ) ( 984 -808 1104 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"1056 -920 1184"
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"trigger_relay"
 "origin"	"1104 -864 1120"
 "target"	"t105"
 }
+
 {
 "classname"	"monster_ogre"
 "origin"	"1120 768 1416"
 "angle"	"180"
 "spawnflags"	"769"
 }
+
 {
 "classname"	"air_bubbles"
 "origin"	"884 1616 440"
 }
+
 {
 "targetname"	"t106"
 "spawnflags"	"768"
@@ -13165,6 +13954,7 @@
 "origin"	"-264 2232 1296"
 "classname"	"info_teleport_destination"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"568 1984 928"
@@ -13172,6 +13962,7 @@
 "target"	"t108"
 "spawnflags"	"256"
 }
+
 {
 "origin"	"424 1960 928"
 "classname"	"path_corner"
@@ -13179,6 +13970,7 @@
 "spawnflags"	"256"
 "targetname"	"t111"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"704 2024 928"
@@ -13186,6 +13978,7 @@
 "target"	"t109"
 "spawnflags"	"256"
 }
+
 {
 "origin"	"712 1712 928"
 "classname"	"path_corner"
@@ -13193,6 +13986,7 @@
 "target"	"t110"
 "spawnflags"	"256"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"712 1416 928"
@@ -13200,6 +13994,7 @@
 "target"	"t109"
 "spawnflags"	"256"
 }
+
 {
 "classname"	"func_door"
 "angle"	"-2"
@@ -13216,6 +14011,7 @@
 ( 440 1976 912 ) ( 408 1976 912 ) ( 408 1944 912 ) WMET4_7 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"monster_ogre"
 "origin"	"240 2048 944"
@@ -13223,6 +14019,7 @@
 "spawnflags"	"257"
 "target"	"t111"
 }
+
 {
 "target"	"t23"
 "spawnflags"	"1792"
@@ -13236,18 +14033,21 @@
 ( -192 1832 1156 ) ( -320 1832 1156 ) ( -320 1824 1156 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"monster_knight"
 "origin"	"576 2768 536"
 "angle"	"0"
 "spawnflags"	"256"
 }
+
 {
 "spawnflags"	"256"
 "angle"	"180"
 "origin"	"824 2776 536"
 "classname"	"monster_knight"
 }
+
 {
 "classname"	"monster_wizard"
 "origin"	"704 -1032 1024"
@@ -13255,6 +14055,7 @@
 "spawnflags"	"256"
 "targetname"	"t52"
 }
+
 {
 "angle"	"90"
 "origin"	"760 -1032 1024"
@@ -13262,6 +14063,7 @@
 "spawnflags"	"768"
 "targetname"	"t114"
 }
+
 {
 "classname"	"monster_wizard"
 "origin"	"816 -1032 1024"
@@ -13269,6 +14071,7 @@
 "spawnflags"	"768"
 "targetname"	"t114"
 }
+
 {
 "targetname"	"t52"
 "classname"	"trigger_teleport"
@@ -13283,6 +14086,7 @@
 ( 672 -1000 1000 ) ( 672 -1008 1000 ) ( 848 -1008 1000 ) WBRICK1_5 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_teleport"
 "spawnflags"	"770"
@@ -13297,6 +14101,7 @@
 ( 728 -1000 1000 ) ( 728 -1008 1000 ) ( 904 -1008 1000 ) WBRICK1_5 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "targetname"	"t114"
 "classname"	"trigger_teleport"
@@ -13311,6 +14116,7 @@
 ( 792 -1000 1000 ) ( 792 -1008 1000 ) ( 968 -1008 1000 ) WBRICK1_5 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"info_teleport_destination"
 "origin"	"896 224 1352"
@@ -13318,6 +14124,7 @@
 "spawnflags"	"256"
 "targetname"	"t112"
 }
+
 {
 "classname"	"info_teleport_destination"
 "origin"	"488 1648 1016"
@@ -13325,6 +14132,7 @@
 "spawnflags"	"768"
 "targetname"	"t113"
 }
+
 {
 "classname"	"trigger_once"
 "spawnflags"	"768"
@@ -13338,6 +14146,7 @@
 ( 744 1392 936 ) ( 664 1392 936 ) ( 664 1320 936 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"info_teleport_destination"
 "origin"	"800 904 928"
@@ -13345,134 +14154,166 @@
 "spawnflags"	"768"
 "targetname"	"t115"
 }
+
 {
 "angle"	"270"
 "origin"	"-256 2232 1242"
 "classname"	"info_player_deathmatch"
 }
+
 {
 "spawnflags"	"1792"
 "origin"	"-256 2096 1218"
 "classname"	"weapon_supershotgun"
 }
+
 {
 "angle"	"270"
 "origin"	"704 424 1266"
 "classname"	"info_player_deathmatch"
 }
+
 {
 "angle"	"270"
 "origin"	"704 2488 946"
 "classname"	"info_player_deathmatch"
 }
+
 {
 "angle"	"270"
 "origin"	"704 1968 546"
 "classname"	"info_player_deathmatch"
 }
+
 {
 "angle"	"90"
 "origin"	"704 104 898"
 "classname"	"info_player_deathmatch"
 }
+
 {
 "angle"	"270"
 "origin"	"704 1568 938"
 "classname"	"info_player_deathmatch"
 }
+
 {
 "spawnflags"	"1792"
 "origin"	"704 1344 912"
 "classname"	"weapon_rocketlauncher"
 }
+
 {
 "angle"	"0"
 "origin"	"712 -576 840"
 "classname"	"info_player_deathmatch"
 }
+
 {
 "spawnflags"	"1792"
 "origin"	"944 -576 816"
 "classname"	"weapon_nailgun"
 }
+
 {
 "angle"	"180"
 "origin"	"1064 -576 1128"
 "classname"	"info_player_deathmatch"
 }
+
 {
 "spawnflags"	"1792"
 "origin"	"696 584 1256"
 "classname"	"weapon_grenadelauncher"
 }
+
 {
 "classname"	"light"
 "origin"	"316 804 780"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"316 804 644"
 "light"	"75"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"item_rockets"
 "origin"	"298 710 706"
 "spawnflags"	"1"
 }
+
 {
 "classname"	"item_shells"
 "origin"	"988 -928 1104"
 "spawnflags"	"1"
 }
+
 {
 "classname"	"item_health"
 "origin"	"-56 2112 1220"
 "spawnflags"	"3584"
 }
+
 {
 "classname"	"item_health"
 "origin"	"-56 2072 1220"
 "spawnflags"	"2305"
 }
+
 {
 "spawnflags"	"1"
 "origin"	"584 2416 512"
 "classname"	"item_spikes"
 }
+
 {
 "origin"	"688 1392 516"
 "classname"	"item_spikes"
 }
+
 {
 "classname"	"item_artifact_invulnerability"
 "origin"	"712 2312 948"
 "spawnflags"	"1792"
 }
+
 {
 "origin"	"32 1392 916"
 "classname"	"item_artifact_envirosuit"
 }
+
 {
 "mangle"	"26 310 0"
 "origin"	"384 488 1552"
 "classname"	"info_intermission"
 }
+
 {
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"800 1160 464"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"608 1160 464"
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"604 1472 464"
 "classname"	"light"
 }
+
 {
 "target"	"t40"
 "classname"	"trigger_teleport"
@@ -13485,21 +14326,25 @@
 ( 1300 1616 1040 ) ( 1268 1616 1040 ) ( 1268 1600 1040 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "mangle"	"-20 75 0"
 "origin"	"456 2144 568"
 "classname"	"info_intermission"
 }
+
 {
 "mangle"	"10 80 0"
 "origin"	"464 1032 1000"
 "classname"	"info_intermission"
 }
+
 {
 "mangle"	"20 135 0"
 "origin"	"1080 -752 1008"
 "classname"	"info_intermission"
 }
+
 {
 "classname"	"trigger_secret"
 {
@@ -13511,61 +14356,74 @@
 ( 352 816 704 ) ( 280 816 704 ) ( 280 784 704 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"path_corner"
 "origin"	"1632 216 896"
 "targetname"	"t116"
 "target"	"t84"
 }
+
 {
 "classname"	"item_spikes"
 "origin"	"1200 48 872"
 "spawnflags"	"1"
 }
+
 {
 "classname"	"item_spikes"
 "origin"	"928 2664 320"
 "spawnflags"	"1"
 }
+
 {
 "classname"	"item_shells"
 "origin"	"1240 768 1384"
 "spawnflags"	"1"
 }
+
 {
 "classname"	"item_shells"
 "origin"	"-88 2160 1224"
 "spawnflags"	"2049"
 }
+
 {
 "classname"	"info_player_coop"
 "origin"	"-208 2272 1240"
 "angle"	"270"
 }
+
 {
 "angle"	"270"
 "origin"	"-304 2272 1240"
 "classname"	"info_player_coop"
 }
+
 {
 "classname"	"info_player_coop"
 "origin"	"-352 2272 1240"
 "angle"	"270"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1288 1648 956"
 "classname"	"light"
 }
+
 {
 "classname"	"item_spikes"
 "origin"	"-264 1464 888"
 }
+
 {
 "spawnflags"	"1792"
 "origin"	"1296 1488 888"
 "classname"	"item_artifact_invisibility"
 }
+
 {
 "spawnflags"	"1792"
 "classname"	"func_wall"
@@ -13586,6 +14444,7 @@
 ( 1312 976 1384 ) ( 1124 976 1384 ) ( 1124 964 1384 ) WMET2_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"func_wall"
 "spawnflags"	"1792"
@@ -13598,28 +14457,33 @@
 ( 1304 1560 864 ) ( 1264 1560 864 ) ( 1264 1552 864 ) COP1_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "target"	"t118"
 "targetname"	"t117"
 "origin"	"-176 1640 888"
 "classname"	"path_corner"
 }
+
 {
 "targetname"	"t118"
 "target"	"t117"
 "classname"	"path_corner"
 "origin"	"-320 1640 888"
 }
+
 {
 "target"	"t117"
 "origin"	"-256 1632 904"
 "classname"	"monster_knight"
 "spawnflags"	"1"
 }
+
 {
 "origin"	"1376 1424 864"
 "classname"	"weapon_grenadelauncher"
 }
+
 {
 "spawnflags"	"1"
 "targetname"	"t120"
@@ -13634,6 +14498,7 @@
 ( 80 952 936 ) ( 64 952 936 ) ( 64 936 936 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "target"	"t120"
 "targetname"	"t53"
@@ -13647,6 +14512,7 @@
 ( 112 952 936 ) ( 96 952 936 ) ( 96 936 936 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "target"	"t120"
 "targetname"	"t39"
@@ -13660,132 +14526,172 @@
 ( 48 952 936 ) ( 32 952 936 ) ( 32 936 936 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"480 2568 568"
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"162 1482 976"
 "classname"	"ambient_drip"
 }
+
 {
 "origin"	"786 1010 584"
 "classname"	"ambient_drip"
 }
+
 {
 "classname"	"ambient_drip"
 "origin"	"778 1210 584"
 }
+
 {
 "origin"	"594 1202 584"
 "classname"	"ambient_drip"
 }
+
 {
 "classname"	"ambient_drip"
 "origin"	"602 1010 584"
 }
+
 {
 "origin"	"786 1514 584"
 "classname"	"ambient_drip"
 }
+
 {
 "classname"	"ambient_drip"
 "origin"	"794 1698 584"
 }
+
 {
 "origin"	"618 1690 584"
 "classname"	"ambient_drip"
 }
+
 {
 "classname"	"ambient_drip"
 "origin"	"618 1522 584"
 }
+
 {
 "origin"	"698 1362 584"
 "classname"	"ambient_drip"
 }
+
 {
 "origin"	"714 1970 592"
 "classname"	"ambient_drip"
 }
+
 {
 "classname"	"ambient_drip"
 "origin"	"898 2170 592"
 }
+
 {
 "origin"	"938 2346 592"
 "classname"	"ambient_drip"
 }
+
 {
 "classname"	"ambient_drip"
 "origin"	"682 2298 592"
 }
+
 {
 "origin"	"458 2306 592"
 "classname"	"ambient_drip"
 }
+
 {
 "origin"	"458 1690 880"
 "classname"	"ambient_drip"
 }
+
 {
 "classname"	"ambient_drip"
 "origin"	"322 1506 880"
 }
+
 {
 "origin"	"338 1226 880"
 "classname"	"ambient_drip"
 }
+
 {
 "classname"	"ambient_drip"
 "origin"	"466 1090 880"
 }
+
 {
 "origin"	"394 882 880"
 "classname"	"ambient_drip"
 }
+
 {
 "classname"	"ambient_drip"
 "origin"	"674 810 880"
 }
+
 {
 "origin"	"914 818 880"
 "classname"	"ambient_drip"
 }
+
 {
 "classname"	"ambient_drip"
 "origin"	"922 1034 880"
 }
+
 {
 "origin"	"1082 1266 880"
 "classname"	"ambient_drip"
 }
+
 {
 "classname"	"ambient_drip"
 "origin"	"994 1442 880"
 }
+
 {
 "origin"	"898 1714 880"
 "classname"	"ambient_drip"
 }
+
 {
 "origin"	"706 1362 1080"
 "classname"	"ambient_drip"
 }
+
 {
 "origin"	"1194 1522 1032"
 "classname"	"ambient_drip"
 }
+
 {
 "classname"	"ambient_drip"
 "origin"	"1314 1354 1032"
 }
+
 {
 "origin"	"442 354 920"
 "classname"	"ambient_swamp1"
 }
+
 {
 "origin"	"978 314 920"
 "classname"	"ambient_swamp2"
+}
+
+{
+	"classname"	"light_environment"
+	"_color"	"0.85 0.72 0.58"
+	"light"	"220"
+	"angles"	"45 120 0"
 }

--- a/Quake/maps/E1M5.MAP
+++ b/Quake/maps/E1M5.MAP
@@ -4,6 +4,12 @@
 "sounds"	"10"
 "worldtype"	"0"
 "message"	"Gloom Keep"
+	"_ambient"	"18"
+	"_minlight"	"6"
+	"_sunlight"	"70"
+	"_sunlight_color"	"0.85 0.72 0.58"
+	"_sun_mangle"	"45 120 0"
+	"fog"	"0.03 0.08 0.11 0.18"
 {
 ( -640 616 372 ) ( -512 616 372 ) ( -512 616 308 ) CITY5_4 0 0 0 1.000000 1.000000
 ( -640 632 372 ) ( -640 616 372 ) ( -640 616 308 ) CITY5_4 0 0 0 1.000000 1.000000
@@ -10088,95 +10094,135 @@
 ( 736 1560 -8 ) ( 672 1560 -8 ) ( 672 1496 -8 ) COP3_4 32 24 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"info_player_start"
 "origin"	"-576 192 184"
 "angle"	"90"
 }
+
 {
 "classname"	"light_flame_large_yellow"
 "origin"	"-710 442 360"
 "light"	"400"
+	"style"	"1"
+	"_color"	"1.00 0.64 0.30"
 }
+
 {
 "origin"	"-444 442 360"
 "classname"	"light_flame_large_yellow"
 "light"	"400"
+	"style"	"1"
+	"_color"	"1.00 0.64 0.30"
 }
+
 {
 "light"	"264"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 "origin"	"-584 736 216"
 }
+
 {
 "light"	"364"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-584 720 470"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-212 440 244"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"164 492 282"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-144 720 438"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-224 944 686"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"0 280 452"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-172 918 392"
 "light"	"264"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"-928 872 686"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-968 368 596"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"264"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 "origin"	"-980 534 192"
 }
+
 {
 "light"	"264"
+	"_color"	"0.88 0.74 0.58"
 "target"	"t5"
 "origin"	"-740 788 216"
 "classname"	"light"
 }
+
 {
 "light"	"264"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-768 272 368"
 "classname"	"light"
 }
+
 {
 "light"	"264"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-344 264 80"
 "classname"	"light"
 }
+
 {
 "light"	"264"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-72 888 148"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-56 1084 176"
 "light"	"264"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "sounds"	"3"
 "classname"	"func_door"
@@ -10191,31 +10237,42 @@
 ( -36 964 86 ) ( -112 964 86 ) ( -112 936 86 ) CITYA1_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "light"	"264"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 "origin"	"-536 1120 208"
 }
+
 {
 "origin"	"-560 1324 104"
 "classname"	"light"
 "light"	"214"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"-312 1592 224"
 "classname"	"light"
 "light"	"264"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-760 1592 224"
 "light"	"264"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"-544 1716 434"
 "classname"	"light"
 "light"	"314"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "targetname"	"t2"
 "classname"	"func_plat"
@@ -10260,6 +10317,7 @@
 ( -496 1656 304 ) ( -592 1656 304 ) ( -592 1584 304 ) PLAT_TOP1 64 -8 0 1.000000 1.000000
 }
 }
+
 {
 "wait"	"-1"
 "angle"	"270"
@@ -10274,141 +10332,189 @@
 ( -532 1080 -32 ) ( -548 1080 -32 ) ( -548 1068 -32 ) +1BUTTON -8 16 0 1.000000 1.000000
 }
 }
+
 {
 "light"	"300"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-544 1540 200"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-544 1636 16"
 "classname"	"light"
 }
+
 {
 "light"	"264"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-320 1676 400"
 "classname"	"light"
 }
+
 {
 "light"	"264"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-768 1672 400"
 "classname"	"light"
 }
+
 {
 "origin"	"-544 1272 368"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "light"	"264"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-264 1408 264"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-824 1408 264"
 "light"	"264"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-48 1392 256"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-152 1592 256"
 "light"	"264"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-320 1312 72"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-184 1336 72"
 "light"	"264"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"120 1312 144"
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"0 1856 56"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "targetname"	"t4"
 "angle"	"90"
 "origin"	"-1168 1564 174"
 "classname"	"trap_spikeshooter"
 }
+
 {
 "targetname"	"t4"
 "classname"	"trap_spikeshooter"
 "origin"	"-1088 1488 174"
 "angle"	"0"
 }
+
 {
 "targetname"	"t4"
 "angle"	"270"
 "origin"	"-1168 1414 174"
 "classname"	"trap_spikeshooter"
 }
+
 {
 "targetname"	"t4"
 "classname"	"trap_spikeshooter"
 "origin"	"-1244 1488 174"
 "angle"	"180"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-1296 1536 190"
 "classname"	"light"
 }
+
 {
 "targetname"	"t5"
 "origin"	"-740 788 132"
 "classname"	"info_null"
 }
+
 {
 "targetname"	"t6"
 "classname"	"info_null"
 "origin"	"-828 948 132"
 }
+
 {
 "targetname"	"t8"
 "classname"	"info_null"
 "origin"	"-644 1156 132"
 }
+
 {
 "light"	"264"
+	"_color"	"0.88 0.74 0.58"
 "target"	"t6"
 "classname"	"light"
 "origin"	"-828 948 188"
 }
+
 {
 "light"	"264"
+	"_color"	"0.88 0.74 0.58"
 "target"	"t8"
 "classname"	"light"
 "origin"	"-644 1156 180"
 }
+
 {
 "classname"	"light"
 "origin"	"-738 758 280"
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"208 1360 285"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"208 1552 285"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"208 1760 285"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "targetname"	"t9"
 "angle"	"-2"
@@ -10416,6 +10522,7 @@
 "origin"	"-740 792 280"
 "classname"	"trap_spikeshooter"
 }
+
 {
 "targetname"	"t10"
 "classname"	"trap_spikeshooter"
@@ -10423,6 +10530,7 @@
 "spawnflags"	"1"
 "angle"	"-2"
 }
+
 {
 "targetname"	"t12"
 "classname"	"trap_spikeshooter"
@@ -10430,6 +10538,7 @@
 "spawnflags"	"1"
 "angle"	"-2"
 }
+
 {
 "target"	"t9"
 "classname"	"trigger_multiple"
@@ -10442,6 +10551,7 @@
 ( -728 800 156 ) ( -752 800 156 ) ( -752 780 156 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "target"	"t10"
 "classname"	"trigger_multiple"
@@ -10454,6 +10564,7 @@
 ( -816 960 156 ) ( -840 960 156 ) ( -840 940 156 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "target"	"t12"
 "classname"	"trigger_multiple"
@@ -10466,42 +10577,61 @@
 ( -632 1168 156 ) ( -656 1168 156 ) ( -656 1148 156 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "origin"	"-984 1488 256"
 "classname"	"light_flame_small_yellow"
 "light"	"300"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 }
+
 {
 "light"	"300"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 "classname"	"light_flame_small_yellow"
 "origin"	"-1168 1304 256"
 }
+
 {
 "classname"	"light"
 "origin"	"-1536 1528 330"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-1528 2208 314"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"-1536 1760 298"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "origin"	"-1536 2096 50"
 "classname"	"light"
 "light"	"264"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-1248 2164 50"
 "light"	"264"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-1208 2176 290"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"func_train"
 "target"	"t31"
@@ -10529,12 +10659,14 @@
 ( -1352 2240 162 ) ( -1392 2240 162 ) ( -1392 2056 162 ) COP1_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "origin"	"-1392 1904 158"
 "classname"	"path_corner"
 "targetname"	"t14"
 "target"	"t31"
 }
+
 {
 "classname"	"func_train"
 "target"	"t15"
@@ -10563,18 +10695,21 @@
 ( -1352 2112 162 ) ( -1312 2112 162 ) ( -1312 2296 162 ) COP1_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "origin"	"-1344 2256 158"
 "classname"	"path_corner"
 "targetname"	"t16"
 "target"	"t15"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"-1344 2112 158"
 "targetname"	"t15"
 "target"	"t16"
 }
+
 {
 "classname"	"func_train"
 "target"	"t17"
@@ -10603,18 +10738,21 @@
 ( -1256 2232 162 ) ( -1296 2232 162 ) ( -1296 2048 162 ) COP1_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "origin"	"-1296 2048 158"
 "classname"	"path_corner"
 "targetname"	"t17"
 "target"	"t18"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"-1296 1962 158"
 "targetname"	"t18"
 "target"	"t17"
 }
+
 {
 "classname"	"func_train"
 "target"	"t19"
@@ -10643,23 +10781,29 @@
 ( -1480 1872 162 ) ( -1480 1912 162 ) ( -1664 1912 162 ) COP1_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "origin"	"-1656 1880 158"
 "classname"	"path_corner"
 "targetname"	"t20"
 "target"	"t19"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"-1800 1880 158"
 "targetname"	"t19"
 "target"	"t20"
 }
+
 {
 "light"	"250"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 "classname"	"light_flame_small_yellow"
 "origin"	"-1336 1920 168"
 }
+
 {
 "classname"	"trap_spikeshooter"
 "origin"	"-1536 2134 54"
@@ -10668,6 +10812,7 @@
 "targetname"	"t29"
 "wait"	".75"
 }
+
 {
 "classname"	"trigger_multiple"
 "target"	"t29"
@@ -10681,12 +10826,15 @@
 ( -1408 2304 2 ) ( -1664 2304 2 ) ( -1664 1536 2 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"-1536 1320 54"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 "style"	"2"
 }
+
 {
 "classname"	"trigger_teleport"
 "target"	"t30"
@@ -10699,32 +10847,42 @@
 ( -1504 1320 6 ) ( -1568 1320 6 ) ( -1568 1316 6 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"info_teleport_destination"
 "origin"	"-1536 1460 138"
 "angle"	"90"
 "targetname"	"t30"
 }
+
 {
 "classname"	"light"
 "origin"	"-1536 1552 298"
 "light"	"364"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-1536 2008 298"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"-1392 2048 158"
 "targetname"	"t31"
 "target"	"t14"
 }
+
 {
 "origin"	"-1656 1848 120"
 "classname"	"light_flame_small_yellow"
 "light"	"364"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 }
+
 {
 "sounds"	"1"
 "classname"	"func_door"
@@ -10740,6 +10898,7 @@
 ( -1400 1824 -2 ) ( -1408 1824 -2 ) ( -1408 1760 -2 ) CITY5_7 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"func_button"
 "angle"	"-2"
@@ -10754,20 +10913,27 @@
 ( -1508 2208 120 ) ( -1564 2208 120 ) ( -1564 2152 120 ) +0FLOORSW 32 32 0 1.000000 1.000000
 }
 }
+
 {
 "origin"	"-1008 2176 330"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-748 2160 548"
 "light"	"350"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-744 2160 372"
 "light"	"264"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "spawnflags"	"4"
 "targetname"	"t35"
@@ -10798,6 +10964,7 @@
 ( 712 1616 184 ) ( 904 1808 88 ) ( 520 1808 88 ) COP3_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"1"
 "targetname"	"t35"
@@ -10829,6 +10996,7 @@
 ( 712 1616 184 ) ( 520 1808 88 ) ( 520 1424 88 ) COP3_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"1"
 "targetname"	"t35"
@@ -10860,6 +11028,7 @@
 ( 712 1616 184 ) ( 904 1424 88 ) ( 904 1808 88 ) COP3_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "targetname"	"t35"
 "spawnflags"	"4"
@@ -10890,6 +11059,7 @@
 ( 712 1616 184 ) ( 520 1424 88 ) ( 904 1424 88 ) COP3_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"0"
 "target"	"t35"
@@ -10905,6 +11075,7 @@
 ( 668 1712 -16 ) ( 668 1680 -16 ) ( 708 1680 -16 ) +0FLOORSW 32 48 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"1"
 "targetname"	"t35"
@@ -10921,6 +11092,7 @@
 ( 568 1744 -8 ) ( 568 1488 -8 ) ( 584 1488 -8 ) CITY5_4 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "targetname"	"t35"
 "spawnflags"	"4"
@@ -10936,6 +11108,7 @@
 ( 824 1488 -8 ) ( 568 1488 -8 ) ( 568 1472 -8 ) CITY5_4 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "targetname"	"t35"
 "spawnflags"	"4"
@@ -10951,6 +11124,7 @@
 ( 824 1760 -8 ) ( 568 1760 -8 ) ( 568 1744 -8 ) CITY5_4 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"1"
 "targetname"	"t35"
@@ -10967,141 +11141,200 @@
 ( 856 1504 -8 ) ( 856 1760 -8 ) ( 840 1760 -8 ) CITY5_4 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"712 1688 368"
 "light"	"350"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"350"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"712 1536 368"
 "classname"	"light"
 }
+
 {
 "light"	"350"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"480 1856 368"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"520 1896 368"
 "light"	"350"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"350"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"904 1896 368"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"944 1856 368"
 "light"	"350"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"350"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"928 1360 368"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"888 1320 368"
 "light"	"350"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"350"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"520 1328 368"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"480 1368 368"
 "light"	"350"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"824 1548 -16"
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"792 1504 -16"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"644 1504 -16"
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"600 1540 -16"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"600 1672 -16"
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"636 1712 -16"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"780 1712 -16"
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"824 1676 -16"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"700 1676 12"
 "light"	"214"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"712 1256 112"
 "classname"	"light_flame_small_yellow"
 "light"	"364"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 }
+
 {
 "light"	"364"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 "classname"	"light_flame_small_yellow"
 "origin"	"408 1616 112"
 }
+
 {
 "origin"	"368 2264 354"
 "classname"	"light_flame_small_yellow"
 "light"	"250"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 }
+
 {
 "light"	"364"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 "classname"	"light_flame_small_yellow"
 "origin"	"1008 1616 112"
 }
+
 {
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-152 2216 432"
 "classname"	"light"
 }
+
 {
 "light"	"350"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-120 2544 560"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"48 2544 560"
 "light"	"300"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"314"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"96 1952 304"
 "classname"	"light"
 }
+
 {
 "sounds"	"1"
 "wait"	"-1"
@@ -11166,56 +11399,80 @@
 ( 208 1698 108 ) ( 208 1678 122 ) ( 192 1678 122 ) CITY5_4 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "origin"	"-216 1816 192"
 "classname"	"light_flame_small_yellow"
 "light"	"364"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 }
+
 {
 "light"	"264"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-512 2136 488"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-512 2296 488"
 "light"	"264"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"264"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-560 2448 488"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-888 2472 488"
 "light"	"264"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"264"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-960 2400 488"
 "classname"	"light"
 }
+
 {
 "origin"	"-744 2552 360"
 "classname"	"light_flame_small_yellow"
 "light"	"364"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 }
+
 {
 "light"	"364"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 "classname"	"light_flame_small_yellow"
 "origin"	"-768 1736 424"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-704 1952 374"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-824 1952 374"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "sounds"	"1"
 "wait"	"1"
@@ -11249,6 +11506,7 @@
 ( -1044 1780 264 ) ( -1068 1780 264 ) ( -1068 1804 264 ) COP1_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "target"	"t37"
 "classname"	"trigger_multiple"
@@ -11261,33 +11519,42 @@
 ( -1004 1832 128 ) ( -1104 1832 128 ) ( -1104 1748 128 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "target"	"t42"
 "classname"	"light"
 "origin"	"-1076 1792 224"
 "light"	"350"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "targetname"	"t42"
 "classname"	"info_null"
 "origin"	"-1056 1792 132"
 }
+
 {
 "light"	"264"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-1028 1792 248"
 "classname"	"light"
 }
+
 {
 "target"	"t44"
 "classname"	"light"
 "origin"	"-804 1116 216"
 "light"	"264"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "targetname"	"t44"
 "classname"	"info_null"
 "origin"	"-804 1116 132"
 }
+
 {
 "targetname"	"t43"
 "classname"	"trap_spikeshooter"
@@ -11295,6 +11562,7 @@
 "spawnflags"	"1"
 "angle"	"-2"
 }
+
 {
 "target"	"t43"
 "classname"	"trigger_multiple"
@@ -11307,16 +11575,22 @@
 ( -792 1128 156 ) ( -816 1128 156 ) ( -816 1108 156 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "origin"	"-320 2016 328"
 "classname"	"light_flame_small_yellow"
 "light"	"364"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 }
+
 {
 "classname"	"light"
 "origin"	"-988 872 380"
 "light"	"314"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "spawnflags"	"1"
 "target"	"t45"
@@ -11330,18 +11604,21 @@
 ( -960 888 332 ) ( -1008 888 332 ) ( -1008 880 332 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "targetname"	"t46"
 "angle"	"270"
 "origin"	"-984 852 328"
 "classname"	"info_teleport_destination"
 }
+
 {
 "targetname"	"t45"
 "angle"	"90"
 "origin"	"704 1520 4"
 "classname"	"info_teleport_destination"
 }
+
 {
 "spawnflags"	"1"
 "target"	"t45"
@@ -11355,6 +11632,7 @@
 ( 412 2584 424 ) ( 412 2536 424 ) ( 420 2536 424 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "spawnflags"	"1"
 "target"	"t46"
@@ -11368,47 +11646,65 @@
 ( 428 2584 424 ) ( 428 2536 424 ) ( 436 2536 424 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "light"	"364"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 "classname"	"light_flame_small_yellow"
 "origin"	"256 1832 104"
 }
+
 {
 "classname"	"light"
 "origin"	"-24 2216 432"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"104 2216 432"
 "classname"	"light"
 }
+
 {
 "light"	"214"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-120 2544 384"
 "classname"	"light"
 }
+
 {
 "light"	"214"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-224 2208 320"
 "classname"	"light"
 }
+
 {
 "light"	"264"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"432 2216 304"
 "classname"	"light"
 }
+
 {
 "origin"	"-544 1936 472"
 "classname"	"light_flame_small_yellow"
 "light"	"364"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 }
+
 {
 "spawnflags"	"2048"
 "sounds"	"1"
 "origin"	"704 1688 48"
 "classname"	"item_key2"
 }
+
 {
 "lip"	"8"
 "wait"	"-1"
@@ -11424,6 +11720,7 @@
 ( -480 1784 320 ) ( -608 1784 320 ) ( -608 1768 320 ) metal2_2 0 0 90 -1.000000 1.000000
 }
 }
+
 {
 "sounds"	"1"
 "wait"	"-1"
@@ -11439,6 +11736,7 @@
 ( -896 1872 128 ) ( -1024 1872 128 ) ( -1024 1856 128 ) CITYA1_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "target"	"t47"
 "classname"	"trigger_once"
@@ -11452,6 +11750,7 @@
 ( -704 1840 280 ) ( -832 1840 280 ) ( -832 1832 280 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "targetname"	"t47"
 "angle"	"270"
@@ -11459,11 +11758,15 @@
 "classname"	"monster_ogre"
 "spawnflags"	"256"
 }
+
 {
 "light"	"314"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 "classname"	"light_flame_small_yellow"
 "origin"	"-56 1280 72"
 }
+
 {
 "sounds"	"1"
 "targetname"	"t35"
@@ -11479,12 +11782,14 @@
 ( 176 1112 64 ) ( 64 1112 64 ) ( 64 1096 64 ) CITY5_4 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "targetname"	"t48"
 "angle"	"90"
 "origin"	"138 1058 98"
 "classname"	"monster_ogre"
 }
+
 {
 "target"	"t48"
 "classname"	"trigger_once"
@@ -11497,15 +11802,20 @@
 ( 240 1704 -8 ) ( 232 1704 -8 ) ( 232 1592 -8 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "origin"	"-576 344 274"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "light"	"314"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-24 1624 64"
 "classname"	"light"
 }
+
 {
 "target"	"t51"
 "classname"	"trigger_once"
@@ -11518,6 +11828,7 @@
 ( -504 328 152 ) ( -632 328 152 ) ( -632 320 152 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "targetname"	"t51"
 "angle"	"270"
@@ -11525,78 +11836,91 @@
 "classname"	"monster_knight"
 "spawnflags"	"256"
 }
+
 {
 "target"	"t62"
 "targetname"	"t61"
 "origin"	"-808 1168 136"
 "classname"	"path_corner"
 }
+
 {
 "target"	"t63"
 "targetname"	"t62"
 "classname"	"path_corner"
 "origin"	"-728 1056 136"
 }
+
 {
 "target"	"t61"
 "targetname"	"t60"
 "origin"	"-752 1056 136"
 "classname"	"path_corner"
 }
+
 {
 "target"	"t60"
 "targetname"	"t59"
 "classname"	"path_corner"
 "origin"	"-784 864 136"
 }
+
 {
 "target"	"t58"
 "targetname"	"t63"
 "origin"	"-784 888 136"
 "classname"	"path_corner"
 }
+
 {
 "target"	"t59"
 "targetname"	"t58"
 "classname"	"path_corner"
 "origin"	"-776 704 136"
 }
+
 {
 "spawnflags"	"1"
 "target"	"t58"
 "origin"	"-824 744 152"
 "classname"	"monster_knight"
 }
+
 {
 "target"	"t65"
 "targetname"	"t64"
 "origin"	"-768 1792 136"
 "classname"	"path_corner"
 }
+
 {
 "target"	"t66"
 "targetname"	"t65"
 "classname"	"path_corner"
 "origin"	"-768 1536 136"
 }
+
 {
 "target"	"t67"
 "targetname"	"t66"
 "origin"	"-624 1400 136"
 "classname"	"path_corner"
 }
+
 {
 "target"	"t64"
 "targetname"	"t67"
 "classname"	"path_corner"
 "origin"	"-744 1536 136"
 }
+
 {
 "target"	"t64"
 "angle"	"270"
 "origin"	"-748 1608 152"
 "classname"	"monster_knight"
 }
+
 {
 "target"	"t68"
 "targetname"	"t69"
@@ -11604,6 +11928,7 @@
 "classname"	"path_corner"
 "spawnflags"	"256"
 }
+
 {
 "target"	"t69"
 "targetname"	"t68"
@@ -11611,6 +11936,7 @@
 "origin"	"-456 1560 328"
 "spawnflags"	"256"
 }
+
 {
 "target"	"t68"
 "angle"	"180"
@@ -11618,12 +11944,14 @@
 "classname"	"monster_ogre"
 "spawnflags"	"257"
 }
+
 {
 "targetname"	"t70"
 "angle"	"270"
 "origin"	"-320 1912 216"
 "classname"	"monster_knight"
 }
+
 {
 "target"	"t70"
 "classname"	"trigger_once"
@@ -11636,6 +11964,7 @@
 ( -440 1248 128 ) ( -664 1248 128 ) ( -664 1240 128 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "target"	"t71"
 "targetname"	"t72"
@@ -11643,6 +11972,7 @@
 "classname"	"path_corner"
 "spawnflags"	"256"
 }
+
 {
 "target"	"t72"
 "targetname"	"t71"
@@ -11650,6 +11980,7 @@
 "origin"	"64 1952 248"
 "spawnflags"	"256"
 }
+
 {
 "target"	"t71"
 "angle"	"180"
@@ -11657,12 +11988,14 @@
 "classname"	"monster_knight"
 "spawnflags"	"257"
 }
+
 {
 "spawnflags"	"1"
 "angle"	"0"
 "origin"	"-1162 1790 152"
 "classname"	"monster_ogre"
 }
+
 {
 "target"	"t77"
 "classname"	"trigger_once"
@@ -11675,12 +12008,14 @@
 ( -1078 2110 78 ) ( -1174 2110 78 ) ( -1174 2006 78 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "targetname"	"t77"
 "angle"	"270"
 "origin"	"-936 2432 172"
 "classname"	"monster_knight"
 }
+
 {
 "targetname"	"t77"
 "angle"	"180"
@@ -11688,6 +12023,7 @@
 "classname"	"monster_knight"
 "spawnflags"	"256"
 }
+
 {
 "targetname"	"t4"
 "angle"	"90"
@@ -11695,23 +12031,27 @@
 "classname"	"monster_knight"
 "spawnflags"	"256"
 }
+
 {
 "targetname"	"t4"
 "classname"	"monster_knight"
 "origin"	"-1320 1352 164"
 "angle"	"90"
 }
+
 {
 "angle"	"315"
 "origin"	"-146 1794 116"
 "classname"	"monster_ogre"
 }
+
 {
 "targetname"	"t29"
 "angle"	"180"
 "origin"	"-1198 2166 36"
 "classname"	"monster_demon1"
 }
+
 {
 "targetname"	"t29"
 "classname"	"monster_demon1"
@@ -11719,54 +12059,63 @@
 "angle"	"90"
 "spawnflags"	"256"
 }
+
 {
 "target"	"t79"
 "targetname"	"t78"
 "origin"	"-1616 2200 196"
 "classname"	"path_corner"
 }
+
 {
 "target"	"t80"
 "targetname"	"t79"
 "classname"	"path_corner"
 "origin"	"-1624 1664 196"
 }
+
 {
 "target"	"t81"
 "targetname"	"t80"
 "origin"	"-1464 1664 196"
 "classname"	"path_corner"
 }
+
 {
 "target"	"t82"
 "targetname"	"t81"
 "classname"	"path_corner"
 "origin"	"-1464 2120 196"
 }
+
 {
 "targetname"	"t82"
 "target"	"t78"
 "origin"	"-1152 2152 196"
 "classname"	"path_corner"
 }
+
 {
 "angle"	"180"
 "target"	"t82"
 "origin"	"-1112 2136 212"
 "classname"	"monster_wizard"
 }
+
 {
 "target"	"t83"
 "targetname"	"t84"
 "origin"	"136 1176 84"
 "classname"	"path_corner"
 }
+
 {
 "target"	"t84"
 "targetname"	"t83"
 "classname"	"path_corner"
 "origin"	"-112 1176 84"
 }
+
 {
 "spawnflags"	"1"
 "target"	"t83"
@@ -11774,16 +12123,19 @@
 "origin"	"56 1176 100"
 "classname"	"monster_knight"
 }
+
 {
 "origin"	"-164 1844 88"
 "classname"	"item_armor2"
 }
+
 {
 "angle"	"90"
 "origin"	"-42 1334 -24"
 "classname"	"monster_ogre"
 "spawnflags"	"257"
 }
+
 {
 "spawnflags"	"768"
 "target"	"t86"
@@ -11791,6 +12143,7 @@
 "origin"	"-184 1568 -40"
 "classname"	"path_corner"
 }
+
 {
 "spawnflags"	"768"
 "target"	"t85"
@@ -11798,6 +12151,7 @@
 "classname"	"path_corner"
 "origin"	"-184 1320 -40"
 }
+
 {
 "spawnflags"	"768"
 "target"	"t85"
@@ -11805,6 +12159,7 @@
 "origin"	"-176 1424 -24"
 "classname"	"monster_knight"
 }
+
 {
 "targetname"	"t70"
 "angle"	"270"
@@ -11812,18 +12167,21 @@
 "classname"	"monster_knight"
 "spawnflags"	"256"
 }
+
 {
 "target"	"t89"
 "targetname"	"t90"
 "origin"	"-768 2240 308"
 "classname"	"path_corner"
 }
+
 {
 "target"	"t90"
 "targetname"	"t89"
 "classname"	"path_corner"
 "origin"	"-768 2080 308"
 }
+
 {
 "spawnflags"	"257"
 "target"	"t89"
@@ -11831,6 +12189,7 @@
 "origin"	"-770 2186 332"
 "classname"	"monster_ogre"
 }
+
 {
 "targetname"	"t35"
 "angle"	"270"
@@ -11839,24 +12198,29 @@
 "target"	"t144"
 "spawnflags"	"768"
 }
+
 {
 "origin"	"632 1528 -4"
 "classname"	"item_health"
 }
+
 {
 "classname"	"item_health"
 "origin"	"632 1568 -4"
 }
+
 {
 "spawnflags"	"1024"
 "origin"	"520 1328 -4"
 "classname"	"item_shells"
 }
+
 {
 "spawnflags"	"1"
 "origin"	"896 1384 -4"
 "classname"	"item_health"
 }
+
 {
 "target"	"t92"
 "targetname"	"t91"
@@ -11864,6 +12228,7 @@
 "classname"	"path_corner"
 "spawnflags"	"256"
 }
+
 {
 "target"	"t91"
 "targetname"	"t92"
@@ -11871,6 +12236,7 @@
 "origin"	"312 1632 4"
 "spawnflags"	"256"
 }
+
 {
 "target"	"t91"
 "angle"	"90"
@@ -11878,6 +12244,7 @@
 "classname"	"monster_knight"
 "spawnflags"	"256"
 }
+
 {
 "target"	"t93"
 "angle"	"270"
@@ -11885,6 +12252,7 @@
 "classname"	"monster_wizard"
 "spawnflags"	"256"
 }
+
 {
 "target"	"t93"
 "targetname"	"t94"
@@ -11892,6 +12260,7 @@
 "classname"	"path_corner"
 "spawnflags"	"256"
 }
+
 {
 "target"	"t94"
 "targetname"	"t93"
@@ -11899,6 +12268,7 @@
 "origin"	"-1536 1936 252"
 "spawnflags"	"256"
 }
+
 {
 "target"	"t95"
 "angle"	"90"
@@ -11906,6 +12276,7 @@
 "classname"	"monster_wizard"
 "spawnflags"	"257"
 }
+
 {
 "target"	"t96"
 "targetname"	"t95"
@@ -11913,6 +12284,7 @@
 "classname"	"path_corner"
 "spawnflags"	"256"
 }
+
 {
 "target"	"t97"
 "targetname"	"t96"
@@ -11920,6 +12292,7 @@
 "origin"	"-520 2400 388"
 "spawnflags"	"256"
 }
+
 {
 "target"	"t98"
 "targetname"	"t97"
@@ -11927,6 +12300,7 @@
 "classname"	"path_corner"
 "spawnflags"	"256"
 }
+
 {
 "target"	"t99"
 "targetname"	"t98"
@@ -11934,6 +12308,7 @@
 "origin"	"-752 2496 388"
 "spawnflags"	"256"
 }
+
 {
 "target"	"t100"
 "targetname"	"t99"
@@ -11941,6 +12316,7 @@
 "classname"	"path_corner"
 "spawnflags"	"256"
 }
+
 {
 "target"	"t95"
 "targetname"	"t100"
@@ -11948,30 +12324,35 @@
 "origin"	"-520 2400 388"
 "spawnflags"	"256"
 }
+
 {
 "target"	"t102"
 "targetname"	"t101"
 "origin"	"528 2136 252"
 "classname"	"path_corner"
 }
+
 {
 "target"	"t103"
 "targetname"	"t102"
 "classname"	"path_corner"
 "origin"	"488 2400 252"
 }
+
 {
 "target"	"t104"
 "targetname"	"t103"
 "origin"	"264 2376 252"
 "classname"	"path_corner"
 }
+
 {
 "targetname"	"t104"
 "target"	"t101"
 "classname"	"path_corner"
 "origin"	"264 2128 252"
 }
+
 {
 "target"	"t101"
 "angle"	"315"
@@ -11979,6 +12360,7 @@
 "classname"	"monster_ogre"
 "spawnflags"	"257"
 }
+
 {
 "spawnflags"	"1"
 "target"	"t103"
@@ -11986,6 +12368,7 @@
 "origin"	"382 2374 268"
 "classname"	"monster_ogre"
 }
+
 {
 "angle"	"180"
 "origin"	"128 2552 492"
@@ -11993,6 +12376,7 @@
 "targetname"	"t114"
 "spawnflags"	"768"
 }
+
 {
 "spawnflags"	"1"
 "target"	"t105"
@@ -12000,63 +12384,74 @@
 "origin"	"64 2304 268"
 "classname"	"monster_knight"
 }
+
 {
 "target"	"t105"
 "targetname"	"t106"
 "origin"	"64 2424 252"
 "classname"	"path_corner"
 }
+
 {
 "target"	"t106"
 "targetname"	"t105"
 "classname"	"path_corner"
 "origin"	"64 2096 252"
 }
+
 {
 "spawnflags"	"1"
 "origin"	"-224 2080 244"
 "classname"	"item_health"
 }
+
 {
 "classname"	"item_health"
 "origin"	"-224 2120 244"
 "spawnflags"	"1"
 }
+
 {
 "spawnflags"	"1"
 "origin"	"-224 2160 244"
 "classname"	"item_health"
 }
+
 {
 "angle"	"180"
 "origin"	"-528 1136 152"
 "classname"	"monster_knight"
 "spawnflags"	"769"
 }
+
 {
 "target"	"t111"
 "targetname"	"t110"
 "origin"	"-744 1576 -40"
 "classname"	"path_corner"
 }
+
 {
 "target"	"t112"
 "targetname"	"t111"
 "classname"	"path_corner"
 "origin"	"-712 1352 -40"
 }
+
 {
 "target"	"t113"
 "targetname"	"t112"
 "origin"	"-328 1296 -40"
 "classname"	"path_corner"
 }
+
 {
 "targetname"	"t113"
 "target"	"t110"
 "classname"	"path_corner"
 "origin"	"-424 1480 -40"
 }
+
 {
 "target"	"t112"
 "angle"	"0"
@@ -12064,132 +12459,161 @@
 "classname"	"monster_demon1"
 "spawnflags"	"256"
 }
+
 {
 "spawnflags"	"1792"
 "origin"	"-112 1656 -48"
 "classname"	"weapon_grenadelauncher"
 }
+
 {
 "spawnflags"	"1792"
 "origin"	"-1304 1360 144"
 "classname"	"weapon_nailgun"
 }
+
 {
 "origin"	"-1656 1520 132"
 "classname"	"item_health"
 }
+
 {
 "classname"	"item_health"
 "origin"	"-1656 1472 132"
 }
+
 {
 "origin"	"-1216 1912 12"
 "classname"	"item_health"
 }
+
 {
 "classname"	"item_health"
 "origin"	"-1272 1912 12"
 }
+
 {
 "spawnflags"	"1"
 "origin"	"-944 2056 132"
 "classname"	"item_health"
 }
+
 {
 "origin"	"-1120 1776 132"
 "classname"	"item_shells"
 }
+
 {
 "origin"	"-136 1200 76"
 "classname"	"item_shells"
 }
+
 {
 "origin"	"112 1824 -44"
 "classname"	"item_health"
 }
+
 {
 "classname"	"item_health"
 "origin"	"72 1824 -44"
 }
+
 {
 "origin"	"-808 1640 132"
 "classname"	"item_shells"
 }
+
 {
 "spawnflags"	"2049"
 "origin"	"-808 1592 132"
 "classname"	"item_health"
 }
+
 {
 "origin"	"-296 1648 -44"
 "classname"	"item_spikes"
 }
+
 {
 "origin"	"-488 2120 288"
 "classname"	"item_rockets"
 }
+
 {
 "spawnflags"	"2304"
 "origin"	"324 1760 -4"
 "classname"	"item_health"
 }
+
 {
 "classname"	"item_health"
 "origin"	"324 1720 -4"
 "spawnflags"	"2304"
 }
+
 {
 "origin"	"240 1608 -4"
 "classname"	"item_shells"
 }
+
 {
 "spawnflags"	"1"
 "origin"	"-824 668 132"
 "classname"	"item_shells"
 }
+
 {
 "origin"	"-1224 1328 144"
 "classname"	"item_health"
 }
+
 {
 "classname"	"item_health"
 "origin"	"-1144 1328 144"
 }
+
 {
 "spawnflags"	"1"
 "origin"	"-800 1240 -44"
 "classname"	"item_health"
 }
+
 {
 "classname"	"item_health"
 "origin"	"-800 1284 -44"
 "spawnflags"	"1"
 }
+
 {
 "spawnflags"	"2048"
 "origin"	"-808 1648 324"
 "classname"	"item_health"
 }
+
 {
 "spawnflags"	"1"
 "origin"	"-808 1608 324"
 "classname"	"item_shells"
 }
+
 {
 "spawnflags"	"1"
 "origin"	"-1064 568 92"
 "classname"	"item_shells"
 }
+
 {
 "spawnflags"	"2048"
 "origin"	"-120 1280 -44"
 "classname"	"item_rockets"
 }
+
 {
 "classname"	"item_health"
 "origin"	"68 1000 72"
 "spawnflags"	"1"
 }
+
 {
 "classname"	"trigger_once"
 "target"	"t114"
@@ -12203,22 +12627,28 @@
 ( -64 2456 300 ) ( -184 2456 300 ) ( -184 2448 300 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "light"	"214"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"48 720 8"
 "classname"	"light"
 }
+
 {
 "light"	"264"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-544 1880 -196"
 "classname"	"light"
 }
+
 {
 "targetname"	"t115"
 "angle"	"90"
 "origin"	"-544 1348 -32"
 "classname"	"info_teleport_destination"
 }
+
 {
 "classname"	"func_plat"
 {
@@ -12246,11 +12676,15 @@
 ( -1112 2062 -2 ) ( -1128 2062 -2 ) ( -1128 2046 -2 ) COP1_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "origin"	"-1096 1920 168"
 "classname"	"light_flame_small_yellow"
 "light"	"250"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 }
+
 {
 "spawnflags"	"1"
 "classname"	"monster_knight"
@@ -12258,69 +12692,82 @@
 "target"	"t116"
 "angle"	"270"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"-72 824 96"
 "targetname"	"t116"
 "target"	"t117"
 }
+
 {
 "origin"	"-72 720 96"
 "classname"	"path_corner"
 "targetname"	"t117"
 "target"	"t116"
 }
+
 {
 "classname"	"info_player_deathmatch"
 "origin"	"-576 376 176"
 "angle"	"90"
 }
+
 {
 "classname"	"info_player_deathmatch"
 "origin"	"-1212 1792 152"
 "angle"	"0"
 }
+
 {
 "classname"	"info_player_deathmatch"
 "origin"	"-1532 1600 152"
 "angle"	"90"
 }
+
 {
 "classname"	"info_player_deathmatch"
 "origin"	"-676 2156 324"
 "angle"	"180"
 }
+
 {
 "classname"	"info_player_deathmatch"
 "origin"	"-212 2312 264"
 "angle"	"315"
 }
+
 {
 "classname"	"info_player_deathmatch"
 "origin"	"-352 1996 220"
 "angle"	"270"
 }
+
 {
 "classname"	"info_player_deathmatch"
 "origin"	"776 1568 20"
 "angle"	"135"
 }
+
 {
 "classname"	"info_player_deathmatch"
 "origin"	"-40 1836 -24"
 "angle"	"270"
 }
+
 {
 "classname"	"weapon_supershotgun"
 "origin"	"-820 2160 300"
 "spawnflags"	"1792"
 "angle"	"90"
 }
+
 {
 "classname"	"info_player_deathmatch"
 "origin"	"-780 1348 -24"
 "angle"	"45"
 }
+
 {
 "spawnflags"	"256"
 "classname"	"monster_knight"
@@ -12328,6 +12775,7 @@
 "angle"	"90"
 "targetname"	"t4"
 }
+
 {
 "classname"	"monster_ogre"
 "origin"	"-978 1790 152"
@@ -12335,6 +12783,7 @@
 "spawnflags"	"769"
 "targetname"	"t70"
 }
+
 {
 "classname"	"monster_knight"
 "origin"	"-1528 1832 152"
@@ -12342,6 +12791,7 @@
 "target"	"t118"
 "spawnflags"	"768"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"-1528 1800 136"
@@ -12349,6 +12799,7 @@
 "target"	"t119"
 "spawnflags"	"768"
 }
+
 {
 "origin"	"-1528 1680 136"
 "classname"	"path_corner"
@@ -12356,46 +12807,64 @@
 "target"	"t118"
 "spawnflags"	"768"
 }
+
 {
 "classname"	"light"
 "origin"	"-544 1248 80"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 "classname"	"light_flame_small_yellow"
 "origin"	"-544 1080 72"
 }
+
 {
 "classname"	"light"
 "origin"	"-544 1088 0"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-336 1608 72"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-728 1560 40"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-744 1296 80"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-320 1984 256"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-712 1920 -208"
 "classname"	"light"
 }
+
 {
 "classname"	"trigger_multiple"
 "target"	"t4"
@@ -12409,16 +12878,21 @@
 ( -1020 1436 132 ) ( -1020 1564 132 ) ( -1044 1564 132 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"-768 1792 312"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-584 192 336"
 "classname"	"light"
 }
+
 {
 "targetname"	"t51"
 "angle"	"225"
@@ -12426,140 +12900,195 @@
 "classname"	"monster_knight"
 "spawnflags"	"256"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-576 584 336"
 "classname"	"light"
 }
+
 {
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-72 552 240"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-584 264 56"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-968 400 8"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-760 288 8"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-216 336 8"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-504 288 8"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"32 416 8"
 "classname"	"light"
 }
+
 {
 "light"	"170"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-448 544 184"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-704 544 184"
 "light"	"170"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"120 1152 144"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"120 1032 144"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-192 1816 144"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-56 1304 40"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-336 552 144"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-808 552 144"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"72 312 144"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-168 1824 8"
 "classname"	"light"
 }
+
 {
 "light"	"160"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-816 688 240"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-824 856 240"
 "light"	"160"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"160"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-728 960 240"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-832 1160 240"
 "light"	"160"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"165"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"712 1288 88"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"976 1616 88"
 "light"	"165"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"165"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"440 1616 88"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"624 1880 88"
 "light"	"165"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"165"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"792 1880 88"
 "classname"	"light"
 }
+
 {
 "sounds"	"3"
 "wait"	"-1"
@@ -12574,6 +13103,7 @@
 ( -704 2040 300 ) ( -768 2040 300 ) ( -768 2024 300 ) ADOOR01_2 0 96 0 1.000000 1.000000
 }
 }
+
 {
 "wait"	"-1"
 "targetname"	"t126"
@@ -12588,6 +13118,7 @@
 ( -768 2040 300 ) ( -832 2040 300 ) ( -832 2024 300 ) ADOOR01_2 0 96 0 1.000000 1.000000
 }
 }
+
 {
 "target"	"t126"
 "wait"	"-1"
@@ -12602,26 +13133,34 @@
 ( -720 2208 292 ) ( -784 2208 292 ) ( -784 2144 292 ) DOOR05_3 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-1624 2264 192"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-1464 2264 192"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "spawnflags"	"1"
 "origin"	"-384 1840 -256"
 "classname"	"item_health"
 }
+
 {
 "light"	"160"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-544 1904 400"
 "classname"	"light"
 }
+
 {
 "sounds"	"3"
 "classname"	"func_door"
@@ -12638,295 +13177,402 @@
 ( -608 1768 320 ) ( -480 1768 320 ) ( -480 1784 320 ) metal2_2 0 0 90 -1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"56 592 -16"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"112 1552 64"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-728 1816 200"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"weapon_supernailgun"
 "origin"	"336 2264 240"
 }
+
 {
 "spawnflags"	"2048"
 "sounds"	"1"
 "classname"	"item_key1"
 "origin"	"-776 1912 328"
 }
+
 {
 "classname"	"light"
 "origin"	"912 1400 72"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"512 1800 72"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"896 1784 72"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"296 1832 72"
 "light"	"160"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-960 1928 208"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-1272 2264 192"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-1096 2256 192"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-928 2264 192"
 "classname"	"light"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-936 2088 192"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-1216 2080 192"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-1640 2136 192"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-1640 1440 192"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-1464 1440 192"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-1320 1896 120"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-1384 1792 120"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-992 2376 192"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-744 2520 272"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"item_spikes"
 "origin"	"-944 2160 132"
 "spawnflags"	"1"
 }
+
 {
 "classname"	"light"
 "origin"	"-1624 1848 64"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-1624 2264 64"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-1448 1632 64"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-512 2184 422"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "spawnflags"	"2048"
 "classname"	"item_health"
 "origin"	"224 2408 244"
 }
+
 {
 "classname"	"item_health"
 "origin"	"-824 2232 300"
 }
+
 {
 "classname"	"item_spikes"
 "origin"	"-776 2232 300"
 "spawnflags"	"1"
 }
+
 {
 "classname"	"item_health"
 "origin"	"432 1256 -4"
 "spawnflags"	"3584"
 }
+
 {
 "spawnflags"	"3584"
 "origin"	"968 1944 -4"
 "classname"	"item_health"
 }
+
 {
 "origin"	"-544 1368 128"
 "classname"	"weapon_rocketlauncher"
 }
+
 {
 "spawnflags"	"3584"
 "origin"	"-528 1088 132"
 "classname"	"item_health"
 }
+
 {
 "classname"	"light"
 "origin"	"40 888 96"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-1120 1920 96"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-1120 1624 189"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-1232 1628 191"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-1296 1436 190"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-1274 1490 154"
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-1170 1382 154"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-1062 1492 154"
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-1168 1594 154"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-1058 1508 176"
 "light"	"75"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-1170 1378 184"
 "light"	"75"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-1168 1324 202"
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"75"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-1058 1464 176"
 "classname"	"light"
 }
+
 {
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-738 822 280"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-826 976 280"
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-826 914 280"
 "classname"	"light"
 }
+
 {
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-804 1150 280"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-802 1086 280"
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-674 1156 280"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-612 1156 280"
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-744 960 164"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"404 2560 452"
 "classname"	"light"
 "style"	"2"
 }
+
 {
 "classname"	"light"
 "origin"	"344 2264 304"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"96 2352 304"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"func_door_secret"
 "angle"	"90"
@@ -12940,6 +13586,7 @@
 ( 560 2304 240 ) ( 544 2304 240 ) ( 544 2224 240 ) CITY5_4 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"func_button"
 "angle"	"-2"
@@ -12954,6 +13601,7 @@
 ( 656 2368 236 ) ( 592 2368 236 ) ( 592 2304 236 ) +0FLOORSW 48 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"func_button"
 "angle"	"-1"
@@ -12969,37 +13617,52 @@
 ( 376 2272 316 ) ( 360 2272 332 ) ( 376 2256 316 ) COP1_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light_torch_small_walltorch"
 "origin"	"626 2378 316"
 "light"	"200"
+	"style"	"1"
+	"_color"	"1.00 0.55 0.24"
 }
+
 {
 "light"	"200"
+	"style"	"1"
+	"_color"	"1.00 0.55 0.24"
 "origin"	"626 2182 316"
 "classname"	"light_torch_small_walltorch"
 }
+
 {
 "classname"	"light"
 "origin"	"296 2548 772"
 "light"	"500"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-544 2040 -198"
 "light"	"300"
+	"_color"	"0.88 0.74 0.58"
 "style"	"2"
 }
+
 {
 "classname"	"light"
 "origin"	"-432 2040 -198"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-664 2048 -198"
 "classname"	"light"
 }
+
 {
 "classname"	"trigger_teleport"
 "target"	"t115"
@@ -13012,12 +13675,15 @@
 ( -520 1708 -244 ) ( -568 1708 -244 ) ( -568 1700 -244 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "style"	"2"
 "classname"	"light"
 "origin"	"-544 1716 -216"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"func_door_secret"
 "angle"	"180"
@@ -13030,6 +13696,7 @@
 ( -504 1768 -264 ) ( -504 1768 -144 ) ( -504 1776 -144 ) METAL4_4 0 4 5 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_secret"
 {
@@ -13041,6 +13708,7 @@
 ( -960 824 328 ) ( -1016 824 328 ) ( -1016 816 328 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_secret"
 {
@@ -13052,6 +13720,7 @@
 ( 576 2312 248 ) ( 568 2312 248 ) ( 568 2224 248 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "spawnflags"	"1"
 "target"	"t110"
@@ -13059,24 +13728,28 @@
 "origin"	"-640 1496 -24"
 "classname"	"monster_demon1"
 }
+
 {
 "targetname"	"t114"
 "angle"	"180"
 "origin"	"256 2552 424"
 "classname"	"monster_knight"
 }
+
 {
 "spawnflags"	"256"
 "angle"	"180"
 "origin"	"368 2640 424"
 "classname"	"monster_knight"
 }
+
 {
 "classname"	"monster_knight"
 "origin"	"368 2456 424"
 "angle"	"180"
 "spawnflags"	"256"
 }
+
 {
 "classname"	"func_door"
 "angle"	"0"
@@ -13115,6 +13788,7 @@
 ( -480 1208 -48 ) ( -480 1224 -48 ) ( -544 1224 -48 ) ADOOR03_6 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"func_door"
 "angle"	"180"
@@ -13154,6 +13828,7 @@
 ( -544 1224 -48 ) ( -608 1224 -48 ) ( -608 1208 -48 ) ADOOR03_6 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_changelevel"
 "map"	"e1m6"
@@ -13166,25 +13841,30 @@
 ( -512 2048 -256 ) ( -576 2048 -256 ) ( -576 2040 -256 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"item_health"
 "origin"	"-464 176 152"
 }
+
 {
 "classname"	"item_health"
 "origin"	"-496 216 152"
 }
+
 {
 "classname"	"monster_knight"
 "origin"	"-768 1960 332"
 "angle"	"90"
 "targetname"	"t126"
 }
+
 {
 "spawnflags"	"1"
 "origin"	"424 2248 244"
 "classname"	"item_spikes"
 }
+
 {
 "targetname"	"t51"
 "target"	"t129"
@@ -13199,6 +13879,7 @@
 ( -480 -8 152 ) ( -544 -8 152 ) ( -544 -16 152 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "target"	"t130"
 "classname"	"trigger_teleport"
@@ -13213,6 +13894,7 @@
 ( -568 -8 152 ) ( -632 -8 152 ) ( -632 -16 152 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "targetname"	"t51"
 "spawnflags"	"768"
@@ -13220,6 +13902,7 @@
 "origin"	"-512 -40 184"
 "classname"	"monster_wizard"
 }
+
 {
 "targetname"	"t51"
 "classname"	"monster_wizard"
@@ -13227,6 +13910,7 @@
 "angle"	"90"
 "spawnflags"	"768"
 }
+
 {
 "targetname"	"t129"
 "spawnflags"	"768"
@@ -13234,6 +13918,7 @@
 "origin"	"-272 288 400"
 "classname"	"info_teleport_destination"
 }
+
 {
 "targetname"	"t130"
 "classname"	"info_teleport_destination"
@@ -13241,6 +13926,7 @@
 "angle"	"45"
 "spawnflags"	"768"
 }
+
 {
 "classname"	"trigger_teleport"
 "spawnflags"	"770"
@@ -13255,6 +13941,7 @@
 ( 336 880 352 ) ( 336 816 352 ) ( 344 816 352 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "target"	"t132"
 "spawnflags"	"258"
@@ -13269,6 +13956,7 @@
 ( 336 792 352 ) ( 336 728 352 ) ( 344 728 352 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"monster_wizard"
 "origin"	"368 848 384"
@@ -13276,6 +13964,7 @@
 "spawnflags"	"768"
 "targetname"	"t131"
 }
+
 {
 "spawnflags"	"256"
 "angle"	"180"
@@ -13283,6 +13972,7 @@
 "classname"	"monster_wizard"
 "targetname"	"t131"
 }
+
 {
 "classname"	"trigger_once"
 "spawnflags"	"256"
@@ -13296,6 +13986,7 @@
 ( -856 824 328 ) ( -864 824 328 ) ( -864 640 328 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"info_teleport_destination"
 "origin"	"-224 696 552"
@@ -13303,6 +13994,7 @@
 "spawnflags"	"256"
 "targetname"	"t132"
 }
+
 {
 "classname"	"info_teleport_destination"
 "origin"	"-888 448 360"
@@ -13310,6 +14002,7 @@
 "spawnflags"	"768"
 "targetname"	"t133"
 }
+
 {
 "sounds"	"1"
 "classname"	"func_door"
@@ -13327,6 +14020,7 @@
 ( -104 2584 400 ) ( -240 2584 400 ) ( -240 2568 400 ) CITYA1_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"monster_ogre"
 "origin"	"-288 2544 424"
@@ -13334,6 +14028,7 @@
 "spawnflags"	"768"
 "targetname"	"t134"
 }
+
 {
 "classname"	"trigger_once"
 "spawnflags"	"768"
@@ -13347,40 +14042,48 @@
 ( 0 2608 336 ) ( -8 2608 336 ) ( -8 2496 336 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_relay"
 "origin"	"-328 2480 416"
 "target"	"t134"
 "spawnflags"	"1024"
 }
+
 {
 "classname"	"light"
 "origin"	"-320 2552 528"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"monster_ogre"
 "origin"	"712 1328 16"
 "angle"	"90"
 "spawnflags"	"768"
 }
+
 {
 "angle"	"0"
 "spawnflags"	"768"
 "origin"	"-1448 2168 24"
 "classname"	"monster_demon1"
 }
+
 {
 "spawnflags"	"769"
 "angle"	"90"
 "origin"	"-512 2216 312"
 "classname"	"monster_knight"
 }
+
 {
 "spawnflags"	"768"
 "origin"	"-944 2120 128"
 "classname"	"item_shells"
 }
+
 {
 "targetname"	"t135"
 "spawnflags"	"769"
@@ -13388,6 +14091,7 @@
 "origin"	"-48 2104 264"
 "classname"	"monster_ogre"
 }
+
 {
 "target"	"t135"
 "spawnflags"	"768"
@@ -13401,6 +14105,7 @@
 ( 104 2016 240 ) ( 0 2016 240 ) ( 0 2008 240 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "target"	"t137"
 "spawnflags"	"768"
@@ -13414,6 +14119,7 @@
 ( -112 1752 112 ) ( -208 1752 112 ) ( -208 1744 112 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "target"	"t138"
 "spawnflags"	"770"
@@ -13428,6 +14134,7 @@
 ( 120 -32 112 ) ( 56 -32 112 ) ( 56 -40 112 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "targetname"	"t137"
 "target"	"t136"
@@ -13442,6 +14149,7 @@
 ( 32 -32 112 ) ( -32 -32 112 ) ( -32 -40 112 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "targetname"	"t137"
 "spawnflags"	"768"
@@ -13449,6 +14157,7 @@
 "origin"	"88 -64 152"
 "classname"	"monster_wizard"
 }
+
 {
 "targetname"	"t137"
 "classname"	"monster_wizard"
@@ -13456,6 +14165,7 @@
 "angle"	"90"
 "spawnflags"	"768"
 }
+
 {
 "targetname"	"t136"
 "spawnflags"	"768"
@@ -13463,6 +14173,7 @@
 "origin"	"-96 1456 168"
 "classname"	"info_teleport_destination"
 }
+
 {
 "targetname"	"t138"
 "spawnflags"	"768"
@@ -13470,11 +14181,13 @@
 "origin"	"104 1624 232"
 "classname"	"info_teleport_destination"
 }
+
 {
 "classname"	"item_shells"
 "origin"	"-220 1828 88"
 "spawnflags"	"1"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"-800 784 328"
@@ -13482,6 +14195,7 @@
 "targetname"	"t140"
 "spawnflags"	"256"
 }
+
 {
 "origin"	"-296 784 328"
 "classname"	"path_corner"
@@ -13489,6 +14203,7 @@
 "target"	"t140"
 "spawnflags"	"256"
 }
+
 {
 "classname"	"monster_demon1"
 "origin"	"-528 784 344"
@@ -13496,22 +14211,26 @@
 "spawnflags"	"257"
 "target"	"t139"
 }
+
 {
 "classname"	"monster_knight"
 "origin"	"-224 896 344"
 "angle"	"270"
 "spawnflags"	"769"
 }
+
 {
 "classname"	"item_health"
 "origin"	"256 1944 -4"
 "spawnflags"	"3584"
 }
+
 {
 "spawnflags"	"3584"
 "origin"	"256 1904 -4"
 "classname"	"item_health"
 }
+
 {
 "classname"	"trigger_teleport"
 "spawnflags"	"770"
@@ -13526,6 +14245,7 @@
 ( 632 1144 -4 ) ( 560 1144 -4 ) ( 560 1136 -4 ) CITY2_7 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "spawnflags"	"770"
 "classname"	"trigger_teleport"
@@ -13540,6 +14260,7 @@
 ( 732 1144 -4 ) ( 660 1144 -4 ) ( 660 1136 -4 ) CITY2_7 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_teleport"
 "spawnflags"	"770"
@@ -13554,6 +14275,7 @@
 ( 828 1144 -4 ) ( 756 1144 -4 ) ( 756 1136 -4 ) CITY2_7 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"monster_demon1"
 "origin"	"596 1096 32"
@@ -13561,6 +14283,7 @@
 "spawnflags"	"768"
 "targetname"	"t144"
 }
+
 {
 "angle"	"90"
 "origin"	"696 1096 32"
@@ -13568,6 +14291,7 @@
 "spawnflags"	"768"
 "targetname"	"t144"
 }
+
 {
 "classname"	"monster_demon1"
 "origin"	"792 1096 32"
@@ -13575,6 +14299,7 @@
 "spawnflags"	"768"
 "targetname"	"t144"
 }
+
 {
 "classname"	"info_teleport_destination"
 "origin"	"712 1376 0"
@@ -13582,6 +14307,7 @@
 "spawnflags"	"768"
 "targetname"	"t141"
 }
+
 {
 "classname"	"info_teleport_destination"
 "origin"	"936 1576 0"
@@ -13589,6 +14315,7 @@
 "spawnflags"	"768"
 "targetname"	"t142"
 }
+
 {
 "classname"	"info_teleport_destination"
 "origin"	"496 1672 0"
@@ -13596,16 +14323,19 @@
 "spawnflags"	"768"
 "targetname"	"t143"
 }
+
 {
 "spawnflags"	"3585"
 "origin"	"896 1296 12"
 "classname"	"item_spikes"
 }
+
 {
 "classname"	"item_spikes"
 "origin"	"944 1296 12"
 "spawnflags"	"2049"
 }
+
 {
 "classname"	"monster_shambler"
 "origin"	"712 1908 24"
@@ -13613,21 +14343,28 @@
 "angle"	"270"
 "targetname"	"t35"
 }
+
 {
 "spawnflags"	"1792"
 "origin"	"-1536 2072 128"
 "classname"	"item_armor2"
 }
+
 {
 "classname"	"light_torch_small_walltorch"
 "origin"	"-150 32 108"
 "light"	"200"
+	"style"	"1"
+	"_color"	"1.00 0.55 0.24"
 }
+
 {
 "classname"	"light"
 "origin"	"-184 160 -16"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"trigger_secret"
 {
@@ -13639,95 +14376,114 @@
 ( -96 168 64 ) ( -248 168 64 ) ( -248 104 64 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"item_health"
 "origin"	"-200 56 56"
 "spawnflags"	"2"
 }
+
 {
 "spawnflags"	"768"
 "angle"	"180"
 "origin"	"-416 1896 -240"
 "classname"	"monster_ogre"
 }
+
 {
 "spawnflags"	"768"
 "classname"	"monster_ogre"
 "origin"	"-672 1888 -240"
 "angle"	"0"
 }
+
 {
 "spawnflags"	"1"
 "origin"	"-1248 2256 0"
 "classname"	"item_shells"
 }
+
 {
 "spawnflags"	"768"
 "origin"	"-680 784 320"
 "classname"	"item_shells"
 }
+
 {
 "spawnflags"	"768"
 "origin"	"-640 784 320"
 "classname"	"item_spikes"
 }
+
 {
 "spawnflags"	"2817"
 "origin"	"480 1328 -4"
 "classname"	"item_shells"
 }
+
 {
 "spawnflags"	"2048"
 "origin"	"280 2664 404"
 "classname"	"item_rockets"
 }
+
 {
 "spawnflags"	"1"
 "origin"	"-136 56 56"
 "classname"	"item_spikes"
 }
+
 {
 "classname"	"item_health"
 "origin"	"920 1944 -4"
 "spawnflags"	"3584"
 }
+
 {
 "spawnflags"	"3584"
 "origin"	"872 1944 -4"
 "classname"	"item_health"
 }
+
 {
 "classname"	"item_spikes"
 "origin"	"416 1808 12"
 "spawnflags"	"2048"
 }
+
 {
 "spawnflags"	"2048"
 "origin"	"416 1760 12"
 "classname"	"item_spikes"
 }
+
 {
 "origin"	"-544 1736 -264"
 "classname"	"item_armor1"
 }
+
 {
 "classname"	"item_shells"
 "origin"	"-808 1608 -48"
 "spawnflags"	"2816"
 }
+
 {
 "classname"	"item_artifact_super_damage"
 "origin"	"-224 936 344"
 }
+
 {
 "mangle"	"24 130 0"
 "origin"	"64 264 592"
 "classname"	"info_intermission"
 }
+
 {
 "origin"	"624 2216 248"
 "classname"	"item_armor2"
 }
+
 {
 "target"	"t115"
 "classname"	"trigger_teleport"
@@ -13740,21 +14496,25 @@
 ( -536 2056 -88 ) ( -568 2056 -88 ) ( -568 2032 -88 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"info_intermission"
 "origin"	"-296 1264 416"
 "mangle"	"20 135 0"
 }
+
 {
 "classname"	"info_intermission"
 "origin"	"128 1832 248"
 "mangle"	"20 225 0"
 }
+
 {
 "classname"	"info_intermission"
 "origin"	"-1536 1432 200"
 "mangle"	"15 90 0"
 }
+
 {
 "classname"	"trigger_secret"
 {
@@ -13766,11 +14526,13 @@
 ( -504 1768 -264 ) ( -584 1768 -264 ) ( -584 1760 -264 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "spawnflags"	"1"
 "origin"	"-936 1904 128"
 "classname"	"item_health"
 }
+
 {
 "spawnflags"	"1792"
 "classname"	"func_wall"
@@ -13783,39 +14545,47 @@
 ( -512 2032 -256 ) ( -576 2032 -256 ) ( -576 2024 -256 ) COP1_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "spawnflags"	"2048"
 "origin"	"-296 1600 -48"
 "classname"	"item_shells"
 }
+
 {
 "classname"	"item_rockets"
 "origin"	"-560 1424 128"
 }
+
 {
 "classname"	"item_health"
 "origin"	"-488 712 128"
 }
+
 {
 "classname"	"item_health"
 "origin"	"-808 1548 132"
 "spawnflags"	"2049"
 }
+
 {
 "angle"	"90"
 "origin"	"-528 192 176"
 "classname"	"info_player_coop"
 }
+
 {
 "classname"	"info_player_coop"
 "origin"	"-624 192 176"
 "angle"	"90"
 }
+
 {
 "angle"	"90"
 "origin"	"-680 192 176"
 "classname"	"info_player_coop"
 }
+
 {
 "classname"	"trigger_secret"
 {
@@ -13827,23 +14597,35 @@
 ( -128 1840 88 ) ( -200 1840 88 ) ( -200 1776 88 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "origin"	"-158 98 120"
 "classname"	"ambient_drip"
 }
+
 {
 "classname"	"ambient_swamp2"
 "origin"	"-918 386 120"
 }
+
 {
 "origin"	"50 650 120"
 "classname"	"ambient_swamp2"
 }
+
 {
 "classname"	"ambient_swamp1"
 "origin"	"10 362 120"
 }
+
 {
 "origin"	"-486 322 120"
 "classname"	"ambient_swamp1"
+}
+
+{
+	"classname"	"light_environment"
+	"_color"	"0.85 0.72 0.58"
+	"light"	"220"
+	"angles"	"45 120 0"
 }

--- a/Quake/maps/E1M6.MAP
+++ b/Quake/maps/E1M6.MAP
@@ -4,6 +4,12 @@
 "classname"	"worldspawn"
 "sounds"	"4"
 "message"	"The Door To Chthon"
+	"_ambient"	"18"
+	"_minlight"	"6"
+	"_sunlight"	"70"
+	"_sunlight_color"	"0.85 0.72 0.58"
+	"_sun_mangle"	"45 120 0"
+	"fog"	"0.03 0.08 0.11 0.18"
 {
 ( 32 936 0 ) ( 32 424 0 ) ( 32 424 -16 ) MMETAL1_1 0 0 0 1.000000 1.000000
 ( 576 960 0 ) ( 0 960 0 ) ( 0 960 -16 ) MMETAL1_1 0 0 0 1.000000 1.000000
@@ -8483,6 +8489,7 @@
 ( -680 2088 -528 ) ( -736 2088 -528 ) ( -736 2080 -528 ) MET5_2 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"func_plat"
 {
@@ -8510,32 +8517,49 @@
 ( 0 704 176 ) ( -128 704 176 ) ( -128 640 176 ) PLAT_TOP2 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"-64 896 456"
 "light"	"400"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-64 512 456"
 "light"	"400"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light_flame_small_white"
 "origin"	"370 802 18"
+	"_color"	"1.00 0.82 0.65"
+	"style"	"1"
 }
+
 {
 "origin"	"370 610 18"
+	"_color"	"1.00 0.82 0.65"
+	"style"	"1"
 "classname"	"light_flame_small_white"
 }
+
 {
 "classname"	"light_flame_small_white"
 "origin"	"50 898 18"
+	"_color"	"1.00 0.82 0.65"
+	"style"	"1"
 }
+
 {
 "origin"	"50 722 18"
+	"_color"	"1.00 0.82 0.65"
+	"style"	"1"
 "classname"	"light_flame_small_white"
 }
+
 {
 "wait"	"-1"
 "classname"	"func_door"
@@ -8575,6 +8599,7 @@
 ( 408 768 0 ) ( 392 768 0 ) ( 392 640 0 ) METAL6_2 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "wait"	"-1"
 "classname"	"func_door"
@@ -8613,49 +8638,68 @@
 ( 408 672 0 ) ( 392 672 0 ) ( 392 544 0 ) METAL6_2 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"520 904 272"
 "light"	"400"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"520 504 272"
 "light"	"400"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"472 824 480"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"472 632 480"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"320 872 480"
 "light"	"400"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"320 536 480"
 "light"	"400"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"168 568 304"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"168 840 304"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"224 320 8"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "target"	"t98"
 "spawnflags"	"2048"
@@ -8663,6 +8707,7 @@
 "origin"	"224 120 56"
 "sounds"	"2"
 }
+
 {
 "classname"	"func_door"
 "angle"	"90"
@@ -8679,6 +8724,7 @@
 ( 248 16 8 ) ( 200 16 8 ) ( 200 -48 8 ) METAL2_5 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"func_button"
 "angle"	"-2"
@@ -8693,41 +8739,56 @@
 ( 96 352 -8 ) ( 64 352 -8 ) ( 64 328 -8 ) MMETAL1_7 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"0 320 176"
+	"_color"	"0.88 0.74 0.58"
 "target"	"t2"
 }
+
 {
 "classname"	"info_null"
 "origin"	"68 316 20"
 "targetname"	"t2"
 }
+
 {
 "classname"	"light"
 "origin"	"224 144 168"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"224 416 416"
 "light"	"500"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"500"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 "origin"	"224 216 416"
 }
+
 {
 "classname"	"light_flame_small_white"
 "origin"	"-142 498 18"
+	"_color"	"1.00 0.82 0.65"
+	"style"	"1"
 }
+
 {
 "light"	"400"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"208 856 104"
 "classname"	"light"
 "style"	"2"
 "target"	"t63"
 }
+
 {
 "classname"	"func_button"
 "angle"	"-2"
@@ -8742,37 +8803,50 @@
 ( 208 896 -8 ) ( 160 896 -8 ) ( 160 880 -8 ) MSWTCH_3 32 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"-192 1152 -48"
 "light"	"400"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-512 1152 -48"
 "light"	"400"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-512 1408 -48"
 "light"	"400"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-192 1408 -48"
 "light"	"400"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-384 1280 32"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-48 1280 160"
 "targetname"	"t3"
 "spawnflags"	"1"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "targetname"	"t88"
 "spawnflags"	"32"
@@ -8789,15 +8863,20 @@
 ( -80 1344 0 ) ( -96 1344 0 ) ( -96 1216 0 ) DR02_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"-192 1280 -168"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-24 1296 -248"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "wait"	"-1"
 "angle"	"-2"
@@ -8815,6 +8894,7 @@
 ( -96 1344 -512 ) ( -128 1344 -512 ) ( -128 1216 -512 ) MMETAL1_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "wait"	"-1"
 "spawnflags"	"4"
@@ -8832,6 +8912,7 @@
 ( -128 1344 -512 ) ( -160 1344 -512 ) ( -160 1216 -512 ) MMETAL1_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "wait"	"10"
 "delay"	"3"
@@ -8846,6 +8927,7 @@
 ( -192 1312 -120 ) ( -200 1312 -120 ) ( -200 1176 -120 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "spawnflags"	"4"
 "targetname"	"t5"
@@ -8863,6 +8945,7 @@
 ( -160 1344 -512 ) ( -192 1344 -512 ) ( -192 1216 -512 ) MMETAL1_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "spawnflags"	"4"
 "lip"	"112"
@@ -8880,6 +8963,7 @@
 ( -192 1344 -512 ) ( -224 1344 -512 ) ( -224 1216 -512 ) MMETAL1_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "spawnflags"	"4"
 "targetname"	"t5"
@@ -8897,6 +8981,7 @@
 ( -224 1344 -512 ) ( -256 1344 -512 ) ( -256 1216 -512 ) MMETAL1_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "spawnflags"	"4"
 "lip"	"80"
@@ -8914,6 +8999,7 @@
 ( -256 1344 -512 ) ( -288 1344 -512 ) ( -288 1216 -512 ) MMETAL1_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "spawnflags"	"4"
 "lip"	"64"
@@ -8931,6 +9017,7 @@
 ( -96 1344 -512 ) ( -320 1344 -512 ) ( -320 1216 -512 ) MMETAL1_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "spawnflags"	"4"
 "angle"	"-2"
@@ -8948,10 +9035,13 @@
 ( -64 1664 -512 ) ( -576 1664 -512 ) ( -576 1216 -512 ) MMETAL1_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "origin"	"-512 1280 -448"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "spawnflags"	"2048"
 "classname"	"item_key1"
@@ -8959,6 +9049,7 @@
 "sounds"	"2"
 "target"	"t34"
 }
+
 {
 "targetname"	"t11"
 "classname"	"monster_ogre"
@@ -8966,12 +9057,14 @@
 "angle"	"180"
 "spawnflags"	"256"
 }
+
 {
 "targetname"	"t11"
 "classname"	"monster_ogre"
 "origin"	"-362 1590 -232"
 "angle"	"90"
 }
+
 {
 "targetname"	"t11"
 "classname"	"monster_ogre"
@@ -8979,6 +9072,7 @@
 "angle"	"270"
 "spawnflags"	"768"
 }
+
 {
 "classname"	"func_plat"
 {
@@ -8998,25 +9092,33 @@
 ( -448 1856 -272 ) ( -576 1856 -272 ) ( -576 1728 -272 ) PLAT_TOP2 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "origin"	"-504 1784 -192"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-704 1952 -352"
 "classname"	"light"
 }
+
 {
 "classname"	"info_teleport_destination"
 "origin"	"-32 1280 -328"
 "angle"	"180"
 "targetname"	"t6"
 }
+
 {
 "classname"	"light"
 "origin"	"-320 832 -192"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "wait"	"-1"
 "targetname"	"t3"
@@ -9032,6 +9134,7 @@
 ( 224 1384 0 ) ( 160 1384 0 ) ( 160 1352 0 ) DR02_1 -32 0 0 1.000000 1.000000
 }
 }
+
 {
 "targetname"	"t87"
 "wait"	"-1"
@@ -9047,17 +9150,21 @@
 ( 288 1312 0 ) ( 272 1312 0 ) ( 272 1248 0 ) DR02_1 -32 0 0 1.000000 1.000000
 }
 }
+
 {
 "light"	"300"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"344 1424 216"
 "classname"	"light"
 }
+
 {
 "target"	"t7"
 "angle"	"270"
 "origin"	"286 782 24"
 "classname"	"monster_ogre"
 }
+
 {
 "target"	"t7"
 "targetname"	"t8"
@@ -9065,6 +9172,7 @@
 "origin"	"200 584 8"
 "classname"	"path_corner"
 }
+
 {
 "target"	"t8"
 "targetname"	"t9"
@@ -9072,6 +9180,7 @@
 "origin"	"-64 584 8"
 "classname"	"path_corner"
 }
+
 {
 "target"	"t8"
 "targetname"	"t7"
@@ -9079,6 +9188,7 @@
 "origin"	"200 1032 8"
 "classname"	"path_corner"
 }
+
 {
 "targetname"	"t82"
 "angle"	"0"
@@ -9086,12 +9196,14 @@
 "classname"	"monster_ogre"
 "spawnflags"	"256"
 }
+
 {
 "angle"	"180"
 "origin"	"398 1454 24"
 "classname"	"monster_ogre"
 "targetname"	"t82"
 }
+
 {
 "spawnflags"	"32"
 "message"	"This door is opened elsewhere."
@@ -9106,44 +9218,61 @@
 ( -80 1280 0 ) ( -96 1280 0 ) ( -96 1216 0 ) DR02_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "origin"	"-96 1240 480"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "origin"	"-96 1320 480"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-96 1184 264"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-96 1344 264"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-480 1360 416"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-248 1192 416"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-480 1200 416"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-232 1392 416"
 "classname"	"light"
 }
+
 {
 "target"	"t11"
 "classname"	"trigger_once"
@@ -9156,6 +9285,7 @@
 ( -72 1312 -336 ) ( -80 1312 -336 ) ( -80 1248 -336 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "target"	"t12"
 "classname"	"trigger_teleport"
@@ -9168,241 +9298,317 @@
 ( -288 800 -256 ) ( -352 800 -256 ) ( -352 768 -256 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "targetname"	"t12"
 "angle"	"180"
 "origin"	"352 868 12"
 "classname"	"info_teleport_destination"
 }
+
 {
 "origin"	"-96 1280 216"
 "classname"	"weapon_supernailgun"
 }
+
 {
 "target"	"t13"
 "origin"	"-256 1648 -248"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "targetname"	"t13"
 "origin"	"-252 1660 -132"
 "classname"	"info_null"
 }
+
 {
 "targetname"	"t14"
 "origin"	"-388 1660 -132"
 "classname"	"info_null"
 }
+
 {
 "targetname"	"t15"
 "origin"	"-764 1660 -132"
 "classname"	"info_null"
 }
+
 {
 "target"	"t14"
 "origin"	"-384 1648 -248"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "target"	"t15"
 "origin"	"-752 1648 -248"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "target"	"t16"
 "origin"	"-512 1648 -248"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "target"	"t17"
 "origin"	"-632 1648 -248"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "targetname"	"t16"
 "origin"	"-516 1660 -140"
 "classname"	"info_null"
 }
+
 {
 "targetname"	"t17"
 "origin"	"-636 1660 -140"
 "classname"	"info_null"
 }
+
 {
 "targetname"	"t21"
 "origin"	"-764 1532 -132"
 "classname"	"info_null"
 }
+
 {
 "targetname"	"t22"
 "origin"	"-764 1412 -132"
 "classname"	"info_null"
 }
+
 {
 "targetname"	"t23"
 "origin"	"-764 1284 -132"
 "classname"	"info_null"
 }
+
 {
 "targetname"	"t20"
 "origin"	"-764 1148 -132"
 "classname"	"info_null"
 }
+
 {
 "targetname"	"t19"
 "origin"	"-764 1028 -132"
 "classname"	"info_null"
 }
+
 {
 "targetname"	"t18"
 "origin"	"-764 964 -132"
 "classname"	"info_null"
 }
+
 {
 "target"	"t21"
 "origin"	"-744 1528 -248"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "target"	"t22"
 "origin"	"-752 1408 -248"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "target"	"t23"
 "origin"	"-752 1280 -248"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "target"	"t20"
 "origin"	"-752 1144 -248"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "target"	"t19"
 "origin"	"-752 1024 -248"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "target"	"t18"
 "origin"	"-752 976 -248"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "targetname"	"t25"
 "origin"	"-636 964 -132"
 "classname"	"info_null"
 }
+
 {
 "targetname"	"t26"
 "origin"	"-516 964 -132"
 "classname"	"info_null"
 }
+
 {
 "targetname"	"t27"
 "origin"	"-388 964 -132"
 "classname"	"info_null"
 }
+
 {
 "targetname"	"t28"
 "origin"	"-252 964 -132"
 "classname"	"info_null"
 }
+
 {
 "targetname"	"t29"
 "origin"	"-196 964 -132"
 "classname"	"info_null"
 }
+
 {
 "targetname"	"t24"
 "origin"	"-196 1660 -132"
 "classname"	"info_null"
 }
+
 {
 "target"	"t24"
 "origin"	"-200 1656 -248"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "target"	"t29"
 "origin"	"-200 968 -248"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "target"	"t28"
 "origin"	"-248 968 -248"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "target"	"t27"
 "origin"	"-392 968 -248"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "target"	"t26"
 "origin"	"-512 968 -248"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "target"	"t25"
 "origin"	"-640 968 -248"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-320 1592 -248"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-448 1592 -248"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-576 1592 -248"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-696 1592 -248"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-696 1464 -248"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-696 1336 -248"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-696 1208 -248"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-696 1056 -248"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-568 1032 -248"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-440 1032 -248"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-248 1032 -248"
 "classname"	"light"
 }
+
 {
 "wait"	"5"
 "spawnflags"	"4"
@@ -9419,6 +9625,7 @@
 ( -448 320 0 ) ( -576 320 0 ) ( -576 288 0 ) MMETAL1_1 0 32 0 1.000000 1.000000
 }
 }
+
 {
 "wait"	"5"
 "targetname"	"t31"
@@ -9435,6 +9642,7 @@
 ( -448 288 16 ) ( -576 288 16 ) ( -576 256 16 ) MMETAL1_1 0 32 0 1.000000 1.000000
 }
 }
+
 {
 "wait"	"8"
 "target"	"t31"
@@ -9449,6 +9657,7 @@
 ( -584 432 63 ) ( -712 432 63 ) ( -712 424 63 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "wait"	"5"
 "targetname"	"t31"
@@ -9465,6 +9674,7 @@
 ( -448 256 32 ) ( -576 256 32 ) ( -576 224 32 ) MMETAL1_1 0 32 0 1.000000 1.000000
 }
 }
+
 {
 "wait"	"5"
 "lip"	"-112"
@@ -9481,6 +9691,7 @@
 ( -448 224 48 ) ( -576 224 48 ) ( -576 192 48 ) MMETAL1_1 0 32 0 1.000000 1.000000
 }
 }
+
 {
 "target"	"t32"
 "classname"	"trigger_teleport"
@@ -9493,17 +9704,21 @@
 ( -480 32 80 ) ( -544 32 80 ) ( -544 8 80 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "angle"	"0"
 "targetname"	"t32"
 "origin"	"-96 800 208"
 "classname"	"info_teleport_destination"
 }
+
 {
 "classname"	"light"
 "origin"	"-512 64 128"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "angle"	"270"
 "classname"	"func_door"
@@ -9542,6 +9757,7 @@
 ( -168 288 0 ) ( -184 288 0 ) ( -184 160 0 ) METAL6_2 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "wait"	"-1"
 "classname"	"func_door"
@@ -9581,19 +9797,23 @@
 ( -184 480 0 ) ( -184 352 0 ) ( -168 352 0 ) METAL6_2 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 "origin"	"-384 880 96"
 "targetname"	"t34"
 "spawnflags"	"1"
 }
+
 {
 "classname"	"monster_ogre"
 "origin"	"-506 566 24"
 "angle"	"90"
 "spawnflags"	"1281"
 }
+
 {
 "classname"	"func_door"
 "angle"	"180"
@@ -9608,22 +9828,27 @@
 ( -448 664 0 ) ( -576 664 0 ) ( -576 648 0 ) DR02_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"item_health"
 "origin"	"472 1496 0"
 }
+
 {
 "classname"	"item_health"
 "origin"	"432 1496 0"
 }
+
 {
 "classname"	"item_health"
 "origin"	"-152 712 192"
 }
+
 {
 "classname"	"item_health"
 "origin"	"-152 888 192"
 }
+
 {
 "classname"	"trigger_teleport"
 "target"	"t53"
@@ -9636,11 +9861,13 @@
 ( -480 440 -160 ) ( -544 440 -160 ) ( -544 408 -160 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"item_health"
 "origin"	"-648 552 304"
 "spawnflags"	"2"
 }
+
 {
 "classname"	"func_door"
 "angle"	"180"
@@ -9655,6 +9882,7 @@
 ( -448 1504 64 ) ( -512 1504 64 ) ( -512 1488 64 ) COP2_6 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"func_door"
 "angle"	"-2"
@@ -9669,6 +9897,7 @@
 ( -320 1504 64 ) ( -384 1504 64 ) ( -384 1488 64 ) COP2_6 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"func_door"
 "angle"	"0"
@@ -9683,6 +9912,7 @@
 ( -192 1504 64 ) ( -256 1504 64 ) ( -256 1488 64 ) COP2_6 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"func_door"
 "angle"	"180"
@@ -9696,6 +9926,7 @@
 ( -192 1320 -24 ) ( -320 1320 -24 ) ( -320 1240 -24 ) MMETAL1_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"func_door"
 "angle"	"0"
@@ -9710,48 +9941,56 @@
 ( -192 1320 -24 ) ( -256 1320 -24 ) ( -256 1240 -24 ) MMETAL1_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "origin"	"-480 1432 -344"
 "classname"	"misc_fireball"
 "speed"	"1000"
 "spawnflags"	"2048"
 }
+
 {
 "origin"	"-480 1280 -344"
 "classname"	"misc_fireball"
 "speed"	"1000"
 "spawnflags"	"2048"
 }
+
 {
 "origin"	"-480 1128 -344"
 "classname"	"misc_fireball"
 "speed"	"1000"
 "spawnflags"	"2048"
 }
+
 {
 "origin"	"-336 1432 -344"
 "classname"	"misc_fireball"
 "speed"	"1000"
 "spawnflags"	"2048"
 }
+
 {
 "origin"	"-336 1120 -344"
 "classname"	"misc_fireball"
 "speed"	"1000"
 "spawnflags"	"2048"
 }
+
 {
 "origin"	"-192 1128 -344"
 "classname"	"misc_fireball"
 "speed"	"1000"
 "spawnflags"	"2048"
 }
+
 {
 "origin"	"-192 1432 -344"
 "classname"	"misc_fireball"
 "speed"	"1000"
 "spawnflags"	"2048"
 }
+
 {
 "wait"	"-1"
 "classname"	"func_button"
@@ -9766,6 +10005,7 @@
 ( -568 1304 16 ) ( -592 1304 16 ) ( -592 1256 16 ) MET5_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"func_train"
 "angle"	"0"
@@ -9924,6 +10164,7 @@
 ( -640 1120 -520 ) ( -768 1120 -520 ) ( -768 1088 -520 ) METAL4_4 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"path_corner"
 "origin"	"-768 1088 -512"
@@ -9931,27 +10172,33 @@
 "targetname"	"t45"
 "target"	"t46"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"-768 2000 -512"
 "targetname"	"t46"
 "target"	"t47"
 }
+
 {
 "classname"	"item_health"
 "origin"	"-720 1968 -512"
 "spawnflags"	"2"
 }
+
 {
 "classname"	"light"
 "origin"	"-704 2016 -432"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"-768 2000 -512"
 "targetname"	"t47"
 "target"	"t45"
 }
+
 {
 "classname"	"monster_ogre"
 "origin"	"-456 1552 88"
@@ -9959,17 +10206,21 @@
 "targetname"	"t44"
 "spawnflags"	"256"
 }
+
 {
 "classname"	"monster_ogre"
 "origin"	"-240 1552 88"
 "angle"	"270"
 "targetname"	"t44"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 "origin"	"-704 1072 -440"
 }
+
 {
 "classname"	"func_door"
 "angle"	"-2"
@@ -10011,6 +10262,7 @@
 ( -616 1336 -512 ) ( -632 1336 -512 ) ( -632 1320 -512 ) MMETAL1_2 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_once"
 "target"	"t48"
@@ -10023,6 +10275,7 @@
 ( -640 1384 -512 ) ( -768 1384 -512 ) ( -768 1376 -512 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"monster_ogre"
 "origin"	"-864 1584 -488"
@@ -10031,6 +10284,7 @@
 "targetname"	"t48"
 "spawnflags"	"768"
 }
+
 {
 "classname"	"monster_ogre"
 "origin"	"-864 1424 -488"
@@ -10039,6 +10293,7 @@
 "targetname"	"t48"
 "spawnflags"	"768"
 }
+
 {
 "classname"	"trigger_counter"
 "targetname"	"t49"
@@ -10052,6 +10307,7 @@
 ( -832 1728 -448 ) ( -856 1728 -448 ) ( -856 1704 -448 ) MMETAL1_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"3"
 "targetname"	"t83"
@@ -10092,6 +10348,7 @@
 ( -616 1848 -512 ) ( -632 1848 -512 ) ( -632 1832 -512 ) MMETAL1_2 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"func_door"
 "angle"	"-1"
@@ -10108,12 +10365,14 @@
 ( -576 896 0 ) ( -608 896 0 ) ( -608 800 0 ) METAL4_4 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"monster_ogre"
 "origin"	"-704 848 24"
 "angle"	"0"
 "targetname"	"t51"
 }
+
 {
 "classname"	"trigger_once"
 "target"	"t51"
@@ -10126,11 +10385,14 @@
 ( -352 928 0 ) ( -360 928 0 ) ( -360 736 0 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"-656 848 120"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"func_door"
 "angle"	"90"
@@ -10145,6 +10407,7 @@
 ( -448 832 256 ) ( -672 832 256 ) ( -672 384 256 ) METAL2_2 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"func_door"
 "angle"	"270"
@@ -10160,24 +10423,28 @@
 ( -448 416 256 ) ( -672 416 256 ) ( -672 224 256 ) METAL2_2 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"monster_zombie"
 "origin"	"-624 352 296"
 "angle"	"90"
 "targetname"	"t52"
 }
+
 {
 "classname"	"monster_zombie"
 "origin"	"-880 368 304"
 "angle"	"90"
 "targetname"	"t52"
 }
+
 {
 "classname"	"monster_zombie"
 "origin"	"-496 352 296"
 "angle"	"90"
 "targetname"	"t52"
 }
+
 {
 "classname"	"monster_zombie"
 "origin"	"-624 480 296"
@@ -10185,6 +10452,7 @@
 "targetname"	"t52"
 "spawnflags"	"768"
 }
+
 {
 "classname"	"monster_zombie"
 "origin"	"-880 464 304"
@@ -10192,6 +10460,7 @@
 "targetname"	"t52"
 "spawnflags"	"256"
 }
+
 {
 "classname"	"monster_zombie"
 "origin"	"-496 480 296"
@@ -10199,38 +10468,52 @@
 "targetname"	"t52"
 "spawnflags"	"256"
 }
+
 {
 "classname"	"info_teleport_destination"
 "origin"	"-648 248 312"
 "angle"	"90"
 "targetname"	"t53"
 }
+
 {
 "classname"	"light"
 "origin"	"-560 592 392"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-568 232 392"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-288 616 -112"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-392 616 -112"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-384 224 -112"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-216 224 -112"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"func_button"
 "angle"	"180"
@@ -10245,24 +10528,35 @@
 ( -1040 448 32 ) ( -1056 448 32 ) ( -1056 384 32 ) MSWTCH_4 0 32 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light_flame_small_white"
 "origin"	"-990 546 40"
+	"_color"	"1.00 0.82 0.65"
+	"style"	"1"
 }
+
 {
 "classname"	"light"
 "origin"	"-928 480 200"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"-990 290 40"
+	"_color"	"1.00 0.82 0.65"
+	"style"	"1"
 "classname"	"light_flame_small_white"
 }
+
 {
 "classname"	"light"
 "origin"	"-928 352 200"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"func_door"
 "angle"	"90"
@@ -10277,6 +10571,7 @@
 ( -832 512 264 ) ( -928 512 264 ) ( -928 448 264 ) METAL2_2 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"func_door"
 "angle"	"270"
@@ -10290,80 +10585,116 @@
 ( -832 416 264 ) ( -928 416 264 ) ( -928 320 264 ) METAL2_2 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"-880 416 360"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"400"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-336 608 448"
 "classname"	"light"
 }
+
 {
 "light"	"400"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-328 480 448"
 "classname"	"light"
 }
+
 {
 "light"	"400"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-304 344 448"
 "classname"	"light"
 }
+
 {
 "light"	"400"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-280 216 448"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 "origin"	"-232 200 168"
 "classname"	"light_flame_small_yellow"
 }
+
 {
 "classname"	"light_flame_small_yellow"
 "origin"	"-696 416 168"
 "light"	"200"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-192 320 72"
 "classname"	"light"
 }
+
 {
 "origin"	"-480 392 224"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 "origin"	"-744 416 168"
 "classname"	"light_flame_small_yellow"
 }
+
 {
 "light"	"200"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 "origin"	"-616 632 168"
 "classname"	"light_flame_small_yellow"
 }
+
 {
 "classname"	"light_flame_small_yellow"
 "origin"	"-416 632 168"
 "light"	"200"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-664 600 64"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-664 232 64"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-504 608 64"
 "classname"	"light"
 }
+
 {
 "wait"	"-1"
 "targetname"	"t52"
@@ -10491,98 +10822,130 @@
 ( -416 448 -264 ) ( -416 320 -264 ) ( -192 256 -264 ) MMETAL1_2 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-376 432 -104"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-272 336 -192"
 "classname"	"light"
 }
+
 {
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-512 392 -104"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-512 96 0"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"style"	"1"
+	"_color"	"1.00 0.58 0.22"
 "origin"	"-240 440 168"
 "classname"	"light_flame_small_yellow"
 }
+
 {
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-672 416 24"
 "classname"	"light"
 }
+
 {
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-776 424 24"
 "classname"	"light"
 }
+
 {
 "classname"	"item_shells"
 "origin"	"-512 992 -256"
 }
+
 {
 "classname"	"light"
 "origin"	"-96 248 80"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-96 392 80"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"info_player_deathmatch"
 "origin"	"-928 416 24"
 "angle"	"0"
 }
+
 {
 "classname"	"weapon_supershotgun"
 "origin"	"-800 416 0"
 "spawnflags"	"1792"
 }
+
 {
 "classname"	"light"
 "origin"	"-544 1800 -376"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"info_player_deathmatch"
 "origin"	"-704 1536 -232"
 "angle"	"270"
 }
+
 {
 "classname"	"weapon_rocketlauncher"
 "origin"	"-696 1008 -256"
 "spawnflags"	"1792"
 }
+
 {
 "classname"	"info_player_deathmatch"
 "origin"	"216 1488 24"
 "angle"	"270"
 }
+
 {
 "classname"	"item_rockets"
 "origin"	"-40 880 192"
 }
+
 {
 "classname"	"item_shells"
 "origin"	"-48 816 192"
 }
+
 {
 "classname"	"light"
 "origin"	"64 832 -192"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"trigger_teleport"
 "target"	"t12"
@@ -10595,30 +10958,35 @@
 ( 96 864 -256 ) ( 88 864 -256 ) ( 88 800 -256 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trap_spikeshooter"
 "origin"	"-88 748 -216"
 "angle"	"90"
 "targetname"	"t62"
 }
+
 {
 "classname"	"trap_spikeshooter"
 "origin"	"-128 916 -216"
 "angle"	"270"
 "targetname"	"t62"
 }
+
 {
 "classname"	"trap_spikeshooter"
 "origin"	"-296 916 -72"
 "angle"	"270"
 "targetname"	"t62"
 }
+
 {
 "classname"	"trap_spikeshooter"
 "origin"	"-264 748 -72"
 "angle"	"90"
 "targetname"	"t62"
 }
+
 {
 "classname"	"trigger_multiple"
 "wait"	"1"
@@ -10632,24 +11000,28 @@
 ( -64 928 -256 ) ( -320 928 -256 ) ( -320 736 -256 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trap_spikeshooter"
 "origin"	"-168 748 -216"
 "angle"	"90"
 "targetname"	"t62"
 }
+
 {
 "classname"	"trap_spikeshooter"
 "origin"	"-184 832 -216"
 "angle"	"0"
 "targetname"	"t62"
 }
+
 {
 "classname"	"trap_spikeshooter"
 "origin"	"-232 916 -72"
 "angle"	"270"
 "targetname"	"t62"
 }
+
 {
 "targetname"	"t48"
 "classname"	"monster_ogre"
@@ -10657,29 +11029,36 @@
 "spawnflags"	"1024"
 "target"	"t50"
 }
+
 {
 "classname"	"info_null"
 "origin"	"196 860 20"
 "targetname"	"t63"
 }
+
 {
 "classname"	"item_health"
 "origin"	"-672 832 0"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "spawnflags"	"1"
 "targetname"	"t34"
 "origin"	"-104 832 -192"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "spawnflags"	"1"
 "targetname"	"t34"
 "origin"	"-264 832 -48"
 "classname"	"light"
 }
+
 {
 "speed"	"400"
 "angle"	"-1"
@@ -10687,6 +11066,7 @@
 "classname"	"misc_fireball"
 "spawnflags"	"2048"
 }
+
 {
 "speed"	"400"
 "angle"	"-1"
@@ -10694,6 +11074,7 @@
 "classname"	"misc_fireball"
 "spawnflags"	"2048"
 }
+
 {
 "speed"	"400"
 "angle"	"-1"
@@ -10701,6 +11082,7 @@
 "classname"	"misc_fireball"
 "spawnflags"	"2048"
 }
+
 {
 "speed"	"400"
 "angle"	"-1"
@@ -10708,51 +11090,66 @@
 "classname"	"misc_fireball"
 "spawnflags"	"2048"
 }
+
 {
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"224 -24 24"
 "classname"	"light"
 }
+
 {
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"224 24 24"
 "classname"	"light"
 }
+
 {
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"224 72 24"
 "classname"	"light"
 }
+
 {
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"224 128 24"
 "classname"	"light"
 }
+
 {
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"224 184 24"
 "classname"	"light"
 }
+
 {
 "spawnflags"	"1792"
 "origin"	"-720 1920 -512"
 "classname"	"item_rockets"
 }
+
 {
 "spawnflags"	"1793"
 "origin"	"-488 1552 64"
 "classname"	"item_spikes"
 }
+
 {
 "spawnflags"	"1792"
 "origin"	"224 120 32"
 "classname"	"item_armor2"
 }
+
 {
 "spawnflags"	"1792"
 "origin"	"-608 1280 -256"
 "classname"	"item_armor2"
 }
+
 {
 "wait"	"1"
 "target"	"t62"
@@ -10766,6 +11163,7 @@
 ( -192 928 -96 ) ( -320 928 -96 ) ( -320 736 -96 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "spawnflags"	"2048"
 "classname"	"func_wall"
@@ -10794,6 +11192,7 @@
 ( 120 352 24 ) ( 120 352 32 ) ( 136 352 32 ) MMETAL1_2 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_once"
 "targetname"	"t70"
@@ -10808,6 +11207,7 @@
 ( -1088 536 32 ) ( -1120 536 32 ) ( -1120 504 32 ) METAL2_4 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"func_door"
 "angle"	"-2"
@@ -10832,6 +11232,7 @@
 ( -760 1632 -448 ) ( -800 1632 -448 ) ( -800 1376 -448 ) METAL4_4 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "lip"	"10"
 "targetname"	"t48"
@@ -10855,62 +11256,88 @@
 ( -936 1632 -448 ) ( -1096 1632 -448 ) ( -1096 1376 -448 ) METAL4_4 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light_flame_small_yellow"
 "origin"	"736 416 40"
+	"_color"	"1.00 0.58 0.22"
+	"style"	"1"
 }
+
 {
 "classname"	"light_flame_small_yellow"
 "origin"	"736 160 40"
+	"_color"	"1.00 0.58 0.22"
+	"style"	"1"
 }
+
 {
 "classname"	"light"
 "origin"	"680 368 160"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"680 208 160"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "spawnflags"	"1"
 "targetname"	"t73"
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"832 288 96"
 "classname"	"light"
 }
+
 {
 "spawnflags"	"1"
 "targetname"	"t76"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1024 288 96"
 "classname"	"light"
 }
+
 {
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"400 384 168"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"400 272 168"
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"400 144 168"
 "classname"	"light"
 }
+
 {
 "origin"	"416 160 40"
+	"_color"	"1.00 0.58 0.22"
+	"style"	"1"
 "classname"	"light_flame_small_yellow"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"472 216 160"
 "classname"	"light"
 }
+
 {
 "sounds"	"1"
 "target"	"t71"
@@ -10927,6 +11354,7 @@
 ( 704 320 -8 ) ( 640 320 -8 ) ( 640 256 -8 ) MSWTCH_3 0 0 90 -1.000000 -1.000000
 }
 }
+
 {
 "speed"	"75"
 "sounds"	"3"
@@ -10943,6 +11371,7 @@
 ( 792 288 0 ) ( 776 288 0 ) ( 776 192 0 ) DR07_1 -48 -8 0 1.000000 1.000000
 }
 }
+
 {
 "speed"	"75"
 "wait"	"-1"
@@ -10957,17 +11386,21 @@
 ( 792 384 0 ) ( 776 384 0 ) ( 776 288 0 ) DR07_1 -48 -8 0 1.000000 1.000000
 }
 }
+
 {
 "style"	"2"
 "target"	"t72"
 "origin"	"656 288 104"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "targetname"	"t72"
 "origin"	"676 292 12"
 "classname"	"info_null"
 }
+
 {
 "sounds"	"3"
 "delay"	"1"
@@ -10983,6 +11416,7 @@
 ( 840 456 88 ) ( 824 456 88 ) ( 824 440 88 ) MMETAL1_5 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"3"
 "delay"	"2"
@@ -10998,6 +11432,7 @@
 ( 872 456 88 ) ( 856 456 88 ) ( 856 440 88 ) MMETAL1_5 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"3"
 "delay"	"3"
@@ -11013,6 +11448,7 @@
 ( 904 456 88 ) ( 888 456 88 ) ( 888 440 88 ) MMETAL1_5 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "sounds"	"3"
 "delay"	"4"
@@ -11028,35 +11464,44 @@
 ( 936 456 88 ) ( 920 456 88 ) ( 920 440 88 ) MMETAL1_5 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "spawnflags"	"1"
 "targetname"	"t74"
 "classname"	"light"
 "origin"	"880 288 96"
 "light"	"140"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "spawnflags"	"1"
 "targetname"	"t75"
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"928 288 96"
 "classname"	"light"
 }
+
 {
 "classname"	"info_player_start"
 "origin"	"-96 800 224"
 "angle"	"0"
 }
+
 {
 "classname"	"light"
 "origin"	"-352 1552 168"
+	"_color"	"0.88 0.74 0.58"
 "target"	"t79"
 }
+
 {
 "classname"	"info_null"
 "origin"	"-356 1532 68"
 "targetname"	"t79"
 }
+
 {
 "sounds"	"1"
 "classname"	"trigger_secret"
@@ -11069,6 +11514,7 @@
 ( -448 160 -40 ) ( -576 160 -40 ) ( -576 0 -40 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_once"
 "target"	"t82"
@@ -11081,46 +11527,55 @@
 ( 256 1128 56 ) ( 128 1128 56 ) ( 128 1120 56 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "speed"	"400"
 "origin"	"-376 568 -120"
 "classname"	"misc_fireball"
 "spawnflags"	"2048"
 }
+
 {
 "classname"	"misc_fireball"
 "origin"	"-304 480 -120"
 "speed"	"400"
 "spawnflags"	"2048"
 }
+
 {
 "speed"	"400"
 "origin"	"-384 256 -120"
 "classname"	"misc_fireball"
 "spawnflags"	"2048"
 }
+
 {
 "classname"	"misc_fireball"
 "origin"	"-288 224 -120"
 "speed"	"400"
 "spawnflags"	"2048"
 }
+
 {
 "angle"	"180"
 "origin"	"488 768 24"
 "classname"	"monster_ogre"
 }
+
 {
 "angle"	"180"
 "origin"	"488 640 24"
 "classname"	"monster_ogre"
 "spawnflags"	"256"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"480 504 80"
 "classname"	"light"
 }
+
 {
 "sounds"	"3"
 "target"	"t83"
@@ -11135,109 +11590,148 @@
 ( -832 1768 -448 ) ( -856 1768 -448 ) ( -856 1744 -448 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"104 1264 -48"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"224 1176 -48"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"216 1296 -48"
 "classname"	"light"
 }
+
 {
 "targetname"	"t3"
 "spawnflags"	"1"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"192 1056 232"
 "classname"	"light"
 }
+
 {
 "spawnflags"	"1"
 "targetname"	"t3"
 "classname"	"light"
 "origin"	"192 1184 232"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "spawnflags"	"1"
 "targetname"	"t3"
 "classname"	"light"
 "origin"	"-32 1280 232"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "targetname"	"t3"
 "spawnflags"	"1"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"96 1272 232"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"192 1264 16"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-128 1280 64"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"320 1280 64"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"-80 608 352"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-80 800 352"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"80 688 24"
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"80 864 24"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-112 528 24"
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"304 608 352"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"304 800 352"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"328 800 24"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"336 608 24"
 "light"	"100"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"func_wall"
 "spawnflags"	"2048"
@@ -11250,6 +11744,7 @@
 ( 128 288 24 ) ( 112 288 24 ) ( 112 240 24 ) MMETAL1_2 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"func_wall"
 "spawnflags"	"2048"
@@ -11270,33 +11765,44 @@
 ( 128 288 8 ) ( 112 288 8 ) ( 112 280 8 ) MMETAL1_2 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"192 984 304"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"192 1128 304"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"192 1280 304"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"32 1280 304"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"192 1008 40"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "spawnflags"	"1"
 "targetname"	"t3"
 }
+
 {
 "classname"	"func_door"
 "angle"	"-2"
@@ -11311,6 +11817,7 @@
 ( 608 1472 0 ) ( 576 1472 0 ) ( 576 1408 0 ) NMETAL2_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"func_plat"
 {
@@ -11338,6 +11845,7 @@
 ( 664 1448 0 ) ( 648 1448 0 ) ( 648 1432 0 ) MET5_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_multiple"
 "health"	"1"
@@ -11351,51 +11859,70 @@
 ( 512 1544 256 ) ( 496 1544 256 ) ( 496 1480 256 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"544 1504 24"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"192 1504 24"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"544 1280 24"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"544 1504 344"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"544 1304 344"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"352 1440 344"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"624 1440 176"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"624 1440 256"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"672 1440 336"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "angle"	"270"
 "target"	"t88"
@@ -11410,24 +11937,30 @@
 ( 472 1248 24 ) ( 424 1248 24 ) ( 424 1232 24 ) MET5_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "style"	"2"
 "target"	"t85"
 "origin"	"448 1312 72"
 "classname"	"light"
 }
+
 {
 "angle"	"270"
 "targetname"	"t85"
 "origin"	"448 1260 52"
 "classname"	"info_null"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"452 1252 20"
 "classname"	"light"
 }
+
 {
 "classname"	"func_wall"
 "spawnflags"	"2048"
@@ -11440,19 +11973,23 @@
 ( 128 352 8 ) ( 112 352 8 ) ( 112 288 8 ) MMETAL1_2 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "angle"	"270"
 "targetname"	"t86"
 "origin"	"-580 1276 36"
 "classname"	"info_null"
 }
+
 {
 "style"	"2"
 "target"	"t86"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-528 1272 40"
 "classname"	"light"
 }
+
 {
 "sounds"	"1"
 "wait"	"-1"
@@ -11467,6 +12004,7 @@
 ( -384 664 0 ) ( -512 664 0 ) ( -512 648 0 ) DR02_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "target"	"t88"
 "targetname"	"t44"
@@ -11480,6 +12018,7 @@
 ( -192 1600 296 ) ( -224 1600 296 ) ( -224 1568 296 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "target"	"t88"
 "targetname"	"t34"
@@ -11493,6 +12032,7 @@
 ( -128 1600 -232 ) ( -160 1600 -232 ) ( -160 1568 -232 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "lip"	"-2"
 "wait"	"-1"
@@ -11508,6 +12048,7 @@
 ( -704 432 64 ) ( -712 432 64 ) ( -712 400 64 ) RUNE1_7 16 0 0 1.000000 1.000000
 }
 }
+
 {
 "lip"	"3"
 "wait"	"-1"
@@ -11522,11 +12063,13 @@
 ( -712 432 64 ) ( -720 432 64 ) ( -720 400 64 ) RUNE2_2 16 0 0 1.000000 1.000000
 }
 }
+
 {
 "spawnflags"	"1"
 "origin"	"-528 48 -81"
 "classname"	"item_rockets"
 }
+
 {
 "sounds"	"1"
 "classname"	"trigger_secret"
@@ -11539,44 +12082,57 @@
 ( -448 448 -144 ) ( -576 448 -144 ) ( -576 352 -144 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "targetname"	"t34"
 "spawnflags"	"1"
 "origin"	"-384 784 96"
 "classname"	"light"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "spawnflags"	"1"
 "targetname"	"t34"
 "origin"	"-192 896 96"
 "classname"	"light"
 }
+
 {
 "spawnflags"	"1"
 "targetname"	"t34"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-192 776 96"
 "classname"	"light"
 }
+
 {
 "spawnflags"	"1"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "targetname"	"t34"
 "origin"	"-512 720 96"
 "classname"	"light"
 }
+
 {
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-104 832 144"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-288 832 144"
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"trigger_secret"
 {
@@ -11588,47 +12144,62 @@
 ( 576 1344 184 ) ( 320 1344 184 ) ( 320 1336 184 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"-704 1760 -352"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-704 1568 -352"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-704 1376 -352"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-704 1176 -440"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-848 1568 -400"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-864 1392 -400"
 "classname"	"light"
 }
+
 {
 "spawnflags"	"1"
 "classname"	"item_spikes"
 "origin"	"-208 608 0"
 }
+
 {
 "classname"	"monster_ogre"
 "origin"	"-128 576 24"
 "angle"	"0"
 "spawnflags"	"768"
 }
+
 {
 "classname"	"trigger_monsterjump"
 {
@@ -11640,12 +12211,14 @@
 ( -192 1480 64 ) ( -512 1480 64 ) ( -512 1472 64 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"monster_demon1"
 "origin"	"-504 504 24"
 "spawnflags"	"769"
 "angle"	"90"
 }
+
 {
 "targetname"	"t90"
 "target"	"t89"
@@ -11660,6 +12233,7 @@
 ( -872 1952 -568 ) ( -880 1952 -568 ) ( -880 1824 -568 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "spawnflags"	"768"
 "targetname"	"t90"
@@ -11667,12 +12241,14 @@
 "origin"	"-944 1888 -544"
 "classname"	"monster_ogre"
 }
+
 {
 "angle"	"270"
 "targetname"	"t89"
 "origin"	"-704 1856 -504"
 "classname"	"info_teleport_destination"
 }
+
 {
 "target"	"t90"
 "classname"	"trigger_once"
@@ -11685,6 +12261,7 @@
 ( -640 1640 -512 ) ( -768 1640 -512 ) ( -768 1632 -512 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "targetname"	"t1"
 "wait"	"-1"
@@ -11700,6 +12277,7 @@
 ( -512 184 80 ) ( -576 184 80 ) ( -576 168 80 ) DR02_1 0 80 0 1.000000 1.000000
 }
 }
+
 {
 "wait"	"-1"
 "angle"	"0"
@@ -11714,36 +12292,42 @@
 ( -448 184 80 ) ( -512 184 80 ) ( -512 168 80 ) DR02_1 0 80 0 1.000000 1.000000
 }
 }
+
 {
 "spawnflags"	"769"
 "angle"	"0"
 "origin"	"-864 496 24"
 "classname"	"monster_ogre"
 }
+
 {
 "classname"	"monster_ogre"
 "origin"	"-864 320 24"
 "angle"	"0"
 "spawnflags"	"257"
 }
+
 {
 "targetname"	"t94"
 "angle"	"270"
 "origin"	"16 1832 32"
 "classname"	"monster_wizard"
 }
+
 {
 "targetname"	"t94"
 "classname"	"monster_wizard"
 "origin"	"104 1832 32"
 "angle"	"270"
 }
+
 {
 "targetname"	"t94"
 "angle"	"270"
 "origin"	"184 1832 32"
 "classname"	"monster_wizard"
 }
+
 {
 "targetname"	"t94"
 "target"	"t91"
@@ -11758,6 +12342,7 @@
 ( 56 1792 -16 ) ( -32 1792 -16 ) ( -32 1776 -16 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "targetname"	"t94"
 "target"	"t93"
@@ -11772,6 +12357,7 @@
 ( 240 1792 -16 ) ( 152 1792 -16 ) ( 152 1776 -16 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "targetname"	"t94"
 "target"	"t92"
@@ -11786,24 +12372,28 @@
 ( 160 1792 -16 ) ( 72 1792 -16 ) ( 72 1776 -16 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "targetname"	"t93"
 "angle"	"0"
 "origin"	"-392 1412 344"
 "classname"	"info_teleport_destination"
 }
+
 {
 "targetname"	"t92"
 "classname"	"info_teleport_destination"
 "origin"	"-456 1296 296"
 "angle"	"0"
 }
+
 {
 "targetname"	"t91"
 "angle"	"0"
 "origin"	"-388 1168 184"
 "classname"	"info_teleport_destination"
 }
+
 {
 "target"	"t94"
 "classname"	"trigger_once"
@@ -11816,6 +12406,7 @@
 ( -64 1440 240 ) ( -128 1440 240 ) ( -128 1376 240 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "target"	"t96"
 "classname"	"trigger_once"
@@ -11828,6 +12419,7 @@
 ( -56 384 0 ) ( -64 384 0 ) ( -64 256 0 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "spawnflags"	"256"
 "targetname"	"t96"
@@ -11835,6 +12427,7 @@
 "origin"	"584 1112 32"
 "classname"	"monster_ogre"
 }
+
 {
 "targetname"	"t96"
 "target"	"t95"
@@ -11849,18 +12442,21 @@
 ( 640 1056 8 ) ( 528 1056 8 ) ( 528 1048 8 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "targetname"	"t95"
 "angle"	"180"
 "origin"	"272 704 16"
 "classname"	"info_teleport_destination"
 }
+
 {
 "classname"	"monster_demon1"
 "origin"	"-48 320 24"
 "angle"	"180"
 "spawnflags"	"768"
 }
+
 {
 "classname"	"monster_shambler"
 "origin"	"728 880 32"
@@ -11868,6 +12464,7 @@
 "targetname"	"t98"
 "spawnflags"	"768"
 }
+
 {
 "targetname"	"t98"
 "classname"	"trigger_teleport"
@@ -11882,12 +12479,14 @@
 ( 728 768 8 ) ( 624 768 8 ) ( 624 720 8 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"info_teleport_destination"
 "origin"	"224 608 8"
 "angle"	"270"
 "targetname"	"t97"
 }
+
 {
 "classname"	"monster_demon1"
 "origin"	"728 880 32"
@@ -11895,6 +12494,7 @@
 "spawnflags"	"1280"
 "targetname"	"t98"
 }
+
 {
 "classname"	"monster_shambler"
 "origin"	"1048 288 24"
@@ -11902,47 +12502,62 @@
 "targetname"	"t76"
 "target"	"t99"
 }
+
 {
 "classname"	"light"
 "origin"	"1216 352 -56"
+	"_color"	"0.88 0.74 0.58"
 "targetname"	"t76"
 "spawnflags"	"1"
 }
+
 {
 "origin"	"1216 224 -56"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 "targetname"	"t76"
 "spawnflags"	"1"
 }
+
 {
 "classname"	"light"
 "origin"	"1088 192 96"
 "targetname"	"t76"
 "spawnflags"	"1"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"1088 384 96"
 "classname"	"light"
 "targetname"	"t76"
 "spawnflags"	"1"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"480 424 80"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"672 288 0"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"616 192 24"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"trigger_changelevel"
 "map"	"e1m7"
@@ -11955,6 +12570,7 @@
 ( 1280 384 -32 ) ( 1152 384 -32 ) ( 1152 192 -32 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_multiple"
 "targetname"	"t71"
@@ -11968,46 +12584,56 @@
 ( 664 536 0 ) ( 640 536 0 ) ( 640 512 0 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"info_intermission"
 "origin"	"48 912 248"
 "mangle"	"20 315 0"
 }
+
 {
 "spawnflags"	"3072"
 "origin"	"-208 656 0"
 "classname"	"item_health"
 }
+
 {
 "classname"	"item_shells"
 "origin"	"536 1296 8"
 }
+
 {
 "classname"	"item_spikes"
 "origin"	"-112 1168 216"
 "spawnflags"	"3073"
 }
+
 {
 "classname"	"item_health"
 "origin"	"-648 224 0"
 }
+
 {
 "origin"	"-688 224 0"
 "classname"	"item_health"
 }
+
 {
 "classname"	"item_rockets"
 "origin"	"-696 600 0"
 }
+
 {
 "classname"	"item_health"
 "origin"	"-152 344 0"
 }
+
 {
 "origin"	"-112 344 0"
 "classname"	"item_health"
 "spawnflags"	"3072"
 }
+
 {
 "classname"	"trigger_once"
 "target"	"t87"
@@ -12020,6 +12646,7 @@
 ( 504 1400 24 ) ( 392 1400 24 ) ( 392 1392 24 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "spawnflags"	"2048"
 "classname"	"func_door"
@@ -12046,35 +12673,44 @@
 ( -336 904 -256 ) ( -368 904 -256 ) ( -368 880 -256 ) MET5_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_relay"
 "origin"	"-728 1240 -240"
 "targetname"	"t34"
 "message"	"Your way has been lit..."
 }
+
 {
 "classname"	"item_artifact_super_damage"
 "origin"	"448 1296 208"
 }
+
 {
 "classname"	"item_health"
 "origin"	"-368 1520 64"
 "spawnflags"	"2"
 }
+
 {
 "classname"	"item_armor2"
 "origin"	"-504 1280 0"
 }
+
 {
 "classname"	"light"
 "origin"	"-288 928 -200"
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-352 928 -200"
 "classname"	"light"
 }
+
 {
 "classname"	"trigger_teleport"
 "target"	"t100"
@@ -12087,12 +12723,14 @@
 ( -672 1048 -512 ) ( -736 1048 -512 ) ( -736 1040 -512 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"info_teleport_destination"
 "origin"	"-96 1408 216"
 "targetname"	"t100"
 "angle"	"270"
 }
+
 {
 "classname"	"trigger_secret"
 {
@@ -12104,38 +12742,46 @@
 ( -640 1080 -508 ) ( -768 1080 -508 ) ( -768 1072 -508 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"item_spikes"
 "origin"	"400 280 0"
 "spawnflags"	"1"
 }
+
 {
 "classname"	"item_health"
 "origin"	"656 136 0"
 }
+
 {
 "origin"	"664 408 0"
 "classname"	"item_health"
 "spawnflags"	"3072"
 }
+
 {
 "classname"	"item_health"
 "origin"	"400 208 0"
 "spawnflags"	"3072"
 }
+
 {
 "classname"	"item_rockets"
 "origin"	"400 320 0"
 "spawnflags"	"3584"
 }
+
 {
 "classname"	"item_armor2"
 "origin"	"864 288 0"
 }
+
 {
 "classname"	"item_shells"
 "origin"	"424 848 0"
 }
+
 {
 "wait"	"2"
 "classname"	"func_button"
@@ -12150,30 +12796,38 @@
 ( 456 928 24 ) ( 504 928 24 ) ( 504 944 24 ) MET5_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"476 924 20"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"480 920 104"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"item_spikes"
 "origin"	"-488 120 80"
 "spawnflags"	"1"
 }
+
 {
 "classname"	"item_health"
 "origin"	"-488 80 80"
 "spawnflags"	"3584"
 }
+
 {
 "classname"	"item_spikes"
 "origin"	"-944 528 0"
 }
+
 {
 "classname"	"func_door"
 "angle"	"-1"
@@ -12256,44 +12910,53 @@
 ( 512 472 -32 ) ( 512 472 96 ) ( 512 456 96 ) DR02_1 32 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"item_rockets"
 "origin"	"-56 1360 -336"
 }
+
 {
 "classname"	"item_health"
 "origin"	"-56 1168 -336"
 "spawnflags"	"1024"
 }
+
 {
 "classname"	"item_spikes"
 "origin"	"-240 1600 -256"
 }
+
 {
 "classname"	"item_health"
 "origin"	"-760 1592 -256"
 "spawnflags"	"3073"
 }
+
 {
 "spawnflags"	"3073"
 "origin"	"-760 1552 -256"
 "classname"	"item_health"
 }
+
 {
 "angle"	"0"
 "origin"	"-72 744 224"
 "classname"	"info_player_coop"
 }
+
 {
 "classname"	"info_player_coop"
 "origin"	"-80 872 224"
 "angle"	"0"
 }
+
 {
 "classname"	"item_spikes"
 "origin"	"-320 1520 64"
 "spawnflags"	"2817"
 }
+
 {
 "target"	"t34"
 "spawnflags"	"1792"
@@ -12307,6 +12970,7 @@
 ( -240 880 -248 ) ( -416 880 -248 ) ( -416 872 -248 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "spawnflags"	"1792"
 "classname"	"func_wall"
@@ -12335,6 +12999,7 @@
 ( 1152 416 0 ) ( 1136 416 0 ) ( 1136 400 0 ) METAL4_5 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "spawnflags"	"1792"
 "classname"	"func_wall"
@@ -12347,6 +13012,7 @@
 ( 1152 304 24 ) ( 1136 304 24 ) ( 1136 272 24 ) METAL4_5 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"func_button"
 "angle"	"-2"
@@ -12362,63 +13028,82 @@
 ( 704 320 -8 ) ( 640 320 -8 ) ( 640 256 -8 ) MSWTCH_3 0 0 90 -1.000000 -1.000000
 }
 }
+
 {
 "classname"	"weapon_rocketlauncher"
 "origin"	"488 1456 0"
 "spawnflags"	"2048"
 }
+
 {
 "angle"	"270"
 "origin"	"-24 888 32"
 "classname"	"info_player_coop"
 }
+
 {
 "classname"	"weapon_supernailgun"
 "origin"	"560 288 0"
 "spawnflags"	"3584"
 }
+
 {
 "spawnflags"	"1792"
 "origin"	"-40 1280 -336"
 "classname"	"weapon_supershotgun"
 }
+
 {
 "spawnflags"	"1792"
 "origin"	"1056 296 8"
 "classname"	"weapon_supernailgun"
 }
+
 {
 "angle"	"90"
 "origin"	"544 176 24"
 "classname"	"info_player_deathmatch"
 }
+
 {
 "angle"	"0"
 "origin"	"-88 504 24"
 "classname"	"info_player_deathmatch"
 }
+
 {
 "angle"	"0"
 "origin"	"-640 416 24"
 "classname"	"info_player_deathmatch"
 }
+
 {
 "angle"	"0"
 "origin"	"-448 1280 24"
 "classname"	"info_player_deathmatch"
 }
+
 {
 "angle"	"0"
 "origin"	"352 1296 24"
 "classname"	"info_player_deathmatch"
 }
+
 {
 "angle"	"270"
 "origin"	"480 824 24"
 "classname"	"info_player_deathmatch"
 }
+
 {
 "angle"	"180"
 "origin"	"-224 1016 -232"
 "classname"	"info_player_deathmatch"
+}
+
+{
+	"classname"	"light_environment"
+	"_color"	"0.85 0.72 0.58"
+	"light"	"220"
+	"angles"	"45 120 0"
 }

--- a/Quake/maps/E1M7.MAP
+++ b/Quake/maps/E1M7.MAP
@@ -4,6 +4,12 @@
 "worldtype"	"1"
 "sounds"	"7"
 "message"	"The House of Chthon"
+	"_ambient"	"18"
+	"_minlight"	"6"
+	"_sunlight"	"70"
+	"_sunlight_color"	"0.85 0.72 0.58"
+	"_sun_mangle"	"45 120 0"
+	"fog"	"0.03 0.08 0.11 0.18"
 {
 ( -128 704 -72 ) ( -128 448 -72 ) ( -128 448 -80 ) METAL5_2 0 0 0 1.000000 1.000000
 ( 704 320 -72 ) ( -320 320 -72 ) ( -320 320 -80 ) METAL5_2 0 0 0 1.000000 1.000000
@@ -3341,118 +3347,172 @@
 ( 1888 384 192 ) ( 1504 384 192 ) ( 1504 -320 192 ) METAL2_2 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "angle"	"0"
 "origin"	"-448 64 56"
 "classname"	"info_player_start"
 }
+
 {
 "origin"	"256 256 80"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"480 448 256"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"488 -320 256"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1024 -320 256"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"1024 448 256"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-280 408 312"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"-256 -256 320"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"832 256 80"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"-256 64 120"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-512 64 120"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"832 -128 80"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"576 -128 80"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"256 -128 80"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"64 -128 80"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"64 256 80"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-64 208 80"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"-64 -80 80"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "origin"	"360 -56 80"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"360 184 80"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"864 64 232"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-320 64 224"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"1024 88 -56"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "origin"	"0 328 256"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"0 -200 256"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-128 64 224"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"64 64 288"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"monster_boss"
 "origin"	"304 64 -48"
@@ -3460,80 +3520,117 @@
 "targetname"	"t4"
 "target"	"t10"
 }
+
 {
 "light"	"300"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"352 64 472"
 "classname"	"light"
 }
+
 {
 "origin"	"-158 354 116"
+	"_color"	"1.00 0.55 0.24"
+	"style"	"1"
 "classname"	"light_torch_small_walltorch"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-192 384 112"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"-96 416 112"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light_torch_small_walltorch"
 "origin"	"-158 -222 116"
+	"_color"	"1.00 0.55 0.24"
+	"style"	"1"
 }
+
 {
 "classname"	"light"
 "origin"	"-192 -256 112"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"-96 -288 112"
 "classname"	"light"
 }
+
 {
 "origin"	"1216 64 184"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "origin"	"930 -222 52"
+	"_color"	"1.00 0.55 0.24"
+	"style"	"1"
 "classname"	"light_torch_small_walltorch"
 }
+
 {
 "classname"	"light_torch_small_walltorch"
 "origin"	"922 346 52"
+	"_color"	"1.00 0.55 0.24"
+	"style"	"1"
 }
+
 {
 "classname"	"light"
 "origin"	"984 408 56"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"984 -280 56"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"872 -304 56"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"872 424 56"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1024 40 -56"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1024 64 -24"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"func_plat"
 "height"	"176"
@@ -3560,181 +3657,233 @@
 ( 1280 128 128 ) ( 1152 128 128 ) ( 1152 0 128 ) PLAT_TOP1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1024 288 56"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1024 -160 56"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"768 352 88"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"512 352 88"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"192 352 88"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"64 352 88"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"768 -224 88"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"512 -224 88"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"192 -224 88"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"64 -224 88"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"80 64 448"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"768 64 448"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"640 64 448"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"448 64 448"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"256 64 448"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"weapon_supershotgun"
 "origin"	"-160 64 208"
 "spawnflags"	"1792"
 }
+
 {
 "classname"	"item_health"
 "origin"	"-312 -312 208"
 "spawnflags"	"1792"
 }
+
 {
 "spawnflags"	"1792"
 "origin"	"-312 -280 208"
 "classname"	"item_health"
 }
+
 {
 "classname"	"item_health"
 "origin"	"-280 -312 208"
 "spawnflags"	"1792"
 }
+
 {
 "spawnflags"	"1792"
 "origin"	"-312 408 208"
 "classname"	"item_health"
 }
+
 {
 "classname"	"item_health"
 "origin"	"-312 376 208"
 "spawnflags"	"1792"
 }
+
 {
 "spawnflags"	"1792"
 "origin"	"-280 408 208"
 "classname"	"item_health"
 }
+
 {
 "classname"	"item_health"
 "origin"	"1048 472 192"
 "spawnflags"	"1792"
 }
+
 {
 "spawnflags"	"1792"
 "origin"	"1048 440 192"
 "classname"	"item_health"
 }
+
 {
 "classname"	"item_health"
 "origin"	"1048 -376 192"
 "spawnflags"	"1792"
 }
+
 {
 "spawnflags"	"1792"
 "origin"	"1048 -344 192"
 "classname"	"item_health"
 }
+
 {
 "classname"	"item_shells"
 "origin"	"48 432 32"
 "spawnflags"	"1793"
 }
+
 {
 "spawnflags"	"1793"
 "origin"	"752 432 32"
 "classname"	"item_shells"
 }
+
 {
 "classname"	"item_shells"
 "origin"	"48 -336 32"
 "spawnflags"	"1793"
 }
+
 {
 "classname"	"item_shells"
 "origin"	"752 -336 32"
 "spawnflags"	"1793"
 }
+
 {
 "classname"	"item_rockets"
 "origin"	"1008 -272 192"
 "spawnflags"	"1793"
 }
+
 {
 "spawnflags"	"1793"
 "origin"	"1008 368 192"
 "classname"	"item_rockets"
 }
+
 {
 "classname"	"weapon_supernailgun"
 "origin"	"1120 64 -32"
 "spawnflags"	"1792"
 }
+
 {
 "classname"	"item_spikes"
 "origin"	"344 392 32"
 "spawnflags"	"1793"
 }
+
 {
 "spawnflags"	"1793"
 "origin"	"344 -296 32"
 "classname"	"item_spikes"
 }
+
 {
 "classname"	"weapon_grenadelauncher"
 "origin"	"-392 64 32"
 "spawnflags"	"1792"
 }
+
 {
 "classname"	"func_wall"
 "spawnflags"	"1792"
@@ -3747,11 +3896,13 @@
 ( 768 -320 240 ) ( 640 -320 240 ) ( 640 -384 240 ) NMETAL2_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"info_player_deathmatch"
 "origin"	"704 -360 280"
 "angle"	"90"
 }
+
 {
 "spawnflags"	"1792"
 "classname"	"func_wall"
@@ -3764,11 +3915,13 @@
 ( 192 -320 240 ) ( 64 -320 240 ) ( 64 -384 240 ) NMETAL2_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "angle"	"90"
 "origin"	"128 -360 280"
 "classname"	"info_player_deathmatch"
 }
+
 {
 "classname"	"func_wall"
 "spawnflags"	"1792"
@@ -3781,6 +3934,7 @@
 ( 192 512 240 ) ( 64 512 240 ) ( 64 448 240 ) NMETAL2_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "spawnflags"	"1792"
 "classname"	"func_wall"
@@ -3793,25 +3947,30 @@
 ( 768 512 240 ) ( 640 512 240 ) ( 640 448 240 ) NMETAL2_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"info_player_deathmatch"
 "origin"	"128 488 280"
 "angle"	"270"
 }
+
 {
 "angle"	"270"
 "origin"	"704 488 280"
 "classname"	"info_player_deathmatch"
 }
+
 {
 "classname"	"info_player_deathmatch"
 "origin"	"-256 64 64"
 }
+
 {
 "classname"	"info_player_deathmatch"
 "origin"	"-256 64 240"
 "angle"	"0"
 }
+
 {
 "spawnflags"	"1792"
 "classname"	"func_wall"
@@ -3824,6 +3983,7 @@
 ( -224 96 208 ) ( -288 96 208 ) ( -288 32 208 ) COP3_4 32 32 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"func_wall"
 "spawnflags"	"1792"
@@ -3836,15 +3996,19 @@
 ( 1056 96 144 ) ( 992 96 144 ) ( 992 32 144 ) COP3_4 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "angle"	"180"
 "origin"	"1024 64 176"
 "classname"	"info_player_deathmatch"
 }
+
 {
 "origin"	"-480 208 120"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "classname"	"info_teleport_destination"
 "origin"	"-256 64 224"
@@ -3852,17 +4016,21 @@
 "angle"	"0"
 "spawnflags"	"1792"
 }
+
 {
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"712 64 16"
 "classname"	"light"
 }
+
 {
 "origin"	"560 -48 0"
 "targetname"	"t10"
 "target"	"t9"
 "classname"	"trigger_relay"
 }
+
 {
 "wait"	"-1"
 "spawnflags"	"1"
@@ -3894,6 +4062,7 @@
 ( 640 64 -72 ) ( 640 -192 -72 ) ( 768 -192 -72 ) METAL4_4 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "wait"	"-1"
 "spawnflags"	"1"
@@ -3925,62 +4094,85 @@
 ( 768 320 -72 ) ( 640 320 -72 ) ( 640 64 -72 ) METAL4_4 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 "origin"	"840 64 -976"
 }
+
 {
 "classname"	"light"
 "origin"	"832 64 -704"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"840 80 -576"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"824 48 -448"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"840 56 -288"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"816 72 -160"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"720 112 -920"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"720 16 -920"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "target"	"t4"
 "spawnflags"	"2049"
 "origin"	"8 64 24"
 "classname"	"item_sigil"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"576 184 0"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"576 -8 0"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "mangle"	"20 315 0"
 "origin"	"-16 384 368"
 "classname"	"info_intermission"
 }
+
 {
 "classname"	"func_door"
 "spawnflags"	"1"
@@ -4006,6 +4198,7 @@
 ( 384 256 144 ) ( 336 256 144 ) ( 336 304 144 ) MET5_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"func_door"
 "spawnflags"	"1"
@@ -4031,6 +4224,7 @@
 ( 384 -176 144 ) ( 336 -176 144 ) ( 336 -128 144 ) MET5_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "angle"	"-2"
 "classname"	"func_button"
@@ -4045,6 +4239,7 @@
 ( 360 -320 184 ) ( 344 -320 184 ) ( 344 -336 184 ) MET5_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"func_button"
 "angle"	"-2"
@@ -4058,41 +4253,57 @@
 ( 856 96 136 ) ( 808 96 136 ) ( 808 56 136 ) +3BUTN 32 -24 90 1.000000 1.000000
 }
 }
+
 {
 "classname"	"event_lightning"
 "origin"	"768 -40 224"
 "targetname"	"t14"
+	"_color"	"0.6 0.75 1.0"
 }
+
 {
 "spawnflags"	"1026"
 "origin"	"976 48 -32"
 "classname"	"item_health"
 }
+
 {
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1064 56 -1008"
 "classname"	"light"
 }
+
 {
 "light"	"250"
+	"style"	"1"
+	"_color"	"1.00 0.64 0.30"
 "origin"	"662 160 -1044"
 "classname"	"light_flame_large_yellow"
 }
+
 {
 "classname"	"light_flame_large_yellow"
 "origin"	"670 -32 -1044"
 "light"	"250"
+	"style"	"1"
+	"_color"	"1.00 0.64 0.30"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"896 56 -816"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"760 64 -816"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "map"	"start"
 "classname"	"trigger_changelevel"
@@ -4106,6 +4317,7 @@
 ( 1016 128 -1056 ) ( 1008 128 -1056 ) ( 1008 0 -1056 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "target"	"t15"
 "classname"	"trigger_teleport"
@@ -4118,37 +4330,46 @@
 ( 1016 64 -904 ) ( 1016 48 -904 ) ( 1032 48 -904 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "targetname"	"t15"
 "angle"	"180"
 "origin"	"944 56 -952"
 "classname"	"info_teleport_destination"
 }
+
 {
 "angle"	"0"
 "origin"	"-472 136 56"
 "classname"	"info_player_coop"
 }
+
 {
 "classname"	"info_player_coop"
 "origin"	"-480 -8 56"
 "angle"	"0"
 }
+
 {
 "angle"	"270"
 "origin"	"-256 208 56"
 "classname"	"info_player_coop"
 }
+
 {
 "classname"	"light"
 "origin"	"224 -320 200"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"224 448 200"
 "classname"	"light"
 }
+
 {
 "spawnflags"	"1792"
 "target"	"t9"
@@ -4164,6 +4385,7 @@
 ( 736 -376 56 ) ( 664 -376 56 ) ( 664 -384 56 ) MET5_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"func_button"
 "angle"	"-2"
@@ -4178,6 +4400,7 @@
 ( 360 -248 184 ) ( 344 -248 184 ) ( 344 -264 184 ) MET5_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"func_wall"
 "spawnflags"	"1024"
@@ -4190,6 +4413,7 @@
 ( 392 -288 176 ) ( 312 -288 176 ) ( 312 -360 176 ) NMETAL2_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"func_wall"
 "spawnflags"	"2816"
@@ -4202,11 +4426,13 @@
 ( 392 -208 176 ) ( 312 -208 176 ) ( 312 -280 176 ) NMETAL2_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"item_spikes"
 "origin"	"328 392 32"
 "spawnflags"	"1793"
 }
+
 {
 "spawnflags"	"2816"
 "classname"	"func_button"
@@ -4221,6 +4447,7 @@
 ( 344 448 184 ) ( 360 448 184 ) ( 360 464 184 ) MET5_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "spawnflags"	"1024"
 "angle"	"-2"
@@ -4235,6 +4462,7 @@
 ( 344 376 184 ) ( 360 376 184 ) ( 360 392 184 ) MET5_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "spawnflags"	"1024"
 "classname"	"func_wall"
@@ -4247,6 +4475,7 @@
 ( 312 416 176 ) ( 392 416 176 ) ( 392 488 176 ) NMETAL2_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "spawnflags"	"2816"
 "classname"	"func_wall"
@@ -4259,22 +4488,27 @@
 ( 312 336 176 ) ( 392 336 176 ) ( 392 408 176 ) NMETAL2_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"monster_shambler"
 "origin"	"1544 344 24"
 }
+
 {
 "origin"	"1632 344 24"
 "classname"	"monster_shambler"
 }
+
 {
 "classname"	"monster_shambler"
 "origin"	"1848 344 24"
 }
+
 {
 "origin"	"1760 344 24"
 "classname"	"monster_shambler"
 }
+
 {
 "classname"	"trigger_teleport"
 "targetname"	"t17"
@@ -4288,6 +4522,7 @@
 ( 1624 352 24 ) ( 1552 352 24 ) ( 1552 280 24 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_teleport"
 "targetname"	"t17"
@@ -4301,6 +4536,7 @@
 ( 1832 352 24 ) ( 1776 352 24 ) ( 1776 336 24 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_once"
 "targetname"	"t16"
@@ -4315,6 +4551,7 @@
 ( 1720 128 24 ) ( 1696 128 24 ) ( 1696 104 24 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_once"
 "targetname"	"t16"
@@ -4329,6 +4566,7 @@
 ( 1720 224 24 ) ( 1696 224 24 ) ( 1696 200 24 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_once"
 "targetname"	"t16"
@@ -4343,6 +4581,7 @@
 ( 1720 344 24 ) ( 1696 344 24 ) ( 1696 320 24 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_once"
 "targetname"	"t16"
@@ -4357,54 +4596,66 @@
 ( 1720 -224 24 ) ( 1696 -224 24 ) ( 1696 -248 24 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_relay"
 "origin"	"1512 128 32"
 "target"	"t16"
 "targetname"	"t18"
 }
+
 {
 "classname"	"info_teleport_destination"
 "origin"	"128 192 320"
 "targetname"	"t19"
 }
+
 {
 "origin"	"128 -64 320"
 "classname"	"info_teleport_destination"
 "targetname"	"t20"
 }
+
 {
 "origin"	"1848 224 24"
 "classname"	"monster_shambler"
 }
+
 {
 "classname"	"monster_shambler"
 "origin"	"1760 224 24"
 }
+
 {
 "origin"	"1632 224 24"
 "classname"	"monster_shambler"
 }
+
 {
 "classname"	"monster_shambler"
 "origin"	"1544 224 24"
 }
+
 {
 "origin"	"1848 -224 24"
 "classname"	"monster_shambler"
 }
+
 {
 "classname"	"monster_shambler"
 "origin"	"1760 -224 24"
 }
+
 {
 "origin"	"1632 -224 24"
 "classname"	"monster_shambler"
 }
+
 {
 "classname"	"monster_shambler"
 "origin"	"1544 -224 24"
 }
+
 {
 "classname"	"trigger_teleport"
 "targetname"	"t21"
@@ -4418,6 +4669,7 @@
 ( 1616 -216 24 ) ( 1568 -216 24 ) ( 1568 -232 24 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_teleport"
 "targetname"	"t21"
@@ -4431,6 +4683,7 @@
 ( 1832 -216 24 ) ( 1784 -216 24 ) ( 1784 -232 24 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_teleport"
 "targetname"	"t22"
@@ -4444,6 +4697,7 @@
 ( 1832 232 24 ) ( 1784 232 24 ) ( 1784 216 24 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_teleport"
 "targetname"	"t22"
@@ -4457,46 +4711,55 @@
 ( 1616 232 24 ) ( 1568 232 24 ) ( 1568 216 24 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"info_teleport_destination"
 "origin"	"352 128 224"
 "angle"	"180"
 "targetname"	"t23"
 }
+
 {
 "origin"	"352 -32 224"
 "classname"	"info_teleport_destination"
 "angle"	"180"
 "targetname"	"t24"
 }
+
 {
 "classname"	"info_teleport_destination"
 "origin"	"576 -96 312"
 "angle"	"180"
 "targetname"	"t26"
 }
+
 {
 "origin"	"672 88 312"
 "classname"	"info_teleport_destination"
 "angle"	"180"
 "targetname"	"t25"
 }
+
 {
 "classname"	"monster_zombie"
 "origin"	"1760 128 24"
 }
+
 {
 "origin"	"1824 128 24"
 "classname"	"monster_zombie"
 }
+
 {
 "classname"	"monster_zombie"
 "origin"	"1568 128 24"
 }
+
 {
 "origin"	"1632 128 24"
 "classname"	"monster_zombie"
 }
+
 {
 "classname"	"trigger_teleport"
 "targetname"	"t27"
@@ -4510,6 +4773,7 @@
 ( 1816 136 24 ) ( 1768 136 24 ) ( 1768 120 24 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_teleport"
 "targetname"	"t27"
@@ -4523,34 +4787,41 @@
 ( 1624 136 24 ) ( 1576 136 24 ) ( 1576 120 24 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"info_teleport_destination"
 "origin"	"248 352 216"
 "angle"	"180"
 "targetname"	"t29"
 }
+
 {
 "classname"	"info_teleport_destination"
 "origin"	"560 -224 216"
 "angle"	"180"
 "targetname"	"t28"
 }
+
 {
 "classname"	"monster_zombie"
 "origin"	"1824 64 24"
 }
+
 {
 "origin"	"1760 64 24"
 "classname"	"monster_zombie"
 }
+
 {
 "classname"	"monster_zombie"
 "origin"	"1632 64 24"
 }
+
 {
 "origin"	"1568 64 24"
 "classname"	"monster_zombie"
 }
+
 {
 "classname"	"trigger_teleport"
 "targetname"	"t30"
@@ -4564,6 +4835,7 @@
 ( 1816 72 24 ) ( 1768 72 24 ) ( 1768 56 24 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_teleport"
 "targetname"	"t30"
@@ -4577,6 +4849,7 @@
 ( 1624 72 24 ) ( 1576 72 24 ) ( 1576 56 24 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_once"
 "targetname"	"t16"
@@ -4591,18 +4864,21 @@
 ( 1704 72 24 ) ( 1688 72 24 ) ( 1688 56 24 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"info_teleport_destination"
 "origin"	"688 352 200"
 "angle"	"180"
 "targetname"	"t31"
 }
+
 {
 "classname"	"info_teleport_destination"
 "origin"	"128 -224 200"
 "angle"	"180"
 "targetname"	"t32"
 }
+
 {
 "classname"	"func_door"
 "angle"	"-2"
@@ -4619,33 +4895,46 @@
 ( 792 72 0 ) ( 776 72 0 ) ( 776 56 0 ) NMETAL2_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "spawnflags"	"1792"
 "origin"	"984 -328 192"
 "classname"	"weapon_rocketlauncher"
 }
+
 {
 "spawnflags"	"1792"
 "origin"	"984 440 192"
 "classname"	"weapon_grenadelauncher"
 }
+
 {
 "spawnflags"	"1792"
 "origin"	"-224 376 192"
 "classname"	"weapon_supernailgun"
 }
+
 {
 "spawnflags"	"1792"
 "origin"	"-216 -288 192"
 "classname"	"weapon_supershotgun"
 }
+
 {
 "spawnflags"	"1792"
 "origin"	"352 456 32"
 "classname"	"weapon_nailgun"
 }
+
 {
 "spawnflags"	"1792"
 "origin"	"0 64 24"
 "classname"	"item_artifact_super_damage"
+}
+
+{
+	"classname"	"light_environment"
+	"_color"	"0.85 0.72 0.58"
+	"light"	"220"
+	"angles"	"45 120 0"
 }

--- a/Quake/maps/E1M8.MAP
+++ b/Quake/maps/E1M8.MAP
@@ -4,6 +4,12 @@
 "classname"	"worldspawn"
 "wad"	"gfx/metal.wad"
 "message"	"Ziggurat Vertigo"
+	"_ambient"	"18"
+	"_minlight"	"6"
+	"_sunlight"	"70"
+	"_sunlight_color"	"0.85 0.72 0.58"
+	"_sun_mangle"	"45 120 0"
+	"fog"	"0.03 0.08 0.11 0.18"
 {
 ( -64 768 656 ) ( -64 -768 656 ) ( -64 -768 464 ) LGMETAL 0 0 0 1.000000 1.000000
 ( 1416 784 656 ) ( -56 784 656 ) ( -56 784 464 ) LGMETAL 0 0 0 1.000000 1.000000
@@ -5888,73 +5894,101 @@
 ( 128 720 96 ) ( 120 720 96 ) ( 120 680 96 ) RUNE_A 0 16 90 1.000000 1.000000
 }
 }
+
 {
 "light"	"500"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"384 64 -752"
 "classname"	"light"
 }
+
 {
 "angle"	"225"
 "origin"	"1024 720 -104"
 "classname"	"info_player_start"
 }
+
 {
 "classname"	"light"
 "origin"	"128 384 -752"
 "light"	"500"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"500"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"384 576 -752"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"960 64 -752"
 "light"	"500"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"500"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1216 384 -752"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"960 704 -704"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"500"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"960 576 -752"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"680 704 -704"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"500"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"680 40 -752"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"672 376 -752"
 "light"	"500"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"136 136 -712"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "origin"	"136 560 -712"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "origin"	"1200 568 -712"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "classname"	"func_plat"
 "speed"	"500"
@@ -5975,31 +6009,42 @@
 ( 1248 736 -736 ) ( 1184 736 -736 ) ( 1184 672 -736 ) METAL2_6 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"1216 704 -568"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1216 704 -440"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1216 704 -312"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1216 704 -176"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1216 704 -48"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"func_plat"
 "speed"	"500"
@@ -6020,35 +6065,48 @@
 ( 96 -672 -736 ) ( 96 -736 -736 ) ( 160 -736 -736 ) METAL2_6 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"152 -632 -712"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"128 -704 -568"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"128 -704 -440"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"128 -704 -312"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"128 -704 -176"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"128 -704 -48"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "speed"	"500"
 "classname"	"func_plat"
@@ -6069,349 +6127,461 @@
 ( 1216 -672 -736 ) ( 1216 -736 -736 ) ( 1280 -736 -736 ) METAL2_6 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "origin"	"1272 -632 -712"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1248 -704 -568"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1248 -704 -440"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1248 -704 -312"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1248 -704 -176"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1248 -704 -48"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"600 -392 64"
 "light"	"400"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1136 -232 -184"
 "light"	"500"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"992 -96 -744"
 "light"	"500"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1280 -368 -696"
 "light"	"500"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"416 -104 -704"
 "light"	"500"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"296 -480 -744"
 "light"	"500"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"300"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"688 -240 -520"
 "classname"	"light"
 }
+
 {
 "origin"	"672 248 -544"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "origin"	"712 520 96"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "origin"	"424 -256 -32"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "origin"	"592 -112 -48"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "origin"	"144 512 -40"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "origin"	"464 64 -64"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "origin"	"888 64 -64"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "origin"	"624 240 -160"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "origin"	"472 360 -64"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "origin"	"880 368 -64"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "origin"	"64 360 -248"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "origin"	"360 704 -248"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "origin"	"416 696 -320"
 "classname"	"weapon_grenadelauncher"
 "spawnflags"	"1792"
 }
+
 {
 "origin"	"48 352 -320"
 "classname"	"item_rockets"
 }
+
 {
 "origin"	"672 80 -496"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "spawnflags"	"1"
 "origin"	"656 72 -576"
 "classname"	"item_spikes"
 }
+
 {
 "origin"	"1264 -128 -576"
 "classname"	"weapon_rocketlauncher"
 "spawnflags"	"1792"
 }
+
 {
 "origin"	"976 -112 -736"
 "classname"	"item_rockets"
 }
+
 {
 "origin"	"704 -272 256"
 "classname"	"weapon_supershotgun"
 "spawnflags"	"1792"
 }
+
 {
 "origin"	"1248 -736 184"
 "classname"	"item_armor2"
 }
+
 {
 "origin"	"144 -744 192"
 "classname"	"item_health"
 }
+
 {
 "origin"	"80 -744 192"
 "classname"	"item_health"
 }
+
 {
 "spawnflags"	"2"
 "origin"	"656 112 256"
 "classname"	"item_health"
 }
+
 {
 "origin"	"24 -136 -624"
 "classname"	"item_health"
 }
+
 {
 "origin"	"80 -136 -624"
 "classname"	"item_health"
 }
+
 {
 "origin"	"24 40 -624"
 "classname"	"item_health"
 }
+
 {
 "origin"	"80 40 -624"
 "classname"	"item_health"
 }
+
 {
 "origin"	"1164 176 0"
 "classname"	"item_spikes"
 "spawnflags"	"1"
 }
+
 {
 "origin"	"864 208 0"
 "classname"	"item_health"
 }
+
 {
 "classname"	"item_health"
 "origin"	"560 224 0"
 }
+
 {
 "origin"	"608 224 0"
 "classname"	"item_health"
 }
+
 {
 "origin"	"96 528 152"
 "classname"	"weapon_supernailgun"
 "spawnflags"	"1792"
 }
+
 {
 "spawnflags"	"1"
 "origin"	"1200 728 192"
 "classname"	"item_spikes"
 }
+
 {
 "origin"	"1216 64 216"
 "classname"	"item_armor2"
 "spawnflags"	"3584"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"320 128 88"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"320 352 88"
 "classname"	"light"
 }
+
 {
 "spawnflags"	"1792"
 "origin"	"320 72 0"
 "classname"	"weapon_nailgun"
 }
+
 {
 "origin"	"672 192 112"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "spawnflags"	"2"
 "origin"	"688 -856 -368"
 "classname"	"item_health"
 }
+
 {
 "origin"	"720 -720 48"
 "classname"	"weapon_rocketlauncher"
 "spawnflags"	"1536"
 }
+
 {
 "origin"	"672 -160 -128"
 "classname"	"item_health"
 }
+
 {
 "origin"	"608 -160 -128"
 "classname"	"item_health"
 }
+
 {
 "angle"	"0"
 "origin"	"1000 -136 -712"
 "classname"	"info_player_deathmatch"
 }
+
 {
 "angle"	"180"
 "origin"	"384 -256 -712"
 "classname"	"info_player_deathmatch"
 }
+
 {
 "angle"	"90"
 "origin"	"672 48 -552"
 "classname"	"info_player_deathmatch"
 }
+
 {
 "angle"	"270"
 "origin"	"880 128 24"
 "classname"	"info_player_deathmatch"
 }
+
 {
 "angle"	"270"
 "origin"	"672 720 -688"
 "classname"	"info_player_deathmatch"
 }
+
 {
 "angle"	"90"
 "origin"	"720 -656 -712"
 "classname"	"info_player_deathmatch"
 }
+
 {
 "origin"	"56 -136 -736"
 "classname"	"item_shells"
 }
+
 {
 "origin"	"880 -720 -736"
 "classname"	"item_shells"
 }
+
 {
 "origin"	"32 704 -736"
 "classname"	"item_shells"
 }
+
 {
 "origin"	"1280 152 -576"
 "classname"	"item_shells"
 }
+
 {
 "origin"	"1264 -288 -576"
 "classname"	"item_shells"
 }
+
 {
 "spawnflags"	"1"
 "origin"	"128 -168 -320"
 "classname"	"item_spikes"
 }
+
 {
 "origin"	"176 -144 -320"
 "classname"	"item_rockets"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1144 -232 88"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1032 88 88"
 "classname"	"light"
 }
+
 {
 "origin"	"984 512 152"
 "classname"	"item_rockets"
 }
+
 {
 "origin"	"1248 -144 152"
 "classname"	"item_shells"
 }
+
 {
 "classname"	"light"
 "origin"	"448 696 -704"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"296 32 -704"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"536 32 -648"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"832 32 -648"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "spawnflags"	"2048"
 "targetname"	"t2"
@@ -6445,6 +6615,7 @@
 ( 640 -24 -688 ) ( 624 -24 -688 ) ( 624 -48 -688 ) METAL1_3 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "message"	"These bars are opened elsewhere..."
 "targetname"	"t2"
@@ -6478,36 +6649,48 @@
 ( 32 -24 -736 ) ( 16 -24 -736 ) ( 16 -40 -736 ) METAL1_3 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"672 256 -408"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"64 264 -352"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"504 712 -352"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1024 360 64"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"88 528 64"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "angle"	"90"
 "origin"	"272 40 -96"
 "classname"	"monster_ogre"
 }
+
 {
 "lip"	"0"
 "speed"	"400"
@@ -6523,26 +6706,33 @@
 ( 320 64 -144 ) ( 224 64 -144 ) ( 224 0 -144 ) METAL4_5 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"64 -56 -680"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"672 0 -632"
 "classname"	"light"
 }
+
 {
 "angle"	"270"
 "origin"	"1216 488 24"
 "classname"	"monster_ogre"
 }
+
 {
 "angle"	"90"
 "origin"	"1024 368 24"
 "classname"	"monster_ogre"
 }
+
 {
 "wait"	"-1"
 "target"	"t2"
@@ -6558,73 +6748,89 @@
 ( 704 32 272 ) ( 640 32 272 ) ( 640 16 272 ) MSWTCH_3 0 16 0 1.000000 1.000000
 }
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"672 48 312"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1040 656 -88"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1320 360 -256"
 "classname"	"light"
 }
+
 {
 "speed"	"150"
 "origin"	"320 -136 -776"
 "classname"	"misc_fireball"
 "spawnflags"	"2048"
 }
+
 {
 "speed"	"150"
 "origin"	"832 536 -752"
 "classname"	"misc_fireball"
 "spawnflags"	"2048"
 }
+
 {
 "speed"	"150"
 "origin"	"1048 416 -752"
 "classname"	"misc_fireball"
 "spawnflags"	"2048"
 }
+
 {
 "classname"	"misc_fireball"
 "origin"	"576 576 -752"
 "speed"	"150"
 "spawnflags"	"2048"
 }
+
 {
 "speed"	"150"
 "origin"	"392 536 -752"
 "classname"	"misc_fireball"
 "spawnflags"	"2048"
 }
+
 {
 "classname"	"misc_fireball"
 "origin"	"296 336 -752"
 "speed"	"150"
 "spawnflags"	"2048"
 }
+
 {
 "angle"	"0"
 "origin"	"80 520 24"
 "classname"	"monster_ogre"
 }
+
 {
 "spawnflags"	"768"
 "angle"	"90"
 "origin"	"592 240 280"
 "classname"	"monster_ogre"
 }
+
 {
 "classname"	"monster_ogre"
 "origin"	"752 240 280"
 "angle"	"90"
 }
+
 {
 "spawnflags"	"256"
 "angle"	"90"
@@ -6632,84 +6838,110 @@
 "classname"	"monster_ogre"
 "target"	"t41"
 }
+
 {
 "classname"	"monster_ogre"
 "origin"	"1024 88 176"
 "angle"	"90"
 "target"	"t43"
 }
+
 {
 "spawnflags"	"256"
 "angle"	"225"
 "origin"	"1216 680 216"
 "classname"	"monster_ogre"
 }
+
 {
 "origin"	"800 -720 -288"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "spawnflags"	"769"
 "angle"	"225"
 "origin"	"848 -144 -552"
 "classname"	"monster_ogre"
 }
+
 {
 "angle"	"315"
 "origin"	"560 -144 -552"
 "classname"	"monster_ogre"
 }
+
 {
 "angle"	"225"
 "origin"	"848 -144 -712"
 "classname"	"monster_ogre"
 "spawnflags"	"256"
 }
+
 {
 "light"	"500"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"128 -248 48"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"544 -224 -320"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"776 -224 -320"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"720 -680 -704"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"728 -504 -704"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"864 -704 -704"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"312 -704 -704"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"72 -128 -584"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"64 56 -584"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "message"	"These bars are opened elsewhere..."
 "angle"	"-1"
@@ -6743,6 +6975,7 @@
 ( 1216 -616 -736 ) ( 1200 -616 -736 ) ( 1200 -632 -736 ) METAL1_3 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "message"	"These bars are opened elsewhere..."
 "targetname"	"t3"
@@ -6776,6 +7009,7 @@
 ( 96 -616 -736 ) ( 80 -616 -736 ) ( 80 -632 -736 ) METAL1_3 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "target"	"t3"
 "wait"	"-1"
@@ -6790,25 +7024,32 @@
 ( 576 -336 -560 ) ( 512 -336 -560 ) ( 512 -352 -560 ) MSWTCH_4 0 16 0 1.000000 1.000000
 }
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"544 -304 -528"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"880 120 32"
 "classname"	"light"
 }
+
 {
 "origin"	"672 536 -712"
 "classname"	"item_artifact_invulnerability"
 }
+
 {
 "classname"	"item_artifact_invulnerability"
 "origin"	"64 -176 -288"
 "spawnflags"	"256"
 }
+
 {
 "classname"	"func_button"
 "angle"	"90"
@@ -6824,6 +7065,7 @@
 ( 624 -128 272 ) ( 560 -128 272 ) ( 560 -144 272 ) MSWTCH_4 16 16 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"monster_shambler"
 "origin"	"608 -424 280"
@@ -6831,28 +7073,33 @@
 "target"	"t35"
 "spawnflags"	"256"
 }
+
 {
 "classname"	"monster_ogre"
 "origin"	"720 -664 80"
 "angle"	"0"
 }
+
 {
 "classname"	"monster_ogre"
 "origin"	"448 -672 -104"
 "angle"	"0"
 "spawnflags"	"256"
 }
+
 {
 "classname"	"monster_ogre"
 "origin"	"72 -256 -296"
 "angle"	"315"
 }
+
 {
 "classname"	"monster_ogre"
 "origin"	"184 -512 24"
 "angle"	"0"
 "target"	"t51"
 }
+
 {
 "classname"	"monster_ogre"
 "origin"	"472 -384 -104"
@@ -6860,30 +7107,39 @@
 "spawnflags"	"256"
 "target"	"t50"
 }
+
 {
 "classname"	"monster_ogre"
 "origin"	"736 -448 72"
 "angle"	"270"
 }
+
 {
 "origin"	"1512 -240 64"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "origin"	"1608 -240 64"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1360 -240 64"
 "classname"	"light"
 }
+
 {
 "angle"	"270"
 "origin"	"1264 -320 24"
 "classname"	"monster_ogre"
 "spawnflags"	"256"
 }
+
 {
 "spawnflags"	"257"
 "classname"	"monster_ogre"
@@ -6891,12 +7147,14 @@
 "angle"	"90"
 "target"	"t54"
 }
+
 {
 "spawnflags"	"1"
 "angle"	"270"
 "origin"	"1024 88 24"
 "classname"	"monster_ogre"
 }
+
 {
 "map"	"e1m5"
 "classname"	"trigger_changelevel"
@@ -6909,6 +7167,7 @@
 ( 1536 -192 0 ) ( 1504 -192 0 ) ( 1504 -288 0 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "wait"	"-1"
 "angle"	"90"
@@ -6934,6 +7193,7 @@
 ( 832 -536 -128 ) ( 800 -536 -128 ) ( 800 -544 -128 ) DR02_1 32 0 0 1.000000 1.000000
 }
 }
+
 {
 "spawnflags"	"2048"
 "targetname"	"t4"
@@ -6959,6 +7219,7 @@
 ( 768 -584 48 ) ( 720 -584 48 ) ( 720 -600 48 ) DR02_1 0 48 0 1.000000 1.000000
 }
 }
+
 {
 "targetname"	"t4"
 "wait"	"-1"
@@ -6991,1186 +7252,1601 @@
 ( 512 -584 -128 ) ( 384 -584 -128 ) ( 384 -600 -128 ) DR02_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "light"	"400"
+	"_color"	"0.88 0.74 0.58"
 "angle"	"90"
 "target"	"t7"
 "origin"	"48 592 160"
 "classname"	"light"
 }
+
 {
 "light"	"400"
+	"_color"	"0.88 0.74 0.58"
 "angle"	"90"
 "target"	"t8"
 "origin"	"48 464 160"
 "classname"	"light"
 }
+
 {
 "targetname"	"t7"
 "origin"	"12 596 540"
 "classname"	"info_null"
 }
+
 {
 "targetname"	"t8"
 "classname"	"info_null"
 "origin"	"12 468 540"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"48 520 192"
 "classname"	"light"
 }
+
 {
 "light"	"400"
+	"_color"	"0.88 0.74 0.58"
 "target"	"t10"
 "angle"	"90"
 "origin"	"272 48 160"
 "classname"	"light"
 }
+
 {
 "light"	"400"
+	"_color"	"0.88 0.74 0.58"
 "target"	"t9"
 "angle"	"90"
 "classname"	"light"
 "origin"	"368 48 160"
 }
+
 {
 "targetname"	"t10"
 "origin"	"276 12 540"
 "classname"	"info_null"
 }
+
 {
 "targetname"	"t9"
 "classname"	"info_null"
 "origin"	"364 12 540"
 }
+
 {
 "classname"	"light"
 "origin"	"320 64 192"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "target"	"t11"
 "angle"	"90"
 "light"	"400"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"560 272 264"
 "classname"	"light"
 }
+
 {
 "target"	"t12"
 "angle"	"90"
 "classname"	"light"
 "origin"	"784 272 264"
 "light"	"400"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "targetname"	"t11"
 "origin"	"548 284 556"
 "classname"	"info_null"
 }
+
 {
 "targetname"	"t12"
 "classname"	"info_null"
 "origin"	"796 284 556"
 }
+
 {
 "target"	"t13"
 "angle"	"90"
 "light"	"400"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"976 16 160"
 "classname"	"light"
 }
+
 {
 "target"	"t14"
 "angle"	"90"
 "classname"	"light"
 "origin"	"1072 16 160"
 "light"	"400"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1024 40 192"
 "classname"	"light"
 }
+
 {
 "targetname"	"t13"
 "origin"	"972 4 540"
 "classname"	"info_null"
 }
+
 {
 "targetname"	"t14"
 "classname"	"info_null"
 "origin"	"1076 4 540"
 }
+
 {
 "target"	"t16"
 "angle"	"90"
 "light"	"400"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1136 16 224"
 "classname"	"light"
 }
+
 {
 "angle"	"90"
 "target"	"t15"
 "classname"	"light"
 "origin"	"1296 16 224"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"1216 32 256"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "targetname"	"t16"
 "origin"	"1140 4 540"
 "classname"	"info_null"
 }
+
 {
 "targetname"	"t15"
 "classname"	"info_null"
 "origin"	"1292 4 540"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"672 264 296"
 "classname"	"light"
 }
+
 {
 "light"	"400"
+	"_color"	"0.88 0.74 0.58"
 "target"	"t17"
 "angle"	"90"
 "origin"	"1168 752 200"
 "classname"	"light"
 }
+
 {
 "light"	"400"
+	"_color"	"0.88 0.74 0.58"
 "angle"	"90"
 "target"	"t18"
 "classname"	"light"
 "origin"	"1264 752 200"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1216 720 264"
 "classname"	"light"
 }
+
 {
 "targetname"	"t17"
 "origin"	"1164 764 548"
 "classname"	"info_null"
 }
+
 {
 "targetname"	"t18"
 "classname"	"info_null"
 "origin"	"1268 764 548"
 }
+
 {
 "target"	"t19"
 "angle"	"90"
 "light"	"400"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1072 464 160"
 "classname"	"light"
 }
+
 {
 "target"	"t20"
 "angle"	"90"
 "classname"	"light"
 "origin"	"1072 592 160"
 "light"	"400"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1048 528 200"
 "classname"	"light"
 }
+
 {
 "targetname"	"t20"
 "origin"	"1084 580 548"
 "classname"	"info_null"
 }
+
 {
 "targetname"	"t19"
 "classname"	"info_null"
 "origin"	"1084 476 548"
 }
+
 {
 "target"	"t22"
 "angle"	"90"
 "light"	"400"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"624 16 400"
 "classname"	"light"
 }
+
 {
 "target"	"t21"
 "angle"	"90"
 "classname"	"light"
 "origin"	"720 16 400"
 "light"	"400"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"672 40 440"
 "classname"	"light"
 }
+
 {
 "targetname"	"t22"
 "origin"	"612 4 556"
 "classname"	"info_null"
 }
+
 {
 "targetname"	"t21"
 "classname"	"info_null"
 "origin"	"732 4 556"
 }
+
 {
 "target"	"t23"
 "angle"	"90"
 "origin"	"272 752 16"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "target"	"t24"
 "classname"	"light"
 "origin"	"496 752 16"
+	"_color"	"0.88 0.74 0.58"
 "angle"	"90"
 }
+
 {
 "target"	"t25"
 "angle"	"90"
 "origin"	"688 752 16"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "target"	"t26"
 "classname"	"light"
 "origin"	"880 752 16"
+	"_color"	"0.88 0.74 0.58"
 "angle"	"90"
 }
+
 {
 "target"	"t27"
 "angle"	"90"
 "origin"	"1104 752 16"
+	"_color"	"0.88 0.74 0.58"
 "classname"	"light"
 }
+
 {
 "targetname"	"t27"
 "origin"	"1092 764 516"
 "classname"	"info_null"
 }
+
 {
 "targetname"	"t26"
 "classname"	"info_null"
 "origin"	"868 764 516"
 }
+
 {
 "targetname"	"t25"
 "origin"	"700 764 516"
 "classname"	"info_null"
 }
+
 {
 "targetname"	"t24"
 "classname"	"info_null"
 "origin"	"508 764 516"
 }
+
 {
 "targetname"	"t23"
 "origin"	"284 764 516"
 "classname"	"info_null"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"304 720 32"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"472 720 32"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"664 712 32"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"848 720 32"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1072 720 32"
 "classname"	"light"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"96 728 504"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"224 728 504"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"352 728 504"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"480 728 504"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"608 728 504"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"736 728 504"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"872 728 504"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"992 728 504"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1112 728 504"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1224 728 504"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"40 576 504"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"40 464 504"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"40 384 504"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"40 280 504"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"40 160 504"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"40 72 504"
 "classname"	"light"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1304 632 504"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1304 536 504"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1304 456 504"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1304 360 504"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1304 256 504"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1304 136 504"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1024 192 192"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1024 376 192"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"120 88 536"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"128 192 536"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"128 320 536"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"128 416 536"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"128 600 536"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"256 640 536"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"448 640 536"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"640 640 536"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"832 640 536"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"960 640 536"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1120 640 536"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1232 576 536"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1240 448 536"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1240 320 536"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1240 184 536"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1240 48 536"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"872 560 192"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"688 568 192"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"512 568 192"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"320 512 192"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"320 320 192"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "mangle"	"30 315 0"
 "origin"	"144 592 -112"
 "classname"	"info_intermission"
 }
+
 {
 "classname"	"info_player_coop"
 "origin"	"824 720 -712"
 "angle"	"270"
 }
+
 {
 "angle"	"270"
 "origin"	"880 720 -712"
 "classname"	"info_player_coop"
 }
+
 {
 "classname"	"info_player_coop"
 "origin"	"568 720 -712"
 "angle"	"270"
 }
+
 {
 "origin"	"672 312 -736"
 "classname"	"item_armor2"
 }
+
 {
 "origin"	"264 96 0"
 "classname"	"item_spikes"
 }
+
 {
 "classname"	"item_spikes"
 "origin"	"344 96 0"
 }
+
 {
 "spawnflags"	"1"
 "origin"	"264 256 0"
 "classname"	"item_health"
 }
+
 {
 "classname"	"item_health"
 "origin"	"264 208 0"
 "spawnflags"	"1"
 }
+
 {
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1200 368 56"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1216 200 72"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"152 696 72"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"232 696 72"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"192 680 240"
 "classname"	"light"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1216 560 80"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1216 696 80"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"944 80 24"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"976 240 24"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1296 -112 24"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"944 -368 24"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1296 -368 24"
 "classname"	"light"
 }
+
 {
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"944 -80 24"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1472 -168 64"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1480 -304 64"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"info_null"
 "origin"	"1332 -596 540"
 }
+
 {
 "origin"	"1332 -468 540"
 "classname"	"info_null"
 }
+
 {
 "classname"	"light"
 "origin"	"1248 -728 504"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1120 -728 504"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"992 -728 504"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"864 -728 504"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"736 -728 504"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"608 -728 504"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"472 -728 504"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"352 -728 504"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"232 -728 504"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"120 -728 504"
 "classname"	"light"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1304 -576 504"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1304 -464 504"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1304 -384 504"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1304 -280 504"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1304 -160 504"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"40 -632 504"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"40 -536 504"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"40 -456 504"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"40 -360 504"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"40 -256 504"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"40 -136 504"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1216 -192 536"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1216 -320 536"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1216 -416 536"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1216 -600 536"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1088 -640 536"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"896 -640 536"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"704 -640 536"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"512 -640 536"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"384 -640 536"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"224 -640 536"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"112 -576 536"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"104 -448 536"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"104 -320 536"
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"175"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"104 -184 536"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"400 -112 288"
 "light"	"300"
+	"_color"	"0.88 0.74 0.58"
 "target"	"t28"
 }
+
 {
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"400 -560 288"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"784 -560 288"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"300"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"784 -120 288"
 "classname"	"light"
 "target"	"t29"
 }
+
 {
 "classname"	"light"
 "origin"	"592 -352 408"
 "light"	"300"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"info_null"
 "origin"	"400 -80 372"
 "targetname"	"t28"
 }
+
 {
 "origin"	"784 -80 372"
 "classname"	"info_null"
 "targetname"	"t29"
 }
+
 {
 "classname"	"light"
 "origin"	"592 -184 304"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"736 -128 -80"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"784 -88 40"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"760 -528 96"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"944 -112 188"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"944 -368 188"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1296 -368 188"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1296 -112 188"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1168 -444 136"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1328 -442 136"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"784 -120 288"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"400 -112 288"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"888 -512 48"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1040 -512 48"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"720 -720 88"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"448 -688 -56"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"232 -560 288"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"448 -688 128"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"1264 -488 -128"
 "classname"	"item_spikes"
 }
+
 {
 "classname"	"item_spikes"
 "origin"	"1216 -488 -128"
 }
+
 {
 "classname"	"light"
 "origin"	"1240 -512 -88"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1088 -512 -88"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"768 -496 -64"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1300 -748 212"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1136 -704 76"
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"304 -680 -232"
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"225"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"424 -680 -232"
 "classname"	"light"
 }
+
 {
 "classname"	"item_health"
 "origin"	"432 -240 256"
 }
+
 {
 "origin"	"432 -296 256"
 "classname"	"item_health"
 }
+
 {
 "classname"	"item_spikes"
 "origin"	"80 560 152"
 }
+
 {
 "classname"	"light"
 "origin"	"32 720 128"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"672 344 224"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"800 344 224"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"544 344 224"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"480 256 224"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"480 152 224"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"480 48 224"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"864 288 224"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"864 200 224"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"864 88 224"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"32 720 -248"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"item_health"
 "origin"	"48 720 -320"
 }
+
 {
 "origin"	"96 720 -320"
 "classname"	"item_health"
 }
+
 {
 "classname"	"item_shells"
 "origin"	"48 400 -320"
 "spawnflags"	"2049"
 }
+
 {
 "classname"	"item_health"
 "origin"	"1088 -304 -576"
 }
+
 {
 "origin"	"1040 -304 -576"
 "classname"	"item_health"
 }
+
 {
 "classname"	"item_health"
 "origin"	"848 -328 -736"
 "spawnflags"	"3073"
 }
+
 {
 "spawnflags"	"3073"
 "origin"	"848 -280 -736"
 "classname"	"item_health"
 }
+
 {
 "classname"	"item_health"
 "origin"	"1248 -192 152"
 }
+
 {
 "origin"	"1248 -240 152"
 "classname"	"item_health"
 "spawnflags"	"3072"
 }
+
 {
 "classname"	"item_spikes"
 "origin"	"280 -488 0"
 "spawnflags"	"2049"
 }
+
 {
 "classname"	"light"
 "origin"	"856 -144 -664"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"856 -312 -664"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"528 -296 -664"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"520 -160 -664"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1208 104 56"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1328 56 40"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"1328 16 -528"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1272 160 -488"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1176 72 -488"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1104 248 -488"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"1200 208 -672"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"1096 112 -672"
 "classname"	"light"
 }
+
 {
 "classname"	"item_spikes"
 "origin"	"1280 112 -576"
 }
+
 {
 "classname"	"func_wall"
 "spawnflags"	"2048"
@@ -8215,20 +8891,25 @@
 ( 656 288 -48 ) ( 656 288 224 ) ( 656 328 224 ) METALT1_1 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"weapon_rocketlauncher"
 "origin"	"672 360 0"
 "spawnflags"	"2048"
 }
+
 {
 "classname"	"light"
 "origin"	"1240 -584 112"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "origin"	"1168 -488 -128"
 "classname"	"item_spikes"
 "spawnflags"	"3072"
 }
+
 {
 "classname"	"func_door"
 "angle"	"0"
@@ -8276,6 +8957,7 @@
 ( 1264 -408 0 ) ( 1264 -408 128 ) ( 1264 -392 128 ) DR02_1 32 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"func_door"
 "angle"	"180"
@@ -8322,12 +9004,14 @@
 ( 1200 -408 0 ) ( 1200 -408 128 ) ( 1200 -392 128 ) DR02_1 32 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"item_key1"
 "origin"	"672 152 52"
 "target"	"t33"
 "spawnflags"	"2048"
 }
+
 {
 "targetname"	"t33"
 "classname"	"trigger_teleport"
@@ -8342,6 +9026,7 @@
 ( 576 -976 0 ) ( 520 -976 0 ) ( 520 -984 0 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "targetname"	"t33"
 "spawnflags"	"258"
@@ -8356,6 +9041,7 @@
 ( 640 -976 0 ) ( 584 -976 0 ) ( 584 -984 0 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "targetname"	"t33"
 "classname"	"trigger_teleport"
@@ -8370,12 +9056,14 @@
 ( 712 -976 0 ) ( 656 -976 0 ) ( 656 -984 0 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"info_teleport_destination"
 "origin"	"720 -216 96"
 "targetname"	"t30"
 "angle"	"90"
 }
+
 {
 "classname"	"info_teleport_destination"
 "origin"	"552 -280 96"
@@ -8383,6 +9071,7 @@
 "spawnflags"	"256"
 "angle"	"90"
 }
+
 {
 "classname"	"monster_wizard"
 "origin"	"608 -1008 40"
@@ -8390,86 +9079,107 @@
 "spawnflags"	"256"
 "targetname"	"t33"
 }
+
 {
 "angle"	"90"
 "origin"	"680 -1008 40"
 "classname"	"monster_wizard"
 "targetname"	"t33"
 }
+
 {
 "classname"	"monster_wizard"
 "origin"	"552 -1008 40"
 "angle"	"90"
 "targetname"	"t33"
 }
+
 {
 "classname"	"info_teleport_destination"
 "origin"	"536 -472 -24"
 "angle"	"90"
 "targetname"	"t34"
 }
+
 {
 "classname"	"item_spikes"
 "origin"	"760 40 0"
 }
+
 {
 "classname"	"item_health"
 "origin"	"1120 48 -576"
 }
+
 {
 "classname"	"item_health"
 "origin"	"1048 616 -736"
 "spawnflags"	"3584"
 }
+
 {
 "classname"	"light"
 "origin"	"160 88 144"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"168 256 144"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"120 360 144"
 "light"	"200"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"light"
 "origin"	"752 120 328"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"592 120 328"
 "classname"	"light"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"448 -512 264"
 "targetname"	"t35"
 "target"	"t36"
 }
+
 {
 "origin"	"736 -520 264"
 "classname"	"path_corner"
 "targetname"	"t36"
 "target"	"t37"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"736 -336 264"
 "targetname"	"t37"
 "target"	"t38"
 }
+
 {
 "origin"	"440 -336 264"
 "classname"	"path_corner"
 "targetname"	"t38"
 "target"	"t35"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"1008 -232 160"
@@ -8477,6 +9187,7 @@
 "targetname"	"t39"
 "target"	"t40"
 }
+
 {
 "spawnflags"	"768"
 "origin"	"1208 -232 160"
@@ -8484,12 +9195,14 @@
 "targetname"	"t40"
 "target"	"t39"
 }
+
 {
 "classname"	"monster_shambler"
 "origin"	"1120 -224 176"
 "spawnflags"	"768"
 "target"	"t39"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"328 440 160"
@@ -8497,6 +9210,7 @@
 "target"	"t41"
 "spawnflags"	"256"
 }
+
 {
 "origin"	"328 240 160"
 "classname"	"path_corner"
@@ -8504,18 +9218,21 @@
 "target"	"t42"
 "spawnflags"	"256"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"1024 152 160"
 "targetname"	"t43"
 "target"	"t44"
 }
+
 {
 "origin"	"1016 416 160"
 "classname"	"path_corner"
 "targetname"	"t44"
 "target"	"t43"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"536 -128 -384"
@@ -8523,6 +9240,7 @@
 "target"	"t48"
 "spawnflags"	"256"
 }
+
 {
 "origin"	"544 -288 -384"
 "classname"	"path_corner"
@@ -8530,6 +9248,7 @@
 "target"	"t47"
 "spawnflags"	"256"
 }
+
 {
 "origin"	"816 -144 -384"
 "classname"	"path_corner"
@@ -8537,6 +9256,7 @@
 "target"	"t45"
 "spawnflags"	"256"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"816 -296 -384"
@@ -8544,6 +9264,7 @@
 "target"	"t46"
 "spawnflags"	"256"
 }
+
 {
 "classname"	"monster_ogre"
 "origin"	"704 -160 -368"
@@ -8551,49 +9272,59 @@
 "spawnflags"	"256"
 "target"	"t45"
 }
+
 {
 "classname"	"item_spikes"
 "origin"	"608 -240 -392"
 "spawnflags"	"1"
 }
+
 {
 "spawnflags"	"2817"
 "origin"	"664 -240 -392"
 "classname"	"item_spikes"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"464 -304 -120"
 "targetname"	"t49"
 "target"	"t50"
 }
+
 {
 "origin"	"464 -472 -120"
 "classname"	"path_corner"
 "target"	"t49"
 "targetname"	"t50"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"272 -512 8"
 "targetname"	"t51"
 "target"	"t52"
 }
+
 {
 "origin"	"88 -512 8"
 "classname"	"path_corner"
 "targetname"	"t52"
 "target"	"t51"
 }
+
 {
 "classname"	"light"
 "origin"	"128 -680 96"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"info_intermission"
 "origin"	"1232 -656 464"
 "mangle"	"20 140 0"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"1008 -320 8"
@@ -8601,6 +9332,7 @@
 "targetname"	"t54"
 "spawnflags"	"256"
 }
+
 {
 "origin"	"1008 -128 8"
 "classname"	"path_corner"
@@ -8608,10 +9340,12 @@
 "target"	"t54"
 "spawnflags"	"256"
 }
+
 {
 "classname"	"item_spikes"
 "origin"	"1272 -520 0"
 }
+
 {
 "classname"	"func_door_secret"
 "angle"	"270"
@@ -8625,6 +9359,7 @@
 ( 1120 232 0 ) ( 1088 232 0 ) ( 1088 144 0 ) METAL4_4 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"trigger_secret"
 {
@@ -8636,56 +9371,75 @@
 ( 1260 172 0 ) ( 1128 172 0 ) ( 1128 168 0 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "spawnflags"	"1"
 "classname"	"item_spikes"
 "origin"	"1216 176 0"
 }
+
 {
 "classname"	"item_artifact_invisibility"
 "origin"	"1208 92 24"
 "spawnflags"	"1792"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"624 968 -672"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"720 968 -672"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"776 808 -672"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"568 808 -672"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"250"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"664 832 -744"
 "classname"	"light"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"672 832 -888"
 "classname"	"light"
 }
+
 {
 "classname"	"light"
 "origin"	"672 728 -888"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 "origin"	"672 608 -888"
 "classname"	"light"
 }
+
 {
 "classname"	"trigger_secret"
 {
@@ -8697,24 +9451,29 @@
 ( 728 888 -744 ) ( 616 888 -744 ) ( 616 792 -744 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "origin"	"672 920 -728"
 "classname"	"item_artifact_super_damage"
 }
+
 {
 "origin"	"768 976 -752"
 "classname"	"item_health"
 }
+
 {
 "classname"	"item_health"
 "origin"	"552 984 -752"
 }
+
 {
 "targetname"	"t55"
 "angle"	"270"
 "origin"	"672 720 -720"
 "classname"	"info_teleport_destination"
 }
+
 {
 "target"	"t55"
 "classname"	"trigger_teleport"
@@ -8727,11 +9486,14 @@
 ( 704 1016 -744 ) ( 640 1016 -744 ) ( 640 1008 -744 ) TRIGGER 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"light"
 "origin"	"1024 728 -120"
 "light"	"150"
+	"_color"	"0.88 0.74 0.58"
 }
+
 {
 "classname"	"monster_ogre"
 "origin"	"600 -496 280"
@@ -8739,6 +9501,7 @@
 "angle"	"0"
 "target"	"t35"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"144 -264 -728"
@@ -8746,6 +9509,7 @@
 "targetname"	"t56"
 "target"	"t57"
 }
+
 {
 "spawnflags"	"768"
 "origin"	"320 -264 -728"
@@ -8753,6 +9517,7 @@
 "targetname"	"t57"
 "target"	"t56"
 }
+
 {
 "classname"	"monster_ogre"
 "origin"	"240 -256 -712"
@@ -8760,6 +9525,7 @@
 "spawnflags"	"768"
 "target"	"t56"
 }
+
 {
 "classname"	"path_corner"
 "origin"	"808 -696 -728"
@@ -8767,6 +9533,7 @@
 "target"	"t58"
 "spawnflags"	"768"
 }
+
 {
 "origin"	"504 -696 -728"
 "classname"	"path_corner"
@@ -8774,6 +9541,7 @@
 "target"	"t59"
 "spawnflags"	"768"
 }
+
 {
 "classname"	"monster_ogre"
 "origin"	"552 -696 -712"
@@ -8781,6 +9549,7 @@
 "spawnflags"	"768"
 "target"	"t58"
 }
+
 {
 "spawnflags"	"1792"
 "classname"	"func_wall"
@@ -8793,6 +9562,7 @@
 ( 1520 -208 0 ) ( 1504 -208 0 ) ( 1504 -272 0 ) METAL4_5 0 0 0 1.000000 1.000000
 }
 }
+
 {
 "classname"	"func_wall"
 "spawnflags"	"2048"
@@ -8809,11 +9579,13 @@
 ( 660 136 0 ) ( 652 144 0 ) ( 660 136 16 ) METALT2_2 0 32 0 1.000000 1.000000
 }
 }
+
 {
 "spawnflags"	"1792"
 "origin"	"672 256 -472"
 "classname"	"weapon_supernailgun"
 }
+
 {
 "target"	"t45"
 "spawnflags"	"768"
@@ -8821,35 +9593,41 @@
 "origin"	"816 -240 -368"
 "classname"	"monster_shambler"
 }
+
 {
 "angle"	"225"
 "origin"	"1312 728 392"
 "classname"	"monster_wizard"
 "spawnflags"	"256"
 }
+
 {
 "angle"	"315"
 "origin"	"32 728 392"
 "classname"	"monster_wizard"
 }
+
 {
 "target"	"t61"
 "targetname"	"t60"
 "origin"	"1208 -144 256"
 "classname"	"path_corner"
 }
+
 {
 "targetname"	"t61"
 "target"	"t60"
 "classname"	"path_corner"
 "origin"	"1032 -400 256"
 }
+
 {
 "target"	"t61"
 "angle"	"225"
 "origin"	"1144 -216 272"
 "classname"	"monster_wizard"
 }
+
 {
 "spawnflags"	"256"
 "targetname"	"t63"
@@ -8857,6 +9635,7 @@
 "origin"	"288 -136 128"
 "classname"	"path_corner"
 }
+
 {
 "spawnflags"	"256"
 "target"	"t63"
@@ -8864,19 +9643,30 @@
 "classname"	"path_corner"
 "origin"	"288 -336 128"
 }
+
 {
 "spawnflags"	"256"
 "target"	"t62"
 "origin"	"280 -384 144"
 "classname"	"monster_wizard"
 }
+
 {
 "classname"	"item_health"
 "origin"	"1160 48 216"
 "spawnflags"	"2305"
 }
+
 {
 "classname"	"light"
 "origin"	"1024 720 -744"
 "light"	"125"
+	"_color"	"0.88 0.74 0.58"
+}
+
+{
+	"classname"	"light_environment"
+	"_color"	"0.85 0.72 0.58"
+	"light"	"220"
+	"angles"	"45 120 0"
 }


### PR DESCRIPTION
## Summary
- add global ambient, fog, and sunlight parameters to every episode one map to create a moodier baseline
- enrich all light entities with color and appropriate styles, including flickering torches and cool fluorescents
- append a sun-casting light_environment entity to each level for consistent outdoor lighting

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6902a35c1660832e942ee61f23b33b18