### PR TITLE
Fix BSPX payload limit pointer arithmetic

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -1762,7 +1762,7 @@ static void Mod_LoadBspx (const byte *buffer)
         }
 
         directory = (const bspx_lump_t *)(header_ptr - entry_size * (size_t)numlumps);
-        payload_limit = (size_t)(directory - buffer);
+payload_limit = (size_t)((const byte *)directory - buffer);
 
         Mod_BspxDebugf ("BSPX: directory has %d lumps (%zu bytes)\n", numlumps, (size_t)numlumps * entry_size);
 


### PR DESCRIPTION
## Summary
- compute BSPX directory payload limit using byte pointer arithmetic to avoid type mismatch

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b5ce57c0c832ea9faba9753030645)