### PR TITLE
Add r_mapoverbrightbits cvar

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -245,6 +245,7 @@ cvar_t	r_filmgrain_size = { "r_filmgrain_size", "3.0", CVAR_ARCHIVE };
 cvar_t	r_filmgrain_strength = { "r_filmgrain_strength", "1.0", CVAR_ARCHIVE };
 
 cvar_t	r_overbrightbits = { "r_overbrightbits", "2", CVAR_ARCHIVE };
+cvar_t	r_mapoverbrightbits = { "r_mapoverbrightbits", "2", CVAR_ARCHIVE };
 
 cvar_t	gl_finish = { "gl_finish","0",CVAR_NONE };
 cvar_t	gl_clear = { "gl_clear","1",CVAR_NONE };
@@ -1688,8 +1689,14 @@ void R_SetupView (void)
 	R_AnimateLight ();
 
 	{
-		int overbright_bits = CLAMP (0, (int)Q_rint (r_overbrightbits.value), 3);
-		float overbright = (float)(1 << overbright_bits);
+		int map_overbright_bits;
+
+		if (!strcmp (r_mapoverbrightbits.string, r_mapoverbrightbits.default_string))
+			map_overbright_bits = CLAMP (0, (int)Q_rint (r_overbrightbits.value), 3);
+		else
+			map_overbright_bits = CLAMP (0, (int)Q_rint (r_mapoverbrightbits.value), 3);
+
+		float overbright = (float)(1 << map_overbright_bits);
 
 		if (overbright > 1.f)
 		{
@@ -1709,8 +1716,8 @@ void R_SetupView (void)
 		r_framedata.rim_alias = q_max(0.f, r_rim_alias.value);
 		r_framedata.rim_world = q_max(0.f, r_rim_world.value);
 		r_framedata.rim_exponent = q_max(0.5f, r_rim_exponent.value);
-                r_framedata.rim_pad0 = 0.f;
-        }
+		r_framedata.rim_pad0 = 0.f;
+	}
 
         {
                 qboolean enable_delux =

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -33,6 +33,7 @@ extern cvar_t gl_fullbrights;
 extern cvar_t gl_farclip;
 extern cvar_t gl_overbright_models;
 extern cvar_t r_overbrightbits;
+extern cvar_t r_mapoverbrightbits;
 extern cvar_t r_waterwarp;
 extern cvar_t r_oldskyleaf;
 extern cvar_t r_drawworld;
@@ -404,11 +405,13 @@ void R_Init (void)
 	Cvar_RegisterVariable (&r_vignette_noise);
 	Cvar_RegisterVariable (&r_lens_planar);
 	Cvar_RegisterVariable (&r_chromatic_aberration);
-        Cvar_RegisterVariable (&r_filmgrain);
-        Cvar_RegisterVariable (&r_filmgrain_size);
-        Cvar_RegisterVariable (&r_filmgrain_strength);
-        Cvar_RegisterVariable (&r_overbrightbits);
+	Cvar_RegisterVariable (&r_filmgrain);
+	Cvar_RegisterVariable (&r_filmgrain_size);
+	Cvar_RegisterVariable (&r_filmgrain_strength);
+	Cvar_RegisterVariable (&r_overbrightbits);
 	Cvar_SetCallback (&r_overbrightbits, R_OverbrightBits_f);
+	Cvar_RegisterVariable (&r_mapoverbrightbits);
+	Cvar_SetCallback (&r_mapoverbrightbits, R_OverbrightBits_f);
 
 	Cvar_RegisterVariable (&gl_finish);
 	Cvar_RegisterVariable (&gl_clear);


### PR DESCRIPTION
## Summary
- add a new `r_mapoverbrightbits` cvar for tuning map overbrightening
- register and clamp the new cvar alongside the existing overbright setting
- use the map-specific value for frame overbright, inheriting `r_overbrightbits` by default

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ccdfb3bd8832eba3dfe9f07fba37f)