### PR TITLE
Support multi-stage material effects

### DIFF
--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -36,6 +36,8 @@ extern cvar_t r_oit;
 extern gltexture_t *lightmap_texture;
 extern gltexture_t *deluxemap_texture;
 
+#define MAX_EFFECT_STAGES 4
+
 extern GLuint gl_bmodel_vbo;
 extern size_t gl_bmodel_vbo_size;
 extern GLuint gl_bmodel_ibo;
@@ -191,6 +193,17 @@ typedef struct bmodel_bindless_gpu_call_s {
 	float		env_params0[4];
 	float		env_params1[4];
 	float		env_params2[4];
+	float		effect_info[4];
+	float		effect_matrix[MAX_EFFECT_STAGES][4];
+	float		effect_translate[MAX_EFFECT_STAGES][4];
+	float		effect_color[MAX_EFFECT_STAGES][4];
+	float		effect_alpha_params0[MAX_EFFECT_STAGES][4];
+	float		effect_alpha_params1[MAX_EFFECT_STAGES][4];
+	float		effect_alpha_params2[MAX_EFFECT_STAGES][4];
+	float		effect_tcmod_params0[MAX_EFFECT_STAGES][4];
+	float		effect_tcmod_params1[MAX_EFFECT_STAGES][4];
+	float		effect_flags[MAX_EFFECT_STAGES][4];
+	GLuint64	effect_handles[MAX_EFFECT_STAGES];
 } bmodel_bindless_gpu_call_t;
 
 typedef struct bmodel_bound_gpu_call_s {
@@ -215,6 +228,16 @@ typedef struct bmodel_bound_gpu_call_s {
 	float		env_params0[4];
 	float		env_params1[4];
 	float		env_params2[4];
+	float		effect_info[4];
+	float		effect_matrix[MAX_EFFECT_STAGES][4];
+	float		effect_translate[MAX_EFFECT_STAGES][4];
+	float		effect_color[MAX_EFFECT_STAGES][4];
+	float		effect_alpha_params0[MAX_EFFECT_STAGES][4];
+	float		effect_alpha_params1[MAX_EFFECT_STAGES][4];
+	float		effect_alpha_params2[MAX_EFFECT_STAGES][4];
+	float		effect_tcmod_params0[MAX_EFFECT_STAGES][4];
+	float		effect_tcmod_params1[MAX_EFFECT_STAGES][4];
+	float		effect_flags[MAX_EFFECT_STAGES][4];
 } bmodel_bound_gpu_call_t;
 
 typedef struct bmodel_gpu_call_remap_s {
@@ -229,7 +252,7 @@ static union {
 	} bindless;
 	struct {
 		bmodel_bound_gpu_call_t		params[MAX_BMODEL_DRAWS];
-		gltexture_t					*textures[MAX_BMODEL_DRAWS][4];
+		gltexture_t					*textures[MAX_BMODEL_DRAWS][4 + MAX_EFFECT_STAGES];
 	} bound;
 } bmodel_calls;
 static bmodel_gpu_call_remap_t		bmodel_call_remap[MAX_BMODEL_DRAWS];
@@ -626,6 +649,7 @@ static void R_FlushBModelCalls (void)
                 GL_BindTextures (0, 2, bmodel_calls.bound.textures[i]);
                 GL_Bind (GL_TEXTURE4, bmodel_calls.bound.textures[i][2]);
                 GL_Bind (GL_TEXTURE5, bmodel_calls.bound.textures[i][3]);
+                GL_BindTextures (6, MAX_EFFECT_STAGES, &bmodel_calls.bound.textures[i][4]);
 			const size_t offset = dstcmdofs + (size_t)i * sizeof (bmodel_draw_indirect_t);
 			GL_DrawElementsIndirectFunc (GL_TRIANGLES, GL_UNSIGNED_INT, (const void *)(uintptr_t)offset);
 
@@ -747,6 +771,7 @@ static void R_PopDepthState(const r_depth_state_t *state)
 #define CALLFLAG_TC_TURB         (1u << 6)
 #define CALLFLAG_TC_ENVMAP       (1u << 7)
 #define CALLFLAG_CUSTOM_FOG      (1u << 8)
+#define CALLFLAG_EFFECTS         (1u << 9)
 
 typedef struct
 {
@@ -1050,6 +1075,29 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
         float           env_params0[4] = { 1.f, 1.f, 1.f, 0.f };
         float           env_params1[4] = { 1.f, 0.f, 0.f, 1.f };
         float           env_params2[4] = { (float)IW_WAVE_SIN, (float)IW_RGB_IDENTITY, (float)IW_BLEND_NONE, 0.f };
+        float           effect_info[4] = { 0.f, 0.f, 0.f, 0.f };
+        float           effect_matrix[MAX_EFFECT_STAGES][4];
+        float           effect_translate[MAX_EFFECT_STAGES][4];
+        float           effect_color[MAX_EFFECT_STAGES][4];
+        float           effect_alpha_params0[MAX_EFFECT_STAGES][4];
+        float           effect_alpha_params1[MAX_EFFECT_STAGES][4];
+        float           effect_alpha_params2[MAX_EFFECT_STAGES][4];
+        float           effect_tcmod_params0[MAX_EFFECT_STAGES][4];
+        float           effect_tcmod_params1[MAX_EFFECT_STAGES][4];
+        float           effect_flags_array[MAX_EFFECT_STAGES][4];
+        gltexture_t     *effect_textures[MAX_EFFECT_STAGES] = { NULL };
+        GLuint64        effect_handles[MAX_EFFECT_STAGES] = { 0 };
+        int             effect_stage_count = 0;
+
+        memset(effect_matrix, 0, sizeof(effect_matrix));
+        memset(effect_translate, 0, sizeof(effect_translate));
+        memset(effect_color, 0, sizeof(effect_color));
+        memset(effect_alpha_params0, 0, sizeof(effect_alpha_params0));
+        memset(effect_alpha_params1, 0, sizeof(effect_alpha_params1));
+        memset(effect_alpha_params2, 0, sizeof(effect_alpha_params2));
+        memset(effect_tcmod_params0, 0, sizeof(effect_tcmod_params0));
+        memset(effect_tcmod_params1, 0, sizeof(effect_tcmod_params1));
+        memset(effect_flags_array, 0, sizeof(effect_flags_array));
 
         IW_TexMatrixIdentity (&tex_matrix);
         IW_TexMatrixIdentity (&emissive_matrix);
@@ -1076,39 +1124,164 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
 
         if (material)
         {
-                if (material->numStages > 0)
-                {
-                        for (int s = 0; s < material->numStages; ++s)
-                        {
-                                const iwStage_t *stage = &material->stages[s];
-                                qboolean wantsEnv = (stage->mapType == IW_MAP_CUBEMAP);
-                                if (!wantsEnv && stage->tcGen[0] && q_strcasestr(stage->tcGen, "environment"))
-                                        wantsEnv = true;
-                                if (!wantsEnv)
-                                {
-                                        for (int tc = 0; tc < stage->numTCMods; ++tc)
-                                        {
-                                                if (stage->tcmods[tc].op == IW_TC_ENVMAP)
-                                                {
-                                                        wantsEnv = true;
-                                                        break;
-                                                }
-                                        }
-                                }
-                                if (wantsEnv)
-                                {
-                                        env_stage = stage;
-                                        break;
-                                }
-                        }
-                }
-
-                IW_MaterialTexMatrix (material, r_framedata.time, &tex_matrix);
                 cull = material->cull;
                 has_material_fog = R_IWShader_GetFogColor(material, fog_color, 0);
+                IW_MaterialTexMatrix (material, r_framedata.time, &tex_matrix);
+
                 if (material->numStages > 0)
                 {
                         const iwStage_t *base_stage = &material->stages[0];
+
+                        for (int s = 0; s < material->numStages; ++s)
+                        {
+                                const iwStage_t *stage = &material->stages[s];
+                                if (!stage)
+                                        continue;
+                                if (!emissive_stage && stage->emissive)
+                                        emissive_stage = stage;
+
+                                if (!env_stage)
+                                {
+                                        qboolean wantsEnv = (stage->mapType == IW_MAP_CUBEMAP);
+                                        if (!wantsEnv && stage->tcGen[0] && q_strcasestr(stage->tcGen, "environment"))
+                                                wantsEnv = true;
+                                        if (!wantsEnv)
+                                        {
+                                                for (int tc = 0; tc < stage->numTCMods; ++tc)
+                                                {
+                                                        if (stage->tcmods[tc].op == IW_TC_ENVMAP)
+                                                        {
+                                                                wantsEnv = true;
+                                                                break;
+                                                        }
+                                                }
+                                        }
+                                        if (wantsEnv)
+                                                env_stage = stage;
+                                }
+                        }
+
+                        if (material->numStages > 1)
+                        {
+                                for (int s = 1; s < material->numStages && effect_stage_count < MAX_EFFECT_STAGES; ++s)
+                                {
+                                        const iwStage_t *stage = &material->stages[s];
+                                        if (!stage || stage == emissive_stage || stage == env_stage)
+                                                continue;
+                                        if (stage->mapType == IW_MAP_CUBEMAP)
+                                                continue;
+                                        if (stage->blendMode != IW_BLEND_ADD && stage->blendMode != IW_BLEND_ADD_ALPHA && stage->blendMode != IW_BLEND_PREMUL)
+                                                continue;
+                                        if (stage->rgbgen != IW_RGB_CONST && stage->rgbgen != IW_RGB_IDENTITY)
+                                                continue;
+
+                                        gltexture_t *stage_tex = R_IWShader_FindStageTexture(t, stage, r_framedata.time);
+                                        if (!stage_tex)
+                                                stage_tex = blacktexture;
+
+                                        float local_matrix[4] = { 1.f, 0.f, 0.f, 1.f };
+                                        float local_translate[4] = { 0.f, 0.f, 0.f, 0.f };
+                                        float local_color[4] = { 1.f, 1.f, 1.f, 1.f };
+                                        float local_alpha0[4] = { 0.f, 1.f, stage->alphaWave.base, stage->alphaWave.amplitude };
+                                        float local_alpha1[4] = { stage->alphaWave.phase, stage->alphaWave.frequency, stage->maskExplicit ? (float)stage->mask : -1.f, (float)stage->alphaWave.func };
+                                        float local_alpha2[4] = { (float)stage->alphaFuncMode, q_clamp(stage->alphaFuncRef, 0.f, 1.f), 0.f, stage->alphaToCoverage ? 1.f : 0.f };
+                                        float local_tc0[4] = { 1.f, 0.f, 0.f, 0.f };
+                                        float local_tc1[4] = { 0.f, 0.f, stage->maskExplicit ? (float)stage->mask : -1.f, (float)IW_WAVE_SIN };
+                                        iwTexMatrix_t stage_matrix;
+                                        IW_TexMatrixIdentity(&stage_matrix);
+                                        if (IW_StageTexMatrix(stage, r_framedata.time, &stage_matrix))
+                                        {
+                                                local_matrix[0] = stage_matrix.matrix[0];
+                                                local_matrix[1] = stage_matrix.matrix[1];
+                                                local_matrix[2] = stage_matrix.matrix[2];
+                                                local_matrix[3] = stage_matrix.matrix[3];
+                                                local_translate[0] = stage_matrix.translate[0];
+                                                local_translate[1] = stage_matrix.translate[1];
+                                        }
+                                        unsigned int stageFlags = 0u;
+                                        for (int tc = 0; tc < stage->numTCMods; ++tc)
+                                        {
+                                                const iwTCMod_t *mod = &stage->tcmods[tc];
+                                                switch (mod->op)
+                                                {
+                                                case IW_TC_STRETCH:
+                                                        stageFlags |= CALLFLAG_TC_STRETCH;
+                                                        local_tc0[0] = mod->wave.base;
+                                                        local_tc0[1] = mod->wave.amplitude;
+                                                        local_tc0[2] = mod->wave.phase;
+                                                        local_tc0[3] = mod->wave.frequency;
+                                                        local_tc1[3] = (float)mod->wave.func;
+                                                        break;
+
+                                                case IW_TC_TURB:
+                                                        stageFlags |= CALLFLAG_TC_TURB;
+                                                        local_tc1[0] = mod->a;
+                                                        local_tc1[1] = mod->b;
+                                                        break;
+
+                                                case IW_TC_ENVMAP:
+                                                        stageFlags |= CALLFLAG_TC_ENVMAP;
+                                                        break;
+
+                                                default:
+                                                        break;
+                                                }
+                                        }
+                                        if ((stageFlags & CALLFLAG_TC_ENVMAP) != 0u)
+                                                continue;
+                                        switch (stage->alphagen)
+                                        {
+                                        case IW_A_CONST:
+                                                local_alpha0[0] = 1.f;
+                                                local_alpha0[1] = q_clamp(stage->aConst, 0.f, 1.f);
+                                                break;
+                                        case IW_A_ENTITY:
+                                                local_alpha0[0] = 2.f;
+                                                break;
+                                        case IW_A_WAVE:
+                                                local_alpha0[0] = 3.f;
+                                                break;
+                                        case IW_A_MASK:
+                                                local_alpha0[0] = 4.f;
+                                                break;
+                                        default:
+                                                local_alpha0[0] = 0.f;
+                                                break;
+                                        }
+                                        if (stage->rgbgen == IW_RGB_CONST)
+                                        {
+                                                local_color[0] = stage->rgbConst[0];
+                                                local_color[1] = stage->rgbConst[1];
+                                                local_color[2] = stage->rgbConst[2];
+                                        }
+
+                                        int idx = effect_stage_count;
+                                        effect_textures[idx] = stage_tex ? stage_tex : blacktexture;
+                                        effect_handles[idx] = (stage_tex && stage_tex->bindless_handle) ? stage_tex->bindless_handle : (blacktexture ? blacktexture->bindless_handle : 0);
+                                        memcpy(effect_matrix[idx], local_matrix, sizeof(local_matrix));
+                                        memcpy(effect_translate[idx], local_translate, sizeof(local_translate));
+                                        memcpy(effect_color[idx], local_color, sizeof(local_color));
+                                        memcpy(effect_alpha_params0[idx], local_alpha0, sizeof(local_alpha0));
+                                        memcpy(effect_alpha_params1[idx], local_alpha1, sizeof(local_alpha1));
+                                        memcpy(effect_alpha_params2[idx], local_alpha2, sizeof(local_alpha2));
+                                        memcpy(effect_tcmod_params0[idx], local_tc0, sizeof(local_tc0));
+                                        memcpy(effect_tcmod_params1[idx], local_tc1, sizeof(local_tc1));
+                                        effect_flags_array[idx][0] = (float)stageFlags;
+                                        effect_flags_array[idx][1] = (float)stage->blendMode;
+                                        ++effect_stage_count;
+                                }
+                        }
+
+                        effect_info[0] = (float)effect_stage_count;
+
+                        for (int i = 0; i < MAX_EFFECT_STAGES; ++i)
+                        {
+                                if (!effect_textures[i])
+                                        effect_textures[i] = blacktexture;
+                                if (effect_handles[i] == 0 && blacktexture)
+                                        effect_handles[i] = blacktexture->bindless_handle;
+                        }
+
                         tcgen_params[0] = (float)base_stage->tcGenMode;
                         tcgen_params[1] = (float)base_stage->tcAlign;
                         tcgen_s[0] = base_stage->tcGenVectors[0][0];
@@ -1276,17 +1449,17 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
                         if (!env_stage)
                                 tc_feature_flags &= ~CALLFLAG_TC_ENVMAP;
                 }
-
-                for (int s = 0; s < material->numStages; ++s)
+        }
+        else
+        {
+                for (int i = 0; i < MAX_EFFECT_STAGES; ++i)
                 {
-                        const iwStage_t *stage = &material->stages[s];
-                        if (!stage->emissive)
-                                continue;
-                        emissive_stage = stage;
-                        break;
+                        if (!effect_textures[i])
+                                effect_textures[i] = blacktexture;
+                        if (effect_handles[i] == 0 && blacktexture)
+                                effect_handles[i] = blacktexture->bindless_handle;
                 }
         }
-
         if (!stageAlphaTest && t && t->type == TEXTYPE_CUTOUT)
         {
                 stageAlphaTest = true;
@@ -1301,7 +1474,6 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
 
         if (num_bmodel_calls == MAX_BMODEL_DRAWS)
                 R_FlushBModelCalls ();
-
         if (t)
         {
                 tx = t->gltexture;
@@ -1331,6 +1503,8 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
                 zfix = 0;
 
         flags = zfix | ((fb != NULL) << 1) | ((r_fullbright_cheatsafe != false) << 2);
+        if (effect_stage_count > 0)
+                flags |= CALLFLAG_EFFECTS;
         if (em != NULL)
                 flags |= CALLFLAG_EMISSIVE;
         if (stageAlphaTest)
@@ -1375,6 +1549,18 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
                 memcpy (call->env_params0, env_params0, sizeof (env_params0));
                 memcpy (call->env_params1, env_params1, sizeof (env_params1));
                 memcpy (call->env_params2, env_params2, sizeof (env_params2));
+                memcpy (call->effect_info, effect_info, sizeof (effect_info));
+                memcpy (call->effect_matrix, effect_matrix, sizeof (effect_matrix));
+                memcpy (call->effect_translate, effect_translate, sizeof (effect_translate));
+                memcpy (call->effect_color, effect_color, sizeof (effect_color));
+                memcpy (call->effect_alpha_params0, effect_alpha_params0, sizeof (effect_alpha_params0));
+                memcpy (call->effect_alpha_params1, effect_alpha_params1, sizeof (effect_alpha_params1));
+                memcpy (call->effect_alpha_params2, effect_alpha_params2, sizeof (effect_alpha_params2));
+                memcpy (call->effect_tcmod_params0, effect_tcmod_params0, sizeof (effect_tcmod_params0));
+                memcpy (call->effect_tcmod_params1, effect_tcmod_params1, sizeof (effect_tcmod_params1));
+                memcpy (call->effect_flags, effect_flags_array, sizeof (effect_flags_array));
+                for (int i = 0; i < MAX_EFFECT_STAGES; ++i)
+                        call->effect_handles[i] = effect_handles[i];
         }
         else
         {
@@ -1410,10 +1596,22 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
                 memcpy (call->env_params0, env_params0, sizeof (env_params0));
                 memcpy (call->env_params1, env_params1, sizeof (env_params1));
                 memcpy (call->env_params2, env_params2, sizeof (env_params2));
+                memcpy (call->effect_info, effect_info, sizeof (effect_info));
+                memcpy (call->effect_matrix, effect_matrix, sizeof (effect_matrix));
+                memcpy (call->effect_translate, effect_translate, sizeof (effect_translate));
+                memcpy (call->effect_color, effect_color, sizeof (effect_color));
+                memcpy (call->effect_alpha_params0, effect_alpha_params0, sizeof (effect_alpha_params0));
+                memcpy (call->effect_alpha_params1, effect_alpha_params1, sizeof (effect_alpha_params1));
+                memcpy (call->effect_alpha_params2, effect_alpha_params2, sizeof (effect_alpha_params2));
+                memcpy (call->effect_tcmod_params0, effect_tcmod_params0, sizeof (effect_tcmod_params0));
+                memcpy (call->effect_tcmod_params1, effect_tcmod_params1, sizeof (effect_tcmod_params1));
+                memcpy (call->effect_flags, effect_flags_array, sizeof (effect_flags_array));
                 textures[0] = tx ? tx : greytexture;
                 textures[1] = fb ? fb : blacktexture;
                 textures[2] = em ? em : blacktexture;
                 textures[3] = env ? env : blacktexture;
+                for (int i = 0; i < MAX_EFFECT_STAGES; ++i)
+                        textures[4 + i] = effect_textures[i] ? effect_textures[i] : blacktexture;
         }
 
         SDL_assert (num_instances > 0);

--- a/Quake/shaders/sky_cubemap.vert
+++ b/Quake/shaders/sky_cubemap.vert
@@ -8,6 +8,8 @@
 
 #include "frame_uniforms.glsl"
 
+#define MAX_EFFECT_STAGES 4
+
 vec3 ApplyFog(vec3 clr, vec3 p)
 {
 	float fog = exp2(-Fog.w * dot(p, p));
@@ -45,6 +47,19 @@ struct Call
 	vec4	env_params0;
 	vec4	env_params1;
 	vec4	env_params2;
+	vec4	effect_info;
+	vec4	effect_matrix[MAX_EFFECT_STAGES];
+	vec4	effect_translate[MAX_EFFECT_STAGES];
+	vec4	effect_color[MAX_EFFECT_STAGES];
+	vec4	effect_alpha_params0[MAX_EFFECT_STAGES];
+	vec4	effect_alpha_params1[MAX_EFFECT_STAGES];
+	vec4	effect_alpha_params2[MAX_EFFECT_STAGES];
+	vec4	effect_tcmod_params0[MAX_EFFECT_STAGES];
+	vec4	effect_tcmod_params1[MAX_EFFECT_STAGES];
+	vec4	effect_flags[MAX_EFFECT_STAGES];
+#if BINDLESS
+	uvec2	effect_handles[MAX_EFFECT_STAGES];
+#endif
 };
 const uint
 	CF_USE_POLYGON_OFFSET = 1u,

--- a/Quake/shaders/sky_layers.vert
+++ b/Quake/shaders/sky_layers.vert
@@ -8,6 +8,8 @@
 
 #include "frame_uniforms.glsl"
 
+#define MAX_EFFECT_STAGES 4
+
 vec3 ApplyFog(vec3 clr, vec3 p)
 {
 	float fog = exp2(-Fog.w * dot(p, p));
@@ -45,6 +47,19 @@ struct Call
 	vec4	env_params0;
 	vec4	env_params1;
 	vec4	env_params2;
+	vec4	effect_info;
+	vec4	effect_matrix[MAX_EFFECT_STAGES];
+	vec4	effect_translate[MAX_EFFECT_STAGES];
+	vec4	effect_color[MAX_EFFECT_STAGES];
+	vec4	effect_alpha_params0[MAX_EFFECT_STAGES];
+	vec4	effect_alpha_params1[MAX_EFFECT_STAGES];
+	vec4	effect_alpha_params2[MAX_EFFECT_STAGES];
+	vec4	effect_tcmod_params0[MAX_EFFECT_STAGES];
+	vec4	effect_tcmod_params1[MAX_EFFECT_STAGES];
+	vec4	effect_flags[MAX_EFFECT_STAGES];
+#if BINDLESS
+	uvec2	effect_handles[MAX_EFFECT_STAGES];
+#endif
 };
 const uint
 	CF_USE_POLYGON_OFFSET = 1u,

--- a/Quake/shaders/skystencil.vert
+++ b/Quake/shaders/skystencil.vert
@@ -8,6 +8,8 @@
 
 #include "frame_uniforms.glsl"
 
+#define MAX_EFFECT_STAGES 4
+
 vec3 ApplyFog(vec3 clr, vec3 p)
 {
 	float fog = exp2(-Fog.w * dot(p, p));
@@ -45,6 +47,19 @@ struct Call
 	vec4	env_params0;
 	vec4	env_params1;
 	vec4	env_params2;
+	vec4	effect_info;
+	vec4	effect_matrix[MAX_EFFECT_STAGES];
+	vec4	effect_translate[MAX_EFFECT_STAGES];
+	vec4	effect_color[MAX_EFFECT_STAGES];
+	vec4	effect_alpha_params0[MAX_EFFECT_STAGES];
+	vec4	effect_alpha_params1[MAX_EFFECT_STAGES];
+	vec4	effect_alpha_params2[MAX_EFFECT_STAGES];
+	vec4	effect_tcmod_params0[MAX_EFFECT_STAGES];
+	vec4	effect_tcmod_params1[MAX_EFFECT_STAGES];
+	vec4	effect_flags[MAX_EFFECT_STAGES];
+#if BINDLESS
+	uvec2	effect_handles[MAX_EFFECT_STAGES];
+#endif
 };
 const uint
 	CF_USE_POLYGON_OFFSET = 1u,

--- a/Quake/shaders/water.vert
+++ b/Quake/shaders/water.vert
@@ -8,6 +8,8 @@
 
 #include "frame_uniforms.glsl"
 
+#define MAX_EFFECT_STAGES 4
+
 vec3 ApplyFog(vec3 clr, vec3 p)
 {
 	float fog = exp2(-Fog.w * dot(p, p));
@@ -45,6 +47,19 @@ struct Call
 	vec4	env_params0;
 	vec4	env_params1;
 	vec4	env_params2;
+	vec4	effect_info;
+	vec4	effect_matrix[MAX_EFFECT_STAGES];
+	vec4	effect_translate[MAX_EFFECT_STAGES];
+	vec4	effect_color[MAX_EFFECT_STAGES];
+	vec4	effect_alpha_params0[MAX_EFFECT_STAGES];
+	vec4	effect_alpha_params1[MAX_EFFECT_STAGES];
+	vec4	effect_alpha_params2[MAX_EFFECT_STAGES];
+	vec4	effect_tcmod_params0[MAX_EFFECT_STAGES];
+	vec4	effect_tcmod_params1[MAX_EFFECT_STAGES];
+	vec4	effect_flags[MAX_EFFECT_STAGES];
+#if BINDLESS
+	uvec2	effect_handles[MAX_EFFECT_STAGES];
+#endif
 };
 const uint
         CF_USE_POLYGON_OFFSET = 1u,
@@ -55,7 +70,8 @@ const uint
 	CF_TC_STRETCH = 32u,
 	CF_TC_TURB = 64u,
 	CF_TC_ENVMAP = 128u,
-        CF_CUSTOM_FOG = 256u
+        CF_CUSTOM_FOG = 256u,
+        CF_EFFECTS = 512u
 ;
 
 const int IW_TCGEN_BASE        = 0;

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -16,6 +16,7 @@ layout(binding=3) uniform sampler2D DeluxTex;
 #define LIGHT_TILES_Y 16
 #define LIGHT_TILES_Z 32
 #define MAX_LIGHTS    64
+#define MAX_EFFECT_STAGES 4
 
 struct Light
 {
@@ -49,8 +50,59 @@ const uint
     CF_TC_STRETCH = 32u,
     CF_TC_TURB = 64u,
     CF_TC_ENVMAP = 128u,
-    CF_CUSTOM_FOG = 256u
+    CF_CUSTOM_FOG = 256u,
+    CF_EFFECTS = 512u
 ;
+
+struct Call
+{
+    uint    flags;
+    float   wateralpha;
+#if BINDLESS
+    uvec2   txhandle;
+    uvec2   fbhandle;
+    uvec2   emhandle;
+    uvec2   envhandle;
+#else
+    int             baseinstance;
+    int             padding;
+#endif
+    vec4    tcmod_matrix;
+    vec4    tcmod_translate;
+    vec4    tcmod_params0;
+    vec4    tcmod_params1;
+    vec4    tcgen_params;
+    vec4    tcgen_s;
+    vec4    tcgen_t;
+    vec4    emissive_matrix;
+    vec4    emissive_translate;
+    vec4    emissive_color;
+    vec4    fog_color;
+    vec4    alpha_params0;
+    vec4    alpha_params1;
+    vec4    alpha_params2;
+    vec4    env_params0;
+    vec4    env_params1;
+    vec4    env_params2;
+    vec4    effect_info;
+    vec4    effect_matrix[MAX_EFFECT_STAGES];
+    vec4    effect_translate[MAX_EFFECT_STAGES];
+    vec4    effect_color[MAX_EFFECT_STAGES];
+    vec4    effect_alpha_params0[MAX_EFFECT_STAGES];
+    vec4    effect_alpha_params1[MAX_EFFECT_STAGES];
+    vec4    effect_alpha_params2[MAX_EFFECT_STAGES];
+    vec4    effect_tcmod_params0[MAX_EFFECT_STAGES];
+    vec4    effect_tcmod_params1[MAX_EFFECT_STAGES];
+    vec4    effect_flags[MAX_EFFECT_STAGES];
+#if BINDLESS
+    uvec2   effect_handles[MAX_EFFECT_STAGES];
+#endif
+};
+
+layout(std430, binding=1) restrict readonly buffer CallBuffer
+{
+    Call call_data[];
+};
 
 const int IW_RGB_VERTEX   = 0;
 const int IW_RGB_CONST    = 1;
@@ -186,6 +238,36 @@ float SampleMaskChannel(vec4 texel, int maskChannel)
     return texel.a;
 }
 
+vec4 ApplyColorMask(vec4 texel, float maskIndex)
+{
+    if (maskIndex < 0.0)
+        return texel;
+
+    int maskChannel = int(maskIndex + 0.5);
+    if (maskChannel == 0)
+    {
+        texel.g = 0.0;
+        texel.b = 0.0;
+    }
+    else if (maskChannel == 1)
+    {
+        texel.r = 0.0;
+        texel.b = 0.0;
+    }
+    else if (maskChannel == 2)
+    {
+        texel.r = 0.0;
+        texel.g = 0.0;
+    }
+    else if (maskChannel == 3)
+    {
+        texel.rgb = vec3(1.0);
+        texel.a = clamp(texel.a, 0.0, 1.0);
+    }
+
+    return texel;
+}
+
 float ComputeStageAlpha(vec4 texel, vec4 params0, vec4 params1)
 {
     int type = int(params0.x + 0.5);
@@ -293,6 +375,11 @@ layout(location=19) flat in vec4 in_fog_color;
 layout(location=21) flat in vec4 in_env_params0;
 layout(location=22) flat in vec4 in_env_params1;
 layout(location=23) flat in vec4 in_env_params2;
+layout(location=24) flat in int in_call_index;
+layout(location=25) in vec2 in_effect_uv[MAX_EFFECT_STAGES];
+#if !BINDLESS
+layout(binding=6) uniform sampler2D EffectTex[MAX_EFFECT_STAGES];
+#endif
 
 #define OUT_COLOR out_fragcolor
 #if OIT
@@ -414,6 +501,7 @@ float specPow16(float x){
 // Ersetze die Normalberechnung & Lichtakkumulation im Hauptteil:
 void main()
 {
+    Call call = call_data[in_call_index];
     vec3 fullbright = vec3(0.);
     vec3 emissive   = vec3(0.);
     vec2 uv = in_uv;
@@ -448,31 +536,7 @@ void main()
     vec4 result = texture(Tex, uv);
 #endif
 
-    float maskIndex = in_stage_params1.z;
-    if (maskIndex >= 0.0)
-    {
-        int maskChannel = int(maskIndex + 0.5);
-        if (maskChannel == 0)
-        {
-            result.g = 0.0;
-            result.b = 0.0;
-        }
-        else if (maskChannel == 1)
-        {
-            result.r = 0.0;
-            result.b = 0.0;
-        }
-        else if (maskChannel == 2)
-        {
-            result.r = 0.0;
-            result.g = 0.0;
-        }
-        else if (maskChannel == 3)
-        {
-            result.rgb = vec3(1.0);
-            result.a = clamp(result.a, 0.0, 1.0);
-        }
-    }
+    result = ApplyColorMask(result, in_stage_params1.z);
 
     float baseAlpha = clamp(in_alpha, 0.0, 1.0);
     float stageAlpha = ComputeStageAlpha(result, in_alpha_params0, in_alpha_params1);
@@ -676,6 +740,41 @@ void main()
 #else
     result.rgb *= total_lightmap;
 #endif
+
+    int effect_count = int(call.effect_info.x + 0.5);
+    if ((call.flags & CF_EFFECTS) == 0u)
+        effect_count = 0;
+    effect_count = clamp(effect_count, 0, MAX_EFFECT_STAGES);
+    for (int i = 0; i < effect_count; ++i)
+    {
+#if BINDLESS
+        vec4 effect_texel = texture(sampler2D(call.effect_handles[i]), in_effect_uv[i]);
+#else
+        vec4 effect_texel = texture(EffectTex[i], in_effect_uv[i]);
+#endif
+        effect_texel = ApplyColorMask(effect_texel, call.effect_tcmod_params1[i].z);
+        float stageAlpha = ComputeStageAlpha(effect_texel, call.effect_alpha_params0[i], call.effect_alpha_params1[i]);
+        vec4 alpha_ctrl = call.effect_alpha_params2[i];
+        if (alpha_ctrl.z > 0.5)
+        {
+            int alphaFunc = int(alpha_ctrl.x + 0.5);
+            float alphaRef = clamp(alpha_ctrl.y, 0.0, 1.0);
+            if (!AlphaTestPass(stageAlpha, alphaFunc, alphaRef))
+                continue;
+        }
+        float finalStageAlpha = clamp(stageAlpha, 0.0, 1.0);
+        vec3 stage_rgb = effect_texel.rgb * call.effect_color[i].rgb;
+        int blendMode = int(call.effect_flags[i].y + 0.5);
+        if (blendMode == IW_BLEND_PREMUL)
+        {
+            vec3 premul_rgb = stage_rgb * finalStageAlpha;
+            result.rgb = premul_rgb + result.rgb * (1.0 - finalStageAlpha);
+        }
+        else
+        {
+            result.rgb += stage_rgb * finalStageAlpha;
+        }
+    }
 
     result.rgb += fullbright + emissive;
 

--- a/Quake/shaders/world.vert
+++ b/Quake/shaders/world.vert
@@ -19,6 +19,7 @@ vec3 ApplyFog(vec3 clr, vec3 p)
 #define LIGHT_TILES_Y 16
 #define LIGHT_TILES_Z 32
 #define MAX_LIGHTS    64
+#define MAX_EFFECT_STAGES 4
 
 struct Light
 {
@@ -74,6 +75,19 @@ struct Call
         vec4    env_params0;
         vec4    env_params1;
         vec4    env_params2;
+        vec4    effect_info;
+        vec4    effect_matrix[MAX_EFFECT_STAGES];
+        vec4    effect_translate[MAX_EFFECT_STAGES];
+        vec4    effect_color[MAX_EFFECT_STAGES];
+        vec4    effect_alpha_params0[MAX_EFFECT_STAGES];
+        vec4    effect_alpha_params1[MAX_EFFECT_STAGES];
+        vec4    effect_alpha_params2[MAX_EFFECT_STAGES];
+        vec4    effect_tcmod_params0[MAX_EFFECT_STAGES];
+        vec4    effect_tcmod_params1[MAX_EFFECT_STAGES];
+        vec4    effect_flags[MAX_EFFECT_STAGES];
+#if BINDLESS
+        uvec2   effect_handles[MAX_EFFECT_STAGES];
+#endif
 };
 const uint
         CF_USE_POLYGON_OFFSET = 1u,
@@ -84,7 +98,8 @@ const uint
 	CF_TC_STRETCH = 32u,
 	CF_TC_TURB = 64u,
 	CF_TC_ENVMAP = 128u,
-        CF_CUSTOM_FOG = 256u
+        CF_CUSTOM_FOG = 256u,
+        CF_EFFECTS = 512u
 ;
 
 const int IW_TCGEN_BASE        = 0;
@@ -173,6 +188,8 @@ layout(location=19) flat out vec4 out_fog_color;
 layout(location=21) flat out vec4 out_env_params0;
 layout(location=22) flat out vec4 out_env_params1;
 layout(location=23) flat out vec4 out_env_params2;
+layout(location=24) flat out int out_call_index;
+layout(location=25) out vec2 out_effect_uv[MAX_EFFECT_STAGES];
 
 float EvaluateWave(vec4 params, int func)
 {
@@ -280,6 +297,8 @@ void main()
                 base_uv = ndc * 0.5 + 0.5;
         }
 
+        vec2 stage_base_uv = base_uv;
+        const vec2 turbScale = vec2(0.125, 0.125);
         vec2 transformed_uv = vec2(dot(call.tcmod_matrix.xy, base_uv),
         dot(call.tcmod_matrix.zw, base_uv)) + call.tcmod_translate.xy;
         if ((call.flags & CF_TC_STRETCH) != 0u)
@@ -292,12 +311,42 @@ void main()
         {
                 float amp = call.tcmod_params1.x;
                 float freq = call.tcmod_params1.y;
-                const vec2 turbScale = vec2(0.125, 0.125);
                 float angle = Time * freq * 6.28318530718 + dot(world_pos.xy, turbScale);
                 float offset = sin(angle) * amp;
                 transformed_uv += vec2(offset);
         }
         out_uv = transformed_uv;
+        out_call_index = DRAW_ID;
+        int effect_count = int(call.effect_info.x + 0.5);
+        if ((call.flags & CF_EFFECTS) == 0u)
+                effect_count = 0;
+        effect_count = clamp(effect_count, 0, MAX_EFFECT_STAGES);
+        for (int i = 0; i < MAX_EFFECT_STAGES; ++i)
+        {
+                vec2 effect_uv = stage_base_uv;
+                if (i < effect_count)
+                {
+                        vec4 mat = call.effect_matrix[i];
+                        vec4 trans = call.effect_translate[i];
+                        effect_uv = vec2(dot(mat.xy, effect_uv), dot(mat.zw, effect_uv)) + trans.xy;
+                        uint stageFlags = uint(call.effect_flags[i].x + 0.5);
+                        if ((stageFlags & CF_TC_STRETCH) != 0u)
+                        {
+                                int func = int(call.effect_tcmod_params1[i].w + 0.5);
+                                float scale = EvaluateWave(call.effect_tcmod_params0[i], func);
+                                effect_uv = (effect_uv - 0.5) * scale + 0.5;
+                        }
+                        if ((stageFlags & CF_TC_TURB) != 0u)
+                        {
+                                float amp = call.effect_tcmod_params1[i].x;
+                                float freq = call.effect_tcmod_params1[i].y;
+                                                float angle = Time * freq * 6.28318530718 + dot(world_pos.xy, turbScale);
+                                float offset = sin(angle) * amp;
+                                effect_uv += vec2(offset);
+                        }
+                }
+                out_effect_uv[i] = effect_uv;
+        }
         vec2 emissive_uv = vec2(dot(call.emissive_matrix.xy, base_uv),
                                 dot(call.emissive_matrix.zw, base_uv)) + call.emissive_translate.xy;
         out_emissive_uv = emissive_uv;


### PR DESCRIPTION
## Summary
- gather additive material effect stages when building bmodel calls, capture their tcmods, alpha control, and bindless handles, and mark calls that need effect processing
- expand the world vertex shader to forward per-stage effect UVs along with the call index so the fragment shader can evaluate each overlay
- extend the world fragment shader to reuse the color-mask helper and to sample and blend additive and premultiplied effect layers against the lit base color

## Testing
- not run (GL shader changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691266bc12a0832e8fc67f1b677c0e86)