### PR TITLE
Fix MD5 alias fullbright textures

### DIFF
--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -68,6 +68,7 @@ typedef struct aliasinstance_s {
 #define ALIAS_INSTANCE_FLAG_PLAYER                (1 << 2)
 #define ALIAS_INSTANCE_FLAG_FULLBRIGHT_HACK       (1 << 3)
 #define ALIAS_INSTANCE_FLAG_ITEM                  (1 << 4)
+#define ALIAS_INSTANCE_FLAG_FORCE_FULLBRIGHT      (1 << 5)
 
 struct ibuf_s {
 	int			count;
@@ -540,6 +541,8 @@ static void R_DrawAliasModel_Real (entity_t *e, qboolean showtris)
                 instance->flags |= ALIAS_INSTANCE_FLAG_FULLBRIGHT_HACK;
         if (e->model->flags & EF_ROTATE)
                 instance->flags |= ALIAS_INSTANCE_FLAG_ITEM;
+        if (paliashdr->poseverttype == PV_IQM)
+                instance->flags |= ALIAS_INSTANCE_FLAG_FORCE_FULLBRIGHT;
 
 	{
 		float prev_model_matrix[16];

--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -173,6 +173,7 @@ const int ALIAS_FLAG_VIEWMODEL = 1 << 1;
 const int ALIAS_FLAG_PLAYER = 1 << 2;
 const int ALIAS_FLAG_FULLBRIGHT_HACK = 1 << 3;
 const int ALIAS_FLAG_ITEM = 1 << 4;
+const int ALIAS_FLAG_FORCE_FULLBRIGHT = 1 << 5;
 
 layout(binding=0) uniform sampler2D Tex;
 layout(binding=1) uniform sampler2D FullbrightTex;
@@ -326,7 +327,7 @@ void main()
         vec3 shadedColor = mix(baseColor, baseColor * lighting, baseSample.a);
 #endif
 
-        if ((in_flags & ALIAS_FLAG_ITEM) != 0)
+        if (((in_flags & ALIAS_FLAG_ITEM) != 0) || ((in_flags & ALIAS_FLAG_FORCE_FULLBRIGHT) != 0))
                 shadedColor += fullbright;
         shadedColor += emissive;
         shadedColor = clamp(shadedColor, 0.0, 1.0);


### PR DESCRIPTION
## Summary
- add a new alias instance flag so MD5/IQM models can request use of their fullbright textures
- update the alias shader to always blend fullbright maps when that flag is present

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6905e0e328fc832e9bfb35bad62e7dd4