### PR TITLE
Color bot navigation debug waypoints

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -2624,14 +2624,14 @@ static void R_ShowBotDebug (void)
 
         count = SV_Bot_GetDebugWaypoints (waypoints, BOT_DEBUG_MAX_WAYPOINTS);
 
-		for (i = 0; i < count; i++)
-		{
-			uint32_t color = 0x7f7f7f7f;
-			float size = q_max (8.0f, waypoints[i].radius * 0.5f);
+                for (i = 0; i < count; i++)
+                {
+                        uint32_t color = waypoints[i].from_nav_file ? 0x7fff0000 : 0x7fffffff;
+                        float size = q_max (8.0f, waypoints[i].radius * 0.5f);
 
-			if (waypoints[i].unreachable)
-				color = 0x7f0000ff;
-			else if (waypoints[i].is_target)
+                        if (waypoints[i].unreachable)
+                                color = 0x7f0000ff;
+                        else if (waypoints[i].is_target)
 				color = 0x7f00ff00;
 
                 R_EmitDiamond (waypoints[i].origin, size, color);

--- a/Quake/server.h
+++ b/Quake/server.h
@@ -324,6 +324,7 @@ typedef struct bot_debug_waypoint_s
         float           radius;
         qboolean        is_target;
         qboolean        unreachable;
+        qboolean        from_nav_file;
 } bot_debug_waypoint_t;
 
 int SV_Bot_GetDebugWaypoints (bot_debug_waypoint_t *out, int max_waypoints);

--- a/Quake/sv_bot.c
+++ b/Quake/sv_bot.c
@@ -2105,6 +2105,7 @@ int SV_Bot_GetDebugWaypoints (bot_debug_waypoint_t *out, int max_waypoints)
                         continue;
 
                 info = &out[count];
+                info->from_nav_file = SV_Bot_HasNavMesh ();
                 SV_Bot_GetNodePosition (wp, info->origin);
                 VectorSubtract (wp->v.maxs, wp->v.mins, extents);
 


### PR DESCRIPTION
## Summary
- track whether bot debug waypoints come from a navigation file
- render navigation-file waypoints blue while leaving generated ones white

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a63333a84832e842227892791e15e)