### PR TITLE
Add renderer shadow map stubs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.7)
 include(${CMAKE_CURRENT_SOURCE_DIR}/Misc/cmake/ExtractVersion.cmake)
 project(ironwail VERSION ${IRONWAIL_VERSION})
 
+option(R_SHADOWMAPS "Enable shadow map stubs" ON)
+
 cmake_policy(SET CMP0072 NEW)   #OpenGL_GL_PREFERENCE to GLVND
 
 if (WIN32)
@@ -42,6 +44,7 @@ target_include_directories(wren PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/wren_vm/wren
 target_compile_definitions(wren PUBLIC WREN_OPT_META=1 WREN_OPT_RANDOM=1)
 
 list(APPEND IWAIL_SRC ${CMAKE_CURRENT_SOURCE_DIR}/wren_vm/wren_runtime.c ${CMAKE_CURRENT_SOURCE_DIR}/wren_vm/wren_bindings.c)
+list(APPEND IWAIL_SRC ${CMAKE_CURRENT_SOURCE_DIR}/renderer/r_shadows.c)
 
 list(REMOVE_ITEM IWAIL_SRC ${CMAKE_CURRENT_SOURCE_DIR}/Quake/lodepng.h)
 list(REMOVE_ITEM IWAIL_SRC ${CMAKE_CURRENT_SOURCE_DIR}/Quake/lodepng.c)
@@ -73,7 +76,7 @@ endif()
 
 add_executable(ironwail ${IWAIL_SRC})
 target_compile_features(ironwail PRIVATE c_std_11 cxx_std_17)
-target_include_directories(ironwail PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/wren_vm ${CMAKE_CURRENT_SOURCE_DIR}/wren_vm/wren/include)
+target_include_directories(ironwail PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/renderer ${CMAKE_CURRENT_SOURCE_DIR}/wren_vm ${CMAKE_CURRENT_SOURCE_DIR}/wren_vm/wren/include)
 target_link_libraries(ironwail PRIVATE wren)
 if (UNIX)
 	target_link_libraries(ironwail PRIVATE m)
@@ -105,6 +108,11 @@ else()
 endif()
 
 target_compile_definitions(ironwail PRIVATE $<$<CONFIG:Debug>:DEBUG=1> $<$<NOT:$<CONFIG:Debug>>:NDEBUG=1> USE_SDL2 USE_CODEC_WAVE)
+if (R_SHADOWMAPS)
+        target_compile_definitions(ironwail PRIVATE R_SHADOWMAPS=1)
+else()
+        target_compile_definitions(ironwail PRIVATE R_SHADOWMAPS=0)
+endif()
 if (MSVC)
 	target_compile_definitions(ironwail PRIVATE _CRT_SECURE_NO_WARNINGS _WIN32)
 endif()

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -23,6 +23,10 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "quakedef.h"
 
+#if R_SHADOWMAPS
+#include "r_shadows.h"
+#endif
+
 #define NOISESCALE     (1.0f / 127.0f)
 
 extern gltexture_t *deluxemap_texture;
@@ -2952,9 +2956,21 @@ void R_RenderView (void)
 	else if (gl_finish.value)
 		glFinish ();
 
-	R_SetupView (); //johnfitz -- this does everything that should be done once per frame
-	R_RenderScene ();
-	R_WarpScaleView ();
+        R_SetupView (); //johnfitz -- this does everything that should be done once per frame
+#if R_SHADOWMAPS
+        if (r_shadows.value)
+                R_BeginShadowPass();
+#endif
+        R_RenderScene ();
+#if R_SHADOWMAPS
+        if (r_shadows.value)
+                R_EndShadowPass();
+#endif
+        R_WarpScaleView ();
+#if R_SHADOWMAPS
+        if (r_shadows.value)
+                R_DrawShadowDebug();
+#endif
 
 	r_frame_rendered_this_update = true;
 

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -24,6 +24,10 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "quakedef.h"
 
+#if R_SHADOWMAPS
+#include "r_shadows.h"
+#endif
+
 //johnfitz -- new cvars
 extern cvar_t r_clearcolor;
 extern cvar_t r_flatlightstyles;
@@ -451,6 +455,10 @@ void R_Init (void)
 	Cvar_SetCallback (&r_lavaalpha, R_SetLavaalpha_f);
 	Cvar_SetCallback (&r_telealpha, R_SetTelealpha_f);
 	Cvar_SetCallback (&r_slimealpha, R_SetSlimealpha_f);
+
+#if R_SHADOWMAPS
+	R_InitShadowMaps();
+#endif
 
 	R_InitParticles ();
 	R_InitDecals ();

--- a/Quake/gl_shadow.c
+++ b/Quake/gl_shadow.c
@@ -1,5 +1,8 @@
 #include "quakedef.h"
 #include "gl_shadow.h"
+#if R_SHADOWMAPS
+#include "r_shadows.h"
+#endif
 #include "gl_texmgr.h"
 
 #define SHADOW_POOL_SIZE 16
@@ -338,6 +341,10 @@ void R_ShadowSyncWorldLights(const gpulight_t *lights, int numlights)
         VectorCopy(src->color, dst->color);
         dst->intensity = 1.0f;
         dst->cube_tex = shadow_manager.fallback_cube_tex;
+
+#if R_SHADOWMAPS
+        R_UploadShadowMatrices(NULL, i); // TODO: upload per-light view-projection matrices.
+#endif
 
         ++count;
     }

--- a/Quake/gl_vidsdl.c
+++ b/Quake/gl_vidsdl.c
@@ -26,6 +26,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "cfgfile.h"
 #include "bgmusic.h"
 #include "resource.h"
+#if R_SHADOWMAPS
+#include "r_shadows.h"
+#endif
 #if defined(SDL_FRAMEWORK) || defined(NO_SDL_CONFIG)
 #include <SDL2/SDL.h>
 #else
@@ -1392,6 +1395,9 @@ void	VID_Shutdown (void)
 	if (vid_initialized)
 	{
 		R_ShutdownShadow ();
+#if R_SHADOWMAPS
+		R_ShutdownShadowMaps();
+#endif
 		VID_FreeMouseCursors();
 		SDL_GL_DeleteContext(gl_context);
 		gl_context = NULL;

--- a/renderer/r_shadows.c
+++ b/renderer/r_shadows.c
@@ -1,0 +1,168 @@
+#include "quakedef.h"
+#include "r_shadows.h"
+
+#ifndef R_SHADOWMAPS
+#define R_SHADOWMAPS 0
+#endif
+
+#if !R_SHADOWMAPS
+
+void R_InitShadowMaps(void) { }
+void R_ShutdownShadowMaps(void) { }
+void R_BeginShadowPass(void) { }
+void R_EndShadowPass(void) { }
+void R_UploadShadowMatrices(const float *viewProj, int lightIndex)
+{
+	(void)viewProj;
+	(void)lightIndex;
+}
+void R_DrawShadowDebug(void) { }
+
+#else /* R_SHADOWMAPS */
+
+shadow_context_t r_shadow_context;
+
+cvar_t r_shadows = {"r_shadows", "0", CVAR_ARCHIVE};
+cvar_t r_shadows_debug = {"r_shadows_debug", "0", 0};
+cvar_t r_shadows_size = {"r_shadows_size", "2048", CVAR_ARCHIVE};
+
+static qboolean shadow_cvars_registered = false;
+static qboolean shadow_initialized = false;
+
+static void R_ShadowMaps_CreateContext(void);
+static void R_ShadowMaps_Reload_f(void);
+
+static void R_ShadowMaps_Register(void)
+{
+	if (shadow_cvars_registered)
+		return;
+
+	Cvar_RegisterVariable(&r_shadows);
+	Cvar_RegisterVariable(&r_shadows_debug);
+	Cvar_RegisterVariable(&r_shadows_size);
+	Cmd_AddCommand("r_shadows_reload", R_ShadowMaps_Reload_f);
+
+	shadow_cvars_registered = true;
+}
+
+static void R_ShadowMaps_Log(const char *message)
+{
+	if (!r_shadows_debug.value)
+		return;
+
+	Con_Printf("[ShadowMaps] %s\n", message);
+}
+
+static int R_ShadowMaps_ClampSize(int size)
+{
+	int clamped = 1;
+
+	if (size <= 0)
+		size = 1;
+
+	while (clamped < size)
+		clamped <<= 1;
+
+	if (clamped < 16)
+		clamped = 16;
+
+	return clamped;
+}
+
+static void R_ShadowMaps_CreateContext(void)
+{
+	if (!r_shadows.value)
+	{
+		R_ShadowMaps_Log("Init skipped (r_shadows is 0)");
+		return;
+	}
+
+	memset(&r_shadow_context, 0, sizeof(r_shadow_context));
+
+	r_shadow_context.size = R_ShadowMaps_ClampSize((int)r_shadows_size.value);
+	r_shadow_context.atlas_cols = 1;
+	r_shadow_context.atlas_rows = 1;
+	r_shadow_context.backend_data = NULL;
+#if defined(GLQUAKE_VERSION)
+	r_shadow_context.gl_backend_data = NULL;
+#endif
+#if defined(VKQUAKE)
+	r_shadow_context.vk_backend_data = NULL;
+#endif
+
+	shadow_initialized = true;
+
+	R_ShadowMaps_Log("Initialized stub context");
+
+	// TODO(backlog): create depth atlas, per-light FBO, pipeline state, sampler, and layout bindings.
+}
+
+void R_InitShadowMaps(void)
+{
+	R_ShadowMaps_Register();
+	R_ShutdownShadowMaps();
+	R_ShadowMaps_CreateContext();
+}
+
+void R_ShutdownShadowMaps(void)
+{
+	if (!shadow_initialized)
+		return;
+
+	shadow_initialized = false;
+	memset(&r_shadow_context, 0, sizeof(r_shadow_context));
+
+	R_ShadowMaps_Log("Shutdown stub context");
+}
+
+static void R_ShadowMaps_Reload_f(void)
+{
+	Con_Printf("[ShadowMaps] Reload requested\n");
+	R_ShutdownShadowMaps();
+	R_ShadowMaps_CreateContext();
+}
+
+void R_BeginShadowPass(void)
+{
+	if (!shadow_initialized || !r_shadows.value)
+		return;
+
+	R_ShadowMaps_Log("Begin shadow pass");
+}
+
+void R_EndShadowPass(void)
+{
+	if (!shadow_initialized || !r_shadows.value)
+		return;
+
+	R_ShadowMaps_Log("End shadow pass");
+}
+
+void R_UploadShadowMatrices(const float *viewProj, int lightIndex)
+{
+	if (!shadow_initialized || !r_shadows.value)
+		return;
+
+	(void)viewProj;
+	(void)lightIndex;
+
+	if (r_shadows_debug.value)
+		Con_Printf("[ShadowMaps] Upload shadow matrices (light %d, TODO)\n", lightIndex);
+
+	// TODO: matrix packing & cascade scheme.
+}
+
+void R_DrawShadowDebug(void)
+{
+	if (!shadow_initialized || !r_shadows.value || !r_shadows_debug.value)
+		return;
+
+	Con_Printf("[ShadowMaps] Debug draw stub (atlas %dx%d, size %d)\n",
+			r_shadow_context.atlas_cols,
+			r_shadow_context.atlas_rows,
+			r_shadow_context.size);
+
+	// TODO: PCF/EVSM options.
+}
+
+#endif /* R_SHADOWMAPS */

--- a/renderer/r_shadows.h
+++ b/renderer/r_shadows.h
@@ -1,0 +1,64 @@
+#ifndef R_SHADOWS_H
+#define R_SHADOWS_H
+
+#include "quakedef.h"
+
+#ifndef R_SHADOWMAPS
+#define R_SHADOWMAPS 0
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(GLQUAKE_VERSION)
+typedef struct shadow_gl_backend_s
+{
+    /* Placeholder for GL shadow resources. */
+    int unused;
+} shadow_gl_backend_t;
+#endif
+
+#if defined(VKQUAKE)
+typedef struct shadow_vk_backend_s
+{
+    /* Placeholder for VK shadow resources. */
+    int unused;
+} shadow_vk_backend_t;
+#endif
+
+typedef struct shadow_context_s
+{
+    int size;
+    int atlas_cols;
+    int atlas_rows;
+#if defined(GLQUAKE_VERSION)
+    /* TODO(backlog): add OpenGL handles for depth atlas and pipelines. */
+    shadow_gl_backend_t *gl_backend_data;
+#endif
+#if defined(VKQUAKE)
+    /* TODO(backlog): add Vulkan handles for depth atlas and pipelines. */
+    shadow_vk_backend_t *vk_backend_data;
+#endif
+    void *backend_data;
+} shadow_context_t;
+
+#if R_SHADOWMAPS
+extern shadow_context_t r_shadow_context;
+extern cvar_t r_shadows;
+extern cvar_t r_shadows_debug;
+extern cvar_t r_shadows_size;
+#endif
+
+void R_InitShadowMaps(void);
+void R_ShutdownShadowMaps(void);
+void R_BeginShadowPass(void);
+void R_EndShadowPass(void);
+void R_UploadShadowMatrices(const float *viewProj, int lightIndex);
+void R_DrawShadowDebug(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* R_SHADOWS_H */


### PR DESCRIPTION
## Summary
- add a renderer-agnostic shadow map stub module with cvars, reload command, and placeholder context data
- integrate the stub calls into the OpenGL renderer init/shutdown path, per-frame flow, and light upload code
- update the build to compile the new module behind an R_SHADOWMAPS feature option that is enabled by default

## Testing
- `cmake -S . -B build` *(fails: missing SDL2 development package in container)*

------
https://chatgpt.com/codex/tasks/task_e_6907717b9fa0832ea3589204c755c493