### PR TITLE
Improve dynamic light falloff and overbright usage

### DIFF
--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -112,6 +112,14 @@ float tri(float x)
 #define SCREEN_SPACE_NOISE() DITHER_NOISE(floor(gl_FragCoord.xy)+0.5)
 #define SUPPRESS_BANDING() bayer(ivec2(gl_FragCoord.xy))
 
+float saturate(float x){ return clamp(x, 0.0, 1.0); }
+
+float smoothstep01(float x)
+{
+        x = saturate(x);
+        return x * x * (3.0 - 2.0 * x);
+}
+
 float r_avertexnormal_dot(vec3 vertexnormal, vec3 dir)
 {
         float d = dot(vertexnormal, dir);
@@ -136,9 +144,13 @@ vec3 ComputeDynamicLights(vec3 world_pos, vec3 normal)
                 float radius_sq = radius * radius;
                 if (dist_sq >= radius_sq)
                         continue;
-                float dist = sqrt(dist_sq);
-                vec3 L = to_light * inversesqrt(max(dist_sq, 1e-8));
-                float attenuation = radius - dist;
+                float inv_dist = inversesqrt(max(dist_sq, 1e-8));
+                float dist = 1.0 / inv_dist;
+                float normalized = smoothstep01((radius - dist) / max(radius, 1e-4));
+                if (normalized <= 0.0)
+                        continue;
+                vec3 L = to_light * inv_dist;
+                float attenuation = normalized * radius;
                 float diffuse = max(dot(normal, L), 0.0);
                 float influence = max(diffuse, light.minlight);
                 accum += light.color * (attenuation * influence);

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -184,6 +184,12 @@ layout(location=1) out vec4 out_velocity;
 float saturate(float x){ return clamp(x,0.0,1.0); }
 vec3  saturate(vec3 v){ return clamp(v,0.0,1.0); }
 
+float smoothstep01(float x)
+{
+    x = saturate(x);
+    return x * x * (3.0 - 2.0 * x);
+}
+
 vec3 clamp_preserving_hue(vec3 value, vec3 limit)
 {
     vec3 positive = max(value, vec3(0.0));
@@ -396,14 +402,15 @@ void main()
                     float Linv = inversesqrt(Llen2);
                     float sdist = 1.0 / Linv; // ≈ length(L)
 
-                    float minlight_span = rad - minl;
-                    float attenuation = saturate((minlight_span - sdist) * (1.0/16.0));
-                    float falloff     = saturate((rad - sdist) * (1.0/256.0));
+                    float minlight_span = max(rad - minl, 1e-4);
+                    float attenuation = smoothstep01((minlight_span - sdist) / minlight_span);
+                    float falloff     = smoothstep01((rad - sdist) / max(rad, 1e-4));
 
                     if (attenuation > 0.0 && falloff > 0.0){
                         vec3  ldir = L * Linv;
                         float ndotl = max(dot(surface_normal, ldir), 0.0);
-                        vec3  light_contrib = (attenuation * falloff) * l.color;
+                        float intensity = attenuation * falloff;
+                        vec3  light_contrib = intensity * l.color;
 
                         if (ndotl > 0.0){
                             // Half-Vektor ohne sqrt: H = normalize(Ldir + V)
@@ -423,9 +430,12 @@ void main()
                 }
             }
             // saturating Add (bleibt <= 1) with hue preservation
-            vec3 dynamic_remaining = max(vec3(0.0), vec3(1.0) - total_light);
-            if (dynamic_remaining.x > 0.0 || dynamic_remaining.y > 0.0 || dynamic_remaining.z > 0.0)
-                total_light += clamp_preserving_hue(dynamic_light, dynamic_remaining);
+            if (dynamic_light.x > 0.0 || dynamic_light.y > 0.0 || dynamic_light.z > 0.0)
+            {
+                float max_dynamic = max(Overbright, 1.0);
+                vec3  cap = vec3(max_dynamic);
+                total_light = clamp_preserving_hue(total_light + dynamic_light, cap);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- smooth the dynamic light attenuation curves in the world and alias shaders for a softer falloff
- allow clustered world dynamic lights to accumulate up to the configured overbright limit instead of clamping at unity

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69053a5d89f8832e87b2179565a07aac