### PR TITLE
Define texture type metadata

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -37,6 +37,7 @@ void Mod_LoadMD3Model (qmodel_t *mod, void *buffer);
 void Mod_LoadMD5MeshModel (qmodel_t *mod, void *buffer);
 void Mod_LoadIQMModel (qmodel_t *mod, const void *buffer);
 static qmodel_t *Mod_LoadModel (qmodel_t *mod, qboolean crash);
+static void Mod_BuildTextureTypes (qmodel_t *mod);
 
 static void Mod_Print (void);
 
@@ -1131,6 +1132,52 @@ static void Mod_LoadTextures (lump_t *l)
 				tx2->alternate_anims = anims[0];
 		}
 	}
+}
+
+static void Mod_BuildTextureTypes (qmodel_t *mod)
+{
+        int counts[TEXTYPE_COUNT] = {0};
+        int cursors[TEXTYPE_COUNT];
+        int i;
+
+        // classify textures; default to the generic type for now
+        for (i = 0; i < mod->numtextures; i++)
+        {
+                texture_t *tex = mod->textures[i];
+                if (!tex)
+                        continue;
+
+                tex->type = TEXTYPE_DEFAULT;
+                counts[tex->type]++;
+        }
+
+        mod->texofs[0] = 0;
+        for (i = 1; i < TEXTYPE_COUNT; i++)
+        {
+                mod->texofs[i] = mod->texofs[i - 1] + counts[i - 1];
+        }
+        mod->texofs[TEXTYPE_COUNT] = mod->texofs[TEXTYPE_COUNT - 1] + counts[TEXTYPE_COUNT - 1];
+
+        if (mod->texofs[TEXTYPE_COUNT] <= 0)
+        {
+                mod->usedtextures = NULL;
+                return;
+        }
+
+        memset (cursors, 0, sizeof(cursors));
+        mod->usedtextures = (int *) Hunk_AllocName (mod->texofs[TEXTYPE_COUNT] * sizeof(int), loadname);
+
+        for (i = 0; i < mod->numtextures; i++)
+        {
+                texture_t *tex = mod->textures[i];
+                int type;
+
+                if (!tex)
+                        continue;
+
+                type = tex->type;
+                mod->usedtextures[mod->texofs[type] + cursors[type]++] = i;
+        }
 }
 
 /*
@@ -2966,6 +3013,7 @@ static void Mod_LoadBrushModel (qmodel_t *mod, void *buffer)
 	Mod_LoadEdges (&header->lumps[LUMP_EDGES], bsp2);
 	Mod_LoadSurfedges (&header->lumps[LUMP_SURFEDGES]);
 	Mod_LoadTextures (&header->lumps[LUMP_TEXTURES]);
+	Mod_BuildTextureTypes (mod);
 	Mod_LoadLighting (&header->lumps[LUMP_LIGHTING]);
 	Mod_LoadPlanes (&header->lumps[LUMP_PLANES]);
 	Mod_LoadTexinfo (&header->lumps[LUMP_TEXINFO]);

--- a/Quake/gl_model.h
+++ b/Quake/gl_model.h
@@ -78,20 +78,35 @@ typedef enum {
 	chain_model = 1
 } texchain_t;
 
+typedef enum textype_e {
+        TEXTYPE_DEFAULT = 0,
+        TEXTYPE_CUTOUT,
+        TEXTYPE_SKY,
+        TEXTYPE_WATER,
+        TEXTYPE_SLIME,
+        TEXTYPE_LAVA,
+        TEXTYPE_TELE,
+
+        TEXTYPE_COUNT,
+
+        TEXTYPE_FIRSTLIQUID = TEXTYPE_WATER,
+        TEXTYPE_LASTLIQUID = TEXTYPE_TELE,
+} textype_t;
+
 typedef struct texture_s
 {
-	char				name[16];
-	unsigned			width, height;
-	unsigned			shift;		// Q64
-	struct gltexture_s	*gltexture; //johnfitz -- pointer to gltexture
-	struct gltexture_s	*fullbright; //johnfitz -- fullbright mask texture
-	struct msurface_s	*texturechains[2];	// for texture chains
-	int					anim_total;				// total tenths in sequence ( 0 = no)
-	int					anim_min, anim_max;		// time for this frame min <=time< max
-	struct texture_s	*anim_next;		// in the animation sequence
-	struct texture_s	*alternate_anims;	// bmodels in frmae 1 use these
+        char                            name[16];
+        unsigned                        width, height;
+        unsigned                        shift;          // Q64
+        struct gltexture_s      *gltexture; //johnfitz -- pointer to gltexture
+        struct gltexture_s      *fullbright; //johnfitz -- fullbright mask texture
+        struct msurface_s       *texturechains[2];      // for texture chains
+        int                                     anim_total;                             // total tenths in sequence ( 0 = no)
+        int                                     anim_min, anim_max;             // time for this frame min <=time< max
+        struct texture_s        *anim_next;             // in the animation sequence
+        struct texture_s        *alternate_anims;       // bmodels in frmae 1 use these
+        textype_t                        type;
 } texture_t;
-
 
 typedef struct efrag_s
 {
@@ -557,6 +572,12 @@ typedef struct qmodel_s
 
 	int			numtextures;
 	texture_t	**textures;
+
+	int			*usedtextures;
+	int			texofs[TEXTYPE_COUNT + 1];
+	int			firstcmd;
+	qboolean	haslitwater;
+	byte		*deluxdata;
 
 	byte		*visdata;
 	void		*lightgrid;


### PR DESCRIPTION
## Summary
- add a dedicated texture type enum and fields on models and textures
- build default texture type offsets and mapping during brush model loading

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922357c66a4832eac99bef653888bad)