### PR TITLE
Handle null vector outputs in AngleVectors

### DIFF
--- a/Quake/mathlib.c
+++ b/Quake/mathlib.c
@@ -251,15 +251,26 @@ void AngleVectors (vec3_t angles, vec3_t forward, vec3_t right, vec3_t up)
 	sr = sin(angle);
 	cr = cos(angle);
 
-	forward[0] = cp*cy;
-	forward[1] = cp*sy;
-	forward[2] = -sp;
-	right[0] = (-1*sr*sp*cy+-1*cr*-sy);
-	right[1] = (-1*sr*sp*sy+-1*cr*cy);
-	right[2] = -1*sr*cp;
-	up[0] = (cr*sp*cy+-sr*-sy);
-	up[1] = (cr*sp*sy+-sr*cy);
-	up[2] = cr*cp;
+	if (forward)
+	{
+		forward[0] = cp*cy;
+		forward[1] = cp*sy;
+		forward[2] = -sp;
+	}
+
+	if (right)
+	{
+		right[0] = (-1*sr*sp*cy+-1*cr*-sy);
+		right[1] = (-1*sr*sp*sy+-1*cr*cy);
+		right[2] = -1*sr*cp;
+	}
+
+	if (up)
+	{
+		up[0] = (cr*sp*cy+-sr*-sy);
+		up[1] = (cr*sp*sy+-sr*cy);
+		up[2] = cr*cp;
+	}
 }
 
 int VectorCompare (const vec3_t v1, const vec3_t v2)


### PR DESCRIPTION
## Summary
- guard the AngleVectors helper against null forward/right/up outputs
- prevent crashes when callers only need a subset of the generated vectors

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69165642a4e4832e85b93147acff7cc7)