### PR TITLE
Add server-controlled multiplayer bots

### DIFF
--- a/Quake/Makefile
+++ b/Quake/Makefile
@@ -274,6 +274,7 @@ OBJS = strlcat.o \
 	pr_edict.o \
 	pr_exec.o \
 	sv_main.o \
+	sv_bot.o \
 	sv_move.o \
 	sv_phys.o \
 	sv_user.o \

--- a/Quake/host.c
+++ b/Quake/host.c
@@ -434,12 +434,15 @@ void SV_ClientPrintf (const char *fmt, ...)
 	va_list		argptr;
 	char		string[1024];
 
-	va_start (argptr,fmt);
-	q_vsnprintf (string, sizeof(string), fmt,argptr);
-	va_end (argptr);
+\tif (host_client && host_client->isbot)
+\t\treturn;
 
-	MSG_WriteByte (&host_client->message, svc_print);
-	MSG_WriteString (&host_client->message, string);
+        va_start (argptr,fmt);
+        q_vsnprintf (string, sizeof(string), fmt,argptr);
+        va_end (argptr);
+
+        MSG_WriteByte (&host_client->message, svc_print);
+        MSG_WriteString (&host_client->message, string);
 }
 
 /*
@@ -461,7 +464,7 @@ void SV_BroadcastPrintf (const char *fmt, ...)
 
 	for (i = 0; i < svs.maxclients; i++)
 	{
-		if (svs.clients[i].active && svs.clients[i].spawned)
+                if (svs.clients[i].active && svs.clients[i].spawned && !svs.clients[i].isbot)
 		{
 			MSG_WriteByte (&svs.clients[i].message, svc_print);
 			MSG_WriteString (&svs.clients[i].message, string);
@@ -506,7 +509,7 @@ void SV_DropClient (qboolean crash)
 	if (!crash)
 	{
 		// send any final messages (don't check for errors)
-		if (NET_CanSendMessage (host_client->netconnection))
+		if (host_client->netconnection && NET_CanSendMessage (host_client->netconnection))
 		{
 			MSG_WriteByte (&host_client->message, svc_disconnect);
 			NET_SendMessage (host_client->netconnection, &host_client->message);
@@ -551,9 +554,13 @@ void SV_DropClient (qboolean crash)
 		Sys_Printf ("Client %s removed\n",host_client->name);
 	}
 
-// break the net connection
-	NET_Close (host_client->netconnection);
-	host_client->netconnection = NULL;
+	// break the net connection
+	if (host_client->netconnection)
+	{
+		NET_Close (host_client->netconnection);
+		host_client->netconnection = NULL;
+	}
+	SV_Bot_ClientDisconnected (host_client);
 
 // free the client (the body stays around)
 	host_client->active = false;
@@ -561,11 +568,11 @@ void SV_DropClient (qboolean crash)
 	host_client->old_frags = -999999;
 	net_activeconnections--;
 
-// send notification to all clients
+	// send notification to all clients
 	for (i = 0, client = svs.clients; i < svs.maxclients; i++, client++)
 	{
-		if (!client->active)
-			continue;
+		if (!client->active || client->isbot)
+                        continue;
 		MSG_WriteByte (&client->message, svc_updatename);
 		MSG_WriteByte (&client->message, host_client - svs.clients);
 		MSG_WriteString (&client->message, "");

--- a/Quake/host_cmd.c
+++ b/Quake/host_cmd.c
@@ -1601,12 +1601,21 @@ static void Host_Status_f (void)
 	if (ipxAvailable)
 		print_fn ("ipx:     %s\n", my_ipx_address);
 	print_fn ("map:     %s\n", sv.name);
-	print_fn ("players: %i active (%i max)\n\n", net_activeconnections, svs.maxclients);
-	for (j = 0, client = svs.clients; j < svs.maxclients; j++, client++)
-	{
-		if (!client->active)
-			continue;
-		seconds = (int)(net_time - NET_QSocketGetTime(client->netconnection));
+\t{
+\t\tint active = 0;
+\t\tfor (j = 0, client = svs.clients; j < svs.maxclients; j++, client++)
+\t\t\tif (client->active)
+\t\t\t\tactive++;
+\t\tprint_fn ("players: %i active (%i max)\n\n", active, svs.maxclients);
+\t}
+\tfor (j = 0, client = svs.clients; j < svs.maxclients; j++, client++)
+\t{
+\t\tif (!client->active)
+\t\t\tcontinue;
+\t\tif (client->isbot || !client->netconnection)
+\t\t\tseconds = 0;
+\t\telse
+\t\t\tseconds = (int)(net_time - NET_QSocketGetTime(client->netconnection));
 		minutes = seconds / 60;
 		if (minutes)
 		{
@@ -1617,8 +1626,11 @@ static void Host_Status_f (void)
 		}
 		else
 			hours = 0;
-		print_fn ("#%-2u %-16.16s  %3i  %2i:%02i:%02i\n", j+1, client->name, (int)client->edict->v.frags, hours, minutes, seconds);
-		print_fn ("   %s\n", NET_QSocketGetAddressString(client->netconnection));
+\t\tprint_fn ("#%-2u %-16.16s  %3i  %2i:%02i:%02i\n", j+1, client->name, (int)client->edict->v.frags, hours, minutes, seconds);
+\t\tif (client->isbot || !client->netconnection)
+\t\t\tprint_fn ("   BOT\n");
+\t\telse
+\t\t\tprint_fn ("   %s\n", NET_QSocketGetAddressString(client->netconnection));
 	}
 }
 
@@ -3130,8 +3142,8 @@ static void Host_Spawn_f (void)
                         PR_ExecuteProgram (pr_global_struct->ClientConnect);
                 }
 
-		if ((Sys_DoubleTime() - NET_QSocketGetTime(host_client->netconnection)) <= qcvm->time)
-			Sys_Printf ("%s entered the game\n", host_client->name);
+\t\tif (host_client->netconnection && (Sys_DoubleTime() - NET_QSocketGetTime(host_client->netconnection)) <= qcvm->time)
+\t\t\tSys_Printf ("%s entered the game\n", host_client->name);
 
 		PR_ExecuteProgram (pr_global_struct->PutClientInServer);
 	}

--- a/Quake/server.h
+++ b/Quake/server.h
@@ -133,6 +133,7 @@ typedef struct client_s
 	qboolean		dropasap;			// has been told to go to another level
 	enum sendsignon_e	sendsignon;			// only valid before spawned
 	int				signonidx;
+	qboolean		isbot;			// true if this client is controlled by the server
 
 	double			last_message;		// reliable messages must be sent
 										// periodically
@@ -163,6 +164,11 @@ typedef struct client_s
 	char			*oldstats_s[MAX_CL_STATS];
 } client_t;
 
+// bot control helpers
+void SV_Bot_Init (void);
+void SV_Bot_Reset (void);
+void SV_Bot_RunFrame (client_t *client);
+void SV_Bot_ClientDisconnected (client_t *client);
 
 //=============================================================================
 

--- a/Quake/sv_bot.c
+++ b/Quake/sv_bot.c
@@ -1,0 +1,381 @@
+#include "quakedef.h"
+
+extern edict_t *sv_player;
+
+static cvar_t sv_bot_spawn = {"sv_bot_spawn", "0", CVAR_NONE};
+static cvar_t sv_bot_remove = {"sv_bot_remove", "0", CVAR_NONE};
+
+typedef struct
+{
+	qboolean	active;
+	vec3_t		wander_dir;
+	float		wander_yaw;
+	double		next_wander_time;
+	double		last_stuck_time;
+	vec3_t		last_position;
+} sv_bot_state_t;
+
+static sv_bot_state_t sv_bot_states[MAX_SCOREBOARD];
+static int bot_name_counter = 1;
+
+static sv_bot_state_t *SV_BotStateForClient (const client_t *client)
+{
+	ptrdiff_t index = client - svs.clients;
+	if (index < 0 || index >= MAX_SCOREBOARD)
+		return NULL;
+	return &sv_bot_states[index];
+}
+
+void SV_Bot_Reset (void)
+{
+	memset (sv_bot_states, 0, sizeof(sv_bot_states));
+	bot_name_counter = 1;
+}
+
+static void SV_Bot_PickWanderDirection (sv_bot_state_t *state)
+{
+	float yaw = (float)(rand () % 360);
+	float radians = yaw * (float)M_PI / 180.0f;
+	vec3_t dir = { (float)cos (radians), (float)sin (radians), 0.0f };
+
+	VectorNormalize (dir);
+	VectorCopy (dir, state->wander_dir);
+	state->wander_yaw = yaw;
+	state->next_wander_time = qcvm->time + 2.0 + ((float)(rand () & 255) / 255.0f) * 4.0f;
+}
+
+static qboolean SV_Bot_NameExists (const char *name)
+{
+	int i;
+
+	for (i = 0; i < svs.maxclients; i++)
+	{
+		if (!svs.clients[i].active)
+			continue;
+		if (q_strcasecmp (svs.clients[i].name, name) == 0)
+			return true;
+	}
+
+	return false;
+}
+
+static void SV_Bot_AssignName (client_t *client)
+{
+	char name[sizeof(client->name)];
+	int attempts = 0;
+
+	do
+	{
+		q_snprintf (name, sizeof(name), "Bot%d", bot_name_counter++);
+		if (bot_name_counter > 9999)
+			bot_name_counter = 1;
+	} while (SV_Bot_NameExists (name) && attempts++ < 10000);
+
+	q_strlcpy (client->name, name, sizeof(client->name));
+}
+
+static client_t *SV_Bot_FindTarget (client_t *bot, qboolean prefer_players)
+{
+	client_t *best = NULL;
+	float best_dist = 0.0f;
+	int i;
+	edict_t *self = bot->edict;
+
+	for (i = 0; i < svs.maxclients; i++)
+	{
+		client_t *candidate = &svs.clients[i];
+		vec3_t delta;
+		float dist;
+
+		if (!candidate->active || !candidate->spawned)
+			continue;
+		if (candidate == bot)
+			continue;
+		if (candidate->edict->free)
+			continue;
+		if (candidate->edict->v.health <= 0)
+			continue;
+		if (prefer_players && candidate->isbot)
+			continue;
+
+		VectorSubtract (candidate->edict->v.origin, self->v.origin, delta);
+		dist = VectorLength (delta);
+
+		if (!best || dist < best_dist)
+		{
+			best = candidate;
+			best_dist = dist;
+		}
+	}
+
+	return best;
+}
+
+static void SV_Bot_UpdateMovement (client_t *client, sv_bot_state_t *state)
+{
+	edict_t *self = client->edict;
+	usercmd_t *cmd = &client->cmd;
+	client_t *enemy = SV_Bot_FindTarget (client, true);
+	vec3_t delta;
+	double now = qcvm->time;
+
+	if (!enemy)
+		enemy = SV_Bot_FindTarget (client, false);
+
+	memset (cmd, 0, sizeof(*cmd));
+	self->v.button0 = 0;
+	self->v.button2 = 0;
+
+	if (state)
+	{
+		if (now - state->last_stuck_time > 1.0)
+		{
+			VectorSubtract (self->v.origin, state->last_position, delta);
+			if (VectorLength (delta) < 16.0f)
+				state->next_wander_time = 0.0;
+			VectorCopy (self->v.origin, state->last_position);
+			state->last_stuck_time = now;
+		}
+
+		if (state->next_wander_time <= now)
+		{
+			SV_Bot_PickWanderDirection (state);
+		}
+	}
+
+	if (enemy)
+	{
+		vec3_t dir;
+		vec3_t angles;
+		float dist;
+		qboolean retreat;
+
+		VectorSubtract (enemy->edict->v.origin, self->v.origin, dir);
+		dist = VectorLength (dir);
+		if (dist > 0)
+			VectorScale (dir, 1.0f / dist, dir);
+		else
+			VectorClear (dir);
+
+		VectorAngles (dir, angles);
+		angles[PITCH] = CLAMP (-60.0f, angles[PITCH], 60.0f);
+		VectorCopy (angles, self->v.v_angle);
+
+		retreat = (self->v.health < 40) || (dist < 100.0f);
+		if (retreat && dist < 400.0f)
+		{
+			cmd->forwardmove = -200.0f;
+			cmd->sidemove = (rand () & 1) ? 180.0f : -180.0f;
+		}
+		else
+		{
+			cmd->forwardmove = 200.0f;
+			if (dist > 80.0f)
+				cmd->sidemove = (rand () & 1) ? 120.0f : -120.0f;
+			if (dist < 600.0f)
+				self->v.button0 = 1;
+		}
+	}
+	else if (state)
+	{
+		vec3_t angles;
+
+		VectorAngles (state->wander_dir, angles);
+		VectorCopy (angles, self->v.v_angle);
+		cmd->forwardmove = 200.0f;
+		if (rand () & 1)
+			cmd->sidemove = (rand () & 1) ? 80.0f : -80.0f;
+	}
+
+	if (self->v.waterlevel >= 2)
+		cmd->upmove = 200.0f;
+
+	VectorCopy (self->v.v_angle, cmd->viewangles);
+}
+
+static qboolean SV_Bot_SpawnOne (void)
+{
+	client_t *client;
+	sv_bot_state_t *state;
+	client_t *saved_client;
+	edict_t *saved_player;
+	cmd_source_t saved_source;
+	int slot;
+
+	if (!sv.active || sv.state != ss_active)
+	{
+		Con_Printf ("Cannot spawn bot: server is not active.\n");
+		return false;
+	}
+
+	for (slot = 0; slot < svs.maxclients; slot++)
+	{
+		if (!svs.clients[slot].active)
+			break;
+	}
+
+	if (slot == svs.maxclients)
+	{
+		Con_Printf ("No free client slots for bot.\n");
+		return false;
+	}
+
+	client = &svs.clients[slot];
+	client->netconnection = NULL;
+
+	SV_ConnectClient (slot);
+	client->isbot = true;
+	client->dropasap = false;
+
+	client->colors = ((rand () & 15) << 4) | (rand () & 15);
+	SV_Bot_AssignName (client);
+
+	saved_client = host_client;
+	saved_player = sv_player;
+	saved_source = cmd_source;
+
+	host_client = client;
+	sv_player = client->edict;
+	cmd_source = src_client;
+
+	Cmd_ExecuteString ("prespawn", src_client);
+	Cmd_ExecuteString ("spawn", src_client);
+	Cmd_ExecuteString ("begin", src_client);
+
+	host_client = saved_client;
+	sv_player = saved_player;
+	cmd_source = saved_source;
+
+	client->spawned = true;
+	client->sendsignon = PRESPAWN_DONE;
+	client->last_message = realtime;
+	SZ_Clear (&client->message);
+
+	state = SV_BotStateForClient (client);
+	if (state)
+	{
+		memset (state, 0, sizeof(*state));
+		state->active = true;
+		VectorCopy (client->edict->v.origin, state->last_position);
+		state->last_stuck_time = qcvm->time;
+		state->next_wander_time = 0.0;
+	}
+
+	MSG_WriteByte (&sv.reliable_datagram, svc_updatename);
+	MSG_WriteByte (&sv.reliable_datagram, slot);
+	MSG_WriteString (&sv.reliable_datagram, client->name);
+	MSG_WriteByte (&sv.reliable_datagram, svc_updatecolors);
+	MSG_WriteByte (&sv.reliable_datagram, slot);
+	MSG_WriteByte (&sv.reliable_datagram, client->colors);
+
+	SV_BroadcastPrintf ("%s has spawned.\n", client->name);
+
+	return true;
+}
+
+static qboolean SV_Bot_RemoveOne (void)
+{
+	int slot;
+	client_t *client;
+	client_t *saved_client;
+
+	for (slot = svs.maxclients - 1; slot >= 0; slot--)
+	{
+		if (svs.clients[slot].active && svs.clients[slot].isbot)
+			break;
+	}
+
+	if (slot < 0)
+	{
+		Con_Printf ("No bots to remove.\n");
+		return false;
+	}
+
+	client = &svs.clients[slot];
+	saved_client = host_client;
+	host_client = client;
+
+	SV_Bot_ClientDisconnected (client);
+	SV_DropClient (false);
+
+	host_client = saved_client;
+	return true;
+}
+
+static void SV_BotSpawn_cvar (cvar_t *var)
+{
+	int count = (int)var->value;
+	int spawned = 0;
+
+	if (count <= 0)
+		return;
+
+	while (spawned < count)
+	{
+		if (!SV_Bot_SpawnOne ())
+			break;
+		spawned++;
+	}
+
+	if (spawned)
+		Con_Printf ("Spawned %d bot(s).\n", spawned);
+
+	Cvar_SetValueQuick (var, 0.0f);
+}
+
+static void SV_BotRemove_cvar (cvar_t *var)
+{
+	int count = (int)var->value;
+	int removed = 0;
+
+	if (count <= 0)
+		return;
+
+	while (removed < count)
+	{
+		if (!SV_Bot_RemoveOne ())
+			break;
+		removed++;
+	}
+
+	if (removed)
+		Con_Printf ("Removed %d bot(s).\n", removed);
+
+	Cvar_SetValueQuick (var, 0.0f);
+}
+
+void SV_Bot_Init (void)
+{
+	Cvar_RegisterVariable (&sv_bot_spawn);
+	Cvar_RegisterVariable (&sv_bot_remove);
+	Cvar_SetCallback (&sv_bot_spawn, SV_BotSpawn_cvar);
+	Cvar_SetCallback (&sv_bot_remove, SV_BotRemove_cvar);
+	SV_Bot_Reset ();
+}
+
+void SV_Bot_RunFrame (client_t *client)
+{
+	sv_bot_state_t *state;
+
+	if (!client || !client->isbot)
+		return;
+
+	state = SV_BotStateForClient (client);
+	if (!client->spawned)
+		return;
+
+	SV_Bot_UpdateMovement (client, state);
+}
+
+void SV_Bot_ClientDisconnected (client_t *client)
+{
+	sv_bot_state_t *state;
+
+	if (!client)
+		return;
+
+	state = SV_BotStateForClient (client);
+	if (state)
+		memset (state, 0, sizeof(*state));
+	client->isbot = false;
+}

--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -181,6 +181,8 @@ void SV_Init (void)
 
 	Cmd_AddCommand ("sv_protocol", &SV_Protocol_f); //johnfitz
 
+	SV_Bot_Init ();
+
 	for (i=0 ; i<MAX_MODELS ; i++)
 		sprintf (localmodels[i], "*%i", i);
 
@@ -390,6 +392,10 @@ CLIENT SPAWNING
 
 static qboolean SV_IsLocalClient (client_t *client)
 {
+	if (client->isbot)
+		return true;
+	if (!client->netconnection)
+		return false;
 	return Q_strcmp (NET_QSocketGetAddressString (client->netconnection), "LOCAL") == 0;
 }
 
@@ -476,7 +482,10 @@ void SV_ConnectClient (int clientnum)
 
 	client = svs.clients + clientnum;
 
-	Con_DPrintf ("Client %s connected\n", NET_QSocketGetAddressString(client->netconnection));
+	{
+		const char *address = client->netconnection ? NET_QSocketGetAddressString (client->netconnection) : "BOT";
+		Con_DPrintf ("Client %s connected\n", address);
+	}
 
 	edictnum = clientnum+1;
 
@@ -1315,7 +1324,7 @@ void SV_UpdateToReliableMessages (void)
 		{
 			for (j=0, client = svs.clients ; j<svs.maxclients ; j++, client++)
 			{
-				if (!client->active)
+				if (!client->active || client->isbot)
 					continue;
 				MSG_WriteByte (&client->message, svc_updatefrags);
 				MSG_WriteByte (&client->message, i);
@@ -1328,7 +1337,7 @@ void SV_UpdateToReliableMessages (void)
 
 	for (j=0, client = svs.clients ; j<svs.maxclients ; j++, client++)
 	{
-		if (!client->active)
+		if (!client->active || client->isbot)
 			continue;
 		SV_WriteStats (client);
 		SV_WriteUnderwaterOverride (client);
@@ -1379,6 +1388,8 @@ void SV_SendClientMessages (void)
 	for (i=0, host_client = svs.clients ; i<svs.maxclients ; i++, host_client++)
 	{
 		if (!host_client->active)
+			continue;
+		if (host_client->isbot)
 			continue;
 
 		if (host_client->spawned)
@@ -1949,6 +1960,7 @@ void SV_SpawnServer (const char *server)
 //
 	//memset (&sv, 0, sizeof(sv));
 	Host_ClearMemory ();
+	SV_Bot_Reset ();
 
 	q_strlcpy (sv.name, server, sizeof(sv.name));
 	if (developer.value || map_checks.value)

--- a/Quake/sv_user.c
+++ b/Quake/sv_user.c
@@ -617,31 +617,41 @@ SV_RunClients
 */
 void SV_RunClients (void)
 {
-	int				i;
+\tint\t\t\ti;
 
-	for (i=0, host_client = svs.clients ; i<svs.maxclients ; i++, host_client++)
-	{
-		if (!host_client->active)
-			continue;
+\tfor (i=0, host_client = svs.clients ; i<svs.maxclients ; i++, host_client++)
+\t{
+\t\tif (!host_client->active)
+\t\t\tcontinue;
 
-		sv_player = host_client->edict;
+\t\tsv_player = host_client->edict;
 
-		if (!SV_ReadClientMessage ())
-		{
-			SV_DropClient (false);	// client misbehaved...
-			continue;
-		}
+\t\tif (host_client->isbot)
+\t\t{
+\t\t\tif (!host_client->spawned)
+\t\t\t\tcontinue;
+\t\t\tSV_Bot_RunFrame (host_client);
+\t\t}
+\t\telse
+\t\t{
+\t\t\tif (!SV_ReadClientMessage ())
+\t\t\t{
+\t\t\t\tSV_DropClient (false);  // client misbehaved...
+\t\t\t\tcontinue;
+\t\t\t}
 
-		if (!host_client->spawned)
-		{
-		// clear client movement until a new packet is received
-			memset (&host_client->cmd, 0, sizeof(host_client->cmd));
-			continue;
-		}
+\t\t\tif (!host_client->spawned)
+\t\t\t{
+\t\t\t\t// clear client movement until a new packet is received
+\t\t\t\tmemset (&host_client->cmd, 0, sizeof(host_client->cmd));
+\t\t\t\tcontinue;
+\t\t\t}
+\t\t}
 
-// always pause in single player if in console or menus
-		if (!sv.paused && (svs.maxclients > 1 || key_dest == key_game) )
-			SV_ClientThink ();
-	}
+\t\t// always pause in single player if in console or menus
+\t\tif (!sv.paused && (svs.maxclients > 1 || key_dest == key_game) )
+\t\t\tSV_ClientThink ();
+\t}
 }
+
 


### PR DESCRIPTION
## Summary
- add a server-side bot module that wanders, hunts players, flees when weak, and exposes sv_bot_spawn/sv_bot_remove cvars
- flag clients controlled by the server as bots and skip network message handling, status output, and disconnects for them
- hook bot lifecycle into server init/shutdown paths and compile the new module

## Testing
- not run (SDL2 development headers unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_6907ba8b6334832e9b9eace1f5a06f1c