### PR TITLE
Fix viewmodel directional lighting damping in low light

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -333,7 +333,10 @@ static void R_UpdateViewweaponLightingParams (void)
 
         vec3_t dir_color;
         float dir_strength = best_diff[0] + best_diff[1] + best_diff[2];
-        float ambient_strength = (ambient_sample[0] + ambient_sample[1] + ambient_sample[2]) * (1.f / 3.f);
+        // ambient_sample is measured in lightmap units (0-255); scale it the same
+        // way as the directional samples so the damping heuristics operate in a
+        // consistent space.
+        float ambient_strength = (ambient_sample[0] + ambient_sample[1] + ambient_sample[2]) * (1.f / (3.f * 200.f));
         float lighting_strength = ambient_strength + dir_strength;
         // Damp coloured highlights when both the local ambient and the detected
         // directional component are very dim.  This prevents the view model from


### PR DESCRIPTION
## Summary
- scale the ambient lighting strength to the same units as directional probes
- avoid exaggerated color casts on the viewmodel when standing in shadow

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6903b240cb9c832ebb6d78a9020f409c