### PR TITLE
Optimize decal rendering and add metal specular

### DIFF
--- a/Quake/r_decals.c
+++ b/Quake/r_decals.c
@@ -118,6 +118,7 @@ static GLushort          *decal_indices = NULL;
 static qboolean          decal_indices_init = false;
 
 static decalvertex_t     *decal_batch = NULL;
+static decal_t           **decal_draw_list = NULL;
 static int                       decal_batch_count = 0;
 static gltexture_t       *decal_batch_texture = NULL;
 static qboolean          decal_batch_showtris = false;
@@ -195,6 +196,15 @@ static void R_ReserveDecalStorage (int desired)
                 if ((size_t)new_capacity > old_capacity)
                         memset (new_batch + old_capacity * 4, 0, ((size_t)new_capacity - old_capacity) * 4 * sizeof (*decal_batch));
                 decal_batch = new_batch;
+        }
+
+        {
+                decal_t **new_draw_list = (decal_t **) realloc (decal_draw_list, (size_t)new_capacity * sizeof (*decal_draw_list));
+                if (!new_draw_list)
+                        Sys_Error ("R_ReserveDecalStorage: failed to allocate %zu bytes for decal draw list", (size_t)new_capacity * sizeof (*decal_draw_list));
+                if ((size_t)new_capacity > old_capacity)
+                        memset (new_draw_list + old_capacity, 0, ((size_t)new_capacity - old_capacity) * sizeof (*decal_draw_list));
+                decal_draw_list = new_draw_list;
         }
 
         r_decal_capacity = new_capacity;
@@ -276,6 +286,22 @@ static void R_RemoveExcessDecals (int limit)
 
                 R_DeactivateDecal (oldest);
         }
+}
+
+static int R_CompareDecalTexture (const void *a, const void *b)
+{
+        const decal_t *const *da = (const decal_t *const *) a;
+        const decal_t *const *db = (const decal_t *const *) b;
+
+        if ((*da)->texture < (*db)->texture)
+                return -1;
+        if ((*da)->texture > (*db)->texture)
+                return 1;
+        if (*da < *db)
+                return -1;
+        if (*da > *db)
+                return 1;
+        return 0;
 }
 
 static void R_InitDecalIndices (void)
@@ -499,10 +525,18 @@ void R_UpdateDecals (void)
         double t = cl.time;
         qboolean debug = r_decals_debug_cvar.value != 0.f;
 
-        R_RemoveExcessDecals (limit);
+        if (limit <= 0)
+        {
+                R_RemoveExcessDecals (limit);
+                R_ClearDecalBatch ();
+                return;
+        }
 
         if (r_active_decal_count <= 0 || !r_decals || r_decal_capacity <= 0)
+        {
+                R_ClearDecalBatch ();
                 return;
+        }
 
         for (i = 0; i < r_decal_capacity; i++)
         {
@@ -951,7 +985,7 @@ static qboolean R_CreateDecal (const decalgeom_t *geom, float radius, decaltype_
         {
                 float spec = 0.f;
                 if (type == DECAL_BLOOD)
-                        spec = 0.5f * CLAMP (0.f, dec->tint[3], 1.f);
+                        spec = 0.2f * CLAMP (0.f, dec->tint[3], 1.f);
                 R_AssignDecalVertices (dec, geom, radius, spec);
         }
 
@@ -1205,12 +1239,13 @@ void R_AddGibDecal (const vec3_t point, int particle_count)
 void R_DrawDecals (qboolean showtris)
 {
         int i;
+        int draw_count = 0;
         qboolean drew = false;
 
         if (!r_decals_cvar.value)
                 return;
 
-        if (r_active_decal_count <= 0 || !r_decals || r_decal_capacity <= 0)
+        if (r_active_decal_count <= 0 || !r_decals || r_decal_capacity <= 0 || !decal_draw_list)
         {
                 R_ClearDecalBatch ();
                 return;
@@ -1223,6 +1258,20 @@ void R_DrawDecals (qboolean showtris)
                         continue;
                 if (!dec->texture)
                         continue;
+                decal_draw_list[draw_count++] = dec;
+        }
+
+        if (!draw_count)
+        {
+                R_ClearDecalBatch ();
+                return;
+        }
+
+        qsort (decal_draw_list, (size_t) draw_count, sizeof (decal_draw_list[0]), R_CompareDecalTexture);
+
+        for (i = 0; i < draw_count; i++)
+        {
+                decal_t *dec = decal_draw_list[i];
 
                 if (!drew)
                 {

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -23,6 +23,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // r_world.c: world model rendering
 
 #include "quakedef.h"
+#include <ctype.h>
+#include <string.h>
 
 extern cvar_t gl_fullbrights, r_oldskyleaf, r_showtris; //johnfitz
 extern cvar_t gl_zfix; // QuakeSpasm z-fighting fix
@@ -145,12 +147,48 @@ Returns the water alpha to use for the entity and texture type combination.
 */
 float GL_WaterAlphaForEntityTextureType (entity_t *ent, textype_t type)
 {
-	float entalpha;
-	if (ent == NULL || ent->alpha == ENTALPHA_DEFAULT)
-		entalpha = GL_WaterAlphaForTextureType(type);
-	else
-		entalpha = ENTALPHA_DECODE(ent->alpha);
-	return entalpha;
+        float entalpha;
+        if (ent == NULL || ent->alpha == ENTALPHA_DEFAULT)
+                entalpha = GL_WaterAlphaForTextureType(type);
+        else
+                entalpha = ENTALPHA_DECODE(ent->alpha);
+        return entalpha;
+}
+
+static qboolean R_TextureNameContains (const texture_t *tex, const char *needle)
+{
+        size_t i;
+        size_t max = sizeof(((texture_t *)0)->name);
+        char lowered[sizeof(((texture_t *)0)->name) + 1];
+
+        if (!tex || !needle || !*needle)
+                return false;
+
+        for (i = 0; i < max; i++)
+        {
+                char c = tex->name[i];
+                lowered[i] = (char)tolower ((unsigned char)c);
+                if (!c)
+                {
+                        i++;
+                        break;
+                }
+        }
+
+        if (i > max)
+                i = max;
+        lowered[i] = '\0';
+
+        return strstr (lowered, needle) != NULL;
+}
+
+static float R_GetTextureSpecular (const texture_t *tex)
+{
+        if (!tex)
+                return 0.f;
+        if (R_TextureNameContains (tex, "metal"))
+                return 0.1f;
+        return 0.f;
 }
 
 typedef struct bmodel_gpu_instance_s {
@@ -163,6 +201,8 @@ typedef struct bmodel_gpu_instance_s {
 typedef struct bmodel_bindless_gpu_call_s {
 	GLuint		flags;
 	GLfloat		alpha;
+	GLfloat		specular;
+	GLfloat		pad;
 	GLuint64	texture;
 	GLuint64	fullbright;
 	GLuint64	emissive;
@@ -171,6 +211,7 @@ typedef struct bmodel_bindless_gpu_call_s {
 typedef struct bmodel_bound_gpu_call_s {
 	GLuint		flags;
 	GLfloat		alpha;
+	GLfloat		specular;
 	GLint		baseinstance;
 	GLint		padding;
 } bmodel_bound_gpu_call_t;
@@ -330,6 +371,7 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
 {
 	GLuint		flags;
 	float		alpha;
+	float		specular;
 	gltexture_t	*tx, *fb, *em;
 
 	if (num_bmodel_calls == MAX_BMODEL_DRAWS)
@@ -360,12 +402,15 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
         if (t && t->type == TEXTYPE_CUTOUT)
                 flags |= CALLFLAG_ALPHA_TEST;
         alpha = t ? GL_WaterAlphaForTextureType (t->type) : 1.f;
+        specular = R_GetTextureSpecular (t);
 
 	if (gl_bindless_able)
 	{
 		bmodel_bindless_gpu_call_t *call = &bmodel_calls.bindless.params[num_bmodel_calls];
 		call->flags = flags;
 		call->alpha = alpha;
+		call->specular = specular;
+		call->pad = 0.f;
 		call->texture = tx ? tx->bindless_handle : greytexture->bindless_handle;
 		call->fullbright = fb ? fb->bindless_handle : blacktexture->bindless_handle;
 		call->emissive = em ? em->bindless_handle : blacktexture->bindless_handle;
@@ -376,6 +421,7 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
 		gltexture_t **textures = bmodel_calls.bound.textures[num_bmodel_calls];
 		call->flags = flags;
 		call->alpha = alpha;
+		call->specular = specular;
 		call->baseinstance = first_instance;
 		call->padding = 0;
 		textures[0] = tx ? tx : greytexture;

--- a/Quake/shaders/sky_cubemap.vert
+++ b/Quake/shaders/sky_cubemap.vert
@@ -19,7 +19,9 @@ struct Call
 {
 	uint	flags;
 	float	wateralpha;
+	float	specular;
 #if BINDLESS
+	float	pad;
 	uvec2	txhandle;
 	uvec2	fbhandle;
 	uvec2	emhandle;

--- a/Quake/shaders/sky_layers.vert
+++ b/Quake/shaders/sky_layers.vert
@@ -19,7 +19,9 @@ struct Call
 {
 	uint	flags;
 	float	wateralpha;
+	float	specular;
 #if BINDLESS
+	float	pad;
 	uvec2	txhandle;
 	uvec2	fbhandle;
 	uvec2	emhandle;

--- a/Quake/shaders/skystencil.vert
+++ b/Quake/shaders/skystencil.vert
@@ -19,7 +19,9 @@ struct Call
 {
 	uint	flags;
 	float	wateralpha;
+	float	specular;
 #if BINDLESS
+	float	pad;
 	uvec2	txhandle;
 	uvec2	fbhandle;
 	uvec2	emhandle;

--- a/Quake/shaders/water.vert
+++ b/Quake/shaders/water.vert
@@ -19,7 +19,9 @@ struct Call
 {
 	uint	flags;
 	float	wateralpha;
+	float	specular;
 #if BINDLESS
+	float	pad;
 	uvec2	txhandle;
 	uvec2	fbhandle;
 	uvec2	emhandle;

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -130,6 +130,8 @@ layout(location=10) flat in uvec2 in_samplers1;
 layout(location=11) noperspective in vec4 in_curr_clip;
 layout(location=12) noperspective in vec4 in_prev_clip;
 
+layout(location=13) flat in float in_specular;
+
 #define OUT_COLOR out_fragcolor
 #if OIT
 vec4 OUT_COLOR;
@@ -372,6 +374,8 @@ void main()
     vec3 total_light = clamp_preserving_hue(static_light, vec3(1.0));
     vec3 specular_light = vec3(0.0);
 
+    float specScale = max(in_specular, 0.0);
+
     vec3 to_eye = EyePos - in_pos;
     float inv_view_len = fastInvLen(to_eye);
     vec3  view_dir = (inv_view_len>0.0) ? to_eye * inv_view_len : vec3(0.0,0.0,1.0);
@@ -437,9 +441,11 @@ void main()
                                 float hinv = inversesqrt(hl2);
                                 float ndoth = max(dot(surface_normal, h*hinv), 0.0);
 
-                                // schneller Specular mit fixer Power
-                                float specTerm = specPow16(ndoth) * ndotl * (0.4); // SPECULAR_SCALE 0.4
-                                specular_light += light_contrib * specTerm;
+                                if (specScale > 0.0){
+                                    // schneller Specular mit fixer Power
+                                    float specTerm = specPow16(ndoth) * ndotl * (0.4); // SPECULAR_SCALE 0.4
+                                    specular_light += light_contrib * specTerm * specScale;
+                                }
                             }
                         }
                         dynamic_light += light_contrib;

--- a/Quake/shaders/world.vert
+++ b/Quake/shaders/world.vert
@@ -5,7 +5,6 @@
 	layout(location=0) uniform int DrawID;
 	#define DRAW_ID			DrawID
 #endif
-
 #include "frame_uniforms.glsl"
 
 vec3 ApplyFog(vec3 clr, vec3 p)
@@ -48,7 +47,9 @@ struct Call
 {
 	uint	flags;
 	float	wateralpha;
+	float	specular;
 #if BINDLESS
+	float	pad;
 	uvec2	txhandle;
 	uvec2	fbhandle;
 	uvec2	emhandle;
@@ -131,6 +132,7 @@ layout(location=8) flat out float out_lmofs;
 #endif
 layout(location=11) noperspective out vec4 out_curr_clip;
 layout(location=12) noperspective out vec4 out_prev_clip;
+layout(location=13) flat out float out_specular;
 
 void main()
 {
@@ -165,6 +167,7 @@ void main()
 #else
 	out_alpha = instance.alpha < 0.0 ? 1.0 : instance.alpha;
 #endif
+	out_specular = call.specular;
 	out_styles.x = GetLightStyle(in_styles.x);
 	if (in_styles.y == 255)
 		out_styles.yzw = vec3(-1.);


### PR DESCRIPTION
## Summary
- keep decals alive until the configured limit and batch draw calls by sorting the active decal list
- lower the blood decal specular contribution to 20%
- add a metal texture heuristic and pass per-surface specular to the world shader so metal gets a 10% highlight

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6906c8fbc010832e810940eab8345a89