### PR TITLE
Use BSPX lighting direction for static shading

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -1758,8 +1758,17 @@ void R_SetupView (void)
                         !r_fullbright_cheatsafe && !r_lightmap_cheatsafe &&
                         cl.worldmodel && cl.worldmodel->deluxdata &&
                         deluxemap_texture;
+                qboolean has_directional = enable_delux && cl.worldmodel && cl.worldmodel->deluxfile;
+                unsigned int delux_flags = 0u;
 
-                r_framedata.delux_enabled = enable_delux ? 1 : 0;
+                if (enable_delux)
+                {
+                        delux_flags |= 1u; // texture + fallback normals available
+                        if (has_directional)
+                                delux_flags |= 2u; // real directional samples present
+                }
+
+                r_framedata.delux_enabled = delux_flags;
                 r_framedata._padding1 = 0;
         }
 

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -449,8 +449,8 @@ typedef struct gpuframedata_s {
 	float	zlogbias;
 	int			numlights;
 	int			prev_frame_valid;
-	int			delux_enabled;
-	int			_padding1;
+	unsigned int		delux_enabled;
+	unsigned int		_padding1;
 } gpuframedata_t;
 
 extern gpulightbuffer_t r_lightbuffer;

--- a/Quake/shaders/frame_uniforms.glsl
+++ b/Quake/shaders/frame_uniforms.glsl
@@ -25,7 +25,7 @@ layout(std140, binding=0) uniform FrameDataUBO
         float   ZLogBias;
         uint    NumLights;
         uint    PrevFrameValid;
-        uint    DeluxEnabled;
+        uint    DeluxEnabled;      // bit0: texture available, bit1: directional samples present
         uint    _Pad1;
 };
 

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -325,7 +325,7 @@ void main()
     vec3 geom_normal = fastNorm(dn);
     vec3 surface_normal = geom_normal;
 
-    if (DeluxEnabled != 0u)
+    if ((DeluxEnabled & 1u) != 0u)
     {
         vec3 accum = vec3(0.0);
         float weight = 0.0;
@@ -353,9 +353,20 @@ void main()
         }
 
         if (weight > 0.0)
-            surface_normal = fastNorm(accum);
+        {
+            vec3 normalized = fastNorm(accum);
+            surface_normal = normalized;
+        }
         else
+        {
             surface_normal = dir0;
+        }
+    }
+
+    if ((DeluxEnabled & 2u) != 0u)
+    {
+        float lambert = max(dot(surface_normal, geom_normal), 0.0);
+        static_light *= lambert;
     }
 
     vec3 total_light = clamp_preserving_hue(static_light, vec3(1.0));


### PR DESCRIPTION
## Summary
- expose deluxemap availability and directional data via bitflags in the frame uniform buffer
- modulate static lightmap samples with BSPX LIGHTINGDIR vectors when present while keeping legacy fallback lighting

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69053ff77ab0832e80472bd65ae6a80b