### PR TITLE
Fix inline model name resolution

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -326,6 +326,12 @@ static void Mod_ResolveModelName (const char *name, char *resolved, size_t resol
                 return;
         }
 
+        if (name[0] == '*')
+        {
+                q_strlcpy (resolved, name, resolved_size);
+                return;
+        }
+
         ext = COM_FileGetExtension (name);
         if (ext[0])
         {


### PR DESCRIPTION
## Summary
- ensure inline brush model names such as `*1` bypass automatic extension resolution
- prevent attempts to load nonexistent files for inline models, avoiding Host_Error crashes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690cdef8edd4832e864f4342ff07f83d