### PR TITLE
Register renderbuffer functions for GL

### DIFF
--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -189,6 +189,10 @@ extern	const char	*gl_version;
 	x(void,			BindFramebuffer, (GLenum target, GLuint framebuffer))\
 	x(void,			GenFramebuffers, (GLsizei n, GLuint *framebuffers))\
 	x(void,			DeleteFramebuffers, (GLsizei n, const GLuint *framebuffers))\
+	x(void,			BindRenderbuffer, (GLenum target, GLuint renderbuffer))\
+	x(void,			GenRenderbuffers, (GLsizei n, GLuint *renderbuffers))\
+	x(void,			DeleteRenderbuffers, (GLsizei n, const GLuint *renderbuffers))\
+	x(void,			RenderbufferStorage, (GLenum target, GLenum internalformat, GLsizei width, GLsizei height))\
 	x(void,			FramebufferTexture2D, (GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level))\
 	x(void,			FramebufferTextureLayer, (GLenum target, GLenum attachment, GLuint texture, GLint level, GLint layer))\
 	x(GLenum,		CheckFramebufferStatus, (GLenum target))\

--- a/Windows/VisualStudio/ironwail.vcxproj
+++ b/Windows/VisualStudio/ironwail.vcxproj
@@ -243,6 +243,7 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
     <ClCompile Include="..\..\Quake\gl_model.c" />
     <ClCompile Include="..\..\Quake\gl_refrag.c" />
     <ClCompile Include="..\..\Quake\gl_rlight.c" />
+    <ClCompile Include="..\..\Quake\gl_shadow.c" />
     <ClCompile Include="..\..\Quake\gl_rmain.c" />
     <ClCompile Include="..\..\Quake\gl_rmisc.c" />
     <ClCompile Include="..\..\Quake\gl_screen.c" />

--- a/Windows/VisualStudio/ironwail.vcxproj.filters
+++ b/Windows/VisualStudio/ironwail.vcxproj.filters
@@ -72,6 +72,9 @@
     <ClCompile Include="..\..\Quake\gl_rlight.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Quake\gl_shadow.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\Quake\gl_rmain.c">
       <Filter>Source Files</Filter>
     </ClCompile>


### PR DESCRIPTION
## Summary
- add the renderbuffer entry points to the OpenGL function table so GL_DeleteRenderbuffersFunc is defined when loading

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6903eda5e8ac832eba75bbd2a4191fe9