### PR TITLE
Fix alias model lighting when r_lightmap is enabled

### DIFF
--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -518,11 +518,11 @@ static void R_DrawAliasModel_Real (entity_t *e, qboolean showtris)
 	// draw it
 	//
 
-	if (r_fullbright_cheatsafe || showtris)
-		lightcolor[0] = lightcolor[1] = lightcolor[2] = 0.5f;
+    if (r_fullbright_cheatsafe || r_lightmap_cheatsafe || showtris)
+            lightcolor[0] = lightcolor[1] = lightcolor[2] = 0.5f;
 
-	if (showtris)
-		entalpha = 1.f;
+        if (showtris)
+                entalpha = 1.f;
 
 	if (!R_Alias_CanAddToBatch (e))
 		R_FlushAliasInstances (showtris);


### PR DESCRIPTION
## Summary
- ensure alias models force neutral lighting when r_lightmap is active to prevent lingering dynamic light tinting

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6904fe1f7d00832e98a970399f6bbc4a