### PR TITLE
Load iwshader files from game directory root

### DIFF
--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -468,8 +468,11 @@ void R_Init (void)
         if (com_gamedir[0])
         {
                 char shaderdir[MAX_OSPATH];
+
                 q_snprintf (shaderdir, sizeof(shaderdir), "%s/shaders", com_gamedir);
                 IW_LoadShaderDirectory (shaderdir);
+
+                IW_LoadShaderDirectory (com_gamedir);
         }
 }
 


### PR DESCRIPTION
## Summary
- load iwshader definitions from both the shaders subdirectory and the root of the current game directory

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690eae645820832eb4786b0ba5452b2b)