### PR TITLE
Tame planar lens distortion strength

### DIFF
--- a/Quake/shaders/postprocess.frag
+++ b/Quake/shaders/postprocess.frag
@@ -97,8 +97,8 @@ void main()
         if (inView)
         {
                 ApplyVignette(color.rgb, uv, viewMin, viewMax, texSize);
-                ApplyPlanarLens(color.rgb, uv, invTexSize, viewMin, viewMax);
                 ApplyChromaticAberration(color.rgb, uv, invTexSize, viewMin, viewMax);
+                ApplyPlanarLens(color.rgb, uv, invTexSize, viewMin, viewMax);
         }
 
         out_fragcolor = color;

--- a/Quake/shaders/postprocess_lens.glsl
+++ b/Quake/shaders/postprocess_lens.glsl
@@ -23,20 +23,24 @@ void ApplyPlanarLens(inout vec3 color, vec2 uv, vec2 invTexSize, vec2 viewMin, v
         float radius2 = radius * radius;
         float radius4 = radius2 * radius2;
 
-        float curvature = distortionCoeff * (radius2 + 0.5 * radius4);
-        vec2 distortion = centered * curvature * intensity;
-        vec2 distortedUV = clamp(uv + distortion, viewMin, viewMax);
+        float distortionStrength = distortionCoeff * intensity;
+        float curvature = distortionStrength * (0.4 * radius2 + 0.1 * radius4);
+        vec2 distortion = centered * curvature;
+        vec2 distortionUV = distortion * viewSize;
+        vec2 distortedUV = clamp(uv + distortionUV, viewMin, viewMax);
         vec3 distortedColor = texture(GammaTexture, distortedUV).rgb;
 
-        vec2 aberrationDir = centered * (0.6 + 0.4 * radius2);
+        vec2 aberrationDir = centered * (0.25 + 0.25 * radius2);
+        vec2 aberrationOffset = aberrationDir * distortionStrength * viewSize;
         vec3 aberrationColor;
-        aberrationColor.r = texture(GammaTexture, clamp(uv + aberrationDir * 0.75 * intensity + invTexSize * 0.5, viewMin, viewMax)).r;
-        aberrationColor.g = texture(GammaTexture, clamp(uv + aberrationDir * 0.55 * intensity, viewMin, viewMax)).g;
-        aberrationColor.b = texture(GammaTexture, clamp(uv - aberrationDir * 0.65 * intensity, viewMin, viewMax)).b;
+        aberrationColor.r = texture(GammaTexture, clamp(uv + aberrationOffset * 0.75 + invTexSize * 0.5, viewMin, viewMax)).r;
+        aberrationColor.g = texture(GammaTexture, clamp(uv + aberrationOffset * 0.55, viewMin, viewMax)).g;
+        aberrationColor.b = texture(GammaTexture, clamp(uv - aberrationOffset * 0.65, viewMin, viewMax)).b;
 
         float halo = haloStrength * smoothstep(0.35, 1.05, radius);
-        vec2 haloOffset = -centered * (0.25 + 0.5 * radius2);
-        vec3 haloColor = texture(GammaTexture, clamp(uv + haloOffset * intensity, viewMin, viewMax)).rgb;
+        vec2 haloOffset = -centered * (0.2 + 0.35 * radius2);
+        vec2 haloOffsetUV = haloOffset * distortionStrength * viewSize;
+        vec3 haloColor = texture(GammaTexture, clamp(uv + haloOffsetUV, viewMin, viewMax)).rgb;
 
         vec3 result = mix(color, distortedColor, intensity * 0.6);
         result = mix(result, aberrationColor, intensity * 0.35);


### PR DESCRIPTION
## Summary
- reduce the planar lens distortion polynomial and derived offsets to produce a gentler warp at full intensity
- scale chromatic aberration and halo offsets with the toned-down distortion strength for a more subtle edge treatment

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f665a4514832e8a9c6241a132771c)