### PR TITLE
Fix bot configuration loaders to free malloc buffers correctly

### DIFF
--- a/Quake/sv_bot.c
+++ b/Quake/sv_bot.c
@@ -470,7 +470,7 @@ static void SV_Bot_LoadSkillSettings (void)
         {
                 if (!SV_Bot_ParseSkillSettings (buffer))
                         SV_Bot_AddFallbackSkillSettings ();
-                Z_Free (buffer);
+                free (buffer);
         }
         else
         {
@@ -629,9 +629,9 @@ static void SV_Bot_LoadProfiles (void)
 
 	if (buffer)
 	{
-		if (!SV_Bot_ParseProfiles (buffer))
-			SV_Bot_AddFallbackProfiles ();
-		Z_Free (buffer);
+                if (!SV_Bot_ParseProfiles (buffer))
+                        SV_Bot_AddFallbackProfiles ();
+                free (buffer);
 	}
 	else
 	{


### PR DESCRIPTION
## Summary
- free the buffers returned by `COM_LoadMallocFile` in the bot skill/profile loaders with `free()` so the allocator matches the allocation

## Testing
- not run (SDL2 development package unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916497231ec832e926e679b440ab105)