### PR TITLE
Fix MD5 muzzle flash lighting

### DIFF
--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -500,14 +500,19 @@ static void R_DrawAliasModel_Real (entity_t *e, qboolean showtris)
 	rs_aliaspolys += paliashdr->numtris;
 	R_SetupAliasLighting (e);
 
-	// Viewmodel muzzle flashes look wrong when shaded using the ambient
-	// lighting at the player's position (typically pitch black in dark
-	// areas).  In the original software renderer the muzzle flash pixels
-	// are effectively fullbright, so replicate that behaviour by forcing a
-	// strong light contribution when the view model is drawing a muzzle
-	// flash frame.
-	if ((e->effects & EF_MUZZLEFLASH) && e == &cl.viewent)
-		lightcolor[0] = lightcolor[1] = lightcolor[2] = 256.0f / 200.0f;
+        // Viewmodel muzzle flashes look wrong when shaded using the ambient
+        // lighting at the player's position (typically pitch black in dark
+        // areas).  In the original software renderer the muzzle flash pixels
+        // are effectively fullbright, so replicate that behaviour by forcing a
+        // strong light contribution when the view model is drawing a muzzle
+        // flash frame.  MD5/IQM versions of player and monster models also rely
+        // on this behaviour for their muzzle flash attachments, so give them
+        // the same treatment.
+        if (e->effects & EF_MUZZLEFLASH)
+        {
+                if (e == &cl.viewent || paliashdr->poseverttype == PV_IQM)
+                        lightcolor[0] = lightcolor[1] = lightcolor[2] = 256.0f / 200.0f;
+        }
 
 	//
 	// draw it


### PR DESCRIPTION
## Summary
- ensure MD5/IQM alias models force bright lighting when rendering muzzle flash frames
- document the shared logic for MD5 muzzle flash handling alongside the existing viewmodel comment

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6903fb40862c832ea46f7948bd220882