### PR TITLE
Add retro particle definitions and QuakeC helpers

### DIFF
--- a/Misc/pak/Makefile
+++ b/Misc/pak/Makefile
@@ -1,8 +1,9 @@
 INPUT := gfx/menumods.lmp \
-	gfx/p_skill.lmp \
-	gfx/skillmenu.lmp \
-	gfx/sp_maps.lmp \
-	default.cfg
+        gfx/p_skill.lmp \
+        gfx/skillmenu.lmp \
+        gfx/sp_maps.lmp \
+        default.cfg \
+        effectinfo.txt
 
 OUTPUT := ironwail.pak
 

--- a/Misc/pak/effectinfo.txt
+++ b/Misc/pak/effectinfo.txt
@@ -1,0 +1,37 @@
+// Retro-minimal particle definitions for Ironwail
+// Keep parameters concise for a period-correct aesthetic.
+
+// Quick spark burst for impacts and hitscan effects
+// spawn_rate: via pointparticles count
+// lifetime: 0.35s, tight velocity for punchy look
+// base_vel: 140 ups, jitter 60
+// gravity: strong downward pull for arcade sparks
+// size: small bright pixels
+// color: warm arc flash
+// airfriction emulates quick slowdown before fade
+
+effect fx_spark_min
+    type spark
+    count 1
+    color 255 220 120
+    size 2 1
+    velocity 140 60
+    gravity 600
+    airfriction 2
+    lifetime 0.35
+
+// Soft lingering puff for bullet impacts or vents
+// base_vel: gentle upward drift, jitter for variability
+// gravity: slight negative lift keeps smoke afloat
+// color: neutral mid-grey for general use
+// size: starts compact, expands as it fades
+
+effect fx_smoke_min
+    type smoke
+    count 1
+    color 160 160 160
+    size 6 12
+    velocity 40 20
+    gravity -20
+    airfriction 1.5
+    lifetime 0.8

--- a/Quake/qc/particles.qc
+++ b/Quake/qc/particles.qc
@@ -1,0 +1,78 @@
+// particles.qc – retro-minimal particle helpers for Ironwail
+// Provides a compact API for mods while staying compatible with
+// classic TempEntity fallbacks when effectinfo-powered particles
+// are unavailable.
+
+float FX_INVALID = -1;
+float FX_SPARK = -1;
+float FX_SMOKE = -1;
+
+float particles_supported = 0;
+
+// Optional overrides for message constants. Uncomment if your
+// progs doesn't already define them in defs.qc.
+// float MSG_BROADCAST = 2;
+// float SVC_TEMPENTITY = 23;
+// float TE_GUNSHOT = 2;
+
+void() Particles_Init =
+{
+    // Detect whether the engine exposes pointparticles/effectinfo
+    if (checkextension("DP_QC_POINTPARTICLES"))
+    {
+        particles_supported = 1;
+        FX_SPARK = particleeffectnum("fx_spark_min");
+        FX_SMOKE = particleeffectnum("fx_smoke_min");
+    }
+    else
+    {
+        particles_supported = 0;
+        FX_SPARK = FX_INVALID;
+        FX_SMOKE = FX_INVALID;
+    }
+};
+
+// Spawns point particles with optional directional bias.
+// Falls back to TE_GUNSHOT bursts if the engine lacks support.
+void(float fx, vector org, vector dir, float count) Particles_Point =
+{
+    if (particles_supported && fx >= 0)
+    {
+        pointparticles(fx, org, dir, count);
+        return;
+    }
+
+    // Retro fallback: approximate the look with TempEntities.
+    if (count < 1)
+        count = 1;
+
+    local float emitted;
+    emitted = 0;
+    while (emitted < count)
+    {
+        WriteByte(MSG_BROADCAST, SVC_TEMPENTITY);
+        WriteByte(MSG_BROADCAST, TE_GUNSHOT);
+        WriteCoord(MSG_BROADCAST, org_x);
+        WriteCoord(MSG_BROADCAST, org_y);
+        WriteCoord(MSG_BROADCAST, org_z);
+        emitted = emitted + 1;
+    }
+};
+
+// Convenience helper that omits direction; the effect definition
+// controls spread/velocity.
+void(float fx, vector org, float count) Particles_Burst =
+{
+    Particles_Point(fx, org, '0 0 0', count);
+};
+
+// --- Example usage --------------------------------------------------------
+void() Test_Spark =
+{
+    Particles_Point(FX_SPARK, self.origin, v_up, 8);
+};
+
+void() Test_SmokeBurst =
+{
+    Particles_Burst(FX_SMOKE, self.origin, 12);
+};


### PR DESCRIPTION
## Summary
- add a minimal effectinfo with spark and smoke presets for retro particle support
- expose a small QuakeC helper API with runtime fallback to temp entities
- package the new effectinfo file in the default pak build

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_690b4b2c45f4832ebe045c7171dbdea8