### PR TITLE
Fix Visual Studio project missing bot server source

### DIFF
--- a/Windows/VisualStudio/ironwail.vcxproj
+++ b/Windows/VisualStudio/ironwail.vcxproj
@@ -335,6 +335,7 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="..\..\Quake\sv_main.c" />
+    <ClCompile Include="..\..\Quake\sv_bot.c" />
     <ClCompile Include="..\..\Quake\sv_move.c" />
     <ClCompile Include="..\..\Quake\sv_phys.c" />
     <ClCompile Include="..\..\Quake\sv_user.c" />

--- a/Windows/VisualStudio/ironwail.vcxproj.filters
+++ b/Windows/VisualStudio/ironwail.vcxproj.filters
@@ -225,6 +225,9 @@
     <ClCompile Include="..\..\Quake\sv_main.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Quake\sv_bot.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\Quake\sv_move.c">
       <Filter>Source Files</Filter>
     </ClCompile>


### PR DESCRIPTION
## Summary
- add the dedicated bot server source file to the Visual Studio project
- map the new translation unit into the project filters for Source Files

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690cdcd53af8832e82d63782dbc86f7c