### PR TITLE
Fix overbright bits cvars

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -245,7 +245,7 @@ cvar_t	r_filmgrain_size = { "r_filmgrain_size", "3.0", CVAR_ARCHIVE };
 cvar_t	r_filmgrain_strength = { "r_filmgrain_strength", "1.0", CVAR_ARCHIVE };
 
 cvar_t	r_overbrightbits = { "r_overbrightbits", "2", CVAR_ARCHIVE };
-cvar_t	r_mapoverbrightbits = { "r_mapoverbrightbits", "2", CVAR_ARCHIVE };
+cvar_t	r_mapoverbrightbits = { "r_mapoverbrightbits", "-1", CVAR_ARCHIVE };
 
 cvar_t	gl_finish = { "gl_finish","0",CVAR_NONE };
 cvar_t	gl_clear = { "gl_clear","1",CVAR_NONE };
@@ -1691,7 +1691,7 @@ void R_SetupView (void)
 	{
 		int map_overbright_bits;
 
-		if (!strcmp (r_mapoverbrightbits.string, r_mapoverbrightbits.default_string))
+		if (r_mapoverbrightbits.value < 0.f)
 			map_overbright_bits = CLAMP (0, (int)Q_rint (r_overbrightbits.value), 3);
 		else
 			map_overbright_bits = CLAMP (0, (int)Q_rint (r_mapoverbrightbits.value), 3);

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -308,7 +308,8 @@ R_OverbrightBits_f
 */
 static void R_OverbrightBits_f (cvar_t *var)
 {
-	int value = CLAMP (0, (int)Q_rint (var->value), 3);
+	int min_value = (var == &r_mapoverbrightbits) ? -1 : 0;
+	int value = CLAMP (min_value, (int)Q_rint (var->value), 3);
 	if (value != (int)var->value)
 		Cvar_SetValueQuick (var, (float)value);
 }


### PR DESCRIPTION
## Summary
- allow r_mapoverbrightbits to use -1 as a sentinel that falls back to r_overbrightbits
- update overbright clamping so map overrides accept the sentinel while user values stay bounded

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e15d2c39c832ea18bab3a94d85137)