### PR TITLE
Implement tcmod UV transforms for iwshader materials

### DIFF
--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -167,6 +167,8 @@ typedef struct bmodel_bindless_gpu_call_s {
 	GLuint64	texture;
 	GLuint64	fullbright;
 	GLuint64	emissive;
+	float		tcmod_matrix[4];
+	float		tcmod_translate[4];
 } bmodel_bindless_gpu_call_t;
 
 typedef struct bmodel_bound_gpu_call_s {
@@ -174,6 +176,8 @@ typedef struct bmodel_bound_gpu_call_s {
 	GLfloat		alpha;
 	GLint		baseinstance;
 	GLint		padding;
+	float		tcmod_matrix[4];
+	float		tcmod_translate[4];
 } bmodel_bound_gpu_call_t;
 
 typedef struct bmodel_gpu_call_remap_s {
@@ -329,49 +333,56 @@ R_AddBModelCall
 */
 static void R_AddBModelCall (int index, int first_instance, int num_instances, texture_t *t, qboolean zfix)
 {
-	GLuint		flags;
-	float		alpha;
-	gltexture_t	*tx, *fb, *em;
+        GLuint          flags;
+        float           alpha;
+        gltexture_t     *tx, *fb, *em;
+        const iwMaterial_t *material = NULL;
+        iwTexMatrix_t   tex_matrix;
 
-	if (t && t->gltexture)
-	{
-		const char *material_name = NULL;
+        IW_TexMatrixIdentity (&tex_matrix);
 
-		if (t->name[0])
-			material_name = t->name;
-		else if (t->gltexture->name[0])
-			material_name = t->gltexture->name;
-		else if (t->gltexture->source_file[0])
-			material_name = t->gltexture->source_file;
+        if (t && t->gltexture)
+        {
+                const char *material_name = NULL;
 
-		IW_MaterialForTexture (material_name);
-	}
-	else
-	{
-		IW_MaterialForTexture (NULL);
-	}
+                if (t->name[0])
+                        material_name = t->name;
+                else if (t->gltexture->name[0])
+                        material_name = t->gltexture->name;
+                else if (t->gltexture->source_file[0])
+                        material_name = t->gltexture->source_file;
 
-	if (num_bmodel_calls == MAX_BMODEL_DRAWS)
-		R_FlushBModelCalls ();
+                material = IW_MaterialForTexture (material_name);
+        }
+        else
+        {
+                material = IW_MaterialForTexture (NULL);
+        }
 
-	if (t)
-	{
-		tx = t->gltexture;
-		fb = t->fullbright;
-		em = t->emissive;
-		if (r_lightmap_cheatsafe)
-			tx = fb = em = NULL;
-		if (!gl_fullbrights.value && t->type != TEXTYPE_SKY)
-			fb = NULL;
-	}
-	else
-	{
-		tx = fb = whitetexture;
-		em = NULL;
-	}
+        if (material)
+                IW_MaterialTexMatrix (material, r_framedata.time, &tex_matrix);
 
-	if (!gl_zfix.value || map_checks.value)
-		zfix = 0;
+        if (num_bmodel_calls == MAX_BMODEL_DRAWS)
+                R_FlushBModelCalls ();
+
+        if (t)
+        {
+                tx = t->gltexture;
+                fb = t->fullbright;
+                em = t->emissive;
+                if (r_lightmap_cheatsafe)
+                        tx = fb = em = NULL;
+                if (!gl_fullbrights.value && t->type != TEXTYPE_SKY)
+                        fb = NULL;
+        }
+        else
+        {
+                tx = fb = whitetexture;
+                em = NULL;
+        }
+
+        if (!gl_zfix.value || map_checks.value)
+                zfix = 0;
 
         flags = zfix | ((fb != NULL) << 1) | ((r_fullbright_cheatsafe != false) << 2);
         if (em != NULL)
@@ -380,35 +391,46 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
                 flags |= CALLFLAG_ALPHA_TEST;
         alpha = t ? GL_WaterAlphaForTextureType (t->type) : 1.f;
 
-	if (gl_bindless_able)
-	{
-		bmodel_bindless_gpu_call_t *call = &bmodel_calls.bindless.params[num_bmodel_calls];
-		call->flags = flags;
-		call->alpha = alpha;
-		call->texture = tx ? tx->bindless_handle : greytexture->bindless_handle;
-		call->fullbright = fb ? fb->bindless_handle : blacktexture->bindless_handle;
-		call->emissive = em ? em->bindless_handle : blacktexture->bindless_handle;
-	}
-	else
-	{
-		bmodel_bound_gpu_call_t *call = &bmodel_calls.bound.params[num_bmodel_calls];
-		gltexture_t **textures = bmodel_calls.bound.textures[num_bmodel_calls];
-		call->flags = flags;
-		call->alpha = alpha;
-		call->baseinstance = first_instance;
-		call->padding = 0;
-		textures[0] = tx ? tx : greytexture;
-		textures[1] = fb ? fb : blacktexture;
-		textures[2] = em ? em : blacktexture;
-	}
+        if (gl_bindless_able)
+        {
+                bmodel_bindless_gpu_call_t *call = &bmodel_calls.bindless.params[num_bmodel_calls];
+                call->flags = flags;
+                call->alpha = alpha;
+                call->texture = tx ? tx->bindless_handle : greytexture->bindless_handle;
+                call->fullbright = fb ? fb->bindless_handle : blacktexture->bindless_handle;
+                call->emissive = em ? em->bindless_handle : blacktexture->bindless_handle;
+                memcpy (call->tcmod_matrix, tex_matrix.matrix, sizeof (tex_matrix.matrix));
+                call->tcmod_translate[0] = tex_matrix.translate[0];
+                call->tcmod_translate[1] = tex_matrix.translate[1];
+                call->tcmod_translate[2] = 0.f;
+                call->tcmod_translate[3] = 0.f;
+        }
+        else
+        {
+                bmodel_bound_gpu_call_t *call = &bmodel_calls.bound.params[num_bmodel_calls];
+                gltexture_t **textures = bmodel_calls.bound.textures[num_bmodel_calls];
+                call->flags = flags;
+                call->alpha = alpha;
+                call->baseinstance = first_instance;
+                call->padding = 0;
+                memcpy (call->tcmod_matrix, tex_matrix.matrix, sizeof (tex_matrix.matrix));
+                call->tcmod_translate[0] = tex_matrix.translate[0];
+                call->tcmod_translate[1] = tex_matrix.translate[1];
+                call->tcmod_translate[2] = 0.f;
+                call->tcmod_translate[3] = 0.f;
+                textures[0] = tx ? tx : greytexture;
+                textures[1] = fb ? fb : blacktexture;
+                textures[2] = em ? em : blacktexture;
+        }
 
-	SDL_assert (num_instances > 0);
-	SDL_assert (num_instances <= MAX_BMODEL_INSTANCES);
-	bmodel_call_remap[num_bmodel_calls].src = index;
-	bmodel_call_remap[num_bmodel_calls].inst = first_instance * MAX_BMODEL_INSTANCES + (num_instances - 1);
+        SDL_assert (num_instances > 0);
+        SDL_assert (num_instances <= MAX_BMODEL_INSTANCES);
+        bmodel_call_remap[num_bmodel_calls].src = index;
+        bmodel_call_remap[num_bmodel_calls].inst = first_instance * MAX_BMODEL_INSTANCES + (num_instances - 1);
 
-	++num_bmodel_calls;
+        ++num_bmodel_calls;
 }
+
 
 /*
 =============

--- a/Quake/renderer/r_iwshader.c
+++ b/Quake/renderer/r_iwshader.c
@@ -7,6 +7,7 @@
 
 #include <errno.h>
 #include <string.h>
+#include <math.h>
 
 #define IW_MAX_MATERIALS 512
 
@@ -1428,6 +1429,116 @@ const iwMaterial_t *IW_MaterialForTexture(const char *textureName)
     }
 
     return iw_last_material;
+}
+
+void IW_TexMatrixIdentity(iwTexMatrix_t *out)
+{
+    if (!out)
+        return;
+
+    out->matrix[0] = 1.f;
+    out->matrix[1] = 0.f;
+    out->matrix[2] = 0.f;
+    out->matrix[3] = 1.f;
+    out->translate[0] = 0.f;
+    out->translate[1] = 0.f;
+}
+
+static void IW_CombineTexMatrix(float matrix[4], float translate[2], const float opMatrix[4], const float opTranslate[2])
+{
+    const float m0 = matrix[0];
+    const float m1 = matrix[1];
+    const float m2 = matrix[2];
+    const float m3 = matrix[3];
+    const float t0 = translate[0];
+    const float t1 = translate[1];
+
+    matrix[0] = opMatrix[0] * m0 + opMatrix[1] * m2;
+    matrix[1] = opMatrix[0] * m1 + opMatrix[1] * m3;
+    matrix[2] = opMatrix[2] * m0 + opMatrix[3] * m2;
+    matrix[3] = opMatrix[2] * m1 + opMatrix[3] * m3;
+    translate[0] = opMatrix[0] * t0 + opMatrix[1] * t1 + opTranslate[0];
+    translate[1] = opMatrix[2] * t0 + opMatrix[3] * t1 + opTranslate[1];
+}
+
+qboolean IW_MaterialTexMatrix(const iwMaterial_t *material, float time, iwTexMatrix_t *out)
+{
+    if (!out)
+        return false;
+
+    IW_TexMatrixIdentity(out);
+
+    if (!material || material->numStages <= 0)
+        return false;
+
+    const iwStage_t *stage = &material->stages[0];
+    if (stage->numTCMods <= 0)
+        return false;
+    if (stage->tcAlign != IW_TC_ALIGN_OBJECT)
+        return false;
+    if (stage->animMap && stage->numAnimFrames > 0)
+        return false;
+
+    float matrix[4] = { 1.f, 0.f, 0.f, 1.f };
+    float translate[2] = { 0.f, 0.f };
+    qboolean modified = false;
+
+    for (int i = 0; i < stage->numTCMods; ++i)
+    {
+        const iwTCMod_t *tc = &stage->tcmods[i];
+        float opMatrix[4] = { 1.f, 0.f, 0.f, 1.f };
+        float opTranslate[2] = { 0.f, 0.f };
+
+        switch (tc->op)
+        {
+        case IW_TC_SCROLL:
+            opTranslate[0] = tc->a * time;
+            opTranslate[1] = tc->b * time;
+            if (tc->a != 0.f || tc->b != 0.f)
+                modified = true;
+            break;
+
+        case IW_TC_SCALE:
+            opMatrix[0] = tc->a;
+            opMatrix[3] = tc->b;
+            if (tc->a != 1.f || tc->b != 1.f)
+                modified = true;
+            break;
+
+        case IW_TC_ROTATE:
+        {
+            float angle = DEG2RAD(tc->a * time);
+            float s = sinf(angle);
+            float c = cosf(angle);
+            opMatrix[0] = c;
+            opMatrix[1] = -s;
+            opMatrix[2] = s;
+            opMatrix[3] = c;
+            opTranslate[0] = 0.5f - 0.5f * c + 0.5f * s;
+            opTranslate[1] = 0.5f - 0.5f * s - 0.5f * c;
+            if (fabsf(s) > 1e-6f || fabsf(c - 1.f) > 1e-6f)
+                modified = true;
+            break;
+        }
+
+        case IW_TC_TRANSLATE:
+            opTranslate[0] = tc->a;
+            opTranslate[1] = tc->b;
+            if (tc->a != 0.f || tc->b != 0.f)
+                modified = true;
+            break;
+
+        default:
+            return false;
+        }
+
+        IW_CombineTexMatrix(matrix, translate, opMatrix, opTranslate);
+    }
+
+    memcpy(out->matrix, matrix, sizeof(matrix));
+    out->translate[0] = translate[0];
+    out->translate[1] = translate[1];
+    return modified;
 }
 
 void IW_DumpMaterials(const char *outPath)

--- a/Quake/renderer/r_iwshader.h
+++ b/Quake/renderer/r_iwshader.h
@@ -166,6 +166,11 @@ typedef struct {
     iwStage_t stages[IW_MAX_STAGES];
 } iwMaterial_t;
 
+typedef struct {
+    float matrix[4];
+    float translate[2];
+} iwTexMatrix_t;
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -178,6 +183,9 @@ void IW_LoadShaderDirectory(const char* dir);
 const iwMaterial_t* IW_FindMaterial(const char* materialName);
 
 const iwMaterial_t* IW_MaterialForTexture(const char* textureName);
+
+void IW_TexMatrixIdentity(iwTexMatrix_t* out);
+qboolean IW_MaterialTexMatrix(const iwMaterial_t* material, float time, iwTexMatrix_t* out);
 
 void IW_DumpMaterials(const char* outPath);
 

--- a/Quake/shaders/sky_cubemap.vert
+++ b/Quake/shaders/sky_cubemap.vert
@@ -27,6 +27,8 @@ struct Call
 	int		baseinstance;
 	int		padding;
 #endif // BINDLESS
+        vec4    tcmod_matrix;
+        vec4    tcmod_translate;
 };
 const uint
 	CF_USE_POLYGON_OFFSET = 1u,

--- a/Quake/shaders/sky_layers.vert
+++ b/Quake/shaders/sky_layers.vert
@@ -27,6 +27,8 @@ struct Call
 	int		baseinstance;
 	int		padding;
 #endif // BINDLESS
+        vec4    tcmod_matrix;
+        vec4    tcmod_translate;
 };
 const uint
 	CF_USE_POLYGON_OFFSET = 1u,

--- a/Quake/shaders/skystencil.vert
+++ b/Quake/shaders/skystencil.vert
@@ -27,6 +27,8 @@ struct Call
 	int		baseinstance;
 	int		padding;
 #endif // BINDLESS
+        vec4    tcmod_matrix;
+        vec4    tcmod_translate;
 };
 const uint
 	CF_USE_POLYGON_OFFSET = 1u,

--- a/Quake/shaders/water.vert
+++ b/Quake/shaders/water.vert
@@ -27,6 +27,8 @@ struct Call
 	int		baseinstance;
 	int		padding;
 #endif // BINDLESS
+        vec4    tcmod_matrix;
+        vec4    tcmod_translate;
 };
 const uint
 	CF_USE_POLYGON_OFFSET = 1u,
@@ -107,7 +109,10 @@ void main()
         out_curr_clip = curr_clip;
         out_prev_clip = prev_clip;
         out_flags = call.flags;
-        out_uv = in_uv.xy;
+        vec2 base_uv = in_uv.xy;
+        vec2 transformed_uv = vec2(dot(call.tcmod_matrix.xy, base_uv),
+                                    dot(call.tcmod_matrix.zw, base_uv)) + call.tcmod_translate.xy;
+        out_uv = transformed_uv;
         out_pos = world_pos - EyePos;
         out_alpha = instance.alpha < 0.0 ? call.wateralpha : instance.alpha;
 #if BINDLESS

--- a/Quake/shaders/world.vert
+++ b/Quake/shaders/world.vert
@@ -56,6 +56,8 @@ struct Call
 	int		baseinstance;
 	int		padding;
 #endif // BINDLESS
+        vec4    tcmod_matrix;
+        vec4    tcmod_translate;
 };
 const uint
 	CF_USE_POLYGON_OFFSET = 1u,
@@ -155,7 +157,10 @@ void main()
 	out_curr_clip = curr_clip;
 	out_prev_clip = prev_clip;
 	out_pos = world_pos;
-	out_uv = in_uv.xy;
+	vec2 base_uv = in_uv.xy;
+        vec2 transformed_uv = vec2(dot(call.tcmod_matrix.xy, base_uv),
+                                    dot(call.tcmod_matrix.zw, base_uv)) + call.tcmod_translate.xy;
+        out_uv = transformed_uv;
 	out_lmuv = in_uv.zw;
 	out_depth = gl_Position.w;
 	out_coord = (gl_Position.xy / gl_Position.w * 0.5 + 0.5) * vec2(LIGHT_TILES_X, LIGHT_TILES_Y);


### PR DESCRIPTION
## Summary
- evaluate tcmod scroll/scale/rotate/translate data when loading iwshader materials
- upload per-call texture matrices to the brush rendering pipeline
- apply the generated UV transforms in world and water vertex shaders so tcmod effects animate textures

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f3f537ea8832e8ff50297c24ab3f0)