### PR TITLE
Implement per-stage iwshader blend/depth state handling

### DIFF
--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -178,6 +178,9 @@ typedef struct bmodel_bindless_gpu_call_s {
 	float		emissive_translate[4];
 	float		emissive_color[4];
 	float		fog_color[4];
+	float		alpha_params0[4];
+	float		alpha_params1[4];
+	float		alpha_params2[4];
 } bmodel_bindless_gpu_call_t;
 
 typedef struct bmodel_bound_gpu_call_s {
@@ -193,6 +196,9 @@ typedef struct bmodel_bound_gpu_call_s {
 	float		emissive_translate[4];
 	float		emissive_color[4];
 	float		fog_color[4];
+	float		alpha_params0[4];
+	float		alpha_params1[4];
+	float		alpha_params2[4];
 } bmodel_bound_gpu_call_t;
 
 typedef struct bmodel_gpu_call_remap_s {
@@ -214,8 +220,66 @@ static bmodel_gpu_call_remap_t		bmodel_call_remap[MAX_BMODEL_DRAWS];
 static iwCull_t				bmodel_call_cull[MAX_BMODEL_DRAWS];
 static GLbyte                           bmodel_call_depth_test[MAX_BMODEL_DRAWS];
 static GLbyte                           bmodel_call_depth_write[MAX_BMODEL_DRAWS];
+static GLbyte                           bmodel_call_depth_func_override[MAX_BMODEL_DRAWS];
+static GLint                            bmodel_call_depth_func[MAX_BMODEL_DRAWS];
+static GLboolean                        bmodel_call_blend_enable[MAX_BMODEL_DRAWS];
+static GLenum                           bmodel_call_blend_src[MAX_BMODEL_DRAWS];
+static GLenum                           bmodel_call_blend_dst[MAX_BMODEL_DRAWS];
+static GLubyte                           bmodel_call_color_mask[MAX_BMODEL_DRAWS];
 static int							num_bmodel_calls;
 static GLuint						bmodel_batch_program;
+
+static GLboolean                        bmodel_initial_blend_enabled;
+static GLint                            bmodel_initial_blend_src_rgb;
+static GLint                            bmodel_initial_blend_dst_rgb;
+static GLint                            bmodel_initial_blend_src_alpha;
+static GLint                            bmodel_initial_blend_dst_alpha;
+static GLubyte                          bmodel_initial_color_mask_bits;
+
+static GLenum IW_BlendFactorToGL(iwBlendFactor_t factor)
+{
+        switch (factor)
+        {
+        case IW_SRC_ZERO: return GL_ZERO;
+        case IW_SRC_ONE: return GL_ONE;
+        case IW_SRC_SRC_COLOR: return GL_SRC_COLOR;
+        case IW_SRC_ONE_MINUS_SRC_COLOR: return GL_ONE_MINUS_SRC_COLOR;
+        case IW_SRC_DST_COLOR: return GL_DST_COLOR;
+        case IW_SRC_ONE_MINUS_DST_COLOR: return GL_ONE_MINUS_DST_COLOR;
+        case IW_SRC_SRC_ALPHA: return GL_SRC_ALPHA;
+        case IW_SRC_ONE_MINUS_SRC_ALPHA: return GL_ONE_MINUS_SRC_ALPHA;
+        case IW_SRC_DST_ALPHA: return GL_DST_ALPHA;
+        case IW_SRC_ONE_MINUS_DST_ALPHA: return GL_ONE_MINUS_DST_ALPHA;
+        default: return GL_ONE;
+        }
+}
+
+static GLenum IW_DepthFuncToGL(iwDepthFunc_t func)
+{
+        switch (func)
+        {
+        case IW_DEPTHFUNC_NEVER: return GL_NEVER;
+        case IW_DEPTHFUNC_LESS: return GL_LESS;
+        case IW_DEPTHFUNC_EQUAL: return GL_EQUAL;
+        case IW_DEPTHFUNC_LEQUAL: return GL_LEQUAL;
+        case IW_DEPTHFUNC_GREATER: return GL_GREATER;
+        case IW_DEPTHFUNC_NOTEQUAL: return GL_NOTEQUAL;
+        case IW_DEPTHFUNC_GEQUAL: return GL_GEQUAL;
+        case IW_DEPTHFUNC_ALWAYS: return GL_ALWAYS;
+        case IW_DEPTHFUNC_DEFAULT: return GL_LEQUAL;
+        default: return GL_LEQUAL;
+        }
+}
+
+static GLubyte IW_ColorMaskBits(iwColorMask_t mask)
+{
+        GLubyte bits = 0;
+        if (mask & IW_COLORMASK_R) bits |= 1;
+        if (mask & IW_COLORMASK_G) bits |= 2;
+        if (mask & IW_COLORMASK_B) bits |= 4;
+        if (mask & IW_COLORMASK_A) bits |= 8;
+        return bits;
+}
 
 typedef struct
 {
@@ -227,10 +291,11 @@ typedef struct
 {
         GLboolean       testEnabled;
         GLboolean       writeMask;
+        GLint           func;
 } r_depth_state_t;
 
 static void R_PushDepthState(r_depth_state_t *state);
-static qboolean R_ApplyDepthState(GLbyte depthTestOverride, GLbyte depthWriteOverride, r_depth_state_t *state);
+static qboolean R_ApplyDepthState(GLbyte depthTestOverride, GLbyte depthWriteOverride, GLint depthFuncOverride, r_depth_state_t *state);
 static void R_PopDepthState(const r_depth_state_t *state);
 
 static void R_PushCullState(r_cull_state_t *state)
@@ -352,8 +417,26 @@ R_ResetBModelCalls
 */
 static void R_ResetBModelCalls (GLuint program)
 {
-	bmodel_batch_program = program;
-	num_bmodel_calls = 0;
+        bmodel_batch_program = program;
+
+        bmodel_initial_blend_enabled = glIsEnabled(GL_BLEND);
+        bmodel_initial_blend_src_rgb = GL_ONE;
+        bmodel_initial_blend_dst_rgb = GL_ZERO;
+        bmodel_initial_blend_src_alpha = GL_ONE;
+        bmodel_initial_blend_dst_alpha = GL_ZERO;
+        glGetIntegerv(GL_BLEND_SRC_RGB, &bmodel_initial_blend_src_rgb);
+        glGetIntegerv(GL_BLEND_DST_RGB, &bmodel_initial_blend_dst_rgb);
+        glGetIntegerv(GL_BLEND_SRC_ALPHA, &bmodel_initial_blend_src_alpha);
+        glGetIntegerv(GL_BLEND_DST_ALPHA, &bmodel_initial_blend_dst_alpha);
+
+        GLboolean maskValues[4] = { GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE };
+        glGetBooleanv(GL_COLOR_WRITEMASK, maskValues);
+        bmodel_initial_color_mask_bits = (maskValues[0] ? 1 : 0) |
+                                         (maskValues[1] ? 2 : 0) |
+                                         (maskValues[2] ? 4 : 0) |
+                                         (maskValues[3] ? 8 : 0);
+
+        num_bmodel_calls = 0;
 }
 
 /*
@@ -367,8 +450,21 @@ static void R_FlushBModelCalls (void)
 	GLbyte	*ofs;
 	size_t	dstcmdofs;
 
-	if (!num_bmodel_calls)
-		return;
+        if (!num_bmodel_calls)
+                return;
+
+        GLboolean initialBlendEnabled = bmodel_initial_blend_enabled;
+        GLint initialBlendSrcRGB = bmodel_initial_blend_src_rgb;
+        GLint initialBlendDstRGB = bmodel_initial_blend_dst_rgb;
+        GLint initialBlendSrcAlpha = bmodel_initial_blend_src_alpha;
+        GLint initialBlendDstAlpha = bmodel_initial_blend_dst_alpha;
+        GLboolean currentBlendEnabled = initialBlendEnabled;
+        GLint currentBlendSrcRGB = initialBlendSrcRGB;
+        GLint currentBlendDstRGB = initialBlendDstRGB;
+        GLint currentBlendSrcAlpha = initialBlendSrcAlpha;
+        GLint currentBlendDstAlpha = initialBlendDstAlpha;
+        GLubyte initialMaskBits = bmodel_initial_color_mask_bits;
+        GLubyte currentColorMask = initialMaskBits;
 
 	GL_ReserveDeviceMemory (GL_DRAW_INDIRECT_BUFFER, sizeof (bmodel_draw_indirect_t) * num_bmodel_calls, &cmdbuf, &dstcmdofs);
 
@@ -396,20 +492,59 @@ static void R_FlushBModelCalls (void)
 		const GLsizei stride = sizeof (bmodel_draw_indirect_t);
 		for (int i = 0; i < num_bmodel_calls; )
 		{
-			iwCull_t cull = bmodel_call_cull[i];
+                iwCull_t cull = bmodel_call_cull[i];
                         GLbyte depthTest = bmodel_call_depth_test[i];
                         GLbyte depthWrite = bmodel_call_depth_write[i];
-			int count = 1;
+                GLint depthFunc = bmodel_call_depth_func_override[i] ? (GLint)bmodel_call_depth_func[i] : -1;
+                GLboolean blendEnable = bmodel_call_blend_enable[i];
+                GLenum blendSrc = bmodel_call_blend_src[i];
+                GLenum blendDst = bmodel_call_blend_dst[i];
+                GLubyte colorMask = bmodel_call_color_mask[i];
+                int count = 1;
                         while (i + count < num_bmodel_calls && bmodel_call_cull[i + count] == cull &&
                                bmodel_call_depth_test[i + count] == depthTest &&
-                               bmodel_call_depth_write[i + count] == depthWrite)
-				++count;
+                               bmodel_call_depth_write[i + count] == depthWrite &&
+                               (bmodel_call_depth_func_override[i + count] ? (GLint)bmodel_call_depth_func[i + count] : -1) == depthFunc &&
+                               bmodel_call_blend_enable[i + count] == blendEnable &&
+                               bmodel_call_blend_src[i + count] == blendSrc &&
+                               bmodel_call_blend_dst[i + count] == blendDst &&
+                               bmodel_call_color_mask[i + count] == colorMask)
+                                ++count;
 
 			r_cull_state_t guard;
 			R_PushCullState(&guard);
 			R_SetCullState(cull);
                         r_depth_state_t depthGuard;
-                        qboolean depthChanged = R_ApplyDepthState(depthTest, depthWrite, &depthGuard);
+                        qboolean depthChanged = R_ApplyDepthState(depthTest, depthWrite, depthFunc, &depthGuard);
+
+                        if (currentColorMask != colorMask)
+                        {
+                                glColorMaski(0,
+                                             (colorMask & 1) ? GL_TRUE : GL_FALSE,
+                                             (colorMask & 2) ? GL_TRUE : GL_FALSE,
+                                             (colorMask & 4) ? GL_TRUE : GL_FALSE,
+                                             (colorMask & 8) ? GL_TRUE : GL_FALSE);
+                                currentColorMask = colorMask;
+                        }
+
+                        if (currentBlendEnabled != blendEnable)
+                        {
+                                if (blendEnable)
+                                        glEnable(GL_BLEND);
+                                else
+                                        glDisable(GL_BLEND);
+                                currentBlendEnabled = blendEnable;
+                        }
+
+                        if (currentBlendSrcRGB != (GLint)blendSrc || currentBlendDstRGB != (GLint)blendDst ||
+                            currentBlendSrcAlpha != (GLint)blendSrc || currentBlendDstAlpha != (GLint)blendDst)
+                        {
+                                glBlendFunc(blendSrc, blendDst);
+                                currentBlendSrcRGB = (GLint)blendSrc;
+                                currentBlendDstRGB = (GLint)blendDst;
+                                currentBlendSrcAlpha = (GLint)blendSrc;
+                                currentBlendDstAlpha = (GLint)blendDst;
+                        }
 
 			const size_t offset = dstcmdofs + (size_t)i * (size_t)stride;
 			const void *indirect = (const void *)(uintptr_t)offset;
@@ -428,17 +563,52 @@ static void R_FlushBModelCalls (void)
 		GL_Upload (GL_SHADER_STORAGE_BUFFER, &bmodel_calls.bound.params, sizeof (bmodel_calls.bound.params[0]) * num_bmodel_calls, &buf, &ofs);
 		GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 1, buf, (GLintptr)ofs, sizeof (bmodel_calls.bound.params[0]) * num_bmodel_calls);
 
-		for (i = 0; i < num_bmodel_calls; i++)
-		{
-			r_cull_state_t guard;
-			R_PushCullState(&guard);
-			R_SetCullState(bmodel_call_cull[i]);
-			r_depth_state_t depthGuard;
-			qboolean depthChanged = R_ApplyDepthState(bmodel_call_depth_test[i], bmodel_call_depth_write[i], &depthGuard);
+        for (i = 0; i < num_bmodel_calls; i++)
+        {
+                GLboolean blendEnable = bmodel_call_blend_enable[i];
+                GLenum blendSrc = bmodel_call_blend_src[i];
+                GLenum blendDst = bmodel_call_blend_dst[i];
+                GLubyte colorMask = bmodel_call_color_mask[i];
+                GLint depthFunc = bmodel_call_depth_func_override[i] ? (GLint)bmodel_call_depth_func[i] : -1;
+                r_cull_state_t guard;
+                R_PushCullState(&guard);
+                R_SetCullState(bmodel_call_cull[i]);
+                r_depth_state_t depthGuard;
+                qboolean depthChanged = R_ApplyDepthState(bmodel_call_depth_test[i], bmodel_call_depth_write[i],
+                        depthFunc, &depthGuard);
 
-			GL_Uniform1iFunc (0, i);
-			GL_BindTextures (0, 2, bmodel_calls.bound.textures[i]);
-			GL_Bind (GL_TEXTURE4, bmodel_calls.bound.textures[i][2]);
+                if (currentColorMask != colorMask)
+                {
+                        glColorMaski(0,
+                                     (colorMask & 1) ? GL_TRUE : GL_FALSE,
+                                     (colorMask & 2) ? GL_TRUE : GL_FALSE,
+                                     (colorMask & 4) ? GL_TRUE : GL_FALSE,
+                                     (colorMask & 8) ? GL_TRUE : GL_FALSE);
+                        currentColorMask = colorMask;
+                }
+
+                if (currentBlendEnabled != blendEnable)
+                {
+                        if (blendEnable)
+                                glEnable(GL_BLEND);
+                        else
+                                glDisable(GL_BLEND);
+                        currentBlendEnabled = blendEnable;
+                }
+
+                if (currentBlendSrcRGB != (GLint)blendSrc || currentBlendDstRGB != (GLint)blendDst ||
+                    currentBlendSrcAlpha != (GLint)blendSrc || currentBlendDstAlpha != (GLint)blendDst)
+                {
+                        glBlendFunc(blendSrc, blendDst);
+                        currentBlendSrcRGB = (GLint)blendSrc;
+                        currentBlendDstRGB = (GLint)blendDst;
+                        currentBlendSrcAlpha = (GLint)blendSrc;
+                        currentBlendDstAlpha = (GLint)blendDst;
+                }
+
+                GL_Uniform1iFunc (0, i);
+                GL_BindTextures (0, 2, bmodel_calls.bound.textures[i]);
+                GL_Bind (GL_TEXTURE4, bmodel_calls.bound.textures[i][2]);
 			const size_t offset = dstcmdofs + (size_t)i * sizeof (bmodel_draw_indirect_t);
 			GL_DrawElementsIndirectFunc (GL_TRIANGLES, GL_UNSIGNED_INT, (const void *)(uintptr_t)offset);
 
@@ -447,9 +617,39 @@ static void R_FlushBModelCalls (void)
 			R_PopCullState(&guard);
 		}
 
-	}
+        }
 
-	num_bmodel_calls = 0;
+        if (currentColorMask != initialMaskBits)
+        {
+                glColorMaski(0,
+                             (initialMaskBits & 1) ? GL_TRUE : GL_FALSE,
+                             (initialMaskBits & 2) ? GL_TRUE : GL_FALSE,
+                             (initialMaskBits & 4) ? GL_TRUE : GL_FALSE,
+                             (initialMaskBits & 8) ? GL_TRUE : GL_FALSE);
+                currentColorMask = initialMaskBits;
+        }
+
+        if (currentBlendSrcRGB != initialBlendSrcRGB || currentBlendDstRGB != initialBlendDstRGB ||
+            currentBlendSrcAlpha != initialBlendSrcAlpha || currentBlendDstAlpha != initialBlendDstAlpha)
+        {
+                glBlendFuncSeparate(initialBlendSrcRGB, initialBlendDstRGB,
+                                     initialBlendSrcAlpha, initialBlendDstAlpha);
+                currentBlendSrcRGB = initialBlendSrcRGB;
+                currentBlendDstRGB = initialBlendDstRGB;
+                currentBlendSrcAlpha = initialBlendSrcAlpha;
+                currentBlendDstAlpha = initialBlendDstAlpha;
+        }
+
+        if (currentBlendEnabled != initialBlendEnabled)
+        {
+                if (initialBlendEnabled)
+                        glEnable(GL_BLEND);
+                else
+                        glDisable(GL_BLEND);
+                currentBlendEnabled = initialBlendEnabled;
+        }
+
+        num_bmodel_calls = 0;
 }
 
 static void R_PushDepthState(r_depth_state_t *state)
@@ -461,11 +661,14 @@ static void R_PushDepthState(r_depth_state_t *state)
         GLboolean mask = GL_TRUE;
         glGetBooleanv(GL_DEPTH_WRITEMASK, &mask);
         state->writeMask = mask;
+        GLint func = GL_LEQUAL;
+        glGetIntegerv(GL_DEPTH_FUNC, &func);
+        state->func = func;
 }
 
-static qboolean R_ApplyDepthState(GLbyte depthTestOverride, GLbyte depthWriteOverride, r_depth_state_t *state)
+static qboolean R_ApplyDepthState(GLbyte depthTestOverride, GLbyte depthWriteOverride, GLint depthFuncOverride, r_depth_state_t *state)
 {
-        if (depthTestOverride < 0 && depthWriteOverride < 0)
+        if (depthTestOverride < 0 && depthWriteOverride < 0 && depthFuncOverride < 0)
                 return false;
 
         R_PushDepthState(state);
@@ -481,9 +684,28 @@ static qboolean R_ApplyDepthState(GLbyte depthTestOverride, GLbyte depthWriteOve
         if (depthWriteOverride >= 0)
                 glDepthMask(depthWriteOverride ? GL_TRUE : GL_FALSE);
 
+        if (depthFuncOverride >= 0)
+                glDepthFunc((GLenum)depthFuncOverride);
+
         const char *depthTestStr = ((depthTestOverride >= 0 ? depthTestOverride : state->testEnabled) ? "on" : "off");
         const char *depthWriteStr = ((depthWriteOverride >= 0 ? depthWriteOverride : state->writeMask) ? "on" : "off");
-        IW_Debugf("depthtest=%s, depthwrite=%s", depthTestStr, depthWriteStr);
+        GLenum func = (depthFuncOverride >= 0) ? (GLenum)depthFuncOverride : (GLenum)state->func;
+        const char *depthFuncStr;
+        switch (func)
+        {
+        case GL_NEVER: depthFuncStr = "never"; break;
+        case GL_LESS: depthFuncStr = "less"; break;
+        case GL_EQUAL: depthFuncStr = "equal"; break;
+        case GL_LEQUAL: depthFuncStr = "lequal"; break;
+        case GL_GREATER: depthFuncStr = "greater"; break;
+        case GL_NOTEQUAL: depthFuncStr = "notequal"; break;
+        case GL_GEQUAL: depthFuncStr = "gequal"; break;
+        case GL_ALWAYS:
+        default:
+                depthFuncStr = "always";
+                break;
+        }
+        IW_Debugf("depthtest=%s, depthwrite=%s, depthfunc=%s", depthTestStr, depthWriteStr, depthFuncStr);
 
         return true;
 }
@@ -499,6 +721,7 @@ static void R_PopDepthState(const r_depth_state_t *state)
                 glDisable(GL_DEPTH_TEST);
 
         glDepthMask(state->writeMask ? GL_TRUE : GL_FALSE);
+        glDepthFunc((GLenum)state->func);
 }
 
 #define CALLFLAG_EMISSIVE        (1u << 3)
@@ -656,13 +879,23 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
         float           fog_color[4] = { 0.f, 0.f, 0.f, 0.f };
         qboolean        has_material_fog = false;
         const iwStage_t *emissive_stage = NULL;
-        float           material_alpha = -1.f;
         iwCull_t        cull = IW_CULL_BACK;
         float           base_tcmod_params0[4] = { 1.f, 0.f, 0.f, 0.f };
         float           base_tcmod_params1[4] = { 0.f, 0.f, -1.f, (float)IW_WAVE_SIN };
         unsigned int    tc_feature_flags = 0u;
         GLbyte           depthTestOverride = -1;
         GLbyte           depthWriteOverride = -1;
+        GLboolean       stageBlendEnabled = GL_FALSE;
+        GLenum          stageBlendSrc = GL_ONE;
+        GLenum          stageBlendDst = GL_ZERO;
+        GLint           stageDepthFunc = -1;
+        GLubyte         stageColorMaskBits = IW_ColorMaskBits(IW_COLORMASK_RGBA);
+        float           alpha_params0[4] = { 0.f, 1.f, 0.f, 0.f };
+        float           alpha_params1[4] = { 0.f, 0.f, -1.f, (float)IW_WAVE_SIN };
+        float           alpha_params2[4] = { (float)IW_ALPHA_FUNC_DISABLED, 0.f, 0.f, 0.f };
+        qboolean        stageAlphaTest = false;
+        iwAlphaFunc_t   stageAlphaFuncMode = IW_ALPHA_FUNC_DISABLED;
+        float           stageAlphaFuncRef = 0.f;
 
         IW_TexMatrixIdentity (&tex_matrix);
         IW_TexMatrixIdentity (&emissive_matrix);
@@ -698,9 +931,100 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
                                 depthTestOverride = base_stage->depthTest ? 1 : 0;
                         if (base_stage->depthWrite != IW_DEPTHWRITE_AUTO)
                                 depthWriteOverride = base_stage->depthWrite ? 1 : 0;
-                        if ((base_stage->blendMode == IW_BLEND_ALPHA || base_stage->blendMode == IW_BLEND_ADD_ALPHA) &&
-                            base_stage->alphagen == IW_A_CONST)
-                                material_alpha = q_clamp(base_stage->aConst, 0.f, 1.f);
+                        if (base_stage->depthFuncExplicit && base_stage->depthFuncMode != IW_DEPTHFUNC_DEFAULT)
+                                stageDepthFunc = IW_DepthFuncToGL(base_stage->depthFuncMode);
+
+                        switch (base_stage->blendMode)
+                        {
+                        case IW_BLEND_ALPHA:
+                                stageBlendEnabled = GL_TRUE;
+                                stageBlendSrc = GL_SRC_ALPHA;
+                                stageBlendDst = GL_ONE_MINUS_SRC_ALPHA;
+                                break;
+
+                        case IW_BLEND_ADD:
+                                stageBlendEnabled = GL_TRUE;
+                                stageBlendSrc = GL_ONE;
+                                stageBlendDst = GL_ONE;
+                                break;
+
+                        case IW_BLEND_MUL:
+                                stageBlendEnabled = GL_TRUE;
+                                stageBlendSrc = GL_DST_COLOR;
+                                stageBlendDst = GL_ZERO;
+                                break;
+
+                        case IW_BLEND_PREMUL:
+                                stageBlendEnabled = GL_TRUE;
+                                stageBlendSrc = GL_ONE;
+                                stageBlendDst = GL_ONE_MINUS_SRC_ALPHA;
+                                break;
+
+                        case IW_BLEND_ADD_ALPHA:
+                                stageBlendEnabled = GL_TRUE;
+                                stageBlendSrc = GL_SRC_ALPHA;
+                                stageBlendDst = GL_ONE;
+                                break;
+
+                        case IW_BLEND_CUSTOM:
+                                stageBlendEnabled = GL_TRUE;
+                                stageBlendSrc = IW_BlendFactorToGL(base_stage->src);
+                                stageBlendDst = IW_BlendFactorToGL(base_stage->dst);
+                                break;
+
+                        default:
+                                stageBlendEnabled = GL_FALSE;
+                                stageBlendSrc = GL_ONE;
+                                stageBlendDst = GL_ZERO;
+                                break;
+                        }
+
+                        stageColorMaskBits = IW_ColorMaskBits(base_stage->colorMask);
+
+                        alpha_params0[0] = 0.f;
+                        alpha_params0[1] = 1.f;
+                        alpha_params0[2] = base_stage->alphaWave.base;
+                        alpha_params0[3] = base_stage->alphaWave.amplitude;
+                        alpha_params1[0] = base_stage->alphaWave.phase;
+                        alpha_params1[1] = base_stage->alphaWave.frequency;
+                        alpha_params1[2] = (float)base_stage->mask;
+                        alpha_params1[3] = (float)base_stage->alphaWave.func;
+
+                        switch (base_stage->alphagen)
+                        {
+                        case IW_A_CONST:
+                                alpha_params0[0] = 1.f;
+                                alpha_params0[1] = q_clamp(base_stage->aConst, 0.f, 1.f);
+                                break;
+
+                        case IW_A_ENTITY:
+                                alpha_params0[0] = 2.f;
+                                break;
+
+                        case IW_A_WAVE:
+                                alpha_params0[0] = 3.f;
+                                break;
+
+                        case IW_A_MASK:
+                                alpha_params0[0] = 4.f;
+                                break;
+
+                        default:
+                                alpha_params0[0] = 0.f;
+                                break;
+                        }
+
+                        stageAlphaFuncMode = base_stage->alphaFuncMode;
+                        stageAlphaFuncRef = q_clamp(base_stage->alphaFuncRef, 0.f, 1.f);
+                        if (stageAlphaFuncMode != IW_ALPHA_FUNC_DISABLED && stageAlphaFuncMode != IW_ALPHA_FUNC_ALWAYS)
+                                stageAlphaTest = true;
+                        else
+                                stageAlphaTest = (stageAlphaFuncMode == IW_ALPHA_FUNC_NEVER);
+
+                        alpha_params2[0] = (float)stageAlphaFuncMode;
+                        alpha_params2[1] = stageAlphaFuncRef;
+                        alpha_params2[2] = stageAlphaTest ? 1.f : 0.f;
+                        alpha_params2[3] = base_stage->alphaToCoverage ? 1.f : 0.f;
 
                         if (base_stage->maskExplicit)
                                 base_tcmod_params1[2] = (float)base_stage->mask;
@@ -745,6 +1069,18 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
                 }
         }
 
+        if (!stageAlphaTest && t && t->type == TEXTYPE_CUTOUT)
+        {
+                stageAlphaTest = true;
+                stageAlphaFuncMode = IW_ALPHA_FUNC_GEQUAL;
+                stageAlphaFuncRef = 2.f / 3.f;
+        }
+
+        stageAlphaFuncRef = q_clamp(stageAlphaFuncRef, 0.f, 1.f);
+        alpha_params2[0] = (float)stageAlphaFuncMode;
+        alpha_params2[1] = stageAlphaFuncRef;
+        alpha_params2[2] = stageAlphaTest ? 1.f : 0.f;
+
         if (num_bmodel_calls == MAX_BMODEL_DRAWS)
                 R_FlushBModelCalls ();
 
@@ -779,14 +1115,12 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
         flags = zfix | ((fb != NULL) << 1) | ((r_fullbright_cheatsafe != false) << 2);
         if (em != NULL)
                 flags |= CALLFLAG_EMISSIVE;
-        if (t && t->type == TEXTYPE_CUTOUT)
+        if (stageAlphaTest)
                 flags |= CALLFLAG_ALPHA_TEST;
         flags |= tc_feature_flags;
         if (has_material_fog)
                 flags |= CALLFLAG_CUSTOM_FOG;
         alpha = t ? GL_WaterAlphaForTextureType (t->type) : 1.f;
-        if (material_alpha >= 0.f)
-                alpha = material_alpha;
 
         if (gl_bindless_able)
         {
@@ -813,6 +1147,9 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
                 call->emissive_color[2] = emissive_color[2];
                 call->emissive_color[3] = (flags & CALLFLAG_EMISSIVE) ? 1.f : 0.f;
                 memcpy (call->fog_color, fog_color, sizeof (fog_color));
+                memcpy (call->alpha_params0, alpha_params0, sizeof (alpha_params0));
+                memcpy (call->alpha_params1, alpha_params1, sizeof (alpha_params1));
+                memcpy (call->alpha_params2, alpha_params2, sizeof (alpha_params2));
         }
         else
         {
@@ -839,6 +1176,9 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
                 call->emissive_color[2] = emissive_color[2];
                 call->emissive_color[3] = (flags & CALLFLAG_EMISSIVE) ? 1.f : 0.f;
                 memcpy (call->fog_color, fog_color, sizeof (fog_color));
+                memcpy (call->alpha_params0, alpha_params0, sizeof (alpha_params0));
+                memcpy (call->alpha_params1, alpha_params1, sizeof (alpha_params1));
+                memcpy (call->alpha_params2, alpha_params2, sizeof (alpha_params2));
                 textures[0] = tx ? tx : greytexture;
                 textures[1] = fb ? fb : blacktexture;
                 textures[2] = em ? em : blacktexture;
@@ -848,6 +1188,12 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
         SDL_assert (num_instances <= MAX_BMODEL_INSTANCES);
         bmodel_call_depth_test[num_bmodel_calls] = depthTestOverride;
         bmodel_call_depth_write[num_bmodel_calls] = depthWriteOverride;
+        bmodel_call_depth_func_override[num_bmodel_calls] = (stageDepthFunc >= 0) ? 1 : 0;
+        bmodel_call_depth_func[num_bmodel_calls] = (stageDepthFunc >= 0) ? stageDepthFunc : GL_LEQUAL;
+        bmodel_call_blend_enable[num_bmodel_calls] = stageBlendEnabled;
+        bmodel_call_blend_src[num_bmodel_calls] = stageBlendSrc;
+        bmodel_call_blend_dst[num_bmodel_calls] = stageBlendDst;
+        bmodel_call_color_mask[num_bmodel_calls] = stageColorMaskBits;
         bmodel_call_cull[num_bmodel_calls] = cull;
         bmodel_call_remap[num_bmodel_calls].src = index;
         bmodel_call_remap[num_bmodel_calls].inst = first_instance * MAX_BMODEL_INSTANCES + (num_instances - 1);

--- a/Quake/renderer/r_iwshader.c
+++ b/Quake/renderer/r_iwshader.c
@@ -373,18 +373,199 @@ static qboolean IW_ReadInt(iwtxtParser_t *parser, int *out, iwtxtToken_t *token)
     return true;
 }
 
+static float IW_NormalizeAlphaRef(double value)
+{
+    float ref = (float)value;
+    if (ref > 1.f)
+        ref = ref / 255.f;
+    return q_clamp(ref, 0.f, 1.f);
+}
+
+static qboolean IW_ParseAlphaFuncDigits(const char *text, float *outRef)
+{
+    if (!text || !*text)
+        return false;
+
+    char *endptr = NULL;
+    double value = strtod(text, &endptr);
+    if (!endptr || endptr == text)
+        return false;
+
+    *outRef = IW_NormalizeAlphaRef(value);
+    return true;
+}
+
+static qboolean IW_ParseAlphaFuncToken(const char *text, iwAlphaFunc_t *func, float *ref, qboolean *needsValue)
+{
+    if (!text || !func || !ref || !needsValue)
+        return false;
+
+    *needsValue = false;
+
+    if (!q_strcasecmp(text, "always"))
+    {
+        *func = IW_ALPHA_FUNC_ALWAYS;
+        *ref = 0.f;
+        return true;
+    }
+    if (!q_strcasecmp(text, "never"))
+    {
+        *func = IW_ALPHA_FUNC_NEVER;
+        *ref = 0.f;
+        return true;
+    }
+
+    if (!q_strncasecmp(text, "gt", 2))
+    {
+        *func = IW_ALPHA_FUNC_GREATER;
+        if (!IW_ParseAlphaFuncDigits(text + 2, ref))
+            *needsValue = true;
+        return true;
+    }
+
+    if (!q_strncasecmp(text, "ge", 2))
+    {
+        *func = IW_ALPHA_FUNC_GEQUAL;
+        if (!IW_ParseAlphaFuncDigits(text + 2, ref))
+            *needsValue = true;
+        return true;
+    }
+
+    if (!q_strncasecmp(text, "lt", 2))
+    {
+        *func = IW_ALPHA_FUNC_LESS;
+        if (!IW_ParseAlphaFuncDigits(text + 2, ref))
+            *needsValue = true;
+        return true;
+    }
+
+    if (!q_strncasecmp(text, "le", 2))
+    {
+        *func = IW_ALPHA_FUNC_LEQUAL;
+        if (!IW_ParseAlphaFuncDigits(text + 2, ref))
+            *needsValue = true;
+        return true;
+    }
+
+    if (!q_strncasecmp(text, "eq", 2))
+    {
+        *func = IW_ALPHA_FUNC_EQUAL;
+        if (!IW_ParseAlphaFuncDigits(text + 2, ref))
+            *needsValue = true;
+        return true;
+    }
+
+    if (!q_strncasecmp(text, "ne", 2))
+    {
+        *func = IW_ALPHA_FUNC_NOTEQUAL;
+        if (!IW_ParseAlphaFuncDigits(text + 2, ref))
+            *needsValue = true;
+        return true;
+    }
+
+    if (!q_strcasecmp(text, "greater"))
+    {
+        *func = IW_ALPHA_FUNC_GREATER;
+        *ref = 0.f;
+        return true;
+    }
+
+    if (!q_strcasecmp(text, "gequal"))
+    {
+        *func = IW_ALPHA_FUNC_GEQUAL;
+        *ref = 0.5f;
+        return true;
+    }
+
+    if (!q_strcasecmp(text, "less"))
+    {
+        *func = IW_ALPHA_FUNC_LESS;
+        *ref = 0.5f;
+        return true;
+    }
+
+    if (!q_strcasecmp(text, "lequal"))
+    {
+        *func = IW_ALPHA_FUNC_LEQUAL;
+        *ref = 0.5f;
+        return true;
+    }
+
+    if (!q_strcasecmp(text, "equal"))
+    {
+        *func = IW_ALPHA_FUNC_EQUAL;
+        *ref = 0.5f;
+        return true;
+    }
+
+    if (!q_strcasecmp(text, "notequal"))
+    {
+        *func = IW_ALPHA_FUNC_NOTEQUAL;
+        *ref = 0.5f;
+        return true;
+    }
+
+    return false;
+}
+
+static qboolean IW_ParseDepthFunc(const char *text, iwDepthFunc_t *out)
+{
+    if (!text || !out)
+        return false;
+
+    if (!q_strcasecmp(text, "never")) { *out = IW_DEPTHFUNC_NEVER; return true; }
+    if (!q_strcasecmp(text, "less")) { *out = IW_DEPTHFUNC_LESS; return true; }
+    if (!q_strcasecmp(text, "equal")) { *out = IW_DEPTHFUNC_EQUAL; return true; }
+    if (!q_strcasecmp(text, "lequal")) { *out = IW_DEPTHFUNC_LEQUAL; return true; }
+    if (!q_strcasecmp(text, "greater")) { *out = IW_DEPTHFUNC_GREATER; return true; }
+    if (!q_strcasecmp(text, "notequal")) { *out = IW_DEPTHFUNC_NOTEQUAL; return true; }
+    if (!q_strcasecmp(text, "gequal")) { *out = IW_DEPTHFUNC_GEQUAL; return true; }
+    if (!q_strcasecmp(text, "always")) { *out = IW_DEPTHFUNC_ALWAYS; return true; }
+
+    return false;
+}
+
+static void IW_NormalizeBlendToken(const char *text, char *out, size_t size)
+{
+    if (!text || !out || size == 0)
+        return;
+
+    size_t j = 0;
+    if ((text[0] == 'g' || text[0] == 'G') && (text[1] == 'l' || text[1] == 'L'))
+    {
+        if (text[2] == '_')
+            text += 3;
+        else
+            text += 2;
+    }
+
+    for (; *text && j + 1 < size; ++text)
+    {
+        if (*text == '_')
+            continue;
+        out[j++] = (char) q_tolower((unsigned char) *text);
+    }
+    out[j] = '\0';
+}
+
 static qboolean IW_ParseBlendFactor(const char *text, iwBlendFactor_t *out)
 {
-    if (!q_strcasecmp(text, "zero")) { *out = IW_SRC_ZERO; return true; }
-    if (!q_strcasecmp(text, "one")) { *out = IW_SRC_ONE; return true; }
-    if (!q_strcasecmp(text, "src_color")) { *out = IW_SRC_SRC_COLOR; return true; }
-    if (!q_strcasecmp(text, "one_minus_src_color")) { *out = IW_SRC_ONE_MINUS_SRC_COLOR; return true; }
-    if (!q_strcasecmp(text, "dst_color")) { *out = IW_SRC_DST_COLOR; return true; }
-    if (!q_strcasecmp(text, "one_minus_dst_color")) { *out = IW_SRC_ONE_MINUS_DST_COLOR; return true; }
-    if (!q_strcasecmp(text, "src_alpha")) { *out = IW_SRC_SRC_ALPHA; return true; }
-    if (!q_strcasecmp(text, "one_minus_src_alpha")) { *out = IW_SRC_ONE_MINUS_SRC_ALPHA; return true; }
-    if (!q_strcasecmp(text, "dst_alpha")) { *out = IW_SRC_DST_ALPHA; return true; }
-    if (!q_strcasecmp(text, "one_minus_dst_alpha")) { *out = IW_SRC_ONE_MINUS_DST_ALPHA; return true; }
+    if (!text || !out)
+        return false;
+
+    char normalized[32];
+    IW_NormalizeBlendToken(text, normalized, sizeof(normalized));
+
+    if (!strcmp(normalized, "zero")) { *out = IW_SRC_ZERO; return true; }
+    if (!strcmp(normalized, "one")) { *out = IW_SRC_ONE; return true; }
+    if (!strcmp(normalized, "srccolor")) { *out = IW_SRC_SRC_COLOR; return true; }
+    if (!strcmp(normalized, "oneminussrccolor")) { *out = IW_SRC_ONE_MINUS_SRC_COLOR; return true; }
+    if (!strcmp(normalized, "dstcolor")) { *out = IW_SRC_DST_COLOR; return true; }
+    if (!strcmp(normalized, "oneminusdstcolor")) { *out = IW_SRC_ONE_MINUS_DST_COLOR; return true; }
+    if (!strcmp(normalized, "srcalpha")) { *out = IW_SRC_SRC_ALPHA; return true; }
+    if (!strcmp(normalized, "oneminussrcalpha")) { *out = IW_SRC_ONE_MINUS_SRC_ALPHA; return true; }
+    if (!strcmp(normalized, "dstalpha")) { *out = IW_SRC_DST_ALPHA; return true; }
+    if (!strcmp(normalized, "oneminusdstalpha")) { *out = IW_SRC_ONE_MINUS_DST_ALPHA; return true; }
     return false;
 }
 
@@ -661,7 +842,12 @@ static void IW_SetStageDefaults(iwStage_t *stage)
     stage->tcAlignExplicit = 0;
     stage->tcGen[0] = '\0';
     stage->alphaFunc[0] = '\0';
+    stage->alphaFuncMode = IW_ALPHA_FUNC_DISABLED;
+    stage->alphaFuncRef = 0.f;
+    stage->alphaFuncExplicit = 0;
     stage->depthFunc[0] = '\0';
+    stage->depthFuncMode = IW_DEPTHFUNC_DEFAULT;
+    stage->depthFuncExplicit = 0;
     stage->stageCondition[0] = '\0';
     stage->hasFogParms = 0;
     stage->alphaToCoverage = 0;
@@ -845,6 +1031,12 @@ static qboolean IW_ParseStage(iwtxtParser_t *parser, iwMaterial_t *material, con
                 stage.dst = IW_SRC_ONE;
             }
             else if (!strcmp(mode, "mul"))
+            {
+                stage.blendMode = IW_BLEND_MUL;
+                stage.src = IW_SRC_DST_COLOR;
+                stage.dst = IW_SRC_ZERO;
+            }
+            else if (!strcmp(mode, "filter"))
             {
                 stage.blendMode = IW_BLEND_MUL;
                 stage.src = IW_SRC_DST_COLOR;
@@ -1323,7 +1515,64 @@ static qboolean IW_ParseStage(iwtxtParser_t *parser, iwMaterial_t *material, con
                     return false;
                 continue;
             }
-            IW_CopyTokenLower(&token, stage.alphaFunc, sizeof(stage.alphaFunc));
+
+            char funcToken[32];
+            IW_CopyTokenLower(&token, funcToken, sizeof(funcToken));
+            q_strlcpy(stage.alphaFunc, funcToken, sizeof(stage.alphaFunc));
+
+            qboolean needsValue = false;
+            float ref = 0.f;
+            if (!IW_ParseAlphaFuncToken(funcToken, &stage.alphaFuncMode, &ref, &needsValue))
+            {
+                IW_LogWarning(filename, token.line, token.column, "unknown alphafunc '%s'", funcToken);
+                stage.alphaFuncMode = IW_ALPHA_FUNC_DISABLED;
+                stage.alphaFuncRef = 0.f;
+                stage.alphaFuncExplicit = 0;
+                stage.alphaFunc[0] = '\0';
+                if (strict)
+                    return false;
+                continue;
+            }
+
+            stage.alphaFuncRef = ref;
+            stage.alphaFuncExplicit = 1;
+
+            if (needsValue)
+            {
+                iwtxtToken_t valueToken;
+                if (!IWTXT_NextToken(parser, &valueToken) || valueToken.type != IWTXT_TOKEN_NUMBER)
+                {
+                    IW_LogWarning(filename, token.line, token.column, "alphafunc requires a numeric value");
+                    stage.alphaFuncMode = IW_ALPHA_FUNC_DISABLED;
+                    stage.alphaFuncRef = 0.f;
+                    stage.alphaFuncExplicit = 0;
+                    stage.alphaFunc[0] = '\0';
+                    if (strict)
+                        return false;
+                    continue;
+                }
+
+                stage.alphaFuncRef = IW_NormalizeAlphaRef(valueToken.number);
+                char valueText[32];
+                IW_CopyTokenText(&valueToken, valueText, sizeof(valueText));
+                q_strlcat(stage.alphaFunc, " ", sizeof(stage.alphaFunc));
+                q_strlcat(stage.alphaFunc, valueText, sizeof(stage.alphaFunc));
+            }
+            else
+            {
+                iwtxtToken_t peek;
+                if (IWTXT_PeekToken(parser, &peek) && peek.type == IWTXT_TOKEN_NUMBER)
+                {
+                    if (IWTXT_NextToken(parser, &peek))
+                    {
+                        stage.alphaFuncRef = IW_NormalizeAlphaRef(peek.number);
+                        char valueText[32];
+                        IW_CopyTokenText(&peek, valueText, sizeof(valueText));
+                        q_strlcat(stage.alphaFunc, " ", sizeof(stage.alphaFunc));
+                        q_strlcat(stage.alphaFunc, valueText, sizeof(stage.alphaFunc));
+                    }
+                }
+            }
         }
         else if (!strcmp(keyword, "depthfunc"))
         {
@@ -1335,6 +1584,15 @@ static qboolean IW_ParseStage(iwtxtParser_t *parser, iwMaterial_t *material, con
                 continue;
             }
             IW_CopyTokenLower(&token, stage.depthFunc, sizeof(stage.depthFunc));
+            stage.depthFuncExplicit = 1;
+            if (!IW_ParseDepthFunc(stage.depthFunc, &stage.depthFuncMode))
+            {
+                IW_LogWarning(filename, token.line, token.column, "unknown depthfunc '%s'", stage.depthFunc);
+                stage.depthFuncMode = IW_DEPTHFUNC_DEFAULT;
+                stage.depthFuncExplicit = 0;
+                if (strict)
+                    return false;
+            }
         }
         else if (!strcmp(keyword, "normalmap"))
         {

--- a/Quake/renderer/r_iwshader.h
+++ b/Quake/renderer/r_iwshader.h
@@ -64,6 +64,30 @@ typedef enum {
 } iwAlphaGen_t;
 
 typedef enum {
+    IW_ALPHA_FUNC_DISABLED = 0,
+    IW_ALPHA_FUNC_NEVER,
+    IW_ALPHA_FUNC_LESS,
+    IW_ALPHA_FUNC_EQUAL,
+    IW_ALPHA_FUNC_LEQUAL,
+    IW_ALPHA_FUNC_GREATER,
+    IW_ALPHA_FUNC_NOTEQUAL,
+    IW_ALPHA_FUNC_GEQUAL,
+    IW_ALPHA_FUNC_ALWAYS
+} iwAlphaFunc_t;
+
+typedef enum {
+    IW_DEPTHFUNC_DEFAULT = -1,
+    IW_DEPTHFUNC_NEVER = 0,
+    IW_DEPTHFUNC_LESS,
+    IW_DEPTHFUNC_EQUAL,
+    IW_DEPTHFUNC_LEQUAL,
+    IW_DEPTHFUNC_GREATER,
+    IW_DEPTHFUNC_NOTEQUAL,
+    IW_DEPTHFUNC_GEQUAL,
+    IW_DEPTHFUNC_ALWAYS
+} iwDepthFunc_t;
+
+typedef enum {
     IW_TC_SCROLL = 0,
     IW_TC_SCALE,
     IW_TC_ROTATE,
@@ -172,7 +196,12 @@ typedef struct {
     int tcAlignExplicit;
     char tcGen[IW_MAX_TCGEN_TEXT];
     char alphaFunc[32];
+    iwAlphaFunc_t alphaFuncMode;
+    float alphaFuncRef;
+    int alphaFuncExplicit;
     char depthFunc[32];
+    iwDepthFunc_t depthFuncMode;
+    int depthFuncExplicit;
     char stageCondition[IW_MAX_STAGE_CONDITION];
     iwFogParms_t fogParms;
     int hasFogParms;

--- a/Quake/shaders/sky_cubemap.vert
+++ b/Quake/shaders/sky_cubemap.vert
@@ -35,6 +35,9 @@ struct Call
         vec4    emissive_translate;
         vec4    emissive_color;
         vec4    fog_color;
+        vec4    alpha_params0;
+        vec4    alpha_params1;
+        vec4    alpha_params2;
 };
 const uint
 	CF_USE_POLYGON_OFFSET = 1u,

--- a/Quake/shaders/sky_layers.vert
+++ b/Quake/shaders/sky_layers.vert
@@ -35,6 +35,9 @@ struct Call
         vec4    emissive_translate;
         vec4    emissive_color;
         vec4    fog_color;
+        vec4    alpha_params0;
+        vec4    alpha_params1;
+        vec4    alpha_params2;
 };
 const uint
 	CF_USE_POLYGON_OFFSET = 1u,

--- a/Quake/shaders/skystencil.vert
+++ b/Quake/shaders/skystencil.vert
@@ -35,6 +35,9 @@ struct Call
         vec4    emissive_translate;
         vec4    emissive_color;
         vec4    fog_color;
+        vec4    alpha_params0;
+        vec4    alpha_params1;
+        vec4    alpha_params2;
 };
 const uint
 	CF_USE_POLYGON_OFFSET = 1u,

--- a/Quake/shaders/water.frag
+++ b/Quake/shaders/water.frag
@@ -77,12 +77,112 @@ float tri(float x)
 
 vec2 ComputeVelocity(vec4 curr_clip, vec4 prev_clip)
 {
-	const float EPS = 1e-6;
-	float inv_curr_w = abs(curr_clip.w) > EPS ? 1.0 / curr_clip.w : 0.0;
-	float inv_prev_w = abs(prev_clip.w) > EPS ? 1.0 / prev_clip.w : 0.0;
-	vec2 curr_ndc = curr_clip.xy * inv_curr_w;
-	vec2 prev_ndc = prev_clip.xy * inv_prev_w;
-	return (curr_ndc - prev_ndc) * 0.5;
+        const float EPS = 1e-6;
+        float inv_curr_w = abs(curr_clip.w) > EPS ? 1.0 / curr_clip.w : 0.0;
+        float inv_prev_w = abs(prev_clip.w) > EPS ? 1.0 / prev_clip.w : 0.0;
+        vec2 curr_ndc = curr_clip.xy * inv_curr_w;
+        vec2 prev_ndc = prev_clip.xy * inv_prev_w;
+        return (curr_ndc - prev_ndc) * 0.5;
+}
+
+float EvaluateWave(vec4 params, int func)
+{
+        float base = params.x;
+        float amplitude = params.y;
+        float phase = params.z;
+        float frequency = params.w;
+        float cycle = Time * frequency + phase / 360.0;
+        float wave = 0.0;
+        const float TAU = 6.28318530718;
+
+        if (func == 0)
+        {
+                float angle = cycle * TAU;
+                wave = sin(angle);
+        }
+        else if (func == 1)
+        {
+                float f = fract(cycle);
+                wave = (abs(f * 2.0 - 1.0) * 2.0) - 1.0;
+        }
+        else if (func == 2)
+        {
+                float angle = cycle * TAU;
+                wave = sign(sin(angle));
+                if (wave == 0.0)
+                        wave = 1.0;
+        }
+        else if (func == 3)
+        {
+                float f = fract(cycle);
+                wave = f * 2.0 - 1.0;
+        }
+        else
+        {
+                float angle = cycle * TAU;
+                wave = sin(angle);
+        }
+
+        return base + amplitude * wave;
+}
+
+float SampleMaskChannel(vec4 texel, int maskChannel)
+{
+        if (maskChannel == 0)
+                return texel.r;
+        if (maskChannel == 1)
+                return texel.g;
+        if (maskChannel == 2)
+                return texel.b;
+        return texel.a;
+}
+
+float ComputeStageAlpha(vec4 texel, vec4 params0, vec4 params1)
+{
+        int type = int(params0.x + 0.5);
+        if (type == 1)
+                return clamp(params0.y, 0.0, 1.0);
+        if (type == 2)
+                return 1.0;
+        if (type == 3)
+        {
+                vec4 waveParams = vec4(params0.z, params0.w, params1.x, params1.y);
+                int func = int(params1.w + 0.5);
+                return clamp(EvaluateWave(waveParams, func), 0.0, 1.0);
+        }
+        if (type == 4)
+        {
+                int maskChannel = int(params1.z + 0.5);
+                return clamp(SampleMaskChannel(texel, maskChannel), 0.0, 1.0);
+        }
+
+        return clamp(texel.a, 0.0, 1.0);
+}
+
+bool AlphaTestPass(float alpha, int func, float ref)
+{
+        const float EPS = 1.0e-4;
+        switch (func)
+        {
+        case 1:
+                return false;
+        case 2:
+                return alpha < ref;
+        case 3:
+                return abs(alpha - ref) <= EPS;
+        case 4:
+                return alpha <= ref;
+        case 5:
+                return alpha > ref;
+        case 6:
+                return abs(alpha - ref) > EPS;
+        case 7:
+                return alpha >= ref;
+        case 8:
+                return true;
+        default:
+                return true;
+        }
 }
 
 layout(location=0) flat in uint in_flags;
@@ -98,7 +198,10 @@ layout(location=7) noperspective in vec4 in_prev_clip;
 layout(location=8) in vec2 in_emissive_uv;
 layout(location=9) flat in vec3 in_emissive_color;
 layout(location=10) flat in vec4 in_stage_params1;
-layout(location=11) flat in vec4 in_fog_color;
+layout(location=11) flat in vec4 in_alpha_params0;
+layout(location=12) flat in vec4 in_alpha_params1;
+layout(location=13) flat in vec4 in_alpha_params2;
+layout(location=14) flat in vec4 in_fog_color;
 
 #define OUT_COLOR out_fragcolor
 #if OIT
@@ -182,12 +285,25 @@ void main()
                         result.r = 0.0;
                         result.g = 0.0;
                 }
-                else if (maskChannel == 3)
-                {
-                        result.rgb = vec3(1.0);
-                        result.a = clamp(result.a, 0.0, 1.0);
-                }
+        else if (maskChannel == 3)
+        {
+                result.rgb = vec3(1.0);
+                result.a = clamp(result.a, 0.0, 1.0);
         }
+    }
+
+    float baseAlpha = clamp(in_alpha, 0.0, 1.0);
+    float stageAlpha = ComputeStageAlpha(result, in_alpha_params0, in_alpha_params1);
+    if (in_alpha_params2.z > 0.5)
+    {
+            int alphaFunc = int(in_alpha_params2.x + 0.5);
+            float alphaRef = clamp(in_alpha_params2.y, 0.0, 1.0);
+            if (!AlphaTestPass(stageAlpha, alphaFunc, alphaRef))
+                    discard;
+    }
+    float finalAlpha = clamp(baseAlpha * stageAlpha, 0.0, 1.0);
+    result.a = finalAlpha;
+
         result.rgb += fullbright;
         result.rgb += emissive;
 
@@ -220,7 +336,7 @@ void main()
         result.rgb = clamp(result.rgb, 0.0, 1.0);
         vec4 fogData = ((in_flags & CF_CUSTOM_FOG) != 0u) ? in_fog_color : Fog;
         result.rgb = ApplyFog(result.rgb, in_pos, fogData);
-        result.a *= in_alpha;
+        result.a = finalAlpha;
         out_fragcolor = result;
 #if !OIT
         vec2 velocity = ComputeVelocity(in_curr_clip, in_prev_clip);

--- a/Quake/shaders/water.vert
+++ b/Quake/shaders/water.vert
@@ -35,6 +35,9 @@ struct Call
         vec4    emissive_translate;
         vec4    emissive_color;
         vec4    fog_color;
+        vec4    alpha_params0;
+        vec4    alpha_params1;
+        vec4    alpha_params2;
 };
 const uint
 	CF_USE_POLYGON_OFFSET = 1u,
@@ -109,7 +112,10 @@ layout(location=7) noperspective out vec4 out_prev_clip;
 layout(location=8) out vec2 out_emissive_uv;
 layout(location=9) flat out vec3 out_emissive_color;
 layout(location=10) flat out vec4 out_stage_params1;
-layout(location=11) flat out vec4 out_fog_color;
+layout(location=11) flat out vec4 out_alpha_params0;
+layout(location=12) flat out vec4 out_alpha_params1;
+layout(location=13) flat out vec4 out_alpha_params2;
+layout(location=14) flat out vec4 out_fog_color;
 
 float EvaluateWave(vec4 params, int func)
 {
@@ -199,6 +205,9 @@ void main()
 #endif
         out_emissive_color = call.emissive_color.xyz;
         out_stage_params1 = call.tcmod_params1;
+        out_alpha_params0 = call.alpha_params0;
+        out_alpha_params1 = call.alpha_params1;
+        out_alpha_params2 = call.alpha_params2;
         out_fog_color = call.fog_color;
 }
 

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -114,6 +114,106 @@ vec3 ComputeSunLight(vec3 pos, vec3 normal)
     return vec3(0.0);
 }
 
+float EvaluateWave(vec4 params, int func)
+{
+    float base = params.x;
+    float amplitude = params.y;
+    float phase = params.z;
+    float frequency = params.w;
+    float cycle = Time * frequency + phase / 360.0;
+    float wave = 0.0;
+    const float TAU = 6.28318530718;
+
+    if (func == 0)
+    {
+        float angle = cycle * TAU;
+        wave = sin(angle);
+    }
+    else if (func == 1)
+    {
+        float f = fract(cycle);
+        wave = (abs(f * 2.0 - 1.0) * 2.0) - 1.0;
+    }
+    else if (func == 2)
+    {
+        float angle = cycle * TAU;
+        wave = sign(sin(angle));
+        if (wave == 0.0)
+            wave = 1.0;
+    }
+    else if (func == 3)
+    {
+        float f = fract(cycle);
+        wave = f * 2.0 - 1.0;
+    }
+    else
+    {
+        float angle = cycle * TAU;
+        wave = sin(angle);
+    }
+
+    return base + amplitude * wave;
+}
+
+float SampleMaskChannel(vec4 texel, int maskChannel)
+{
+    if (maskChannel == 0)
+        return texel.r;
+    if (maskChannel == 1)
+        return texel.g;
+    if (maskChannel == 2)
+        return texel.b;
+    return texel.a;
+}
+
+float ComputeStageAlpha(vec4 texel, vec4 params0, vec4 params1)
+{
+    int type = int(params0.x + 0.5);
+    if (type == 1)
+        return clamp(params0.y, 0.0, 1.0);
+    if (type == 2)
+        return 1.0;
+    if (type == 3)
+    {
+        vec4 waveParams = vec4(params0.z, params0.w, params1.x, params1.y);
+        int func = int(params1.w + 0.5);
+        return clamp(EvaluateWave(waveParams, func), 0.0, 1.0);
+    }
+    if (type == 4)
+    {
+        int maskChannel = int(params1.z + 0.5);
+        return clamp(SampleMaskChannel(texel, maskChannel), 0.0, 1.0);
+    }
+
+    return clamp(texel.a, 0.0, 1.0);
+}
+
+bool AlphaTestPass(float alpha, int func, float ref)
+{
+    const float EPS = 1.0e-4;
+    switch (func)
+    {
+    case 1:
+        return false;
+    case 2:
+        return alpha < ref;
+    case 3:
+        return abs(alpha - ref) <= EPS;
+    case 4:
+        return alpha <= ref;
+    case 5:
+        return alpha > ref;
+    case 6:
+        return abs(alpha - ref) > EPS;
+    case 7:
+        return alpha >= ref;
+    case 8:
+        return true;
+    default:
+        return true;
+    }
+}
+
 layout(location=0) flat in uint in_flags;
 layout(location=1) flat in float in_alpha;
 layout(location=2) in vec3 in_pos;
@@ -136,7 +236,10 @@ layout(location=12) noperspective in vec4 in_prev_clip;
 layout(location=13) in vec2 in_emissive_uv;
 layout(location=14) flat in vec3 in_emissive_color;
 layout(location=15) flat in vec4 in_stage_params1;
-layout(location=16) flat in vec4 in_fog_color;
+layout(location=16) flat in vec4 in_alpha_params0;
+layout(location=17) flat in vec4 in_alpha_params1;
+layout(location=18) flat in vec4 in_alpha_params2;
+layout(location=19) flat in vec4 in_fog_color;
 
 #define OUT_COLOR out_fragcolor
 #if OIT
@@ -318,15 +421,17 @@ void main()
         }
     }
 
-#if MODE == 1
-  #if USE_BRANCHLESS_ALPHA
-    // branchless discard vermeiden → identische Optik, aber OIT kann abweichen.
-    // Wenn du strikt discard brauchst, setze USE_BRANCHLESS_ALPHA=0.
-    if (result.a < 0.666) { discard; }
-  #else
-    if (result.a < 0.666) discard;
-  #endif
-#endif
+    float baseAlpha = clamp(in_alpha, 0.0, 1.0);
+    float stageAlpha = ComputeStageAlpha(result, in_alpha_params0, in_alpha_params1);
+    if (in_alpha_params2.z > 0.5)
+    {
+        int alphaFunc = int(in_alpha_params2.x + 0.5);
+        float alphaRef = clamp(in_alpha_params2.y, 0.0, 1.0);
+        if (!AlphaTestPass(stageAlpha, alphaFunc, alphaRef))
+            discard;
+    }
+    float finalAlpha = clamp(baseAlpha * stageAlpha, 0.0, 1.0);
+    result.a = finalAlpha;
 
     // Lightmap fetch: unverändert, aber mit weniger temporären Vektoren
     vec2 lmuv = in_lmuv;
@@ -545,7 +650,7 @@ void main()
     vec4 fogData = ((in_flags & CF_CUSTOM_FOG) != 0u) ? in_fog_color : Fog;
     result.rgb = ApplyFog(result.rgb, in_pos - EyePos, fogData);
 
-    result.a = in_alpha;
+    result.a = finalAlpha;
 
 #if OIT
     OUT_COLOR = result; // Rest bleibt wie gehabt im OIT-Zweig

--- a/Quake/shaders/world.vert
+++ b/Quake/shaders/world.vert
@@ -64,6 +64,9 @@ struct Call
         vec4    emissive_translate;
         vec4    emissive_color;
         vec4    fog_color;
+        vec4    alpha_params0;
+        vec4    alpha_params1;
+        vec4    alpha_params2;
 };
 const uint
 	CF_USE_POLYGON_OFFSET = 1u,
@@ -146,7 +149,10 @@ layout(location=12) noperspective out vec4 out_prev_clip;
 layout(location=13) out vec2 out_emissive_uv;
 layout(location=14) flat out vec3 out_emissive_color;
 layout(location=15) flat out vec4 out_stage_params1;
-layout(location=16) flat out vec4 out_fog_color;
+layout(location=16) flat out vec4 out_alpha_params0;
+layout(location=17) flat out vec4 out_alpha_params1;
+layout(location=18) flat out vec4 out_alpha_params2;
+layout(location=19) flat out vec4 out_fog_color;
 
 float EvaluateWave(vec4 params, int func)
 {
@@ -268,5 +274,8 @@ void main()
 #endif
         out_emissive_color = call.emissive_color.xyz;
         out_stage_params1 = call.tcmod_params1;
+        out_alpha_params0 = call.alpha_params0;
+        out_alpha_params1 = call.alpha_params1;
+        out_alpha_params2 = call.alpha_params2;
         out_fog_color = call.fog_color;
 }


### PR DESCRIPTION
## Summary
- extend iwshader parser and material stages with alpha/depth enums and blend factor helpers
- propagate per-stage blend, depth, alpha, and color mask data through bmodel call submission
- update world and water shaders (plus sky variants) to consume new alpha parameters and enforce alpha tests

## Testing
- not run (SDL2 dependency missing in container environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912377d5bbc832e8f6bde8e77cd1cfd)