### PR TITLE
Add gl_shadow.c to Visual Studio project

### DIFF
--- a/Windows/VisualStudio/ironwail.vcxproj
+++ b/Windows/VisualStudio/ironwail.vcxproj
@@ -243,6 +243,7 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
     <ClCompile Include="..\..\Quake\gl_model.c" />
     <ClCompile Include="..\..\Quake\gl_refrag.c" />
     <ClCompile Include="..\..\Quake\gl_rlight.c" />
+    <ClCompile Include="..\..\Quake\gl_shadow.c" />
     <ClCompile Include="..\..\Quake\gl_rmain.c" />
     <ClCompile Include="..\..\Quake\gl_rmisc.c" />
     <ClCompile Include="..\..\Quake\gl_screen.c" />

--- a/Windows/VisualStudio/ironwail.vcxproj.filters
+++ b/Windows/VisualStudio/ironwail.vcxproj.filters
@@ -72,6 +72,9 @@
     <ClCompile Include="..\..\Quake\gl_rlight.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Quake\gl_shadow.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\Quake\gl_rmain.c">
       <Filter>Source Files</Filter>
     </ClCompile>


### PR DESCRIPTION
## Summary
- include the shadow rendering source file in the Visual Studio project to provide R_ShadowSyncWorldLights
- register gl_shadow.c in the project filters so it appears alongside the other GL sources

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_6903eda5e8ac832eba75bbd2a4191fe9