### PR TITLE
Fix decal rendering and add debug mode

### DIFF
--- a/Quake/cl_tent.c
+++ b/Quake/cl_tent.c
@@ -203,6 +203,7 @@ void CL_ParseTEnt (void)
 		pos[1] = MSG_ReadCoord (cl.protocolflags);
 		pos[2] = MSG_ReadCoord (cl.protocolflags);
 		R_RunParticleEffect (pos, vec3_origin, 0, 20);
+		R_AddBulletDecal (pos);
 		break;
 
 	case TE_EXPLOSION:			// rocket explosion

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -2750,6 +2750,7 @@ void R_ShowTris (void)
 	}
 
 	R_DrawParticles_ShowTris ();
+	R_DrawDecals_ShowTris ();
 
 	glPolygonMode (GL_FRONT_AND_BACK, GL_FILL);
 	GL_PolygonOffset (OFFSET_NONE);
@@ -2830,11 +2831,15 @@ void R_RenderScene (void)
 
 	Fog_EnableGFog (); //johnfitz
 
+	R_UpdateDecals ();
+
 	R_DrawViewModel (); //johnfitz -- moved here from R_RenderView
 
 	S_ExtraUpdate (); // don't let sound get messed up if going slow
 
 	R_DrawEntitiesOnList (false); //johnfitz -- false means this is the pass for nonalpha entities
+
+	R_DrawDecals (false);
 
 	R_DrawParticles (false);
 

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -481,6 +481,7 @@ void R_Init (void)
 	Cvar_SetCallback (&r_slimealpha, R_SetSlimealpha_f);
 
 	R_InitParticles ();
+	R_InitDecals ();
 	R_SetClearColor_f (&r_clearcolor); //johnfitz
 
 	Sky_Init (); //johnfitz
@@ -638,20 +639,21 @@ void R_NewMap (void)
 	R_ClearEfrags ();
 	r_viewleaf = NULL;
 	R_ClearParticles ();
+	R_ClearDecals ();
 	VEC_CLEAR (r_pointfile);
 
 	GL_BuildLightmaps ();
-        GL_BuildBModelVertexBuffer ();
-        GL_BuildBModelMarkBuffers ();
+	GL_BuildBModelVertexBuffer ();
+	GL_BuildBModelMarkBuffers ();
         //ericw -- no longer load alias models into a VBO here, it's done in Mod_LoadAliasModel
 
-        r_framecount = 0; //johnfitz -- paranoid?
-        r_visframecount = 0; //johnfitz -- paranoid?
+	r_framecount = 0; //johnfitz -- paranoid?
+	r_visframecount = 0; //johnfitz -- paranoid?
 
 
-        Sky_NewMap (); //johnfitz -- skybox in worldspawn
-        Fog_NewMap (); //johnfitz -- global fog in worldspawn
-        R_ParseWorldspawn (); //ericw -- wateralpha, lavaalpha, telealpha, slimealpha in worldspawn
+	Sky_NewMap (); //johnfitz -- skybox in worldspawn
+	Fog_NewMap (); //johnfitz -- global fog in worldspawn
+	R_ParseWorldspawn (); //ericw -- wateralpha, lavaalpha, telealpha, slimealpha in worldspawn
 
 	// Load pointfile if map has no vis data and either developer mode is on or the game was started from a map editing tool
 	if (developer.value || map_checks.value)

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -478,6 +478,13 @@ void R_EntityMatrix (float matrix[16], vec3_t origin, vec3_t angles, unsigned ch
 void R_InitParticles (void);
 void R_DrawParticles (qboolean alpha);
 void R_DrawParticles_ShowTris (void);
+void R_InitDecals (void);
+void R_ClearDecals (void);
+void R_UpdateDecals (void);
+void R_AddBulletDecal (const vec3_t point);
+void R_AddBloodDecal (const vec3_t point, const vec3_t dir);
+void R_DrawDecals (qboolean showtris);
+void R_DrawDecals_ShowTris (void);
 void CL_RunParticles (void);
 void R_ClearParticles (void);
 

--- a/Quake/r_decals.c
+++ b/Quake/r_decals.c
@@ -78,12 +78,14 @@ static decalvertex_t     decal_batch[4 * MAX_DECALS];
 static int                       decal_batch_count = 0;
 static gltexture_t       *decal_batch_texture = NULL;
 static qboolean          decal_batch_showtris = false;
+static qboolean          decal_batch_force_white = false;
 
 static cvar_t    r_decals_cvar = {"r_decals", "1", CVAR_ARCHIVE};
 static cvar_t    r_decals_blood_cvar = {"r_decals_blood", "1", CVAR_ARCHIVE};
 static cvar_t    r_decals_bullet_cvar = {"r_decals_bullet", "1", CVAR_ARCHIVE};
 static cvar_t    r_decals_lifetime_cvar = {"r_decals_lifetime", "20", CVAR_ARCHIVE};
 static cvar_t    r_decals_max_cvar = {"r_decals_max", "128", CVAR_ARCHIVE};
+static cvar_t    r_decals_debug_cvar = {"r_decals_debug", "0", CVAR_NONE};
 
 static int R_GetDecalLimit (void)
 {
@@ -114,6 +116,7 @@ static void R_ClearDecalBatch (void)
         decal_batch_count = 0;
         decal_batch_texture = NULL;
         decal_batch_showtris = false;
+        decal_batch_force_white = false;
 }
 
 static void R_FlushDecalBatch (void)
@@ -126,7 +129,7 @@ static void R_FlushDecalBatch (void)
 
         R_InitDecalIndices ();
 
-        GL_Bind (GL_TEXTURE0, decal_batch_showtris ? whitetexture : decal_batch_texture);
+        GL_Bind (GL_TEXTURE0, (decal_batch_showtris || decal_batch_force_white) ? whitetexture : decal_batch_texture);
 
         GL_Upload (GL_ARRAY_BUFFER, decal_batch, sizeof(decal_batch[0]) * decal_batch_count * 4, &buf, &ofs);
         GL_BindBuffer (GL_ARRAY_BUFFER, buf);
@@ -140,7 +143,7 @@ static void R_FlushDecalBatch (void)
         R_ClearDecalBatch ();
 }
 
-static void R_AppendDecalToBatch (decal_t *dec, qboolean showtris)
+static void R_AppendDecalToBatch (decal_t *dec, qboolean showtris, qboolean force_white)
 {
         if (!dec->texture)
                 return;
@@ -149,13 +152,15 @@ static void R_AppendDecalToBatch (decal_t *dec, qboolean showtris)
         {
                 decal_batch_texture = dec->texture;
                 decal_batch_showtris = showtris;
+                decal_batch_force_white = force_white;
         }
 
-        if (decal_batch_count == MAX_DECALS || decal_batch_texture != dec->texture || decal_batch_showtris != showtris)
+        if (decal_batch_count == MAX_DECALS || decal_batch_texture != dec->texture || decal_batch_showtris != showtris || decal_batch_force_white != force_white)
         {
                 R_FlushDecalBatch ();
                 decal_batch_texture = dec->texture;
                 decal_batch_showtris = showtris;
+                decal_batch_force_white = force_white;
         }
 
         if (decal_batch_count == MAX_DECALS)
@@ -245,6 +250,7 @@ void R_InitDecals (void)
         Cvar_RegisterVariable (&r_decals_bullet_cvar);
         Cvar_RegisterVariable (&r_decals_lifetime_cvar);
         Cvar_RegisterVariable (&r_decals_max_cvar);
+        Cvar_RegisterVariable (&r_decals_debug_cvar);
 
         for (i = 0; i < DECAL_COUNT; i++)
                 R_GenerateDecalTexture ((decaltype_t)i);
@@ -516,6 +522,16 @@ static qboolean R_CreateDecal (const decalgeom_t *geom, float radius, decaltype_
         dec->die = cl.time + R_GetDecalLifetime ();
         dec->active = true;
         R_AssignDecalVertices (dec, geom, radius);
+
+        if (r_decals_debug_cvar.value > 0.f)
+        {
+                const char *typename = (type == DECAL_BULLET) ? "bullet" : (type == DECAL_BLOOD) ? "blood" : "unknown";
+                Con_Printf ("[decals] created %s decal at (%.2f %.2f %.2f) normal (%.2f %.2f %.2f) radius %.2f\n",
+                        typename,
+                        geom->origin[0], geom->origin[1], geom->origin[2],
+                        geom->normal[0], geom->normal[1], geom->normal[2],
+                        radius);
+        }
         return true;
 }
 
@@ -602,7 +618,7 @@ void R_DrawDecals (qboolean showtris)
                         drew = true;
                 }
 
-                R_AppendDecalToBatch (dec, showtris);
+                R_AppendDecalToBatch (dec, showtris, (!showtris && r_decals_debug_cvar.value > 0.f));
         }
 
         if (drew)

--- a/Quake/r_part.c
+++ b/Quake/r_part.c
@@ -328,6 +328,11 @@ R_RunParticleEffect
 */
 void R_RunParticleEffect (vec3_t org, vec3_t dir, int color, int count)
 {
+	if (color >= 67 && color <= 74 && count > 0)
+	{
+		R_AddBloodDecal (org, dir);
+	}
+
 	int			i, j;
 	particle_t	*p;
 


### PR DESCRIPTION
## Summary
- hook bullet impact temp entities and blood particle effects into the decal system
- initialize, update, and draw decals as part of the main render flow and showtris debug view
- add a decal debug cvar that logs placements and renders decals with a white quad for visualization

## Testing
- cmake -S . -B build *(fails: missing SDL2 development files)*

------
https://chatgpt.com/codex/tasks/task_e_6904e962b3d8832eba3e6634c35206db