### PR TITLE
Add runtime support for iwshader emissive stages

### DIFF
--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -23,7 +23,10 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // r_world.c: world model rendering
 
 #include "quakedef.h"
+#include "gl_texmgr.h"
 #include "renderer/r_iwshader.h"
+
+#include <math.h>
 
 extern cvar_t gl_fullbrights, r_oldskyleaf, r_showtris; //johnfitz
 extern cvar_t gl_zfix; // QuakeSpasm z-fighting fix
@@ -169,6 +172,9 @@ typedef struct bmodel_bindless_gpu_call_s {
 	GLuint64	emissive;
 	float		tcmod_matrix[4];
 	float		tcmod_translate[4];
+	float		emissive_matrix[4];
+	float		emissive_translate[4];
+	float		emissive_color[4];
 } bmodel_bindless_gpu_call_t;
 
 typedef struct bmodel_bound_gpu_call_s {
@@ -178,6 +184,9 @@ typedef struct bmodel_bound_gpu_call_s {
 	GLint		padding;
 	float		tcmod_matrix[4];
 	float		tcmod_translate[4];
+	float		emissive_matrix[4];
+	float		emissive_translate[4];
+	float		emissive_color[4];
 } bmodel_bound_gpu_call_t;
 
 typedef struct bmodel_gpu_call_remap_s {
@@ -326,6 +335,85 @@ static void R_FlushBModelCalls (void)
 #define CALLFLAG_EMISSIVE        (1u << 3)
 #define CALLFLAG_ALPHA_TEST      (1u << 4)
 
+static gltexture_t *R_IWShader_FindTextureForPath(const texture_t *base, const char *path)
+{
+        gltexture_t *tex = NULL;
+
+        if (!path || !*path)
+                return base ? base->gltexture : NULL;
+
+        if (path[0] == '$')
+        {
+                if (!q_strcasecmp(path, "$white"))
+                        return whitetexture;
+                if (!q_strcasecmp(path, "$black"))
+                        return blacktexture;
+                if (!q_strcasecmp(path, "$grey") || !q_strcasecmp(path, "$gray"))
+                        return greytexture;
+                return base ? base->gltexture : NULL;
+        }
+
+        qmodel_t *owner = (base && base->gltexture) ? base->gltexture->owner : NULL;
+        if (owner)
+        {
+                char full_name[MAX_OSPATH];
+                q_snprintf(full_name, sizeof(full_name), "%s:%s", owner->name, path);
+                tex = TexMgr_FindTexture(owner, full_name);
+                if (!tex)
+                        tex = TexMgr_FindTexture(owner, path);
+                if (!tex && owner->textures)
+                {
+                        for (int i = 0; i < owner->numtextures; ++i)
+                        {
+                                texture_t *other = owner->textures[i];
+                                if (!other || !other->gltexture)
+                                        continue;
+                                if (!q_strcasecmp(other->name, path))
+                                        return other->gltexture;
+                        }
+                }
+        }
+
+        if (!tex)
+                tex = TexMgr_FindTexture(NULL, path);
+        if (!tex && base)
+                tex = base->gltexture;
+        return tex;
+}
+
+static gltexture_t *R_IWShader_FindStageTexture(const texture_t *base, const iwStage_t *stage, float time)
+{
+        if (!stage)
+                return base ? base->gltexture : NULL;
+
+        const char *path = stage->mapPath;
+        if (stage->animMap && stage->numAnimFrames > 0)
+        {
+                float fps = stage->animFps != 0.f ? fabsf(stage->animFps) : 1.f;
+                int frame = (int)floor(time * fps);
+                frame %= stage->numAnimFrames;
+                if (frame < 0)
+                        frame += stage->numAnimFrames;
+                if (frame >= 0 && frame < stage->numAnimFrames)
+                        path = stage->animPaths[frame];
+        }
+
+        return R_IWShader_FindTextureForPath(base, path);
+}
+
+static void R_IWShader_EmissiveColor(const iwStage_t *stage, float color[3])
+{
+        color[0] = color[1] = color[2] = 1.f;
+        if (!stage)
+                return;
+        if (stage->rgbgen == IW_RGB_CONST)
+        {
+                color[0] = stage->rgbConst[0];
+                color[1] = stage->rgbConst[1];
+                color[2] = stage->rgbConst[2];
+        }
+}
+
 /*
 =============
 R_AddBModelCall
@@ -338,8 +426,14 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
         gltexture_t     *tx, *fb, *em;
         const iwMaterial_t *material = NULL;
         iwTexMatrix_t   tex_matrix;
+        iwTexMatrix_t   emissive_matrix;
+        float           emissive_color[3];
+        const iwStage_t *emissive_stage = NULL;
+        float           material_alpha = -1.f;
 
         IW_TexMatrixIdentity (&tex_matrix);
+        IW_TexMatrixIdentity (&emissive_matrix);
+        R_IWShader_EmissiveColor (NULL, emissive_color);
 
         if (t && t->gltexture)
         {
@@ -360,7 +454,25 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
         }
 
         if (material)
+        {
                 IW_MaterialTexMatrix (material, r_framedata.time, &tex_matrix);
+                if (material->numStages > 0)
+                {
+                        const iwStage_t *base_stage = &material->stages[0];
+                        if ((base_stage->blendMode == IW_BLEND_ALPHA || base_stage->blendMode == IW_BLEND_ADD_ALPHA) &&
+                            base_stage->alphagen == IW_A_CONST)
+                                material_alpha = q_clamp(base_stage->aConst, 0.f, 1.f);
+                }
+
+                for (int s = 0; s < material->numStages; ++s)
+                {
+                        const iwStage_t *stage = &material->stages[s];
+                        if (!stage->emissive)
+                                continue;
+                        emissive_stage = stage;
+                        break;
+                }
+        }
 
         if (num_bmodel_calls == MAX_BMODEL_DRAWS)
                 R_FlushBModelCalls ();
@@ -381,6 +493,15 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
                 em = NULL;
         }
 
+        if (emissive_stage)
+        {
+                gltexture_t *stage_tex = R_IWShader_FindStageTexture(t, emissive_stage, r_framedata.time);
+                if (stage_tex)
+                        em = stage_tex;
+                R_IWShader_EmissiveColor(emissive_stage, emissive_color);
+                IW_StageTexMatrix(emissive_stage, r_framedata.time, &emissive_matrix);
+        }
+
         if (!gl_zfix.value || map_checks.value)
                 zfix = 0;
 
@@ -390,6 +511,8 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
         if (t && t->type == TEXTYPE_CUTOUT)
                 flags |= CALLFLAG_ALPHA_TEST;
         alpha = t ? GL_WaterAlphaForTextureType (t->type) : 1.f;
+        if (material_alpha >= 0.f)
+                alpha = material_alpha;
 
         if (gl_bindless_able)
         {
@@ -404,6 +527,15 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
                 call->tcmod_translate[1] = tex_matrix.translate[1];
                 call->tcmod_translate[2] = 0.f;
                 call->tcmod_translate[3] = 0.f;
+                memcpy (call->emissive_matrix, emissive_matrix.matrix, sizeof (emissive_matrix.matrix));
+                call->emissive_translate[0] = emissive_matrix.translate[0];
+                call->emissive_translate[1] = emissive_matrix.translate[1];
+                call->emissive_translate[2] = 0.f;
+                call->emissive_translate[3] = 0.f;
+                call->emissive_color[0] = emissive_color[0];
+                call->emissive_color[1] = emissive_color[1];
+                call->emissive_color[2] = emissive_color[2];
+                call->emissive_color[3] = (flags & CALLFLAG_EMISSIVE) ? 1.f : 0.f;
         }
         else
         {
@@ -418,6 +550,15 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
                 call->tcmod_translate[1] = tex_matrix.translate[1];
                 call->tcmod_translate[2] = 0.f;
                 call->tcmod_translate[3] = 0.f;
+                memcpy (call->emissive_matrix, emissive_matrix.matrix, sizeof (emissive_matrix.matrix));
+                call->emissive_translate[0] = emissive_matrix.translate[0];
+                call->emissive_translate[1] = emissive_matrix.translate[1];
+                call->emissive_translate[2] = 0.f;
+                call->emissive_translate[3] = 0.f;
+                call->emissive_color[0] = emissive_color[0];
+                call->emissive_color[1] = emissive_color[1];
+                call->emissive_color[2] = emissive_color[2];
+                call->emissive_color[3] = (flags & CALLFLAG_EMISSIVE) ? 1.f : 0.f;
                 textures[0] = tx ? tx : greytexture;
                 textures[1] = fb ? fb : blacktexture;
                 textures[2] = em ? em : blacktexture;

--- a/Quake/renderer/r_iwshader.c
+++ b/Quake/renderer/r_iwshader.c
@@ -1461,22 +1461,16 @@ static void IW_CombineTexMatrix(float matrix[4], float translate[2], const float
     translate[1] = opMatrix[2] * t0 + opMatrix[3] * t1 + opTranslate[1];
 }
 
-qboolean IW_MaterialTexMatrix(const iwMaterial_t *material, float time, iwTexMatrix_t *out)
+static qboolean IW_StageTexMatrixInternal(const iwStage_t *stage, float time, iwTexMatrix_t *out)
 {
-    if (!out)
+    if (!stage || !out)
         return false;
 
     IW_TexMatrixIdentity(out);
 
-    if (!material || material->numStages <= 0)
-        return false;
-
-    const iwStage_t *stage = &material->stages[0];
     if (stage->numTCMods <= 0)
         return false;
     if (stage->tcAlign != IW_TC_ALIGN_OBJECT)
-        return false;
-    if (stage->animMap && stage->numAnimFrames > 0)
         return false;
 
     float matrix[4] = { 1.f, 0.f, 0.f, 1.f };
@@ -1539,6 +1533,23 @@ qboolean IW_MaterialTexMatrix(const iwMaterial_t *material, float time, iwTexMat
     out->translate[0] = translate[0];
     out->translate[1] = translate[1];
     return modified;
+}
+
+qboolean IW_StageTexMatrix(const iwStage_t *stage, float time, iwTexMatrix_t *out)
+{
+    return IW_StageTexMatrixInternal(stage, time, out);
+}
+
+qboolean IW_MaterialTexMatrix(const iwMaterial_t *material, float time, iwTexMatrix_t *out)
+{
+    if (!material || material->numStages <= 0 || !out)
+    {
+        if (out)
+            IW_TexMatrixIdentity(out);
+        return false;
+    }
+
+    return IW_StageTexMatrixInternal(&material->stages[0], time, out);
 }
 
 void IW_DumpMaterials(const char *outPath)

--- a/Quake/renderer/r_iwshader.h
+++ b/Quake/renderer/r_iwshader.h
@@ -185,6 +185,7 @@ const iwMaterial_t* IW_FindMaterial(const char* materialName);
 const iwMaterial_t* IW_MaterialForTexture(const char* textureName);
 
 void IW_TexMatrixIdentity(iwTexMatrix_t* out);
+qboolean IW_StageTexMatrix(const iwStage_t* stage, float time, iwTexMatrix_t* out);
 qboolean IW_MaterialTexMatrix(const iwMaterial_t* material, float time, iwTexMatrix_t* out);
 
 void IW_DumpMaterials(const char* outPath);

--- a/Quake/shaders/sky_cubemap.vert
+++ b/Quake/shaders/sky_cubemap.vert
@@ -29,6 +29,9 @@ struct Call
 #endif // BINDLESS
         vec4    tcmod_matrix;
         vec4    tcmod_translate;
+        vec4    emissive_matrix;
+        vec4    emissive_translate;
+        vec4    emissive_color;
 };
 const uint
 	CF_USE_POLYGON_OFFSET = 1u,

--- a/Quake/shaders/sky_layers.vert
+++ b/Quake/shaders/sky_layers.vert
@@ -29,6 +29,9 @@ struct Call
 #endif // BINDLESS
         vec4    tcmod_matrix;
         vec4    tcmod_translate;
+        vec4    emissive_matrix;
+        vec4    emissive_translate;
+        vec4    emissive_color;
 };
 const uint
 	CF_USE_POLYGON_OFFSET = 1u,

--- a/Quake/shaders/skystencil.vert
+++ b/Quake/shaders/skystencil.vert
@@ -29,6 +29,9 @@ struct Call
 #endif // BINDLESS
         vec4    tcmod_matrix;
         vec4    tcmod_translate;
+        vec4    emissive_matrix;
+        vec4    emissive_translate;
+        vec4    emissive_color;
 };
 const uint
 	CF_USE_POLYGON_OFFSET = 1u,

--- a/Quake/shaders/water.frag
+++ b/Quake/shaders/water.frag
@@ -91,6 +91,8 @@ layout(location=3) in vec3 in_pos;
 #endif
 layout(location=6) noperspective in vec4 in_curr_clip;
 layout(location=7) noperspective in vec4 in_prev_clip;
+layout(location=8) in vec2 in_emissive_uv;
+layout(location=9) flat in vec3 in_emissive_color;
 
 #define OUT_COLOR out_fragcolor
 #if OIT
@@ -146,13 +148,13 @@ void main()
         if ((in_flags & CF_USE_EMISSIVE) != 0u)
         {
                 sampler2D EmissiveSampler = sampler2D(in_samplers1.xy);
-                emissive = texture(EmissiveSampler, uv).rgb;
+                emissive = texture(EmissiveSampler, in_emissive_uv).rgb * in_emissive_color;
         }
 #else
         if ((in_flags & CF_USE_FULLBRIGHT) != 0u)
                 fullbright = texture(FullbrightTex, uv).rgb;
         if ((in_flags & CF_USE_EMISSIVE) != 0u)
-                emissive = texture(EmissiveTex, uv).rgb;
+                emissive = texture(EmissiveTex, in_emissive_uv).rgb * in_emissive_color;
 #endif
         vec4 result = texture(Tex, uv);
         result.rgb += fullbright;

--- a/Quake/shaders/water.vert
+++ b/Quake/shaders/water.vert
@@ -29,6 +29,9 @@ struct Call
 #endif // BINDLESS
         vec4    tcmod_matrix;
         vec4    tcmod_translate;
+        vec4    emissive_matrix;
+        vec4    emissive_translate;
+        vec4    emissive_color;
 };
 const uint
 	CF_USE_POLYGON_OFFSET = 1u,
@@ -96,6 +99,9 @@ layout(location=3) out vec3 out_pos;
 layout(location=6) noperspective out vec4 out_curr_clip;
 layout(location=7) noperspective out vec4 out_prev_clip;
 
+layout(location=8) out vec2 out_emissive_uv;
+layout(location=9) flat out vec3 out_emissive_color;
+
 void main()
 {
         Call call = call_data[DRAW_ID];
@@ -113,6 +119,9 @@ void main()
         vec2 transformed_uv = vec2(dot(call.tcmod_matrix.xy, base_uv),
                                     dot(call.tcmod_matrix.zw, base_uv)) + call.tcmod_translate.xy;
         out_uv = transformed_uv;
+        vec2 emissive_uv = vec2(dot(call.emissive_matrix.xy, base_uv),
+                                dot(call.emissive_matrix.zw, base_uv)) + call.emissive_translate.xy;
+        out_emissive_uv = emissive_uv;
         out_pos = world_pos - EyePos;
         out_alpha = instance.alpha < 0.0 ? call.wateralpha : instance.alpha;
 #if BINDLESS
@@ -123,4 +132,5 @@ void main()
                 out_samplers0.zw = out_samplers0.xy;
         out_samplers1.xy = call.emhandle;
 #endif
+        out_emissive_color = call.emissive_color.xyz;
 }

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -129,6 +129,8 @@ layout(location=10) flat in uvec2 in_samplers1;
 #endif
 layout(location=11) noperspective in vec4 in_curr_clip;
 layout(location=12) noperspective in vec4 in_prev_clip;
+layout(location=13) in vec2 in_emissive_uv;
+layout(location=14) flat in vec3 in_emissive_color;
 
 #define OUT_COLOR out_fragcolor
 #if OIT
@@ -266,13 +268,13 @@ void main()
     }
     if ((in_flags & CF_USE_EMISSIVE) != 0u){
         sampler2D EmissiveSampler = sampler2D(in_samplers1.xy);
-        emissive = texture(EmissiveSampler, uv).rgb;
+        emissive = texture(EmissiveSampler, in_emissive_uv).rgb * in_emissive_color;
     }
 #else
     if ((in_flags & CF_USE_FULLBRIGHT) != 0u)
         fullbright = texture(FullbrightTex, uv).rgb;
     if ((in_flags & CF_USE_EMISSIVE) != 0u)
-        emissive = texture(EmissiveTex, uv).rgb;
+        emissive = texture(EmissiveTex, in_emissive_uv).rgb * in_emissive_color;
 #endif
 
     // Textur: kleinere negative LOD-Bias nur wenn DITHER aktiv

--- a/Quake/shaders/world.vert
+++ b/Quake/shaders/world.vert
@@ -58,6 +58,9 @@ struct Call
 #endif // BINDLESS
         vec4    tcmod_matrix;
         vec4    tcmod_translate;
+        vec4    emissive_matrix;
+        vec4    emissive_translate;
+        vec4    emissive_color;
 };
 const uint
 	CF_USE_POLYGON_OFFSET = 1u,
@@ -133,6 +136,8 @@ layout(location=8) flat out float out_lmofs;
 #endif
 layout(location=11) noperspective out vec4 out_curr_clip;
 layout(location=12) noperspective out vec4 out_prev_clip;
+layout(location=13) out vec2 out_emissive_uv;
+layout(location=14) flat out vec3 out_emissive_color;
 
 void main()
 {
@@ -161,6 +166,9 @@ void main()
         vec2 transformed_uv = vec2(dot(call.tcmod_matrix.xy, base_uv),
                                     dot(call.tcmod_matrix.zw, base_uv)) + call.tcmod_translate.xy;
         out_uv = transformed_uv;
+        vec2 emissive_uv = vec2(dot(call.emissive_matrix.xy, base_uv),
+                                dot(call.emissive_matrix.zw, base_uv)) + call.emissive_translate.xy;
+        out_emissive_uv = emissive_uv;
 	out_lmuv = in_uv.zw;
 	out_depth = gl_Position.w;
 	out_coord = (gl_Position.xy / gl_Position.w * 0.5 + 0.5) * vec2(LIGHT_TILES_X, LIGHT_TILES_Y);
@@ -193,4 +201,5 @@ void main()
 		out_samplers0.zw = out_samplers0.xy;
 	out_samplers1.xy = call.emhandle;
 #endif
+        out_emissive_color = call.emissive_color.xyz;
 }


### PR DESCRIPTION
## Summary
- apply iwshader material data when building world draw calls, including emissive textures and alpha overrides
- extend GPU call structs and world/water shaders to handle emissive UV transforms and color
- keep sky shader structs in sync with new emissive metadata

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f488b09d8832eb7789be602c91094)