### PR TITLE
Allow bot debug drawing in multiplayer

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -2611,8 +2611,8 @@ static void R_ShowBotDebug (void)
         int count;
         int i;
 
-        if (bot_debug.value <= 0.0f || cl.maxclients > 1 || !r_drawentities.value || !sv.active)
-                return;
+	if (bot_debug.value <= 0.0f || !r_drawentities.value || !sv.active)
+		return;
 
         GL_BeginGroup ("Bot debug");
 


### PR DESCRIPTION
## Summary
- allow bot debug overlays to render without restricting to single-client sessions

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a5c0109a4832e9f003036dd289add)