### PR TITLE
Fix black screen by restoring scene rendering

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -1564,7 +1564,6 @@ qboolean GL_NeedsPostprocess (void)
 {
         if (vid_gamma.value != 1.f || vid_contrast.value != 1.f || softemu || R_GetEffectiveAlphaMode () == ALPHAMODE_OIT || R_DoFEnabled ())
                 return true;
-		return true;
         return false;
 }
 
@@ -2952,7 +2951,10 @@ void R_RenderView (void)
 	else if (gl_finish.value)
 		glFinish ();
 
-        R_SetupView (); //johnfitz -- this does everything that should be done once per frame
+	R_SetupView (); //johnfitz -- this does everything that should be done once per frame
+
+	R_RenderScene ();
+	R_WarpScaleView ();
 
 	r_frame_rendered_this_update = true;
 


### PR DESCRIPTION
## Summary
- call the 3D rendering and warp passes from `R_RenderView` so the scene is actually drawn each frame
- fix `GL_NeedsPostprocess` so it only flags post-processing when any effect is active

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690b92c6efa0832ea528ed2eabfaff4e