### PR TITLE
Fix particle rendering with OIT enabled

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -2800,6 +2800,9 @@ void R_RenderScene (void)
 
 	R_EndTranslucency ();
 
+	if (R_GetEffectiveAlphaMode () == ALPHAMODE_OIT)
+		R_DrawParticles_PostOIT ();
+
 	R_ShowTris (); //johnfitz
 
 	R_ShowBoundingBoxes (); //johnfitz

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -481,6 +481,7 @@ void R_EntityMatrix (float matrix[16], vec3_t origin, vec3_t angles, unsigned ch
 
 void R_InitParticles (void);
 void R_DrawParticles (qboolean alpha);
+void R_DrawParticles_PostOIT (void);
 void R_DrawParticles_ShowTris (void);
 int R_Effectinfo_Index (const char *name);
 qboolean R_Effectinfo_SpawnIndex (int index, const vec3_t org, const vec3_t dir, float count);

--- a/Quake/r_part.c
+++ b/Quake/r_part.c
@@ -3773,6 +3773,7 @@ static void R_DrawParticles_Real (qboolean alpha, qboolean showtris)
 {
         extern cvar_t r_particles;
         qboolean dither;
+        qboolean oit_alpha_pass;
 
         if (!r_particles.value)
                 return;
@@ -3786,6 +3787,7 @@ static void R_DrawParticles_Real (qboolean alpha, qboolean showtris)
         GL_BeginGroup ("Particles");
 
         dither = (softemu == SOFTEMU_COARSE && !showtris);
+        oit_alpha_pass = (!showtris && alpha && R_GetEffectiveAlphaMode () == ALPHAMODE_OIT);
 
         if (showtris)
         {
@@ -3794,8 +3796,11 @@ static void R_DrawParticles_Real (qboolean alpha, qboolean showtris)
         else
         {
                 R_DrawParticles_Pass (EFFECT_BLEND_ALPHA, false, dither);
-                R_DrawParticles_Pass (EFFECT_BLEND_ADD, false, dither);
-                R_DrawParticles_Pass (EFFECT_BLEND_INVMOD, false, dither);
+                if (!oit_alpha_pass)
+                {
+                        R_DrawParticles_Pass (EFFECT_BLEND_ADD, false, dither);
+                        R_DrawParticles_Pass (EFFECT_BLEND_INVMOD, false, dither);
+                }
         }
 
         GL_EndGroup ();
@@ -3808,7 +3813,31 @@ R_DrawParticles -- johnfitz -- moved all non-drawing code to CL_RunParticles
 */
 void R_DrawParticles (qboolean alpha)
 {
-	R_DrawParticles_Real (alpha, false);
+        R_DrawParticles_Real (alpha, false);
+}
+
+void R_DrawParticles_PostOIT (void)
+{
+        extern cvar_t r_particles;
+        qboolean dither;
+
+        if (R_GetEffectiveAlphaMode () != ALPHAMODE_OIT)
+                return;
+
+        if (!r_particles.value)
+                return;
+
+        if (!r_numactiveparticles)
+                return;
+
+        dither = (softemu == SOFTEMU_COARSE);
+
+        GL_BeginGroup ("Particles");
+
+        R_DrawParticles_Pass (EFFECT_BLEND_ADD, false, dither);
+        R_DrawParticles_Pass (EFFECT_BLEND_INVMOD, false, dither);
+
+        GL_EndGroup ();
 }
 /*
 ===============


### PR DESCRIPTION
## Summary
- avoid rendering additive and inverse-modulated particles during the weighted OIT pass
- add a follow-up particle draw after the OIT resolve to handle non-alpha blends with standard blending
- expose the new helper so the renderer can trigger it when OIT is active

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914eab850b0832e8dd5065eec16b2fa)