### PR TITLE
Implement configurable viewmodel lighting pipeline

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -102,6 +102,231 @@ static float GL_TemperedOverbright (float overbright)
 	return q_max (tempered, 1.f);
 }
 
+static void R_ViewweaponResetCaches (void)
+{
+        memset (&viewweapon_origin_cache, 0, sizeof (viewweapon_origin_cache));
+        memset (viewweapon_probe_caches, 0, sizeof (viewweapon_probe_caches));
+        viewweapon_smooth_valid = false;
+        viewweapon_flash_intensity = 0.f;
+        viewweapon_flash_timestamp = 0.0;
+        viewweapon_active_mode = 0;
+}
+
+static void R_ViewweaponDecayFlash (double now)
+{
+	if (viewweapon_flash_timestamp == 0.0)
+	{
+		viewweapon_flash_timestamp = now;
+		return;
+	}
+	double delta = now - viewweapon_flash_timestamp;
+	if (delta <= 0.0)
+		return;
+	float decay = (float)(delta * 8.0);
+	if (viewweapon_flash_intensity > 0.f)
+		viewweapon_flash_intensity = q_max (0.f, viewweapon_flash_intensity - decay);
+	viewweapon_flash_timestamp = now;
+}
+
+int R_ViewweaponLightingMode (void)
+{
+	return viewweapon_active_mode;
+}
+
+void R_Viewweapon_AddMuzzleFlash (void)
+{
+	viewweapon_flash_intensity = 1.f;
+	viewweapon_flash_timestamp = cl.time;
+}
+
+static void R_UpdateViewweaponLightingParams (void)
+{
+	int mode = CLAMP (0, (int)Q_rint (r_viewweaponLighting.value), 2);
+	if (r_fullbright_cheatsafe || r_lightmap_cheatsafe || r_showtris.value >= 1.f)
+		mode = 0;
+
+	viewweapon_active_mode = mode;
+	r_framedata.viewweapon_mode = (float)mode;
+
+	if (viewweapon_cached_world != cl.worldmodel)
+	{
+		viewweapon_cached_world = cl.worldmodel;
+		R_ViewweaponResetCaches ();
+	}
+
+	R_ViewweaponDecayFlash (cl.time);
+	r_framedata.viewweapon_flash = viewweapon_flash_intensity;
+
+	float ambient_scale = q_max (0.f, r_viewweaponAmbient.value);
+	float dir_scale = q_max (0.f, r_viewweaponDirScale.value);
+	float rim = q_max (0.f, r_viewweaponRim.value);
+	float spec = q_max (0.f, r_viewweaponSpec.value);
+	float dlights = q_max (0.f, r_viewweaponDLights.value);
+	if (!r_dynamic.value)
+		dlights = 0.f;
+	float muzzle = q_max (0.f, r_viewweaponMuzzleflashBoost.value);
+	float fogfix = r_viewweaponFogFix.value;
+	float minlight = q_max (0.f, ambient_scale * 0.08f);
+
+	r_framedata.viewweapon_rim = rim;
+	r_framedata.viewweapon_spec = spec;
+	r_framedata.viewweapon_dlights = dlights;
+	r_framedata.viewweapon_muzzleboost = muzzle;
+	r_framedata.viewweapon_fogfix = fogfix;
+	r_framedata.viewweapon_minlight = minlight;
+	r_framedata.viewweapon_pad0 = 0.f;
+	r_framedata.viewweapon_pad1 = 0.f;
+
+	float half_lambert = 0.f;
+	if (mode >= 2)
+		half_lambert = 1.f;
+	else if (mode == 1)
+		half_lambert = 0.5f;
+	r_framedata.viewweapon_half_lambert = half_lambert;
+
+	if (mode <= 0)
+	{
+		if (!viewweapon_smooth_valid)
+		{
+			VectorClear (viewweapon_smooth_ambient);
+			VectorClear (viewweapon_smooth_dir_color);
+			viewweapon_smooth_dir_dir[0] = 0.f;
+			viewweapon_smooth_dir_dir[1] = 0.f;
+			viewweapon_smooth_dir_dir[2] = -1.f;
+			viewweapon_smooth_valid = true;
+		}
+		VectorCopy (viewweapon_smooth_ambient, r_framedata.viewweapon_ambient);
+		VectorCopy (viewweapon_smooth_dir_color, r_framedata.viewweapon_dir_color);
+		VectorCopy (viewweapon_smooth_dir_dir, r_framedata.viewweapon_dir_dir);
+		return;
+	}
+
+	vec3_t ambient_sample = { 0.f, 0.f, 0.f };
+	vec3_t best_diff = { 0.f, 0.f, 0.f };
+	vec3_t best_dir = { -vpn[0], -vpn[1], -vpn[2] };
+	float best_weight = 0.f;
+
+	vec3_t saved_lightcolor;
+	VectorCopy (lightcolor, saved_lightcolor);
+
+	if (cl.worldmodel && cl.worldmodel->lightdata)
+	{
+		if (R_LightPoint (r_refdef.vieworg, 0.f, &viewweapon_origin_cache))
+			VectorCopy (lightcolor, ambient_sample);
+		else
+			VectorClear (ambient_sample);
+
+		vec3_t base_ambient;
+		VectorScale (ambient_sample, 1.f / 200.f, base_ambient);
+
+		vec3_t dirs[VIEWWEAPON_PROBE_COUNT];
+		VectorCopy (vpn, dirs[0]);
+		dirs[1][0] = -vpn[0];
+		dirs[1][1] = -vpn[1];
+		dirs[1][2] = -vpn[2];
+		VectorCopy (vup, dirs[2]);
+		dirs[3][0] = -vup[0];
+		dirs[3][1] = -vup[1];
+		dirs[3][2] = -vup[2];
+		VectorCopy (vright, dirs[4]);
+		dirs[5][0] = -vright[0];
+		dirs[5][1] = -vright[1];
+		dirs[5][2] = -vright[2];
+
+		for (int i = 0; i < VIEWWEAPON_PROBE_COUNT; ++i)
+		{
+			vec3_t sample_pos;
+			VectorMA (r_refdef.vieworg, VIEWWEAPON_PROBE_DISTANCE, dirs[i], sample_pos);
+			if (!R_LightPoint (sample_pos, 0.f, &viewweapon_probe_caches[i]))
+				continue;
+
+			vec3_t sample_linear;
+			VectorScale (lightcolor, 1.f / 200.f, sample_linear);
+			vec3_t diff;
+			float weight = 0.f;
+			for (int j = 0; j < 3; ++j)
+			{
+				float delta = sample_linear[j] - base_ambient[j];
+				if (delta > 0.f)
+				{
+					diff[j] = delta;
+					weight += delta;
+				}
+				else
+					diff[j] = 0.f;
+			}
+			if (weight > best_weight)
+			{
+				best_weight = weight;
+				VectorCopy (diff, best_diff);
+				VectorCopy (dirs[i], best_dir);
+			}
+		}
+	}
+	else
+	{
+		ambient_sample[0] = ambient_sample[1] = ambient_sample[2] = 96.f;
+	}
+
+	VectorCopy (saved_lightcolor, lightcolor);
+
+	vec3_t ambient_linear;
+	VectorScale (ambient_sample, 1.f / 200.f, ambient_linear);
+	VectorScale (ambient_linear, ambient_scale, ambient_linear);
+
+	float ambient_floor = ambient_scale * 0.1f;
+	for (int i = 0; i < 3; ++i)
+	{
+		if (ambient_linear[i] < ambient_floor)
+			ambient_linear[i] = ambient_floor;
+	}
+
+	vec3_t dir_color;
+	VectorScale (best_diff, dir_scale, dir_color);
+
+	if (VectorNormalize (best_dir) == 0.f)
+	{
+		best_dir[0] = -vpn[0];
+		best_dir[1] = -vpn[1];
+		best_dir[2] = -vpn[2];
+		VectorNormalize (best_dir);
+	}
+
+	if (!viewweapon_smooth_valid)
+	{
+		VectorCopy (ambient_linear, viewweapon_smooth_ambient);
+		VectorCopy (dir_color, viewweapon_smooth_dir_color);
+		VectorCopy (best_dir, viewweapon_smooth_dir_dir);
+		viewweapon_smooth_valid = true;
+	}
+	else
+	{
+		for (int i = 0; i < 3; ++i)
+		{
+			viewweapon_smooth_ambient[i] += (ambient_linear[i] - viewweapon_smooth_ambient[i]) * VIEWWEAPON_SMOOTHING;
+			viewweapon_smooth_dir_color[i] += (dir_color[i] - viewweapon_smooth_dir_color[i]) * VIEWWEAPON_SMOOTHING;
+			viewweapon_smooth_dir_dir[i] += (best_dir[i] - viewweapon_smooth_dir_dir[i]) * VIEWWEAPON_SMOOTHING;
+		}
+		if (VectorNormalize (viewweapon_smooth_dir_dir) == 0.f)
+		{
+			viewweapon_smooth_dir_dir[0] = -vpn[0];
+			viewweapon_smooth_dir_dir[1] = -vpn[1];
+			viewweapon_smooth_dir_dir[2] = -vpn[2];
+			VectorNormalize (viewweapon_smooth_dir_dir);
+		}
+	}
+
+	for (int i = 0; i < 3; ++i)
+	{
+		if (viewweapon_smooth_dir_color[i] < 0.f)
+			viewweapon_smooth_dir_color[i] = 0.f;
+	}
+
+	VectorCopy (viewweapon_smooth_ambient, r_framedata.viewweapon_ambient);
+	VectorCopy (viewweapon_smooth_dir_color, r_framedata.viewweapon_dir_color);
+	VectorCopy (viewweapon_smooth_dir_dir, r_framedata.viewweapon_dir_dir);
+}
+
 static qboolean MatrixInverse4x4(const float m[16], float out[16])
 {
     float inv[16];
@@ -205,6 +430,15 @@ cvar_t	r_dof = { "r_dof", "0", CVAR_ARCHIVE };
 cvar_t	r_rim_alias = { "r_rim_alias", "0.25", CVAR_ARCHIVE };
 cvar_t	r_rim_world = { "r_rim_world", "0.15", CVAR_ARCHIVE };
 cvar_t	r_rim_exponent = { "r_rim_exponent", "4.0", CVAR_ARCHIVE };
+cvar_t	r_viewweaponLighting = { "r_viewweaponLighting", "2", CVAR_ARCHIVE };
+cvar_t	r_viewweaponAmbient = { "r_viewweaponAmbient", "1.0", CVAR_ARCHIVE };
+cvar_t	r_viewweaponDirScale = { "r_viewweaponDirScale", "1.25", CVAR_ARCHIVE };
+cvar_t	r_viewweaponRim = { "r_viewweaponRim", "0.3", CVAR_ARCHIVE };
+cvar_t	r_viewweaponSpec = { "r_viewweaponSpec", "0.2", CVAR_ARCHIVE };
+cvar_t	r_viewweaponDLights = { "r_viewweaponDLights", "1.0", CVAR_ARCHIVE };
+cvar_t	r_viewweaponMuzzleflashBoost = { "r_viewweaponMuzzleflashBoost", "0.35", CVAR_ARCHIVE };
+cvar_t	r_viewweaponFogFix = { "r_viewweaponFogFix", "0.2", CVAR_ARCHIVE };
+cvar_t	r_viewweaponMode = { "r_viewweaponMode", "modern", CVAR_ARCHIVE };
 cvar_t	r_dof_focus = { "r_dof_focus", "64", CVAR_ARCHIVE };
 cvar_t	r_dof_range = { "r_dof_range", "48", CVAR_ARCHIVE };
 cvar_t	r_dof_strength = { "r_dof_strength", "6", CVAR_ARCHIVE };
@@ -305,6 +539,21 @@ cvar_t	r_scale = { "r_scale", "1", CVAR_ARCHIVE };
 
 static float view_znear;
 static float view_zfar;
+
+#define VIEWWEAPON_PROBE_COUNT 6
+#define VIEWWEAPON_PROBE_DISTANCE 96.0f
+#define VIEWWEAPON_SMOOTHING 0.2f
+
+static lightcache_t viewweapon_origin_cache;
+static lightcache_t viewweapon_probe_caches[VIEWWEAPON_PROBE_COUNT];
+static const qmodel_t* viewweapon_cached_world = NULL;
+static vec3_t viewweapon_smooth_ambient = { 0.f, 0.f, 0.f };
+static vec3_t viewweapon_smooth_dir_color = { 0.f, 0.f, 0.f };
+static vec3_t viewweapon_smooth_dir_dir = { 0.f, 0.f, -1.f };
+static qboolean viewweapon_smooth_valid = false;
+static float viewweapon_flash_intensity = 0.f;
+static double viewweapon_flash_timestamp = 0.0;
+static int viewweapon_active_mode = 0;
 
 static qboolean R_DoFEnabled (void)
 {
@@ -1818,13 +2067,15 @@ void R_SetupView (void)
 	Fog_SetupFrame (); //johnfitz
 	Sky_SetupFrame ();
 
-	// build the transformation matrix for the given view angles
-	VectorCopy (r_refdef.vieworg, r_origin);
-	AngleVectors (r_refdef.viewangles, vpn, vright, vup);
+        // build the transformation matrix for the given view angles
+        VectorCopy (r_refdef.vieworg, r_origin);
+        AngleVectors (r_refdef.viewangles, vpn, vright, vup);
 
-	// current viewleaf
-	r_oldviewleaf = r_viewleaf;
-	r_viewleaf = Mod_PointInLeaf (r_origin, cl.worldmodel);
+        R_UpdateViewweaponLightingParams ();
+
+        // current viewleaf
+        r_oldviewleaf = r_viewleaf;
+        r_viewleaf = Mod_PointInLeaf (r_origin, cl.worldmodel);
 
 	V_SetContentsColor (r_viewleaf->contents);
 	V_CalcBlend ();

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -315,9 +315,59 @@ R_OverbrightBits_f
 */
 static void R_OverbrightBits_f (cvar_t *var)
 {
-	int value = CLAMP (0, (int)Q_rint (var->value), 3);
-	if (value != (int)var->value)
-		Cvar_SetValueQuick (var, (float)value);
+        int value = CLAMP (0, (int)Q_rint (var->value), 3);
+        if (value != (int)var->value)
+                Cvar_SetValueQuick (var, (float)value);
+}
+
+static void R_ViewweaponMode_f (cvar_t *var)
+{
+        const char *mode = var->string;
+
+        if (!mode || !*mode)
+                return;
+
+        if (!Q_strcasecmp (mode, "classic"))
+        {
+                Cvar_SetValueQuick (&r_viewweaponLighting, 0.f);
+                Cvar_SetValueQuick (&r_viewweaponAmbient, 1.0f);
+                Cvar_SetValueQuick (&r_viewweaponDirScale, 1.0f);
+                Cvar_SetValueQuick (&r_viewweaponRim, 0.0f);
+                Cvar_SetValueQuick (&r_viewweaponSpec, 0.0f);
+                Cvar_SetValueQuick (&r_viewweaponDLights, 1.0f);
+                Cvar_SetValueQuick (&r_viewweaponMuzzleflashBoost, 0.35f);
+                Cvar_SetValueQuick (&r_viewweaponFogFix, 0.0f);
+        }
+        else if (!Q_strcasecmp (mode, "q3"))
+        {
+                Cvar_SetValueQuick (&r_viewweaponLighting, 1.f);
+                Cvar_SetValueQuick (&r_viewweaponAmbient, 0.9f);
+                Cvar_SetValueQuick (&r_viewweaponDirScale, 1.0f);
+                Cvar_SetValueQuick (&r_viewweaponRim, 0.15f);
+                Cvar_SetValueQuick (&r_viewweaponSpec, 0.05f);
+                Cvar_SetValueQuick (&r_viewweaponDLights, 1.0f);
+                Cvar_SetValueQuick (&r_viewweaponMuzzleflashBoost, 0.25f);
+                Cvar_SetValueQuick (&r_viewweaponFogFix, 0.1f);
+        }
+        else if (!Q_strcasecmp (mode, "modern"))
+        {
+                Cvar_SetValueQuick (&r_viewweaponLighting, 2.f);
+                Cvar_SetValueQuick (&r_viewweaponAmbient, 1.0f);
+                Cvar_SetValueQuick (&r_viewweaponDirScale, 1.25f);
+                Cvar_SetValueQuick (&r_viewweaponRim, 0.3f);
+                Cvar_SetValueQuick (&r_viewweaponSpec, 0.2f);
+                Cvar_SetValueQuick (&r_viewweaponDLights, 1.15f);
+                Cvar_SetValueQuick (&r_viewweaponMuzzleflashBoost, 0.35f);
+                Cvar_SetValueQuick (&r_viewweaponFogFix, 0.2f);
+        }
+        else if (!Q_strcasecmp (mode, "custom"))
+        {
+                return;
+        }
+        else
+        {
+                Con_Printf ("Unknown r_viewweaponMode preset \"%s\"\n", mode);
+        }
 }
 
 /*
@@ -380,6 +430,16 @@ void R_Init (void)
 	Cvar_RegisterVariable (&r_rim_alias);
 	Cvar_RegisterVariable (&r_rim_world);
 	Cvar_RegisterVariable (&r_rim_exponent);
+	Cvar_RegisterVariable (&r_viewweaponLighting);
+	Cvar_RegisterVariable (&r_viewweaponAmbient);
+	Cvar_RegisterVariable (&r_viewweaponDirScale);
+	Cvar_RegisterVariable (&r_viewweaponRim);
+	Cvar_RegisterVariable (&r_viewweaponSpec);
+	Cvar_RegisterVariable (&r_viewweaponDLights);
+	Cvar_RegisterVariable (&r_viewweaponMuzzleflashBoost);
+	Cvar_RegisterVariable (&r_viewweaponFogFix);
+	Cvar_RegisterVariable (&r_viewweaponMode);
+	Cvar_SetCallback (&r_viewweaponMode, R_ViewweaponMode_f);
         Cvar_RegisterVariable (&r_dof_autofocus);
 	Cvar_RegisterVariable (&r_dof_focus);
 	Cvar_RegisterVariable (&r_dof_range);

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -112,6 +112,15 @@ extern	cvar_t	r_alphasort;
 extern	cvar_t	r_rim_alias;
 extern	cvar_t	r_rim_world;
 extern	cvar_t	r_rim_exponent;
+extern	cvar_t	r_viewweaponLighting;
+extern	cvar_t	r_viewweaponAmbient;
+extern	cvar_t	r_viewweaponDirScale;
+extern	cvar_t	r_viewweaponRim;
+extern	cvar_t	r_viewweaponSpec;
+extern	cvar_t	r_viewweaponDLights;
+extern	cvar_t	r_viewweaponMuzzleflashBoost;
+extern	cvar_t	r_viewweaponFogFix;
+extern	cvar_t	r_viewweaponMode;
 
 extern	cvar_t	gl_clear;
 extern	cvar_t	gl_polyblend;
@@ -447,6 +456,20 @@ typedef struct gpuframedata_s {
 	int			prev_frame_valid;
 	int			delux_enabled;
 	int			_padding1;
+	vec3_t	viewweapon_ambient;
+	float	viewweapon_mode;
+	vec3_t	viewweapon_dir_color;
+	float	viewweapon_rim;
+	vec3_t	viewweapon_dir_dir;
+	float	viewweapon_spec;
+	float	viewweapon_dlights;
+	float	viewweapon_muzzleboost;
+	float	viewweapon_fogfix;
+	float	viewweapon_minlight;
+	float	viewweapon_flash;
+	float	viewweapon_half_lambert;
+	float	viewweapon_pad0;
+	float	viewweapon_pad1;
 } gpuframedata_t;
 
 extern gpulightbuffer_t r_lightbuffer;
@@ -485,6 +508,9 @@ void R_DrawSpriteModels (entity_t **ents, int count);
 void R_DrawBrushModels_ShowTris (entity_t **ents, int count);
 void R_DrawAliasModels_ShowTris (entity_t **ents, int count);
 void R_DrawSpriteModels_ShowTris (entity_t **ents, int count);
+void R_DrawViewModel (void);
+int R_ViewweaponLightingMode (void);
+void R_Viewweapon_AddMuzzleFlash (void);
 
 entity_t **R_GetVisEntities (modtype_t type, qboolean translucent, int *outcount);
 

--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -498,16 +498,24 @@ static void R_DrawAliasModel_Real (entity_t *e, qboolean showtris)
         // set up lighting
         //
 	rs_aliaspolys += paliashdr->numtris;
-	R_SetupAliasLighting (e);
+        R_SetupAliasLighting (e);
 
-	// Viewmodel muzzle flashes look wrong when shaded using the ambient
-	// lighting at the player's position (typically pitch black in dark
-	// areas).  In the original software renderer the muzzle flash pixels
-	// are effectively fullbright, so replicate that behaviour by forcing a
-	// strong light contribution when the view model is drawing a muzzle
-	// flash frame.
-	if ((e->effects & EF_MUZZLEFLASH) && e == &cl.viewent)
-		lightcolor[0] = lightcolor[1] = lightcolor[2] = 256.0f / 200.0f;
+        {
+                int viewweapon_mode = 0;
+                if (e == &cl.viewent)
+                        viewweapon_mode = R_ViewweaponLightingMode ();
+
+                if (viewweapon_mode > 0)
+                {
+                        if ((e->effects & EF_MUZZLEFLASH) && !showtris)
+                                R_Viewweapon_AddMuzzleFlash ();
+                        lightcolor[0] = lightcolor[1] = lightcolor[2] = 1.f;
+                }
+                else if ((e->effects & EF_MUZZLEFLASH) && e == &cl.viewent)
+                {
+                        lightcolor[0] = lightcolor[1] = lightcolor[2] = 256.0f / 200.0f;
+                }
+        }
 
 	//
 	// draw it

--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -243,70 +243,127 @@ void main()
         fullbright = texture(FullbrightTex, uv).rgb;
         emissive = texture(EmissiveTex, uv).rgb;
 #endif
-        vec3 localNormal = normalize(in_local_normal);
-        vec3 shadevector = normalize(in_shadevector);
-        float shade = r_avertexnormal_dot(localNormal, shadevector);
-        vec3 lighting = (in_color.rgb * _FrameLightmapStrength) * shade;
         vec3 worldNormal = in_world_normal;
         if (dot(worldNormal, worldNormal) > 0.0)
                 worldNormal = normalize(worldNormal);
         else
                 worldNormal = vec3(0.0, 0.0, 1.0);
-        lighting += ComputeDynamicLights(in_world_pos, worldNormal);
-        if (_FrameRimAlias > 0.0)
+        vec3 localNormal = normalize(in_local_normal);
+        vec3 shadevector = normalize(in_shadevector);
+        float shade = r_avertexnormal_dot(localNormal, shadevector);
+        bool isViewmodel = (in_flags & ALIAS_FLAG_VIEWMODEL) != 0;
+        float viewMode = _FrameViewweaponMode;
+        vec3 lighting;
+
+        if (!isViewmodel || viewMode < 0.5)
         {
+                lighting = (in_color.rgb * _FrameLightmapStrength) * shade;
+                lighting += ComputeDynamicLights(in_world_pos, worldNormal);
+                if (_FrameRimAlias > 0.0)
+                {
+                        vec3 to_eye = EyePos - in_world_pos;
+                        float inv_len = inversesqrt(max(dot(to_eye, to_eye), 1e-8));
+                        vec3 view_dir = to_eye * inv_len;
+                        float ndotv = max(dot(worldNormal, view_dir), 0.0);
+                        float fresnel = pow(clamp(1.0 - ndotv, 0.0, 1.0), _FrameRimExponent);
+                        lighting += vec3(_FrameRimAlias * fresnel);
+                }
+                lighting = max(lighting, vec3(0.0));
+        }
+        else
+        {
+                vec3 ambient = _FrameViewweaponAmbient;
+                vec3 dirColor = _FrameViewweaponDirColor;
+                vec3 dirDir = _FrameViewweaponDirDirection;
+                float dirLen = length(dirDir);
+                if (dirLen > 1e-4)
+                        dirDir /= dirLen;
+                else
+                        dirDir = vec3(0.0, 0.0, -1.0);
+                float ndotl = max(dot(worldNormal, -dirDir), 0.0);
+                float halfLambert = ndotl * 0.5 + 0.5;
+                float lambertMix = clamp(_FrameViewweaponHalfLambert, 0.0, 1.0);
+                float shadeTerm = mix(ndotl, halfLambert, lambertMix);
+                vec3 directional = dirColor * shadeTerm;
+                vec3 dynamic = ComputeDynamicLights(in_world_pos, worldNormal) * _FrameViewweaponDLights;
+                lighting = ambient + directional + dynamic;
+                float muzzleBoost = _FrameViewweaponMuzzleBoost * _FrameViewweaponFlash;
+                lighting += vec3(muzzleBoost);
                 vec3 to_eye = EyePos - in_world_pos;
                 float inv_len = inversesqrt(max(dot(to_eye, to_eye), 1e-8));
                 vec3 view_dir = to_eye * inv_len;
-                float ndotv = max(dot(worldNormal, view_dir), 0.0);
-                float fresnel = pow(clamp(1.0 - ndotv, 0.0, 1.0), _FrameRimExponent);
-                lighting += vec3(_FrameRimAlias * fresnel);
+                if (_FrameViewweaponRim > 0.0)
+                {
+                        float ndotv = max(dot(worldNormal, view_dir), 0.0);
+                        float rim = pow(clamp(1.0 - ndotv, 0.0, 1.0), 3.0);
+                        lighting += vec3(_FrameViewweaponRim * rim);
+                }
+                if (_FrameViewweaponSpec > 0.0)
+                {
+                        vec3 light_dir = normalize(-dirDir);
+                        vec3 half_vec = normalize(light_dir + view_dir);
+                        float specTerm = pow(max(dot(worldNormal, half_vec), 0.0), 32.0);
+                        lighting += vec3(_FrameViewweaponSpec * specTerm);
+                }
+                lighting = max(lighting, vec3(_FrameViewweaponMinLight));
         }
-        lighting = max(lighting, vec3(0.0));
 
         uint overbrightFlag = floatBitsToUint(Fog.w) >> 31u;
         bool useFullbrightHack = ((in_flags & ALIAS_FLAG_FULLBRIGHT_HACK) != 0) && overbrightFlag == 0u;
 
-        if (useFullbrightHack)
+        if (!isViewmodel || viewMode < 0.5)
         {
-                lighting = vec3(256.0 / 200.0);
+                if (useFullbrightHack)
+                {
+                        lighting = vec3(256.0 / 200.0);
+                }
+                else
+                {
+                        float sum = lighting.x + lighting.y + lighting.z;
+                        if ((in_flags & ALIAS_FLAG_VIEWMODEL) != 0)
+                        {
+                                const float minSum = 72.0 / 200.0;
+                                if (sum < minSum)
+                                {
+                                        float add = (minSum - sum) / 3.0;
+                                        lighting += vec3(add);
+                                        sum = minSum;
+                                }
+                        }
+                        else if ((in_flags & ALIAS_FLAG_PLAYER) != 0)
+                        {
+                                const float minSum = 24.0 / 200.0;
+                                if (sum < minSum)
+                                {
+                                        float add = (minSum - sum) / 3.0;
+                                        lighting += vec3(add);
+                                        sum = minSum;
+                                }
+                        }
+                        if (overbrightFlag != 0u)
+                        {
+                                const float maxSum = 288.0 / 200.0;
+                                if (sum > maxSum)
+                                {
+                                        float scale = maxSum / sum;
+                                        lighting *= scale;
+                                }
+                        }
+                }
         }
-        else
+        else if (overbrightFlag != 0u)
         {
                 float sum = lighting.x + lighting.y + lighting.z;
-                if ((in_flags & ALIAS_FLAG_VIEWMODEL) != 0)
+                const float maxSum = 288.0 / 200.0;
+                if (sum > maxSum)
                 {
-                        const float minSum = 72.0 / 200.0;
-                        if (sum < minSum)
-                        {
-                                float add = (minSum - sum) / 3.0;
-                                lighting += vec3(add);
-                                sum = minSum;
-                        }
-                }
-                else if ((in_flags & ALIAS_FLAG_PLAYER) != 0)
-                {
-                        const float minSum = 24.0 / 200.0;
-                        if (sum < minSum)
-                        {
-                                float add = (minSum - sum) / 3.0;
-                                lighting += vec3(add);
-                                sum = minSum;
-                        }
-                }
-                if (overbrightFlag != 0u)
-                {
-                        const float maxSum = 288.0 / 200.0;
-                        if (sum > maxSum)
-                        {
-                                float scale = maxSum / sum;
-                                lighting *= scale;
-                                sum = maxSum;
-                        }
+                        float scale = maxSum / sum;
+                        lighting *= scale;
                 }
         }
 
         lighting = ldexp(lighting, ivec3(int(overbrightFlag)));
+
 
 #if ALPHATEST
         vec3 shadedColor = baseColor * lighting;
@@ -322,6 +379,14 @@ void main()
         vec4 result = vec4(shadedColor, in_color.a);
         float fog = exp2(abs(Fog.w) * -dot(in_pos, in_pos));
         fog = clamp(fog, 0.0, 1.0);
+        if (isViewmodel && viewMode >= 0.5)
+        {
+                float fogFix = _FrameViewweaponFogFix;
+                if (fogFix > 0.0)
+                        fog = mix(fog, 1.0, clamp(fogFix, 0.0, 1.0));
+                else if (fogFix < 0.0)
+                        fog = mix(fog, 0.0, clamp(-fogFix, 0.0, 1.0));
+        }
         result.rgb = mix(Fog.rgb, result.rgb, fog);
         out_fragcolor = result;
 #if !OIT

--- a/Quake/shaders/frame_uniforms.glsl
+++ b/Quake/shaders/frame_uniforms.glsl
@@ -27,6 +27,20 @@ layout(std140, binding=0) uniform FrameDataUBO
         uint    PrevFrameValid;
         uint    DeluxEnabled;
         uint    _Pad1;
+        vec3    ViewweaponAmbient;
+        float   ViewweaponMode;
+        vec3    ViewweaponDirColor;
+        float   ViewweaponRim;
+        vec3    ViewweaponDirDirection;
+        float   ViewweaponSpec;
+        float   ViewweaponDLights;
+        float   ViewweaponMuzzleBoost;
+        float   ViewweaponFogFix;
+        float   ViewweaponMinLight;
+        float   ViewweaponFlash;
+        float   ViewweaponHalfLambert;
+        float   ViewweaponPad0;
+        float   ViewweaponPad1;
 };
 
 #endif // FRAME_UNIFORMS_GLSL


### PR DESCRIPTION
## Summary
- compute dedicated viewmodel lighting data (ambient, directional, rim, specular, muzzle flash, fog fix) and upload it to the frame UBO
- update alias rendering to consume the new lighting path while preserving the legacy fallback when disabled
- add cvars and presets for configuring the viewmodel lighting behaviour

## Testing
- cmake -S . -B build -G Ninja *(fails: missing SDL2 development files in container)*

------
https://chatgpt.com/codex/tasks/task_e_6902b63fb30c832ead9944a0230ec523