### PR TITLE
Align decompressed vis buffer allocations

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -267,7 +267,7 @@ static byte *Mod_DecompressVis (byte *in, qmodel_t *model)
 
 	if (!mod_decompressed || row > mod_decompressed_capacity)
 	{
-		size_t new_capacity = row;
+		size_t new_capacity = (row + (size_t)VIS_ALIGN_MASK) & ~((size_t)VIS_ALIGN_MASK);
 		byte *newbuf = (byte *) realloc (mod_decompressed, new_capacity);
 		if (!newbuf)
 			Sys_Error ("Mod_DecompressVis: realloc() failed on %zu bytes", new_capacity);


### PR DESCRIPTION
## Summary
- round Mod_DecompressVis buffer reallocation size up to VIS alignment to match consumers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6906358001a8832eba00435e42c709ca