### PR TITLE
Fix blood decals failing to spawn

### DIFF
--- a/Quake/r_decals.c
+++ b/Quake/r_decals.c
@@ -854,6 +854,9 @@ static qboolean R_SurfacePointHasMargin (const msurface_t *surf, const vec3_t po
                 dist = DotProduct (point, edge_normal) - DotProduct (v0->position, edge_normal);
                 dist /= edge_normal_len;
 
+                if (surf->flags & SURF_PLANEBACK)
+                        dist = -dist;
+
                 if (dist + epsilon < margin)
                         return false;
         }


### PR DESCRIPTION
## Summary
- ensure the decal edge-distance check handles back-facing surfaces

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690764232da4832ea4c47afa8979e0c4