### PR TITLE
Parse BSPX directories with 24-character names

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -1746,7 +1746,7 @@ static void Mod_LoadBspx (const byte *buffer)
 
         typedef struct bspx_lump_s
         {
-                char name[16];
+                char name[24];
                 int fileofs;
                 int filelen;
         } bspx_lump_t;
@@ -1817,7 +1817,7 @@ static void Mod_LoadBspx (const byte *buffer)
         for (int i = 0; i < numlumps; ++i)
         {
                 const bspx_lump_t *entry = directory + i;
-                char lumpname[17];
+                char lumpname[25];
                 size_t lumpofs, lumplen;
                 int raw_ofs = LittleLong (entry->fileofs);
                 int raw_len = LittleLong (entry->filelen);

--- a/Quake/gl_model.h
+++ b/Quake/gl_model.h
@@ -376,7 +376,7 @@ typedef struct bspx_static_light_s
 
 typedef struct bspx_entry_s
 {
-        char    name[17];
+        char    name[25];
         const byte *data;
         size_t  length;
 } bspx_entry_t;


### PR DESCRIPTION
## Summary
- parse BSPX directory entries using the correct 24-byte names and updated entry size
- store the full BSPX lump names so accompanying data can be imported

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bb361685c832e82aa6208f3b7d17b)