### PR TITLE
Add map and final overbright controls

### DIFF
--- a/Quake/gl_rlight.c
+++ b/Quake/gl_rlight.c
@@ -393,6 +393,8 @@ static void InterpolateLightmap (vec3_t color, msurface_t *surf, int ds, int dt)
 	color[0] = ((((((((r11-r10) * dsfrac) >> 4) + r10)-((((r01-r00) * dsfrac) >> 4) + r00)) * dtfrac) >> 4) + ((((r01-r00) * dsfrac) >> 4) + r00)) * (1.f/256.f);
 	color[1] = ((((((((g11-g10) * dsfrac) >> 4) + g10)-((((g01-g00) * dsfrac) >> 4) + g00)) * dtfrac) >> 4) + ((((g01-g00) * dsfrac) >> 4) + g00)) * (1.f/256.f);
 	color[2] = ((((((((b11-b10) * dsfrac) >> 4) + b10)-((((b01-b00) * dsfrac) >> 4) + b00)) * dtfrac) >> 4) + ((((b01-b00) * dsfrac) >> 4) + b00)) * (1.f/256.f);
+
+	VectorScale (color, r_framedata.map_overbright, color);
 }
 
 /*

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -86,22 +86,6 @@ static float GL_ConsoleVisibility (void)
 	return CLAMP (0.f, scr_con_current / height, 1.f);
 }
 
-static float GL_TemperedOverbright (float overbright)
-{
-	if (overbright <= 1.f)
-		return 1.f;
-
-	/*
-	* Compress the raw 2^n scaling so the boost favours highlights over the
-	* rest of the scene.  A sub-linear exponent keeps very bright areas hot
-	* while easing off on mid and dark tones to avoid washing out the image.
-	*/
-	const float exponent = 0.75f;
-	float tempered = powf (overbright, exponent);
-
-	return q_max (tempered, 1.f);
-}
-
 static qboolean MatrixInverse4x4(const float m[16], float out[16])
 {
     float inv[16];
@@ -245,6 +229,7 @@ cvar_t	r_filmgrain = { "r_filmgrain", "0.05", CVAR_ARCHIVE };
 cvar_t	r_filmgrain_size = { "r_filmgrain_size", "3.0", CVAR_ARCHIVE };
 cvar_t	r_filmgrain_strength = { "r_filmgrain_strength", "1.0", CVAR_ARCHIVE };
 
+cvar_t	r_mapoverbrightbits = { "r_mapoverbrightbits", "2", CVAR_ARCHIVE };
 cvar_t	r_overbrightbits = { "r_overbrightbits", "2", CVAR_ARCHIVE };
 
 cvar_t	gl_finish = { "gl_finish","0",CVAR_NONE };
@@ -1689,36 +1674,27 @@ void R_SetupView (void)
 	R_AnimateLight ();
 
 	{
-                int overbright_bits = CLAMP (0, (int)Q_rint (r_overbrightbits.value), 3);
-                float overbright = (float)(1 << overbright_bits);
+		int map_overbright_bits = CLAMP (0, (int)Q_rint (r_mapoverbrightbits.value), 2);
+		int overbright_bits = CLAMP (0, (int)Q_rint (r_overbrightbits.value), 2);
+		float map_overbright = (float)(1 << map_overbright_bits);
+		float overbright = (float)(1 << overbright_bits);
 
-                if (overbright > 1.f)
-                {
-			overbright = GL_TemperedOverbright (overbright);
+		r_framedata.map_overbright = map_overbright;
+		r_framedata.identity_light = 1.f / map_overbright;
+		r_framedata.overbright = overbright;
+		float dynamic_light_clamp = r_dynamic_light_clamp.value;
+		if (dynamic_light_clamp <= 0.f)
+		dynamic_light_clamp = q_max (map_overbright, 1.f);
+		else
+		dynamic_light_clamp = q_max (dynamic_light_clamp, 0.f);
 
-			float console_vis = GL_ConsoleVisibility ();
-			if (console_vis > 0.f)
-			{
-				float compensated = 1.f + (overbright - 1.f) * (1.f - console_vis);
-				overbright = compensated;
-                        }
-                }
-
-
-                r_framedata.overbright = overbright;
-                float dynamic_light_clamp = r_dynamic_light_clamp.value;
-                if (dynamic_light_clamp <= 0.f)
-                        dynamic_light_clamp = q_max (overbright, 1.f);
-                else
-                        dynamic_light_clamp = q_max (dynamic_light_clamp, 0.f);
-
-                r_framedata.dynamic_light_clamp = dynamic_light_clamp;
-                r_framedata.lightmap_strength = q_max(0.f, r_lightmap_strength.value);
-                r_framedata.rim_alias = q_max(0.f, r_rim_alias.value);
-                r_framedata.rim_world = q_max(0.f, r_rim_world.value);
-                r_framedata.rim_exponent = q_max(0.5f, r_rim_exponent.value);
-                r_framedata.rim_pad0 = 0.f;
-        }
+		r_framedata.dynamic_light_clamp = dynamic_light_clamp;
+		r_framedata.lightmap_strength = q_max(0.f, r_lightmap_strength.value);
+		r_framedata.rim_alias = q_max(0.f, r_rim_alias.value);
+		r_framedata.rim_world = q_max(0.f, r_rim_world.value);
+		r_framedata.rim_exponent = q_max(0.5f, r_rim_exponent.value);
+		r_framedata.rim_pad0 = 0.f;
+		}
 
         {
                 qboolean enable_delux =

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -32,6 +32,7 @@ extern cvar_t r_lerplightstyles;
 extern cvar_t gl_fullbrights;
 extern cvar_t gl_farclip;
 extern cvar_t gl_overbright_models;
+extern cvar_t r_mapoverbrightbits;
 extern cvar_t r_overbrightbits;
 extern cvar_t r_waterwarp;
 extern cvar_t r_oldskyleaf;
@@ -307,9 +308,21 @@ R_OverbrightBits_f
 */
 static void R_OverbrightBits_f (cvar_t *var)
 {
-	int value = CLAMP (0, (int)Q_rint (var->value), 3);
-	if (value != (int)var->value)
-		Cvar_SetValueQuick (var, (float)value);
+int value = CLAMP (0, (int)Q_rint (var->value), 2);
+if (value != (int)var->value)
+Cvar_SetValueQuick (var, (float)value);
+}
+
+/*
+====================
+R_MapOverbrightBits_f
+====================
+*/
+static void R_MapOverbrightBits_f (cvar_t *var)
+{
+int value = CLAMP (0, (int)Q_rint (var->value), 2);
+if (value != (int)var->value)
+Cvar_SetValueQuick (var, (float)value);
 }
 
 /*
@@ -405,13 +418,15 @@ void R_Init (void)
 	Cvar_RegisterVariable (&r_vignette_noise);
 	Cvar_RegisterVariable (&r_lens_planar);
 	Cvar_RegisterVariable (&r_chromatic_aberration);
-        Cvar_RegisterVariable (&r_filmgrain);
-        Cvar_RegisterVariable (&r_filmgrain_size);
-        Cvar_RegisterVariable (&r_filmgrain_strength);
-        Cvar_RegisterVariable (&r_overbrightbits);
-	Cvar_SetCallback (&r_overbrightbits, R_OverbrightBits_f);
+Cvar_RegisterVariable (&r_filmgrain);
+Cvar_RegisterVariable (&r_filmgrain_size);
+Cvar_RegisterVariable (&r_filmgrain_strength);
+Cvar_RegisterVariable (&r_mapoverbrightbits);
+Cvar_RegisterVariable (&r_overbrightbits);
+Cvar_SetCallback (&r_overbrightbits, R_OverbrightBits_f);
+Cvar_SetCallback (&r_mapoverbrightbits, R_MapOverbrightBits_f);
 
-	Cvar_RegisterVariable (&gl_finish);
+Cvar_RegisterVariable (&gl_finish);
 	Cvar_RegisterVariable (&gl_clear);
 	Cvar_RegisterVariable (&gl_polyblend);
 	Cvar_RegisterVariable (&gl_playermip);

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -453,6 +453,8 @@ typedef struct gpuframedata_s {
 	float	screendither;
 	float	texturedither;
 	float	overbright;
+	float	map_overbright;
+	float	identity_light;
 	float	dynamic_light_clamp;
 	float	lightmap_strength;
 	float	rim_alias;

--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -33,6 +33,8 @@ layout(std140, binding=0) uniform FrameDataUBO
         float   _FrameScreenDither;
         float   _FrameTextureDither;
         float   _FrameOverbright;
+        float   _FrameMapOverbright;
+        float   _FrameIdentityLight;
         float   _FrameDynamicLightClamp;
         float   _FrameLightmapStrength;
         float   _FrameRimAlias;
@@ -309,8 +311,9 @@ void main()
         }
         lighting = max(lighting, vec3(0.0));
 
-        uint overbrightFlag = floatBitsToUint(Fog.w) >> 31u;
-        bool useFullbrightHack = ((in_flags & ALIAS_FLAG_FULLBRIGHT_HACK) != 0) && overbrightFlag == 0u;
+float mapOverbright = _FrameMapOverbright;
+uint overbrightFlag = mapOverbright > 1.0 ? 1u : 0u;
+bool useFullbrightHack = ((in_flags & ALIAS_FLAG_FULLBRIGHT_HACK) != 0) && overbrightFlag == 0u;
 
         if (useFullbrightHack)
         {
@@ -351,7 +354,8 @@ void main()
                 }
         }
 
-        lighting = ldexp(lighting, ivec3(int(overbrightFlag)));
+lighting = max(lighting, vec3(0.0));
+lighting *= _FrameIdentityLight;
 
 #if ALPHATEST
         vec3 shadedColor = baseColor * lighting;
@@ -359,10 +363,11 @@ void main()
         vec3 shadedColor = mix(baseColor, baseColor * lighting, baseSample.a);
 #endif
 
-        if (((in_flags & ALIAS_FLAG_ITEM) != 0) || ((in_flags & ALIAS_FLAG_FORCE_FULLBRIGHT) != 0))
-                shadedColor += fullbright;
-        shadedColor += emissive;
-        shadedColor = clamp(shadedColor, 0.0, 1.0);
+if (((in_flags & ALIAS_FLAG_ITEM) != 0) || ((in_flags & ALIAS_FLAG_FORCE_FULLBRIGHT) != 0))
+shadedColor += fullbright;
+shadedColor += emissive;
+shadedColor *= _FrameOverbright;
+shadedColor = clamp(shadedColor, 0.0, 1.0);
 
 	vec4 result = vec4(shadedColor, in_color.a);
 	if ((in_flags & ALIAS_FLAG_VIEWMODEL) != 0)

--- a/Quake/shaders/frame_uniforms.glsl
+++ b/Quake/shaders/frame_uniforms.glsl
@@ -12,6 +12,8 @@ layout(std140, binding=0) uniform FrameDataUBO
         float   ScreenDither;
         float   TextureDither;
         float   Overbright;
+        float   MapOverbright;
+        float   IdentityLight;
         float   DynamicLightClamp;
         float   LightmapStrength;
         float   RimAlias;

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -575,6 +575,7 @@ void main()
     }
 
     static_light *= LightmapStrength;
+    static_light *= MapOverbright;
 
     // schnellere Flächennormalen aus Derivaten
     vec3 dn = cross(DFDX(in_pos), DFDY(in_pos));
@@ -728,7 +729,7 @@ void main()
     if (sun_remaining.x > 0.0 || sun_remaining.y > 0.0 || sun_remaining.z > 0.0)
         total_light += clamp_preserving_hue(sun_light, sun_remaining);
 
-    vec3 total_light_clamped = clamp_preserving_hue(total_light, vec3(Overbright));
+    vec3 total_light_clamped = max(total_light, vec3(0.0));
 
 #if DITHER >= 2
     vec3 total_light_unit = total_light_clamped / Overbright;
@@ -835,6 +836,7 @@ void main()
         result.rgb = ApplyEnvBlend(result.rgb, env_color, env_amount, blendMode);
     }
 
+    result.rgb *= Overbright;
     result = clamp(result, 0.0, 1.0);
     vec4 fogData = ((in_flags & CF_CUSTOM_FOG) != 0u) ? in_fog_color : Fog;
     result.rgb = ApplyFog(result.rgb, in_pos - EyePos, fogData);


### PR DESCRIPTION
## Summary
- add a separate r_mapoverbrightbits cvar with clamped bitshift scaling alongside the existing renderer overbright bits
- pass map overbright and identity light factors through frame data so lightmap sampling and model lighting are scaled correctly
- apply the final overbright modulation uniformly in shaders after lighting calculations and clamp the output

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c8c797500832eabef1be8b5369182)