### PR TITLE
Handle missing BSP texture data safely

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -666,7 +666,10 @@ static void Mod_LoadTextures (lump_t *l)
 	{
 		m->dataofs[i] = LittleLong(m->dataofs[i]);
 		if (m->dataofs[i] == -1)
+		{
+			loadmodel->textures[i] = NULL;
 			continue;
+		}
 
 		int dataofs = m->dataofs[i];
 		if (dataofs < 0 || (size_t)l->filelen < sizeof(*mt) || (size_t)dataofs > (size_t)l->filelen - sizeof(*mt))
@@ -693,6 +696,7 @@ static void Mod_LoadTextures (lump_t *l)
 		if (mt->width <= 0 || mt->height <= 0)
 		{
 			Con_Warning ("Zero sized texture %s in %s!\n", mt->name, loadmodel->name);
+			loadmodel->textures[i] = NULL;
 			continue;
 		}
 


### PR DESCRIPTION
## Summary
- ensure BSP textures with missing data offsets are recorded as null so later code can fall back to dummy textures
- mark zero-sized BSP textures as missing to avoid dereferencing uninitialized texture pointers

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_69063640ced4832ebcbcda7c46029760