### PR TITLE
Fix alias model and rendering constants for build

### DIFF
--- a/Quake/gl_mesh.c
+++ b/Quake/gl_mesh.c
@@ -52,23 +52,23 @@ void GL_MakeAliasModelDisplayLists (qmodel_t *aliasmodel, aliashdr_t *paliashdr)
 	aliasmesh_t *desc;
 
 	// first, copy the verts onto the hunk
-	verts = (trivertx_t *) Hunk_AllocNoFill (paliashdr->numposes * paliashdr->numverts * sizeof(trivertx_t));
-	paliashdr->vertexes = (byte *)verts - (byte *)paliashdr;
-	for (i=0 ; i<paliashdr->numposes ; i++)
-		for (j=0 ; j<paliashdr->numverts ; j++)
-			verts[i*paliashdr->numverts + j] = poseverts[i][j];
+verts = (trivertx_t *) Hunk_AllocNoFill (paliashdr->nummorphposes * paliashdr->numverts * sizeof(trivertx_t));
+paliashdr->vertexes = (byte *)verts - (byte *)paliashdr;
+for (i=0 ; i<paliashdr->nummorphposes ; i++)
+for (j=0 ; j<paliashdr->numverts ; j++)
+verts[i*paliashdr->numverts + j] = poseverts_mdl[i][j];
 
 	// there can never be more than this number of verts and we just put them all on the hunk
 	// (each vertex can be used twice, once with the original UVs and once with the seam adjustment)
-	desc = (aliasmesh_t *) Hunk_Alloc (sizeof (aliasmesh_t) * pheader->numverts * 2);
+desc = (aliasmesh_t *) Hunk_Alloc (sizeof (aliasmesh_t) * paliashdr->numverts * 2);
 
 	// there will always be this number of indexes
-	indexes = (unsigned short *) Hunk_Alloc (sizeof (unsigned short) * pheader->numtris * 3);
+indexes = (unsigned short *) Hunk_Alloc (sizeof (unsigned short) * paliashdr->numtris * 3);
 
-	pheader->indexes = (intptr_t) indexes - (intptr_t) pheader;
-	pheader->meshdesc = (intptr_t) desc - (intptr_t) pheader;
-	pheader->numindexes = 0;
-	pheader->numverts_vbo = 0;
+paliashdr->indexes = (intptr_t) indexes - (intptr_t) paliashdr;
+paliashdr->meshdesc = (intptr_t) desc - (intptr_t) paliashdr;
+paliashdr->numindexes = 0;
+paliashdr->numverts_vbo = 0;
 
 	mark = Hunk_LowMark ();
 
@@ -76,7 +76,7 @@ void GL_MakeAliasModelDisplayLists (qmodel_t *aliasmodel, aliashdr_t *paliashdr)
 	// each value is the final index + 1, or 0 if the corresponding vertex hasn't been emitted yet
 	remap = (unsigned short *) Hunk_Alloc (paliashdr->numverts * 2 * sizeof (remap[0]));
 
-	for (i = 0; i < pheader->numtris; i++)
+for (i = 0; i < paliashdr->numtris; i++)
 	{
 		for (j = 0; j < 3; j++)
 		{
@@ -101,23 +101,23 @@ void GL_MakeAliasModelDisplayLists (qmodel_t *aliasmodel, aliashdr_t *paliashdr)
 				if (v & 1)
 					s += paliashdr->skinwidth / 2;
 
-				desc[pheader->numverts_vbo].vertindex = vertindex;
-				desc[pheader->numverts_vbo].st[0] = s;
-				desc[pheader->numverts_vbo].st[1] = t;
+desc[paliashdr->numverts_vbo].vertindex = vertindex;
+desc[paliashdr->numverts_vbo].st[0] = s;
+desc[paliashdr->numverts_vbo].st[1] = t;
 
-				remap[v] = ++pheader->numverts_vbo;
-			}
+remap[v] = ++paliashdr->numverts_vbo;
+}
 
-			// emit index
-			indexes[pheader->numindexes++] = remap[v] - 1;
-		}
-	}
+// emit index
+indexes[paliashdr->numindexes++] = remap[v] - 1;
+}
+}
 
 	// free temporary data
 	Hunk_FreeToLowMark (mark);
 
 	// upload immediately
-	GLMesh_LoadVertexBuffer (aliasmodel, pheader);
+GLMesh_LoadVertexBuffer (aliasmodel, paliashdr);
 }
 
 /*
@@ -153,10 +153,10 @@ void GLMesh_LoadVertexBuffer (qmodel_t *m, aliashdr_t *mainhdr)
 		switch(hdr->poseverttype)
 		{
 		case PV_QUAKE1:
-			totalvbosize += (hdr->numposes * hdr->numverts_vbo * sizeof (meshxyz_t)); // ericw -- what RMQEngine called nummeshframes is called numposes in QuakeSpasm
+			totalvbosize += (hdr->nummorphposes * hdr->numverts_vbo * sizeof (meshxyz_t)); // ericw -- what RMQEngine called nummeshframes is called nummorphposes in QuakeSpasm
 			break;
 		case PV_IQM:
-			totalvbosize += (hdr->numposes * hdr->numverts_vbo * sizeof (iqmvert_t));
+			totalvbosize += (hdr->nummorphposes * hdr->numverts_vbo * sizeof (iqmvert_t));
 			animsize += hdr->numboneposes * hdr->numbones * sizeof (bonepose_t);
 			break;
 		default:
@@ -222,7 +222,7 @@ void GLMesh_LoadVertexBuffer (qmodel_t *m, aliashdr_t *mainhdr)
 		switch(hdr->poseverttype)
 		{
 		case PV_QUAKE1:
-			for (f = 0; f < hdr->numposes; f++) // ericw -- what RMQEngine called nummeshframes is called numposes in QuakeSpasm
+			for (f = 0; f < hdr->nummorphposes; f++) // ericw -- what RMQEngine called nummeshframes is called nummorphposes in QuakeSpasm
 			{
 				int v;
 				meshxyz_t *xyz = (meshxyz_t *) (vbodata + vertofs);
@@ -249,7 +249,7 @@ void GLMesh_LoadVertexBuffer (qmodel_t *m, aliashdr_t *mainhdr)
 			}
 			break;
 		case PV_IQM:
-			for (f = 0; f < hdr->numposes; f++) // ericw -- what RMQEngine called nummeshframes is called numposes in QuakeSpasm
+			for (f = 0; f < hdr->nummorphposes; f++) // ericw -- what RMQEngine called nummeshframes is called nummorphposes in QuakeSpasm
 			{
 				int v;
 				iqmvert_t *xyz = (iqmvert_t *) (vbodata + vertofs);

--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -58,6 +58,7 @@ void Cache_Flush_f (cvar_t* var); // woods #loadskins
 
 cvar_t	scr_concolor = {"scr_concolor", "", CVAR_ARCHIVE}; // woods #concolor
 cvar_t	scr_conback = {"scr_conback", "", CVAR_ARCHIVE}; // woods #conback
+cvar_t	gl_subdivide_size = {"gl_subdivide_size", "128", CVAR_ARCHIVE};
 
 extern cvar_t	r_fastturb; // woods #fastturb
 
@@ -81,9 +82,9 @@ Console_Color_Completion_f -- woods #iwtabcomplete
 */
 static void Console_Color_Completion_f(cvar_t* cvar, const char* partial)
 {
-	Con_AddToTabList("0x000000", partial, "black", NULL); // #demolistsort add arg
-	Con_AddToTabList("0x1e1e1e", partial, "dark grey", NULL); // #demolistsort add arg
-	Con_AddToTabList("0x2c190c", partial, "quake brown", NULL); // #demolistsort add arg
+	Con_AddToTabList("0x000000", partial, "black"); // #demolistsort add arg
+	Con_AddToTabList("0x1e1e1e", partial, "dark grey"); // #demolistsort add arg
+	Con_AddToTabList("0x2c190c", partial, "quake brown"); // #demolistsort add arg
 
 	return;
 }

--- a/Quake/gl_model.h
+++ b/Quake/gl_model.h
@@ -460,6 +460,15 @@ extern	trivertx_t		*poseverts_mdl[MAXALIASFRAMES];
 //
 
 typedef enum {mod_brush, mod_sprite, mod_alias, mod_ext_invalid} modtype_t;
+#define mod_numtypes (mod_ext_invalid + 1)
+
+typedef struct bspx_static_light_s
+{
+        vec3_t          origin;
+        float           radius;
+        vec3_t          color;
+        float           intensity;
+} bspx_static_light_t;
 
 //Spike -- these are misnamed/ambiguous.
 #define	EF_ROCKET	1			// leave a trail
@@ -584,6 +593,12 @@ typedef struct qmodel_s
 	byte		*lightdata;
 	size_t		lightdatasamples;
 	char		*entities;
+	const bspx_static_light_t	*bspx_static_lights;
+	int			bspx_num_static_lights;
+	const bspx_static_light_t	*bspx_static_shadow_lights;
+	int			bspx_num_static_shadow_lights;
+	const int		*bspx_static_shadow_indices;
+	int			bspx_num_static_shadow_indices;
 
 	qboolean	viswarn; // for Mod_DecompressVis()
 

--- a/Quake/gl_refrag.c
+++ b/Quake/gl_refrag.c
@@ -186,12 +186,12 @@ void R_AddStaticModels (const byte *vis)
 		int half = count / 2;
 		int shift = 0;
 
-		// make sure we don't overflow the sort key
-		while (maxleaf > MODSORT_BITS)
-		{
-			maxleaf >>= 1;
-			shift++;
-		}
+// make sure we don't overflow the sort key
+while (maxleaf > MODSORT_MASK)
+{
+maxleaf >>= 1;
+shift++;
+}
 
 		for (i = 0, j = count - 1; i < half; i++, j--)
 		{

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -722,4 +722,7 @@ void GL_PostProcess (void);
 
 float GL_WaterAlphaForTextureType (textype_t type);
 
+#define MODSORT_BITS 16
+#define MODSORT_MASK ((1 << MODSORT_BITS) - 1)
 #endif	/* GLQUAKE_H */
+


### PR DESCRIPTION
## Summary
- update alias mesh setup to use morph pose counts and shared pose vertex storage
- add missing cvar and BSPX static light definitions for model data
- define model sort constants and guard entity sorting overflow handling

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692237bba40c832eb5a896dffaac6054)