### PR TITLE
Spawn blood decals with blood particle effects

### DIFF
--- a/Quake/r_decals.c
+++ b/Quake/r_decals.c
@@ -664,7 +664,7 @@ void R_AddBulletDecal (const vec3_t point)
 {
         decalgeom_t geom;
         float radius;
-        const float tint[4] = {0.6f, 0.6f, 0.6f, 0.5f};
+        const float tint[4] = {0.6f, 0.6f, 0.6f, 0.8f};
 
         if (!r_decals_cvar.value || !r_decals_bullet_cvar.value)
                 return;
@@ -699,7 +699,7 @@ void R_AddBloodDecal (const vec3_t point, const vec3_t dir)
         vec3_t negpref;
         vec3_t up = {0.f, 0.f, 1.f};
         qboolean spawned = false;
-        const float tint[4] = {1.f, 1.f, 1.f, 0.75f};
+        const float tint[4] = {1.f, 1.f, 1.f, 0.8f};
 
         if (!r_decals_cvar.value || !r_decals_blood_cvar.value)
                 return;
@@ -793,8 +793,8 @@ static void R_SpawnBloodPool (entity_t *ent)
         vec3_t base_point;
         vec3_t up = {0.f, 0.f, 1.f};
         float large_radius = BLOOD_POOL_RADIUS;
-        const float pool_tint[4] = {1.f, 1.f, 1.f, 0.65f};
-        const float small_tint[4] = {1.f, 1.f, 1.f, 0.5f};
+        const float pool_tint[4] = {1.f, 1.f, 1.f, 0.8f};
+        const float small_tint[4] = {1.f, 1.f, 1.f, 0.8f};
         int small_count;
         int spawned = 0;
 

--- a/Quake/r_part.c
+++ b/Quake/r_part.c
@@ -331,6 +331,14 @@ void R_RunParticleEffect (vec3_t org, vec3_t dir, int color, int count)
 	int			i, j;
 	particle_t	*p;
 
+	if (count > 0)
+	{
+		int basecolor = color & ~7;
+
+		if (basecolor == 64 || basecolor == 72)
+			R_AddBloodDecal (org, dir);
+	}
+
 	for (i=0 ; i<count ; i++)
 	{
 		if (!(p = R_AllocParticle ()))


### PR DESCRIPTION
## Summary
- spawn a blood decal when blood particle effects are emitted, matching the projectile impact location
- standardize decal tint alpha values to 80% so bullet and blood decals share consistent opacity

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6905223bafc8832e919120b68c126eba