### PR TITLE
Preload script assets before maps and face attacker on death

### DIFF
--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -26,6 +26,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "quakedef.h"
 #include "bgmusic.h"
 #include "steam.h"
+#include "render.h"
+#include "renderer/r_iwshader.h"
 
 const char *svc_strings[] =
 {
@@ -398,14 +400,18 @@ void CL_ParseServerInfo (void)
 // now we try to load everything else until a cache allocation fails
 //
 
-	// copy the naked name of the map file to the cl structure -- O.S
-	COM_StripExtension (COM_SkipPath(model_precache[1]), cl.mapname, sizeof(cl.mapname));
+        // copy the naked name of the map file to the cl structure -- O.S
+        COM_StripExtension (COM_SkipPath(model_precache[1]), cl.mapname, sizeof(cl.mapname));
 
-	for (i = 1; i < nummodels; i++)
-	{
-		cl.model_precache[i] = Mod_ForName (model_precache[i], false);
-		if (cl.model_precache[i] == NULL)
-		{
+        IW_ShaderSystem_PrepareForGameDir (com_gamedir);
+        if (nummodels > 1 && model_precache[1][0])
+                R_Particles_LoadEffectInfoForMap (NULL, model_precache[1]);
+
+        for (i = 1; i < nummodels; i++)
+        {
+                cl.model_precache[i] = Mod_ForName (model_precache[i], false);
+                if (cl.model_precache[i] == NULL)
+                {
 			Host_Error ("Model %s not found", model_precache[i]);
 		}
 		CL_KeepaliveMessage ();

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -467,15 +467,7 @@ void R_Init (void)
         Fog_Init (); //johnfitz
 
         IW_ShaderSystem_Init ();
-        if (com_gamedir[0])
-        {
-                char shaderdir[MAX_OSPATH];
-
-                q_snprintf (shaderdir, sizeof(shaderdir), "%s/shaders", com_gamedir);
-                IW_LoadShaderDirectory (shaderdir);
-
-                IW_LoadShaderDirectory (com_gamedir);
-        }
+        IW_ShaderSystem_PrepareForGameDir (com_gamedir);
 }
 
 /*

--- a/Quake/r_part.c
+++ b/Quake/r_part.c
@@ -1321,7 +1321,7 @@ static qboolean R_Effectinfo_LoadFile (const char* filename)
         return result;
 }
 
-void R_Particles_LoadEffectInfo (const char* customfile)
+void R_Particles_LoadEffectInfoForMap (const char* customfile, const char* worldmodelname)
 {
         char basefile[MAX_QPATH];
         char mapfile[MAX_QPATH];
@@ -1338,13 +1338,22 @@ void R_Particles_LoadEffectInfo (const char* customfile)
         }
         else
         {
+                const char* mapname = worldmodelname;
+
                 loaded = R_Effectinfo_LoadFile ("effectinfo.txt");
                 if (loaded)
                         q_strlcpy (effectinfo_source, "effectinfo.txt", sizeof (effectinfo_source));
 
-                if (cl.worldmodel && cl.worldmodel->name[0])
+                if (!mapname || !*mapname)
                 {
-                        COM_StripExtension (cl.worldmodel->name, basefile, sizeof (basefile));
+                        if (cl.worldmodel && cl.worldmodel->name[0])
+                                mapname = cl.worldmodel->name;
+                }
+
+                mapfile[0] = '\0';
+                if (mapname && *mapname)
+                {
+                        COM_StripExtension (mapname, basefile, sizeof (basefile));
                         dpsnprintf (mapfile, sizeof (mapfile), "%s_effectinfo.txt", basefile);
                         loaded_map = R_Effectinfo_LoadFile (mapfile);
                 }
@@ -1377,6 +1386,11 @@ void R_Particles_LoadEffectInfo (const char* customfile)
         }
 
         R_Effectinfo_DebugPrintLoaded ();
+}
+
+void R_Particles_LoadEffectInfo (const char* customfile)
+{
+        R_Particles_LoadEffectInfoForMap (customfile, NULL);
 }
 
 static void R_Particles_ReloadEffects_f (void)

--- a/Quake/render.h
+++ b/Quake/render.h
@@ -130,6 +130,7 @@ void R_AddStaticModels (const byte *vis);
 void R_NewMap (void);
 
 void R_Particles_LoadEffectInfo (const char *customfile);
+void R_Particles_LoadEffectInfoForMap (const char *customfile, const char *worldmodelname);
 
 
 void R_ParseParticleEffect (void);

--- a/Quake/renderer/r_iwshader.c
+++ b/Quake/renderer/r_iwshader.c
@@ -85,6 +85,17 @@ static char iw_last_texture[IW_MAX_PATH];
 static char iw_last_texture_display[IW_MAX_PATH];
 static qboolean iw_last_material_broken;
 static const char *iw_last_broken_name;
+static char iw_loaded_gamedir[MAX_OSPATH];
+
+static void IW_ResetState(void)
+{
+    iw_num_materials = 0;
+    iw_last_material = NULL;
+    iw_last_texture[0] = '\0';
+    iw_last_texture_display[0] = '\0';
+    iw_last_material_broken = false;
+    iw_last_broken_name = NULL;
+}
 
 static void IW_LogWarning(const char *file, int line, int column, const char *fmt, ...)
 {
@@ -1383,12 +1394,8 @@ void IW_ShaderSystem_Init(void)
     Cvar_RegisterVariable(&r_iwshader_debug_cvar);
     iwshader_dump_cmd = Cmd_AddCommand("r_iwshader_dump", IW_DumpMaterials_f);
 
-    iw_num_materials = 0;
-    iw_last_material = NULL;
-    iw_last_texture[0] = '\0';
-    iw_last_texture_display[0] = '\0';
-    iw_last_material_broken = false;
-    iw_last_broken_name = NULL;
+    IW_ResetState();
+    iw_loaded_gamedir[0] = '\0';
     iw_initialized = true;
 }
 
@@ -1403,13 +1410,9 @@ void IW_ShaderSystem_Shutdown(void)
         iwshader_dump_cmd = NULL;
     }
 
-    iw_num_materials = 0;
-    iw_last_material = NULL;
-    iw_last_texture[0] = '\0';
-    iw_last_texture_display[0] = '\0';
-    iw_last_material_broken = false;
-    iw_last_broken_name = NULL;
+    IW_ResetState();
     iw_initialized = false;
+    iw_loaded_gamedir[0] = '\0';
 }
 
 void IW_LoadShaderDirectory(const char *dir)
@@ -1480,6 +1483,27 @@ void IW_LoadShaderDirectory(const char *dir)
             }
         }
     }
+}
+
+void IW_ShaderSystem_PrepareForGameDir(const char *gamedir)
+{
+    char shaderdir[MAX_OSPATH];
+
+    if (!iw_initialized || !r_iwshader_cvar.value)
+        return;
+
+    if (!gamedir || !*gamedir)
+        return;
+
+    if (iw_loaded_gamedir[0] && !strcmp(iw_loaded_gamedir, gamedir))
+        return;
+
+    IW_ResetState();
+    q_strlcpy(iw_loaded_gamedir, gamedir, sizeof(iw_loaded_gamedir));
+
+    q_snprintf(shaderdir, sizeof(shaderdir), "%s/shaders", gamedir);
+    IW_LoadShaderDirectory(shaderdir);
+    IW_LoadShaderDirectory(gamedir);
 }
 
 static const iwMaterialEntry_t *IW_FindMaterialEntryNormalized(const char *name)

--- a/Quake/renderer/r_iwshader.h
+++ b/Quake/renderer/r_iwshader.h
@@ -180,6 +180,8 @@ extern "C" {
 void IW_ShaderSystem_Init(void);
 void IW_ShaderSystem_Shutdown(void);
 
+void IW_ShaderSystem_PrepareForGameDir(const char* gamedir);
+
 void IW_LoadShaderDirectory(const char* dir);
 
 const iwMaterial_t* IW_FindMaterial(const char* materialName);

--- a/Quake/view.c
+++ b/Quake/view.c
@@ -261,6 +261,12 @@ float		v_blend[4];		// rgba 0.0 - 1.0; see note in V_PolyBlend for more info
 
 //johnfitz -- deleted BuildGammaTable(), V_CheckGamma(), gammatable[], and ramps[][]
 
+static vec3_t v_last_damage_dir;
+static double v_last_damage_time;
+static qboolean v_last_damage_dir_valid;
+static qboolean v_death_view_active;
+static vec3_t v_death_view_angles;
+
 /*
 ============
 V_ResetEffects
@@ -269,10 +275,12 @@ V_ResetEffects
 void V_ResetEffects (void)
 {
 	cshift_empty.percent = 0;
-	memset (v_blend, 0, sizeof (v_blend));
-	v_dmg_time = 0.f;
-	v_dmg_roll = 0.f;
-	v_dmg_pitch = 0.f;
+        memset (v_blend, 0, sizeof (v_blend));
+        v_dmg_time = 0.f;
+        v_dmg_roll = 0.f;
+        v_dmg_pitch = 0.f;
+        v_last_damage_dir_valid = false;
+        v_death_view_active = false;
 }
 
 /*
@@ -289,6 +297,7 @@ void V_ParseDamage (void)
 	entity_t	*ent;
 	float	side;
 	float	count;
+	float	dirLength;
 
 	armor = MSG_ReadByte ();
 	blood = MSG_ReadByte ();
@@ -332,7 +341,18 @@ void V_ParseDamage (void)
 	ent = &cl_entities[cl.viewentity];
 
 	VectorSubtract (from, ent->origin, from);
-	VectorNormalize (from);
+	dirLength = VectorNormalize (from);
+
+	if (dirLength > 0.f)
+	{
+		VectorCopy (from, v_last_damage_dir);
+		v_last_damage_dir_valid = true;
+		v_last_damage_time = cl.time;
+	}
+	else
+	{
+		v_last_damage_dir_valid = false;
+	}
 
 	AngleVectors (ent->angles, forward, right, up);
 
@@ -796,6 +816,24 @@ void V_CalcRefdef (void)
 	r_refdef.vieworg[2] += 1.0/32;
 
 	VectorCopy (cl.viewangles, r_refdef.viewangles);
+
+	if (cl.stats[STAT_HEALTH] <= 0)
+	{
+		if (!v_death_view_active)
+		{
+			if (v_last_damage_dir_valid && (cl.time - v_last_damage_time) <= 1.0)
+				VectorAngles (v_last_damage_dir, v_death_view_angles);
+			else
+				VectorCopy (r_refdef.viewangles, v_death_view_angles);
+			v_death_view_active = true;
+		}
+		r_refdef.viewangles[PITCH] = v_death_view_angles[PITCH];
+		r_refdef.viewangles[YAW] = v_death_view_angles[YAW];
+	}
+	else
+	{
+		v_death_view_active = false;
+	}
 	V_CalcViewRoll ();
 	V_AddIdle ();
 


### PR DESCRIPTION
## Summary
- reload iwshader materials when the active game directory changes and call the loader before map models are parsed
- allow effectinfo to be preloaded for a given map name and hook it up ahead of map loading
- cache the last damage direction so the death camera snaps toward the attacker

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691107984cf0832e828a62281ee6c234)