### PR TITLE
Implement renderer pools for particles and decals

### DIFF
--- a/Quake/r_decals.c
+++ b/Quake/r_decals.c
@@ -26,7 +26,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include <string.h>
 #include <stdlib.h>
 
-static const int R_DECAL_INITIAL_CAPACITY = 256;
 static const int R_DECAL_CAP_MAX = 16384;
 #define DECAL_TEXTURE_SIZE      64
 #define DECAL_OFFSET            0.25f
@@ -129,6 +128,7 @@ static cvar_t    r_decals_blood_cvar = {"r_decals_blood", "1", CVAR_ARCHIVE};
 static cvar_t    r_decals_bullet_cvar = {"r_decals_bullet", "1", CVAR_ARCHIVE};
 static cvar_t    r_decals_max_cvar = {"r_decals_max", "128", CVAR_ARCHIVE};
 static cvar_t    r_decals_debug_cvar = {"r_decals_debug", "0", 0};
+static cvar_t    r_decals_pool_cvar = {"r_decals_pool", "4096", CVAR_ARCHIVE};
 
 extern vec3_t lightcolor;
 
@@ -137,10 +137,32 @@ static double r_last_gib_decal_time = -9999.0;
 static vec3_t r_last_gib_decal_origin = {0.f, 0.f, 0.f};
 static int r_active_decal_count = 0;
 
+static int R_GetDecalPoolCapacity (void)
+{
+        int pool = (int)r_decals_pool_cvar.value;
+
+        if (pool < 0)
+                pool = 0;
+        if (pool > R_DECAL_CAP_MAX)
+                pool = R_DECAL_CAP_MAX;
+
+        return pool;
+}
+
 static void R_ReserveDecalStorage (int desired)
 {
         size_t old_capacity = (size_t) r_decal_capacity;
         int new_capacity;
+        int pool_limit = R_GetDecalPoolCapacity ();
+
+        if (desired > pool_limit)
+                desired = pool_limit;
+
+        if (desired <= 0)
+        {
+                r_decal_capacity = 0;
+                return;
+        }
 
         if (desired > R_DECAL_CAP_MAX)
                 desired = R_DECAL_CAP_MAX;
@@ -149,12 +171,12 @@ static void R_ReserveDecalStorage (int desired)
                 return;
 
         if (r_decal_capacity <= 0)
-                new_capacity = R_DECAL_INITIAL_CAPACITY;
+                new_capacity = desired;
         else
                 new_capacity = r_decal_capacity;
 
         if (new_capacity <= 0)
-                new_capacity = R_DECAL_INITIAL_CAPACITY;
+                new_capacity = desired;
 
         while (new_capacity < desired && new_capacity < R_DECAL_CAP_MAX)
         {
@@ -216,6 +238,10 @@ static void R_ReserveDecalStorage (int desired)
 static int R_GetDecalLimit (void)
 {
         int desired = (int) CLAMP (0, r_decals_max_cvar.value, (float) R_DECAL_CAP_MAX);
+        int pool_limit = R_GetDecalPoolCapacity ();
+
+        if (desired > pool_limit)
+                desired = pool_limit;
 
         if (r_decals_max_cvar.value > (float) R_DECAL_CAP_MAX)
                 Cvar_SetValueQuick (&r_decals_max_cvar, (float) R_DECAL_CAP_MAX);
@@ -495,14 +521,19 @@ static void R_GenerateDecalTexture (decaltype_t type)
 void R_InitDecals (void)
 {
         int i;
+        int pool_capacity;
 
         Cvar_RegisterVariable (&r_decals_cvar);
         Cvar_RegisterVariable (&r_decals_blood_cvar);
         Cvar_RegisterVariable (&r_decals_bullet_cvar);
         Cvar_RegisterVariable (&r_decals_max_cvar);
         Cvar_RegisterVariable (&r_decals_debug_cvar);
+        Cvar_RegisterVariable (&r_decals_pool_cvar);
 
-        R_ReserveDecalStorage (R_DECAL_INITIAL_CAPACITY);
+        pool_capacity = R_GetDecalPoolCapacity ();
+
+        if (pool_capacity > 0)
+                R_ReserveDecalStorage (pool_capacity);
 
         for (i = 0; i < DECAL_COUNT; i++)
                 R_GenerateDecalTexture ((decaltype_t)i);

--- a/Quake/r_part.c
+++ b/Quake/r_part.c
@@ -152,6 +152,7 @@ particle_t* particles;
 int         r_numparticles, r_numactiveparticles;
 
 static particle_dp_t         particle_dp[MAX_PARTICLES];
+static cvar_t        r_particles_pool = { "r_particles_pool", "16384", CVAR_ARCHIVE };
 
 #define MAX_EFFECTINFO               256
 #define MAX_EFFECT_EMITTERS          1024
@@ -1444,9 +1445,47 @@ R_AllocParticle
 */
 static particle_t* R_AllocParticle (void)
 {
+        int idx;
+
+        if (r_numparticles <= 0)
+                return NULL;
+
         if (r_numactiveparticles < r_numparticles)
         {
-                int idx = r_numactiveparticles++;
+                idx = r_numactiveparticles++;
+        }
+        else
+        {
+                double now = cl.time;
+                float best_remaining = 0.f;
+                int best_idx = -1;
+                int i;
+
+                for (i = 0; i < r_numactiveparticles; i++)
+                {
+                        particle_t *candidate = &particles[i];
+                        float remaining = candidate->die - (float)now;
+
+                        if (remaining <= 0.f)
+                        {
+                                best_idx = i;
+                                break;
+                        }
+
+                        if (best_idx < 0 || remaining < best_remaining)
+                        {
+                                best_idx = i;
+                                best_remaining = remaining;
+                        }
+                }
+
+                if (best_idx < 0)
+                        best_idx = 0;
+
+                idx = best_idx;
+        }
+
+        {
                 particle_t* p = &particles[idx];
                 particle_dp_t* ext = &particle_dp[idx];
                 p->spawn = cl.time;
@@ -1467,7 +1506,6 @@ static particle_t* R_AllocParticle (void)
                 memset (ext, 0, sizeof (*ext));
                 return p;
         }
-        return NULL;
 }
 
 /*
@@ -1477,24 +1515,33 @@ R_InitParticles
 */
 void R_InitParticles (void)
 {
-	int     i;
+        int     i;
+        int     pool_size;
 
-	i = COM_CheckParm ("-particles");
+        Cvar_RegisterVariable (&r_particles_pool);
 
-	if (i && i < com_argc - 1)
-	{
-		r_numparticles = atoi (com_argv[i + 1]);
-		if (r_numparticles < ABSOLUTE_MIN_PARTICLES)
-			r_numparticles = ABSOLUTE_MIN_PARTICLES;
-	}
-	else
-	{
-		r_numparticles = MAX_PARTICLES;
-	}
+        pool_size = (int)CLAMP ((float)ABSOLUTE_MIN_PARTICLES, r_particles_pool.value, (float)MAX_PARTICLES);
 
-	particles = (particle_t*)
-		Hunk_AllocName (r_numparticles * sizeof (particle_t), "particles");
-	r_numactiveparticles = 0;
+        i = COM_CheckParm ("-particles");
+
+        if (i && i < com_argc - 1)
+        {
+                pool_size = atoi (com_argv[i + 1]);
+                if (pool_size < ABSOLUTE_MIN_PARTICLES)
+                        pool_size = ABSOLUTE_MIN_PARTICLES;
+        }
+        if (pool_size > MAX_PARTICLES)
+                pool_size = MAX_PARTICLES;
+
+        Cvar_SetValueQuick (&r_particles_pool, (float)pool_size);
+
+        r_numparticles = pool_size;
+
+        particles = (particle_t*)
+                Hunk_AllocName (r_numparticles * sizeof (particle_t), "particles");
+        memset (particles, 0, (size_t)r_numparticles * sizeof (*particles));
+        memset (particle_dp, 0, (size_t)r_numparticles * sizeof (*particle_dp));
+        r_numactiveparticles = 0;
 
         Cvar_RegisterVariable (&r_particles); //johnfitz
         Cvar_RegisterVariable (&r_particles_debug);


### PR DESCRIPTION
## Summary
- add a configurable particle pool that reuses the oldest live particle when the pool is exhausted
- add a configurable decal pool and clamp allocations to the configured capacity while retaining LRU recycling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690d1a017b1c832ebb3624198e48741d