### PR TITLE
Fix BSPX loader directory offset handling

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -1792,10 +1792,14 @@ static void Mod_LoadBspx (const byte *buffer)
                         continue;
 
                 header_offset = (size_t)(candidate - buffer);
-                if (header_offset < entry_size * (size_t)numlumps)
+
+                if (header_offset > filesize - header_size)
                         continue;
 
-                directory = (const bspx_lump_t *)(candidate - entry_size * (size_t)numlumps);
+                if ((size_t)numlumps > (filesize - header_offset - header_size) / entry_size)
+                        continue;
+
+                directory = (const bspx_lump_t *)(candidate + header_size);
                 header_ptr = candidate;
                 break;
         }


### PR DESCRIPTION
## Summary
- parse BSPX directories located after the header instead of before it
- add bounds checks while scanning for BSPX headers to avoid overflow and invalid directories

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bb8bbae18832e8a9b1806d9855c27)