### PR TITLE
Fix standard BSP lightmap loading

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -2050,9 +2050,9 @@ static void Mod_LoadLighting (lump_t *l)
 #endif
 
         loadmodel->lightdata = (byte *) Hunk_AllocNameNoFill (l->filelen * 3, litfilename);
-        in = loadmodel->lightdata + l->filelen * 2;
+        in = mod_base + l->fileofs;
         out = loadmodel->lightdata;
-        memcpy (in, mod_base + l->fileofs, l->filelen);
+
         for (i = 0; i < l->filelen; i++)
         {
                 d = *in++;


### PR DESCRIPTION
## Summary
- avoid overlapping source/destination when expanding legacy BSP light data
- ensure standard Quake BSP lightmaps are expanded directly from the raw lump bytes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f8b4d8150832eb1e1c439e67b868e)