### PR TITLE
Fix waypoint debug size calculation

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -2624,15 +2624,15 @@ static void R_ShowBotDebug (void)
 
         count = SV_Bot_GetDebugWaypoints (waypoints, BOT_DEBUG_MAX_WAYPOINTS);
 
-        for (i = 0; i < count; i++)
-        {
-                uint32_t color = 0x7f7f7f7f;
-                float size = max (8.0f, waypoints[i].radius * 0.5f);
+		for (i = 0; i < count; i++)
+		{
+			uint32_t color = 0x7f7f7f7f;
+			float size = q_max (8.0f, waypoints[i].radius * 0.5f);
 
-                if (waypoints[i].unreachable)
-                        color = 0x7f0000ff;
-                else if (waypoints[i].is_target)
-                        color = 0x7f00ff00;
+			if (waypoints[i].unreachable)
+				color = 0x7f0000ff;
+			else if (waypoints[i].is_target)
+				color = 0x7f00ff00;
 
                 R_EmitDiamond (waypoints[i].origin, size, color);
         }


### PR DESCRIPTION
## Summary
- replace use of undefined max macro in bot debug waypoint rendering with q_max
- keep waypoint size calculation consistent with engine helper macros

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a59bea380832e9cec79f2bcbd76a9)