### PR TITLE
Add missing lightmap strength to frame data

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -1688,6 +1688,7 @@ void R_SetupView (void)
                         dynamic_light_clamp = q_max (dynamic_light_clamp, 0.f);
 
                 r_framedata.dynamic_light_clamp = dynamic_light_clamp;
+		r_framedata.lightmap_strength = 1.f;
 		r_framedata.rim_alias = q_max(0.f, r_rim_alias.value);
 		r_framedata.rim_world = q_max(0.f, r_rim_world.value);
 		r_framedata.rim_exponent = q_max(0.5f, r_rim_exponent.value);

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -455,6 +455,7 @@ typedef struct gpuframedata_s {
 	float	map_overbright;
 	float	identity_light;
 	float	dynamic_light_clamp;
+	float	lightmap_strength;
 	float	rim_alias;
 	float	rim_world;
 	float	rim_exponent;


### PR DESCRIPTION
## Summary
- add the lightmap_strength value to the GPU frame data structure to match shader expectations
- populate lightmap_strength each frame so map overbright bits no longer leave the uniform undefined

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cb694de84832eb87d274440f9812b)