### PR TITLE
Reset world surface offset before collecting textures

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -3404,10 +3404,11 @@ visdone:
 //
 // set up the submodels (FIXME: this is confusing)
 //
-	if (mod->numsubmodels > 1)
-		mod->nummodelsurfaces = mod->submodels[1].firstface;
-	else
-		mod->nummodelsurfaces = mod->numsurfaces;
+    if (mod->numsubmodels > 1)
+        mod->nummodelsurfaces = mod->submodels[1].firstface;
+    else
+        mod->nummodelsurfaces = mod->numsurfaces;
+    mod->firstmodelsurface = 0;
 	mod->sortkey = (CRC_Block (mod->name, strlen(mod->name)) & MODSORT_MODELMASK) << MODSORT_FRAMEBITS;
 	Mod_FindUsedTextures (mod);
 


### PR DESCRIPTION
## Summary
- reset the worldmodel surface offset before enumerating used textures so stale data from previous loads cannot leak in
- ensures that brush models build their texture tables from the correct surface range instead of collapsing to the first entry

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910c4804c58832ea833bf7f78d23531)