### PR TITLE
Add underwater caustics rendering

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -27,6 +27,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 extern gltexture_t *deluxemap_texture;
 
+extern gltexture_t *r_caustics_texture;
+
 qboolean	r_cache_thrash;		// compatability
 
 gpuframedata_t r_framedata;
@@ -205,6 +207,10 @@ cvar_t	r_dof = { "r_dof", "0", CVAR_ARCHIVE };
 cvar_t	r_rim_alias = { "r_rim_alias", "0.25", CVAR_ARCHIVE };
 cvar_t	r_rim_world = { "r_rim_world", "0.15", CVAR_ARCHIVE };
 cvar_t	r_rim_exponent = { "r_rim_exponent", "4.0", CVAR_ARCHIVE };
+cvar_t	r_caustics = { "r_caustics", "1", CVAR_ARCHIVE };
+cvar_t	r_caustics_strength = { "r_caustics_strength", "0.6", CVAR_ARCHIVE };
+cvar_t	r_caustics_scale = { "r_caustics_scale", "0.035", CVAR_ARCHIVE };
+cvar_t	r_caustics_speed = { "r_caustics_speed", "0.8", CVAR_ARCHIVE };
 cvar_t	r_dof_focus = { "r_dof_focus", "64", CVAR_ARCHIVE };
 cvar_t	r_dof_range = { "r_dof_range", "48", CVAR_ARCHIVE };
 cvar_t	r_dof_strength = { "r_dof_strength", "6", CVAR_ARCHIVE };
@@ -1838,17 +1844,42 @@ void R_SetupView (void)
 	V_SetContentsColor (r_viewleaf->contents);
 	V_CalcBlend ();
 
+	int viewer_contents = r_viewleaf ? r_viewleaf->contents : 0;
+	qboolean forced_underwater = M_ForcedUnderwater ();
+	qboolean viewer_underwater =
+		(viewer_contents == CONTENTS_WATER || viewer_contents == CONTENTS_SLIME) ||
+		cl.forceunderwater || forced_underwater;
+
+	{
+		float layer_count = (float)R_CAUSTICS_TEXTURE_COUNT;
+		float inv_layer_count = layer_count > 0.f ? 1.f / layer_count : 0.f;
+		float caustic_scale = q_max(0.001f, r_caustics_scale.value);
+		float caustic_speed = q_max(0.01f, r_caustics_speed.value);
+		float strength = 0.f;
+		if (viewer_underwater && r_caustics_texture && r_caustics.value > 0.f)
+			strength = q_max(0.f, r_caustics_strength.value);
+		r_framedata.caustics_params0[0] = strength;
+		r_framedata.caustics_params0[1] = caustic_scale;
+		r_framedata.caustics_params0[2] = caustic_speed;
+		r_framedata.caustics_params0[3] = layer_count;
+		r_framedata.caustics_params1[0] = inv_layer_count;
+		r_framedata.caustics_params1[1] = 0.35f;
+		r_framedata.caustics_params1[2] = 0.6f;
+		r_framedata.caustics_params1[3] = 0.f;
+	}
+
 	//johnfitz -- calculate r_fovx and r_fovy here
 	r_fovx = r_refdef.fov_x;
 	r_fovy = r_refdef.fov_y;
 	water_warp = false;
 	if (r_waterwarp.value)
 	{
-		int contents = Mod_PointInLeaf (r_origin, cl.worldmodel)->contents;
-		qboolean forced = M_ForcedUnderwater ();
-		if (contents == CONTENTS_WATER || contents == CONTENTS_SLIME || contents == CONTENTS_LAVA || cl.forceunderwater || forced)
+		qboolean warp_underwater =
+			(viewer_contents == CONTENTS_WATER || viewer_contents == CONTENTS_SLIME || viewer_contents == CONTENTS_LAVA) ||
+			cl.forceunderwater || forced_underwater;
+		if (warp_underwater)
 		{
-			double t = forced ? realtime : cl.time;
+			double t = forced_underwater ? realtime : cl.time;
 			if (r_waterwarp.value > 1.f)
 			{
 				//variance is a percentage of width, where width = 2 * tan(fov / 2) otherwise the effect is too dramatic at high FOV and too subtle at low FOV.  what a mess!

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -53,6 +53,10 @@ extern cvar_t r_alphasort;
 extern cvar_t r_oit;
 extern cvar_t r_dither;
 extern cvar_t r_dof;
+extern cvar_t r_caustics;
+extern cvar_t r_caustics_strength;
+extern cvar_t r_caustics_scale;
+extern cvar_t r_caustics_speed;
 extern cvar_t r_dof_autofocus;
 extern cvar_t r_dof_focus;
 extern cvar_t r_dof_range;
@@ -105,10 +109,99 @@ extern cvar_t r_simd;
 #endif
 qboolean use_simd;
 
+gltexture_t *r_caustics_texture;
+
 extern gltexture_t *playertextures[MAX_SCOREBOARD]; //johnfitz
 
 extern char r_showbboxes_filter_strings[MAXCMDLINE];
 extern qboolean r_showbboxes_filter_byindex;
+
+static float R_SampleCausticPattern(float x, float y, float time)
+{
+        const float angles[3] = { 0.0f, 2.09439510239f, 4.18879020479f };
+        float sum = 0.f;
+        float detail = 0.f;
+        for (int i = 0; i < 3; ++i)
+        {
+                float angle = angles[i];
+                float cs = cosf(angle);
+                float sn = sinf(angle);
+                float wave = sinf((x * cs + y * sn) * 3.5f + time * (1.3f + 0.45f * i));
+                float cross = sinf((x * -sn + y * cs) * 3.5f - time * (1.1f + 0.35f * i));
+                sum += wave;
+                detail += cross;
+        }
+        float base = sum * (1.f / 3.f);
+        float highlight = powf(q_max(0.f, 1.f - fabsf(base)), 3.f);
+        float fine = powf(q_max(0.f, 1.f - fabsf(detail * (1.f / 3.f))), 6.f);
+        return CLAMP(0.f, highlight + fine * 0.65f, 1.f);
+}
+
+static void R_BuildCausticLayer(unsigned *dst, float phase)
+{
+        const float scale = 4.5f;
+        const int size = R_CAUSTICS_TEXTURE_SIZE;
+        float time = phase * 6.28318530718f;
+        for (int y = 0; y < size; ++y)
+        {
+                for (int x = 0; x < size; ++x)
+                {
+                        float u = (x + 0.5f) / (float)size;
+                        float v = (y + 0.5f) / (float)size;
+                        float intensity = R_SampleCausticPattern(u * scale, v * scale, time);
+                        intensity = intensity * 0.85f + 0.1f;
+                        intensity = CLAMP(0.f, intensity, 1.f);
+                        unsigned value = (unsigned)(intensity * 255.f + 0.5f);
+                        dst[y * size + x] = (value) | (value << 8) | (value << 16) | 0xFF000000u;
+                }
+        }
+}
+
+static void R_InitCaustics(void)
+{
+        if (isDedicated)
+                return;
+        if (r_caustics_texture)
+                return;
+
+        unsigned *layers[R_CAUSTICS_TEXTURE_COUNT];
+        unsigned *layer_ptrs[R_CAUSTICS_TEXTURE_COUNT];
+        size_t pixels = (size_t)R_CAUSTICS_TEXTURE_SIZE * R_CAUSTICS_TEXTURE_SIZE;
+
+        for (int i = 0; i < R_CAUSTICS_TEXTURE_COUNT; ++i)
+        {
+                layers[i] = (unsigned *) Z_Malloc(pixels * sizeof(unsigned));
+                R_BuildCausticLayer(layers[i], (float)i / (float)R_CAUSTICS_TEXTURE_COUNT);
+                layer_ptrs[i] = layers[i];
+        }
+
+        gltexture_t *tex = TexMgr_LoadImageEx(
+                NULL,
+                "procedural_caustics",
+                R_CAUSTICS_TEXTURE_SIZE,
+                R_CAUSTICS_TEXTURE_SIZE,
+                R_CAUSTICS_TEXTURE_COUNT,
+                SRC_RGBA,
+                (byte *) layer_ptrs,
+                "",
+                0,
+                TEXPREF_PERSIST | TEXPREF_LINEAR | TEXPREF_MIPMAP | TEXPREF_NOPICMIP | TEXPREF_ARRAY
+        );
+
+        if (!tex)
+        {
+                Con_DPrintf("R_InitCaustics: failed to create caustic texture
+");
+        }
+        else
+        {
+                r_caustics_texture = tex;
+        }
+
+        for (int i = 0; i < R_CAUSTICS_TEXTURE_COUNT; ++i)
+                Z_Free(layers[i]);
+}
+
 
 /*
 ====================
@@ -380,6 +473,10 @@ void R_Init (void)
 	Cvar_RegisterVariable (&r_rim_alias);
 	Cvar_RegisterVariable (&r_rim_world);
 	Cvar_RegisterVariable (&r_rim_exponent);
+	Cvar_RegisterVariable (&r_caustics);
+	Cvar_RegisterVariable (&r_caustics_strength);
+	Cvar_RegisterVariable (&r_caustics_scale);
+	Cvar_RegisterVariable (&r_caustics_speed);
         Cvar_RegisterVariable (&r_dof_autofocus);
 	Cvar_RegisterVariable (&r_dof_focus);
 	Cvar_RegisterVariable (&r_dof_range);
@@ -480,6 +577,7 @@ void R_Init (void)
 
 	Sky_Init (); //johnfitz
 	Fog_Init (); //johnfitz
+	R_InitCaustics ();
 }
 
 /*

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -441,6 +441,8 @@ typedef struct gpuframedata_s {
 	float	rim_world;
 	float	rim_exponent;
 	float	rim_pad0;
+	float	caustics_params0[4];
+	float	caustics_params1[4];
 	vec3_t	eyepos;
 	float	time;
 	vec3_t	prev_eyepos;
@@ -455,6 +457,11 @@ typedef struct gpuframedata_s {
 
 extern gpulightbuffer_t r_lightbuffer;
 extern gpuframedata_t r_framedata;
+
+#define R_CAUSTICS_TEXTURE_SIZE 128
+#define R_CAUSTICS_TEXTURE_COUNT 32
+
+extern gltexture_t *r_caustics_texture;
 
 void R_AnimateLight (void);
 void R_MarkSurfaces (void);

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -30,6 +30,7 @@ extern cvar_t r_oit;
 
 extern gltexture_t *lightmap_texture;
 extern gltexture_t *deluxemap_texture;
+extern gltexture_t *r_caustics_texture;
 
 extern GLuint gl_bmodel_vbo;
 extern size_t gl_bmodel_vbo_size;
@@ -530,6 +531,7 @@ static void R_DrawBrushModels_Real (entity_t **ents, int count, brushpass_t pass
                 GL_Bind (GL_TEXTURE3, NULL);
         }
 
+        GL_Bind (GL_TEXTURE5, r_caustics_texture);
         GL_Upload (GL_SHADER_STORAGE_BUFFER, bmodel_instances, sizeof(bmodel_instances[0]) * totalinst, &buf, &ofs);
         GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 2, buf, (GLintptr)ofs, sizeof(bmodel_instances[0]) * totalinst);
 
@@ -634,6 +636,7 @@ void R_DrawBrushModels_Water (entity_t **ents, int count, qboolean translucent)
                 GL_Bind (GL_TEXTURE3, use_delux ? deluxemap_texture : NULL);
         }
 
+        GL_Bind (GL_TEXTURE5, r_caustics_texture);
 	GL_Upload (GL_SHADER_STORAGE_BUFFER, bmodel_instances, sizeof(bmodel_instances[0]) * totalinst, &buf, &ofs);
 	GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 2, buf, (GLintptr)ofs, sizeof(bmodel_instances[0]) * count);
 

--- a/Quake/shaders/frame_uniforms.glsl
+++ b/Quake/shaders/frame_uniforms.glsl
@@ -17,6 +17,8 @@ layout(std140, binding=0) uniform FrameDataUBO
         float   RimWorld;
         float   RimExponent;
         float   _PadRim;
+        vec4    CausticsParams0;
+        vec4    CausticsParams1;
         vec3    EyePos;
         float   Time;
         vec3    PrevEyePos;

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -9,6 +9,8 @@
 layout(binding=2) uniform sampler2D LMTex;
 layout(binding=3) uniform sampler2D DeluxTex;
 
+layout(binding=5) uniform sampler2DArray CausticsTex;
+
 #include "frame_uniforms.glsl"
 
 #define LIGHT_TILES_X 32
@@ -453,6 +455,60 @@ void main()
                 vec3  cap = vec3(max_dynamic);
                 total_light = clamp_preserving_hue(total_light + dynamic_light, cap);
             }
+        }
+    }
+
+    if (CausticsParams0.x > 0.0 && CausticsParams0.w > 0.5)
+    {
+        float layerCount = CausticsParams0.w;
+        float invLayerCount = CausticsParams1.x;
+        float speed = CausticsParams0.z;
+        float anim = Time * speed;
+        float frame = anim * layerCount;
+        float cycles = floor(frame * invLayerCount);
+        float wrapped = frame - layerCount * cycles;
+        float layer0 = floor(wrapped);
+        float blend = wrapped - layer0;
+        float layer1 = layer0 + 1.0;
+        if (layer1 >= layerCount)
+            layer1 -= layerCount;
+
+        vec2 worldXY = in_pos.xy * CausticsParams0.y;
+        vec2 offsetA = vec2(Time * 0.053, Time * 0.071);
+        vec2 offsetB = vec2(-Time * 0.041, Time * 0.029);
+        const mat2 rot = mat2(0.7660444, -0.6427876, 0.6427876, 0.7660444);
+
+        vec2 uvA = fract(worldXY + offsetA);
+        vec2 uvB = fract(rot * worldXY + offsetB);
+
+        float causticA0 = texture(CausticsTex, vec3(uvA, layer0)).r;
+        float causticA1 = texture(CausticsTex, vec3(uvA, layer1)).r;
+        float causticA = mix(causticA0, causticA1, blend);
+
+        float causticB0 = texture(CausticsTex, vec3(uvB, layer0)).r;
+        float causticB1 = texture(CausticsTex, vec3(uvB, layer1)).r;
+        float causticB = mix(causticB0, causticB1, blend);
+
+        float mixFactor = clamp(CausticsParams1.y, 0.0, 1.0);
+        float pattern = mix(causticA, causticB, mixFactor);
+        pattern = pow(clamp(pattern, 0.0, 1.0), 1.35);
+
+        float alignment = max(dot(surface_normal, vec3(0.0, 0.0, 1.0)), 0.0);
+        float normalPower = max(CausticsParams1.z, 0.001);
+        float orientation = pow(alignment, normalPower);
+        float caustic = pattern * orientation;
+
+        if (CausticsParams1.w > 0.0)
+        {
+            float depth = max(EyePos.z - in_pos.z, 0.0);
+            caustic *= exp(-depth * CausticsParams1.w);
+        }
+
+        vec3 causticLight = vec3(caustic * CausticsParams0.x);
+        if (causticLight.x > 0.0 || causticLight.y > 0.0 || causticLight.z > 0.0)
+        {
+            vec3 causticRemaining = max(vec3(0.0), vec3(1.0) - total_light);
+            total_light += clamp_preserving_hue(causticLight, causticRemaining);
         }
     }
 


### PR DESCRIPTION
## Summary
- generate a procedural caustics texture array at initialization and expose tuning cvars
- extend frame data and shaders to animate caustic lighting when the player is submerged
- bind the caustic texture during world and water rendering passes

## Testing
- cmake -S . -B build -GNinja *(fails: missing SDL2 configuration)*

------
https://chatgpt.com/codex/tasks/task_e_690666bf32d4832ea0322ea2d7aef2b0