### PR TITLE
Handle realloc failures in dynamic buffers

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -201,10 +201,13 @@ static byte *Mod_DecompressVis (byte *in, qmodel_t *model)
 	row = (model->numleafs+7)>>3;
 	if (mod_decompressed == NULL || row > mod_decompressed_capacity)
 	{
+		byte	*newbuffer;
+
 		mod_decompressed_capacity = (row + VIS_ALIGN_MASK) & ~VIS_ALIGN_MASK;
-		mod_decompressed = (byte *) realloc (mod_decompressed, mod_decompressed_capacity);
-		if (!mod_decompressed)
+		newbuffer = (byte *) realloc (mod_decompressed, mod_decompressed_capacity);
+		if (!newbuffer)
 			Sys_Error ("Mod_DecompressVis: realloc() failed on %d bytes", mod_decompressed_capacity);
+		mod_decompressed = newbuffer;
 	}
 	out = mod_decompressed;
 	outend = mod_decompressed + row;
@@ -264,11 +267,14 @@ byte *Mod_NoVisPVS (qmodel_t *model)
 	pvsbytes = (pvsbytes + VIS_ALIGN_MASK) & ~VIS_ALIGN_MASK; // round up
 	if (mod_novis == NULL || pvsbytes > mod_novis_capacity)
 	{
+		byte	*newbuffer;
+
 		mod_novis_capacity = pvsbytes;
-		mod_novis = (byte *) realloc (mod_novis, mod_novis_capacity);
-		if (!mod_novis)
+		newbuffer = (byte *) realloc (mod_novis, mod_novis_capacity);
+		if (!newbuffer)
 			Sys_Error ("Mod_NoVisPVS: realloc() failed on %d bytes", mod_novis_capacity);
-		
+
+		mod_novis = newbuffer;
 		memset(mod_novis, 0xff, mod_novis_capacity);
 	}
 	return mod_novis;

--- a/Quake/pr_cmds.c
+++ b/Quake/pr_cmds.c
@@ -855,10 +855,13 @@ static int PF_newcheckclient (int check)
 	pvsbytes = (sv.worldmodel->numleafs+7)>>3;
 	if (checkpvs == NULL || pvsbytes > checkpvs_capacity)
 	{
+		byte *newbuffer;
+
 		checkpvs_capacity = pvsbytes;
-		checkpvs = (byte *) realloc (checkpvs, checkpvs_capacity);
-		if (!checkpvs)
+		newbuffer = (byte *) realloc (checkpvs, checkpvs_capacity);
+		if (!newbuffer)
 			Sys_Error ("PF_newcheckclient: realloc() failed on %d bytes", checkpvs_capacity);
+		checkpvs = newbuffer;
 	}
 	memcpy (checkpvs, pvs, pvsbytes);
 
@@ -2101,12 +2104,14 @@ static void PF_cl_playerkey_f(void)
 }
 
 
-static struct
+typedef struct qcpic_cache_s
 {
-	char name[MAX_QPATH];
-	unsigned int flags;
-	qpic_t *pic;
-} *qcpics;
+        char name[MAX_QPATH];
+        unsigned int flags;
+        qpic_t *pic;
+} qcpic_cache_t;
+
+static qcpic_cache_t *qcpics;
 static size_t numqcpics;
 static size_t maxqcpics;
 void PR_ReloadPics(qboolean purge)
@@ -2147,8 +2152,17 @@ static qpic_t *DrawQC_CachePic(const char *picname, unsigned int flags)
 
 	if (i+1 > maxqcpics)
 	{
-		maxqcpics = i + 32;
-		qcpics = realloc(qcpics, maxqcpics * sizeof(*qcpics));
+		size_t newmax = i + 32;
+		qcpic_cache_t *newbuffer = (qcpic_cache_t *)realloc(qcpics, newmax * sizeof(*qcpics));
+
+		if (!newbuffer)
+			Sys_Error ("DrawQC_CachePic: realloc() failed on %zu bytes", newmax * sizeof(*qcpics));
+
+		if (newmax > maxqcpics)
+			memset(newbuffer + maxqcpics, 0, (newmax - maxqcpics) * sizeof(*qcpics));
+
+		qcpics = newbuffer;
+		maxqcpics = newmax;
 	}
 
 	strcpy(qcpics[i].name, picname);
@@ -3153,11 +3167,12 @@ static int tokenizeqc(const char *str, qboolean dpfuckage)
 {
 	//FIXME: if dpfuckage, then we should handle punctuation specially, as well as /*.
 	const char *start = str;
-	while(qctoken_count > 0)
-	{
-		qctoken_count--;
-		free(qctoken[qctoken_count].token);
-	}
+        while(qctoken_count > 0)
+        {
+                qctoken_count--;
+                free(qctoken[qctoken_count].token);
+                qctoken[qctoken_count].token = NULL;
+        }
 	qctoken_count = 0;
 	while (qctoken_count < MAXQCTOKENS)
 	{


### PR DESCRIPTION
## Summary
- guard realloc calls in BSP visibility helpers to avoid leaking the previous buffer on allocation failure
- add a named cache entry struct for QC pics and zero freshly extended entries after resizing
- ensure QC token cleanup resets pointers after free to make static analyzers happy

## Testing
- not run (SDL2 dependency unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69167b3d5514832e95a18390315c47c0)