### PR TITLE
Add extension fallback for model loading

### DIFF
--- a/Quake/common.c
+++ b/Quake/common.c
@@ -1126,8 +1126,33 @@ void COM_StripExtension (const char *in, char *out, size_t outsize)
 		if (out[length] == '/' || out[length] == '\\')
 			return;	/* no extension */
 	}
-	if (length > 0)
-		out[length] = '\0';
+        if (length > 0)
+                out[length] = '\0';
+}
+
+qboolean COM_StripModelExtension (const char *in, char *out, size_t outsize)
+{
+        const char      *ext;
+        char            *dot;
+
+        if (!outsize)
+                return false;
+
+        if (in != out)
+                q_strlcpy (out, in, outsize);
+
+        ext = COM_FileGetExtension (out);
+        if (!ext[0])
+                return false;
+
+        if (q_strcasecmp (ext, "md5") && q_strcasecmp (ext, "md2") && q_strcasecmp (ext, "mdl"))
+                return false;
+
+        dot = strrchr (out, '.');
+        if (dot)
+                *dot = '\0';
+
+        return true;
 }
 
 /*

--- a/Quake/common.h
+++ b/Quake/common.h
@@ -326,6 +326,7 @@ void COM_SwitchGame (const char *paths);
 const char *COM_SkipPath (const char *pathname);
 const char *COM_SkipSpace (const char *str);
 void COM_StripExtension (const char *in, char *out, size_t outsize);
+qboolean COM_StripModelExtension (const char *in, char *out, size_t outsize);
 void COM_FileBase (const char *in, char *out, size_t outsize);
 void COM_AddExtension (char *path, const char *extension, size_t len);
 #if 0 /* COM_DefaultExtension can be dangerous */

--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -311,6 +311,43 @@ void Mod_ResetAll (void)
 	mod_numknown = 0;
 }
 
+static void Mod_ResolveModelName (const char *name, char *resolved, size_t resolved_size)
+{
+        const char *ext;
+        static const char * const model_exts[] = {"md5", "md2", "mdl"};
+        size_t i;
+
+        if (!resolved_size)
+                return;
+
+        if (!name[0])
+        {
+                resolved[0] = '\0';
+                return;
+        }
+
+        ext = COM_FileGetExtension (name);
+        if (ext[0])
+        {
+                q_strlcpy (resolved, name, resolved_size);
+                return;
+        }
+
+        for (i = 0; i < countof(model_exts); i++)
+        {
+                char candidate[MAX_QPATH];
+
+                q_snprintf (candidate, sizeof(candidate), "%s.%s", name, model_exts[i]);
+                if (COM_FileExists (candidate, NULL))
+                {
+                        q_strlcpy (resolved, candidate, resolved_size);
+                        return;
+                }
+        }
+
+        q_snprintf (resolved, resolved_size, "%s.mdl", name);
+}
+
 /*
 ==================
 Mod_FindName
@@ -355,8 +392,10 @@ Mod_TouchModel
 void Mod_TouchModel (const char *name)
 {
 	qmodel_t	*mod;
+	char		resolved[MAX_QPATH];
 
-	mod = Mod_FindName (name);
+	Mod_ResolveModelName (name, resolved, sizeof(resolved));
+	mod = Mod_FindName (resolved);
 
 	if (!mod->needload)
 	{
@@ -456,8 +495,10 @@ Loads in a model for the given name
 qmodel_t *Mod_ForName (const char *name, qboolean crash)
 {
 	qmodel_t	*mod;
+	char		resolved[MAX_QPATH];
 
-	mod = Mod_FindName (name);
+	Mod_ResolveModelName (name, resolved, sizeof(resolved));
+	mod = Mod_FindName (resolved);
 
 	return Mod_LoadModel (mod, crash);
 }

--- a/Quake/pr_cmds.c
+++ b/Quake/pr_cmds.c
@@ -307,14 +307,21 @@ static void PF_setmodel (void)
 	const char	*m, **check;
 	qmodel_t	*mod;
 	edict_t		*e;
+	char		normalized_model[MAX_QPATH];
+	char		normalized_precache[MAX_QPATH];
 
 	e = G_EDICT(OFS_PARM0);
 	m = G_STRING(OFS_PARM1);
+
+	COM_StripModelExtension (m, normalized_model, sizeof(normalized_model));
 
 // check to see if model was properly precached
 	for (i = 0, check = sv.model_precache; *check; i++, check++)
 	{
 		if (!strcmp(*check, m))
+			break;
+		COM_StripModelExtension (*check, normalized_precache, sizeof(normalized_precache));
+		if (!strcmp(normalized_precache, normalized_model))
 			break;
 	}
 
@@ -1174,6 +1181,8 @@ static void PF_precache_model (void)
 {
 	const char	*s;
 	int		i;
+	char		normalized_request[MAX_QPATH];
+	char		normalized_precache[MAX_QPATH];
 
 	if (sv.state != ss_loading)
 		PR_RunError ("PF_Precache_*: Precache can only be done in spawn functions");
@@ -1181,6 +1190,8 @@ static void PF_precache_model (void)
 	s = G_STRING(OFS_PARM0);
 	G_INT(OFS_RETURN) = G_INT(OFS_PARM0);
 	PR_CheckEmptyString (s);
+
+	COM_StripModelExtension (s, normalized_request, sizeof(normalized_request));
 
 	for (i = 0; i < MAX_MODELS; i++)
 	{
@@ -1191,6 +1202,9 @@ static void PF_precache_model (void)
 			return;
 		}
 		if (!strcmp(sv.model_precache[i], s))
+			return;
+		COM_StripModelExtension (sv.model_precache[i], normalized_precache, sizeof(normalized_precache));
+		if (!strcmp(normalized_precache, normalized_request))
 			return;
 	}
 	PR_RunError ("PF_precache_model: overflow");

--- a/Quake/qc/client.qc
+++ b/Quake/qc/client.qc
@@ -785,10 +785,10 @@ void() PutClientInServer =
 	self.fixangle = TRUE;		// turn this way immediately
 
 	// oh, this is a hack!
-	setmodel (self, "progs/eyes.mdl");
+	setmodel (self, "progs/eyes");
 	modelindex_eyes = self.modelindex;
 
-	setmodel (self, "progs/player.mdl");
+	setmodel (self, "progs/player");
 	modelindex_player = self.modelindex;
 
 	setsize (self, VEC_HULL_MIN, VEC_HULL_MAX);

--- a/Quake/qc/items.qc
+++ b/Quake/qc/items.qc
@@ -300,8 +300,8 @@ void() item_armor1 =
 	self.touch = armor_touch;
 	self.armortype = 0.3;
 	self.armorvalue = 100;
-	precache_model ("progs/armor.mdl");
-	setmodel (self, "progs/armor.mdl");
+	precache_model ("progs/armor");
+	setmodel (self, "progs/armor");
 	self.skin = 0;
 	setsize (self, '-16 -16 0', '16 16 56');
 	StartItem ();
@@ -315,8 +315,8 @@ void() item_armor2 =
 	self.touch = armor_touch;
 	self.armortype = 0.6;
 	self.armorvalue = 150;
-	precache_model ("progs/armor.mdl");
-	setmodel (self, "progs/armor.mdl");
+	precache_model ("progs/armor");
+	setmodel (self, "progs/armor");
 	self.skin = 1;
 	setsize (self, '-16 -16 0', '16 16 56');
 	StartItem ();
@@ -330,8 +330,8 @@ void() item_armorInv =
 	self.touch = armor_touch;
 	self.armortype = 0.8;
 	self.armorvalue = 200;
-	precache_model ("progs/armor.mdl");
-	setmodel (self, "progs/armor.mdl");
+	precache_model ("progs/armor");
+	setmodel (self, "progs/armor");
 	self.skin = 2;
 	setsize (self, '-16 -16 0', '16 16 56');
 	StartItem ();
@@ -568,8 +568,8 @@ QUAKED weapon_supershotgun (0 .5 .8) (-16 -16 0) (16 16 32)
 */
 void() weapon_supershotgun =
 {
-	precache_model ("progs/g_shot.mdl");
-	setmodel (self, "progs/g_shot.mdl");
+	precache_model ("progs/g_shot");
+	setmodel (self, "progs/g_shot");
 	self.weapon = IT_SUPER_SHOTGUN;
 	self.netname = "$qc_double_shotgun";
 	self.touch = weapon_touch;
@@ -582,8 +582,8 @@ void() weapon_supershotgun =
 
 void() weapon_nailgun =
 {
-	precache_model ("progs/g_nail.mdl");
-	setmodel (self, "progs/g_nail.mdl");
+	precache_model ("progs/g_nail");
+	setmodel (self, "progs/g_nail");
 	self.weapon = IT_NAILGUN;
 	self.netname = "$qc_nailgun";
 	self.touch = weapon_touch;
@@ -596,8 +596,8 @@ void() weapon_nailgun =
 
 void() weapon_supernailgun =
 {
-	precache_model ("progs/g_nail2.mdl");
-	setmodel (self, "progs/g_nail2.mdl");
+	precache_model ("progs/g_nail2");
+	setmodel (self, "progs/g_nail2");
 	self.weapon = IT_SUPER_NAILGUN;
 	self.netname = "$qc_super_nailgun";
 	self.touch = weapon_touch;
@@ -610,8 +610,8 @@ void() weapon_supernailgun =
 
 void() weapon_grenadelauncher =
 {
-	precache_model ("progs/g_rock.mdl");
-	setmodel (self, "progs/g_rock.mdl");
+	precache_model ("progs/g_rock");
+	setmodel (self, "progs/g_rock");
 	self.weapon = IT_GRENADE_LAUNCHER;
 	self.netname = "$qc_grenade_launcher";
 	self.touch = weapon_touch;
@@ -624,8 +624,8 @@ void() weapon_grenadelauncher =
 
 void() weapon_rocketlauncher =
 {
-	precache_model ("progs/g_rock2.mdl");
-	setmodel (self, "progs/g_rock2.mdl");
+	precache_model ("progs/g_rock2");
+	setmodel (self, "progs/g_rock2");
 	self.weapon = IT_ROCKET_LAUNCHER;
 	self.netname = "$qc_rocket_launcher";
 	self.touch = weapon_touch;
@@ -639,8 +639,8 @@ void() weapon_rocketlauncher =
 
 void() weapon_lightning =
 {
-	precache_model ("progs/g_light.mdl");
-	setmodel (self, "progs/g_light.mdl");
+	precache_model ("progs/g_light");
+	setmodel (self, "progs/g_light");
 	self.weapon = IT_LIGHTNING;
 	self.netname = "$qc_thunderbolt";
 	self.touch = weapon_touch;
@@ -1003,20 +1003,20 @@ void() item_key1 =
 {
 	if (world.worldtype == WORLDTYPE_MEDIEVAL)
 	{
-		precache_model ("progs/w_s_key.mdl");
-		setmodel (self, "progs/w_s_key.mdl");
+		precache_model ("progs/w_s_key");
+		setmodel (self, "progs/w_s_key");
 		self.netname = "$qc_silver_key";
 	}
 	else if (world.worldtype == WORLDTYPE_METAL)
 	{
-		precache_model ("progs/m_s_key.mdl");
-		setmodel (self, "progs/m_s_key.mdl");
+		precache_model ("progs/m_s_key");
+		setmodel (self, "progs/m_s_key");
 		self.netname = "$qc_silver_runekey";
 	}
 	else if (world.worldtype == WORLDTYPE_BASE)
 	{
-		precache_model2 ("progs/b_s_key.mdl");
-		setmodel (self, "progs/b_s_key.mdl");
+		precache_model2 ("progs/b_s_key");
+		setmodel (self, "progs/b_s_key");
 		self.netname = "$qc_silver_keycard";
 	}
 
@@ -1042,22 +1042,22 @@ void() item_key2 =
 {
 	if (world.worldtype == WORLDTYPE_MEDIEVAL)
 	{
-		precache_model ("progs/w_g_key.mdl");
-		setmodel (self, "progs/w_g_key.mdl");
+		precache_model ("progs/w_g_key");
+		setmodel (self, "progs/w_g_key");
 		self.netname = "$qc_gold_key";
 	}
 
 	if (world.worldtype == WORLDTYPE_METAL)
 	{
-		precache_model ("progs/m_g_key.mdl");
-		setmodel (self, "progs/m_g_key.mdl");
+		precache_model ("progs/m_g_key");
+		setmodel (self, "progs/m_g_key");
 		self.netname = "$qc_gold_runekey";
 	}
 
 	if (world.worldtype == WORLDTYPE_BASE)
 	{
-		precache_model2 ("progs/b_g_key.mdl");
-		setmodel (self, "progs/b_g_key.mdl");
+		precache_model2 ("progs/b_g_key");
+		setmodel (self, "progs/b_g_key");
 		self.netname = "$qc_gold_keycard";
 	}
 
@@ -1115,26 +1115,26 @@ void() item_sigil =
 
 	if (self.spawnflags & 1)
 	{
-		precache_model ("progs/end1.mdl");
-		setmodel (self, "progs/end1.mdl");
+		precache_model ("progs/end1");
+		setmodel (self, "progs/end1");
 	}
 
 	if (self.spawnflags & 2)
 	{
-		precache_model2 ("progs/end2.mdl");
-		setmodel (self, "progs/end2.mdl");
+		precache_model2 ("progs/end2");
+		setmodel (self, "progs/end2");
 	}
 
 	if (self.spawnflags & 4)
 	{
-		precache_model2 ("progs/end3.mdl");
-		setmodel (self, "progs/end3.mdl");
+		precache_model2 ("progs/end3");
+		setmodel (self, "progs/end3");
 	}
 
 	if (self.spawnflags & 8)
 	{
-		precache_model2 ("progs/end4.mdl");
-		setmodel (self, "progs/end4.mdl");
+		precache_model2 ("progs/end4");
+		setmodel (self, "progs/end4");
 	}
 	
 	self.touch = sigil_touch;
@@ -1220,12 +1220,12 @@ void() item_artifact_invulnerability =
 {
 	self.touch = powerup_touch;
 
-	precache_model ("progs/invulner.mdl");
+	precache_model ("progs/invulner");
 	precache_sound ("items/protect.wav");
 	precache_sound ("items/protect2.wav");
 	precache_sound ("items/protect3.wav");
 	self.noise = "items/protect.wav";
-	setmodel (self, "progs/invulner.mdl");
+	setmodel (self, "progs/invulner");
 	self.netname = "$qc_pentagram_of_protection";
 	self.items = IT_INVULNERABILITY;
 	setsize (self, '-16 -16 -24', '16 16 32');
@@ -1239,11 +1239,11 @@ void() item_artifact_envirosuit =
 {
 	self.touch = powerup_touch;
 
-	precache_model ("progs/suit.mdl");
+	precache_model ("progs/suit");
 	precache_sound ("items/suit.wav");
 	precache_sound ("items/suit2.wav");
 	self.noise = "items/suit.wav";
-	setmodel (self, "progs/suit.mdl");
+	setmodel (self, "progs/suit");
 	self.netname = "$qc_biosuit";
 	self.items = IT_SUIT;
 	setsize (self, '-16 -16 -24', '16 16 32');
@@ -1258,12 +1258,12 @@ void() item_artifact_invisibility =
 {
 	self.touch = powerup_touch;
 
-	precache_model ("progs/invisibl.mdl");
+	precache_model ("progs/invisibl");
 	precache_sound ("items/inv1.wav");
 	precache_sound ("items/inv2.wav");
 	precache_sound ("items/inv3.wav");
 	self.noise = "items/inv1.wav";
-	setmodel (self, "progs/invisibl.mdl");
+	setmodel (self, "progs/invisibl");
 	self.netname = "$qc_ring_of_shadows";
 	self.items = IT_INVISIBILITY;
 	setsize (self, '-16 -16 -24', '16 16 32');
@@ -1278,12 +1278,12 @@ void() item_artifact_super_damage =
 {
 	self.touch = powerup_touch;
 
-	precache_model ("progs/quaddama.mdl");
+	precache_model ("progs/quaddama");
 	precache_sound ("items/damage.wav");
 	precache_sound ("items/damage2.wav");
 	precache_sound ("items/damage3.wav");
 	self.noise = "items/damage.wav";
-	setmodel (self, "progs/quaddama.mdl");
+	setmodel (self, "progs/quaddama");
 	self.netname = "$qc_quad_damage";
 	self.items = IT_QUAD;
 	setsize (self, '-16 -16 -24', '16 16 32');
@@ -1474,7 +1474,7 @@ void() DropBackpack =
 	item.flags = FL_ITEM;
 	item.solid = SOLID_TRIGGER;
 	item.movetype = MOVETYPE_TOSS;
-	setmodel (item, "progs/backpack.mdl");
+	setmodel (item, "progs/backpack");
 	setsize (item, '-16 -16 0', '16 16 56');
 	item.touch = BackpackTouch;
 	

--- a/Quake/qc/misc.qc
+++ b/Quake/qc/misc.qc
@@ -140,8 +140,8 @@ Default style is 0
 */
 void() light_torch_small_walltorch =
 {
-	precache_model ("progs/flame.mdl");
-	setmodel (self, "progs/flame.mdl");
+	precache_model ("progs/flame");
+	setmodel (self, "progs/flame");
 	FireAmbient ();
 	makestatic (self);
 };
@@ -151,8 +151,8 @@ Large yellow flame ball
 */
 void() light_flame_large_yellow =
 {
-	precache_model ("progs/flame2.mdl");
-	setmodel (self, "progs/flame2.mdl");
+	precache_model ("progs/flame2");
+	setmodel (self, "progs/flame2");
 	self.frame = 1;
 	FireAmbient ();
 	makestatic (self);
@@ -163,8 +163,8 @@ Small yellow flame ball
 */
 void() light_flame_small_yellow =
 {
-	precache_model ("progs/flame2.mdl");
-	setmodel (self, "progs/flame2.mdl");
+	precache_model ("progs/flame2");
+	setmodel (self, "progs/flame2");
 	FireAmbient ();
 	makestatic (self);
 };
@@ -174,8 +174,8 @@ Small white flame ball
 */
 void() light_flame_small_white =
 {
-	precache_model ("progs/flame2.mdl");
-	setmodel (self, "progs/flame2.mdl");
+	precache_model ("progs/flame2");
+	setmodel (self, "progs/flame2");
 	FireAmbient ();
 	makestatic (self);
 };
@@ -191,7 +191,7 @@ void() fire_fly;
 void() fire_touch;
 void() misc_fireball =
 {	
-	precache_model ("progs/lavaball.mdl");
+	precache_model ("progs/lavaball");
 	self.classname = "fireball";
 	self.nextthink = time + (random() * 5);
 	self.think = fire_fly;
@@ -214,7 +214,7 @@ void() fire_fly =
 	fireball.velocity_y = (random() * 100) - 50;
 	fireball.velocity_z = self.speed + (random() * 200);
 	fireball.classname = "fireball";
-	setmodel (fireball, "progs/lavaball.mdl");
+	setmodel (fireball, "progs/lavaball");
 	setsize (fireball, '0 0 0', '0 0 0');
 	setorigin (fireball, self.origin);
 	fireball.nextthink = time + 5;
@@ -352,7 +352,7 @@ void() trap_spikeshooter =
 
 	if (self.spawnflags & SPAWNFLAG_LASER)
 	{
-		precache_model2 ("progs/laser.mdl");
+		precache_model2 ("progs/laser");
 		
 		precache_sound2 ("enforcer/enfire.wav");
 		precache_sound2 ("enforcer/enfstop.wav");
@@ -516,8 +516,8 @@ void() viewthing =
 {
 	self.movetype = MOVETYPE_NONE;
 	self.solid = SOLID_NOT;
-	precache_model ("progs/player.mdl");
-	setmodel (self, "progs/player.mdl");
+	precache_model ("progs/player");
+	setmodel (self, "progs/player");
 };
 
 

--- a/Quake/qc/monsters/chthon.qc
+++ b/Quake/qc/monsters/chthon.qc
@@ -259,7 +259,7 @@ void(vector p) boss_missile =
 
 	launch_spike (org, vec);
 	newmis.classname = "chthon_lavaball";
-	setmodel (newmis, "progs/lavaball.mdl");
+	setmodel (newmis, "progs/lavaball");
 	newmis.avelocity = '200 100 300';
 	setsize (newmis, VEC_ORIGIN, VEC_ORIGIN);		
 	newmis.velocity = vec*300;
@@ -278,7 +278,7 @@ void() boss_awake =
 	self.movetype = MOVETYPE_STEP;
 	self.takedamage = DAMAGE_NO;
 	
-	setmodel (self, "progs/boss.mdl");
+	setmodel (self, "progs/boss");
 
 	self.netname = "$qc_chthon";
 	self.killstring = "$qc_ks_chthon";
@@ -314,8 +314,8 @@ void() monster_boss =
 		return;
 	}
 
-	precache_model ("progs/boss.mdl");
-	precache_model ("progs/lavaball.mdl");
+	precache_model ("progs/boss");
+	precache_model ("progs/lavaball");
 
 	precache_sound ("weapons/rocket1i.wav");
 	precache_sound ("boss1/out1.wav");

--- a/Quake/qc/monsters/enforcer.qc
+++ b/Quake/qc/monsters/enforcer.qc
@@ -104,7 +104,7 @@ void(vector org, vector vec) LaunchLaser =
 	newmis.solid = SOLID_BBOX;
 	newmis.effects = EF_DIMLIGHT;
 
-	setmodel (newmis, "progs/laser.mdl");
+	setmodel (newmis, "progs/laser");
 	setsize (newmis, '0 0 0', '0 0 0');		
 
 	setorigin (newmis, org);
@@ -322,10 +322,10 @@ void() enf_die =
 	if (self.health < -35)
 	{
 		sound (self, CHAN_VOICE, "player/udeath.wav", 1, ATTN_NORM);
-		ThrowHead ("progs/h_mega.mdl", self.health);
-		ThrowGib ("progs/gib1.mdl", self.health);
-		ThrowGib ("progs/gib2.mdl", self.health);
-		ThrowGib ("progs/gib3.mdl", self.health);
+		ThrowHead ("progs/h_mega", self.health);
+		ThrowGib ("progs/gib1", self.health);
+		ThrowGib ("progs/gib2", self.health);
+		ThrowGib ("progs/gib3", self.health);
 		return;
 	}
 
@@ -348,9 +348,9 @@ void() monster_enforcer =
 		return;
 	}
 	
-	precache_model2 ("progs/enforcer.mdl");
-	precache_model2 ("progs/h_mega.mdl");
-	precache_model2 ("progs/laser.mdl");
+	precache_model2 ("progs/enforcer");
+	precache_model2 ("progs/h_mega");
+	precache_model2 ("progs/laser");
 
 	precache_sound2 ("enforcer/death1.wav");
 	precache_sound2 ("enforcer/enfire.wav");
@@ -366,7 +366,7 @@ void() monster_enforcer =
 	self.solid = SOLID_SLIDEBOX;
 	self.movetype = MOVETYPE_STEP;
 
-	setmodel (self, "progs/enforcer.mdl");
+	setmodel (self, "progs/enforcer");
 
 	self.netname = "$qc_enforcer";
 	self.killstring = "$qc_ks_enforcer";

--- a/Quake/qc/monsters/fiend.qc
+++ b/Quake/qc/monsters/fiend.qc
@@ -184,10 +184,10 @@ void() demon_die =
 	if (self.health < -80)
 	{
 		sound (self, CHAN_VOICE, "player/udeath.wav", 1, ATTN_NORM);
-		ThrowHead ("progs/h_demon.mdl", self.health);
-		ThrowGib ("progs/gib1.mdl", self.health);
-		ThrowGib ("progs/gib1.mdl", self.health);
-		ThrowGib ("progs/gib1.mdl", self.health);
+		ThrowHead ("progs/h_demon", self.health);
+		ThrowGib ("progs/gib1", self.health);
+		ThrowGib ("progs/gib1", self.health);
+		ThrowGib ("progs/gib1", self.health);
 		return;
 	}
 
@@ -210,8 +210,8 @@ void() monster_demon1 =
 		remove(self);
 		return;
 	}
-	precache_model ("progs/demon.mdl");
-	precache_model ("progs/h_demon.mdl");
+	precache_model ("progs/demon");
+	precache_model ("progs/h_demon");
 
 	precache_sound ("demon/ddeath.wav");
 	precache_sound ("demon/dhit2.wav");
@@ -223,7 +223,7 @@ void() monster_demon1 =
 	self.solid = SOLID_SLIDEBOX;
 	self.movetype = MOVETYPE_STEP;
 
-	setmodel (self, "progs/demon.mdl");
+	setmodel (self, "progs/demon");
 	self.noise = "demon/sight2.wav";
 	self.killstring = "$qc_ks_fiend";
 

--- a/Quake/qc/monsters/grunt.qc
+++ b/Quake/qc/monsters/grunt.qc
@@ -266,10 +266,10 @@ void() army_die =
 	if (self.health < -35)
 	{
 		sound (self, CHAN_VOICE, "player/udeath.wav", 1, ATTN_NORM);
-		ThrowHead ("progs/h_guard.mdl", self.health);
-		ThrowGib ("progs/gib1.mdl", self.health);
-		ThrowGib ("progs/gib2.mdl", self.health);
-		ThrowGib ("progs/gib3.mdl", self.health);
+		ThrowHead ("progs/h_guard", self.health);
+		ThrowGib ("progs/gib1", self.health);
+		ThrowGib ("progs/gib2", self.health);
+		ThrowGib ("progs/gib3", self.health);
 		return;
 	}
 
@@ -291,11 +291,11 @@ void() monster_army =
 		return;
 	}
 	
-	precache_model ("progs/soldier.mdl");
-	precache_model ("progs/h_guard.mdl");
-	precache_model ("progs/gib1.mdl");
-	precache_model ("progs/gib2.mdl");
-	precache_model ("progs/gib3.mdl");
+	precache_model ("progs/soldier");
+	precache_model ("progs/h_guard");
+	precache_model ("progs/gib1");
+	precache_model ("progs/gib2");
+	precache_model ("progs/gib3");
 
 	precache_sound ("soldier/death1.wav");
 	precache_sound ("soldier/idle.wav");
@@ -310,7 +310,7 @@ void() monster_army =
 	self.solid = SOLID_SLIDEBOX;
 	self.movetype = MOVETYPE_STEP;
 
-	setmodel (self, "progs/soldier.mdl");
+	setmodel (self, "progs/soldier");
 
 	self.noise = "soldier/sight1.wav";
 	self.netname = "$qc_grunt";

--- a/Quake/qc/monsters/hellknight.qc
+++ b/Quake/qc/monsters/hellknight.qc
@@ -93,7 +93,7 @@ void(float offset) hknight_shot =
 	
 	launch_spike (org, vec);
 	newmis.classname = "knight_spike";
-	setmodel (newmis, "progs/k_spike.mdl");
+	setmodel (newmis, "progs/k_spike");
 	setsize (newmis, VEC_ORIGIN, VEC_ORIGIN);		
 	newmis.velocity = vec*300;
 	if (cvar("pr_checkextension"))
@@ -238,10 +238,10 @@ void() hknight_die =
 	if (self.health < -40)
 	{
 		sound (self, CHAN_VOICE, "player/udeath.wav", 1, ATTN_NORM);
-		ThrowHead ("progs/h_hellkn.mdl", self.health);
-		ThrowGib ("progs/gib1.mdl", self.health);
-		ThrowGib ("progs/gib2.mdl", self.health);
-		ThrowGib ("progs/gib3.mdl", self.health);
+		ThrowHead ("progs/h_hellkn", self.health);
+		ThrowGib ("progs/gib1", self.health);
+		ThrowGib ("progs/gib2", self.health);
+		ThrowGib ("progs/gib3", self.health);
 		return;
 	}
 
@@ -443,9 +443,9 @@ void() monster_hell_knight =
 		return;
 	}
 
-	precache_model2 ("progs/hknight.mdl");
-	precache_model2 ("progs/k_spike.mdl");
-	precache_model2 ("progs/h_hellkn.mdl");
+	precache_model2 ("progs/hknight");
+	precache_model2 ("progs/k_spike");
+	precache_model2 ("progs/h_hellkn");
 
 	
 	precache_sound2 ("hknight/attack1.wav");
@@ -463,7 +463,7 @@ void() monster_hell_knight =
 	self.solid = SOLID_SLIDEBOX;
 	self.movetype = MOVETYPE_STEP;
 
-	setmodel (self, "progs/hknight.mdl");
+	setmodel (self, "progs/hknight");
 
 	self.noise = "hknight/sight1.wav";
 	self.netname = "$qc_death_knight";

--- a/Quake/qc/monsters/knight.qc
+++ b/Quake/qc/monsters/knight.qc
@@ -229,10 +229,10 @@ void() knight_die =
 	if (self.health < -40)
 	{
 		sound (self, CHAN_VOICE, "player/udeath.wav", 1, ATTN_NORM);
-		ThrowHead ("progs/h_knight.mdl", self.health);
-		ThrowGib ("progs/gib1.mdl", self.health);
-		ThrowGib ("progs/gib2.mdl", self.health);
-		ThrowGib ("progs/gib3.mdl", self.health);
+		ThrowHead ("progs/h_knight", self.health);
+		ThrowGib ("progs/gib1", self.health);
+		ThrowGib ("progs/gib2", self.health);
+		ThrowGib ("progs/gib3", self.health);
 		return;
 	}
 
@@ -257,8 +257,8 @@ void() monster_knight =
 		return;
 	}
 
-	precache_model ("progs/knight.mdl");
-	precache_model ("progs/h_knight.mdl");
+	precache_model ("progs/knight");
+	precache_model ("progs/h_knight");
 
 	precache_sound ("knight/kdeath.wav");
 	precache_sound ("knight/khurt.wav");
@@ -270,7 +270,7 @@ void() monster_knight =
 	self.solid = SOLID_SLIDEBOX;
 	self.movetype = MOVETYPE_STEP;
 
-	setmodel (self, "progs/knight.mdl");
+	setmodel (self, "progs/knight");
 
 	self.noise = "knight/ksight.wav";
 	self.netname = "$qc_knight";

--- a/Quake/qc/monsters/ogre.qc
+++ b/Quake/qc/monsters/ogre.qc
@@ -145,7 +145,7 @@ void() OgreFireGrenade =
 	missile.nextthink = time + 2.5;
 	missile.think = OgreGrenadeExplode;
 
-	setmodel (missile, "progs/grenade.mdl");
+	setmodel (missile, "progs/grenade");
 	setsize (missile, '0 0 0', '0 0 0');		
 	setorigin (missile, self.origin);
 };
@@ -461,10 +461,10 @@ void() ogre_die =
 	if (self.health < -80)
 	{
 		sound (self, CHAN_VOICE, "player/udeath.wav", 1, ATTN_NORM);
-		ThrowHead ("progs/h_ogre.mdl", self.health);
-		ThrowGib ("progs/gib3.mdl", self.health);
-		ThrowGib ("progs/gib3.mdl", self.health);
-		ThrowGib ("progs/gib3.mdl", self.health);
+		ThrowHead ("progs/h_ogre", self.health);
+		ThrowGib ("progs/gib3", self.health);
+		ThrowGib ("progs/gib3", self.health);
+		ThrowGib ("progs/gib3", self.health);
 		return;
 	}
 
@@ -496,9 +496,9 @@ void() monster_ogre =
 		return;
 	}
 
-	precache_model ("progs/ogre.mdl");
-	precache_model ("progs/h_ogre.mdl");
-	precache_model ("progs/grenade.mdl");
+	precache_model ("progs/ogre");
+	precache_model ("progs/h_ogre");
+	precache_model ("progs/grenade");
 
 	precache_sound ("ogre/ogdrag.wav");
 	precache_sound ("ogre/ogdth.wav");
@@ -511,7 +511,7 @@ void() monster_ogre =
 	self.solid = SOLID_SLIDEBOX;
 	self.movetype = MOVETYPE_STEP;
 
-	setmodel (self, "progs/ogre.mdl");
+	setmodel (self, "progs/ogre");
 
 	self.noise = "ogre/ogwake.wav";
 	self.netname = "$qc_ogre";

--- a/Quake/qc/monsters/rotfish.qc
+++ b/Quake/qc/monsters/rotfish.qc
@@ -187,7 +187,7 @@ void() monster_fish =
 		return;
 	}
 	
-	precache_model2 ("progs/fish.mdl");
+	precache_model2 ("progs/fish");
 
 	precache_sound2 ("fish/death.wav");
 	precache_sound2 ("fish/bite.wav");
@@ -196,7 +196,7 @@ void() monster_fish =
 	self.solid = SOLID_SLIDEBOX;
 	self.movetype = MOVETYPE_STEP;
 
-	setmodel (self, "progs/fish.mdl");
+	setmodel (self, "progs/fish");
 
 	self.netname = "$qc_rotfish";
 	self.noise = "fish/idle.wav";

--- a/Quake/qc/monsters/rottweiler.qc
+++ b/Quake/qc/monsters/rottweiler.qc
@@ -255,10 +255,10 @@ void() dog_die =
 	if (self.health < -35)
 	{
 		sound (self, CHAN_VOICE, "player/udeath.wav", 1, ATTN_NORM);
-		ThrowGib ("progs/gib3.mdl", self.health);
-		ThrowGib ("progs/gib3.mdl", self.health);
-		ThrowGib ("progs/gib3.mdl", self.health);
-		ThrowHead ("progs/h_dog.mdl", self.health);
+		ThrowGib ("progs/gib3", self.health);
+		ThrowGib ("progs/gib3", self.health);
+		ThrowGib ("progs/gib3", self.health);
+		ThrowHead ("progs/h_dog", self.health);
 		return;
 	}
 
@@ -352,8 +352,8 @@ void() monster_dog =
 		remove(self);
 		return;
 	}
-	precache_model ("progs/h_dog.mdl");
-	precache_model ("progs/dog.mdl");
+	precache_model ("progs/h_dog");
+	precache_model ("progs/dog");
 
 	precache_sound ("dog/dattack1.wav");
 	precache_sound ("dog/ddeath.wav");
@@ -364,7 +364,7 @@ void() monster_dog =
 	self.solid = SOLID_SLIDEBOX;
 	self.movetype = MOVETYPE_STEP;
 
-	setmodel (self, "progs/dog.mdl");
+	setmodel (self, "progs/dog");
 
 	self.noise = "dog/dsight.wav";	
 	self.netname = "$qc_rottweiler";

--- a/Quake/qc/monsters/scrag.qc
+++ b/Quake/qc/monsters/scrag.qc
@@ -225,7 +225,7 @@ void() Wiz_FastFire =
 		newmis.velocity = vec*600;
 		newmis.owner = self.owner;
 		newmis.classname = "wizard_spike";
-		setmodel (newmis, "progs/w_spike.mdl");
+		setmodel (newmis, "progs/w_spike");
 		setsize (newmis, VEC_ORIGIN, VEC_ORIGIN);		
 	}
 
@@ -381,10 +381,10 @@ void() wiz_die =
 	if (self.health < -40)
 	{
 		sound (self, CHAN_VOICE, "player/udeath.wav", 1, ATTN_NORM);
-		ThrowHead ("progs/h_wizard.mdl", self.health);
-		ThrowGib ("progs/gib2.mdl", self.health);
-		ThrowGib ("progs/gib2.mdl", self.health);
-		ThrowGib ("progs/gib2.mdl", self.health);
+		ThrowHead ("progs/h_wizard", self.health);
+		ThrowGib ("progs/gib2", self.health);
+		ThrowGib ("progs/gib2", self.health);
+		ThrowGib ("progs/gib2", self.health);
 		return;
 	}
 
@@ -419,9 +419,9 @@ void() monster_wizard =
 		return;
 	}
 	
-	precache_model ("progs/wizard.mdl");
-	precache_model ("progs/h_wizard.mdl");
-	precache_model ("progs/w_spike.mdl");
+	precache_model ("progs/wizard");
+	precache_model ("progs/h_wizard");
+	precache_model ("progs/w_spike");
 
 	precache_sound ("wizard/hit.wav");		// used by c code
 	precache_sound ("wizard/wattack.wav");
@@ -434,7 +434,7 @@ void() monster_wizard =
 	self.solid = SOLID_SLIDEBOX;
 	self.movetype = MOVETYPE_STEP;
 
-	setmodel (self, "progs/wizard.mdl");
+	setmodel (self, "progs/wizard");
 
 	self.noise = "wizard/wsight.wav";
 	self.netname = "$qc_scrag";

--- a/Quake/qc/monsters/shambler.qc
+++ b/Quake/qc/monsters/shambler.qc
@@ -272,7 +272,7 @@ void() sham_magic3     =[      $magic3,       sham_magic4    ] {
 	ai_face();
 	self.owner = spawn();
 	o = self.owner;
-	setmodel (o, "progs/s_light.mdl");
+	setmodel (o, "progs/s_light");
 	setorigin (o, self.origin);
 	o.angles = self.angles;
 	o.nextthink = time + 0.7;
@@ -365,10 +365,10 @@ void() sham_die =
 	if (self.health < -60)
 	{
 		sound (self, CHAN_VOICE, "player/udeath.wav", 1, ATTN_NORM);
-		ThrowHead ("progs/h_shams.mdl", self.health);
-		ThrowGib ("progs/gib1.mdl", self.health);
-		ThrowGib ("progs/gib2.mdl", self.health);
-		ThrowGib ("progs/gib3.mdl", self.health);
+		ThrowHead ("progs/h_shams", self.health);
+		ThrowGib ("progs/gib1", self.health);
+		ThrowGib ("progs/gib2", self.health);
+		ThrowGib ("progs/gib3", self.health);
 		return;
 	}
 
@@ -390,10 +390,10 @@ void() monster_shambler =
 		return;
 	}
 
-	precache_model ("progs/shambler.mdl");
-	precache_model ("progs/s_light.mdl");
-	precache_model ("progs/h_shams.mdl");
-	precache_model ("progs/bolt.mdl");
+	precache_model ("progs/shambler");
+	precache_model ("progs/s_light");
+	precache_model ("progs/h_shams");
+	precache_model ("progs/bolt");
 	
 	precache_sound ("shambler/sattck1.wav");
 	precache_sound ("shambler/sboom.wav");
@@ -407,7 +407,7 @@ void() monster_shambler =
 
 	self.solid = SOLID_SLIDEBOX;
 	self.movetype = MOVETYPE_STEP;
-	setmodel (self, "progs/shambler.mdl");
+	setmodel (self, "progs/shambler");
 	
 	self.noise = "shambler/ssight.wav";
 	self.netname = "$qc_shambler";

--- a/Quake/qc/monsters/shub.qc
+++ b/Quake/qc/monsters/shub.qc
@@ -245,11 +245,11 @@ void() finale_4 =
 				r = random();
 
 				if (r < 0.3)				
-					ThrowGib ("progs/gib1.mdl", -999);
+					ThrowGib ("progs/gib1", -999);
 				else if (r < 0.6)
-					ThrowGib ("progs/gib2.mdl", -999);
+					ThrowGib ("progs/gib2", -999);
 				else
-					ThrowGib ("progs/gib3.mdl", -999);
+					ThrowGib ("progs/gib3", -999);
 
 				y = y + 32;
 			}
@@ -266,7 +266,7 @@ void() finale_4 =
 
 // put a player model down
 	n = spawn();
-	setmodel (n, "progs/player.mdl");
+	setmodel (n, "progs/player");
 	oldo = oldo - '32 264 0';
 	setorigin (n, oldo);
 	n.angles = '0 290 0';
@@ -319,7 +319,7 @@ void() monster_oldone =
 		return;
 	}
 
-	precache_model2 ("progs/oldone.mdl");
+	precache_model2 ("progs/oldone");
 
 	precache_sound2 ("boss2/death.wav");
 	precache_sound2 ("boss2/idle.wav");
@@ -329,7 +329,7 @@ void() monster_oldone =
 	self.solid = SOLID_SLIDEBOX;
 	self.movetype = MOVETYPE_STEP;
 	
-	setmodel (self, "progs/oldone.mdl");
+	setmodel (self, "progs/oldone");
 	self.netname = "$qc_shub";
 	self.killstring = "$qc_ks_shub";
 

--- a/Quake/qc/monsters/spawn.qc
+++ b/Quake/qc/monsters/spawn.qc
@@ -209,7 +209,7 @@ void() monster_tarbaby =
 		return;
 	}
 	
-	precache_model2 ("progs/tarbaby.mdl");
+	precache_model2 ("progs/tarbaby");
 
 	precache_sound2 ("blob/death1.wav");
 	precache_sound2 ("blob/hit1.wav");
@@ -219,7 +219,7 @@ void() monster_tarbaby =
 	self.solid = SOLID_SLIDEBOX;
 	self.movetype = MOVETYPE_STEP;
 
-	setmodel (self, "progs/tarbaby.mdl");
+	setmodel (self, "progs/tarbaby");
 
 	self.noise = "blob/sight1.wav";
 	self.netname = "$qc_spawn";

--- a/Quake/qc/monsters/vore.qc
+++ b/Quake/qc/monsters/vore.qc
@@ -129,10 +129,10 @@ void() shalrath_die =
 	if (self.health < -90)
 	{
 		sound (self, CHAN_VOICE, "player/udeath.wav", 1, ATTN_NORM);
-		ThrowHead ("progs/h_shal.mdl", self.health);
-		ThrowGib ("progs/gib1.mdl", self.health);
-		ThrowGib ("progs/gib2.mdl", self.health);
-		ThrowGib ("progs/gib3.mdl", self.health);
+		ThrowHead ("progs/h_shal", self.health);
+		ThrowGib ("progs/gib1", self.health);
+		ThrowGib ("progs/gib2", self.health);
+		ThrowGib ("progs/gib3", self.health);
 		return;
 	}
 
@@ -171,7 +171,7 @@ void() ShalMissile =
 
 	missile.solid = SOLID_BBOX;
 	missile.movetype = MOVETYPE_FLYMISSILE;
-	setmodel (missile, "progs/v_spike.mdl");
+	setmodel (missile, "progs/v_spike");
 
 	setsize (missile, '0 0 0', '0 0 0');		
 
@@ -239,9 +239,9 @@ void() monster_shalrath =
 		return;
 	}
 
-	precache_model2 ("progs/shalrath.mdl");
-	precache_model2 ("progs/h_shal.mdl");
-	precache_model2 ("progs/v_spike.mdl");
+	precache_model2 ("progs/shalrath");
+	precache_model2 ("progs/h_shal");
+	precache_model2 ("progs/v_spike");
 	
 	precache_sound2 ("shalrath/attack.wav");
 	precache_sound2 ("shalrath/attack2.wav");
@@ -253,7 +253,7 @@ void() monster_shalrath =
 	self.solid = SOLID_SLIDEBOX;
 	self.movetype = MOVETYPE_STEP;
 	
-	setmodel (self, "progs/shalrath.mdl");
+	setmodel (self, "progs/shalrath");
 
 	self.noise = "shalrath/sight.wav";
 	self.netname = "$qc_vore";

--- a/Quake/qc/monsters/zombie.qc
+++ b/Quake/qc/monsters/zombie.qc
@@ -212,7 +212,7 @@ void(vector st) ZombieFireGrenade =
 	missile.nextthink = time + 2.5;
 	missile.think = SUB_Remove;
 
-	setmodel (missile, "progs/zom_gib.mdl");
+	setmodel (missile, "progs/zom_gib");
 	setsize (missile, '0 0 0', '0 0 0');		
 	setorigin (missile, org);
 };
@@ -412,10 +412,10 @@ void() zombie_paine30	=[	$paine30,	zombie_run1		] {};
 void() zombie_die =
 {
 	sound (self, CHAN_VOICE, "zombie/z_gib.wav", 1, ATTN_NORM);
-	ThrowHead ("progs/h_zombie.mdl", self.health);
-	ThrowGib ("progs/gib1.mdl", self.health);
-	ThrowGib ("progs/gib2.mdl", self.health);
-	ThrowGib ("progs/gib3.mdl", self.health);
+	ThrowHead ("progs/h_zombie", self.health);
+	ThrowGib ("progs/gib1", self.health);
+	ThrowGib ("progs/gib2", self.health);
+	ThrowGib ("progs/gib3", self.health);
 };
 
 /*
@@ -500,9 +500,9 @@ void() monster_zombie =
 		return;
 	}
 
-	precache_model ("progs/zombie.mdl");
-	precache_model ("progs/h_zombie.mdl");
-	precache_model ("progs/zom_gib.mdl");
+	precache_model ("progs/zombie");
+	precache_model ("progs/h_zombie");
+	precache_model ("progs/zom_gib");
 
 	precache_sound ("zombie/z_idle.wav");
 	precache_sound ("zombie/z_idle1.wav");
@@ -518,7 +518,7 @@ void() monster_zombie =
 	self.solid = SOLID_SLIDEBOX;
 	self.movetype = MOVETYPE_STEP;
 
-	setmodel (self, "progs/zombie.mdl");
+	setmodel (self, "progs/zombie");
 
 	self.noise = "zombie/z_idle.wav";
 	self.netname = "$qc_zombie";

--- a/Quake/qc/plats.qc
+++ b/Quake/qc/plats.qc
@@ -383,8 +383,8 @@ void() misc_teleporttrain =
 	self.noise1 = ("misc/null.wav");
 	precache_sound ("misc/null.wav");
 
-	precache_model2 ("progs/teleport.mdl");
-	setmodel (self, "progs/teleport.mdl");
+	precache_model2 ("progs/teleport");
+	setmodel (self, "progs/teleport");
 	setsize (self, self.mins , self.maxs);
 	setorigin (self, self.origin);
 

--- a/Quake/qc/player.qc
+++ b/Quake/qc/player.qc
@@ -556,10 +556,10 @@ void(string gibname, float dm) ThrowHead =
 
 void() GibPlayer =
 {
-	ThrowHead ("progs/h_player.mdl", self.health);
-	ThrowGib ("progs/gib1.mdl", self.health);
-	ThrowGib ("progs/gib2.mdl", self.health);
-	ThrowGib ("progs/gib3.mdl", self.health);
+	ThrowHead ("progs/h_player", self.health);
+	ThrowGib ("progs/gib1", self.health);
+	ThrowGib ("progs/gib2", self.health);
+	ThrowGib ("progs/gib3", self.health);
 
 	self.deadflag = DEAD_DEAD;
 
@@ -640,7 +640,7 @@ void() PlayerDie =
 void() set_suicide_frame =
 {	// used by klill command and diconnect command
 
-	if (self.model != "progs/player.mdl")
+	if (self.model != "progs/player")
 		return;	// allready gibbed
 
 	self.frame = $deatha11;

--- a/Quake/qc/weapons.old
+++ b/Quake/qc/weapons.old
@@ -124,7 +124,7 @@ void(vector org, vector vel) SpawnMeatSpray =
 	missile.nextthink = time + 1;
 	missile.think = SUB_Remove;
 
-	setmodel (missile, "progs/zom_gib.mdl");
+	setmodel (missile, "progs/zom_gib");
 	setsize (missile, '0 0 0', '0 0 0');		
 	setorigin (missile, org);
 };
@@ -419,7 +419,7 @@ void() W_FireRocket =
 	missile.nextthink = time + 5;
 	missile.think = SUB_Remove;
 
-	setmodel (missile, "progs/missile.mdl");
+	setmodel (missile, "progs/missile");
 	setsize (missile, '0 0 0', '0 0 0');		
 	setorigin (missile, self.origin + v_forward*8 + '0 0 16');
 };
@@ -609,7 +609,7 @@ void() W_FireGrenade =
 	missile.nextthink = time + 2.5;
 	missile.think = GrenadeExplode;
 
-	setmodel (missile, "progs/grenade.mdl");
+	setmodel (missile, "progs/grenade");
 	setsize (missile, '0 0 0', '0 0 0');		
 	setorigin (missile, self.origin);
 };
@@ -641,7 +641,7 @@ void(vector org, vector dir) launch_spike =
 	newmis.classname = "spike";
 	newmis.think = SUB_Remove;
 	newmis.nextthink = time + 6;
-	setmodel (newmis, "progs/spike.mdl");
+	setmodel (newmis, "progs/spike");
 	setsize (newmis, VEC_ORIGIN, VEC_ORIGIN);		
 	setorigin (newmis, org);
 
@@ -660,7 +660,7 @@ void() W_FireSuperSpikes =
 	launch_spike (self.origin + '0 0 16', dir);
 	newmis.classname = "super_spike";
 	newmis.touch = superspike_touch;
-	setmodel (newmis, "progs/s_spike.mdl");
+	setmodel (newmis, "progs/s_spike");
 	setsize (newmis, VEC_ORIGIN, VEC_ORIGIN);		
 	self.punchangle_x = -2;
 };
@@ -788,48 +788,48 @@ void() W_SetCurrentAmmo =
 	if (self.weapon == IT_AXE)
 	{
 		self.currentammo = 0;
-		self.weaponmodel = "progs/v_axe.mdl";
+		self.weaponmodel = "progs/v_axe";
 	}
 	else if (self.weapon == IT_SHOTGUN)
 	{
 		self.currentammo = self.ammo_shells;
-		self.weaponmodel = "progs/v_shot.mdl";
+		self.weaponmodel = "progs/v_shot";
 		self.items = self.items | IT_SHELLS;
 	}
 	else if (self.weapon == IT_SUPER_SHOTGUN)
 	{
 		self.currentammo = self.ammo_shells;
-		self.weaponmodel = "progs/v_shot2.mdl";
+		self.weaponmodel = "progs/v_shot2";
 		self.items = self.items | IT_SHELLS;
 	}
 	else if (self.weapon == IT_NAILGUN)
 	{
 		self.currentammo = self.ammo_nails;
-		self.weaponmodel = "progs/v_nail.mdl";
+		self.weaponmodel = "progs/v_nail";
 		self.items = self.items | IT_NAILS;
 	}
 	else if (self.weapon == IT_SUPER_NAILGUN)
 	{
 		self.currentammo = self.ammo_nails;
-		self.weaponmodel = "progs/v_nail2.mdl";
+		self.weaponmodel = "progs/v_nail2";
 		self.items = self.items | IT_NAILS;
 	}
 	else if (self.weapon == IT_GRENADE_LAUNCHER)
 	{
 		self.currentammo = self.ammo_rockets;
-		self.weaponmodel = "progs/v_rock.mdl";
+		self.weaponmodel = "progs/v_rock";
 		self.items = self.items | IT_ROCKETS;
 	}
 	else if (self.weapon == IT_ROCKET_LAUNCHER)
 	{
 		self.currentammo = self.ammo_rockets;
-		self.weaponmodel = "progs/v_rock2.mdl";
+		self.weaponmodel = "progs/v_rock2";
 		self.items = self.items | IT_ROCKETS;
 	}
 	else if (self.weapon == IT_LIGHTNING)
 	{
 		self.currentammo = self.ammo_cells;
-		self.weaponmodel = "progs/v_light.mdl";
+		self.weaponmodel = "progs/v_light";
 		self.items = self.items | IT_CELLS;
 	}
 	else

--- a/Quake/qc/weapons.qc
+++ b/Quake/qc/weapons.qc
@@ -209,7 +209,7 @@ void(vector org, vector vel) SpawnMeatSpray =
 	missile.nextthink = time + 1;
 	missile.think = SUB_Remove;
 
-	setmodel (missile, "progs/zom_gib.mdl");
+	setmodel (missile, "progs/zom_gib");
 	setsize (missile, '0 0 0', '0 0 0');		
 	setorigin (missile, org);
 };
@@ -532,7 +532,7 @@ void() W_FireRocket =
 	missile.nextthink = time + 5;
 	missile.think = SUB_Remove;
 
-	setmodel (missile, "progs/missile.mdl");
+	setmodel (missile, "progs/missile");
 	setsize (missile, '0 0 0', '0 0 0');		
 	setorigin (missile, self.origin + v_forward*8 + '0 0 16');
 };
@@ -725,7 +725,7 @@ void() W_FireGrenade =
 	missile.nextthink = time + 2.5;
 	missile.think = GrenadeExplode;
 
-	setmodel (missile, "progs/grenade.mdl");
+	setmodel (missile, "progs/grenade");
 	setsize (missile, '0 0 0', '0 0 0');		
 	setorigin (missile, self.origin);
 };
@@ -757,7 +757,7 @@ void(vector org, vector dir) launch_spike =
 	newmis.classname = "spike";
 	newmis.think = SUB_Remove;
 	newmis.nextthink = time + 6;
-	setmodel (newmis, "progs/spike.mdl");
+	setmodel (newmis, "progs/spike");
 	
 	// attach nail trail
 	FX_AttachTrail(newmis, FX_NAIL_TRAIL);
@@ -779,7 +779,7 @@ void() W_FireSuperSpikes =
 	launch_spike (self.origin + '0 0 16', dir);
 	newmis.classname = "super_spike";
 	newmis.touch = superspike_touch;
-	setmodel (newmis, "progs/s_spike.mdl");
+	setmodel (newmis, "progs/s_spike");
 	setsize (newmis, VEC_ORIGIN, VEC_ORIGIN);		
 	self.punchangle_x = -2;
 };
@@ -910,48 +910,48 @@ void() W_SetCurrentAmmo =
 	if (self.weapon == IT_AXE)
 	{
 		self.currentammo = 0;
-		self.weaponmodel = "progs/v_axe.mdl";
+		self.weaponmodel = "progs/v_axe";
 	}
 	else if (self.weapon == IT_SHOTGUN)
 	{
 		self.currentammo = self.ammo_shells;
-		self.weaponmodel = "progs/v_shot.mdl";
+		self.weaponmodel = "progs/v_shot";
 		self.items = self.items | IT_SHELLS;
 	}
 	else if (self.weapon == IT_SUPER_SHOTGUN)
 	{
 		self.currentammo = self.ammo_shells;
-		self.weaponmodel = "progs/v_shot2.mdl";
+		self.weaponmodel = "progs/v_shot2";
 		self.items = self.items | IT_SHELLS;
 	}
 	else if (self.weapon == IT_NAILGUN)
 	{
 		self.currentammo = self.ammo_nails;
-		self.weaponmodel = "progs/v_nail.mdl";
+		self.weaponmodel = "progs/v_nail";
 		self.items = self.items | IT_NAILS;
 	}
 	else if (self.weapon == IT_SUPER_NAILGUN)
 	{
 		self.currentammo = self.ammo_nails;
-		self.weaponmodel = "progs/v_nail2.mdl";
+		self.weaponmodel = "progs/v_nail2";
 		self.items = self.items | IT_NAILS;
 	}
 	else if (self.weapon == IT_GRENADE_LAUNCHER)
 	{
 		self.currentammo = self.ammo_rockets;
-		self.weaponmodel = "progs/v_rock.mdl";
+		self.weaponmodel = "progs/v_rock";
 		self.items = self.items | IT_ROCKETS;
 	}
 	else if (self.weapon == IT_ROCKET_LAUNCHER)
 	{
 		self.currentammo = self.ammo_rockets;
-		self.weaponmodel = "progs/v_rock2.mdl";
+		self.weaponmodel = "progs/v_rock2";
 		self.items = self.items | IT_ROCKETS;
 	}
 	else if (self.weapon == IT_LIGHTNING)
 	{
 		self.currentammo = self.ammo_cells;
-		self.weaponmodel = "progs/v_light.mdl";
+		self.weaponmodel = "progs/v_light";
 		self.items = self.items | IT_CELLS;
 	}
 	else

--- a/Quake/qc/world.qc
+++ b/Quake/qc/world.qc
@@ -277,39 +277,39 @@ void() worldspawn =
 	precache_sound ("misc/water1.wav");			// swimming
 	precache_sound ("misc/water2.wav");			// swimming
 
-	precache_model ("progs/player.mdl");
-	precache_model ("progs/eyes.mdl");
-	precache_model ("progs/h_player.mdl");
-	precache_model ("progs/gib1.mdl");
-	precache_model ("progs/gib2.mdl");
-	precache_model ("progs/gib3.mdl");
+	precache_model ("progs/player");
+	precache_model ("progs/eyes");
+	precache_model ("progs/h_player");
+	precache_model ("progs/gib1");
+	precache_model ("progs/gib2");
+	precache_model ("progs/gib3");
 
 	precache_model ("progs/s_bubble.spr");	// drowning bubbles
 	precache_model ("progs/s_explod.spr");	// sprite explosion
 
-	precache_model ("progs/v_axe.mdl");
-	precache_model ("progs/v_shot.mdl");
-	precache_model ("progs/v_nail.mdl");
-	precache_model ("progs/v_rock.mdl");
-	precache_model ("progs/v_shot2.mdl");
-	precache_model ("progs/v_nail2.mdl");
-	precache_model ("progs/v_rock2.mdl");
+	precache_model ("progs/v_axe");
+	precache_model ("progs/v_shot");
+	precache_model ("progs/v_nail");
+	precache_model ("progs/v_rock");
+	precache_model ("progs/v_shot2");
+	precache_model ("progs/v_nail2");
+	precache_model ("progs/v_rock2");
 
-	precache_model ("progs/bolt.mdl");		// for lightning gun
-	precache_model ("progs/bolt2.mdl");		// for lightning gun
-	precache_model ("progs/bolt3.mdl");		// for boss shock
-	precache_model ("progs/lavaball.mdl");	// for testing
+	precache_model ("progs/bolt");		// for lightning gun
+	precache_model ("progs/bolt2");		// for lightning gun
+	precache_model ("progs/bolt3");		// for boss shock
+	precache_model ("progs/lavaball");	// for testing
 	
-	precache_model ("progs/missile.mdl");
-	precache_model ("progs/grenade.mdl");
-	precache_model ("progs/spike.mdl");
-	precache_model ("progs/s_spike.mdl");
+	precache_model ("progs/missile");
+	precache_model ("progs/grenade");
+	precache_model ("progs/spike");
+	precache_model ("progs/s_spike");
 
-	precache_model ("progs/backpack.mdl");
+	precache_model ("progs/backpack");
 
-	precache_model ("progs/zom_gib.mdl");
+	precache_model ("progs/zom_gib");
 
-	precache_model ("progs/v_light.mdl");
+	precache_model ("progs/v_light");
 	
 
 //

--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -1516,13 +1516,22 @@ SV_ModelIndex
 int SV_ModelIndex (const char *name)
 {
 	int		i;
+	char		normalized_request[MAX_QPATH];
+	char		normalized_precache[MAX_QPATH];
 
 	if (!name || !name[0])
 		return 0;
 
+	COM_StripModelExtension (name, normalized_request, sizeof(normalized_request));
+
 	for (i=0 ; i<MAX_MODELS && sv.model_precache[i] ; i++)
+	{
 		if (!strcmp(sv.model_precache[i], name))
 			return i;
+		COM_StripModelExtension (sv.model_precache[i], normalized_precache, sizeof(normalized_precache));
+		if (!strcmp(normalized_precache, normalized_request))
+			return i;
+	}
 	if (i==MAX_MODELS || !sv.model_precache[i])
 		Sys_Error ("SV_ModelIndex: model %s not precached", name);
 	return i;
@@ -1559,7 +1568,7 @@ void SV_CreateBaseline (void)
 		if (entnum > 0 && entnum <= svs.maxclients)
 		{
 			svent->baseline.colormap = entnum;
-			svent->baseline.modelindex = SV_ModelIndex("progs/player.mdl");
+			svent->baseline.modelindex = SV_ModelIndex("progs/player");
 			svent->baseline.alpha = ENTALPHA_DEFAULT; //johnfitz -- alpha support
 			svent->baseline.scale = ENTSCALE_DEFAULT;
 		}


### PR DESCRIPTION
## Summary
- resolve model paths without fixed extensions by probing .md5/.md2/.mdl before loading
- match precache and setmodel calls regardless of model extension casing
- update QuakeC scripts to omit hardcoded .mdl suffixes so fallback logic is used consistently

## Testing
- cmake -S . -B build *(fails: missing SDL2 package)*

------
https://chatgpt.com/codex/tasks/task_e_690c64623d6c832e819dd240e100e5c4