### PR TITLE
Fix iwshader loader handling of OS paths

### DIFF
--- a/Quake/common/com_iwtext.c
+++ b/Quake/common/com_iwtext.c
@@ -62,8 +62,13 @@ static qboolean IWTXT_ParseNumber(const char *text, size_t len, double *out)
 qboolean IWTXT_LoadFile(const char *path, char **outBuf, int *outLen)
 {
     byte *data = COM_LoadMallocFile(path, NULL);
+
     if (!data)
-        return false;
+    {
+        data = COM_LoadMallocFile_TextMode_OSPath(path, NULL);
+        if (!data)
+            return false;
+    }
 
     if (outLen)
         *outLen = (int)strlen((const char *)data);


### PR DESCRIPTION
## Summary
- allow the iwshader text loader to fall back to OS-path file loading when the virtual filesystem lookup fails

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e992d560c832e9cebf4873c340eca)