### PR TITLE
Guard iwshader console spam behind debug cvar

### DIFF
--- a/Quake/renderer/r_iwshader.c
+++ b/Quake/renderer/r_iwshader.c
@@ -1346,7 +1346,7 @@ void IW_LoadShaderDirectory(const char *dir)
         q_strlcpy(path, base, sizeof(path));
         q_strlcat(path, find->name, sizeof(path));
 
-        if (r_iwshader_debug_cvar.value)
+        if ((int) r_iwshader_debug_cvar.value == 1)
             Con_Printf("iwshader: loading %s\n", path);
 
         int addedMaterials = IW_ParseShaderFile(path);
@@ -1418,7 +1418,7 @@ const iwMaterial_t *IW_MaterialForTexture(const char *textureName)
     else
         q_strlcpy(iw_last_texture_display, textureName, sizeof(iw_last_texture_display));
 
-    if (textureName && *textureName)
+    if (textureName && *textureName && (int) r_iwshader_debug_cvar.value == 1)
     {
         const char *displayName = iw_last_texture_display[0] ? iw_last_texture_display : textureName;
         if (iw_last_material)


### PR DESCRIPTION
## Summary
- avoid printing iwshader material messages unless r_iwshader_debug is set to 1, keeping highlight mode 2 from spamming the console

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690eb7bc3720832ea7ca0d92f71c8cc0)