### PR TITLE
Add material-driven fog support to iwshader

### DIFF
--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -177,6 +177,7 @@ typedef struct bmodel_bindless_gpu_call_s {
 	float		emissive_matrix[4];
 	float		emissive_translate[4];
 	float		emissive_color[4];
+	float		fog_color[4];
 } bmodel_bindless_gpu_call_t;
 
 typedef struct bmodel_bound_gpu_call_s {
@@ -191,6 +192,7 @@ typedef struct bmodel_bound_gpu_call_s {
 	float		emissive_matrix[4];
 	float		emissive_translate[4];
 	float		emissive_color[4];
+	float		fog_color[4];
 } bmodel_bound_gpu_call_t;
 
 typedef struct bmodel_gpu_call_remap_s {
@@ -504,6 +506,7 @@ static void R_PopDepthState(const r_depth_state_t *state)
 #define CALLFLAG_TC_STRETCH      (1u << 5)
 #define CALLFLAG_TC_TURB         (1u << 6)
 #define CALLFLAG_TC_ENVMAP       (1u << 7)
+#define CALLFLAG_CUSTOM_FOG      (1u << 8)
 
 static gltexture_t *R_IWShader_FindTextureForPath(const texture_t *base, const char *path)
 {
@@ -584,6 +587,58 @@ static void R_IWShader_EmissiveColor(const iwStage_t *stage, float color[3])
         }
 }
 
+static qboolean R_IWShader_FogFromParms(const iwFogParms_t *parms, float fog_color[4])
+{
+        if (!parms || !parms->hasColor)
+                return false;
+
+        float density = 0.f;
+        if (parms->hasDensity)
+        {
+                density = parms->density;
+        }
+        else if (parms->hasDepthForOpaque && parms->depthForOpaque > 0.f)
+        {
+                density = 1.f / parms->depthForOpaque;
+        }
+        else
+        {
+                return false;
+        }
+
+        density = fabsf(density);
+        fog_color[0] = q_clamp(parms->color[0], 0.f, 1.f);
+        fog_color[1] = q_clamp(parms->color[1], 0.f, 1.f);
+        fog_color[2] = q_clamp(parms->color[2], 0.f, 1.f);
+        fog_color[3] = density * density;
+        return fog_color[3] > 0.f;
+}
+
+static qboolean R_IWShader_GetFogColor(const iwMaterial_t *material, float fog_color[4], int depth)
+{
+        if (!material || depth > 4)
+                return false;
+
+        if (material->hasFogParms && R_IWShader_FogFromParms(&material->fogParms, fog_color))
+                return true;
+
+        for (int i = 0; i < material->numStages; ++i)
+        {
+                const iwStage_t *stage = &material->stages[i];
+                if (stage->hasFogParms && R_IWShader_FogFromParms(&stage->fogParms, fog_color))
+                        return true;
+        }
+
+        if (material->hasFog && material->fogShader[0])
+        {
+                const iwMaterial_t *fog_material = IW_FindMaterial(material->fogShader);
+                if (fog_material && fog_material != material)
+                        return R_IWShader_GetFogColor(fog_material, fog_color, depth + 1);
+        }
+
+        return false;
+}
+
 /*
 =============
 R_AddBModelCall
@@ -598,6 +653,8 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
         iwTexMatrix_t   tex_matrix;
         iwTexMatrix_t   emissive_matrix;
         float           emissive_color[3];
+        float           fog_color[4] = { 0.f, 0.f, 0.f, 0.f };
+        qboolean        has_material_fog = false;
         const iwStage_t *emissive_stage = NULL;
         float           material_alpha = -1.f;
         iwCull_t        cull = IW_CULL_BACK;
@@ -633,6 +690,7 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
         {
                 IW_MaterialTexMatrix (material, r_framedata.time, &tex_matrix);
                 cull = material->cull;
+                has_material_fog = R_IWShader_GetFogColor(material, fog_color, 0);
                 if (material->numStages > 0)
                 {
                         const iwStage_t *base_stage = &material->stages[0];
@@ -724,6 +782,8 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
         if (t && t->type == TEXTYPE_CUTOUT)
                 flags |= CALLFLAG_ALPHA_TEST;
         flags |= tc_feature_flags;
+        if (has_material_fog)
+                flags |= CALLFLAG_CUSTOM_FOG;
         alpha = t ? GL_WaterAlphaForTextureType (t->type) : 1.f;
         if (material_alpha >= 0.f)
                 alpha = material_alpha;
@@ -752,6 +812,7 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
                 call->emissive_color[1] = emissive_color[1];
                 call->emissive_color[2] = emissive_color[2];
                 call->emissive_color[3] = (flags & CALLFLAG_EMISSIVE) ? 1.f : 0.f;
+                memcpy (call->fog_color, fog_color, sizeof (fog_color));
         }
         else
         {
@@ -777,6 +838,7 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
                 call->emissive_color[1] = emissive_color[1];
                 call->emissive_color[2] = emissive_color[2];
                 call->emissive_color[3] = (flags & CALLFLAG_EMISSIVE) ? 1.f : 0.f;
+                memcpy (call->fog_color, fog_color, sizeof (fog_color));
                 textures[0] = tx ? tx : greytexture;
                 textures[1] = fb ? fb : blacktexture;
                 textures[2] = em ? em : blacktexture;

--- a/Quake/shaders/sky_cubemap.vert
+++ b/Quake/shaders/sky_cubemap.vert
@@ -34,6 +34,7 @@ struct Call
         vec4    emissive_matrix;
         vec4    emissive_translate;
         vec4    emissive_color;
+        vec4    fog_color;
 };
 const uint
 	CF_USE_POLYGON_OFFSET = 1u,
@@ -42,7 +43,8 @@ const uint
 	CF_USE_EMISSIVE = 8u,
 	CF_TC_STRETCH = 32u,
 	CF_TC_TURB = 64u,
-	CF_TC_ENVMAP = 128u
+	CF_TC_ENVMAP = 128u,
+	CF_CUSTOM_FOG = 256u
 ;
 
 layout(std430, binding=1) restrict readonly buffer CallBuffer

--- a/Quake/shaders/sky_layers.vert
+++ b/Quake/shaders/sky_layers.vert
@@ -34,6 +34,7 @@ struct Call
         vec4    emissive_matrix;
         vec4    emissive_translate;
         vec4    emissive_color;
+        vec4    fog_color;
 };
 const uint
 	CF_USE_POLYGON_OFFSET = 1u,
@@ -42,7 +43,8 @@ const uint
 	CF_USE_EMISSIVE = 8u,
 	CF_TC_STRETCH = 32u,
 	CF_TC_TURB = 64u,
-	CF_TC_ENVMAP = 128u
+	CF_TC_ENVMAP = 128u,
+	CF_CUSTOM_FOG = 256u
 ;
 
 layout(std430, binding=1) restrict readonly buffer CallBuffer

--- a/Quake/shaders/skystencil.vert
+++ b/Quake/shaders/skystencil.vert
@@ -34,6 +34,7 @@ struct Call
         vec4    emissive_matrix;
         vec4    emissive_translate;
         vec4    emissive_color;
+        vec4    fog_color;
 };
 const uint
 	CF_USE_POLYGON_OFFSET = 1u,
@@ -42,7 +43,8 @@ const uint
 	CF_USE_EMISSIVE = 8u,
 	CF_TC_STRETCH = 32u,
 	CF_TC_TURB = 64u,
-	CF_TC_ENVMAP = 128u
+	CF_TC_ENVMAP = 128u,
+	CF_CUSTOM_FOG = 256u
 ;
 
 layout(std430, binding=1) restrict readonly buffer CallBuffer

--- a/Quake/shaders/water.frag
+++ b/Quake/shaders/water.frag
@@ -8,11 +8,11 @@
 
 #include "frame_uniforms.glsl"
 
-vec3 ApplyFog(vec3 clr, vec3 p)
+vec3 ApplyFog(vec3 clr, vec3 p, vec4 fogData)
 {
-        float fog = exp2(-Fog.w * dot(p, p));
+        float fog = exp2(-fogData.w * dot(p, p));
         fog = clamp(fog, 0.0, 1.0);
-        return mix(Fog.rgb, clr, fog);
+        return mix(fogData.rgb, clr, fog);
 }
 
 const uint
@@ -23,7 +23,8 @@ const uint
         CF_ALPHA_TEST = 16u,
         CF_TC_STRETCH = 32u,
         CF_TC_TURB = 64u,
-        CF_TC_ENVMAP = 128u
+        CF_TC_ENVMAP = 128u,
+        CF_CUSTOM_FOG = 256u
 ;
 
 // ALU-only 16x16 Bayer matrix
@@ -97,6 +98,7 @@ layout(location=7) noperspective in vec4 in_prev_clip;
 layout(location=8) in vec2 in_emissive_uv;
 layout(location=9) flat in vec3 in_emissive_color;
 layout(location=10) flat in vec4 in_stage_params1;
+layout(location=11) flat in vec4 in_fog_color;
 
 #define OUT_COLOR out_fragcolor
 #if OIT
@@ -216,7 +218,8 @@ void main()
         }
 
         result.rgb = clamp(result.rgb, 0.0, 1.0);
-        result.rgb = ApplyFog(result.rgb, in_pos);
+        vec4 fogData = ((in_flags & CF_CUSTOM_FOG) != 0u) ? in_fog_color : Fog;
+        result.rgb = ApplyFog(result.rgb, in_pos, fogData);
         result.a *= in_alpha;
         out_fragcolor = result;
 #if !OIT

--- a/Quake/shaders/water.vert
+++ b/Quake/shaders/water.vert
@@ -34,6 +34,7 @@ struct Call
         vec4    emissive_matrix;
         vec4    emissive_translate;
         vec4    emissive_color;
+        vec4    fog_color;
 };
 const uint
 	CF_USE_POLYGON_OFFSET = 1u,
@@ -43,7 +44,8 @@ const uint
 	CF_ALPHA_TEST = 16u,
 	CF_TC_STRETCH = 32u,
 	CF_TC_TURB = 64u,
-	CF_TC_ENVMAP = 128u
+	CF_TC_ENVMAP = 128u,
+	CF_CUSTOM_FOG = 256u
 ;
 
 layout(std430, binding=1) restrict readonly buffer CallBuffer
@@ -107,6 +109,7 @@ layout(location=7) noperspective out vec4 out_prev_clip;
 layout(location=8) out vec2 out_emissive_uv;
 layout(location=9) flat out vec3 out_emissive_color;
 layout(location=10) flat out vec4 out_stage_params1;
+layout(location=11) flat out vec4 out_fog_color;
 
 float EvaluateWave(vec4 params, int func)
 {
@@ -196,5 +199,6 @@ void main()
 #endif
         out_emissive_color = call.emissive_color.xyz;
         out_stage_params1 = call.tcmod_params1;
+        out_fog_color = call.fog_color;
 }
 

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -32,11 +32,11 @@ layout(std430, binding=0) restrict readonly buffer LightBuffer
 
 layout(rg32ui, binding=0) uniform readonly uimage3D LightClusters;
 
-vec3 ApplyFog(vec3 clr, vec3 p)
+vec3 ApplyFog(vec3 clr, vec3 p, vec4 fogData)
 {
-    float fog = exp2(-Fog.w * dot(p, p));
+    float fog = exp2(-fogData.w * dot(p, p));
     fog = clamp(fog, 0.0, 1.0);
-    return mix(Fog.rgb, clr, fog);
+    return mix(fogData.rgb, clr, fog);
 }
 
 const uint
@@ -47,7 +47,8 @@ const uint
     CF_ALPHA_TEST = 16u,
     CF_TC_STRETCH = 32u,
     CF_TC_TURB = 64u,
-    CF_TC_ENVMAP = 128u
+    CF_TC_ENVMAP = 128u,
+    CF_CUSTOM_FOG = 256u
 ;
 
 // ALU-only 16x16 Bayer matrix
@@ -135,6 +136,7 @@ layout(location=12) noperspective in vec4 in_prev_clip;
 layout(location=13) in vec2 in_emissive_uv;
 layout(location=14) flat in vec3 in_emissive_color;
 layout(location=15) flat in vec4 in_stage_params1;
+layout(location=16) flat in vec4 in_fog_color;
 
 #define OUT_COLOR out_fragcolor
 #if OIT
@@ -540,7 +542,8 @@ void main()
     }
 
     result = clamp(result, 0.0, 1.0);
-    result.rgb = ApplyFog(result.rgb, in_pos - EyePos);
+    vec4 fogData = ((in_flags & CF_CUSTOM_FOG) != 0u) ? in_fog_color : Fog;
+    result.rgb = ApplyFog(result.rgb, in_pos - EyePos, fogData);
 
     result.a = in_alpha;
 

--- a/Quake/shaders/world.vert
+++ b/Quake/shaders/world.vert
@@ -63,6 +63,7 @@ struct Call
         vec4    emissive_matrix;
         vec4    emissive_translate;
         vec4    emissive_color;
+        vec4    fog_color;
 };
 const uint
 	CF_USE_POLYGON_OFFSET = 1u,
@@ -72,7 +73,8 @@ const uint
 	CF_ALPHA_TEST = 16u,
 	CF_TC_STRETCH = 32u,
 	CF_TC_TURB = 64u,
-	CF_TC_ENVMAP = 128u
+	CF_TC_ENVMAP = 128u,
+	CF_CUSTOM_FOG = 256u
 ;
 
 layout(std430, binding=1) restrict readonly buffer CallBuffer
@@ -144,6 +146,7 @@ layout(location=12) noperspective out vec4 out_prev_clip;
 layout(location=13) out vec2 out_emissive_uv;
 layout(location=14) flat out vec3 out_emissive_color;
 layout(location=15) flat out vec4 out_stage_params1;
+layout(location=16) flat out vec4 out_fog_color;
 
 float EvaluateWave(vec4 params, int func)
 {
@@ -265,4 +268,5 @@ void main()
 #endif
         out_emissive_color = call.emissive_color.xyz;
         out_stage_params1 = call.tcmod_params1;
+        out_fog_color = call.fog_color;
 }


### PR DESCRIPTION
## Summary
- extract fog color and density from iwshader materials, including referenced fog shaders and stages
- extend brush draw calls and shaders to upload per-call fog data and honor custom fog flags
- blend scene color with material fog parameters when rendering world and water passes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69123216f078832eac6d282673f5b831)