### PR TITLE
Fix overbright scaling in world shader

### DIFF
--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -728,11 +728,13 @@ void main()
     if (sun_remaining.x > 0.0 || sun_remaining.y > 0.0 || sun_remaining.z > 0.0)
         total_light += clamp_preserving_hue(sun_light, sun_remaining);
 
+    vec3 total_light_clamped = clamp_preserving_hue(total_light, vec3(Overbright));
+
 #if DITHER >= 2
-    vec3 total_light_unit = clamp_preserving_hue(total_light, vec3(1.0));
-    vec3 total_lightmap = clamp_preserving_hue(floor(total_light_unit * 63.0 + 0.5) * (Overbright/63.0), vec3(1.0));
+    vec3 total_light_unit = total_light_clamped / Overbright;
+    vec3 total_lightmap = clamp_preserving_hue(floor(total_light_unit * 63.0 + 0.5) * (Overbright/63.0), vec3(Overbright));
 #else
-    vec3 total_lightmap = clamp_preserving_hue(total_light * Overbright, vec3(1.0));
+    vec3 total_lightmap = total_light_clamped;
 #endif
 
 #if MODE != 1


### PR DESCRIPTION
## Summary
- clamp world lighting using the configured overbright range
- ensure dithering quantization preserves values above 1.0 instead of clipping

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c5b4de600832ead5cffabb9b245b0)