### PR TITLE
Stop additive particles from using atlas alpha

### DIFF
--- a/Quake/r_part.c
+++ b/Quake/r_part.c
@@ -1838,7 +1838,8 @@ static void R_InitParticleAtlas (void)
                                         particle_atlas = TexMgr_LoadImageEx (NULL, "particles/atlas",
                                                 ext_width, ext_height, 1, ext_fmt,
                                                 ext_data, "particles/particlefont", 0,
-                                                TEXPREF_LINEAR | TEXPREF_NOPICMIP | TEXPREF_PERSIST | TEXPREF_CLAMP);
+                                                TEXPREF_LINEAR | TEXPREF_NOPICMIP | TEXPREF_PERSIST | TEXPREF_CLAMP |
+                                                TEXPREF_ALPHA);
                                         if (particle_atlas)
                                         {
                                                 R_ParticleAtlas_SetMetrics (ext_width, ext_height, tile_width_px, tile_height_px);
@@ -1974,10 +1975,11 @@ static void R_InitParticleAtlas (void)
                         }
                 }
 
-                particle_atlas = TexMgr_LoadImageEx (NULL, "particles/atlas",
-                        atlas_width, atlas_height, 1, SRC_RGBA,
-                        (byte*)data, "", 0,
-                        TEXPREF_LINEAR | TEXPREF_NOPICMIP | TEXPREF_PERSIST | TEXPREF_CLAMP);
+		particle_atlas = TexMgr_LoadImageEx (NULL, "particles/atlas",
+			atlas_width, atlas_height, 1, SRC_RGBA,
+			(byte*)data, "", 0,
+			TEXPREF_LINEAR | TEXPREF_NOPICMIP | TEXPREF_PERSIST | TEXPREF_CLAMP |
+			TEXPREF_ALPHA);
 
                 if (!particle_atlas) {
                         Con_Printf ("R_InitParticleAtlas: failed to create particle atlas\n");
@@ -3343,39 +3345,39 @@ static void R_DrawParticles_Pass (effectblend_t blend, qboolean showtris, qboole
                 VectorCopy (p->org, v->pos);
                 VectorCopy (p->vel, v->vel);
 
-                if (showtris)
-                {
-                        v->color[0] = 255;
-                        v->color[1] = 255;
-                        v->color[2] = 255;
-                        v->color[3] = 255;
-                        alphabyte = 255;
-                        glowbyte = 0;
-                }
-                else if (p->custom)
-                {
-                        v->color[0] = (GLubyte)q_min (255, (int)(p->custom_color[0] * 255.f + 0.5f));
-                        v->color[1] = (GLubyte)q_min (255, (int)(p->custom_color[1] * 255.f + 0.5f));
-                        v->color[2] = (GLubyte)q_min (255, (int)(p->custom_color[2] * 255.f + 0.5f));
-                        alphabyte = (GLubyte)q_min (255, (int)(alphaval * 255.f + 0.5f));
-                        glowbyte = (GLubyte)q_min (255, (int)(glow * PARTICLE_GLOW_SCALE + 0.5f));
-                        v->color[3] = alphabyte;
-                }
-                else
-                {
-                        GLubyte* c = (GLubyte*)&d_8to24table[(int)p->color];
-                        alphabyte = (GLubyte)q_min (255, (int)(alphaval * 255.f + 0.5f));
-                        glowbyte = (GLubyte)q_min (255, (int)(glow * PARTICLE_GLOW_SCALE + 0.5f));
-                        v->color[0] = c[0];
-                        v->color[1] = c[1];
-                        v->color[2] = c[2];
-                        v->color[3] = alphabyte;
-                }
+               if (showtris)
+               {
+                       v->color[0] = 255;
+                       v->color[1] = 255;
+                       v->color[2] = 255;
+                       v->color[3] = 255;
+                       alphabyte = 255;
+                       glowbyte = 0;
+               }
+               else if (p->custom)
+               {
+                       v->color[0] = (GLubyte)q_min (255, (int)(p->custom_color[0] * 255.f + 0.5f));
+                       v->color[1] = (GLubyte)q_min (255, (int)(p->custom_color[1] * 255.f + 0.5f));
+                       v->color[2] = (GLubyte)q_min (255, (int)(p->custom_color[2] * 255.f + 0.5f));
+                       alphabyte = (GLubyte)q_min (255, (int)(alphaval * 255.f + 0.5f));
+                       glowbyte = (GLubyte)q_min (255, (int)(glow * PARTICLE_GLOW_SCALE + 0.5f));
+                       v->color[3] = alphabyte;
+               }
+               else
+               {
+                       GLubyte* c = (GLubyte*)&d_8to24table[(int)p->color];
+                       alphabyte = (GLubyte)q_min (255, (int)(alphaval * 255.f + 0.5f));
+                       glowbyte = (GLubyte)q_min (255, (int)(glow * PARTICLE_GLOW_SCALE + 0.5f));
+                       v->color[0] = c[0];
+                       v->color[1] = c[1];
+                       v->color[2] = c[2];
+                       v->color[3] = alphabyte;
+               }
 
-                v->params[0] = showtris ? 0 : glowbyte;
-                v->params[1] = (GLubyte)texindex;
-                v->params[2] = (GLubyte)orient;
-                v->params[3] = 0;
+               v->params[0] = showtris ? 0 : glowbyte;
+               v->params[1] = (GLubyte)texindex;
+               v->params[2] = (GLubyte)orient;
+               v->params[3] = (GLubyte)(showtris ? EFFECT_BLEND_ALPHA : particle_blend);
 
                 {
                         float width = size_x * size_factor;

--- a/Quake/shaders/particles.frag
+++ b/Quake/shaders/particles.frag
@@ -65,7 +65,7 @@ layout(location=4) in vec2 in_corner;
 
 #define OUT_COLOR out_fragcolor
 #if OIT
-	vec4 OUT_COLOR;
+        vec4 OUT_COLOR;
 	layout(location=0) out vec4 out_accum;
 	layout(location=1) out float out_reveal;
 
@@ -98,18 +98,27 @@ layout(location=4) in vec2 in_corner;
 
 	#define main main_body
 #else
-	layout(location=0) out vec4 OUT_COLOR;
-	layout(location=1) out vec4 out_velocity;
+        layout(location=0) out vec4 OUT_COLOR;
+        layout(location=1) out vec4 out_velocity;
 #endif // OIT
+
+const int BLEND_ALPHA = 0;
+const int BLEND_ADD = 1;
+const int BLEND_INVMOD = 2;
 
 void main()
 {
-	vec4 texel = texture(ParticleAtlas, in_uv);
-	vec4 color = in_color * texel;
+        vec4 texel = texture(ParticleAtlas, in_uv);
+        int blend = int(in_params.w + 0.5);
+        if (blend == BLEND_ADD || blend == BLEND_INVMOD)
+        {
+                texel.a = 1.0;
+        }
+        vec4 color = in_color * texel;
 #if !OIT
-	out_velocity = vec4(0.0);
+        out_velocity = vec4(0.0);
 #endif
-	float glow = in_params.x;
+        float glow = in_params.x;
 	color.rgb *= (1.0 + glow);
 	color.rgb = ApplyFog(color.rgb, in_pos);
 	float radius = length(in_corner * in_params.y);

--- a/Quake/shaders/particles.vert
+++ b/Quake/shaders/particles.vert
@@ -143,7 +143,7 @@ void main()
 
         out_uv = uv;
         out_color = in_color;
-        out_params = vec4(in_params.x * GLOW_INV_SCALE, uvScale, float(orient), 0.0);
+        out_params = vec4(in_params.x * GLOW_INV_SCALE, uvScale, float(orient), in_params.w);
         out_corner = fadeCorner;
 #if OIT
         out_color.a *= 0.9;


### PR DESCRIPTION
## Summary
- restore particle color packing while tagging each sprite with its blend mode
- have the particle shader ignore atlas alpha for additive and inverse-modulate passes so the vertex alpha controls intensity again

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913aa902d10832e8bcedf7889ca0657)