### PR TITLE
Fix MSVC renderer include paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,12 +46,12 @@ target_compile_definitions(wren PUBLIC WREN_OPT_META=1 WREN_OPT_RANDOM=1)
 list(APPEND IWAIL_SRC ${CMAKE_CURRENT_SOURCE_DIR}/wren_vm/wren_runtime.c ${CMAKE_CURRENT_SOURCE_DIR}/wren_vm/wren_bindings.c)
 list(APPEND IWAIL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/renderer/r_shadows.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/renderer/rw_renderer_impl.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/renderer/rw_renderer_facade.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/renderer/rw_renderer_impl.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/renderer/rw_renderer_facade.c
 )
 
 add_library(rw_renderer_iface INTERFACE)
-target_include_directories(rw_renderer_iface INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/src)
+target_include_directories(rw_renderer_iface INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/renderer)
 target_compile_definitions(rw_renderer_iface INTERFACE RW_RENDERER_DLL_READY=1 RW_RENDERER_LINK_STATIC=1)
 
 list(REMOVE_ITEM IWAIL_SRC ${CMAKE_CURRENT_SOURCE_DIR}/Quake/lodepng.h)
@@ -84,7 +84,7 @@ endif()
 
 add_executable(ironwail ${IWAIL_SRC})
 target_compile_features(ironwail PRIVATE c_std_11 cxx_std_17)
-target_include_directories(ironwail PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/renderer ${CMAKE_CURRENT_SOURCE_DIR}/src ${CMAKE_CURRENT_SOURCE_DIR}/wren_vm ${CMAKE_CURRENT_SOURCE_DIR}/wren_vm/wren/include)
+target_include_directories(ironwail PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/renderer ${CMAKE_CURRENT_SOURCE_DIR}/Quake ${CMAKE_CURRENT_SOURCE_DIR}/wren_vm ${CMAKE_CURRENT_SOURCE_DIR}/wren_vm/wren/include)
 target_link_libraries(ironwail PRIVATE rw_renderer_iface wren)
 if (UNIX)
 	target_link_libraries(ironwail PRIVATE m)

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -23,7 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // r_misc.c
 
 #include "quakedef.h"
-#include "renderer/rw_renderer.h"
+#include "../renderer/rw_renderer.h"
 
 #if R_SHADOWMAPS
 #include "r_shadows.h"

--- a/Quake/gl_screen.c
+++ b/Quake/gl_screen.c
@@ -25,7 +25,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "quakedef.h"
 #include "steam.h"
-#include "renderer/rw_renderer.h"
+#include "../renderer/rw_renderer.h"
 #include <time.h>
 
 /*

--- a/Quake/host.c
+++ b/Quake/host.c
@@ -25,7 +25,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "quakedef.h"
 #include "bgmusic.h"
 #include "steam.h"
-#include "renderer/rw_renderer.h"
+#include "../renderer/rw_renderer.h"
 #include "../wren_vm/wren_runtime.h"
 #include <setjmp.h>
 

--- a/renderer/rw_renderer_facade.c
+++ b/renderer/rw_renderer_facade.c
@@ -1,4 +1,6 @@
-#include "renderer/rw_renderer.h"
+#include "quakedef.h"
+
+#include "rw_renderer.h"
 
 static rw_renderer_t *s_active_renderer = NULL;
 

--- a/renderer/rw_renderer_impl.c
+++ b/renderer/rw_renderer_impl.c
@@ -1,10 +1,11 @@
+#include "quakedef.h"
+
 #define RW_RENDERER_EXPORTS
-#include "renderer/rw_renderer.h"
+#include "rw_renderer.h"
 
 #include <stdlib.h>
 #include <string.h>
 
-#include "../Quake/quakedef.h"
 #include "../Quake/vid.h"
 #include "../Quake/glquake.h"
 #include "../Quake/draw.h"


### PR DESCRIPTION
## Summary
- include `quakedef.h` in the renderer sources so MSVC can build its precompiled header
- point Quake sources at the renderer header via a relative include path
- update the CMake build to reference the renderer directory and expose the Quake headers

## Testing
- cmake -S . -B build *(fails: missing SDL2 development files)*

------
https://chatgpt.com/codex/tasks/task_e_6908e80d5518832eb6c64a90a0925530