### PR TITLE
Integrate server bots into multiplayer flow

### DIFF
--- a/Docs/bots.md
+++ b/Docs/bots.md
@@ -1,0 +1,21 @@
+# Multiplayer bot support
+
+Ironwail ships with a lightweight server-side bot controller that can be used in any multiplayer session.
+
+## Spawning bots
+
+* Open the server console and set `sv_bot_spawn` to the number of bots you would like to add. For example, `sv_bot_spawn 3` queues three bot spawns.
+* Bots will take the first free client slots, automatically spawn into the current map, and begin roaming/fighting other clients.
+
+## Removing bots
+
+* Set `sv_bot_remove` to the number of bots you want to kick, e.g. `sv_bot_remove 2`.
+* Removal happens immediately, starting from the highest-numbered bot slots.
+
+## Behaviour and limitations
+
+* Bots are entirely server-side: they do not consume network slots and stay active across level changes until removed.
+* They perform basic wandering, target the closest enemy (favouring human players), and retreat when wounded.
+* Bots respect water movement and fire when in range, but they do not execute map objectives or advanced tactics.
+
+Use these controls to quickly populate a listen or dedicated server for testing multiplayer maps or practicing movement and combat.

--- a/Quake/host.c
+++ b/Quake/host.c
@@ -505,7 +505,9 @@ void SV_DropClient (qboolean crash)
 	int		i;
 	client_t *client;
 
-	if (!crash)
+    	SV_Bot_ClientDisconnected (host_client);
+
+	if (!crash && host_client->netconnection)
 	{
 		// send any final messages (don't check for errors)
 		if (NET_CanSendMessage (host_client->netconnection))
@@ -554,14 +556,18 @@ void SV_DropClient (qboolean crash)
 	}
 
 // break the net connection
-	NET_Close (host_client->netconnection);
-	host_client->netconnection = NULL;
+	if (host_client->netconnection)
+	{
+		NET_Close (host_client->netconnection);
+		host_client->netconnection = NULL;
+	}
 
 // free the client (the body stays around)
 	host_client->active = false;
 	host_client->name[0] = 0;
 	host_client->old_frags = -999999;
-	net_activeconnections--;
+	if (!host_client->isbot && net_activeconnections > 0)
+		net_activeconnections--;
 
 // send notification to all clients
 	for (i = 0, client = svs.clients; i < svs.maxclients; i++, client++)

--- a/Quake/server.h
+++ b/Quake/server.h
@@ -148,6 +148,7 @@ typedef struct client_s
 	edict_t			*edict;				// EDICT_NUM(clientnum+1)
 	char			name[32];			// for printing to other people
 	int				colors;
+	qboolean		isbot;				// true if this client is a local bot
 
 	float			ping_times[NUM_PING_TIMES];
 	int				num_pings;			// ping_times[num_pings%NUM_PING_TIMES]
@@ -306,5 +307,10 @@ void SV_CheckForNewClients (void);
 void SV_RunClients (void);
 void SV_SaveSpawnparms (void);
 void SV_SpawnServer (const char *server);
+
+void SV_Bot_Init (void);
+void SV_Bot_Reset (void);
+void SV_Bot_RunFrame (client_t *client);
+void SV_Bot_ClientDisconnected (client_t *client);
 
 #endif	/* QUAKE_SERVER_H */

--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -181,6 +181,8 @@ void SV_Init (void)
 
 	Cmd_AddCommand ("sv_protocol", &SV_Protocol_f); //johnfitz
 
+	SV_Bot_Init ();
+
 	for (i=0 ; i<MAX_MODELS ; i++)
 		sprintf (localmodels[i], "*%i", i);
 
@@ -476,7 +478,10 @@ void SV_ConnectClient (int clientnum)
 
 	client = svs.clients + clientnum;
 
-	Con_DPrintf ("Client %s connected\n", NET_QSocketGetAddressString(client->netconnection));
+	if (client->netconnection)
+		Con_DPrintf ("Client %s connected\n", NET_QSocketGetAddressString(client->netconnection));
+	else
+		Con_DPrintf ("Bot client connected (slot %d)\n", clientnum + 1);
 
 	edictnum = clientnum+1;
 
@@ -1381,6 +1386,15 @@ void SV_SendClientMessages (void)
 		if (!host_client->active)
 			continue;
 
+		if (host_client->isbot)
+		{
+			SZ_Clear (&host_client->message);
+			host_client->last_message = realtime;
+			if (host_client->sendsignon == PRESPAWN_FLUSH)
+				host_client->sendsignon = PRESPAWN_DONE;
+			continue;
+		}
+
 		if (host_client->spawned)
 		{
 			if (!SV_SendClientDatagram (host_client))
@@ -1958,6 +1972,8 @@ void SV_SpawnServer (const char *server)
 //
 	//memset (&sv, 0, sizeof(sv));
 	Host_ClearMemory ();
+
+	SV_Bot_Reset ();
 
 	q_strlcpy (sv.name, server, sizeof(sv.name));
 	if (developer.value || map_checks.value)

--- a/Quake/sv_user.c
+++ b/Quake/sv_user.c
@@ -626,7 +626,11 @@ void SV_RunClients (void)
 
 		sv_player = host_client->edict;
 
-		if (!SV_ReadClientMessage ())
+		if (host_client->isbot)
+		{
+			SV_Bot_RunFrame (host_client);
+		}
+		else if (!SV_ReadClientMessage ())
 		{
 			SV_DropClient (false);	// client misbehaved...
 			continue;


### PR DESCRIPTION
## Summary
- integrate bot lifecycle hooks into server startup, per-frame processing, and disconnect handling
- guard network send logic from running on bot clients and log bot connections explicitly
- add a short guide covering the sv_bot_spawn and sv_bot_remove controls

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690c9ed2bb84832ebcccd0311f67e8ba