### PR TITLE
Fix particle compiler errors

### DIFF
--- a/Quake/common.h
+++ b/Quake/common.h
@@ -108,6 +108,9 @@ GENERIC_TYPES (IMPL_GENERIC_FUNCS, NO_COMMA)
 	 (x) > (_maxval) ? (_maxval) : (x))
 #endif
 
+#define q_clamp(value, _minval, _maxval)      CLAMP((_minval), (value), (_maxval))
+#define clamp(value, _minval, _maxval)        CLAMP((_minval), (value), (_maxval))
+
 #define LERP(a, b, t) ((a) + ((b)-(a))*(t))
 
 #define countof(arr) (sizeof(arr) / sizeof(arr[0]))

--- a/Quake/mathlib.h
+++ b/Quake/mathlib.h
@@ -81,6 +81,9 @@ do\
 
 void VectorAngles (const vec3_t forward, vec3_t angles); //johnfitz
 
+void ProjectPointOnPlane( vec3_t dst, const vec3_t p, const vec3_t normal );
+void PerpendicularVector( vec3_t dst, const vec3_t src );
+
 void VectorMA (const vec3_t veca, float scale, const vec3_t vecb, vec3_t vecc);
 void VectorLerp (const vec3_t veca, const vec3_t vecb, float frac, vec3_t dst);
 

--- a/Quake/r_part.c
+++ b/Quake/r_part.c
@@ -23,6 +23,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "quakedef.h"
 
+extern cvar_t sv_gravity;
+
 #define MAX_PARTICLES            16384   // default max # of particles at one
 //  time
 #define ABSOLUTE_MIN_PARTICLES   512     // no fewer than this no matter what's
@@ -1864,8 +1866,6 @@ void CL_RunParticles (void)
 	particle_t* p;
 	int             i, cur, active;
 	float           time1, time2, time3, dvel, frametime, grav;
-	extern  cvar_t  sv_gravity;
-
 	frametime = cl.time - cl.oldtime;
 	time3 = frametime * 15;
 	time2 = frametime * 10;
@@ -1932,7 +1932,7 @@ void CL_RunParticles (void)
                                         }
                                         else
                                         {
-                                                float backoff = VectorDot (vel, trace.plane.normal);
+                                                float backoff = DotProduct (vel, trace.plane.normal);
                                                 backoff *= (1.f + ext->bounce);
                                                 vel[0] -= backoff * trace.plane.normal[0];
                                                 vel[1] -= backoff * trace.plane.normal[1];


### PR DESCRIPTION
## Summary
- add value-first clamp helper macros so particle code no longer relies on implicit declarations
- declare the math helper prototypes used by the particle system
- include the gravity cvar and use DotProduct to fix particle bounce math

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690cdba6f704832e8fb3736b2aefe373