### PR TITLE
Fix missing prototypes for shader parser helpers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.7)
 include(${CMAKE_CURRENT_SOURCE_DIR}/Misc/cmake/ExtractVersion.cmake)
 project(ironwail VERSION ${IRONWAIL_VERSION})
 
+enable_testing()
+
 option(R_SHADOWMAPS "Enable shadow map stubs" ON)
 
 cmake_policy(SET CMP0072 NEW)   #OpenGL_GL_PREFERENCE to GLVND
@@ -169,11 +171,30 @@ if (PC_MIKMOD_FOUND OR PC_MODPLUG_FOUND OR PC_XMP_FOUND)
     target_compile_definitions(ironwail PRIVATE USE_CODEC_UMX)
 endif()
 
+add_executable(iwshader_parser_test
+    tests/iwshader_parser_test.c
+    tests/iwshader_test_stubs.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/Quake/renderer/r_iwshader.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/Quake/common/com_iwtext.c)
+
+target_include_directories(iwshader_parser_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/Quake
+    ${CMAKE_CURRENT_SOURCE_DIR}/Quake/common
+    ${CMAKE_CURRENT_SOURCE_DIR}/Quake/renderer)
+
+target_compile_definitions(iwshader_parser_test PRIVATE IW_BUILD_TESTS)
+
+if (UNIX)
+    target_link_libraries(iwshader_parser_test PRIVATE m)
+endif()
+
+add_test(NAME iwshader_parser_test COMMAND iwshader_parser_test)
+
 if (WIN32)
-	#Copy DLL dependencies to output folder
-	add_custom_command(TARGET ironwail POST_BUILD
-		COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_RUNTIME_DLLS:ironwail> $<TARGET_FILE_DIR:ironwail>
-		COMMAND_EXPAND_LISTS)
+        #Copy DLL dependencies to output folder
+        add_custom_command(TARGET ironwail POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_RUNTIME_DLLS:ironwail> $<TARGET_FILE_DIR:ironwail>
+                COMMAND_EXPAND_LISTS)
 
 	#VORBISFILE and OPUSFILE both use the libogg-0.dll
 	if (OGG_DLL AND (PC_VORBISFILE_FOUND OR PC_OPUSFILE_FOUND))

--- a/Quake/renderer/r_iwshader.c
+++ b/Quake/renderer/r_iwshader.c
@@ -62,6 +62,8 @@ static size_t IW_WindowsUtf8CharCount(const char *text)
 #endif
 
 static char *IW_PreprocessShaderText(const char *input, int length, int *outLength);
+static qboolean IW_IsStageKeyword(const char *keyword);
+static qboolean IW_ReadFloat(iwtxtParser_t *parser, float *out, iwtxtToken_t *token);
 
 static cvar_t r_iwshader_cvar = { "r_iwshader", "1", CVAR_ARCHIVE };
 static cvar_t r_iwshader_strict_cvar = { "r_iwshader_strict", "0", CVAR_NONE };
@@ -224,12 +226,122 @@ static void IW_CopyTokenText(const iwtxtToken_t *token, char *dst, size_t size)
     dst[n] = '\0';
 }
 
+static void IW_AppendTokenText(const iwtxtToken_t *token, char *buffer, size_t size)
+{
+    if (!token || !buffer || size == 0)
+        return;
+
+    char temp[IW_MAX_DIRECTIVE_TEXT];
+    IW_CopyTokenText(token, temp, sizeof(temp));
+    if (buffer[0])
+        q_strlcat(buffer, " ", size);
+    q_strlcat(buffer, temp, size);
+}
+
+static void IW_CollectLineTokens(iwtxtParser_t *parser, int line, char *buffer, size_t size, qboolean stopAtStageKeyword)
+{
+    if (!parser || !buffer || size == 0)
+        return;
+
+    iwtxtToken_t tok;
+    while (IWTXT_PeekToken(parser, &tok))
+    {
+        if (tok.type == IWTXT_TOKEN_EOF)
+            break;
+        if (tok.type == IWTXT_TOKEN_SYMBOL && tok.length == 1 && tok.text[0] == '}')
+            break;
+        if (tok.line != line)
+            break;
+        if (stopAtStageKeyword && tok.type == IWTXT_TOKEN_STRING)
+        {
+            char lower[32];
+            IW_CopyTokenLower(&tok, lower, sizeof(lower));
+            if (IW_IsStageKeyword(lower))
+                break;
+        }
+        if (!IWTXT_NextToken(parser, &tok))
+            break;
+        IW_AppendTokenText(&tok, buffer, size);
+    }
+}
+
+static void IW_SetStageMapPath(iwStage_t *stage, const iwtxtToken_t *token, iwMapType_t defaultType)
+{
+    if (!stage || !token)
+        return;
+
+    IW_CopyTokenText(token, stage->mapPath, sizeof(stage->mapPath));
+    for (size_t i = 0; stage->mapPath[i]; ++i)
+        if (stage->mapPath[i] == '\\')
+            stage->mapPath[i] = '/';
+
+    stage->animMap = 0;
+    stage->numAnimFrames = 0;
+    stage->animFps = 0.f;
+    stage->mapType = defaultType;
+    if (!q_strcasecmp(stage->mapPath, "$lightmap"))
+        stage->mapType = IW_MAP_LIGHTMAP;
+    else if (!q_strcasecmp(stage->mapPath, "$white"))
+        stage->mapType = IW_MAP_PROCEDURAL_WHITE;
+    else if (!q_strcasecmp(stage->mapPath, "$black"))
+        stage->mapType = IW_MAP_PROCEDURAL_BLACK;
+    stage->isClamp = (defaultType == IW_MAP_CLAMP2D);
+}
+
+static qboolean IW_ParseFogParmsValues(iwtxtParser_t *parser, iwFogParms_t *out, const char *filename, const iwtxtToken_t *token)
+{
+    if (!parser || !out)
+        return false;
+
+    iwFogParms_t result;
+    memset(&result, 0, sizeof(result));
+
+    iwtxtToken_t value;
+    if (IWTXT_PeekToken(parser, &value) && value.type == IWTXT_TOKEN_SYMBOL && value.length == 1 && value.text[0] == '(')
+        IWTXT_NextToken(parser, &value);
+
+    for (int i = 0; i < 3; ++i)
+    {
+        if (!IW_ReadFloat(parser, &result.color[i], &value))
+        {
+            if (token)
+                IW_LogWarning(filename, token->line, token->column, "fogparms requires color components");
+            else
+                IW_LogWarning(filename, value.line, value.column, "fogparms requires color components");
+            return false;
+        }
+    }
+    result.hasColor = 1;
+
+    if (IWTXT_PeekToken(parser, &value) && value.type == IWTXT_TOKEN_SYMBOL && value.length == 1 && value.text[0] == ')')
+        IWTXT_NextToken(parser, &value);
+
+    if (IWTXT_PeekToken(parser, &value) && value.type == IWTXT_TOKEN_NUMBER)
+    {
+        result.depthForOpaque = (float)value.number;
+        result.hasDepthForOpaque = 1;
+        IWTXT_NextToken(parser, &value);
+
+        if (IWTXT_PeekToken(parser, &value) && value.type == IWTXT_TOKEN_NUMBER)
+        {
+            result.density = (float)value.number;
+            result.hasDensity = 1;
+            IWTXT_NextToken(parser, &value);
+        }
+    }
+
+    *out = result;
+    return true;
+}
+
 static qboolean IW_IsStageKeyword(const char *keyword)
 {
     static const char *const stageKeywords[] = {
         "map", "blend", "mask", "rgbgen", "alphagen", "tcmod",
         "tcscale", "tcoffset", "tcalign", "depthwrite", "depthtest",
         "colormask", "emissive", "clamp", "animmap", "alpha2coverage",
+        "tcgen", "alphafunc", "depthfunc", "clampmap", "cubemap",
+        "glossmap", "normalmap", "specular", "if", "endif", "fogparms",
         NULL
     };
 
@@ -520,6 +632,7 @@ static void IW_SetStageDefaults(iwStage_t *stage)
 {
     memset(stage, 0, sizeof(*stage));
     q_strlcpy(stage->mapPath, "$white", sizeof(stage->mapPath));
+    stage->mapType = IW_MAP_PROCEDURAL_WHITE;
     stage->blendMode = IW_BLEND_NONE;
     stage->src = IW_SRC_ONE;
     stage->dst = IW_SRC_ZERO;
@@ -546,12 +659,21 @@ static void IW_SetStageDefaults(iwStage_t *stage)
     stage->colorMask = IW_COLORMASK_RGBA;
     stage->tcAlign = IW_TC_ALIGN_OBJECT;
     stage->tcAlignExplicit = 0;
+    stage->tcGen[0] = '\0';
+    stage->alphaFunc[0] = '\0';
+    stage->depthFunc[0] = '\0';
+    stage->stageCondition[0] = '\0';
+    stage->hasFogParms = 0;
     stage->alphaToCoverage = 0;
     stage->animMap = 0;
     stage->animFps = 0.f;
     stage->numAnimFrames = 0;
     stage->clamp = 0;
+    stage->isClamp = 0;
     stage->numTCMods = 0;
+    stage->normalMap[0] = '\0';
+    stage->glossMap[0] = '\0';
+    stage->specularScale = 1.f;
 }
 
 static qboolean IW_ParseTCMod(iwtxtParser_t *parser, iwStage_t *stage, const iwtxtToken_t *firstToken, const char *filename)
@@ -695,13 +817,7 @@ static qboolean IW_ParseStage(iwtxtParser_t *parser, iwMaterial_t *material, con
                     return false;
                 continue;
             }
-            IW_CopyTokenText(&token, stage.mapPath, sizeof(stage.mapPath));
-            for (size_t i = 0; stage.mapPath[i]; ++i)
-                if (stage.mapPath[i] == '\\')
-                    stage.mapPath[i] = '/';
-            stage.animMap = 0;
-            stage.numAnimFrames = 0;
-            stage.animFps = 0.f;
+            IW_SetStageMapPath(&stage, &token, IW_MAP_TEXTURE2D);
         }
         else if (!strcmp(keyword, "blend"))
         {
@@ -1018,6 +1134,28 @@ static qboolean IW_ParseStage(iwtxtParser_t *parser, iwMaterial_t *material, con
             }
             stage.clamp = value ? 1 : 0;
         }
+        else if (!strcmp(keyword, "clampmap"))
+        {
+            if (!IWTXT_NextToken(parser, &token) || token.type == IWTXT_TOKEN_SYMBOL)
+            {
+                IW_LogWarning(filename, token.line, token.column, "clampmap requires a texture path");
+                if (strict)
+                    return false;
+                continue;
+            }
+            IW_SetStageMapPath(&stage, &token, IW_MAP_CLAMP2D);
+        }
+        else if (!strcmp(keyword, "cubemap"))
+        {
+            if (!IWTXT_NextToken(parser, &token) || token.type == IWTXT_TOKEN_SYMBOL)
+            {
+                IW_LogWarning(filename, token.line, token.column, "cubemap requires a texture path");
+                if (strict)
+                    return false;
+                continue;
+            }
+            IW_SetStageMapPath(&stage, &token, IW_MAP_CUBEMAP);
+        }
         else if (!strcmp(keyword, "depthwrite"))
         {
             int value;
@@ -1146,6 +1284,8 @@ static qboolean IW_ParseStage(iwtxtParser_t *parser, iwMaterial_t *material, con
             else
             {
                 q_strlcpy(stage.mapPath, stage.animPaths[0], sizeof(stage.mapPath));
+                stage.mapType = IW_MAP_TEXTURE2D;
+                stage.isClamp = 0;
             }
         }
         else if (!strcmp(keyword, "alpha2coverage"))
@@ -1160,6 +1300,110 @@ static qboolean IW_ParseStage(iwtxtParser_t *parser, iwMaterial_t *material, con
                 continue;
             }
             stage.alphaToCoverage = value ? 1 : 0;
+        }
+        else if (!strcmp(keyword, "tcgen"))
+        {
+            if (!IWTXT_NextToken(parser, &token))
+            {
+                IW_LogWarning(filename, token.line, token.column, "tcgen requires arguments");
+                if (strict)
+                    return false;
+                continue;
+            }
+            stage.tcGen[0] = '\0';
+            IW_CopyTokenText(&token, stage.tcGen, sizeof(stage.tcGen));
+            IW_CollectLineTokens(parser, token.line, stage.tcGen, sizeof(stage.tcGen), true);
+        }
+        else if (!strcmp(keyword, "alphafunc"))
+        {
+            if (!IWTXT_NextToken(parser, &token) || token.type != IWTXT_TOKEN_STRING)
+            {
+                IW_LogWarning(filename, token.line, token.column, "alphafunc requires a value");
+                if (strict)
+                    return false;
+                continue;
+            }
+            IW_CopyTokenLower(&token, stage.alphaFunc, sizeof(stage.alphaFunc));
+        }
+        else if (!strcmp(keyword, "depthfunc"))
+        {
+            if (!IWTXT_NextToken(parser, &token) || token.type != IWTXT_TOKEN_STRING)
+            {
+                IW_LogWarning(filename, token.line, token.column, "depthfunc requires a value");
+                if (strict)
+                    return false;
+                continue;
+            }
+            IW_CopyTokenLower(&token, stage.depthFunc, sizeof(stage.depthFunc));
+        }
+        else if (!strcmp(keyword, "normalmap"))
+        {
+            if (!IWTXT_NextToken(parser, &token) || token.type == IWTXT_TOKEN_SYMBOL)
+            {
+                IW_LogWarning(filename, token.line, token.column, "normalmap requires a texture path");
+                if (strict)
+                    return false;
+                continue;
+            }
+            IW_CopyTokenText(&token, stage.normalMap, sizeof(stage.normalMap));
+            for (size_t i = 0; stage.normalMap[i]; ++i)
+                if (stage.normalMap[i] == '\\')
+                    stage.normalMap[i] = '/';
+        }
+        else if (!strcmp(keyword, "glossmap"))
+        {
+            if (!IWTXT_NextToken(parser, &token) || token.type == IWTXT_TOKEN_SYMBOL)
+            {
+                IW_LogWarning(filename, token.line, token.column, "glossmap requires a texture path");
+                if (strict)
+                    return false;
+                continue;
+            }
+            IW_CopyTokenText(&token, stage.glossMap, sizeof(stage.glossMap));
+            for (size_t i = 0; stage.glossMap[i]; ++i)
+                if (stage.glossMap[i] == '\\')
+                    stage.glossMap[i] = '/';
+        }
+        else if (!strcmp(keyword, "specular"))
+        {
+            float value;
+            iwtxtToken_t valueToken;
+            if (!IW_ReadFloat(parser, &value, &valueToken))
+            {
+                IW_LogWarning(filename, token.line, token.column, "specular requires a float value");
+                if (strict)
+                    return false;
+                continue;
+            }
+            stage.specularScale = value;
+        }
+        else if (!strcmp(keyword, "if"))
+        {
+            if (!IWTXT_NextToken(parser, &token))
+            {
+                IW_LogWarning(filename, token.line, token.column, "if requires a condition");
+                if (strict)
+                    return false;
+                continue;
+            }
+            stage.stageCondition[0] = '\0';
+            IW_CopyTokenText(&token, stage.stageCondition, sizeof(stage.stageCondition));
+            IW_CollectLineTokens(parser, token.line, stage.stageCondition, sizeof(stage.stageCondition), true);
+        }
+        else if (!strcmp(keyword, "endif"))
+        {
+            /* marker keyword - no action needed */
+        }
+        else if (!strcmp(keyword, "fogparms"))
+        {
+            if (!IW_ParseFogParmsValues(parser, &stage.fogParms, filename, &token))
+            {
+                if (strict)
+                    return false;
+                stage.hasFogParms = 0;
+                continue;
+            }
+            stage.hasFogParms = 1;
         }
         else
         {
@@ -1333,6 +1577,142 @@ static qboolean IW_ParseGlobalKey(iwtxtParser_t *parser, iwMaterial_t *material,
             material->strict = 0;
         }
         material->strict = material->strict ? 1 : 0;
+        return true;
+    }
+    else if (!strcmp(keyword, "fog"))
+    {
+        iwtxtToken_t value;
+        if (!IWTXT_NextToken(parser, &value))
+        {
+            IW_LogWarning(filename, token->line, token->column, "fog requires a shader name");
+            return false;
+        }
+        if (value.type != IWTXT_TOKEN_STRING)
+        {
+            IW_LogWarning(filename, value.line, value.column, "fog requires a shader name");
+            return false;
+        }
+        IW_CopyTokenText(&value, material->fogShader, sizeof(material->fogShader));
+        for (size_t i = 0; material->fogShader[i]; ++i)
+            if (material->fogShader[i] == '\\')
+                material->fogShader[i] = '/';
+        material->hasFog = 1;
+        return true;
+    }
+    else if (!strcmp(keyword, "fogparms"))
+    {
+        if (!IW_ParseFogParmsValues(parser, &material->fogParms, filename, token))
+            return false;
+        material->hasFogParms = 1;
+        return true;
+    }
+    else if (!strcmp(keyword, "deformvertexes"))
+    {
+        char directive[IW_MAX_DIRECTIVE_TEXT];
+        directive[0] = '\0';
+        IW_CopyTokenText(token, directive, sizeof(directive));
+        iwtxtToken_t value;
+        if (IWTXT_PeekToken(parser, &value) && value.line == token->line && !(value.type == IWTXT_TOKEN_SYMBOL && value.length == 1 && value.text[0] == '}'))
+        {
+            if (IWTXT_NextToken(parser, &value))
+            {
+                IW_AppendTokenText(&value, directive, sizeof(directive));
+                IW_CollectLineTokens(parser, value.line, directive, sizeof(directive), false);
+            }
+        }
+        if (material->numDeformVertexes >= IW_MAX_DEFORM_COMMANDS)
+        {
+            IW_ParseWarn(filename, token, "too many deformvertexes directives (limit %d)", IW_MAX_DEFORM_COMMANDS);
+            return true;
+        }
+        q_strlcpy(material->deformVertexes[material->numDeformVertexes++], directive, sizeof(material->deformVertexes[0]));
+        return true;
+    }
+    else if (!strncmp(keyword, "q3map", 5))
+    {
+        char directive[IW_MAX_DIRECTIVE_TEXT];
+        directive[0] = '\0';
+        IW_CopyTokenText(token, directive, sizeof(directive));
+        iwtxtToken_t value;
+        if (IWTXT_PeekToken(parser, &value) && value.line == token->line && !(value.type == IWTXT_TOKEN_SYMBOL && value.length == 1 && value.text[0] == '}'))
+        {
+            if (IWTXT_NextToken(parser, &value))
+            {
+                IW_AppendTokenText(&value, directive, sizeof(directive));
+                IW_CollectLineTokens(parser, value.line, directive, sizeof(directive), false);
+            }
+        }
+        if (material->numQ3MapDirectives >= IW_MAX_Q3MAP_DIRECTIVES)
+        {
+            IW_ParseWarn(filename, token, "too many q3map directives (limit %d)", IW_MAX_Q3MAP_DIRECTIVES);
+            return true;
+        }
+        q_strlcpy(material->q3mapDirectives[material->numQ3MapDirectives++], directive, sizeof(material->q3mapDirectives[0]));
+        return true;
+    }
+    else if (!strcmp(keyword, "tesssize"))
+    {
+        float value;
+        iwtxtToken_t valueToken;
+        if (!IW_ReadFloat(parser, &value, &valueToken))
+        {
+            IW_LogWarning(filename, token->line, token->column, "tesssize requires a float value");
+            return false;
+        }
+        material->tessSize = value;
+        material->hasTessSize = 1;
+        return true;
+    }
+    else if (!strcmp(keyword, "portal"))
+    {
+        material->portal = 1;
+        iwtxtToken_t value;
+        if (IWTXT_PeekToken(parser, &value) && value.line == token->line)
+        {
+            if (value.type == IWTXT_TOKEN_NUMBER)
+            {
+                IWTXT_NextToken(parser, &value);
+                material->portal = (value.number != 0.0);
+            }
+            else if (value.type == IWTXT_TOKEN_STRING)
+            {
+                char val[16];
+                IW_CopyTokenLower(&value, val, sizeof(val));
+                if (!strcmp(val, "on") || !strcmp(val, "1"))
+                {
+                    IWTXT_NextToken(parser, &value);
+                    material->portal = 1;
+                }
+                else if (!strcmp(val, "off") || !strcmp(val, "0"))
+                {
+                    IWTXT_NextToken(parser, &value);
+                    material->portal = 0;
+                }
+            }
+        }
+        return true;
+    }
+    else if (!strcmp(keyword, "skyparms"))
+    {
+        iwtxtToken_t value;
+        for (int i = 0; i < 3; ++i)
+        {
+            if (!IWTXT_NextToken(parser, &value))
+            {
+                IW_LogWarning(filename, token->line, token->column, "skyparms requires three strings");
+                return false;
+            }
+            if (value.type != IWTXT_TOKEN_STRING)
+            {
+                IW_LogWarning(filename, value.line, value.column, "skyparms requires three strings");
+                return false;
+            }
+            IW_CopyTokenText(&value, material->skyParms[i], sizeof(material->skyParms[i]));
+            for (size_t c = 0; material->skyParms[i][c]; ++c)
+                if (material->skyParms[i][c] == '\\')
+                    material->skyParms[i][c] = '/';
+        }
+        material->hasSkyParms = 1;
         return true;
     }
 
@@ -1892,6 +2272,27 @@ void IW_DumpMaterials(const char *outPath)
             fprintf(f, "    detail 1\n");
         if (mat->strict)
             fprintf(f, "    strict 1\n");
+        if (mat->hasFog)
+            fprintf(f, "    fog %s\n", mat->fogShader);
+        if (mat->hasFogParms && mat->fogParms.hasColor)
+        {
+            fprintf(f, "    fogparms ( %g %g %g )", mat->fogParms.color[0], mat->fogParms.color[1], mat->fogParms.color[2]);
+            if (mat->fogParms.hasDepthForOpaque)
+                fprintf(f, " %g", mat->fogParms.depthForOpaque);
+            if (mat->fogParms.hasDensity)
+                fprintf(f, " %g", mat->fogParms.density);
+            fprintf(f, "\n");
+        }
+        if (mat->hasTessSize)
+            fprintf(f, "    tesssize %g\n", mat->tessSize);
+        if (mat->portal)
+            fprintf(f, "    portal %d\n", mat->portal);
+        if (mat->hasSkyParms)
+            fprintf(f, "    skyparms %s %s %s\n", mat->skyParms[0], mat->skyParms[1], mat->skyParms[2]);
+        for (int q = 0; q < mat->numQ3MapDirectives; ++q)
+            fprintf(f, "    %s\n", mat->q3mapDirectives[q]);
+        for (int d = 0; d < mat->numDeformVertexes; ++d)
+            fprintf(f, "    %s\n", mat->deformVertexes[d]);
 
         const iwStage_t *baseStage = mat->numStages > 0 ? &mat->stages[0] : NULL;
         char materialBlendDesc[64];
@@ -1929,8 +2330,15 @@ void IW_DumpMaterials(const char *outPath)
             }
             else
             {
-                fprintf(f, "        map %s\n", stage->mapPath);
+                const char *mapKeyword = "map";
+                if (stage->mapType == IW_MAP_CLAMP2D && stage->isClamp)
+                    mapKeyword = "clampmap";
+                else if (stage->mapType == IW_MAP_CUBEMAP)
+                    mapKeyword = "cubeMap";
+                fprintf(f, "        %s %s\n", mapKeyword, stage->mapPath);
             }
+            if (stage->tcGen[0])
+                fprintf(f, "        tcgen %s\n", stage->tcGen);
             switch (stage->blendMode)
             {
             case IW_BLEND_ALPHA: fprintf(f, "        blend alpha\n"); break;
@@ -1951,6 +2359,8 @@ void IW_DumpMaterials(const char *outPath)
                 fprintf(f, "        depthwrite %d\n", stage->depthWrite ? 1 : 0);
             if (!stage->depthTest)
                 fprintf(f, "        depthtest off\n");
+            if (stage->depthFunc[0])
+                fprintf(f, "        depthfunc %s\n", stage->depthFunc);
             switch (stage->rgbgen)
             {
             case IW_RGB_VERTEX:
@@ -1995,10 +2405,29 @@ void IW_DumpMaterials(const char *outPath)
                 fprintf(f, "        emissive 1\n");
             if (stage->clamp)
                 fprintf(f, "        clamp 1\n");
+            if (stage->alphaFunc[0])
+                fprintf(f, "        alphafunc %s\n", stage->alphaFunc);
             if (stage->tcAlignExplicit || stage->tcAlign != IW_TC_ALIGN_OBJECT)
                 fprintf(f, "        tcalign %s\n", IW_TCAlignName(stage->tcAlign));
             if (stage->colorMask != IW_COLORMASK_RGBA)
                 fprintf(f, "        colormask %s\n", IW_ColorMaskName(stage->colorMask));
+            if (stage->normalMap[0])
+                fprintf(f, "        normalmap %s\n", stage->normalMap);
+            if (stage->glossMap[0])
+                fprintf(f, "        glossmap %s\n", stage->glossMap);
+            if (fabsf(stage->specularScale - 1.f) > 1e-6f)
+                fprintf(f, "        specular %g\n", stage->specularScale);
+            if (stage->hasFogParms && stage->fogParms.hasColor)
+            {
+                fprintf(f, "        fogparms ( %g %g %g )", stage->fogParms.color[0], stage->fogParms.color[1], stage->fogParms.color[2]);
+                if (stage->fogParms.hasDepthForOpaque)
+                    fprintf(f, " %g", stage->fogParms.depthForOpaque);
+                if (stage->fogParms.hasDensity)
+                    fprintf(f, " %g", stage->fogParms.density);
+                fprintf(f, "\n");
+            }
+            if (stage->stageCondition[0])
+                fprintf(f, "        // condition: %s\n", stage->stageCondition);
             if (stage->alphaToCoverage)
                 fprintf(f, "        alpha2coverage 1\n");
             char stageBlendDesc[64];
@@ -2105,6 +2534,47 @@ void IW_Debugf(const char *fmt, ...)
 
     Con_Printf("iwshader: %s\n", msg);
 }
+
+#ifdef IW_BUILD_TESTS
+qboolean IW_ParseShaderTextForTesting(const char *text, iwMaterial_t *outMaterial)
+{
+    if (!text || !outMaterial)
+        return false;
+
+    iwtxtParser_t parser;
+    IWTXT_Init(&parser, text, (int)strlen(text), "<memory>");
+
+    iwtxtToken_t token;
+    while (IWTXT_NextToken(&parser, &token))
+    {
+        if (token.type == IWTXT_TOKEN_EOF)
+            break;
+        if (token.type != IWTXT_TOKEN_STRING)
+            continue;
+
+        char keyword[32];
+        IW_CopyTokenLower(&token, keyword, sizeof(keyword));
+        if (!strcmp(keyword, "shader"))
+        {
+            iwtxtToken_t nameToken;
+            if (!IWTXT_NextToken(&parser, &nameToken) || nameToken.type != IWTXT_TOKEN_STRING)
+                return false;
+
+            IW_ResetState();
+            IW_ParseShaderDefinition(&parser, &nameToken, "<memory>");
+            if (iw_num_materials <= 0)
+                return false;
+
+            iwMaterial_t parsed = iw_materials[iw_num_materials - 1].material;
+            IW_ResetState();
+            *outMaterial = parsed;
+            return true;
+        }
+    }
+
+    return false;
+}
+#endif
 
 #define IW_MAX_MACROS 64
 #define IW_MACRO_NAME 64

--- a/Quake/renderer/r_iwshader.h
+++ b/Quake/renderer/r_iwshader.h
@@ -6,6 +6,11 @@
 #define IW_MAX_NAME         96
 #define IW_MAX_PATH         96
 #define IW_MAX_ANIM_FRAMES  64
+#define IW_MAX_Q3MAP_DIRECTIVES 32
+#define IW_MAX_DEFORM_COMMANDS 16
+#define IW_MAX_DIRECTIVE_TEXT 192
+#define IW_MAX_STAGE_CONDITION 96
+#define IW_MAX_TCGEN_TEXT   96
 
 #define IW_DEPTHWRITE_AUTO  (-1)
 
@@ -75,6 +80,24 @@ typedef enum {
 } iwTCAlign_t;
 
 typedef enum {
+    IW_MAP_TEXTURE2D = 0,
+    IW_MAP_CLAMP2D,
+    IW_MAP_CUBEMAP,
+    IW_MAP_LIGHTMAP,
+    IW_MAP_PROCEDURAL_WHITE,
+    IW_MAP_PROCEDURAL_BLACK
+} iwMapType_t;
+
+typedef struct {
+    float color[3];
+    float depthForOpaque;
+    float density;
+    int hasColor;
+    int hasDepthForOpaque;
+    int hasDensity;
+} iwFogParms_t;
+
+typedef enum {
     IW_WAVE_SIN = 0,
     IW_WAVE_TRIANGLE,
     IW_WAVE_SQUARE,
@@ -128,6 +151,8 @@ typedef struct {
 typedef struct {
     char mapPath[IW_MAX_PATH];
     int clamp;
+    int isClamp;
+    iwMapType_t mapType;
     iwBlendMode_t blendMode;
     iwBlendFactor_t src, dst;
     iwRGBGen_t rgbgen;
@@ -145,6 +170,12 @@ typedef struct {
     iwColorMask_t colorMask;
     iwTCAlign_t tcAlign;
     int tcAlignExplicit;
+    char tcGen[IW_MAX_TCGEN_TEXT];
+    char alphaFunc[32];
+    char depthFunc[32];
+    char stageCondition[IW_MAX_STAGE_CONDITION];
+    iwFogParms_t fogParms;
+    int hasFogParms;
     int alphaToCoverage;
     int animMap;
     float animFps;
@@ -152,6 +183,9 @@ typedef struct {
     char animPaths[IW_MAX_ANIM_FRAMES][IW_MAX_PATH];
     int numTCMods;
     iwTCMod_t tcmods[IW_MAX_TCMODS];
+    char normalMap[IW_MAX_PATH];
+    char glossMap[IW_MAX_PATH];
+    float specularScale;
 } iwStage_t;
 
 typedef struct {
@@ -164,6 +198,19 @@ typedef struct {
     int detail;
     char editorImage[IW_MAX_PATH];
     int strict;
+    char fogShader[IW_MAX_PATH];
+    int hasFog;
+    iwFogParms_t fogParms;
+    int hasFogParms;
+    int portal;
+    int hasSkyParms;
+    char skyParms[3][IW_MAX_PATH];
+    float tessSize;
+    int hasTessSize;
+    int numQ3MapDirectives;
+    char q3mapDirectives[IW_MAX_Q3MAP_DIRECTIVES][IW_MAX_DIRECTIVE_TEXT];
+    int numDeformVertexes;
+    char deformVertexes[IW_MAX_DEFORM_COMMANDS][IW_MAX_DIRECTIVE_TEXT];
     int numStages;
     iwStage_t stages[IW_MAX_STAGES];
 } iwMaterial_t;
@@ -198,6 +245,10 @@ const iwMaterial_t* IW_DebugLastMaterial(void);
 const char* IW_DebugLastTexture(void);
 qboolean IW_DebugOverlayText(char* buffer, size_t bufferSize);
 void IW_Debugf(const char* fmt, ...) FUNC_PRINTF(1, 2);
+
+#ifdef IW_BUILD_TESTS
+qboolean IW_ParseShaderTextForTesting(const char *text, iwMaterial_t *outMaterial);
+#endif
 
 #ifdef __cplusplus
 }

--- a/tests/iwshader_parser_test.c
+++ b/tests/iwshader_parser_test.c
@@ -1,0 +1,107 @@
+#include "Quake/renderer/r_iwshader.h"
+
+#include <assert.h>
+#include <math.h>
+#include <string.h>
+
+static void expect_float(float actual, float expected)
+{
+    assert(fabsf(actual - expected) < 1e-5f);
+}
+
+int main(void)
+{
+    static const char *shader_text =
+        "shader tests/dp_material\n"
+        "{\n"
+        "    q3map_sun 1 0.5 0.25 100 45 30\n"
+        "    deformVertexes wave sin 1 0 0 1\n"
+        "    tessSize 32\n"
+        "    portal\n"
+        "    fog textures/fogs/testfog\n"
+        "    fogparms ( 0.2 0.3 0.4 ) 128\n"
+        "    skyparms env/test 512 env/test_near\n"
+        "\n"
+        "    stage {\n"
+        "        clampmap textures/dp/diffuse.tga\n"
+        "        tcgen vector ( 1 0 0 ) ( 0 1 0 )\n"
+        "        depthfunc equal\n"
+        "        alphafunc gequal\n"
+        "        normalmap textures/dp/normal.tga\n"
+        "        glossmap textures/dp/gloss.tga\n"
+        "        specular 0.75\n"
+        "        if dp_extensions\n"
+        "        fogparms ( 0.1 0.2 0.3 ) 512 0.5\n"
+        "    }\n"
+        "\n"
+        "    stage {\n"
+        "        map $white\n"
+        "    }\n"
+        "\n"
+        "    stage {\n"
+        "        cubeMap env/dp/sky\n"
+        "    }\n"
+        "}\n";
+
+    iwMaterial_t material;
+    assert(IW_ParseShaderTextForTesting(shader_text, &material));
+
+    assert(material.numQ3MapDirectives == 1);
+    assert(strcmp(material.q3mapDirectives[0], "q3map_sun 1 0.5 0.25 100 45 30") == 0);
+
+    assert(material.numDeformVertexes == 1);
+    assert(strcmp(material.deformVertexes[0], "deformVertexes wave sin 1 0 0 1") == 0);
+
+    assert(material.hasTessSize);
+    expect_float(material.tessSize, 32.0f);
+
+    assert(material.portal == 1);
+    assert(material.hasFog);
+    assert(strcmp(material.fogShader, "textures/fogs/testfog") == 0);
+
+    assert(material.hasFogParms);
+    assert(material.fogParms.hasColor);
+    expect_float(material.fogParms.color[0], 0.2f);
+    expect_float(material.fogParms.color[1], 0.3f);
+    expect_float(material.fogParms.color[2], 0.4f);
+    assert(material.fogParms.hasDepthForOpaque);
+    expect_float(material.fogParms.depthForOpaque, 128.0f);
+
+    assert(material.hasSkyParms);
+    assert(strcmp(material.skyParms[0], "env/test") == 0);
+    assert(strcmp(material.skyParms[1], "512") == 0);
+    assert(strcmp(material.skyParms[2], "env/test_near") == 0);
+
+    assert(material.numStages == 3);
+
+    const iwStage_t *stage0 = &material.stages[0];
+    assert(stage0->mapType == IW_MAP_CLAMP2D);
+    assert(stage0->isClamp);
+    assert(strcmp(stage0->mapPath, "textures/dp/diffuse.tga") == 0);
+    assert(strcmp(stage0->tcGen, "vector ( 1 0 0 ) ( 0 1 0 )") == 0);
+    assert(strcmp(stage0->depthFunc, "equal") == 0);
+    assert(strcmp(stage0->alphaFunc, "gequal") == 0);
+    assert(strcmp(stage0->normalMap, "textures/dp/normal.tga") == 0);
+    assert(strcmp(stage0->glossMap, "textures/dp/gloss.tga") == 0);
+    expect_float(stage0->specularScale, 0.75f);
+    assert(stage0->stageCondition[0] != '\0');
+    assert(strcmp(stage0->stageCondition, "dp_extensions") == 0);
+    assert(stage0->hasFogParms);
+    expect_float(stage0->fogParms.color[0], 0.1f);
+    expect_float(stage0->fogParms.color[1], 0.2f);
+    expect_float(stage0->fogParms.color[2], 0.3f);
+    assert(stage0->fogParms.hasDepthForOpaque);
+    expect_float(stage0->fogParms.depthForOpaque, 512.0f);
+    assert(stage0->fogParms.hasDensity);
+    expect_float(stage0->fogParms.density, 0.5f);
+
+    const iwStage_t *stage1 = &material.stages[1];
+    assert(stage1->mapType == IW_MAP_PROCEDURAL_WHITE);
+    assert(strcmp(stage1->mapPath, "$white") == 0);
+
+    const iwStage_t *stage2 = &material.stages[2];
+    assert(stage2->mapType == IW_MAP_CUBEMAP);
+    assert(strcmp(stage2->mapPath, "env/dp/sky") == 0);
+
+    return 0;
+}

--- a/tests/iwshader_test_stubs.c
+++ b/tests/iwshader_test_stubs.c
@@ -1,0 +1,87 @@
+#include "quakedef.h"
+
+#include <stdarg.h>
+#include <stdio.h>
+
+void Con_Printf(const char *fmt, ...)
+{
+    (void)fmt;
+}
+
+void Con_Warning(const char *fmt, ...)
+{
+    (void)fmt;
+}
+
+void Cvar_RegisterVariable(cvar_t *var)
+{
+    (void)var;
+}
+
+cmd_function_t *Cmd_AddCommand(const char *cmd_name, xcommand_t function)
+{
+    (void)cmd_name;
+    (void)function;
+    return NULL;
+}
+
+void Cmd_RemoveCommand(cmd_function_t *cmd)
+{
+    (void)cmd;
+}
+
+int Cmd_Argc(void)
+{
+    return 0;
+}
+
+const char *Cmd_Argv(int arg)
+{
+    (void)arg;
+    return "";
+}
+
+FILE *Sys_fopen(const char *path, const char *mode)
+{
+    return fopen(path, mode);
+}
+
+int Sys_FileType(const char *path)
+{
+    (void)path;
+    return FS_ENT_FILE;
+}
+
+findfile_t *Sys_FindFirst(const char *dir, const char *ext)
+{
+    (void)dir;
+    (void)ext;
+    return NULL;
+}
+
+findfile_t *Sys_FindNext(findfile_t *find)
+{
+    (void)find;
+    return NULL;
+}
+
+void Sys_FindClose(findfile_t *find)
+{
+    (void)find;
+}
+
+byte *COM_LoadMallocFile(const char *path, int *len)
+{
+    (void)path;
+    if (len)
+        *len = 0;
+    return NULL;
+}
+
+byte *COM_LoadMallocFile_TextMode_OSPath(const char *path, int *len)
+{
+    (void)path;
+    if (len)
+        *len = 0;
+    return NULL;
+}


### PR DESCRIPTION
## Summary
- extend shader stage and material structures to retain DP keywords and fog parameters for later use
- parse DarkPlaces-specific map, tcgen, depth/alpha func, q3map, and fog directives without altering GL state and expose them in material dumps
- add a focused parser unit test with supporting stubs to exercise the new functionality
- declare helper prototypes early in r_iwshader.c so Visual Studio picks up IW_IsStageKeyword and IW_ReadFloat without implicit declarations

## Testing
- cmake -S . -B build *(fails: SDL2Config.cmake missing in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69112f56fe70832e894ac806740c3f4a)