### PR TITLE
Add ZEISS Planar lens post-processing effect

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -238,6 +238,7 @@ cvar_t	r_vignette_color_g = { "r_vignette_color_g", "0.0", CVAR_ARCHIVE };
 cvar_t	r_vignette_color_b = { "r_vignette_color_b", "0.0", CVAR_ARCHIVE };
 cvar_t	r_vignette_blend_mode = { "r_vignette_blend_mode", "0", CVAR_ARCHIVE };
 cvar_t	r_vignette_noise = { "r_vignette_noise", "0.0", CVAR_ARCHIVE };
+cvar_t	r_lens_planar = { "r_lens_planar", "0", CVAR_ARCHIVE };
 cvar_t	r_chromatic_aberration = { "r_chromatic_aberration", "0", CVAR_ARCHIVE };
 cvar_t	r_filmgrain = { "r_filmgrain", "0", CVAR_ARCHIVE };
 cvar_t	r_filmgrain_size = { "r_filmgrain_size", "3.0", CVAR_ARCHIVE };
@@ -786,6 +787,7 @@ void GL_PostProcess (void)
 	palidx = GLPalette_Postprocess ();
 	dither = (softemu == SOFTEMU_FINE) ? NOISESCALE * r_dither.value * r_softemu_dither_screen.value : 0.f;
 
+	float lens_intensity = q_min (1.f, q_max (0.f, r_lens_planar.value));
 	float bloom_intensity = q_max (0.f, r_bloom.value);
 	float exposure = q_max (0.f, r_tonemap_exposure.value);
 	float tonemap_mode = q_max (0.f, r_tonemap.value);
@@ -877,6 +879,12 @@ void GL_PostProcess (void)
                 q_max (0.f, r_chromatic_aberration.value),
                 0.f,
                 0.f);
+
+        GL_Uniform4fFunc (18,
+                lens_intensity,
+                0.045f,
+                0.35f,
+                0.12f);
 
         {
                 float filmgrain_intensity = q_max (0.f, r_filmgrain.value);

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -77,6 +77,7 @@ extern cvar_t r_vignette_color_g;
 extern cvar_t r_vignette_color_b;
 extern cvar_t r_vignette_blend_mode;
 extern cvar_t r_vignette_noise;
+extern cvar_t r_lens_planar;
 extern cvar_t r_chromatic_aberration;
 extern cvar_t r_filmgrain;
 extern cvar_t r_filmgrain_size;
@@ -400,6 +401,7 @@ void R_Init (void)
 	Cvar_RegisterVariable (&r_vignette_color_b);
 	Cvar_RegisterVariable (&r_vignette_blend_mode);
 	Cvar_RegisterVariable (&r_vignette_noise);
+	Cvar_RegisterVariable (&r_lens_planar);
 	Cvar_RegisterVariable (&r_chromatic_aberration);
         Cvar_RegisterVariable (&r_filmgrain);
         Cvar_RegisterVariable (&r_filmgrain_size);

--- a/Quake/shaders/postprocess.frag
+++ b/Quake/shaders/postprocess.frag
@@ -26,12 +26,14 @@ layout(location=14) uniform vec4 SSAOParams1; // x: samples, y: power, zw: reser
 layout(location=15) uniform mat4 ProjectionMatrix;
 layout(location=16) uniform mat4 InverseProjectionMatrix;
 layout(location=17) uniform vec4 DebugParams; // x: SSAO debug, yzw: reserved
+layout(location=18) uniform vec4 LensParams0; // x: intensity, y: distortion, z: halo strength, w: tint strength
 
 #include "postprocess_common.glsl"
 #include "postprocess_ssao.glsl"
 #include "postprocess_motion_blur.glsl"
 #include "postprocess_dof.glsl"
 #include "postprocess_vignette.glsl"
+#include "postprocess_lens.glsl"
 #include "postprocess_chromatic.glsl"
 #include "postprocess_hdr.glsl"
 
@@ -95,6 +97,7 @@ void main()
         if (inView)
         {
                 ApplyVignette(color.rgb, uv, viewMin, viewMax, texSize);
+                ApplyPlanarLens(color.rgb, uv, invTexSize, viewMin, viewMax);
                 ApplyChromaticAberration(color.rgb, uv, invTexSize, viewMin, viewMax);
         }
 

--- a/Quake/shaders/postprocess_lens.glsl
+++ b/Quake/shaders/postprocess_lens.glsl
@@ -1,0 +1,51 @@
+#ifndef POSTPROCESS_LENS_GLSL
+#define POSTPROCESS_LENS_GLSL
+
+// Simulates optical characteristics of a ZEISS Planar 0.7/50mm lens.
+// Adds gentle barrel distortion, subtle spherical aberration and edge halos.
+void ApplyPlanarLens(inout vec3 color, vec2 uv, vec2 invTexSize, vec2 viewMin, vec2 viewMax)
+{
+        float intensity = clamp(LensParams0.x, 0.0, 1.0);
+        if (intensity <= 1e-4)
+                return;
+
+        float distortionCoeff = max(LensParams0.y, 0.0);
+        float haloStrength = max(LensParams0.z, 0.0);
+        float tintStrength = max(LensParams0.w, 0.0);
+
+        vec2 viewSize = max(viewMax - viewMin, vec2(1e-6));
+        vec2 viewUV = clamp((uv - viewMin) / viewSize, vec2(0.0), vec2(1.0));
+        vec2 centered = viewUV - vec2(0.5);
+
+        float aspect = viewSize.y > 1e-6 ? viewSize.x / viewSize.y : 1.0;
+        vec2 elliptical = vec2(centered.x * aspect, centered.y);
+        float radius = length(elliptical);
+        float radius2 = radius * radius;
+        float radius4 = radius2 * radius2;
+
+        float curvature = distortionCoeff * (radius2 + 0.5 * radius4);
+        vec2 distortion = centered * curvature * intensity;
+        vec2 distortedUV = clamp(uv + distortion, viewMin, viewMax);
+        vec3 distortedColor = texture(GammaTexture, distortedUV).rgb;
+
+        vec2 aberrationDir = centered * (0.6 + 0.4 * radius2);
+        vec3 aberrationColor;
+        aberrationColor.r = texture(GammaTexture, clamp(uv + aberrationDir * 0.75 * intensity + invTexSize * 0.5, viewMin, viewMax)).r;
+        aberrationColor.g = texture(GammaTexture, clamp(uv + aberrationDir * 0.55 * intensity, viewMin, viewMax)).g;
+        aberrationColor.b = texture(GammaTexture, clamp(uv - aberrationDir * 0.65 * intensity, viewMin, viewMax)).b;
+
+        float halo = haloStrength * smoothstep(0.35, 1.05, radius);
+        vec2 haloOffset = -centered * (0.25 + 0.5 * radius2);
+        vec3 haloColor = texture(GammaTexture, clamp(uv + haloOffset * intensity, viewMin, viewMax)).rgb;
+
+        vec3 result = mix(color, distortedColor, intensity * 0.6);
+        result = mix(result, aberrationColor, intensity * 0.35);
+        result += haloColor * halo * intensity * 0.2;
+
+        vec3 tint = vec3(1.02, 1.0, 0.985);
+        result = mix(result, result * tint, tintStrength * intensity);
+
+        color = clamp(result, 0.0, 1.0);
+}
+
+#endif // POSTPROCESS_LENS_GLSL


### PR DESCRIPTION
## Summary
- add a Planar-inspired post-process shader that simulates ZEISS 0.7/50mm lens traits during compositing
- expose the r_lens_planar cvar and plumb its uniform parameters through the post-processing pipeline

## Testing
- python3 Misc/validate_shaders.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f637537b4832e9a26b10a74da8045)