### PR TITLE
Fix particle atlas alpha handling

### DIFF
--- a/Quake/r_part.c
+++ b/Quake/r_part.c
@@ -1838,7 +1838,8 @@ static void R_InitParticleAtlas (void)
                                         particle_atlas = TexMgr_LoadImageEx (NULL, "particles/atlas",
                                                 ext_width, ext_height, 1, ext_fmt,
                                                 ext_data, "particles/particlefont", 0,
-                                                TEXPREF_LINEAR | TEXPREF_NOPICMIP | TEXPREF_PERSIST | TEXPREF_CLAMP);
+                                                TEXPREF_LINEAR | TEXPREF_NOPICMIP | TEXPREF_PERSIST | TEXPREF_CLAMP |
+                                                TEXPREF_ALPHA);
                                         if (particle_atlas)
                                         {
                                                 R_ParticleAtlas_SetMetrics (ext_width, ext_height, tile_width_px, tile_height_px);
@@ -1974,10 +1975,11 @@ static void R_InitParticleAtlas (void)
                         }
                 }
 
-                particle_atlas = TexMgr_LoadImageEx (NULL, "particles/atlas",
-                        atlas_width, atlas_height, 1, SRC_RGBA,
-                        (byte*)data, "", 0,
-                        TEXPREF_LINEAR | TEXPREF_NOPICMIP | TEXPREF_PERSIST | TEXPREF_CLAMP);
+		particle_atlas = TexMgr_LoadImageEx (NULL, "particles/atlas",
+			atlas_width, atlas_height, 1, SRC_RGBA,
+			(byte*)data, "", 0,
+			TEXPREF_LINEAR | TEXPREF_NOPICMIP | TEXPREF_PERSIST | TEXPREF_CLAMP |
+			TEXPREF_ALPHA);
 
                 if (!particle_atlas) {
                         Con_Printf ("R_InitParticleAtlas: failed to create particle atlas\n");


### PR DESCRIPTION
## Summary
- ensure externally supplied particle atlases are uploaded with alpha so example particles render correctly
- do the same for the generated fallback atlas to keep blending behavior consistent

## Testing
- not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913aa902d10832e8bcedf7889ca0657)