### PR TITLE
Handle invalid model type

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -643,11 +643,17 @@ static qmodel_t *Mod_LoadModel (qmodel_t *mod, qboolean crash)
         default:
                 Mod_LoadBrushModel (mod, buf);
                 break;
-	}
+        }
 
-	free (buf);
+        if (crash && mod->type == mod_ext_invalid)
+        {
+                Host_Error ("Mod_LoadModel: couldn't load %s", mod->name);
+                return NULL;
+        }
 
-	return mod;
+        free (buf);
+
+        return mod;
 }
 
 /*

--- a/Quake/gl_model.h
+++ b/Quake/gl_model.h
@@ -396,7 +396,7 @@ extern	trivertx_t			*poseverts[MAXALIASFRAMES];
 // Whole model
 //
 
-typedef enum {mod_brush, mod_alias, mod_sprite, mod_numtypes} modtype_t;
+typedef enum {mod_brush, mod_alias, mod_sprite, mod_ext_invalid, mod_numtypes} modtype_t;
 
 #define	EF_ROCKET	1			// leave a trail
 #define	EF_GRENADE	2			// leave a trail


### PR DESCRIPTION
## Summary
- add an explicit invalid model type to the Quake renderer model enum
- guard model loading to error out when unsupported model types are requested in crash mode

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cfb35463c832e9ef0d8f7f90ddcac)