### PR TITLE
Fix planar lens postprocess distortion

### DIFF
--- a/Quake/shaders/postprocess.frag
+++ b/Quake/shaders/postprocess.frag
@@ -97,8 +97,8 @@ void main()
         if (inView)
         {
                 ApplyVignette(color.rgb, uv, viewMin, viewMax, texSize);
-                ApplyPlanarLens(color.rgb, uv, invTexSize, viewMin, viewMax);
                 ApplyChromaticAberration(color.rgb, uv, invTexSize, viewMin, viewMax);
+                ApplyPlanarLens(color.rgb, uv, invTexSize, viewMin, viewMax);
         }
 
         out_fragcolor = color;

--- a/Quake/shaders/postprocess_lens.glsl
+++ b/Quake/shaders/postprocess_lens.glsl
@@ -25,18 +25,21 @@ void ApplyPlanarLens(inout vec3 color, vec2 uv, vec2 invTexSize, vec2 viewMin, v
 
         float curvature = distortionCoeff * (radius2 + 0.5 * radius4);
         vec2 distortion = centered * curvature * intensity;
-        vec2 distortedUV = clamp(uv + distortion, viewMin, viewMax);
+        vec2 distortionUV = distortion * viewSize;
+        vec2 distortedUV = clamp(uv + distortionUV, viewMin, viewMax);
         vec3 distortedColor = texture(GammaTexture, distortedUV).rgb;
 
         vec2 aberrationDir = centered * (0.6 + 0.4 * radius2);
+        vec2 aberrationOffset = aberrationDir * intensity * viewSize;
         vec3 aberrationColor;
-        aberrationColor.r = texture(GammaTexture, clamp(uv + aberrationDir * 0.75 * intensity + invTexSize * 0.5, viewMin, viewMax)).r;
-        aberrationColor.g = texture(GammaTexture, clamp(uv + aberrationDir * 0.55 * intensity, viewMin, viewMax)).g;
-        aberrationColor.b = texture(GammaTexture, clamp(uv - aberrationDir * 0.65 * intensity, viewMin, viewMax)).b;
+        aberrationColor.r = texture(GammaTexture, clamp(uv + aberrationOffset * 0.75 + invTexSize * 0.5, viewMin, viewMax)).r;
+        aberrationColor.g = texture(GammaTexture, clamp(uv + aberrationOffset * 0.55, viewMin, viewMax)).g;
+        aberrationColor.b = texture(GammaTexture, clamp(uv - aberrationOffset * 0.65, viewMin, viewMax)).b;
 
         float halo = haloStrength * smoothstep(0.35, 1.05, radius);
         vec2 haloOffset = -centered * (0.25 + 0.5 * radius2);
-        vec3 haloColor = texture(GammaTexture, clamp(uv + haloOffset * intensity, viewMin, viewMax)).rgb;
+        vec2 haloOffsetUV = haloOffset * intensity * viewSize;
+        vec3 haloColor = texture(GammaTexture, clamp(uv + haloOffsetUV, viewMin, viewMax)).rgb;
 
         vec3 result = mix(color, distortedColor, intensity * 0.6);
         result = mix(result, aberrationColor, intensity * 0.35);


### PR DESCRIPTION
## Summary
- run the planar lens pass after other full-screen post effects so it distorts the final image instead of earlier passes
- scale lens distortion, chromatic offsets, and halo sampling by the active view size to remove exaggerated warping artifacts

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f665a4514832e8a9c6241a132771c)