### PR TITLE
Fix BSPX lighting byte handling

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -1758,9 +1758,27 @@ static void Mod_LoadLighting (lump_t *l)
         unsigned int path_id;
         int samplecount = 0;
         size_t bspx_rgb_samplecount = Mod_BspxPredictRgbSampleCount (mod_base, mod_bspx_filesize);
-        size_t expected_samples = (bspx_rgb_samplecount > 0) ? bspx_rgb_samplecount :
-                ((l->filelen > 0) ? (size_t) l->filelen : 0);
-        uint64_t expected_lit_size = 8ull + expected_samples * 3ull;
+
+        // FIX: bspx_rgb_samplecount ist bereits in Bytes (RGB), nicht in Samples!
+        // Wenn wir BSPX RGB-Daten haben, verwenden wir diese Größe direkt
+        // Andernfalls berechnen wir aus dem BSP lump (der grayscale ist)
+        size_t expected_lit_bytes;
+        if (bspx_rgb_samplecount > 0)
+        {
+                // BSPX gibt uns bereits RGB-Bytes zurück
+                expected_lit_bytes = bspx_rgb_samplecount;
+        }
+        else if (l->filelen > 0)
+        {
+                // BSP lump ist grayscale, also * 3 für RGB
+                expected_lit_bytes = (size_t)l->filelen * 3;
+        }
+        else
+        {
+                expected_lit_bytes = 0;
+        }
+
+        uint64_t expected_lit_size = 8ull + expected_lit_bytes;
 
         loadmodel->lightdata = NULL;
         loadmodel->deluxdata = NULL;
@@ -1789,18 +1807,55 @@ static void Mod_LoadLighting (lump_t *l)
                         i = LittleLong (((int *)data)[1]);
                         if (i == 1)
                         {
-                                if ((uint64_t)com_filesize == expected_lit_size && expected_samples <= (size_t)INT_MAX)
+                                // FIX: Verbesserte Validierung
+                                if ((uint64_t)com_filesize == expected_lit_size)
                                 {
-                                        Con_DPrintf2 ("%s loaded\n", litfilename);
-                                        loadmodel->lightdata = data + 8;
-                                        loadmodel->litfile = true;
-                                        samplecount = (int)expected_samples;
-                                        Mod_LoadDeluxemap (dlitfilename, luxfilename, samplecount);
-                                        return;
+                                        // Berechne samplecount aus den tatsächlichen Bytes
+                                        size_t actual_data_size = (size_t)com_filesize - 8;
+                                        if (actual_data_size % 3 == 0 && actual_data_size / 3 <= (size_t)INT_MAX)
+                                        {
+                                                Con_DPrintf2 ("%s loaded\n", litfilename);
+                                                loadmodel->lightdata = data + 8;
+                                                loadmodel->litfile = true;
+                                                samplecount = (int)(actual_data_size / 3);
+                                                Mod_LoadDeluxemap (dlitfilename, luxfilename, samplecount);
+                                                return;
+                                        }
                                 }
+
+                                // Wenn die Größe nicht genau passt, aber nahe dran ist, gib detaillierte Info
+                                if ((uint64_t)com_filesize != expected_lit_size)
+                                {
+                                        // Prüfe ob es vielleicht ein off-by-one bei der BSPX-Vorhersage ist
+                                        uint64_t diff = ((uint64_t)com_filesize > expected_lit_size) ?
+                                                        ((uint64_t)com_filesize - expected_lit_size) :
+                                                        (expected_lit_size - (uint64_t)com_filesize);
+
+                                        if (diff <= 3 && (size_t)(com_filesize - 8) % 3 == 0)
+                                        {
+                                                // Kleine Diskrepanz, wahrscheinlich harmlos - lade trotzdem
+                                                Con_DWarning ("Minor size mismatch in %s (expected %" SDL_PRIu64 ", got %" SDL_PRIs64 ", diff %" SDL_PRIu64 ")\n",
+                                                        litfilename, expected_lit_size, com_filesize, diff);
+
+                                                size_t actual_data_size = (size_t)com_filesize - 8;
+                                                loadmodel->lightdata = data + 8;
+                                                loadmodel->litfile = true;
+                                                samplecount = (int)(actual_data_size / 3);
+                                                Mod_LoadDeluxemap (dlitfilename, luxfilename, samplecount);
+                                                return;
+                                        }
+                                }
+
                                 Hunk_FreeToLowMark (mark);
                                 Con_Printf ("Outdated .lit file (%s should be %" SDL_PRIu64 " bytes, not %" SDL_PRIs64 ")\n",
                                         litfilename, expected_lit_size, com_filesize);
+
+                                // Debug info wenn BSPX beteiligt ist
+                                if (bspx_rgb_samplecount > 0)
+                                {
+                                        Con_DPrintf2 ("  (BSPX predicted %zu RGB bytes, BSP lump has %d bytes)\n",
+                                                bspx_rgb_samplecount, l->filelen);
+                                }
                         }
                         else
                         {
@@ -1815,6 +1870,7 @@ static void Mod_LoadLighting (lump_t *l)
                 }
         }
 
+        // Wenn wir BSPX RGB lighting haben, verwenden wir das
         if (bspx_rgb_samplecount > 0)
         {
                 if (bspx_rgb_samplecount > (size_t)INT_MAX)
@@ -1824,7 +1880,9 @@ static void Mod_LoadLighting (lump_t *l)
                 }
                 else
                 {
-                        Mod_LoadDeluxemap (dlitfilename, luxfilename, (int)bspx_rgb_samplecount);
+                        // Berechne samplecount: bspx_rgb_samplecount ist in Bytes, wir brauchen die Anzahl der Samples
+                        samplecount = (int)(bspx_rgb_samplecount / 3);
+                        Mod_LoadDeluxemap (dlitfilename, luxfilename, samplecount);
                         return;
                 }
         }


### PR DESCRIPTION
## Summary
- correct the expected byte calculation for BSPX RGB lighting data
- enhance .lit validation and allow tolerating minor size mismatches
- compute deluxemap sample counts from actual RGB byte lengths

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69061d9bad0c832ea70aeb358f7db643