### PR TITLE
Implement material-driven renderer state

### DIFF
--- a/Quake/gl_vidsdl.c
+++ b/Quake/gl_vidsdl.c
@@ -92,6 +92,10 @@ float gl_max_anisotropy; //johnfitz
 int gl_stencilbits;
 
 unsigned glstate;
+static GLboolean gl_color_mask_state[4] = {GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE};
+static qboolean gl_polygon_offset_enabled_state = false;
+static float gl_polygon_offset_factor_state = 0.f;
+static float gl_polygon_offset_units_state = 0.f;
 GLint ssbo_align;
 GLint ubo_align;
 static GLuint globalvao;
@@ -1106,7 +1110,7 @@ GL_SetStateEx
 */
 static void GL_SetStateEx (unsigned mask, unsigned force)
 {
-	unsigned diff = (mask ^ glstate) | force;
+        unsigned diff = (mask ^ glstate) | force;
 
 	if (diff & GLS_MASK_BLEND)
 	{
@@ -1211,7 +1215,63 @@ static void GL_SetStateEx (unsigned mask, unsigned force)
 		}
 	}
 
-	glstate = mask;
+        glstate = mask;
+}
+
+void GL_GetColorMask(GLboolean mask[4])
+{
+        if (!mask)
+                return;
+        memcpy(mask, gl_color_mask_state, sizeof(gl_color_mask_state));
+}
+
+void GL_SetColorMask(GLboolean r, GLboolean g, GLboolean b, GLboolean a)
+{
+        if (gl_color_mask_state[0] == r &&
+            gl_color_mask_state[1] == g &&
+            gl_color_mask_state[2] == b &&
+            gl_color_mask_state[3] == a)
+                return;
+
+        glColorMask(r, g, b, a);
+        gl_color_mask_state[0] = r;
+        gl_color_mask_state[1] = g;
+        gl_color_mask_state[2] = b;
+        gl_color_mask_state[3] = a;
+}
+
+void GL_GetPolygonOffset(qboolean *enabled, float *factor, float *units)
+{
+        if (enabled)
+                *enabled = gl_polygon_offset_enabled_state;
+        if (factor)
+                *factor = gl_polygon_offset_factor_state;
+        if (units)
+                *units = gl_polygon_offset_units_state;
+}
+
+void GL_SetPolygonOffset(qboolean enable, float factor, float units)
+{
+        if (enable)
+        {
+                if (!gl_polygon_offset_enabled_state)
+                        glEnable(GL_POLYGON_OFFSET_FILL);
+                if (!gl_polygon_offset_enabled_state ||
+                    gl_polygon_offset_factor_state != factor ||
+                    gl_polygon_offset_units_state != units)
+                        glPolygonOffset(factor, units);
+                gl_polygon_offset_enabled_state = true;
+                gl_polygon_offset_factor_state = factor;
+                gl_polygon_offset_units_state = units;
+        }
+        else
+        {
+                if (gl_polygon_offset_enabled_state)
+                        glDisable(GL_POLYGON_OFFSET_FILL);
+                gl_polygon_offset_enabled_state = false;
+                gl_polygon_offset_factor_state = factor;
+                gl_polygon_offset_units_state = units;
+        }
 }
 
 /*
@@ -1221,7 +1281,7 @@ GL_SetState
 */
 void GL_SetState (unsigned mask)
 {
-	GL_SetStateEx (mask, 0);
+        GL_SetStateEx (mask, 0);
 }
 
 /*
@@ -1231,7 +1291,9 @@ GL_ResetState
 */
 void GL_ResetState (void)
 {
-	GL_SetStateEx (GLS_DEFAULT_STATE, ~0u);
+        GL_SetStateEx (GLS_DEFAULT_STATE, ~0u);
+        GL_SetColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+        GL_SetPolygonOffset(false, 0.f, 0.f);
 }
 
 /*
@@ -1256,8 +1318,10 @@ static void GL_SetupState (void)
 		glDepthFunc (GL_LEQUAL);
 	}
 	glFrontFace (GL_CW); //johnfitz -- glquake used CCW with backwards culling -- let's do it right
-	glPolygonMode (GL_FRONT_AND_BACK, GL_FILL);
-	GL_DepthRange (ZRANGE_FULL); //johnfitz -- moved here becuase gl_ztrick is gone.
+        glPolygonMode (GL_FRONT_AND_BACK, GL_FILL);
+        GL_DepthRange (ZRANGE_FULL); //johnfitz -- moved here becuase gl_ztrick is gone.
+        GL_SetColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+        GL_SetPolygonOffset(false, 0.f, 0.f);
 	glEnable (GL_BLEND);
 	glEnable (GL_TEXTURE_CUBE_MAP_SEAMLESS);
 	glEnable (GL_SAMPLE_SHADING);

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -319,6 +319,10 @@ typedef enum {
 extern unsigned glstate;
 void GL_SetState (unsigned mask);
 void GL_ResetState (void);
+void GL_GetColorMask(GLboolean mask[4]);
+void GL_SetColorMask(GLboolean r, GLboolean g, GLboolean b, GLboolean a);
+void GL_GetPolygonOffset(qboolean *enabled, float *factor, float *units);
+void GL_SetPolygonOffset(qboolean enable, float factor, float units);
 
 extern GLint ssbo_align; // SSBO alignment - 1
 extern GLint ubo_align; // UBO alignment - 1

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -27,6 +27,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "renderer/r_iwshader.h"
 
 #include <math.h>
+#include <stdlib.h>
 
 extern cvar_t gl_fullbrights, r_oldskyleaf, r_showtris; //johnfitz
 extern cvar_t gl_zfix; // QuakeSpasm z-fighting fix
@@ -201,12 +202,134 @@ static union {
 	} bindless;
 	struct {
 		bmodel_bound_gpu_call_t		params[MAX_BMODEL_DRAWS];
-		gltexture_t					*textures[MAX_BMODEL_DRAWS][3];
+		gltexture_t						*textures[MAX_BMODEL_DRAWS][3];
 	} bound;
 } bmodel_calls;
 static bmodel_gpu_call_remap_t		bmodel_call_remap[MAX_BMODEL_DRAWS];
-static int							num_bmodel_calls;
-static GLuint						bmodel_batch_program;
+static int								num_bmodel_calls;
+static GLuint							bmodel_batch_program;
+
+typedef enum {
+	BMODEL_QUEUE_OPAQUE = 0,
+	BMODEL_QUEUE_DECAL,
+	BMODEL_QUEUE_ALPHA_TEST,
+	BMODEL_QUEUE_TRANSLUCENT,
+	BMODEL_QUEUE_OVERLAY,
+	BMODEL_QUEUE_COUNT
+} bmodel_queue_t;
+
+static const char *const bmodel_queue_names[BMODEL_QUEUE_COUNT] = {
+	"OPAQUE",
+	"DECAL",
+	"ALPHA_TEST",
+	"TRANSLUCENT",
+	"OVERLAY"
+};
+
+typedef struct {
+	unsigned				cullMask;
+	iwCull_t				cullMode;
+	qboolean			depthTest;
+	qboolean			depthWrite;
+	qboolean			colorMaskEnabled;
+	GLboolean		colorMask[4];
+	iwColorMask_t	colorMaskBits;
+	qboolean			polygonOffsetEnabled;
+	float				polygonOffsetFactor;
+	float				polygonOffsetUnits;
+	qboolean			clampDiffuse;
+	qboolean			clampEmissive;
+	bmodel_queue_t	queue;
+	float				sortKey;
+	int					sortValue;
+	const iwMaterial_t	*material;
+} bmodel_cpu_call_t;
+
+static bmodel_cpu_call_t bmodel_cpu_calls[MAX_BMODEL_DRAWS];
+static int				bmodel_call_order[MAX_BMODEL_DRAWS];
+static qboolean	bmodel_calls_require_bound;
+
+static int R_CompareBModelCalls(const void *a, const void *b)
+{
+        int ia = *(const int *)a;
+        int ib = *(const int *)b;
+        const bmodel_cpu_call_t *ca = &bmodel_cpu_calls[ia];
+        const bmodel_cpu_call_t *cb = &bmodel_cpu_calls[ib];
+
+        if (ca->queue != cb->queue)
+                return (ca->queue < cb->queue) ? -1 : 1;
+
+        if (ca->queue == BMODEL_QUEUE_TRANSLUCENT)
+        {
+                if (ca->sortKey > cb->sortKey)
+                        return -1;
+                if (ca->sortKey < cb->sortKey)
+                        return 1;
+        }
+        else if (ca->sortValue != cb->sortValue)
+        {
+                return (ca->sortValue < cb->sortValue) ? -1 : 1;
+        }
+
+        if (ia < ib)
+                return -1;
+        if (ia > ib)
+                return 1;
+        return 0;
+}
+
+static void R_SortBModelCalls(void)
+{
+        if (num_bmodel_calls <= 1)
+                return;
+
+        for (int i = 0; i < num_bmodel_calls; ++i)
+                bmodel_call_order[i] = i;
+
+        qsort(bmodel_call_order, num_bmodel_calls, sizeof(bmodel_call_order[0]), R_CompareBModelCalls);
+
+        qboolean changed = false;
+        for (int i = 0; i < num_bmodel_calls; ++i)
+        {
+                if (bmodel_call_order[i] != i)
+                {
+                        changed = true;
+                        break;
+                }
+        }
+
+        if (!changed)
+                return;
+
+        static bmodel_bindless_gpu_call_t bindless_tmp[MAX_BMODEL_DRAWS];
+        static bmodel_bound_gpu_call_t bound_tmp[MAX_BMODEL_DRAWS];
+        static gltexture_t *textures_tmp[MAX_BMODEL_DRAWS][3];
+        static bmodel_gpu_call_remap_t remap_tmp[MAX_BMODEL_DRAWS];
+        static bmodel_cpu_call_t cpu_tmp[MAX_BMODEL_DRAWS];
+
+        for (int i = 0; i < num_bmodel_calls; ++i)
+        {
+                int src = bmodel_call_order[i];
+                bindless_tmp[i] = bmodel_calls.bindless.params[src];
+                bound_tmp[i] = bmodel_calls.bound.params[src];
+                for (int t = 0; t < 3; ++t)
+                        textures_tmp[i][t] = bmodel_calls.bound.textures[src][t];
+                remap_tmp[i] = bmodel_call_remap[src];
+                cpu_tmp[i] = bmodel_cpu_calls[src];
+        }
+
+        for (int i = 0; i < num_bmodel_calls; ++i)
+        {
+                bmodel_calls.bindless.params[i] = bindless_tmp[i];
+                bmodel_calls.bound.params[i] = bound_tmp[i];
+                for (int t = 0; t < 3; ++t)
+                        bmodel_calls.bound.textures[i][t] = textures_tmp[i][t];
+                bmodel_call_remap[i] = remap_tmp[i];
+                bmodel_cpu_calls[i] = cpu_tmp[i];
+        }
+}
+
+
 
 /*
 =============
@@ -270,8 +393,9 @@ R_ResetBModelCalls
 */
 static void R_ResetBModelCalls (GLuint program)
 {
-	bmodel_batch_program = program;
-	num_bmodel_calls = 0;
+        bmodel_batch_program = program;
+        num_bmodel_calls = 0;
+        bmodel_calls_require_bound = false;
 }
 
 /*
@@ -281,56 +405,165 @@ R_FlushBModelCalls
 */
 static void R_FlushBModelCalls (void)
 {
-	GLuint	cmdbuf, buf;
-	GLbyte	*ofs;
-	size_t	dstcmdofs;
+        GLuint  cmdbuf, buf;
+        GLbyte  *ofs;
+        size_t  dstcmdofs;
 
-	if (!num_bmodel_calls)
-		return;
+        if (!num_bmodel_calls)
+                return;
 
-	GL_ReserveDeviceMemory (GL_DRAW_INDIRECT_BUFFER, sizeof (bmodel_draw_indirect_t) * num_bmodel_calls, &cmdbuf, &dstcmdofs);
+        R_SortBModelCalls();
 
-	GL_UseProgram (glprogs.gather_indirect);
-	GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 5, gl_bmodel_indirect_buffer, 0, gl_bmodel_indirect_buffer_size);
-	GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 6, cmdbuf, dstcmdofs, sizeof (bmodel_draw_indirect_t) * num_bmodel_calls);
-	GL_Upload (GL_SHADER_STORAGE_BUFFER, bmodel_call_remap, sizeof (bmodel_call_remap[0]) * num_bmodel_calls, &buf, &ofs);
-	GL_BindBufferRange  (GL_SHADER_STORAGE_BUFFER, 7, buf, (GLintptr)ofs, sizeof (bmodel_call_remap[0]) * num_bmodel_calls);
-	GL_DispatchComputeFunc ((num_bmodel_calls + 63) / 64, 1, 1);
-	GL_MemoryBarrierFunc (GL_COMMAND_BARRIER_BIT);
+        qboolean use_bindless = gl_bindless_able && !bmodel_calls_require_bound;
 
-	GL_UseProgram (bmodel_batch_program);
-	GL_BindBuffer (GL_ELEMENT_ARRAY_BUFFER, gl_bmodel_ibo);
-	GL_BindBuffer (GL_ARRAY_BUFFER, gl_bmodel_vbo);
-	GL_BindBuffer (GL_DRAW_INDIRECT_BUFFER, cmdbuf);
-	GL_VertexAttribPointerFunc (0, 3, GL_FLOAT, GL_FALSE, sizeof (glvert_t), (void *) offsetof (glvert_t, pos));
-	GL_VertexAttribPointerFunc (1, 4, GL_FLOAT, GL_FALSE, sizeof (glvert_t), (void *) offsetof (glvert_t, st));
-	GL_VertexAttribPointerFunc (2, 1, GL_FLOAT, GL_FALSE, sizeof (glvert_t), (void *) offsetof (glvert_t, lmofs));
-	GL_VertexAttribIPointerFunc (3, 4, GL_UNSIGNED_BYTE, sizeof (glvert_t), (void *) offsetof (glvert_t, styles));
+        GL_ReserveDeviceMemory (GL_DRAW_INDIRECT_BUFFER, sizeof (bmodel_draw_indirect_t) * num_bmodel_calls, &cmdbuf, &dstcmdofs);
 
-	if (gl_bindless_able)
-	{
-		GL_Upload (GL_SHADER_STORAGE_BUFFER, bmodel_calls.bindless.params, sizeof (bmodel_calls.bindless.params[0]) * num_bmodel_calls, &buf, &ofs);
-		GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 1, buf, (GLintptr)ofs, sizeof (bmodel_calls.bindless.params[0]) * num_bmodel_calls);
-		GL_MultiDrawElementsIndirectFunc (GL_TRIANGLES, GL_UNSIGNED_INT, (const void *)dstcmdofs, num_bmodel_calls, sizeof (bmodel_draw_indirect_t));
-	}
-	else
-	{
-		int i;
+        GL_UseProgram (glprogs.gather_indirect);
+        GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 5, gl_bmodel_indirect_buffer, 0, gl_bmodel_indirect_buffer_size);
+        GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 6, cmdbuf, dstcmdofs, sizeof (bmodel_draw_indirect_t) * num_bmodel_calls);
+        GL_Upload (GL_SHADER_STORAGE_BUFFER, bmodel_call_remap, sizeof (bmodel_call_remap[0]) * num_bmodel_calls, &buf, &ofs);
+        GL_BindBufferRange  (GL_SHADER_STORAGE_BUFFER, 7, buf, (GLintptr)ofs, sizeof (bmodel_call_remap[0]) * num_bmodel_calls);
+        GL_DispatchComputeFunc ((num_bmodel_calls + 63) / 64, 1, 1);
+        GL_MemoryBarrierFunc (GL_COMMAND_BARRIER_BIT);
 
-		GL_Upload (GL_SHADER_STORAGE_BUFFER, &bmodel_calls.bound.params, sizeof (bmodel_calls.bound.params[0]) * num_bmodel_calls, &buf, &ofs);
-		GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 1, buf, (GLintptr)ofs, sizeof (bmodel_calls.bound.params[0]) * num_bmodel_calls);
+        GL_UseProgram (bmodel_batch_program);
+        GL_BindBuffer (GL_ELEMENT_ARRAY_BUFFER, gl_bmodel_ibo);
+        GL_BindBuffer (GL_ARRAY_BUFFER, gl_bmodel_vbo);
+        GL_BindBuffer (GL_DRAW_INDIRECT_BUFFER, cmdbuf);
+        GL_VertexAttribPointerFunc (0, 3, GL_FLOAT, GL_FALSE, sizeof (glvert_t), (void *) offsetof (glvert_t, pos));
+        GL_VertexAttribPointerFunc (1, 4, GL_FLOAT, GL_FALSE, sizeof (glvert_t), (void *) offsetof (glvert_t, st));
+        GL_VertexAttribPointerFunc (2, 1, GL_FLOAT, GL_FALSE, sizeof (glvert_t), (void *) offsetof (glvert_t, lmofs));
+        GL_VertexAttribIPointerFunc (3, 4, GL_UNSIGNED_BYTE, sizeof (glvert_t), (void *) offsetof (glvert_t, styles));
 
-		for (i = 0; i < num_bmodel_calls; i++)
-		{
-			GL_Uniform1iFunc (0, i);
-			GL_BindTextures (0, 2, bmodel_calls.bound.textures[i]);
-			GL_Bind (GL_TEXTURE4, bmodel_calls.bound.textures[i][2]);
-			GL_DrawElementsIndirectFunc (GL_TRIANGLES, GL_UNSIGNED_INT, (const byte *)(dstcmdofs + i * sizeof (bmodel_draw_indirect_t)));
-		}
-	}
+        if (use_bindless)
+        {
+                GL_Upload (GL_SHADER_STORAGE_BUFFER, bmodel_calls.bindless.params, sizeof (bmodel_calls.bindless.params[0]) * num_bmodel_calls, &buf, &ofs);
+                GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 1, buf, (GLintptr)ofs, sizeof (bmodel_calls.bindless.params[0]) * num_bmodel_calls);
+        }
+        else
+        {
+                GL_Upload (GL_SHADER_STORAGE_BUFFER, &bmodel_calls.bound.params, sizeof (bmodel_calls.bound.params[0]) * num_bmodel_calls, &buf, &ofs);
+                GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 1, buf, (GLintptr)ofs, sizeof (bmodel_calls.bound.params[0]) * num_bmodel_calls);
+        }
 
-	num_bmodel_calls = 0;
+        for (int i = 0; i < num_bmodel_calls; ++i)
+        {
+                bmodel_cpu_call_t *cpu = &bmodel_cpu_calls[i];
+
+                unsigned prev_state = glstate;
+                unsigned desired_state = (prev_state & ~(GLS_MASK_CULL | GLS_NO_ZTEST | GLS_NO_ZWRITE));
+                desired_state = (desired_state & ~GLS_MASK_CULL) | cpu->cullMask;
+                if (!cpu->depthTest)
+                        desired_state |= GLS_NO_ZTEST;
+                else
+                        desired_state &= ~GLS_NO_ZTEST;
+                if (!cpu->depthWrite)
+                        desired_state |= GLS_NO_ZWRITE;
+                else
+                        desired_state &= ~GLS_NO_ZWRITE;
+
+                if (desired_state != glstate)
+                        GL_SetState (desired_state);
+
+                GLboolean prev_mask[4];
+                GL_GetColorMask (prev_mask);
+                qboolean restore_color = false;
+                if (cpu->colorMaskEnabled)
+                {
+                        GL_SetColorMask (cpu->colorMask[0], cpu->colorMask[1], cpu->colorMask[2], cpu->colorMask[3]);
+                        restore_color = true;
+                }
+                else if (!(prev_mask[0] && prev_mask[1] && prev_mask[2] && prev_mask[3]))
+                {
+                        GL_SetColorMask (GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+                        restore_color = true;
+                }
+
+                qboolean prev_poly_enabled;
+                float prev_poly_factor, prev_poly_units;
+                GL_GetPolygonOffset (&prev_poly_enabled, &prev_poly_factor, &prev_poly_units);
+                qboolean restore_poly = false;
+                if (cpu->polygonOffsetEnabled)
+                {
+                        if (!prev_poly_enabled || prev_poly_factor != cpu->polygonOffsetFactor || prev_poly_units != cpu->polygonOffsetUnits)
+                                GL_SetPolygonOffset (true, cpu->polygonOffsetFactor, cpu->polygonOffsetUnits);
+                        restore_poly = true;
+                }
+                else if (prev_poly_enabled)
+                {
+                        GL_SetPolygonOffset (false, 0.f, 0.f);
+                        restore_poly = true;
+                }
+
+                GLint diffuse_wrap[2] = {0, 0};
+                GLint emissive_wrap[2] = {0, 0};
+                qboolean restore_diffuse_wrap = false;
+                qboolean restore_emissive_wrap = false;
+
+                if (!use_bindless)
+                {
+                        gltexture_t **textures = bmodel_calls.bound.textures[i];
+                        gltexture_t *diffuse = textures[0] ? textures[0] : greytexture;
+                        gltexture_t *fullbright = textures[1] ? textures[1] : blacktexture;
+                        gltexture_t *emissive = textures[2] ? textures[2] : blacktexture;
+
+                        GL_Bind (GL_TEXTURE0, diffuse);
+                        GL_Bind (GL_TEXTURE1, fullbright);
+                        GL_Bind (GL_TEXTURE4, emissive);
+
+                        if (cpu->clampDiffuse && diffuse)
+                        {
+                                glGetTexParameteriv (diffuse->target, GL_TEXTURE_WRAP_S, &diffuse_wrap[0]);
+                                glGetTexParameteriv (diffuse->target, GL_TEXTURE_WRAP_T, &diffuse_wrap[1]);
+                                glTexParameteri (diffuse->target, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+                                glTexParameteri (diffuse->target, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+                                restore_diffuse_wrap = true;
+                        }
+
+                        if (cpu->clampEmissive && emissive)
+                        {
+                                glGetTexParameteriv (emissive->target, GL_TEXTURE_WRAP_S, &emissive_wrap[0]);
+                                glGetTexParameteriv (emissive->target, GL_TEXTURE_WRAP_T, &emissive_wrap[1]);
+                                glTexParameteri (emissive->target, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+                                glTexParameteri (emissive->target, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+                                restore_emissive_wrap = true;
+                        }
+                }
+
+                GL_Uniform1iFunc (0, i);
+
+                GL_DrawElementsIndirectFunc (GL_TRIANGLES, GL_UNSIGNED_INT,
+                        (const GLvoid *)(dstcmdofs + (size_t)i * sizeof (bmodel_draw_indirect_t)));
+
+                if (!use_bindless)
+                {
+                        gltexture_t **textures = bmodel_calls.bound.textures[i];
+                        gltexture_t *diffuse = textures[0] ? textures[0] : greytexture;
+                        gltexture_t *emissive = textures[2] ? textures[2] : blacktexture;
+
+                        if (restore_diffuse_wrap && diffuse)
+                        {
+                                glTexParameteri (diffuse->target, GL_TEXTURE_WRAP_S, diffuse_wrap[0]);
+                                glTexParameteri (diffuse->target, GL_TEXTURE_WRAP_T, diffuse_wrap[1]);
+                        }
+                        if (restore_emissive_wrap && emissive)
+                        {
+                                glTexParameteri (emissive->target, GL_TEXTURE_WRAP_S, emissive_wrap[0]);
+                                glTexParameteri (emissive->target, GL_TEXTURE_WRAP_T, emissive_wrap[1]);
+                        }
+                }
+
+                if (restore_poly)
+                        GL_SetPolygonOffset (prev_poly_enabled, prev_poly_factor, prev_poly_units);
+                if (restore_color)
+                        GL_SetColorMask (prev_mask[0], prev_mask[1], prev_mask[2], prev_mask[3]);
+                if (glstate != prev_state)
+                        GL_SetState (prev_state);
+        }
+
+        num_bmodel_calls = 0;
 }
+
 
 #define CALLFLAG_EMISSIVE        (1u << 3)
 #define CALLFLAG_ALPHA_TEST      (1u << 4)
@@ -419,7 +652,7 @@ static void R_IWShader_EmissiveColor(const iwStage_t *stage, float color[3])
 R_AddBModelCall
 =============
 */
-static void R_AddBModelCall (int index, int first_instance, int num_instances, texture_t *t, qboolean zfix)
+static void R_AddBModelCall (brushpass_t pass, qboolean translucent_pass, int index, int first_instance, int num_instances, texture_t *t, qboolean zfix, entity_t *base_entity)
 {
         GLuint          flags;
         float           alpha;
@@ -428,6 +661,7 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
         iwTexMatrix_t   tex_matrix;
         iwTexMatrix_t   emissive_matrix;
         float           emissive_color[3];
+        const iwStage_t *base_stage = NULL;
         const iwStage_t *emissive_stage = NULL;
         float           material_alpha = -1.f;
 
@@ -458,7 +692,7 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
                 IW_MaterialTexMatrix (material, r_framedata.time, &tex_matrix);
                 if (material->numStages > 0)
                 {
-                        const iwStage_t *base_stage = &material->stages[0];
+                        base_stage = &material->stages[0];
                         if ((base_stage->blendMode == IW_BLEND_ALPHA || base_stage->blendMode == IW_BLEND_ADD_ALPHA) &&
                             base_stage->alphagen == IW_A_CONST)
                                 material_alpha = q_clamp(base_stage->aConst, 0.f, 1.f);
@@ -563,6 +797,128 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
                 textures[1] = fb ? fb : blacktexture;
                 textures[2] = em ? em : blacktexture;
         }
+
+        iwColorMask_t mask = base_stage ? base_stage->colorMask : IW_COLORMASK_RGBA;
+        qboolean colorMaskEnabled = (mask != IW_COLORMASK_RGBA);
+        GLboolean maskValues[4] = {
+                (mask & IW_COLORMASK_R) != 0,
+                (mask & IW_COLORMASK_G) != 0,
+                (mask & IW_COLORMASK_B) != 0,
+                (mask & IW_COLORMASK_A) != 0
+        };
+
+        qboolean clampDiffuse = base_stage && base_stage->clamp;
+        qboolean clampEmissive = emissive_stage && emissive_stage->clamp;
+        if (clampDiffuse || clampEmissive)
+                bmodel_calls_require_bound = true;
+
+        iwCull_t cullMode = material ? material->cull : IW_CULL_BACK;
+        unsigned cullMask = GLS_CULL_BACK;
+        if (cullMode == IW_CULL_FRONT)
+                cullMask = GLS_CULL_FRONT;
+        else if (cullMode == IW_CULL_NONE)
+                cullMask = GLS_CULL_NONE;
+
+        bmodel_queue_t queue = BMODEL_QUEUE_OPAQUE;
+        if (pass == BP_SKYLAYERS || pass == BP_SKYCUBEMAP || pass == BP_SKYSTENCIL)
+                queue = BMODEL_QUEUE_OVERLAY;
+        else if (translucent_pass)
+                queue = BMODEL_QUEUE_TRANSLUCENT;
+        else if (flags & CALLFLAG_ALPHA_TEST)
+                queue = BMODEL_QUEUE_ALPHA_TEST;
+
+        if (material)
+        {
+                switch (material->sort)
+                {
+                case IW_SORT_DECAL:
+                        queue = BMODEL_QUEUE_DECAL;
+                        break;
+                case IW_SORT_ALPHA:
+                case IW_SORT_ADDITIVE:
+                        queue = BMODEL_QUEUE_TRANSLUCENT;
+                        break;
+                case IW_SORT_SKY:
+                        queue = BMODEL_QUEUE_OVERLAY;
+                        break;
+                case IW_SORT_CUSTOM:
+                        if (material->sortValue >= 0)
+                        {
+                                int bucket = material->sortValue;
+                                if (bucket < 0)
+                                        bucket = 0;
+                                if (bucket >= BMODEL_QUEUE_COUNT)
+                                        bucket = BMODEL_QUEUE_COUNT - 1;
+                                queue = (bmodel_queue_t)bucket;
+                        }
+                        break;
+                default:
+                        break;
+                }
+        }
+
+        qboolean depthTest = base_stage ? (base_stage->depthTest != 0) : true;
+        qboolean defaultDepthWrite = (queue != BMODEL_QUEUE_TRANSLUCENT);
+        qboolean depthWrite;
+        if (base_stage)
+        {
+                if (base_stage->depthWrite == IW_DEPTHWRITE_AUTO)
+                        depthWrite = defaultDepthWrite;
+                else
+                        depthWrite = base_stage->depthWrite != 0;
+        }
+        else
+        {
+                depthWrite = defaultDepthWrite;
+        }
+
+        qboolean polygonOffsetEnabled = material && material->polygonOffset.enabled;
+        float polygonOffsetFactor = polygonOffsetEnabled ? material->polygonOffset.factor : 0.f;
+        float polygonOffsetUnits = polygonOffsetEnabled ? material->polygonOffset.units : 0.f;
+
+        int sortValue = 0;
+        if (material && material->sortValue >= 0)
+                sortValue = material->sortValue;
+
+        float sortKey = 0.f;
+        if (queue == BMODEL_QUEUE_TRANSLUCENT && base_entity)
+        {
+                vec3_t diff;
+                VectorSubtract (base_entity->origin, r_refdef.vieworg, diff);
+                sortKey = DotProduct (diff, diff);
+        }
+        else
+        {
+                sortKey = (float)sortValue;
+        }
+
+        if (material)
+        {
+                IW_Debugf ("Cull=%d", material->cull);
+                IW_DebugSetMaterialState (material, bmodel_queue_names[queue], depthTest, depthWrite,
+                        mask, cullMode, polygonOffsetEnabled, polygonOffsetFactor, polygonOffsetUnits);
+        }
+
+        bmodel_cpu_call_t *cpu = &bmodel_cpu_calls[num_bmodel_calls];
+        cpu->cullMask = cullMask;
+        cpu->cullMode = cullMode;
+        cpu->depthTest = depthTest;
+        cpu->depthWrite = depthWrite;
+        cpu->colorMaskEnabled = colorMaskEnabled;
+        cpu->colorMaskBits = mask;
+        cpu->colorMask[0] = maskValues[0];
+        cpu->colorMask[1] = maskValues[1];
+        cpu->colorMask[2] = maskValues[2];
+        cpu->colorMask[3] = maskValues[3];
+        cpu->polygonOffsetEnabled = polygonOffsetEnabled;
+        cpu->polygonOffsetFactor = polygonOffsetFactor;
+        cpu->polygonOffsetUnits = polygonOffsetUnits;
+        cpu->clampDiffuse = clampDiffuse;
+        cpu->clampEmissive = clampEmissive;
+        cpu->queue = queue;
+        cpu->sortKey = sortKey;
+        cpu->sortValue = sortValue;
+        cpu->material = material;
 
         SDL_assert (num_instances > 0);
         SDL_assert (num_instances <= MAX_BMODEL_INSTANCES);
@@ -735,7 +1091,7 @@ static void R_DrawBrushModels_Real (entity_t **ents, int count, brushpass_t pass
                 for (j = model->texofs[texbegin]; j < model->texofs[texend]; j++)
                 {
                         texture_t *t = model->textures[model->usedtextures[j]];
-                        R_AddBModelCall (model->firstcmd + j, baseinst, numinst, pass != BP_SHOWTRIS ? R_TextureAnimation (t, frame) : 0, zfix);
+                        R_AddBModelCall (pass, translucent, model->firstcmd + j, baseinst, numinst, pass != BP_SHOWTRIS ? R_TextureAnimation (t, frame) : 0, zfix, e);
                 }
 
                 baseinst += numinst;
@@ -839,7 +1195,7 @@ void R_DrawBrushModels_Water (entity_t **ents, int count, qboolean translucent)
 			texture_t *t = model->textures[model->usedtextures[j]];
 			if ((GL_WaterAlphaForEntityTextureType (e, t->type) < 1.f) != translucent)
 				continue;
-			R_AddBModelCall (model->firstcmd + j, baseinst, numinst, R_TextureAnimation (t, frame), !isworld);
+			R_AddBModelCall (BP_SOLID, translucent, model->firstcmd + j, baseinst, numinst, R_TextureAnimation (t, frame), !isworld, e);
 		}
 
 		baseinst += numinst;

--- a/Quake/renderer/r_iwshader.c
+++ b/Quake/renderer/r_iwshader.c
@@ -9,6 +9,7 @@
 #include <string.h>
 #include <math.h>
 #include <stdlib.h>
+#include <stdarg.h>
 
 #define IW_MAX_MATERIALS 512
 
@@ -86,6 +87,24 @@ static char iw_last_texture_display[IW_MAX_PATH];
 static qboolean iw_last_material_broken;
 static const char *iw_last_broken_name;
 
+typedef struct
+{
+    char queue[32];
+    qboolean hasQueue;
+    qboolean hasDepth;
+    qboolean depthTest;
+    qboolean depthWrite;
+    iwColorMask_t colorMask;
+    qboolean hasColorMask;
+    iwCull_t cullMode;
+    qboolean hasCull;
+    qboolean polygonOffsetEnabled;
+    float polygonOffsetFactor;
+    float polygonOffsetUnits;
+} iwDebugState_t;
+
+static iwDebugState_t iw_last_debug_state;
+
 static void IW_LogWarning(const char *file, int line, int column, const char *fmt, ...)
 {
     char msg[512];
@@ -96,6 +115,20 @@ static void IW_LogWarning(const char *file, int line, int column, const char *fm
     va_end(args);
 
     Con_Printf("iwshader: %s:%d:%d: %s\n", file ? file : "<unknown>", line, column, msg);
+}
+
+void IW_Debugf(const char *fmt, ...)
+{
+    if ((int)r_iwshader_debug_cvar.value < 2)
+        return;
+
+    char msg[512];
+    va_list args;
+    va_start(args, fmt);
+    q_vsnprintf(msg, sizeof(msg), fmt, args);
+    va_end(args);
+
+    Con_Printf("iwshader: %s\n", msg);
 }
 
 static qboolean IW_NormalizeName(const char *input, char *output, size_t size, qboolean drop_extension)
@@ -1135,20 +1168,43 @@ static qboolean IW_ParseGlobalKey(iwtxtParser_t *parser, iwMaterial_t *material,
             IW_LogWarning(filename, token->line, token->column, "polygonoffset requires a value");
             return false;
         }
+
+        iwPolygonOffset_t *po = &material->polygonOffset;
+        po->enabled = 0;
+        po->factor = 0.f;
+        po->units = 0.f;
+
         if (value.type == IWTXT_TOKEN_STRING)
         {
             char mode[8];
             IW_CopyTokenLower(&value, mode, sizeof(mode));
             if (!strcmp(mode, "on"))
-                material->polygonOffset = 1;
+            {
+                po->enabled = 1;
+                po->factor = 1.f;
+                po->units = 1.f;
+            }
             else if (!strcmp(mode, "off"))
-                material->polygonOffset = 0;
+            {
+                po->enabled = 0;
+            }
             else
+            {
                 IW_LogWarning(filename, value.line, value.column, "unknown polygonoffset '%s'", mode);
+            }
         }
         else if (value.type == IWTXT_TOKEN_NUMBER)
         {
-            material->polygonOffset = (value.number != 0.0);
+            po->enabled = (value.number != 0.0);
+            po->factor = (float)value.number;
+            po->units = 1.f;
+
+            iwtxtToken_t next;
+            if (IWTXT_PeekToken(parser, &next) && next.type == IWTXT_TOKEN_NUMBER)
+            {
+                IWTXT_NextToken(parser, &next);
+                po->units = (float)next.number;
+            }
         }
         else
         {
@@ -1368,6 +1424,7 @@ void IW_ShaderSystem_Init(void)
     iw_last_texture_display[0] = '\0';
     iw_last_material_broken = false;
     iw_last_broken_name = NULL;
+    memset(&iw_last_debug_state, 0, sizeof(iw_last_debug_state));
     iw_initialized = true;
 }
 
@@ -1388,6 +1445,7 @@ void IW_ShaderSystem_Shutdown(void)
     iw_last_texture_display[0] = '\0';
     iw_last_material_broken = false;
     iw_last_broken_name = NULL;
+    memset(&iw_last_debug_state, 0, sizeof(iw_last_debug_state));
     iw_initialized = false;
 }
 
@@ -1490,6 +1548,7 @@ const iwMaterial_t *IW_MaterialForTexture(const char *textureName)
     iw_last_texture_display[0] = '\0';
     iw_last_material_broken = false;
     iw_last_broken_name = NULL;
+    memset(&iw_last_debug_state, 0, sizeof(iw_last_debug_state));
 
     if (!iw_initialized || !r_iwshader_cvar.value)
         return NULL;
@@ -1712,8 +1771,13 @@ void IW_DumpMaterials(const char *outPath)
             if (mat->surfaceFlags & iw_surfaceparms[sp].flag)
                 fprintf(f, "    surfaceparm %s\n", iw_surfaceparms[sp].name);
         }
-        if (mat->polygonOffset)
-            fprintf(f, "    polygonoffset on\n");
+        if (mat->polygonOffset.enabled)
+        {
+            if (fabsf(mat->polygonOffset.factor - 1.f) < 1e-6f && fabsf(mat->polygonOffset.units - 1.f) < 1e-6f)
+                fprintf(f, "    polygonoffset on\n");
+            else
+                fprintf(f, "    polygonoffset %g %g\n", mat->polygonOffset.factor, mat->polygonOffset.units);
+        }
         if (mat->detail)
             fprintf(f, "    detail 1\n");
         if (mat->strict)
@@ -1873,7 +1937,87 @@ qboolean IW_DebugOverlayText(char *buffer, size_t bufferSize)
     if (!tex)
         return false;
     if (iw_last_material)
-        q_snprintf(buffer, bufferSize, "iwshader: %s -> %s", tex, iw_last_material->name);
+    {
+        char extras[160];
+        extras[0] = '\0';
+
+        char sortInfo[32];
+        sortInfo[0] = '\0';
+        const char *sortName = "opaque";
+        switch (iw_last_material->sort)
+        {
+        case IW_SORT_ALPHA:
+            sortName = "alpha";
+            break;
+        case IW_SORT_ADDITIVE:
+            sortName = "additive";
+            break;
+        case IW_SORT_DECAL:
+            sortName = "decal";
+            break;
+        case IW_SORT_SKY:
+            sortName = "sky";
+            break;
+        case IW_SORT_CUSTOM:
+            sortName = "custom";
+            break;
+        default:
+            break;
+        }
+        if (iw_last_material->sort == IW_SORT_CUSTOM && iw_last_material->sortValue >= 0)
+            q_snprintf(sortInfo, sizeof(sortInfo), "%s/%d", sortName, iw_last_material->sortValue);
+        else if (iw_last_material->sortValue >= 0)
+            q_snprintf(sortInfo, sizeof(sortInfo), "%s/%d", sortName, iw_last_material->sortValue);
+        else
+            q_snprintf(sortInfo, sizeof(sortInfo), "%s", sortName);
+
+        if (sortInfo[0])
+        {
+            q_snprintf(extras + strlen(extras), sizeof(extras) - strlen(extras),
+                "%ssort=%s", extras[0] ? " " : "", sortInfo);
+        }
+
+        if (iw_last_debug_state.hasQueue)
+        {
+            q_snprintf(extras + strlen(extras), sizeof(extras) - strlen(extras),
+                "%squeue=%s", extras[0] ? " " : "", iw_last_debug_state.queue);
+        }
+        if (iw_last_debug_state.hasDepth)
+        {
+            q_snprintf(extras + strlen(extras), sizeof(extras) - strlen(extras),
+                "%sdepthtest=%s depthwrite=%s", extras[0] ? " " : "",
+                iw_last_debug_state.depthTest ? "on" : "off",
+                iw_last_debug_state.depthWrite ? "on" : "off");
+        }
+        if (iw_last_debug_state.hasColorMask)
+        {
+            q_snprintf(extras + strlen(extras), sizeof(extras) - strlen(extras),
+                "%scolormask=%s", extras[0] ? " " : "",
+                IW_ColorMaskName(iw_last_debug_state.colorMask));
+        }
+        if (iw_last_debug_state.hasCull)
+        {
+            const char *cull = "back";
+            if (iw_last_debug_state.cullMode == IW_CULL_FRONT)
+                cull = "front";
+            else if (iw_last_debug_state.cullMode == IW_CULL_NONE)
+                cull = "none";
+            q_snprintf(extras + strlen(extras), sizeof(extras) - strlen(extras),
+                "%scull=%s", extras[0] ? " " : "", cull);
+        }
+        if (iw_last_debug_state.polygonOffsetEnabled)
+        {
+            q_snprintf(extras + strlen(extras), sizeof(extras) - strlen(extras),
+                "%spolygonoffset=%g,%g", extras[0] ? " " : "",
+                iw_last_debug_state.polygonOffsetFactor,
+                iw_last_debug_state.polygonOffsetUnits);
+        }
+
+        if (extras[0])
+            q_snprintf(buffer, bufferSize, "iwshader: %s -> %s (%s)", tex, iw_last_material->name, extras);
+        else
+            q_snprintf(buffer, bufferSize, "iwshader: %s -> %s", tex, iw_last_material->name);
+    }
     else if (iw_last_material_broken)
     {
         if (iw_last_broken_name && *iw_last_broken_name)
@@ -1884,6 +2028,37 @@ qboolean IW_DebugOverlayText(char *buffer, size_t bufferSize)
     else
         return false;
     return true;
+}
+
+void IW_DebugSetMaterialState(const iwMaterial_t *material, const char *queue,
+    qboolean depthTest, qboolean depthWrite, iwColorMask_t colorMask,
+    iwCull_t cullMode, qboolean polygonOffsetEnabled, float polygonOffsetFactor,
+    float polygonOffsetUnits)
+{
+    if (!material || material != iw_last_material)
+        return;
+
+    memset(&iw_last_debug_state, 0, sizeof(iw_last_debug_state));
+
+    if (queue && *queue)
+    {
+        q_strlcpy(iw_last_debug_state.queue, queue, sizeof(iw_last_debug_state.queue));
+        iw_last_debug_state.hasQueue = true;
+    }
+
+    iw_last_debug_state.depthTest = depthTest ? true : false;
+    iw_last_debug_state.depthWrite = depthWrite ? true : false;
+    iw_last_debug_state.hasDepth = true;
+
+    iw_last_debug_state.colorMask = colorMask;
+    iw_last_debug_state.hasColorMask = true;
+
+    iw_last_debug_state.cullMode = cullMode;
+    iw_last_debug_state.hasCull = true;
+
+    iw_last_debug_state.polygonOffsetEnabled = polygonOffsetEnabled;
+    iw_last_debug_state.polygonOffsetFactor = polygonOffsetFactor;
+    iw_last_debug_state.polygonOffsetUnits = polygonOffsetUnits;
 }
 
 #define IW_MAX_MACROS 64

--- a/Quake/renderer/r_iwshader.h
+++ b/Quake/renderer/r_iwshader.h
@@ -153,12 +153,18 @@ typedef struct {
 } iwStage_t;
 
 typedef struct {
+    int enabled;
+    float factor;
+    float units;
+} iwPolygonOffset_t;
+
+typedef struct {
     char name[IW_MAX_NAME];
     iwSort_t sort;
     int sortValue;
     iwCull_t cull;
     unsigned int surfaceFlags;
-    int polygonOffset;
+    iwPolygonOffset_t polygonOffset;
     int detail;
     char editorImage[IW_MAX_PATH];
     int strict;
@@ -193,6 +199,11 @@ void IW_DumpMaterials(const char* outPath);
 const iwMaterial_t* IW_DebugLastMaterial(void);
 const char* IW_DebugLastTexture(void);
 qboolean IW_DebugOverlayText(char* buffer, size_t bufferSize);
+void IW_Debugf(const char *fmt, ...);
+void IW_DebugSetMaterialState(const iwMaterial_t *material, const char *queue,
+    qboolean depthTest, qboolean depthWrite, iwColorMask_t colorMask,
+    iwCull_t cullMode, qboolean polygonOffsetEnabled, float polygonOffsetFactor,
+    float polygonOffsetUnits);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
- add renderer queues and per-call material state tracking for brush model draws, including culling, depth, color mask, polygon offset, clamp, and sort handling
- extend iwshader parser/debug output to expose polygon offset, color mask, depth, cull, and queue metadata
- add GL helpers for color masks and polygon offset management with state restoration

## Testing
- cmake -S . -B build *(fails: missing SDL2 package)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69109c97c454832eb598514ff97e7ad5)