### PR TITLE
Declare SV_ConnectClient prototype

### DIFF
--- a/Quake/server.h
+++ b/Quake/server.h
@@ -294,6 +294,8 @@ void SV_AddClientToServer (struct qsocket_s	*ret);
 void SV_ClientPrintf (const char *fmt, ...) FUNC_PRINTF(1,2);
 void SV_BroadcastPrintf (const char *fmt, ...) FUNC_PRINTF(1,2);
 
+void SV_ConnectClient (int clientnum);
+
 void SV_Physics (void);
 
 qboolean SV_CheckBottom (edict_t *ent);


### PR DESCRIPTION
## Summary
- add the missing SV_ConnectClient prototype to server.h so it can be referenced safely from other translation units

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690cddb119fc832e9b2b5a662f1e8d88