### PR TITLE
Fix bindless vertex shaders using uniform DrawID

### DIFF
--- a/Quake/shaders/sky_cubemap.vert
+++ b/Quake/shaders/sky_cubemap.vert
@@ -1,10 +1,8 @@
 #if BINDLESS
 	#extension GL_ARB_shader_draw_parameters : require
-	#define DRAW_ID			gl_DrawIDARB
-#else
-	layout(location=0) uniform int DrawID;
-	#define DRAW_ID			DrawID
 #endif
+layout(location=0) uniform int DrawID;
+#define DRAW_ID			DrawID
 
 #include "frame_uniforms.glsl"
 
@@ -50,7 +48,7 @@ const uint TCGEN_SCREEN = 2u;
 
 bool ScreenViewportValid()
 {
-        return Frame.ScreenTexScale.z > 0.0 && Frame.ScreenTexScale.w > 0.0;
+        return ScreenTexScale.z > 0.0 && ScreenTexScale.w > 0.0;
 }
 
 vec2 EvaluateBaseUV(uint mode, vec4 basis0, vec4 basis1, vec3 world_pos, vec4 clip_pos, vec2 object_uv)
@@ -64,7 +62,7 @@ vec2 EvaluateBaseUV(uint mode, vec4 basis0, vec4 basis1, vec3 world_pos, vec4 cl
         {
                 vec2 screen01 = clip_pos.xy / clip_pos.w * 0.5 + 0.5;
                 if (ScreenViewportValid())
-                        return screen01 * Frame.ScreenTexScale.zw;
+                        return screen01 * ScreenTexScale.zw;
                 return screen01;
         }
         return object_uv;
@@ -73,7 +71,7 @@ vec2 EvaluateBaseUV(uint mode, vec4 basis0, vec4 basis1, vec3 world_pos, vec4 cl
 vec2 FinalizeUV(uint mode, vec2 uv)
 {
         if (mode == TCGEN_SCREEN && ScreenViewportValid())
-                return uv * Frame.ScreenTexScale.xy;
+                return uv * ScreenTexScale.xy;
         return uv;
 }
 

--- a/Quake/shaders/sky_layers.vert
+++ b/Quake/shaders/sky_layers.vert
@@ -1,10 +1,8 @@
 #if BINDLESS
 	#extension GL_ARB_shader_draw_parameters : require
-	#define DRAW_ID			gl_DrawIDARB
-#else
-	layout(location=0) uniform int DrawID;
-	#define DRAW_ID			DrawID
 #endif
+layout(location=0) uniform int DrawID;
+#define DRAW_ID			DrawID
 
 #include "frame_uniforms.glsl"
 
@@ -50,7 +48,7 @@ const uint TCGEN_SCREEN = 2u;
 
 bool ScreenViewportValid()
 {
-        return Frame.ScreenTexScale.z > 0.0 && Frame.ScreenTexScale.w > 0.0;
+        return ScreenTexScale.z > 0.0 && ScreenTexScale.w > 0.0;
 }
 
 vec2 EvaluateBaseUV(uint mode, vec4 basis0, vec4 basis1, vec3 world_pos, vec4 clip_pos, vec2 object_uv)
@@ -64,7 +62,7 @@ vec2 EvaluateBaseUV(uint mode, vec4 basis0, vec4 basis1, vec3 world_pos, vec4 cl
         {
                 vec2 screen01 = clip_pos.xy / clip_pos.w * 0.5 + 0.5;
                 if (ScreenViewportValid())
-                        return screen01 * Frame.ScreenTexScale.zw;
+                        return screen01 * ScreenTexScale.zw;
                 return screen01;
         }
         return object_uv;
@@ -73,7 +71,7 @@ vec2 EvaluateBaseUV(uint mode, vec4 basis0, vec4 basis1, vec3 world_pos, vec4 cl
 vec2 FinalizeUV(uint mode, vec2 uv)
 {
         if (mode == TCGEN_SCREEN && ScreenViewportValid())
-                return uv * Frame.ScreenTexScale.xy;
+                return uv * ScreenTexScale.xy;
         return uv;
 }
 

--- a/Quake/shaders/skystencil.vert
+++ b/Quake/shaders/skystencil.vert
@@ -1,10 +1,8 @@
 #if BINDLESS
 	#extension GL_ARB_shader_draw_parameters : require
-	#define DRAW_ID			gl_DrawIDARB
-#else
-	layout(location=0) uniform int DrawID;
-	#define DRAW_ID			DrawID
 #endif
+layout(location=0) uniform int DrawID;
+#define DRAW_ID			DrawID
 
 #include "frame_uniforms.glsl"
 

--- a/Quake/shaders/water.vert
+++ b/Quake/shaders/water.vert
@@ -1,10 +1,8 @@
 #if BINDLESS
 	#extension GL_ARB_shader_draw_parameters : require
-	#define DRAW_ID			gl_DrawIDARB
-#else
-	layout(location=0) uniform int DrawID;
-	#define DRAW_ID			DrawID
 #endif
+layout(location=0) uniform int DrawID;
+#define DRAW_ID			DrawID
 
 #include "frame_uniforms.glsl"
 
@@ -51,7 +49,7 @@ const uint TCGEN_SCREEN = 2u;
 
 bool ScreenViewportValid()
 {
-        return Frame.ScreenTexScale.z > 0.0 && Frame.ScreenTexScale.w > 0.0;
+        return ScreenTexScale.z > 0.0 && ScreenTexScale.w > 0.0;
 }
 
 vec2 EvaluateBaseUV(uint mode, vec4 basis0, vec4 basis1, vec3 world_pos, vec4 clip_pos, vec2 object_uv)
@@ -65,7 +63,7 @@ vec2 EvaluateBaseUV(uint mode, vec4 basis0, vec4 basis1, vec3 world_pos, vec4 cl
         {
                 vec2 screen01 = clip_pos.xy / clip_pos.w * 0.5 + 0.5;
                 if (ScreenViewportValid())
-                        return screen01 * Frame.ScreenTexScale.zw;
+                        return screen01 * ScreenTexScale.zw;
                 return screen01;
         }
         return object_uv;
@@ -74,7 +72,7 @@ vec2 EvaluateBaseUV(uint mode, vec4 basis0, vec4 basis1, vec3 world_pos, vec4 cl
 vec2 FinalizeUV(uint mode, vec2 uv)
 {
         if (mode == TCGEN_SCREEN && ScreenViewportValid())
-                return uv * Frame.ScreenTexScale.xy;
+                return uv * ScreenTexScale.xy;
         return uv;
 }
 

--- a/Quake/shaders/world.vert
+++ b/Quake/shaders/world.vert
@@ -1,10 +1,8 @@
 #if BINDLESS
 	#extension GL_ARB_shader_draw_parameters : require
-	#define DRAW_ID			gl_DrawIDARB
-#else
-	layout(location=0) uniform int DrawID;
-	#define DRAW_ID			DrawID
 #endif
+layout(location=0) uniform int DrawID;
+#define DRAW_ID			DrawID
 
 #include "frame_uniforms.glsl"
 
@@ -80,7 +78,7 @@ const uint TCGEN_SCREEN = 2u;
 
 bool ScreenViewportValid()
 {
-        return Frame.ScreenTexScale.z > 0.0 && Frame.ScreenTexScale.w > 0.0;
+        return ScreenTexScale.z > 0.0 && ScreenTexScale.w > 0.0;
 }
 
 vec2 EvaluateBaseUV(uint mode, vec4 basis0, vec4 basis1, vec3 world_pos, vec4 clip_pos, vec2 object_uv)
@@ -94,7 +92,7 @@ vec2 EvaluateBaseUV(uint mode, vec4 basis0, vec4 basis1, vec3 world_pos, vec4 cl
         {
                 vec2 screen01 = clip_pos.xy / clip_pos.w * 0.5 + 0.5;
                 if (ScreenViewportValid())
-                        return screen01 * Frame.ScreenTexScale.zw;
+                        return screen01 * ScreenTexScale.zw;
                 return screen01;
         }
         return object_uv;
@@ -103,7 +101,7 @@ vec2 EvaluateBaseUV(uint mode, vec4 basis0, vec4 basis1, vec3 world_pos, vec4 cl
 vec2 FinalizeUV(uint mode, vec2 uv)
 {
         if (mode == TCGEN_SCREEN && ScreenViewportValid())
-                return uv * Frame.ScreenTexScale.xy;
+                return uv * ScreenTexScale.xy;
         return uv;
 }
 


### PR DESCRIPTION
## Summary
- use the DrawID uniform in all bindless-enabled vertex shaders so each draw reads the correct call data
- reference ScreenTexScale directly from the frame UBO to avoid undefined Frame symbol during compilation

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910b54b6764832ea9abae84a0474434)