### PR TITLE
Add shadow stubs and fix particle atlas size

### DIFF
--- a/Quake/r_part.c
+++ b/Quake/r_part.c
@@ -96,14 +96,20 @@ static float R_ParticleNoise (int x, int y, int seed)
         return (n & 0x00FFFFFFu) * (1.0f / 16777215.0f);
 }
 
+enum
+{
+        PARTICLE_ATLAS_WIDTH = PARTICLE_TEX_TILE_SIZE * NUM_PARTICLE_TEXTURES,
+        PARTICLE_ATLAS_HEIGHT = PARTICLE_TEX_TILE_SIZE
+};
+
 static void R_InitParticleAtlas (void)
 {
         if (particle_atlas)
                 return;
 
-        const int atlas_width = PARTICLE_TEX_TILE_SIZE * NUM_PARTICLE_TEXTURES;
-        const int atlas_height = PARTICLE_TEX_TILE_SIZE;
-        uint32_t data[atlas_width * atlas_height];
+        const int atlas_width = PARTICLE_ATLAS_WIDTH;
+        const int atlas_height = PARTICLE_ATLAS_HEIGHT;
+        uint32_t data[PARTICLE_ATLAS_WIDTH * PARTICLE_ATLAS_HEIGHT];
         int tex, y, x;
 
         for (tex = 0; tex < NUM_PARTICLE_TEXTURES; tex++)

--- a/Windows/VisualStudio/ironwail.vcxproj
+++ b/Windows/VisualStudio/ironwail.vcxproj
@@ -244,6 +244,7 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
     <ClCompile Include="..\..\Quake\gl_refrag.c" />
     <ClCompile Include="..\..\Quake\gl_rlight.c" />
     <ClCompile Include="..\..\Quake\gl_shadow.c" />
+    <ClCompile Include="..\..\renderer\r_shadows.c" />
     <ClCompile Include="..\..\Quake\gl_rmain.c" />
     <ClCompile Include="..\..\Quake\gl_rmisc.c" />
     <ClCompile Include="..\..\Quake\gl_screen.c" />
@@ -464,6 +465,7 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
     <ClInclude Include="..\..\Quake\render.h" />
     <ClInclude Include="..\..\Quake\resource.h" />
     <ClInclude Include="..\..\Quake\sbar.h" />
+    <ClInclude Include="..\..\renderer\r_shadows.h" />
     <ClInclude Include="..\..\Quake\screen.h" />
     <ClInclude Include="..\..\Quake\sidebar.h" />
     <ClInclude Include="..\..\Quake\server.h" />

--- a/Windows/VisualStudio/ironwail.vcxproj.filters
+++ b/Windows/VisualStudio/ironwail.vcxproj.filters
@@ -252,6 +252,9 @@
     <ClCompile Include="..\..\Quake\gl_shaders.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\renderer\r_shadows.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\Quake\steam.c">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -438,6 +441,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Quake\sbar.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\renderer\r_shadows.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Quake\screen.h">

--- a/renderer/r_shadows.c
+++ b/renderer/r_shadows.c
@@ -1,0 +1,86 @@
+#include "r_shadows.h"
+
+#if R_SHADOWMAPS
+
+#include "../Quake/gl_shadow.h"
+#include "../Quake/glquake.h"
+
+cvar_t r_shadows = { "r_shadows", "1", CVAR_ARCHIVE };
+
+static qboolean shadowmaps_initialized = false;
+
+static void R_ShadowEnsureInitialized(void)
+{
+        if (shadowmaps_initialized)
+                return;
+
+        Cvar_RegisterVariable(&r_shadows);
+        R_InitShadow();
+        shadowmaps_initialized = true;
+}
+
+void R_InitShadowMaps(void)
+{
+        R_ShadowEnsureInitialized();
+        if (shadowmaps_initialized)
+                R_ResizeShadowMapIfNeeded();
+}
+
+void R_BeginShadowPass(void)
+{
+        if (!shadowmaps_initialized)
+                R_ShadowEnsureInitialized();
+
+        if (!shadowmaps_initialized || !r_shadows.value)
+                return;
+
+        R_ResizeShadowMapIfNeeded();
+        R_ShadowBeginFrame(r_framecount);
+}
+
+void R_EndShadowPass(void)
+{
+        if (!shadowmaps_initialized || !r_shadows.value)
+                return;
+
+        R_ShadowEndFrame();
+}
+
+void R_DrawShadowDebug(void)
+{
+        /* Debug rendering is not yet implemented. */
+}
+
+void R_UploadShadowMatrices(const float *matrices, int light_index)
+{
+        (void)matrices;
+        (void)light_index;
+}
+
+#else /* !R_SHADOWMAPS */
+
+cvar_t r_shadows = { "r_shadows", "0", CVAR_NONE };
+
+void R_InitShadowMaps(void)
+{
+}
+
+void R_BeginShadowPass(void)
+{
+}
+
+void R_EndShadowPass(void)
+{
+}
+
+void R_DrawShadowDebug(void)
+{
+}
+
+void R_UploadShadowMatrices(const float *matrices, int light_index)
+{
+        (void)matrices;
+        (void)light_index;
+}
+
+#endif

--- a/renderer/r_shadows.h
+++ b/renderer/r_shadows.h
@@ -1,0 +1,22 @@
+#ifndef R_SHADOWS_H
+#define R_SHADOWS_H
+
+#include "quakedef.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern cvar_t r_shadows;
+
+void R_InitShadowMaps(void);
+void R_BeginShadowPass(void);
+void R_EndShadowPass(void);
+void R_DrawShadowDebug(void);
+void R_UploadShadowMatrices(const float *matrices, int light_index);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* R_SHADOWS_H */


### PR DESCRIPTION
## Summary
- replace the particle atlas allocation with a compile-time constant size so MSVC accepts the array definition
- add stubbed shadow-map entry points, register the r_shadows cvar, and wire the new module into the Visual Studio project

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690b8c04d5ac832e96488f1611887c7b