### PR TITLE
Increase OpenGL minimum requirement to 4.6

### DIFF
--- a/Quake/gl_shaders.c
+++ b/Quake/gl_shaders.c
@@ -138,7 +138,7 @@ static GLuint GL_CreateShader (GLenum type, const char *source, const char *extr
 	}
 
 	q_snprintf (header, sizeof (header),
-		"#version 430\n"
+		"#version 460\n"
 		"\n"
 		"#define BINDLESS %d\n"
 		"#define REVERSED_Z %d\n",

--- a/Quake/gl_vidsdl.c
+++ b/Quake/gl_vidsdl.c
@@ -49,7 +49,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #define MAKE_GL_VERSION(major, minor)		(((major) << 16) | (minor))
 #define MIN_GL_VERSION_MAJOR				4
-#define MIN_GL_VERSION_MINOR				3
+#define MIN_GL_VERSION_MINOR				6
 #define MIN_GL_VERSION						MAKE_GL_VERSION(MIN_GL_VERSION_MAJOR, MIN_GL_VERSION_MINOR)
 #define MIN_GL_VERSION_STR					QS_STRINGIFY(MIN_GL_VERSION_MAJOR)"."QS_STRINGIFY(MIN_GL_VERSION_MINOR)
 

--- a/README.md
+++ b/README.md
@@ -63,4 +63,4 @@ Additional engine services (physics tracing, sound, networking, etc.) currently 
 
 Notes:
 1. Requirements are based on reported OpenGL capabilities; unexpected incompatibilities may still exist.
-2. macOS is currently unsupported because Ironwail targets OpenGL 4.3 for compute shaders, while Apple only provides OpenGL up to 4.1.
+2. macOS is currently unsupported because Ironwail targets OpenGL 4.6 for compute shaders, while Apple only provides OpenGL up to 4.1.


### PR DESCRIPTION
## Summary
- raise the SDL OpenGL context request to version 4.6
- update the GLSL shader preamble to use `#version 460`
- document the new requirement in the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6907a0034abc832e83de06f384a62725