### PR TITLE
Fix iwshader tokenizer classification of partial numeric tokens

### DIFF
--- a/Quake/common/com_iwtext.c
+++ b/Quake/common/com_iwtext.c
@@ -53,8 +53,9 @@ static qboolean IWTXT_ParseNumber(const char *text, size_t len, double *out)
 
     char *endptr;
     double value = strtod(temp, &endptr);
-    if (endptr == temp)
+    if (endptr == temp || *endptr != '\0')
         return false;
+
     *out = value;
     return true;
 }


### PR DESCRIPTION
## Summary
- update the iwshader text parser so numeric detection requires the entire token to be numeric
- prevent shader names such as +0WATER1 from being misclassified as numbers, avoiding "shader name expected" warnings

## Testing
- not run (parser change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e9cc50628832e80ed0da9dd83f8e7)