### PR TITLE
Tighten dynamic light falloff at distance

### DIFF
--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -150,7 +150,10 @@ vec3 ComputeDynamicLights(vec3 world_pos, vec3 normal)
                 if (normalized <= 0.0)
                         continue;
                 vec3 L = to_light * inv_dist;
-                float attenuation = normalized * radius;
+                float fade = normalized * normalized;
+                float inv_radius_sq = 1.0 / max(radius_sq, 1e-4);
+                float distance_falloff = 1.0 / (1.0 + dist_sq * inv_radius_sq);
+                float attenuation = fade * distance_falloff * radius;
                 float diffuse = max(dot(normal, L), 0.0);
                 float influence = max(diffuse, light.minlight);
                 accum += light.color * (attenuation * influence);

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -418,11 +418,15 @@ void main()
                     float attenuation = smoothstep01((minlight_span - sdist) / minlight_span);
                     float falloff     = smoothstep01((rad - sdist) / max(rad, 1e-4));
                     float axialFalloff = smoothstep01((l.radius - absdist) / max(l.radius, 1e-4));
+                    float distance_sq = Llen2 + dist * dist;
+                    float inv_radius_sq = 1.0 / max(l.radius * l.radius, 1e-4);
+                    float distance_falloff = 1.0 / (1.0 + distance_sq * inv_radius_sq);
+                    falloff *= falloff;
 
                     if (attenuation > 0.0 && falloff > 0.0 && axialFalloff > 0.0){
                         vec3  ldir = L * Linv;
                         float ndotl = max(dot(surface_normal, ldir), 0.0);
-                        float intensity = attenuation * falloff * axialFalloff;
+                        float intensity = attenuation * falloff * axialFalloff * distance_falloff;
                         vec3  light_contrib = intensity * l.color;
 
                         if (ndotl > 0.0){


### PR DESCRIPTION
## Summary
- add distance-based attenuation to clustered dynamic lights so world geometry is less overlit at range
- apply matching attenuation changes to alias model lighting for consistent dynamic light behaviour

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_6905f14c29b4832e8021be03153f0855