### PR TITLE
Integrate QuakeC particle effects with effectinfo definitions

### DIFF
--- a/Misc/pak/effectinfo.txt
+++ b/Misc/pak/effectinfo.txt
@@ -183,3 +183,49 @@ effect fx_smoke_min
     gravity -20
     airfriction 1.5
     lifetime 0.8
+
+// --- Ironwail QC helpers -------------------------------------------------
+
+// Directional spray for bullet and gib blood.
+effect fx_blood_spray
+    type spark
+    count 1
+    color 200 30 30
+    size 2 4
+    velocity 140 80
+    gravity 650
+    airfriction 1.4
+    lifetime 0.45
+
+// Chunky embers used when bodies explode into pieces.
+effect fx_gib_chunk
+    type spark
+    count 1
+    color 255 120 60
+    size 3 2
+    velocity 150 90
+    gravity 900
+    airfriction 2.5
+    lifetime 0.35
+
+// Electrical flash for lightning gun impact points.
+effect fx_lightning_hit
+    type spark
+    count 1
+    color 180 210 255
+    size 2 2
+    velocity 220 120
+    gravity 500
+    airfriction 1.9
+    lifetime 0.28
+
+// Compact fiery burst for small explosions or barrels.
+effect fx_explosion_burst
+    type spark
+    count 1
+    color 255 200 120
+    size 6 3
+    velocity 190 110
+    gravity 780
+    airfriction 2.3
+    lifetime 0.42

--- a/Quake/qc/defs.qc
+++ b/Quake/qc/defs.qc
@@ -774,6 +774,9 @@ void draw_worldtext( string s, vector origin, float size, float lifetime, float 
 void draw_sphere( vector origin, float radius, float colormap, float lifetime, float depthtest ) = #0:ex_draw_sphere;
 void draw_cylinder( vector origin, float halfHeight, float radius, float colormap, float lifetime, float depthtest ) = #0:ex_draw_cylinder;
 
+float( string effectname ) particleeffectnum = #0:particleeffectnum;
+void( float effectnum, vector origin, vector direction, float count ) pointparticles = #0:pointparticles;
+
 // Bot functions that return a value based on "BOT_GOAL_<X>", depending on the status of the goal.
 float bot_movetopoint( entity bot, vector point ) = #0:ex_bot_movetopoint;
 float bot_followentity( entity bot, entity goal ) = #0:ex_bot_followentity;

--- a/Quake/qc/misc.qc
+++ b/Quake/qc/misc.qc
@@ -243,7 +243,7 @@ void() barrel_explode =
 	// did say self.owner
 	T_RadiusDamage (self, self.enemy, 160, world);
 	sound (self, CHAN_VOICE, "weapons/r_exp3.wav", 1, ATTN_NORM);
-	particle (self.origin, '0 0 0', 75, 255);
+        Particles_ExplosionBurst(self.origin, 255);
 
 	self.origin_z = self.origin_z + 32;
 	BecomeExplosion ();

--- a/Quake/qc/particles.qc
+++ b/Quake/qc/particles.qc
@@ -6,6 +6,10 @@
 float FX_INVALID = -1;
 float FX_SPARK = -1;
 float FX_SMOKE = -1;
+float FX_BLOOD = -1;
+float FX_GIB = -1;
+float FX_LIGHTNING = -1;
+float FX_EXPLOSION = -1;
 
 float particles_supported = 0;
 
@@ -15,21 +19,31 @@ float particles_supported = 0;
 // float SVC_TEMPENTITY = 23;
 // float TE_GUNSHOT = 2;
 
+float(string name) Particles_FetchEffect =
+{
+    local float fx;
+    fx = particleeffectnum(name);
+    if (fx < 0)
+        return FX_INVALID;
+    return fx;
+};
+
 void() Particles_Init =
 {
+    particles_supported = 0;
+    FX_SPARK = FX_SMOKE = FX_BLOOD = FX_GIB = FX_LIGHTNING = FX_EXPLOSION = FX_INVALID;
+
     // Detect whether the engine exposes pointparticles/effectinfo
-    if (checkextension("DP_QC_POINTPARTICLES"))
-    {
-        particles_supported = 1;
-        FX_SPARK = particleeffectnum("fx_spark_min");
-        FX_SMOKE = particleeffectnum("fx_smoke_min");
-    }
-    else
-    {
-        particles_supported = 0;
-        FX_SPARK = FX_INVALID;
-        FX_SMOKE = FX_INVALID;
-    }
+    if (!checkextension("DP_QC_POINTPARTICLES"))
+        return;
+
+    particles_supported = 1;
+    FX_SPARK = Particles_FetchEffect("fx_spark_min");
+    FX_SMOKE = Particles_FetchEffect("fx_smoke_min");
+    FX_BLOOD = Particles_FetchEffect("fx_blood_spray");
+    FX_GIB = Particles_FetchEffect("fx_gib_chunk");
+    FX_LIGHTNING = Particles_FetchEffect("fx_lightning_hit");
+    FX_EXPLOSION = Particles_FetchEffect("fx_explosion_burst");
 };
 
 // Spawns point particles with optional directional bias.
@@ -66,13 +80,62 @@ void(float fx, vector org, float count) Particles_Burst =
     Particles_Point(fx, org, '0 0 0', count);
 };
 
-// --- Example usage --------------------------------------------------------
-void() Test_Spark =
+// Blood spray helper used by gib/death impacts.
+void(vector org, vector dir, float count) Particles_Blood =
 {
-    Particles_Point(FX_SPARK, self.origin, v_up, 8);
+    if (count < 1)
+        count = 1;
+
+    if (particles_supported && FX_BLOOD >= 0)
+    {
+        pointparticles(FX_BLOOD, org, dir, count);
+        return;
+    }
+
+    particle(org, dir, 73, count);
 };
 
-void() Test_SmokeBurst =
+// Gib chunk helper for secondary gore bursts.
+void(vector org, vector dir, float count) Particles_Gib =
 {
-    Particles_Burst(FX_SMOKE, self.origin, 12);
+    if (count < 1)
+        count = 1;
+
+    if (particles_supported && FX_GIB >= 0)
+    {
+        pointparticles(FX_GIB, org, dir, count);
+        return;
+    }
+
+    particle(org, dir, 0, count);
+};
+
+// Concentrated sparks for lightning gun contacts.
+void(vector org, float count) Particles_LightningHit =
+{
+    if (count < 1)
+        count = 1;
+
+    if (particles_supported && FX_LIGHTNING >= 0)
+    {
+        pointparticles(FX_LIGHTNING, org, '0 0 200', count);
+        return;
+    }
+
+    particle(org, '0 0 100', 225, count);
+};
+
+// Fiery burst used for barrels and small explosions.
+void(vector org, float count) Particles_ExplosionBurst =
+{
+    if (count < 1)
+        count = 1;
+
+    if (particles_supported && FX_EXPLOSION >= 0)
+    {
+        pointparticles(FX_EXPLOSION, org, '0 0 0', count);
+        return;
+    }
+
+    particle(org, '0 0 0', 75, count);
 };

--- a/Quake/qc/progs.src
+++ b/Quake/qc/progs.src
@@ -1,6 +1,7 @@
 ../progs.dat
 
 defs.qc
+particles.qc
 subs.qc
 fight.qc
 ai.qc

--- a/Quake/qc/weapons.qc
+++ b/Quake/qc/weapons.qc
@@ -136,7 +136,7 @@ SpawnBlood
 */
 void(vector org, vector vel, float damage) SpawnBlood =
 {
-	particle (org, vel*0.1, 73, damage*2);
+        Particles_Blood(org, vel*0.1, damage*2);
 };
 
 /*
@@ -160,7 +160,7 @@ SpawnChunk
 */
 void(vector org, vector vel) SpawnChunk =
 {
-	particle (org, vel*0.02, 0, 10);
+        Particles_Gib(org, vel*0.02, 10);
 };
 
 /*
@@ -451,13 +451,13 @@ void(vector p1, vector p2, entity from, float damage) LightningDamage =
 
 	e1 = e2 = world;
 
-	traceline (p1, p2, FALSE, self);
-	if (trace_ent.takedamage)
-	{
-		particle (trace_endpos, '0 0 100', 225, damage*4);
-		T_Damage (trace_ent, from, from, damage);
-		if (self.classname == "player")
-		{
+        traceline (p1, p2, FALSE, self);
+        if (trace_ent.takedamage)
+        {
+                Particles_LightningHit(trace_endpos, damage*4);
+                T_Damage (trace_ent, from, from, damage);
+                if (self.classname == "player")
+                {
 			if (other.classname == "player")
 				trace_ent.velocity_z = trace_ent.velocity_z + 400;
 		}
@@ -465,21 +465,21 @@ void(vector p1, vector p2, entity from, float damage) LightningDamage =
 
 	e1 = trace_ent;
 
-	traceline (p1 + f, p2 + f, FALSE, self);
-	if (trace_ent != e1 && trace_ent.takedamage)
-	{
-		particle (trace_endpos, '0 0 100', 225, damage*4);
-		T_Damage (trace_ent, from, from, damage);
-	}
+        traceline (p1 + f, p2 + f, FALSE, self);
+        if (trace_ent != e1 && trace_ent.takedamage)
+        {
+                Particles_LightningHit(trace_endpos, damage*4);
+                T_Damage (trace_ent, from, from, damage);
+        }
 
 	e2 = trace_ent;
 
-	traceline (p1 - f, p2 - f, FALSE, self);
-	if (trace_ent != e1 && trace_ent != e2 && trace_ent.takedamage)
-	{
-		particle (trace_endpos, '0 0 100', 225, damage*4);
-		T_Damage (trace_ent, from, from, damage);
-	}
+        traceline (p1 - f, p2 - f, FALSE, self);
+        if (trace_ent != e1 && trace_ent != e2 && trace_ent.takedamage)
+        {
+                Particles_LightningHit(trace_endpos, damage*4);
+                T_Damage (trace_ent, from, from, damage);
+        }
 };
 
 

--- a/Quake/qc/world.qc
+++ b/Quake/qc/world.qc
@@ -191,14 +191,16 @@ float startingserverflags;
  
 void() worldspawn =
 {
-	startingserverflags = serverflags;
-	lastspawn = world;
-	InitBodyQueue ();
+        startingserverflags = serverflags;
+        lastspawn = world;
+        InitBodyQueue ();
 
-	// custom map attributes
-	if (self.model == "maps/e1m8.bsp")
-		cvar_set ("sv_gravity", "100");
-	else
+        Particles_Init();
+
+        // custom map attributes
+        if (self.model == "maps/e1m8.bsp")
+                cvar_set ("sv_gravity", "100");
+        else
 		cvar_set ("sv_gravity", "800");
 
 	// the area based ambient sounds MUST be the first precache_sounds


### PR DESCRIPTION
## Summary
- expose the point particle builtins and compile the shared particles.qc helpers
- switch QuakeC gameplay code to use the new helper API for blood, gibs, lightning, and barrel explosions
- extend effectsinfo.txt with matching particle definitions for the new helpers

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690b6046c4d0832e8a35506bd31a9a0f