### PR TITLE
Prefer brush texture names when applying iwshader materials

### DIFF
--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -336,12 +336,14 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
 	if (t && t->gltexture)
 	{
 		const char *material_name = NULL;
-		if (t->gltexture->source_file[0])
-			material_name = t->gltexture->source_file;
+
+		if (t->name[0])
+			material_name = t->name;
 		else if (t->gltexture->name[0])
 			material_name = t->gltexture->name;
-		else if (t->name[0])
-			material_name = t->name;
+		else if (t->gltexture->source_file[0])
+			material_name = t->gltexture->source_file;
+
 		IW_MaterialForTexture (material_name);
 	}
 	else


### PR DESCRIPTION
## Summary
- prefer brush texture names over source file names when selecting iwshader materials for brush models

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690eb2798d20832ebb584dc2a8d570e7)