### PR TITLE
Fix view weapon lighting uniforms

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -557,21 +557,6 @@ cvar_t	r_scale = { "r_scale", "1", CVAR_ARCHIVE };
 static float view_znear;
 static float view_zfar;
 
-#define VIEWWEAPON_PROBE_COUNT 6
-#define VIEWWEAPON_PROBE_DISTANCE 96.0f
-#define VIEWWEAPON_SMOOTHING 0.2f
-
-static lightcache_t viewweapon_origin_cache;
-static lightcache_t viewweapon_probe_caches[VIEWWEAPON_PROBE_COUNT];
-static const qmodel_t* viewweapon_cached_world = NULL;
-static vec3_t viewweapon_smooth_ambient = { 0.f, 0.f, 0.f };
-static vec3_t viewweapon_smooth_dir_color = { 0.f, 0.f, 0.f };
-static vec3_t viewweapon_smooth_dir_dir = { 0.f, 0.f, -1.f };
-static qboolean viewweapon_smooth_valid = false;
-static float viewweapon_flash_intensity = 0.f;
-static double viewweapon_flash_timestamp = 0.0;
-static int viewweapon_active_mode = 0;
-
 static qboolean R_DoFEnabled (void)
 {
         return r_dof.value > 0.f && r_dof_strength.value > 0.f;

--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -46,8 +46,22 @@ layout(std140, binding=0) uniform FrameDataUBO
         float   _FrameZLogBias;
         uint    NumLights;
         uint    _FramePrevFrameValid;
+        uint    _FrameDeluxEnabled;
         uint    _FramePad1;
-        uint    _FramePad2;
+        vec3    _FrameViewweaponAmbient;
+        float   _FrameViewweaponMode;
+        vec3    _FrameViewweaponDirColor;
+        float   _FrameViewweaponRim;
+        vec3    _FrameViewweaponDirDirection;
+        float   _FrameViewweaponSpec;
+        float   _FrameViewweaponDLights;
+        float   _FrameViewweaponMuzzleBoost;
+        float   _FrameViewweaponFogFix;
+        float   _FrameViewweaponMinLight;
+        float   _FrameViewweaponFlash;
+        float   _FrameViewweaponHalfLambert;
+        float   _FrameViewweaponPad0;
+        float   _FrameViewweaponPad1;
 };
 
 struct Light


### PR DESCRIPTION
## Summary
- remove a redundant block of view weapon state definitions from `gl_rmain.c`
- define the view weapon lighting uniforms in `alias.frag`'s `FrameDataUBO` so the shader compiles with the GPU frame data layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6902bd88fd9c832e946ca36f91f7074b