### PR TITLE
Add log messages for bot navigation file availability

### DIFF
--- a/Quake/sv_bot.c
+++ b/Quake/sv_bot.c
@@ -530,11 +530,11 @@ static qboolean SV_Bot_LoadNavMeshFromPath (const char *path)
 
 	result = SV_Bot_ParseNavFile (buffer, size, path);
 	free (buffer);
-	if (result)
-	{
-		Con_Printf ("Loaded navigation mesh from %s (%d nodes, %d links)\n", path, bot_nav_mesh.node_count, bot_nav_mesh.link_count);
-	}
-	return result;
+        if (result)
+        {
+                Con_Printf ("Using bot navigation file: %s (%d nodes, %d links)\n", path, bot_nav_mesh.node_count, bot_nav_mesh.link_count);
+        }
+        return result;
 }
 
 void SV_Bot_LoadNavigation (const char *mapname)
@@ -555,13 +555,15 @@ void SV_Bot_LoadNavigation (const char *mapname)
 	if (!mapname || !*mapname)
 		return;
 
-	for (i = 0; i < (int)(sizeof(patterns) / sizeof(patterns[0])); i++)
-	{
-		char path[MAX_QPATH];
-		q_snprintf (path, sizeof(path), patterns[i], mapname);
-		if (SV_Bot_LoadNavMeshFromPath (path))
-			return;
-	}
+        for (i = 0; i < (int)(sizeof(patterns) / sizeof(patterns[0])); i++)
+        {
+                char path[MAX_QPATH];
+                q_snprintf (path, sizeof(path), patterns[i], mapname);
+                if (SV_Bot_LoadNavMeshFromPath (path))
+                        return;
+        }
+
+        Con_Printf ("No bot navigation file present for %s\n", mapname);
 }
 
 static void SV_Bot_InitPathNode (bot_path_node_t *node)


### PR DESCRIPTION
## Summary
- log which bot navigation file is loaded
- report when no navigation file is present for the map

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a49d8f5b0832eaeb98aeb9bcc8011)