### PR TITLE
Revamp god ray direction computation

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -102,6 +102,79 @@ static float GL_TemperedOverbright (float overbright)
 	return q_max (tempered, 1.f);
 }
 
+static void R_ComputeGodRaysDirection (float light_x, float light_y, float wall_angle,
+	float *out_dir_x, float *out_dir_y)
+{
+	const float center_x = 0.5f;
+	const float center_y = 0.5f;
+	const float min_length_sq = 1e-6f;
+
+	float delta_x = center_x - light_x;
+	float delta_y = center_y - light_y;
+	float delta_length_sq = delta_x * delta_x + delta_y * delta_y;
+
+	float normal_x;
+	float normal_y;
+
+	float horizontal_sign = (delta_x >= 0.f) ? 1.f : -1.f;
+	float vertical_sign = (delta_y >= 0.f) ? 1.f : -1.f;
+
+	if (delta_length_sq < min_length_sq)
+	{
+		normal_x = horizontal_sign;
+		normal_y = vertical_sign;
+
+		float normal_length_sq = normal_x * normal_x + normal_y * normal_y;
+		if (normal_length_sq > min_length_sq)
+		{
+			float inv_normal_length = 1.f / sqrtf (normal_length_sq);
+			normal_x *= inv_normal_length;
+			normal_y *= inv_normal_length;
+		}
+	}
+	else
+	{
+		float inv_delta_length = 1.f / sqrtf (delta_length_sq);
+		normal_x = delta_x * inv_delta_length;
+		normal_y = delta_y * inv_delta_length;
+	}
+
+	float tangent_x = -normal_y;
+	float tangent_y = normal_x;
+
+	if (tangent_y * vertical_sign < 0.f)
+	{
+		tangent_x = -tangent_x;
+		tangent_y = -tangent_y;
+	}
+
+	if (fabsf (tangent_y) < 1e-4f && tangent_x * horizontal_sign < 0.f)
+	{
+		tangent_x = -tangent_x;
+	}
+
+	float angle = q_min (90.f, q_max (0.f, wall_angle));
+	float angle_rad = DEG2RAD (angle);
+	float cos_a = cosf (angle_rad);
+	float sin_a = sinf (angle_rad);
+
+	float dir_x = normal_x * cos_a + tangent_x * sin_a;
+	float dir_y = normal_y * cos_a + tangent_y * sin_a;
+	float dir_length_sq = dir_x * dir_x + dir_y * dir_y;
+
+	if (dir_length_sq > min_length_sq)
+	{
+		float inv_dir_length = 1.f / sqrtf (dir_length_sq);
+		*out_dir_x = dir_x * inv_dir_length;
+		*out_dir_y = dir_y * inv_dir_length;
+	}
+	else
+	{
+		*out_dir_x = normal_x;
+		*out_dir_y = normal_y;
+	}
+}
+
 static qboolean MatrixInverse4x4(const float m[16], float out[16])
 {
     float inv[16];
@@ -909,16 +982,14 @@ void GL_PostProcess (void)
                 {
                         if (godrays_mode_value == 1)
                         {
+                                float vertical_sign = (godrays_light_y <= 0.5f) ? 1.f : -1.f;
                                 godrays_dir_x = 0.f;
-                                godrays_dir_y = 1.f;
+                                godrays_dir_y = vertical_sign;
                         }
                         else if (godrays_mode_value <= 0)
                         {
-                                float wall_angle = q_min (90.f, q_max (0.f, r_godrays_wall_angle.value));
-                                float angle_rad = DEG2RAD (wall_angle);
-                                float horizontal_sign = (godrays_light_x <= 0.5f) ? 1.f : -1.f;
-                                godrays_dir_x = horizontal_sign * cosf (angle_rad);
-                                godrays_dir_y = sinf (angle_rad);
+                                R_ComputeGodRaysDirection (godrays_light_x, godrays_light_y,
+                                        r_godrays_wall_angle.value, &godrays_dir_x, &godrays_dir_y);
                         }
                 }
 


### PR DESCRIPTION
## Summary
- add a helper that derives the screen-space god ray direction from light position and wall angle
- update the post-process setup to use the new helper and respect vertical orientation for mode 1

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69076a83fc1c832e9453af9fdb64cac9