### PR TITLE
Handle bots without network sockets

### DIFF
--- a/Quake/host_cmd.c
+++ b/Quake/host_cmd.c
@@ -1606,7 +1606,14 @@ static void Host_Status_f (void)
 	{
 		if (!client->active)
 			continue;
-		seconds = (int)(net_time - NET_QSocketGetTime(client->netconnection));
+                double connect_time;
+                const char *address;
+
+                connect_time = client->netconnection ?
+                        NET_QSocketGetTime(client->netconnection) : net_time;
+                address = client->netconnection ?
+                        NET_QSocketGetAddressString(client->netconnection) : "BOT";
+                seconds = (int)(net_time - connect_time);
 		minutes = seconds / 60;
 		if (minutes)
 		{
@@ -1618,7 +1625,7 @@ static void Host_Status_f (void)
 		else
 			hours = 0;
 		print_fn ("#%-2u %-16.16s  %3i  %2i:%02i:%02i\n", j+1, client->name, (int)client->edict->v.frags, hours, minutes, seconds);
-		print_fn ("   %s\n", NET_QSocketGetAddressString(client->netconnection));
+                print_fn ("   %s\n", address);
 	}
 }
 
@@ -3130,8 +3137,12 @@ static void Host_Spawn_f (void)
                         PR_ExecuteProgram (pr_global_struct->ClientConnect);
                 }
 
-		if ((Sys_DoubleTime() - NET_QSocketGetTime(host_client->netconnection)) <= qcvm->time)
-			Sys_Printf ("%s entered the game\n", host_client->name);
+                double connect_time;
+
+                connect_time = host_client->netconnection ?
+                        NET_QSocketGetTime(host_client->netconnection) : Sys_DoubleTime();
+                if ((Sys_DoubleTime() - connect_time) <= qcvm->time)
+                        Sys_Printf ("%s entered the game\n", host_client->name);
 
 		PR_ExecuteProgram (pr_global_struct->PutClientInServer);
 	}

--- a/Quake/net_dgrm.c
+++ b/Quake/net_dgrm.c
@@ -943,8 +943,16 @@ static qsocket_t *_Datagram_CheckNewConnections (void)
 		MSG_WriteString(&net_message, client->name);
 		MSG_WriteLong(&net_message, client->colors);
 		MSG_WriteLong(&net_message, (int)client->edict->v.frags);
-		MSG_WriteLong(&net_message, (int)(net_time - client->netconnection->connecttime));
-		MSG_WriteString(&net_message, client->netconnection->address);
+                if (client->netconnection)
+                {
+                        MSG_WriteLong(&net_message, (int)(net_time - client->netconnection->connecttime));
+                        MSG_WriteString(&net_message, client->netconnection->address);
+                }
+                else
+                {
+                        MSG_WriteLong(&net_message, 0);
+                        MSG_WriteString(&net_message, "BOT");
+                }
 		*((int *)net_message.data) = BigLong(NETFLAG_CTL | (net_message.cursize & NETFLAG_LENGTH_MASK));
 		dfunc.Write (acceptsock, net_message.data, net_message.cursize, &clientaddr);
 		SZ_Clear(&net_message);

--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -392,7 +392,9 @@ CLIENT SPAWNING
 
 static qboolean SV_IsLocalClient (client_t *client)
 {
-	return Q_strcmp (NET_QSocketGetAddressString (client->netconnection), "LOCAL") == 0;
+        if (!client->netconnection)
+                return false;
+        return Q_strcmp (NET_QSocketGetAddressString (client->netconnection), "LOCAL") == 0;
 }
 
 /*


### PR DESCRIPTION
## Summary
- avoid dereferencing null `netconnection` pointers when spawning bots or listing status
- provide fallback metadata for bots when responding to server info queries
- guard local-client detection against bot clients that lack sockets

## Testing
- cmake -S . -B build *(fails: missing SDL2 development package)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910e1dcdf68832e81e8217c8d534de0)