### PR TITLE
Add textured particle atlas with fading and glow

### DIFF
--- a/Quake/r_part.c
+++ b/Quake/r_part.c
@@ -38,15 +38,137 @@ int			r_numparticles, r_numactiveparticles;
 static float uvscale;
 static float texturescalefactor; //johnfitz -- compensate for apparent size of different particle textures
 
+#define PARTICLE_TEX_TILE_SIZE          32
+#define NUM_PARTICLE_TEXTURES           4
+
+typedef struct particleappearance_s
+{
+        float   alpha_start;
+        float   alpha_end;
+        float   fade;
+        float   glow;
+        int             texture;
+} particleappearance_t;
+
+enum
+{
+        PARTICLE_TEX_SOFT = 0,
+        PARTICLE_TEX_GLOW,
+        PARTICLE_TEX_SMOKE,
+        PARTICLE_TEX_STREAK
+};
+
+static const particleappearance_t particle_appearance[] =
+{
+        {1.f, 0.f, 1.4f, 0.2f, PARTICLE_TEX_STREAK}, // pt_static
+        {1.f, 0.f, 1.1f, 0.0f, PARTICLE_TEX_SMOKE},   // pt_grav
+        {1.f, 0.f, 1.0f, 0.0f, PARTICLE_TEX_SMOKE},   // pt_slowgrav
+        {1.f, 0.f, 0.7f, 0.6f, PARTICLE_TEX_GLOW},    // pt_fire
+        {1.f, 0.f, 0.8f, 0.5f, PARTICLE_TEX_GLOW},    // pt_explode
+        {1.f, 0.f, 0.9f, 0.45f, PARTICLE_TEX_GLOW},   // pt_explode2
+        {1.f, 0.f, 1.2f, 0.0f, PARTICLE_TEX_SMOKE},   // pt_blob
+        {1.f, 0.f, 1.2f, 0.0f, PARTICLE_TEX_SMOKE}    // pt_blob2
+};
+
+static const particleappearance_t particle_appearance_default = {1.f, 0.f, 1.f, 0.f, PARTICLE_TEX_SOFT};
+
+static gltexture_t *particle_atlas;
+static float particle_atlas_tile_width;
+static float particle_atlas_tile_height;
+static float particle_atlas_tile_margin;
+
 cvar_t	r_particles = {"r_particles","2", CVAR_ARCHIVE}; //johnfitz
 
 typedef struct particlevert_t {
 	vec3_t		pos;
 	GLubyte		color[4];
+	GLubyte		params[4];
 } particlevert_t;
 
 static particlevert_t partverts[MAX_PARTICLES];
 static int numpartverts = 0;
+
+static float R_ParticleNoise (int x, int y, int seed)
+{
+        uint32_t n = (uint32_t)(x * 1973 + y * 9277 + seed * 26699);
+        n ^= n >> 13;
+        n *= 1274126177u;
+        return (n & 0x00FFFFFFu) * (1.0f / 16777215.0f);
+}
+
+static void R_InitParticleAtlas (void)
+{
+        if (particle_atlas)
+                return;
+
+        const int atlas_width = PARTICLE_TEX_TILE_SIZE * NUM_PARTICLE_TEXTURES;
+        const int atlas_height = PARTICLE_TEX_TILE_SIZE;
+        uint32_t data[atlas_width * atlas_height];
+        int tex, y, x;
+
+        for (tex = 0; tex < NUM_PARTICLE_TEXTURES; tex++)
+        {
+                for (y = 0; y < PARTICLE_TEX_TILE_SIZE; y++)
+                {
+                        for (x = 0; x < PARTICLE_TEX_TILE_SIZE; x++)
+                        {
+                                int atlas_x = tex * PARTICLE_TEX_TILE_SIZE + x;
+                                float u = ((float)x + 0.5f) / (float)PARTICLE_TEX_TILE_SIZE - 0.5f;
+                                float v = ((float)y + 0.5f) / (float)PARTICLE_TEX_TILE_SIZE - 0.5f;
+                                float radius = sqrtf (u*u + v*v);
+                                float alpha = 0.0f;
+                                float intensity;
+
+                                switch (tex)
+                                {
+                                case PARTICLE_TEX_SOFT:
+                                        alpha = q_max (0.f, 1.f - radius * 2.f);
+                                        alpha = powf (alpha, 1.2f);
+                                        break;
+
+                                case PARTICLE_TEX_GLOW:
+                                        alpha = q_max (0.f, 1.f - radius * 2.f);
+                                        alpha = powf (alpha, 3.0f);
+                                        break;
+
+                                case PARTICLE_TEX_SMOKE:
+                                {
+                                        float noise = R_ParticleNoise (x, y, 11);
+                                        float noise2 = R_ParticleNoise (x, y, 29);
+                                        float base = q_max (0.f, 1.f - radius * 2.f);
+                                        alpha = base * (0.55f + 0.45f * noise);
+                                        alpha = powf (alpha, 1.4f);
+                                        alpha = q_min (1.f, alpha + noise2 * 0.2f * base);
+                                        break;
+                                }
+
+                                case PARTICLE_TEX_STREAK:
+                                {
+                                        float horiz = q_max (0.f, 1.f - fabsf (v) * 6.f);
+                                        float taper = q_max (0.f, 1.f - fabsf (u) * 1.6f);
+                                        alpha = powf (horiz * taper, 1.1f);
+                                        break;
+                                }
+                                }
+
+                                alpha = q_max (0.f, q_min (alpha, 1.f));
+                                intensity = alpha;
+
+                                ((byte *)&data[y * atlas_width + atlas_x])[0] = (byte)q_min (255, (int)(intensity * 255.f + 0.5f));
+                                ((byte *)&data[y * atlas_width + atlas_x])[1] = ((byte *)&data[y * atlas_width + atlas_x])[0];
+                                ((byte *)&data[y * atlas_width + atlas_x])[2] = ((byte *)&data[y * atlas_width + atlas_x])[0];
+                                ((byte *)&data[y * atlas_width + atlas_x])[3] = (byte)q_min (255, (int)(alpha * 255.f + 0.5f));
+                        }
+                }
+        }
+
+        particle_atlas = TexMgr_LoadImageEx (NULL, "particles/atlas", atlas_width, atlas_height, 1, SRC_RGBA,
+                (byte *)data, "", 0, TEXPREF_LINEAR | TEXPREF_NOPICMIP | TEXPREF_PERSIST | TEXPREF_CLAMP);
+
+        particle_atlas_tile_width = 1.0f / (float)NUM_PARTICLE_TEXTURES;
+        particle_atlas_tile_height = 1.0f;
+        particle_atlas_tile_margin = 0.5f / (float)PARTICLE_TEX_TILE_SIZE;
+}
 
 /*
 ===============
@@ -78,7 +200,7 @@ particle_t *R_AllocParticle (void)
 	if (r_numactiveparticles < r_numparticles)
 	{
 		particle_t *p = &particles[r_numactiveparticles++];
-		p->spawn = cl.time - 0.001;
+                p->spawn = cl.time;
 		return p;
 	}
 	return NULL;
@@ -110,9 +232,11 @@ void R_InitParticles (void)
 			Hunk_AllocName (r_numparticles * sizeof(particle_t), "particles");
 	r_numactiveparticles = 0;
 
-	Cvar_RegisterVariable (&r_particles); //johnfitz
-	Cvar_SetCallback (&r_particles, R_SetParticleTexture_f);
-	R_SetParticleTexture_f (&r_particles); // set default
+        Cvar_RegisterVariable (&r_particles); //johnfitz
+        Cvar_SetCallback (&r_particles, R_SetParticleTexture_f);
+        R_SetParticleTexture_f (&r_particles); // set default
+
+        R_InitParticleAtlas ();
 }
 
 /*
@@ -673,10 +797,11 @@ static void R_FlushParticleBatch (void)
 
 	GL_Upload (GL_ARRAY_BUFFER, partverts, sizeof(partverts[0]) * numpartverts, &buf, &ofs);
 	GL_BindBuffer (GL_ARRAY_BUFFER, buf);
-	GL_VertexAttribPointerFunc (0, 3, GL_FLOAT, GL_FALSE, sizeof(partverts[0]), ofs + offsetof(particlevert_t, pos));
-	GL_VertexAttribPointerFunc (1, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(partverts[0]), ofs + offsetof(particlevert_t, color));
+        GL_VertexAttribPointerFunc (0, 3, GL_FLOAT, GL_FALSE, sizeof(partverts[0]), ofs + offsetof(particlevert_t, pos));
+        GL_VertexAttribPointerFunc (1, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(partverts[0]), ofs + offsetof(particlevert_t, color));
+        GL_VertexAttribPointerFunc (2, 4, GL_UNSIGNED_BYTE, GL_FALSE, sizeof(partverts[0]), ofs + offsetof(particlevert_t, params));
 
-	GL_DrawArraysInstancedFunc (GL_TRIANGLE_STRIP, 0, 4, numpartverts);
+        GL_DrawArraysInstancedFunc (GL_TRIANGLE_STRIP, 0, 4, numpartverts);
 
 	numpartverts = 0;
 }
@@ -694,7 +819,7 @@ static void R_DrawParticles_Real (qboolean alpha, qboolean showtris)
 	extern	cvar_t	r_particles; //johnfitz
 	//float			alpha; //johnfitz -- particle transparency
 	float			scalex, scaley;
-	qboolean		dither, oit;
+	qboolean		dither, oit, wants_alpha;
 	int				i;
 
 	if (!r_particles.value)
@@ -703,8 +828,9 @@ static void R_DrawParticles_Real (qboolean alpha, qboolean showtris)
 	if (!r_numactiveparticles)
 		return;
 
-	// square particles are drawn opaque (avoiding alpha sorting issues)
-	if (!showtris && alpha != ((int)r_particles.value != 2))
+	wants_alpha = ((int)r_particles.value != 1);
+
+	if (!showtris && alpha != wants_alpha)
 		return;
 
 	GL_BeginGroup ("Particles");
@@ -718,14 +844,25 @@ static void R_DrawParticles_Real (qboolean alpha, qboolean showtris)
 	// then down by 0.25f for quad particles
 	scalex = scaley = texturescalefactor * 0.375f;
 	// projection factors (see GL_FrustumMatrix), negated to make things easier in the shader
-	scalex *=  r_matproj[1*4 + 0]; // -1 / tan (fovx/2)
+	scalex *=	r_matproj[1*4 + 0]; // -1 / tan (fovx/2)
 	scaley *= -r_matproj[2*4 + 1]; // -1 / tan (fovy/2)
 	GL_Uniform3fFunc (0, scalex, scaley, uvscale);
 
-	if (alpha)
-		GL_SetState (GLS_BLEND_ALPHA_OIT | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (2) | GLS_INSTANCED_ATTRIBS (2));
+	if (particle_atlas)
+	{
+		GL_Bind (GL_TEXTURE0, particle_atlas);
+		GL_Uniform4fFunc (1, particle_atlas_tile_width, particle_atlas_tile_height, particle_atlas_tile_margin, particle_atlas_tile_margin);
+	}
 	else
-		GL_SetState (GLS_BLEND_OPAQUE | GLS_CULL_NONE | GLS_ATTRIBS (2) | GLS_INSTANCED_ATTRIBS (2));
+	{
+		GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, 0);
+		GL_Uniform4fFunc (1, 1.f, 1.f, 0.f, 0.f);
+	}
+
+	if (alpha)
+		GL_SetState (GLS_BLEND_ALPHA_OIT | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (3) | GLS_INSTANCED_ATTRIBS (3));
+	else
+		GL_SetState (GLS_BLEND_OPAQUE | GLS_CULL_NONE | GLS_ATTRIBS (3) | GLS_INSTANCED_ATTRIBS (3));
 
 	numpartverts = 0;
 	for (i = 0, p = particles; i < r_numactiveparticles; i++, p++)
@@ -733,18 +870,53 @@ static void R_DrawParticles_Real (qboolean alpha, qboolean showtris)
 		if (numpartverts == countof(partverts))
 			R_FlushParticleBatch ();
 
-		v = &partverts[numpartverts++];
-		VectorCopy (p->org, v->pos);
+		{
+			const particleappearance_t *appearance;
+			float lifetime, life, fade, alphaval, glow;
+			GLubyte alphabyte, glowbyte;
+			int texindex;
 
-		//johnfitz -- particle transparency and fade out
-		c = showtris ? color : (GLubyte *) &d_8to24table[(int)p->color];
-		*(uint32_t*)&v->color = *(uint32_t*)c;
-		v->color[0] = c[0];
-		v->color[1] = c[1];
-		v->color[2] = c[2];
-		//alpha = CLAMP(0, p->die + 0.5 - cl.time, 1);
-		v->color[3] = c[3]; //(int)(alpha * 255);
-		//johnfitz
+			if ((unsigned)p->type < countof(particle_appearance))
+				appearance = &particle_appearance[p->type];
+			else
+				appearance = &particle_appearance_default;
+
+			lifetime = p->die - p->spawn;
+			life = 0.f;
+			if (lifetime > 0.f)
+				life = (cl.time - p->spawn) / lifetime;
+			life = q_min (1.f, q_max (0.f, life));
+			fade = appearance->fade > 0.f ? powf (life, appearance->fade) : life;
+			alphaval = appearance->alpha_start + (appearance->alpha_end - appearance->alpha_start) * fade;
+			alphaval = q_min (1.f, q_max (0.f, alphaval));
+			if (!showtris && alphaval <= 0.f)
+				continue;
+
+			glow = q_min (1.f, q_max (0.f, appearance->glow));
+			texindex = appearance->texture;
+			if (texindex < 0 || texindex >= NUM_PARTICLE_TEXTURES)
+				texindex = PARTICLE_TEX_SOFT;
+
+			alphabyte = (GLubyte)q_min (255, (int)(alphaval * 255.f + 0.5f));
+			glowbyte = (GLubyte)q_min (255, (int)(glow * 255.f + 0.5f));
+
+			v = &partverts[numpartverts];
+			VectorCopy (p->org, v->pos);
+
+			c = showtris ? color : (GLubyte *) &d_8to24table[(int)p->color];
+			*(uint32_t*)&v->color = *(uint32_t*)c;
+			v->color[0] = c[0];
+			v->color[1] = c[1];
+			v->color[2] = c[2];
+			v->color[3] = showtris ? 255 : alphabyte;
+
+			v->params[0] = showtris ? 0 : glowbyte;
+			v->params[1] = (GLubyte)texindex;
+			v->params[2] = 0;
+			v->params[3] = 0;
+
+			numpartverts++;
+		}
 	}
 
 	R_FlushParticleBatch ();

--- a/Quake/shaders/particles.frag
+++ b/Quake/shaders/particles.frag
@@ -13,10 +13,10 @@ float bayer01(ivec2 coord)
 	coord &= 15;
 	coord.y ^= coord.x;
 	uint v = uint(coord.y | (coord.x << 8));	// 0  0  0  0 | x3 x2 x1 x0 |  0  0  0  0 | y3 y2 y1 y0
-	v = (v ^ (v << 2)) & 0x3333;				// 0  0 x3 x2 |  0  0 x1 x0 |  0  0 y3 y2 |  0  0 y1 y0
-	v = (v ^ (v << 1)) & 0x5555;				// 0 x3  0 x2 |  0 x1  0 x0 |  0 y3  0 y2 |  0 y1  0 y0
-	v |= v >> 7;								// 0 x3  0 x2 |  0 x1  0 x0 | x3 y3 x2 y2 | x1 y1 x0 y0
-	v = bitfieldReverse(v) >> 24;				// 0  0  0  0 |  0  0  0  0 | y0 x0 y1 x1 | y2 x2 y3 x3
+	v = (v ^ (v << 2)) & 0x3333;							// 0  0 x3 x2 |  0  0 x1 x0 |  0  0 y3 y2 |  0  0 y1 y0
+	v = (v ^ (v << 1)) & 0x5555;							// 0 x3  0 x2 |  0 x1  0 x0 |  0 y3  0 y2 |  0 y1  0 y0
+	v |= v >> 7;										// 0 x3  0 x2 |  0 x1  0 x0 | x3 y3 x2 y2 | x1 y1 x0 y0
+	v = bitfieldReverse(v) >> 24;						// 0  0  0  0 |  0  0  0  0 | y0 x0 y1 x1 | y2 x2 y3 x3
 	return float(v) * (1.0/256.0);
 }
 
@@ -26,7 +26,7 @@ float bayer(ivec2 coord)
 }
 
 // Hash without Sine
-// https://www.shadertoy.com/view/4djSRW 
+// https://www.shadertoy.com/view/4djSRW
 float whitenoise01(vec2 p)
 {
 	vec3 p3 = fract(vec3(p.xyx) * .1031);
@@ -41,7 +41,7 @@ float whitenoise(vec2 p)
 
 // Convert uniform distribution to triangle-shaped distribution
 // Input in [0..1], output in [-1..1]
-// Based on https://www.shadertoy.com/view/4t2SDh 
+// Based on https://www.shadertoy.com/view/4t2SDh
 float tri(float x)
 {
 	float orig = x * 2.0 - 1.0;
@@ -55,9 +55,13 @@ float tri(float x)
 #define SCREEN_SPACE_NOISE() DITHER_NOISE(floor(gl_FragCoord.xy)+0.5)
 #define SUPPRESS_BANDING() bayer(ivec2(gl_FragCoord.xy))
 
+layout(binding=0) uniform sampler2D ParticleAtlas;
+
 layout(location=0) in vec2 in_uv;
 layout(location=1) in vec4 in_color;
 layout(location=2) in vec3 in_pos;
+layout(location=3) in vec4 in_params;
+layout(location=4) in vec2 in_corner;
 
 #define OUT_COLOR out_fragcolor
 #if OIT
@@ -95,27 +99,31 @@ layout(location=2) in vec3 in_pos;
 	#define main main_body
 #else
 	layout(location=0) out vec4 OUT_COLOR;
-        layout(location=1) out vec4 out_velocity;
+	layout(location=1) out vec4 out_velocity;
 #endif // OIT
 
 void main()
 {
-	out_fragcolor = in_color;
+	vec4 texel = texture(ParticleAtlas, in_uv);
+	vec4 color = in_color * texel;
 #if !OIT
-        out_velocity = vec4(0.0);
+	out_velocity = vec4(0.0);
 #endif
-	out_fragcolor.rgb = ApplyFog(out_fragcolor.rgb, in_pos);
-	float radius = length(in_uv);
+	float glow = in_params.x;
+	color.rgb *= (1.0 + glow);
+	color.rgb = ApplyFog(color.rgb, in_pos);
+	float radius = length(in_corner * in_params.y);
 	float pixel = fwidth(radius);
-	out_fragcolor.a *= clamp((1. - radius) / pixel, 0., 1.);
+	color.a *= clamp((1. - radius) / pixel, 0., 1.);
 #if DITHER
 	if (Fog.w > 0.)
 	{
-		out_fragcolor.rgb = sqrt(out_fragcolor.rgb);
-		out_fragcolor.rgb += SCREEN_SPACE_NOISE() * ScreenDither;
-		out_fragcolor.rgb *= out_fragcolor.rgb;
+		color.rgb = sqrt(color.rgb);
+		color.rgb += SCREEN_SPACE_NOISE() * ScreenDither;
+		color.rgb *= color.rgb;
 	}
 #else
-	out_fragcolor.rgb += SUPPRESS_BANDING() * ScreenDither;
+	color.rgb += SUPPRESS_BANDING() * ScreenDither;
 #endif
+	out_fragcolor = color;
 }

--- a/Quake/shaders/particles.vert
+++ b/Quake/shaders/particles.vert
@@ -10,14 +10,19 @@ vec3 ApplyFog(vec3 clr, vec3 p)
 
 layout(location=0) in vec3 in_pos;
 layout(location=1) in vec4 in_color;
+layout(location=2) in vec4 in_params;
 
 layout(location=0) out vec2 out_uv;
 layout(location=1) out vec4 out_color;
 layout(location=2) out vec3 out_pos;
+layout(location=3) out vec4 out_params;
+layout(location=4) out vec2 out_corner;
 
 layout(location=0) uniform vec3 Params;
 #define ProjScale	Params.xy
-#define UVScale	Params.z
+#define UVScale Params.z
+
+layout(location=1) uniform vec4 AtlasInfo;
 
 void main()
 {
@@ -34,9 +39,21 @@ void main()
 	// perform the billboarding
 	gl_Position.xy += ProjScale * uintBitsToFloat(floatBitsToUint(vec2(depthscale)) ^ flipsign);
 
+	float textureIndex = in_params.y;
+	float tileCount = AtlasInfo.x > 0.0 ? 1.0 / AtlasInfo.x : 1.0;
+	textureIndex = clamp(textureIndex, 0.0, max(tileCount - 1.0, 0.0));
+
+	vec2 uv01 = corner * 0.5 + 0.5;
+	uv01 = (uv01 - 0.5) * UVScale + 0.5;
+	vec2 margin = vec2(AtlasInfo.z, AtlasInfo.w);
+	uv01 = clamp(uv01, margin, vec2(1.0) - margin);
+	vec2 uv = vec2(textureIndex * AtlasInfo.x, 0.0) + uv01 * vec2(AtlasInfo.x, AtlasInfo.y);
+
 	out_pos = in_pos - EyePos; // FIXME: use corner position
-	out_uv = corner * UVScale;
+	out_uv = uv;
 	out_color = in_color;
+	out_params = vec4(in_params.x * (1.0 / 255.0), UVScale, 0.0, 0.0);
+	out_corner = corner;
 #if OIT
 	out_color.a *= 0.9;
 #endif


### PR DESCRIPTION
## Summary
- add particle appearance metadata and generate a procedural particle atlas for textured rendering
- pass per-particle parameters to the renderer to drive alpha fades, glow strength, and atlas selection
- update the particle shaders to sample the atlas, apply glow, and retain radial falloff blending

## Testing
- make -C Quake *(fails: sdl2-config missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_690b4e8e5164832e9894c306395ee17f