### PR TITLE
Make dynamic light clamp configurable

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -193,6 +193,7 @@ cvar_t	r_wateralpha = { "r_wateralpha","1",CVAR_ARCHIVE };
 cvar_t	r_litwater = { "r_litwater","1",CVAR_NONE };
 cvar_t	r_deluxemaps = { "r_deluxemaps", "1", CVAR_ARCHIVE };
 cvar_t	r_dynamic = { "r_dynamic","1",CVAR_ARCHIVE };
+cvar_t	r_dynamic_light_clamp = { "r_dynamic_light_clamp", "0", CVAR_ARCHIVE };
 cvar_t	r_novis = { "r_novis","0",CVAR_ARCHIVE };
 #if defined(USE_SIMD)
 cvar_t	r_simd = { "r_simd","1",CVAR_ARCHIVE };
@@ -1688,11 +1689,11 @@ void R_SetupView (void)
 	R_AnimateLight ();
 
 	{
-		int overbright_bits = CLAMP (0, (int)Q_rint (r_overbrightbits.value), 3);
-		float overbright = (float)(1 << overbright_bits);
+                int overbright_bits = CLAMP (0, (int)Q_rint (r_overbrightbits.value), 3);
+                float overbright = (float)(1 << overbright_bits);
 
-		if (overbright > 1.f)
-		{
+                if (overbright > 1.f)
+                {
 			overbright = GL_TemperedOverbright (overbright);
 
 			float console_vis = GL_ConsoleVisibility ();
@@ -1700,15 +1701,22 @@ void R_SetupView (void)
 			{
 				float compensated = 1.f + (overbright - 1.f) * (1.f - console_vis);
 				overbright = compensated;
-			}
-		}
+                        }
+                }
 
 
-		r_framedata.overbright = overbright;
-		r_framedata.lightmap_strength = q_max(0.f, r_lightmap_strength.value);
-		r_framedata.rim_alias = q_max(0.f, r_rim_alias.value);
-		r_framedata.rim_world = q_max(0.f, r_rim_world.value);
-		r_framedata.rim_exponent = q_max(0.5f, r_rim_exponent.value);
+                r_framedata.overbright = overbright;
+                float dynamic_light_clamp = r_dynamic_light_clamp.value;
+                if (dynamic_light_clamp <= 0.f)
+                        dynamic_light_clamp = q_max (overbright, 1.f);
+                else
+                        dynamic_light_clamp = q_max (dynamic_light_clamp, 0.f);
+
+                r_framedata.dynamic_light_clamp = dynamic_light_clamp;
+                r_framedata.lightmap_strength = q_max(0.f, r_lightmap_strength.value);
+                r_framedata.rim_alias = q_max(0.f, r_rim_alias.value);
+                r_framedata.rim_world = q_max(0.f, r_rim_world.value);
+                r_framedata.rim_exponent = q_max(0.5f, r_rim_exponent.value);
                 r_framedata.rim_pad0 = 0.f;
         }
 

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -356,6 +356,7 @@ void R_Init (void)
         Cvar_RegisterVariable (&r_litwater);
         Cvar_RegisterVariable (&r_deluxemaps);
         Cvar_RegisterVariable (&r_dynamic);
+	Cvar_RegisterVariable (&r_dynamic_light_clamp);
 	Cvar_RegisterVariable (&r_novis);
 #if defined(USE_SIMD)
 	Cvar_RegisterVariable (&r_simd);

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -115,6 +115,7 @@ extern	cvar_t	r_slimealpha;
 extern	cvar_t	r_litwater;
 extern	cvar_t	r_deluxemaps;
 extern	cvar_t	r_dynamic;
+extern	cvar_t	r_dynamic_light_clamp;
 extern	cvar_t	r_novis;
 extern	cvar_t	r_scale;
 
@@ -452,6 +453,7 @@ typedef struct gpuframedata_s {
 	float	screendither;
 	float	texturedither;
 	float	overbright;
+	float	dynamic_light_clamp;
 	float	lightmap_strength;
 	float	rim_alias;
 	float	rim_world;

--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -33,6 +33,7 @@ layout(std140, binding=0) uniform FrameDataUBO
         float   _FrameScreenDither;
         float   _FrameTextureDither;
         float   _FrameOverbright;
+        float   _FrameDynamicLightClamp;
         float   _FrameLightmapStrength;
         float   _FrameRimAlias;
         float   _FrameRimWorld;

--- a/Quake/shaders/frame_uniforms.glsl
+++ b/Quake/shaders/frame_uniforms.glsl
@@ -12,6 +12,7 @@ layout(std140, binding=0) uniform FrameDataUBO
         float   ScreenDither;
         float   TextureDither;
         float   Overbright;
+        float   DynamicLightClamp;
         float   LightmapStrength;
         float   RimAlias;
         float   RimWorld;

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -705,7 +705,7 @@ void main()
             // saturating Add (bleibt <= 1) with hue preservation
             if (dynamic_light.x > 0.0 || dynamic_light.y > 0.0 || dynamic_light.z > 0.0)
             {
-                float max_dynamic = max(Overbright, 1.0);
+                float max_dynamic = DynamicLightClamp;
                 vec3  cap = vec3(max_dynamic);
                 total_light = clamp_preserving_hue(total_light + dynamic_light, cap);
             }


### PR DESCRIPTION
## Summary
- add an r_dynamic_light_clamp cvar to configure dynamic light saturation
- propagate the clamp value through frame data to shaders
- use the configurable clamp in the world shader to limit dynamic light accumulation

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c5234064c832eb55377336c2fb963)