### PR TITLE
Add iwshader parsing subsystem and debug overlay

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,9 @@ target_compile_definitions(wren PUBLIC WREN_OPT_META=1 WREN_OPT_RANDOM=1)
 
 list(APPEND IWAIL_SRC ${CMAKE_CURRENT_SOURCE_DIR}/wren_vm/wren_runtime.c ${CMAKE_CURRENT_SOURCE_DIR}/wren_vm/wren_bindings.c)
 list(APPEND IWAIL_SRC ${CMAKE_CURRENT_SOURCE_DIR}/renderer/r_shadows.c)
+list(APPEND IWAIL_SRC
+    ${CMAKE_CURRENT_SOURCE_DIR}/Quake/common/com_iwtext.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/Quake/renderer/r_iwshader.c)
 
 list(REMOVE_ITEM IWAIL_SRC ${CMAKE_CURRENT_SOURCE_DIR}/Quake/lodepng.h)
 list(REMOVE_ITEM IWAIL_SRC ${CMAKE_CURRENT_SOURCE_DIR}/Quake/lodepng.c)

--- a/Quake/Makefile
+++ b/Quake/Makefile
@@ -224,10 +224,11 @@ GLOBJS = \
 	r_world.o \
 	gl_screen.o \
 	gl_shaders.o \
-	gl_sky.o \
-	gl_warp.o \
-	$(SYSOBJ_GL_VID) \
-	gl_draw.o \
+        gl_sky.o \
+        gl_warp.o \
+        r_iwshader.o \
+        $(SYSOBJ_GL_VID) \
+        gl_draw.o \
 	image.o \
 	gl_texmgr.o \
 	gl_mesh.o \
@@ -261,6 +262,7 @@ OBJS = strlcat.o \
         wad.o \
         cmd.o \
         common.o \
+        common/com_iwtext.o \
         steam.o \
 	json.o \
 	miniz.o \

--- a/Quake/Makefile.w32
+++ b/Quake/Makefile.w32
@@ -230,10 +230,11 @@ GLOBJS = \
 	r_world.o \
 	gl_screen.o \
 	gl_shaders.o \
-	gl_sky.o \
-	gl_warp.o \
-	$(SYSOBJ_GL_VID) \
-	gl_draw.o \
+        gl_sky.o \
+        gl_warp.o \
+        r_iwshader.o \
+        $(SYSOBJ_GL_VID) \
+        gl_draw.o \
 	image.o \
 	gl_texmgr.o \
 	gl_mesh.o \
@@ -267,6 +268,7 @@ OBJS = strlcat.o \
         wad.o \
         cmd.o \
         common.o \
+        common/com_iwtext.o \
         steam.o \
 	json.o \
 	miniz.o \

--- a/Quake/Makefile.w64
+++ b/Quake/Makefile.w64
@@ -223,10 +223,11 @@ GLOBJS = \
 	r_world.o \
 	gl_screen.o \
 	gl_shaders.o \
-	gl_sky.o \
-	gl_warp.o \
-	$(SYSOBJ_GL_VID) \
-	gl_draw.o \
+        gl_sky.o \
+        gl_warp.o \
+        r_iwshader.o \
+        $(SYSOBJ_GL_VID) \
+        gl_draw.o \
 	image.o \
 	gl_texmgr.o \
 	gl_mesh.o \
@@ -260,6 +261,7 @@ OBJS = strlcat.o \
         wad.o \
         cmd.o \
         common.o \
+        common/com_iwtext.o \
         steam.o \
 	json.o \
 	miniz.o \

--- a/Quake/common/com_iwtext.c
+++ b/Quake/common/com_iwtext.c
@@ -1,0 +1,226 @@
+#include "quakedef.h"
+#include "com_iwtext.h"
+
+static void IWTXT_SkipWhitespace(iwtxtParser_t *parser)
+{
+    while (parser->cursor < parser->end)
+    {
+        char c = *parser->cursor;
+        if (c == '\r')
+        {
+            parser->cursor++;
+            continue;
+        }
+        if (c == '\n')
+        {
+            parser->cursor++;
+            parser->line++;
+            parser->column = 1;
+            continue;
+        }
+        if (c == ' ' || c == '\t' || c == '\f' || c == '\v')
+        {
+            parser->cursor++;
+            parser->column++;
+            continue;
+        }
+        if (c == '#')
+        {
+            while (parser->cursor < parser->end && *parser->cursor != '\n')
+                parser->cursor++;
+            continue;
+        }
+        if (c == '/')
+        {
+            if ((parser->cursor + 1) < parser->end && parser->cursor[1] == '/')
+            {
+                parser->cursor += 2;
+                while (parser->cursor < parser->end && *parser->cursor != '\n')
+                    parser->cursor++;
+                continue;
+            }
+        }
+        break;
+    }
+}
+
+static qboolean IWTXT_ParseNumber(const char *text, size_t len, double *out)
+{
+    char temp[64];
+    size_t copy = q_min(len, sizeof(temp) - 1);
+    memcpy(temp, text, copy);
+    temp[copy] = '\0';
+
+    char *endptr;
+    double value = strtod(temp, &endptr);
+    if (endptr == temp)
+        return false;
+    *out = value;
+    return true;
+}
+
+qboolean IWTXT_LoadFile(const char *path, char **outBuf, int *outLen)
+{
+    byte *data = COM_LoadMallocFile(path, NULL);
+    if (!data)
+        return false;
+
+    if (outLen)
+        *outLen = (int)strlen((const char *)data);
+
+    *outBuf = (char *)data;
+    return true;
+}
+
+void IWTXT_Free(void *p)
+{
+    if (p)
+        free(p);
+}
+
+void IWTXT_Init(iwtxtParser_t *parser, const char *buffer, int length, const char *filename)
+{
+    parser->filename = filename;
+    parser->buffer = buffer;
+    parser->cursor = buffer;
+    parser->end = buffer + length;
+    parser->line = 1;
+    parser->column = 1;
+    parser->has_peek = false;
+}
+
+static qboolean IWTXT_InternalNext(iwtxtParser_t *parser, iwtxtToken_t *out)
+{
+    IWTXT_SkipWhitespace(parser);
+    if (parser->cursor >= parser->end || *parser->cursor == '\0')
+    {
+        if (out)
+        {
+            out->type = IWTXT_TOKEN_EOF;
+            out->text = parser->cursor;
+            out->length = 0;
+            out->number = 0.0;
+            out->line = parser->line;
+            out->column = parser->column;
+        }
+        return false;
+    }
+
+    const char *start = parser->cursor;
+    int line = parser->line;
+    int column = parser->column;
+    char c = *parser->cursor;
+
+    if (c == '{' || c == '}' || c == '(' || c == ')')
+    {
+        parser->cursor++;
+        parser->column++;
+        if (out)
+        {
+            out->type = IWTXT_TOKEN_SYMBOL;
+            out->text = start;
+            out->length = 1;
+            out->number = 0.0;
+            out->line = line;
+            out->column = column;
+        }
+        return true;
+    }
+
+    if (c == '"')
+    {
+        parser->cursor++;
+        parser->column++;
+        start = parser->cursor;
+        while (parser->cursor < parser->end && *parser->cursor != '"' && *parser->cursor != '\n')
+        {
+            parser->cursor++;
+            parser->column++;
+        }
+        const char *end = parser->cursor;
+        if (parser->cursor < parser->end && *parser->cursor == '"')
+        {
+            parser->cursor++;
+            parser->column++;
+        }
+        if (out)
+        {
+            out->type = IWTXT_TOKEN_STRING;
+            out->text = start;
+            out->length = (size_t)(end - start);
+            out->number = 0.0;
+            out->line = line;
+            out->column = column;
+        }
+        return true;
+    }
+
+    while (parser->cursor < parser->end)
+    {
+        c = *parser->cursor;
+        if (c == '\r' || c == '\n' || c == '\t' || c == ' ' || c == '\f' || c == '\v' || c == '{' || c == '}')
+            break;
+        if (c == '#')
+            break;
+        if (c == '/')
+        {
+            if ((parser->cursor + 1) < parser->end && parser->cursor[1] == '/')
+                break;
+        }
+        parser->cursor++;
+        parser->column++;
+    }
+
+    size_t len = (size_t)(parser->cursor - start);
+    if (out)
+    {
+        out->text = start;
+        out->length = len;
+        out->line = line;
+        out->column = column;
+        if (IWTXT_ParseNumber(start, len, &out->number))
+            out->type = IWTXT_TOKEN_NUMBER;
+        else
+            out->type = IWTXT_TOKEN_STRING;
+    }
+    return true;
+}
+
+qboolean IWTXT_NextToken(iwtxtParser_t *parser, iwtxtToken_t *out)
+{
+    if (parser->has_peek)
+    {
+        if (out)
+            *out = parser->peek;
+        parser->has_peek = false;
+        return out ? (out->type != IWTXT_TOKEN_EOF) : (parser->peek.type != IWTXT_TOKEN_EOF);
+    }
+    return IWTXT_InternalNext(parser, out);
+}
+
+qboolean IWTXT_PeekToken(iwtxtParser_t *parser, iwtxtToken_t *out)
+{
+    if (!parser->has_peek)
+    {
+        iwtxtToken_t tmp;
+        if (!IWTXT_InternalNext(parser, &tmp))
+        {
+            if (out)
+            {
+                out->type = IWTXT_TOKEN_EOF;
+                out->text = parser->end;
+                out->length = 0;
+                out->number = 0.0;
+                out->line = parser->line;
+                out->column = parser->column;
+            }
+            return false;
+        }
+        parser->peek = tmp;
+        parser->has_peek = true;
+    }
+    if (out)
+        *out = parser->peek;
+    return true;
+}
+

--- a/Quake/common/com_iwtext.h
+++ b/Quake/common/com_iwtext.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "q_stdinc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    IWTXT_TOKEN_EOF = 0,
+    IWTXT_TOKEN_STRING,
+    IWTXT_TOKEN_NUMBER,
+    IWTXT_TOKEN_SYMBOL
+} iwtxtTokenType_t;
+
+typedef struct {
+    iwtxtTokenType_t type;
+    const char *text;
+    size_t length;
+    double number;
+    int line;
+    int column;
+} iwtxtToken_t;
+
+typedef struct {
+    const char *filename;
+    const char *buffer;
+    const char *cursor;
+    const char *end;
+    int line;
+    int column;
+    qboolean has_peek;
+    iwtxtToken_t peek;
+} iwtxtParser_t;
+
+qboolean IWTXT_LoadFile(const char *path, char **outBuf, int *outLen);
+void IWTXT_Free(void *p);
+
+void IWTXT_Init(iwtxtParser_t *parser, const char *buffer, int length, const char *filename);
+qboolean IWTXT_NextToken(iwtxtParser_t *parser, iwtxtToken_t *out);
+qboolean IWTXT_PeekToken(iwtxtParser_t *parser, iwtxtToken_t *out);
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -23,6 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // r_misc.c
 
 #include "quakedef.h"
+#include "renderer/r_iwshader.h"
 
 //johnfitz -- new cvars
 extern cvar_t r_clearcolor;
@@ -460,8 +461,16 @@ void R_Init (void)
 	R_InitDecals ();
 	R_SetClearColor_f (&r_clearcolor); //johnfitz
 
-	Sky_Init (); //johnfitz
-	Fog_Init (); //johnfitz
+        Sky_Init (); //johnfitz
+        Fog_Init (); //johnfitz
+
+        IW_ShaderSystem_Init ();
+        if (com_gamedir[0])
+        {
+                char shaderdir[MAX_OSPATH];
+                q_snprintf (shaderdir, sizeof(shaderdir), "%s/shaders", com_gamedir);
+                IW_LoadShaderDirectory (shaderdir);
+        }
 }
 
 /*

--- a/Quake/gl_screen.c
+++ b/Quake/gl_screen.c
@@ -24,6 +24,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // screen.c -- master for refresh, status bar, console, chat, notify, etc
 
 #include "quakedef.h"
+#include "renderer/r_iwshader.h"
 #include "steam.h"
 #include <time.h>
 
@@ -1018,6 +1019,17 @@ void SCR_DrawDevStats (void)
 
 	sprintf (str, "GL upload|%4iK %4iK", dev_stats.gpu_upload/1024, dev_peakstats.gpu_upload/1024);
 	Draw_String (x, (y++)*8-x, str);
+}
+
+static void SCR_DrawIWShaderDebug (void)
+{
+	char buffer[256];
+
+	if (!IW_DebugOverlayText (buffer, sizeof(buffer)))
+		return;
+
+	GL_SetCanvas (CANVAS_DEFAULT);
+	Draw_String (8, 8, buffer);
 }
 
 /*
@@ -2157,6 +2169,7 @@ void SCR_UpdateScreen (void)
 		SCR_CheckDrawCenterString ();
 		Sbar_Draw ();
 		SCR_DrawDevStats (); //johnfitz
+		SCR_DrawIWShaderDebug ();
 		SCR_DrawClock (); //johnfitz
 		SCR_DrawDemoControls ();
 		SCR_DrawSpeed ();

--- a/Quake/gl_vidsdl.c
+++ b/Quake/gl_vidsdl.c
@@ -23,6 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // gl_vidsdl.c -- SDL GL vid component
 
 #include "quakedef.h"
+#include "renderer/r_iwshader.h"
 #include "cfgfile.h"
 #include "bgmusic.h"
 #include "resource.h"
@@ -1397,6 +1398,7 @@ void	VID_Shutdown (void)
 {
 	if (vid_initialized)
 	{
+		IW_ShaderSystem_Shutdown ();
 		R_ShutdownShadow ();
 #if R_SHADOWMAPS
 		R_ShutdownShadowMaps();

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -23,6 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // r_world.c: world model rendering
 
 #include "quakedef.h"
+#include "renderer/r_iwshader.h"
 
 extern cvar_t gl_fullbrights, r_oldskyleaf, r_showtris; //johnfitz
 extern cvar_t gl_zfix; // QuakeSpasm z-fighting fix
@@ -331,6 +332,22 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
 	GLuint		flags;
 	float		alpha;
 	gltexture_t	*tx, *fb, *em;
+
+	if (t && t->gltexture)
+	{
+		const char *material_name = NULL;
+		if (t->gltexture->source_file[0])
+			material_name = t->gltexture->source_file;
+		else if (t->gltexture->name[0])
+			material_name = t->gltexture->name;
+		else if (t->name[0])
+			material_name = t->name;
+		IW_MaterialForTexture (material_name);
+	}
+	else
+	{
+		IW_MaterialForTexture (NULL);
+	}
 
 	if (num_bmodel_calls == MAX_BMODEL_DRAWS)
 		R_FlushBModelCalls ();

--- a/Quake/renderer/r_iwshader.c
+++ b/Quake/renderer/r_iwshader.c
@@ -1,0 +1,916 @@
+#include "quakedef.h"
+#include "glquake.h"
+#include "render.h"
+#include "../common/com_iwtext.h"
+#include "r_iwshader.h"
+
+#define IW_MAX_MATERIALS 512
+
+static cvar_t r_iwshader_cvar = { "r_iwshader", "1", CVAR_ARCHIVE };
+static cvar_t r_iwshader_strict_cvar = { "r_iwshader_strict", "0", CVAR_NONE };
+static cvar_t r_iwshader_debug_cvar = { "r_iwshader_debug", "0", CVAR_NONE };
+
+static cmd_function_t *iwshader_dump_cmd;
+static void IW_DumpMaterials_f(void);
+
+typedef struct
+{
+    iwMaterial_t material;
+    char normalized[IW_MAX_NAME];
+} iwMaterialEntry_t;
+
+static iwMaterialEntry_t iw_materials[IW_MAX_MATERIALS];
+static int iw_num_materials;
+static qboolean iw_initialized;
+
+static const iwMaterial_t *iw_last_material;
+static char iw_last_texture[IW_MAX_PATH];
+static char iw_last_texture_display[IW_MAX_PATH];
+
+static void IW_LogWarning(const char *file, int line, int column, const char *fmt, ...)
+{
+    char msg[512];
+    va_list args;
+
+    va_start(args, fmt);
+    q_vsnprintf(msg, sizeof(msg), fmt, args);
+    va_end(args);
+
+    Con_Printf("iwshader: %s:%d:%d: %s\n", file ? file : "<unknown>", line, column, msg);
+}
+
+static qboolean IW_NormalizeName(const char *input, char *output, size_t size, qboolean drop_extension)
+{
+    size_t len = 0;
+    if (!input || !output || size == 0)
+        return false;
+
+    while (*input && len + 1 < size)
+    {
+        char c = *input++;
+        if (c == '\r' || c == '\n' || c == '\t')
+            break;
+        if (c == '\\')
+            c = '/';
+        output[len++] = (char) q_tolower(c);
+    }
+    output[len] = '\0';
+
+    while (len > 0 && output[len - 1] == ' ')
+    {
+        output[len - 1] = '\0';
+        --len;
+    }
+
+    if (drop_extension && len > 0)
+    {
+        char *dot = strrchr(output, '.');
+        char *slash = strrchr(output, '/');
+        if (dot && (!slash || slash < dot))
+            *dot = '\0';
+    }
+
+    return output[0] != '\0';
+}
+
+static void IW_CopyTokenLower(const iwtxtToken_t *token, char *dst, size_t size)
+{
+    size_t n = q_min(token->length, size - 1);
+    size_t i;
+    for (i = 0; i < n; ++i)
+    {
+        char c = token->text[i];
+        if (c == '\\')
+            c = '/';
+        dst[i] = (char) q_tolower(c);
+    }
+    dst[i] = '\0';
+}
+
+static void IW_CopyTokenText(const iwtxtToken_t *token, char *dst, size_t size)
+{
+    size_t n = q_min(token->length, size - 1);
+    memcpy(dst, token->text, n);
+    dst[n] = '\0';
+}
+
+static qboolean IW_ParseBlendFactor(const char *text, iwBlendFactor_t *out)
+{
+    if (!Q_strcasecmp(text, "zero")) { *out = IW_SRC_ZERO; return true; }
+    if (!Q_strcasecmp(text, "one")) { *out = IW_SRC_ONE; return true; }
+    if (!Q_strcasecmp(text, "src_color")) { *out = IW_SRC_SRC_COLOR; return true; }
+    if (!Q_strcasecmp(text, "one_minus_src_color")) { *out = IW_SRC_ONE_MINUS_SRC_COLOR; return true; }
+    if (!Q_strcasecmp(text, "dst_color")) { *out = IW_SRC_DST_COLOR; return true; }
+    if (!Q_strcasecmp(text, "one_minus_dst_color")) { *out = IW_SRC_ONE_MINUS_DST_COLOR; return true; }
+    if (!Q_strcasecmp(text, "src_alpha")) { *out = IW_SRC_SRC_ALPHA; return true; }
+    if (!Q_strcasecmp(text, "one_minus_src_alpha")) { *out = IW_SRC_ONE_MINUS_SRC_ALPHA; return true; }
+    if (!Q_strcasecmp(text, "dst_alpha")) { *out = IW_SRC_DST_ALPHA; return true; }
+    if (!Q_strcasecmp(text, "one_minus_dst_alpha")) { *out = IW_SRC_ONE_MINUS_DST_ALPHA; return true; }
+    return false;
+}
+
+static qboolean IW_ReadFloat(iwtxtParser_t *parser, float *out, iwtxtToken_t *token)
+{
+    if (!IWTXT_NextToken(parser, token))
+        return false;
+    if (token->type != IWTXT_TOKEN_NUMBER)
+        return false;
+    *out = (float)token->number;
+    return true;
+}
+
+static qboolean IW_ReadInt(iwtxtParser_t *parser, int *out, iwtxtToken_t *token)
+{
+    if (!IWTXT_NextToken(parser, token))
+        return false;
+    if (token->type != IWTXT_TOKEN_NUMBER)
+        return false;
+    *out = (int)token->number;
+    return true;
+}
+
+static void IW_SkipBraces(iwtxtParser_t *parser)
+{
+    iwtxtToken_t token;
+    int depth = 0;
+    while (IWTXT_NextToken(parser, &token))
+    {
+        if (token.type == IWTXT_TOKEN_SYMBOL && token.length == 1)
+        {
+            if (token.text[0] == '{')
+                depth++;
+            else if (token.text[0] == '}')
+            {
+                if (depth == 0)
+                    break;
+                depth--;
+            }
+        }
+    }
+}
+
+static void IW_SetStageDefaults(iwStage_t *stage)
+{
+    memset(stage, 0, sizeof(*stage));
+    q_strlcpy(stage->mapPath, "$white", sizeof(stage->mapPath));
+    stage->blendMode = IW_BLEND_NONE;
+    stage->src = IW_SRC_ONE;
+    stage->dst = IW_SRC_ZERO;
+    stage->rgbgen = IW_RGB_VERTEX;
+    stage->rgbConst[0] = stage->rgbConst[1] = stage->rgbConst[2] = 1.f;
+    stage->alphagen = IW_A_VERTEX;
+    stage->aConst = 1.f;
+    stage->emissive = 0;
+    stage->clamp = 0;
+    stage->numTCMods = 0;
+}
+
+static qboolean IW_ParseTCMod(iwtxtParser_t *parser, iwStage_t *stage, const iwtxtToken_t *firstToken, const char *filename)
+{
+    char op[16];
+    IW_CopyTokenLower(firstToken, op, sizeof(op));
+
+    if (stage->numTCMods >= IW_MAX_TCMODS)
+    {
+        IW_LogWarning(filename, firstToken->line, firstToken->column, "too many tcmods (max %d)", IW_MAX_TCMODS);
+        IW_SkipBraces(parser);
+        return false;
+    }
+
+    iwTCMod_t *tc = &stage->tcmods[stage->numTCMods];
+    memset(tc, 0, sizeof(*tc));
+
+    iwtxtToken_t token;
+    if (!strcmp(op, "scroll"))
+    {
+        tc->op = IW_TC_SCROLL;
+        if (!IW_ReadFloat(parser, &tc->a, &token) || !IW_ReadFloat(parser, &tc->b, &token))
+        {
+            IW_LogWarning(filename, token.line, token.column, "tcmod scroll requires two floats");
+            return false;
+        }
+    }
+    else if (!strcmp(op, "scale"))
+    {
+        tc->op = IW_TC_SCALE;
+        if (!IW_ReadFloat(parser, &tc->a, &token) || !IW_ReadFloat(parser, &tc->b, &token))
+        {
+            IW_LogWarning(filename, token.line, token.column, "tcmod scale requires two floats");
+            return false;
+        }
+    }
+    else if (!strcmp(op, "rotate"))
+    {
+        tc->op = IW_TC_ROTATE;
+        if (!IW_ReadFloat(parser, &tc->a, &token))
+        {
+            IW_LogWarning(filename, token.line, token.column, "tcmod rotate requires a float");
+            return false;
+        }
+    }
+    else if (!strcmp(op, "envmap"))
+    {
+        tc->op = IW_TC_ENVMAP;
+        tc->a = tc->b = 0.f;
+    }
+    else
+    {
+        IW_LogWarning(filename, firstToken->line, firstToken->column, "unknown tcmod '%s'", op);
+        return false;
+    }
+
+    stage->numTCMods++;
+    return true;
+}
+
+static qboolean IW_ParseStage(iwtxtParser_t *parser, iwMaterial_t *material, const char *filename, qboolean strict)
+{
+    iwStage_t stage;
+    IW_SetStageDefaults(&stage);
+
+    iwtxtToken_t token;
+    qboolean valid = true;
+
+    while (IWTXT_NextToken(parser, &token))
+    {
+        if (token.type == IWTXT_TOKEN_SYMBOL && token.length == 1 && token.text[0] == '}')
+            break;
+
+        if (token.type != IWTXT_TOKEN_STRING)
+        {
+            IW_LogWarning(filename, token.line, token.column, "unexpected token inside stage");
+            if (strict)
+            {
+                IW_SkipBraces(parser);
+                return false;
+            }
+            continue;
+        }
+
+        char keyword[32];
+        IW_CopyTokenLower(&token, keyword, sizeof(keyword));
+
+        if (!strcmp(keyword, "map"))
+        {
+            if (!IWTXT_NextToken(parser, &token) || token.type == IWTXT_TOKEN_SYMBOL)
+            {
+                IW_LogWarning(filename, token.line, token.column, "map requires a texture path");
+                if (strict)
+                    return false;
+                continue;
+            }
+            IW_CopyTokenText(&token, stage.mapPath, sizeof(stage.mapPath));
+            for (size_t i = 0; stage.mapPath[i]; ++i)
+                if (stage.mapPath[i] == '\\')
+                    stage.mapPath[i] = '/';
+        }
+        else if (!strcmp(keyword, "blend"))
+        {
+            iwtxtToken_t tok;
+            if (!IWTXT_NextToken(parser, &tok) || tok.type != IWTXT_TOKEN_STRING)
+            {
+                IW_LogWarning(filename, tok.line, tok.column, "blend requires parameters");
+                if (strict)
+                    return false;
+                continue;
+            }
+
+            char mode[32];
+            IW_CopyTokenLower(&tok, mode, sizeof(mode));
+            if (!strcmp(mode, "alpha"))
+            {
+                stage.blendMode = IW_BLEND_ALPHA;
+            }
+            else if (!strcmp(mode, "add"))
+            {
+                stage.blendMode = IW_BLEND_ADD;
+            }
+            else if (!strcmp(mode, "mul"))
+            {
+                stage.blendMode = IW_BLEND_MUL;
+            }
+            else if (!strcmp(mode, "premul"))
+            {
+                stage.blendMode = IW_BLEND_PREMUL;
+            }
+            else
+            {
+                char srcbuf[32], dstbuf[32];
+                IW_CopyTokenLower(&tok, srcbuf, sizeof(srcbuf));
+                if (!IWTXT_NextToken(parser, &tok) || tok.type != IWTXT_TOKEN_STRING)
+                {
+                    IW_LogWarning(filename, tok.line, tok.column, "blend requires two blend factors");
+                    if (strict)
+                        return false;
+                    continue;
+                }
+                IW_CopyTokenLower(&tok, dstbuf, sizeof(dstbuf));
+                if (!IW_ParseBlendFactor(srcbuf, &stage.src) || !IW_ParseBlendFactor(dstbuf, &stage.dst))
+                {
+                    IW_LogWarning(filename, tok.line, tok.column, "invalid blend factors '%s %s'", srcbuf, dstbuf);
+                    if (strict)
+                        return false;
+                    continue;
+                }
+                stage.blendMode = IW_BLEND_CUSTOM;
+            }
+        }
+        else if (!strcmp(keyword, "rgbgen"))
+        {
+            if (!IWTXT_NextToken(parser, &token) || token.type != IWTXT_TOKEN_STRING)
+            {
+                IW_LogWarning(filename, token.line, token.column, "rgbgen requires a mode");
+                if (strict)
+                    return false;
+                continue;
+            }
+            char mode[32];
+            IW_CopyTokenLower(&token, mode, sizeof(mode));
+            if (!strcmp(mode, "vertex"))
+            {
+                stage.rgbgen = IW_RGB_VERTEX;
+            }
+            else if (!strcmp(mode, "identity"))
+            {
+                stage.rgbgen = IW_RGB_IDENTITY;
+            }
+            else if (!strcmp(mode, "const"))
+            {
+                stage.rgbgen = IW_RGB_CONST;
+                if (!IW_ReadFloat(parser, &stage.rgbConst[0], &token) ||
+                    !IW_ReadFloat(parser, &stage.rgbConst[1], &token) ||
+                    !IW_ReadFloat(parser, &stage.rgbConst[2], &token))
+                {
+                    IW_LogWarning(filename, token.line, token.column, "rgbgen const requires three floats");
+                    if (strict)
+                        return false;
+                }
+            }
+            else
+            {
+                IW_LogWarning(filename, token.line, token.column, "unknown rgbgen '%s'", mode);
+                if (strict)
+                    return false;
+            }
+        }
+        else if (!strcmp(keyword, "alphagen"))
+        {
+            if (!IWTXT_NextToken(parser, &token) || token.type != IWTXT_TOKEN_STRING)
+            {
+                IW_LogWarning(filename, token.line, token.column, "alphagen requires a mode");
+                if (strict)
+                    return false;
+                continue;
+            }
+            char mode[32];
+            IW_CopyTokenLower(&token, mode, sizeof(mode));
+            if (!strcmp(mode, "vertex"))
+            {
+                stage.alphagen = IW_A_VERTEX;
+            }
+            else if (!strcmp(mode, "mask"))
+            {
+                stage.alphagen = IW_A_MASK;
+            }
+            else if (!strcmp(mode, "const"))
+            {
+                stage.alphagen = IW_A_CONST;
+                if (!IW_ReadFloat(parser, &stage.aConst, &token))
+                {
+                    IW_LogWarning(filename, token.line, token.column, "alphagen const requires a float");
+                    if (strict)
+                        return false;
+                }
+            }
+            else
+            {
+                IW_LogWarning(filename, token.line, token.column, "unknown alphagen '%s'", mode);
+                if (strict)
+                    return false;
+            }
+        }
+        else if (!strcmp(keyword, "tcmod"))
+        {
+            if (!IWTXT_NextToken(parser, &token) || token.type != IWTXT_TOKEN_STRING)
+            {
+                IW_LogWarning(filename, token.line, token.column, "tcmod requires an operator");
+                if (strict)
+                    return false;
+                continue;
+            }
+            if (!IW_ParseTCMod(parser, &stage, &token, filename) && strict)
+                return false;
+        }
+        else if (!strcmp(keyword, "emissive"))
+        {
+            int value;
+            if (!IW_ReadInt(parser, &value, &token))
+            {
+                IW_LogWarning(filename, token.line, token.column, "emissive requires 0 or 1");
+                if (strict)
+                    return false;
+                continue;
+            }
+            stage.emissive = value ? 1 : 0;
+        }
+        else if (!strcmp(keyword, "clamp"))
+        {
+            int value;
+            if (!IW_ReadInt(parser, &value, &token))
+            {
+                IW_LogWarning(filename, token.line, token.column, "clamp requires 0 or 1");
+                if (strict)
+                    return false;
+                continue;
+            }
+            stage.clamp = value ? 1 : 0;
+        }
+        else
+        {
+            IW_LogWarning(filename, token.line, token.column, "unknown stage keyword '%s'", keyword);
+            if (strict)
+            {
+                IW_SkipBraces(parser);
+                return false;
+            }
+            valid = false;
+        }
+    }
+
+    if (!valid && strict)
+        return false;
+
+    if (material->numStages >= IW_MAX_STAGES)
+    {
+        IW_LogWarning(filename, token.line, token.column, "too many stages (max %d)", IW_MAX_STAGES);
+        return false;
+    }
+
+    material->stages[material->numStages++] = stage;
+    return true;
+}
+
+static qboolean IW_ParseGlobalKey(iwtxtParser_t *parser, iwMaterial_t *material, const char *keyword, const iwtxtToken_t *token, const char *filename)
+{
+    if (!strcmp(keyword, "cull"))
+    {
+        iwtxtToken_t value;
+        if (!IWTXT_NextToken(parser, &value) || value.type != IWTXT_TOKEN_STRING)
+        {
+            IW_LogWarning(filename, value.line, value.column, "cull requires a value");
+            return false;
+        }
+        char mode[16];
+        IW_CopyTokenLower(&value, mode, sizeof(mode));
+        if (!strcmp(mode, "back"))
+            material->cull = IW_CULL_BACK;
+        else if (!strcmp(mode, "front"))
+            material->cull = IW_CULL_FRONT;
+        else if (!strcmp(mode, "none"))
+            material->cull = IW_CULL_NONE;
+        else
+            IW_LogWarning(filename, value.line, value.column, "unknown cull '%s'", mode);
+        return true;
+    }
+    else if (!strcmp(keyword, "sort"))
+    {
+        iwtxtToken_t value;
+        if (!IWTXT_NextToken(parser, &value) || value.type != IWTXT_TOKEN_STRING)
+        {
+            IW_LogWarning(filename, value.line, value.column, "sort requires a value");
+            return false;
+        }
+        char mode[16];
+        IW_CopyTokenLower(&value, mode, sizeof(mode));
+        if (!strcmp(mode, "opaque"))
+            material->sort = IW_SORT_OPAQUE;
+        else if (!strcmp(mode, "alpha"))
+            material->sort = IW_SORT_ALPHA;
+        else if (!strcmp(mode, "additive"))
+            material->sort = IW_SORT_ADDITIVE;
+        else if (!strcmp(mode, "decal"))
+            material->sort = IW_SORT_DECAL;
+        else if (!strcmp(mode, "sky"))
+            material->sort = IW_SORT_SKY;
+        else
+            IW_LogWarning(filename, value.line, value.column, "unknown sort '%s'", mode);
+        return true;
+    }
+    else if (!strcmp(keyword, "strict"))
+    {
+        iwtxtToken_t value;
+        if (!IW_ReadInt(parser, &material->strict, &value))
+        {
+            IW_LogWarning(filename, value.line, value.column, "strict requires 0 or 1");
+            material->strict = 0;
+        }
+        material->strict = material->strict ? 1 : 0;
+        return true;
+    }
+
+    IW_LogWarning(filename, token->line, token->column, "unknown keyword '%s'", keyword);
+    return false;
+}
+
+static void IW_RegisterMaterial(const iwMaterial_t *material)
+{
+    char normalized[IW_MAX_NAME];
+    if (!IW_NormalizeName(material->name, normalized, sizeof(normalized), false))
+        return;
+
+    for (int i = 0; i < iw_num_materials; ++i)
+    {
+        if (!strcmp(iw_materials[i].normalized, normalized))
+        {
+            iw_materials[i].material = *material;
+            return;
+        }
+    }
+
+    if (iw_num_materials >= IW_MAX_MATERIALS)
+    {
+        Con_Warning("iwshader: material limit (%d) reached\n", IW_MAX_MATERIALS);
+        return;
+    }
+
+    iw_materials[iw_num_materials].material = *material;
+    q_strlcpy(iw_materials[iw_num_materials].normalized, normalized, sizeof(normalized));
+    iw_num_materials++;
+}
+
+static void IW_ParseShaderDefinition(iwtxtParser_t *parser, const iwtxtToken_t *nameToken, const char *filename)
+{
+    iwMaterial_t material;
+    memset(&material, 0, sizeof(material));
+    material.sort = IW_SORT_OPAQUE;
+    material.cull = IW_CULL_BACK;
+    material.strict = 0;
+    material.numStages = 0;
+    IW_CopyTokenText(nameToken, material.name, sizeof(material.name));
+
+    iwtxtToken_t token;
+    if (!IWTXT_NextToken(parser, &token) || token.type != IWTXT_TOKEN_SYMBOL || token.length != 1 || token.text[0] != '{')
+    {
+        IW_LogWarning(filename, token.line, token.column, "expected '{' after shader name");
+        return;
+    }
+
+    while (IWTXT_NextToken(parser, &token))
+    {
+        if (token.type == IWTXT_TOKEN_SYMBOL && token.length == 1 && token.text[0] == '}')
+            break;
+
+        if (token.type == IWTXT_TOKEN_STRING)
+        {
+            char keyword[32];
+            IW_CopyTokenLower(&token, keyword, sizeof(keyword));
+            if (!strcmp(keyword, "stage"))
+            {
+                if (!IWTXT_NextToken(parser, &token) || token.type != IWTXT_TOKEN_SYMBOL || token.length != 1 || token.text[0] != '{')
+                {
+                    IW_LogWarning(filename, token.line, token.column, "expected '{' after stage");
+                    IW_SkipBraces(parser);
+                    continue;
+                }
+                qboolean strict = material.strict || (r_iwshader_strict_cvar.value != 0.f);
+                if (!IW_ParseStage(parser, &material, filename, strict))
+                    continue;
+            }
+            else
+            {
+                IW_ParseGlobalKey(parser, &material, keyword, &token, filename);
+            }
+        }
+        else
+        {
+            IW_LogWarning(filename, token.line, token.column, "unexpected token in shader");
+        }
+    }
+
+    if (material.numStages == 0)
+    {
+        iwStage_t stage;
+        IW_SetStageDefaults(&stage);
+        material.stages[0] = stage;
+        material.numStages = 1;
+    }
+
+    IW_RegisterMaterial(&material);
+}
+
+static void IW_ParseShaderFile(const char *path)
+{
+    char *buffer;
+    int length;
+    if (!IWTXT_LoadFile(path, &buffer, &length))
+        return;
+
+    iwtxtParser_t parser;
+    IWTXT_Init(&parser, buffer, length, path);
+
+    iwtxtToken_t token;
+    while (IWTXT_NextToken(&parser, &token))
+    {
+        if (token.type == IWTXT_TOKEN_EOF)
+            break;
+        if (token.type != IWTXT_TOKEN_STRING)
+            continue;
+
+        char keyword[32];
+        IW_CopyTokenLower(&token, keyword, sizeof(keyword));
+        if (!strcmp(keyword, "shader"))
+        {
+            if (!IWTXT_NextToken(&parser, &token))
+                break;
+            if (token.type != IWTXT_TOKEN_STRING)
+            {
+                IW_LogWarning(path, token.line, token.column, "shader name expected");
+                continue;
+            }
+            IW_ParseShaderDefinition(&parser, &token, path);
+        }
+        else
+        {
+            IW_LogWarning(path, token.line, token.column, "unexpected token '%s'", keyword);
+        }
+    }
+
+    IWTXT_Free(buffer);
+}
+
+void IW_ShaderSystem_Init(void)
+{
+    if (iw_initialized)
+        return;
+
+    Cvar_RegisterVariable(&r_iwshader_cvar);
+    Cvar_RegisterVariable(&r_iwshader_strict_cvar);
+    Cvar_RegisterVariable(&r_iwshader_debug_cvar);
+    iwshader_dump_cmd = Cmd_AddCommand("r_iwshader_dump", IW_DumpMaterials_f);
+
+    iw_num_materials = 0;
+    iw_last_material = NULL;
+    iw_last_texture[0] = '\0';
+    iw_last_texture_display[0] = '\0';
+    iw_initialized = true;
+}
+
+void IW_ShaderSystem_Shutdown(void)
+{
+    if (!iw_initialized)
+        return;
+
+    if (iwshader_dump_cmd)
+    {
+        Cmd_RemoveCommand(iwshader_dump_cmd);
+        iwshader_dump_cmd = NULL;
+    }
+
+    iw_num_materials = 0;
+    iw_last_material = NULL;
+    iw_last_texture[0] = '\0';
+    iw_last_texture_display[0] = '\0';
+    iw_initialized = false;
+}
+
+void IW_LoadShaderDirectory(const char *dir)
+{
+    if (!dir || !*dir)
+        return;
+
+    findfile_t *find;
+    char base[MAX_OSPATH];
+    q_strlcpy(base, dir, sizeof(base));
+
+    size_t len = strlen(base);
+    if (len > 0 && base[len - 1] == '\\')
+    {
+        base[len - 1] = '\0';
+        --len;
+    }
+    if (len > 0 && base[len - 1] != '/')
+    {
+        if (len + 1 < sizeof(base))
+        {
+            base[len] = '/';
+            base[len + 1] = '\0';
+            ++len;
+        }
+    }
+
+    find = Sys_FindFirst(base, "iwshader");
+    for (; find; find = Sys_FindNext(find))
+    {
+        if (find->attribs & FA_DIRECTORY)
+            continue;
+
+        char path[MAX_OSPATH];
+        q_strlcpy(path, base, sizeof(path));
+        q_strlcat(path, find->name, sizeof(path));
+        IW_ParseShaderFile(path);
+    }
+}
+
+const iwMaterial_t *IW_FindMaterial(const char *materialName)
+{
+    char normalized[IW_MAX_NAME];
+    if (!IW_NormalizeName(materialName, normalized, sizeof(normalized), false))
+        return NULL;
+
+    for (int i = 0; i < iw_num_materials; ++i)
+    {
+        if (!strcmp(iw_materials[i].normalized, normalized))
+            return &iw_materials[i].material;
+    }
+    return NULL;
+}
+
+static const iwMaterial_t *IW_FindMaterialNormalized(const char *name)
+{
+    for (int i = 0; i < iw_num_materials; ++i)
+    {
+        if (!strcmp(iw_materials[i].normalized, name))
+            return &iw_materials[i].material;
+    }
+    return NULL;
+}
+
+const iwMaterial_t *IW_MaterialForTexture(const char *textureName)
+{
+    iw_last_material = NULL;
+    iw_last_texture[0] = '\0';
+    iw_last_texture_display[0] = '\0';
+
+    if (!iw_initialized || !r_iwshader_cvar.value)
+        return NULL;
+
+    if (!textureName || !*textureName)
+        return NULL;
+
+    q_strlcpy(iw_last_texture, textureName, sizeof(iw_last_texture));
+
+    char normalized[IW_MAX_NAME];
+    if (IW_NormalizeName(textureName, normalized, sizeof(normalized), false))
+    {
+        iw_last_material = IW_FindMaterialNormalized(normalized);
+    }
+
+    if (!iw_last_material && IW_NormalizeName(textureName, normalized, sizeof(normalized), true))
+    {
+        iw_last_material = IW_FindMaterialNormalized(normalized);
+    }
+
+    if (IW_NormalizeName(textureName, iw_last_texture_display, sizeof(iw_last_texture_display), true))
+        ;
+    else
+        q_strlcpy(iw_last_texture_display, textureName, sizeof(iw_last_texture_display));
+
+    return iw_last_material;
+}
+
+void IW_DumpMaterials(const char *outPath)
+{
+    FILE *f = Sys_fopen(outPath, "w");
+    if (!f)
+    {
+        Con_Printf("iwshader: could not open %s for writing\n", outPath);
+        return;
+    }
+
+    for (int i = 0; i < iw_num_materials; ++i)
+    {
+        const iwMaterial_t *mat = &iw_materials[i].material;
+        fprintf(f, "shader %s\n{\n", mat->name);
+        if (mat->cull != IW_CULL_BACK)
+        {
+            const char *cull = mat->cull == IW_CULL_FRONT ? "front" : "none";
+            fprintf(f, "    cull %s\n", cull);
+        }
+        if (mat->sort != IW_SORT_OPAQUE)
+        {
+            const char *sort = "opaque";
+            switch (mat->sort)
+            {
+            case IW_SORT_ALPHA: sort = "alpha"; break;
+            case IW_SORT_ADDITIVE: sort = "additive"; break;
+            case IW_SORT_DECAL: sort = "decal"; break;
+            case IW_SORT_SKY: sort = "sky"; break;
+            default: break;
+            }
+            fprintf(f, "    sort %s\n", sort);
+        }
+        if (mat->strict)
+            fprintf(f, "    strict 1\n");
+
+        for (int s = 0; s < mat->numStages; ++s)
+        {
+            const iwStage_t *stage = &mat->stages[s];
+            fprintf(f, "    stage {\n");
+            fprintf(f, "        map %s\n", stage->mapPath);
+            switch (stage->blendMode)
+            {
+            case IW_BLEND_ALPHA: fprintf(f, "        blend alpha\n"); break;
+            case IW_BLEND_ADD: fprintf(f, "        blend add\n"); break;
+            case IW_BLEND_MUL: fprintf(f, "        blend mul\n"); break;
+            case IW_BLEND_PREMUL: fprintf(f, "        blend premul\n"); break;
+            case IW_BLEND_CUSTOM:
+                fprintf(f, "        blend %d %d\n", stage->src, stage->dst);
+                break;
+            default:
+                break;
+            }
+            switch (stage->rgbgen)
+            {
+            case IW_RGB_VERTEX:
+                fprintf(f, "        rgbgen vertex\n");
+                break;
+            case IW_RGB_CONST:
+                fprintf(f, "        rgbgen const %g %g %g\n", stage->rgbConst[0], stage->rgbConst[1], stage->rgbConst[2]);
+                break;
+            case IW_RGB_IDENTITY:
+                fprintf(f, "        rgbgen identity\n");
+                break;
+            default:
+                break;
+            }
+            switch (stage->alphagen)
+            {
+            case IW_A_VERTEX:
+                fprintf(f, "        alphagen vertex\n");
+                break;
+            case IW_A_CONST:
+                fprintf(f, "        alphagen const %g\n", stage->aConst);
+                break;
+            case IW_A_MASK:
+                fprintf(f, "        alphagen mask\n");
+                break;
+            }
+            if (stage->emissive)
+                fprintf(f, "        emissive 1\n");
+            if (stage->clamp)
+                fprintf(f, "        clamp 1\n");
+            for (int t = 0; t < stage->numTCMods; ++t)
+            {
+                const iwTCMod_t *tc = &stage->tcmods[t];
+                switch (tc->op)
+                {
+                case IW_TC_SCROLL:
+                    fprintf(f, "        tcmod scroll %g %g\n", tc->a, tc->b);
+                    break;
+                case IW_TC_SCALE:
+                    fprintf(f, "        tcmod scale %g %g\n", tc->a, tc->b);
+                    break;
+                case IW_TC_ROTATE:
+                    fprintf(f, "        tcmod rotate %g\n", tc->a);
+                    break;
+                case IW_TC_ENVMAP:
+                    fprintf(f, "        tcmod envmap\n");
+                    break;
+                }
+            }
+            fprintf(f, "    }\n");
+        }
+        fprintf(f, "}\n\n");
+    }
+
+    fclose(f);
+    Con_Printf("iwshader: wrote %d materials to %s\n", iw_num_materials, outPath);
+}
+
+static void IW_DumpMaterials_f(void)
+{
+    if (Cmd_Argc() < 2)
+    {
+        Con_Printf("usage: r_iwshader_dump <path>\n");
+        return;
+    }
+
+    IW_DumpMaterials(Cmd_Argv(1));
+}
+
+const iwMaterial_t *IW_DebugLastMaterial(void)
+{
+    return iw_last_material;
+}
+
+const char *IW_DebugLastTexture(void)
+{
+    return iw_last_texture_display[0] ? iw_last_texture_display : NULL;
+}
+
+qboolean IW_DebugOverlayText(char *buffer, size_t bufferSize)
+{
+    if (!buffer || bufferSize == 0)
+        return false;
+    if (!r_iwshader_debug_cvar.value)
+        return false;
+    const char *tex = IW_DebugLastTexture();
+    if (!tex)
+        return false;
+    if (iw_last_material)
+        q_snprintf(buffer, bufferSize, "iwshader: %s -> %s", tex, iw_last_material->name);
+    else
+        q_snprintf(buffer, bufferSize, "iwshader: %s (no material)", tex);
+    return true;
+}
+

--- a/Quake/renderer/r_iwshader.h
+++ b/Quake/renderer/r_iwshader.h
@@ -1,0 +1,110 @@
+#pragma once
+#include <stdint.h>
+
+#define IW_MAX_STAGES   4
+#define IW_MAX_TCMODS   4
+#define IW_MAX_NAME     96
+#define IW_MAX_PATH     96
+
+typedef enum {
+    IW_SORT_OPAQUE = 0,
+    IW_SORT_ALPHA,
+    IW_SORT_ADDITIVE,
+    IW_SORT_DECAL,
+    IW_SORT_SKY
+} iwSort_t;
+
+typedef enum {
+    IW_CULL_BACK = 0,
+    IW_CULL_FRONT,
+    IW_CULL_NONE
+} iwCull_t;
+
+typedef enum {
+    IW_BLEND_NONE = 0,
+    IW_BLEND_ALPHA,
+    IW_BLEND_ADD,
+    IW_BLEND_MUL,
+    IW_BLEND_PREMUL,
+    IW_BLEND_CUSTOM
+} iwBlendMode_t;
+
+typedef enum {
+    IW_SRC_ZERO = 0, IW_SRC_ONE,
+    IW_SRC_SRC_COLOR, IW_SRC_ONE_MINUS_SRC_COLOR,
+    IW_SRC_DST_COLOR, IW_SRC_ONE_MINUS_DST_COLOR,
+    IW_SRC_SRC_ALPHA, IW_SRC_ONE_MINUS_SRC_ALPHA,
+    IW_SRC_DST_ALPHA, IW_SRC_ONE_MINUS_DST_ALPHA
+} iwBlendFactor_t;
+
+typedef enum {
+    IW_RGB_VERTEX = 0,
+    IW_RGB_CONST,
+    IW_RGB_IDENTITY,
+    IW_RGB_ENTITY
+} iwRGBGen_t;
+
+typedef enum {
+    IW_A_VERTEX = 0,
+    IW_A_CONST,
+    IW_A_MASK
+} iwAlphaGen_t;
+
+typedef enum {
+    IW_TC_SCROLL = 0,
+    IW_TC_SCALE,
+    IW_TC_ROTATE,
+    IW_TC_ENVMAP
+} iwTCOp_t;
+
+typedef struct {
+    iwTCOp_t op;
+    float a, b;
+} iwTCMod_t;
+
+typedef struct {
+    char mapPath[IW_MAX_PATH];
+    int clamp;
+    iwBlendMode_t blendMode;
+    iwBlendFactor_t src, dst;
+    iwRGBGen_t rgbgen;
+    float rgbConst[3];
+    iwAlphaGen_t alphagen;
+    float aConst;
+    int emissive;
+    int numTCMods;
+    iwTCMod_t tcmods[IW_MAX_TCMODS];
+} iwStage_t;
+
+typedef struct {
+    char name[IW_MAX_NAME];
+    iwSort_t sort;
+    iwCull_t cull;
+    int strict;
+    int numStages;
+    iwStage_t stages[IW_MAX_STAGES];
+} iwMaterial_t;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void IW_ShaderSystem_Init(void);
+void IW_ShaderSystem_Shutdown(void);
+
+void IW_LoadShaderDirectory(const char* dir);
+
+const iwMaterial_t* IW_FindMaterial(const char* materialName);
+
+const iwMaterial_t* IW_MaterialForTexture(const char* textureName);
+
+void IW_DumpMaterials(const char* outPath);
+
+const iwMaterial_t* IW_DebugLastMaterial(void);
+const char* IW_DebugLastTexture(void);
+qboolean IW_DebugOverlayText(char* buffer, size_t bufferSize);
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/examples/shaders/test.iwshader
+++ b/examples/shaders/test.iwshader
@@ -1,0 +1,35 @@
+shader textures/base/computer_panel
+{
+    cull back
+    sort opaque
+    stage { map textures/base/computer_panel_d }
+    stage {
+        map textures/base/computer_panel_emissive
+        emissive 1
+        blend add
+        rgbgen const 1 1 1
+    }
+}
+
+shader textures/decals/crack01
+{
+    sort decal
+    cull none
+    stage {
+        map textures/decals/crack01_a
+        alphagen mask
+        blend alpha
+    }
+}
+
+shader textures/lava/scroll_lava
+{
+    sort additive
+    stage {
+        map textures/lava/lava01
+        tcmod scroll 0.03 0.00
+        rgbgen const 1 0.7 0.2
+        blend add
+        emissive 1
+    }
+}


### PR DESCRIPTION
## Summary
- add a lightweight text tokenizer and iwshader parser/registry with cvars and a dump command
- initialize the iwshader subsystem during renderer startup, look up materials on texture binds, and expose a HUD debug overlay
- update build scripts to compile the new sources and provide an example iwshader file

## Testing
- cmake -S . -B build *(fails: missing SDL2 development files in the container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e806dae70832e80b872f49dd471d7)