### PR TITLE
Handle BSPX static light and shadow data

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -1050,6 +1050,116 @@ static qboolean Mod_BspxImportDeluxemap (const char *lumpname, const byte *data,
         return false;
 }
 
+static qboolean Mod_BspxImportStaticLights (const char *lumpname, const byte *data, size_t length,
+        bspx_static_light_t **out_lights, int *out_count)
+{
+        const size_t stride_with_intensity = sizeof(float) * 8;
+        const size_t stride_without_intensity = sizeof(float) * 7;
+        size_t stride = 0;
+        qboolean has_intensity = true;
+        int count;
+        bspx_static_light_t *lights;
+
+        if (!out_lights || !out_count)
+                return false;
+
+        *out_lights = NULL;
+        *out_count = 0;
+
+        if (!data || length == 0)
+                return true;
+
+        if (length % stride_with_intensity == 0)
+        {
+                stride = stride_with_intensity;
+                has_intensity = true;
+        }
+        else if (length % stride_without_intensity == 0)
+        {
+                stride = stride_without_intensity;
+                has_intensity = false;
+        }
+        else
+        {
+                Con_DPrintf2 ("BSPX lump %s has unexpected size %zu (expected multiples of %zu or %zu)\n",
+                        lumpname, length, stride_with_intensity, stride_without_intensity);
+                return false;
+        }
+
+        count = (int)(length / stride);
+        if (count <= 0)
+                return true;
+
+        lights = (bspx_static_light_t *) Hunk_AllocName (count * sizeof(*lights), lumpname);
+        if (!lights)
+                return false;
+
+        for (int i = 0; i < count; ++i)
+        {
+                const float *src = (const float *)(data + i * stride);
+                float intensity = 1.0f;
+
+                lights[i].origin[0] = LittleFloat (src[0]);
+                lights[i].origin[1] = LittleFloat (src[1]);
+                lights[i].origin[2] = LittleFloat (src[2]);
+
+                lights[i].radius = LittleFloat (src[3]);
+                if (lights[i].radius < 0.0f)
+                        lights[i].radius = 0.0f;
+
+                lights[i].color[0] = LittleFloat (src[4]);
+                lights[i].color[1] = LittleFloat (src[5]);
+                lights[i].color[2] = LittleFloat (src[6]);
+
+                if (has_intensity)
+                        intensity = LittleFloat (src[7]);
+
+                lights[i].intensity = (intensity > 0.0f) ? intensity : 0.0f;
+        }
+
+        *out_lights = lights;
+        *out_count = count;
+        return true;
+}
+
+static qboolean Mod_BspxImportStaticShadowIndices (const char *lumpname, const byte *data, size_t length,
+        int **out_indices, int *out_count)
+{
+        int count;
+        int *indices;
+
+        if (!out_indices || !out_count)
+                return false;
+
+        *out_indices = NULL;
+        *out_count = 0;
+
+        if (!data || length == 0)
+                return true;
+
+        if (length % sizeof(int))
+        {
+                Con_DPrintf2 ("BSPX lump %s has unexpected size %zu (expected multiple of %zu)\n",
+                        lumpname, length, sizeof(int));
+                return false;
+        }
+
+        count = (int)(length / sizeof(int));
+        if (count <= 0)
+                return true;
+
+        indices = (int *) Hunk_AllocName (count * sizeof(*indices), lumpname);
+        if (!indices)
+                return false;
+
+        for (int i = 0; i < count; ++i)
+                indices[i] = LittleLong (((const int *)data)[i]);
+
+        *out_indices = indices;
+        *out_count = count;
+        return true;
+}
+
 static void Mod_LoadBspx (const byte *buffer)
 {
         typedef struct bspx_lump_s
@@ -1135,6 +1245,21 @@ static void Mod_LoadBspx (const byte *buffer)
                          !q_strcasecmp (lumpname, "DLIT")))
                 {
                         Mod_BspxImportDeluxemap (lumpname, buffer + lumpofs, lumplen);
+                }
+
+                if (!q_strcasecmp (lumpname, "STATICLIGHTS") || !q_strcasecmp (lumpname, "STATIC_LIGHTS"))
+                {
+                        Mod_BspxImportStaticLights (lumpname, buffer + lumpofs, lumplen,
+                                &loadmodel->bspx_static_lights, &loadmodel->bspx_num_static_lights);
+                }
+                else if (!q_strcasecmp (lumpname, "STATICSHADOWS") || !q_strcasecmp (lumpname, "STATIC_SHADOWS"))
+                {
+                        if (!Mod_BspxImportStaticLights (lumpname, buffer + lumpofs, lumplen,
+                                        &loadmodel->bspx_static_shadow_lights, &loadmodel->bspx_num_static_shadow_lights))
+                        {
+                                Mod_BspxImportStaticShadowIndices (lumpname, buffer + lumpofs, lumplen,
+                                        &loadmodel->bspx_static_shadow_indices, &loadmodel->bspx_num_static_shadow_indices);
+                        }
                 }
         }
 }
@@ -2799,9 +2924,15 @@ static void Mod_LoadBrushModel (qmodel_t *mod, void *buffer)
 	dmodel_t 	*bm;
 	float		radius; //johnfitz
 
-	loadmodel->type = mod_brush;
-	loadmodel->numdeluxsamples = 0;
-	mod_bspx_filesize = (com_filesize > 0) ? (size_t)com_filesize : 0;
+        loadmodel->type = mod_brush;
+        loadmodel->numdeluxsamples = 0;
+        loadmodel->bspx_num_static_lights = 0;
+        loadmodel->bspx_static_lights = NULL;
+        loadmodel->bspx_num_static_shadow_lights = 0;
+        loadmodel->bspx_static_shadow_lights = NULL;
+        loadmodel->bspx_num_static_shadow_indices = 0;
+        loadmodel->bspx_static_shadow_indices = NULL;
+        mod_bspx_filesize = (com_filesize > 0) ? (size_t)com_filesize : 0;
 
 	header = (dheader_t *)buffer;
 

--- a/Quake/gl_model.h
+++ b/Quake/gl_model.h
@@ -361,10 +361,18 @@ typedef struct
 } bonepose_t; //pose data for a single bone.
 typedef struct
 {
-	int parent; //-1 for a root bone
-	char name[32];
-	bonepose_t inverse;
+        int parent; //-1 for a root bone
+        char name[32];
+        bonepose_t inverse;
 } boneinfo_t;
+
+typedef struct bspx_static_light_s
+{
+        vec3_t  origin;
+        float   radius;
+        vec3_t  color;
+        float   intensity;
+} bspx_static_light_t;
 
 #define	MAXALIASVERTS		0x7fff //16-bit index buffer + onseam duplication
 #define	MAXALIASVERTS_QS	2000 //johnfitz -- was 1024
@@ -498,6 +506,13 @@ typedef struct qmodel_s
 	qboolean	litfile;
 	qboolean	deluxfile;
 	qboolean	viswarn; // for Mod_DecompressVis()
+
+	int			bspx_num_static_lights;
+	bspx_static_light_t	*bspx_static_lights;
+	int			bspx_num_static_shadow_lights;
+	bspx_static_light_t	*bspx_static_shadow_lights;
+	int			bspx_num_static_shadow_indices;
+	int			*bspx_static_shadow_indices;
 
 	int			bspversion;
 	int			contentstransparent;	//spike -- added this so we can disable glitchy wateralpha where its not supported.

--- a/Quake/gl_rlight.c
+++ b/Quake/gl_rlight.c
@@ -189,6 +189,14 @@ void R_PushDlights (void)
 	gpu_cluster_inputs_t cluster_inputs;
 
         int dynamic_count = 0;
+        int static_light_count = cl.worldmodel ? cl.worldmodel->bspx_num_static_lights : 0;
+        int static_shadow_light_count = cl.worldmodel ? cl.worldmodel->bspx_num_static_shadow_lights : 0;
+
+        int static_light_index_map_size = (static_light_count > 0) ? static_light_count : 1;
+        int static_shadow_index_map_size = (static_shadow_light_count > 0) ? static_shadow_light_count : 1;
+
+        int static_light_index_map[static_light_index_map_size];
+        int static_shadow_light_index_map[static_shadow_index_map_size];
 
         r_framedata.numlights = 0;
 
@@ -237,9 +245,11 @@ void R_PushDlights (void)
                 if (cl.worldmodel)
                 {
                         R_AppendBspxLights (cl.worldmodel->bspx_static_lights,
-                                cl.worldmodel->bspx_num_static_lights, NULL);
+                                cl.worldmodel->bspx_num_static_lights,
+                                (static_light_count > 0) ? static_light_index_map : NULL);
                         R_AppendBspxLights (cl.worldmodel->bspx_static_shadow_lights,
-                                cl.worldmodel->bspx_num_static_shadow_lights, NULL);
+                                cl.worldmodel->bspx_num_static_shadow_lights,
+                                (static_shadow_light_count > 0) ? static_shadow_light_index_map : NULL);
                 }
         }
 
@@ -257,13 +267,16 @@ void R_PushDlights (void)
                         cl.worldmodel->bspx_num_static_shadow_lights > 0)
                 {
                         int count = cl.worldmodel->bspx_num_static_shadow_lights;
-                        const bspx_static_light_t *lights = cl.worldmodel->bspx_static_shadow_lights;
 
                         for (int k = 0; k < count && shadow_count < MAX_DLIGHTS; ++k)
                         {
-                                if (lights[k].radius <= 0.0f)
+                                int mapped_index = (static_shadow_light_count > 0) ?
+                                        static_shadow_light_index_map[k] : -1;
+
+                                if (mapped_index < 0 || mapped_index >= r_framedata.numlights)
                                         continue;
-                                R_FillGpuLightFromBspx (&lights[k], &shadow_lights[shadow_count++]);
+
+                                shadow_lights[shadow_count++] = r_lightbuffer.lights[mapped_index];
                         }
                 }
 
@@ -272,10 +285,9 @@ void R_PushDlights (void)
                 {
                         const int *indices = cl.worldmodel->bspx_static_shadow_indices;
                         int count = cl.worldmodel->bspx_num_static_shadow_indices;
-                        const bspx_static_light_t *lights = cl.worldmodel->bspx_static_lights;
                         int maxlights = cl.worldmodel->bspx_num_static_lights;
 
-                        if (lights && maxlights > 0)
+                        if (cl.worldmodel->bspx_static_lights && maxlights > 0)
                         {
                                 for (int k = 0; k < count && shadow_count < MAX_DLIGHTS; ++k)
                                 {
@@ -285,16 +297,22 @@ void R_PushDlights (void)
                                         if (idx < 0 || idx >= maxlights)
                                                 continue;
 
-                                        if (lights[idx].radius <= 0.0f)
+                                        if (static_light_count <= 0)
+                                                continue;
+
+                                        int mapped_index = static_light_index_map[idx];
+
+                                        if (mapped_index < 0 || mapped_index >= r_framedata.numlights)
                                                 continue;
 
                                         for (int n = dynamic_count; n < shadow_count; ++n)
                                         {
                                                 const gpulight_t *existing = &shadow_lights[n];
-                                                if (fabsf(existing->pos[0] - lights[idx].origin[0]) < 0.01f &&
-                                                    fabsf(existing->pos[1] - lights[idx].origin[1]) < 0.01f &&
-                                                    fabsf(existing->pos[2] - lights[idx].origin[2]) < 0.01f &&
-                                                    fabsf(existing->radius - lights[idx].radius) < 0.01f)
+                                                const gpulight_t *candidate = &r_lightbuffer.lights[mapped_index];
+                                                if (fabsf(existing->pos[0] - candidate->pos[0]) < 0.01f &&
+                                                    fabsf(existing->pos[1] - candidate->pos[1]) < 0.01f &&
+                                                    fabsf(existing->pos[2] - candidate->pos[2]) < 0.01f &&
+                                                    fabsf(existing->radius - candidate->radius) < 0.01f)
                                                 {
                                                         duplicate = true;
                                                         break;
@@ -303,7 +321,7 @@ void R_PushDlights (void)
                                         if (duplicate)
                                                 continue;
 
-                                        R_FillGpuLightFromBspx (&lights[idx], &shadow_lights[shadow_count++]);
+                                        shadow_lights[shadow_count++] = r_lightbuffer.lights[mapped_index];
                                 }
                         }
                 }

--- a/Quake/gl_rlight.c
+++ b/Quake/gl_rlight.c
@@ -22,12 +22,62 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // r_light.c
 
 #include "quakedef.h"
+#include "gl_shadow.h"
 
 extern cvar_t r_flatlightstyles; //johnfitz
 extern cvar_t r_lerplightstyles;
 extern cvar_t r_dynamic;
 
 gpulightbuffer_t r_lightbuffer;
+
+static void R_FillGpuLightFromBspx (const bspx_static_light_t *src, gpulight_t *dst)
+{
+        float intensity = (src->intensity > 0.0f) ? src->intensity : 0.0f;
+
+        VectorCopy (src->origin, dst->pos);
+        dst->radius = (src->radius > 0.0f) ? src->radius : 0.0f;
+        dst->color[0] = q_max (0.f, src->color[0] * intensity);
+        dst->color[1] = q_max (0.f, src->color[1] * intensity);
+        dst->color[2] = q_max (0.f, src->color[2] * intensity);
+        dst->minlight = 0.0f;
+}
+
+static int R_AppendBspxLights (const bspx_static_light_t *lights, int count, int *index_map)
+{
+        int appended = 0;
+
+        if (!lights || count <= 0)
+                return 0;
+
+        if (index_map)
+        {
+                for (int i = 0; i < count; ++i)
+                        index_map[i] = -1;
+        }
+
+        for (int i = 0; i < count && r_framedata.numlights < MAX_DLIGHTS; ++i)
+        {
+                const bspx_static_light_t *src = &lights[i];
+                gpulight_t *dst;
+
+                if (src->radius <= 0.0f)
+                        continue;
+
+                dst = &r_lightbuffer.lights[r_framedata.numlights++];
+                if (index_map)
+                        index_map[i] = r_framedata.numlights - 1;
+                R_FillGpuLightFromBspx (src, dst);
+                appended++;
+        }
+
+        if (index_map)
+        {
+                for (int i = appended; i < count; ++i)
+                        index_map[i] = (index_map[i] >= 0) ? index_map[i] : -1;
+        }
+
+        return appended;
+}
 
 /*
 ==================
@@ -138,50 +188,134 @@ void R_PushDlights (void)
 	GLbyte			*ofs;
 	gpu_cluster_inputs_t cluster_inputs;
 
-	r_framedata.numlights = 0;
+        int dynamic_count = 0;
 
-	if (r_dynamic.value)
-	{
-		dlight_t *l;
-		for (i = 0, l = cl_dlights; i < MAX_DLIGHTS; i++, l++)
-		{
-			gpulight_t *out;
-			qboolean cull = false;
+        r_framedata.numlights = 0;
 
-			if (l->spawn > cl.time)
-			{
-				l->die = 0.f;
-				continue;
-			}
+        if (r_dynamic.value)
+        {
+                dlight_t *l;
+                for (i = 0, l = cl_dlights; i < MAX_DLIGHTS; i++, l++)
+                {
+                        gpulight_t *out;
+                        qboolean cull = false;
 
-			if (l->die < cl.time || !l->radius)
-				continue;
+                        if (l->spawn > cl.time)
+                        {
+                                l->die = 0.f;
+                                continue;
+                        }
 
-			for (j = 0; j < 4; j++)
-			{
-				mplane_t *p = &frustum[j];
-				if (DotProduct (p->normal, l->origin) - p->dist + l->radius < 0.f)
-				{
-					cull = true;
-					break;
-				}
-			}
-			if (cull)
-				continue;
+                        if (l->die < cl.time || !l->radius)
+                                continue;
 
-			out = &r_lightbuffer.lights[r_framedata.numlights++];
-			out->pos[0]   = l->origin[0];
-			out->pos[1]   = l->origin[1];
-			out->pos[2]   = l->origin[2];
-			out->radius   = l->radius;
-			out->color[0] = l->color[0];
-			out->color[1] = l->color[1];
-			out->color[2] = l->color[2];
-			out->minlight = l->minlight;
-		}
-	}
+                        for (j = 0; j < 4; j++)
+                        {
+                                mplane_t *p = &frustum[j];
+                                if (DotProduct (p->normal, l->origin) - p->dist + l->radius < 0.f)
+                                {
+                                        cull = true;
+                                        break;
+                                }
+                        }
+                        if (cull)
+                                continue;
 
-	GL_BeginGroup ("Light clustering");
+                        out = &r_lightbuffer.lights[r_framedata.numlights++];
+                        out->pos[0]   = l->origin[0];
+                        out->pos[1]   = l->origin[1];
+                        out->pos[2]   = l->origin[2];
+                        out->radius   = l->radius;
+                        out->color[0] = l->color[0];
+                        out->color[1] = l->color[1];
+                        out->color[2] = l->color[2];
+                        out->minlight = l->minlight;
+                }
+
+                dynamic_count = r_framedata.numlights;
+
+                if (cl.worldmodel)
+                {
+                        R_AppendBspxLights (cl.worldmodel->bspx_static_lights,
+                                cl.worldmodel->bspx_num_static_lights, NULL);
+                        R_AppendBspxLights (cl.worldmodel->bspx_static_shadow_lights,
+                                cl.worldmodel->bspx_num_static_shadow_lights, NULL);
+                }
+        }
+
+        if (cl.worldmodel &&
+                (cl.worldmodel->bspx_num_static_shadow_lights > 0 ||
+                 cl.worldmodel->bspx_num_static_shadow_indices > 0))
+        {
+                gpulight_t shadow_lights[MAX_DLIGHTS];
+                int shadow_count = 0;
+
+                for (i = 0; i < dynamic_count && shadow_count < MAX_DLIGHTS; ++i)
+                        shadow_lights[shadow_count++] = r_lightbuffer.lights[i];
+
+                if (cl.worldmodel->bspx_static_shadow_lights &&
+                        cl.worldmodel->bspx_num_static_shadow_lights > 0)
+                {
+                        int count = cl.worldmodel->bspx_num_static_shadow_lights;
+                        const bspx_static_light_t *lights = cl.worldmodel->bspx_static_shadow_lights;
+
+                        for (int k = 0; k < count && shadow_count < MAX_DLIGHTS; ++k)
+                        {
+                                if (lights[k].radius <= 0.0f)
+                                        continue;
+                                R_FillGpuLightFromBspx (&lights[k], &shadow_lights[shadow_count++]);
+                        }
+                }
+
+                if (cl.worldmodel->bspx_static_shadow_indices &&
+                        cl.worldmodel->bspx_num_static_shadow_indices > 0)
+                {
+                        const int *indices = cl.worldmodel->bspx_static_shadow_indices;
+                        int count = cl.worldmodel->bspx_num_static_shadow_indices;
+                        const bspx_static_light_t *lights = cl.worldmodel->bspx_static_lights;
+                        int maxlights = cl.worldmodel->bspx_num_static_lights;
+
+                        if (lights && maxlights > 0)
+                        {
+                                for (int k = 0; k < count && shadow_count < MAX_DLIGHTS; ++k)
+                                {
+                                        int idx = indices[k];
+                                        qboolean duplicate = false;
+
+                                        if (idx < 0 || idx >= maxlights)
+                                                continue;
+
+                                        if (lights[idx].radius <= 0.0f)
+                                                continue;
+
+                                        for (int n = dynamic_count; n < shadow_count; ++n)
+                                        {
+                                                const gpulight_t *existing = &shadow_lights[n];
+                                                if (fabsf(existing->pos[0] - lights[idx].origin[0]) < 0.01f &&
+                                                    fabsf(existing->pos[1] - lights[idx].origin[1]) < 0.01f &&
+                                                    fabsf(existing->pos[2] - lights[idx].origin[2]) < 0.01f &&
+                                                    fabsf(existing->radius - lights[idx].radius) < 0.01f)
+                                                {
+                                                        duplicate = true;
+                                                        break;
+                                                }
+                                        }
+                                        if (duplicate)
+                                                continue;
+
+                                        R_FillGpuLightFromBspx (&lights[idx], &shadow_lights[shadow_count++]);
+                                }
+                        }
+                }
+
+                R_ShadowSyncWorldLights (shadow_lights, shadow_count);
+        }
+        else
+        {
+                R_ShadowSyncWorldLights (r_lightbuffer.lights, r_framedata.numlights);
+        }
+
+        GL_BeginGroup ("Light clustering");
 
 	R_UploadFrameData ();
 

--- a/Quake/gl_rlight.c
+++ b/Quake/gl_rlight.c
@@ -24,6 +24,11 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "quakedef.h"
 #include "gl_shadow.h"
 
+enum
+{
+        BSPX_INDEX_MAP_CAP = MAX_DLIGHTS
+};
+
 extern cvar_t r_flatlightstyles; //johnfitz
 extern cvar_t r_lerplightstyles;
 extern cvar_t r_dynamic;
@@ -42,16 +47,16 @@ static void R_FillGpuLightFromBspx (const bspx_static_light_t *src, gpulight_t *
         dst->minlight = 0.0f;
 }
 
-static int R_AppendBspxLights (const bspx_static_light_t *lights, int count, int *index_map)
+static int R_AppendBspxLights (const bspx_static_light_t *lights, int count, int *index_map, int index_map_cap)
 {
         int appended = 0;
 
         if (!lights || count <= 0)
                 return 0;
 
-        if (index_map)
+        if (index_map && index_map_cap > 0)
         {
-                for (int i = 0; i < count; ++i)
+                for (int i = 0; i < index_map_cap; ++i)
                         index_map[i] = -1;
         }
 
@@ -64,16 +69,10 @@ static int R_AppendBspxLights (const bspx_static_light_t *lights, int count, int
                         continue;
 
                 dst = &r_lightbuffer.lights[r_framedata.numlights++];
-                if (index_map)
+                if (index_map && i < index_map_cap)
                         index_map[i] = r_framedata.numlights - 1;
                 R_FillGpuLightFromBspx (src, dst);
                 appended++;
-        }
-
-        if (index_map)
-        {
-                for (int i = appended; i < count; ++i)
-                        index_map[i] = (index_map[i] >= 0) ? index_map[i] : -1;
         }
 
         return appended;
@@ -191,12 +190,17 @@ void R_PushDlights (void)
         int dynamic_count = 0;
         int static_light_count = cl.worldmodel ? cl.worldmodel->bspx_num_static_lights : 0;
         int static_shadow_light_count = cl.worldmodel ? cl.worldmodel->bspx_num_static_shadow_lights : 0;
+        int static_light_map_count = q_min (static_light_count, BSPX_INDEX_MAP_CAP);
+        int static_shadow_light_map_count = q_min (static_shadow_light_count, BSPX_INDEX_MAP_CAP);
 
-        int static_light_index_map_size = (static_light_count > 0) ? static_light_count : 1;
-        int static_shadow_index_map_size = (static_shadow_light_count > 0) ? static_shadow_light_count : 1;
+        int static_light_index_map[BSPX_INDEX_MAP_CAP];
+        int static_shadow_light_index_map[BSPX_INDEX_MAP_CAP];
 
-        int static_light_index_map[static_light_index_map_size];
-        int static_shadow_light_index_map[static_shadow_index_map_size];
+        for (int i = 0; i < BSPX_INDEX_MAP_CAP; ++i)
+        {
+                static_light_index_map[i] = -1;
+                static_shadow_light_index_map[i] = -1;
+        }
 
         r_framedata.numlights = 0;
 
@@ -246,10 +250,12 @@ void R_PushDlights (void)
                 {
                         R_AppendBspxLights (cl.worldmodel->bspx_static_lights,
                                 cl.worldmodel->bspx_num_static_lights,
-                                (static_light_count > 0) ? static_light_index_map : NULL);
+                                (static_light_map_count > 0) ? static_light_index_map : NULL,
+                                static_light_map_count);
                         R_AppendBspxLights (cl.worldmodel->bspx_static_shadow_lights,
                                 cl.worldmodel->bspx_num_static_shadow_lights,
-                                (static_shadow_light_count > 0) ? static_shadow_light_index_map : NULL);
+                                (static_shadow_light_map_count > 0) ? static_shadow_light_index_map : NULL,
+                                static_shadow_light_map_count);
                 }
         }
 
@@ -270,7 +276,7 @@ void R_PushDlights (void)
 
                         for (int k = 0; k < count && shadow_count < MAX_DLIGHTS; ++k)
                         {
-                                int mapped_index = (static_shadow_light_count > 0) ?
+                                int mapped_index = (k < static_shadow_light_map_count) ?
                                         static_shadow_light_index_map[k] : -1;
 
                                 if (mapped_index < 0 || mapped_index >= r_framedata.numlights)
@@ -297,10 +303,11 @@ void R_PushDlights (void)
                                         if (idx < 0 || idx >= maxlights)
                                                 continue;
 
-                                        if (static_light_count <= 0)
+                                        if (static_light_map_count <= 0)
                                                 continue;
 
-                                        int mapped_index = static_light_index_map[idx];
+                                        int mapped_index = (idx < static_light_map_count) ?
+                                                static_light_index_map[idx] : -1;
 
                                         if (mapped_index < 0 || mapped_index >= r_framedata.numlights)
                                                 continue;

--- a/docs/bspx.md
+++ b/docs/bspx.md
@@ -10,6 +10,8 @@ Ironwail can read and cache [BSPX](https://www.quaddicted.com/files/maps/bspx.tx
 | `FACENORMALS`   | Per-surface normals stored as float triples. | Used as the preferred normal in decal projection (`r_decals`), falling back to averaged vertex normals. |
 | `RGBLIGHTING`   | Packed RGB lightmap samples. | Copied into the standard lightmap buffer when `r_bspx_lighting` is enabled and no external `.lit` file overrides the map. |
 | `LIGHTINGDIR`   | Directional lighting samples aligned with the BSP lightmap. | When `r_bspx_lighting` is enabled the samples populate per-surface deluxemaps so shaders can reconstruct smooth normals; otherwise the data remains cached for tooling. |
+| `STATICLIGHTS`  | Array of static point lights stored as float tuples. | Converted into GPU lights at runtime so BSPX maps can ship with authored static light sources. |
+| `STATICSHADOWS` | Static shadow metadata. | When supplied as light tuples they are treated as additional shadow-casting lights; index payloads mark entries inside `STATICLIGHTS` that should feed the shadow system. |
 | `ENVMAP`, `SURFENVMAP` | Additional material metadata. | Stored as opaque blobs for future renderer features. |
 | `BRUSHLIST`     | List of brush indices. | Available through the `bspx_brushlist` console command for debugging tools. |
 | `ZIP_PAKFILE`   | Embedded archive payload. | Parsed and stored as an opaque blob. |


### PR DESCRIPTION
## Summary
- parse BSPX STATICLIGHTS and STATICSHADOWS lumps and persist their payload on brush models
- feed the parsed static light data into the frame light buffer and shadow synchronisation routines
- document the newly supported BSPX static light and shadow lumps

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6903c31eb0d0832eb498f32b30f1bc3e