### PR TITLE
Fix OIT particle visibility and reduce blood gloss

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -2768,7 +2768,9 @@ R_RenderScene
 */
 void R_RenderScene (void)
 {
-	R_SetupScene (); //johnfitz -- this does everything that should be done once per call to RenderScene
+        alphamode_t alphamode = R_GetEffectiveAlphaMode ();
+
+        R_SetupScene (); //johnfitz -- this does everything that should be done once per call to RenderScene
 
 	R_Clear ();
 
@@ -2790,18 +2792,22 @@ void R_RenderScene (void)
 
 	R_DrawWater (false);
 
-	R_BeginTranslucency ();
+        R_BeginTranslucency ();
 
-	R_DrawWater (true);
+        R_DrawWater (true);
 
-	R_DrawEntitiesOnList (true); //johnfitz -- true means this is the pass for alpha entities
+        if (alphamode == ALPHAMODE_OIT)
+                R_DrawParticles (true);
 
-	R_DrawParticles (true);
+        R_DrawEntitiesOnList (true); //johnfitz -- true means this is the pass for alpha entities
 
-	R_EndTranslucency ();
+        if (alphamode != ALPHAMODE_OIT)
+                R_DrawParticles (true);
 
-	if (R_GetEffectiveAlphaMode () == ALPHAMODE_OIT)
-		R_DrawParticles_PostOIT ();
+        R_EndTranslucency ();
+
+        if (alphamode == ALPHAMODE_OIT)
+                R_DrawParticles_PostOIT ();
 
 	R_ShowTris (); //johnfitz
 

--- a/Quake/r_decals.c
+++ b/Quake/r_decals.c
@@ -1007,7 +1007,7 @@ static qboolean R_CreateDecal (const decalgeom_t *geom, float radius, decaltype_
         {
                 float spec = 0.f;
                 if (type == DECAL_BLOOD)
-                        spec = 0.2f * CLAMP (0.f, dec->tint[3], 1.f);
+                        spec = 0.1f * CLAMP (0.f, dec->tint[3], 1.f);
                 R_AssignDecalVertices (dec, geom, radius, spec);
         }
 


### PR DESCRIPTION
## Summary
- adjust the translucent render sequence so particles draw in the OIT pass and survive the resolve step
- lower the specular term applied to blood decals for a less shiny look

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691673c2a960832eae10a91b70429049)