### PR TITLE
Fix gl_model lighting build errors

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -26,6 +26,11 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "quakedef.h"
 
+#define INVALID_LIGHTSTYLE_OLD 255
+#define INVALID_LIGHTSTYLE     255
+
+struct decoupled_lm_info_s;
+
 static qmodel_t*	loadmodel;
 static char	loadname[32];	// for hunk tags
 
@@ -34,11 +39,16 @@ static void Mod_LoadBrushModel (qmodel_t *mod, void *buffer);
 static void Mod_LoadAliasModel (qmodel_t *mod, void *buffer);
 static void Mod_LoadMD5MeshModel (qmodel_t *mod, const char *buffer);
 static qmodel_t *Mod_LoadModel (qmodel_t *mod, qboolean crash);
+static qboolean Mod_ParseWorldspawnKey (qmodel_t *mod, const char *key, char *value, size_t valuesize);
+static void BSPX_LightGridLoad (qmodel_t *mod, void *lump, int lumpsize);
 
 static void Mod_Print (void);
 
 static cvar_t	external_ents = {"external_ents", "1", CVAR_ARCHIVE};
 static cvar_t	external_vis = {"external_vis", "1", CVAR_ARCHIVE};
+static cvar_t	gl_loadlitfiles = {"gl_loadlitfiles", "1", CVAR_ARCHIVE};
+static cvar_t	external_lits_dir = {"external_lits_dir", "", CVAR_ARCHIVE};
+static cvar_t	mod_ignorelmscale = {"mod_ignorelmscale", "0", 0};
 cvar_t			r_md5 = {"r_md5", "1", CVAR_ARCHIVE};
 
 static byte	*mod_novis;
@@ -93,9 +103,12 @@ Mod_Init
 */
 void Mod_Init (void)
 {
-	Cvar_RegisterVariable (&external_vis);
-	Cvar_RegisterVariable (&external_ents);
-	Cvar_RegisterVariable (&r_md5);
+        Cvar_RegisterVariable (&external_vis);
+        Cvar_RegisterVariable (&external_ents);
+        Cvar_RegisterVariable (&gl_loadlitfiles);
+        Cvar_RegisterVariable (&external_lits_dir);
+        Cvar_RegisterVariable (&mod_ignorelmscale);
+        Cvar_RegisterVariable (&r_md5);
 	Cvar_SetCallback (&r_md5, R_MD5_f);
 
 	Cmd_AddCommand ("mcache", Mod_Print);
@@ -498,13 +511,16 @@ static void Q1BSPX_Setup(qmodel_t *mod, char *filebase, unsigned int filelen, lu
 	bspxbase = filebase;
 	bspxheader = NULL;
 
-	for (i = 0; i < numlumps; i++, lumps++)
-	{
-		if ((lumps->fileofs & 3) && i != LUMP_ENTITIES)
-			misaligned = true;
-		if (offs < lumps->fileofs + lumps->filelen)
-			offs = lumps->fileofs + lumps->filelen;
-	}
+        for (i = 0; i < numlumps; i++, lumps++)
+        {
+                if ((lumps->fileofs & 3) && i != LUMP_ENTITIES)
+                        misaligned = true;
+                {
+                        unsigned int lump_end = (unsigned int)lumps->fileofs + (unsigned int)lumps->filelen;
+                        if (offs < lump_end)
+                                offs = lump_end;
+                }
+        }
 	if (misaligned)
 		Con_DWarning("%s contains misaligned lumps\n", mod->name);
 	offs = (offs + 3) & ~3;
@@ -614,6 +630,7 @@ static void Mod_LoadTextures (lump_t *l)
 	char		filename[MAX_OSPATH], mapname[MAX_OSPATH];
 	byte		*data;
 	enum srcformat fmt;
+	qboolean	malloced;
 //johnfitz
 
 	//johnfitz -- don't return early if no textures; still need to create dummy texture
@@ -700,6 +717,7 @@ static void Mod_LoadTextures (lump_t *l)
 		}
 
 		//johnfitz -- lots of changes
+		malloced = false;
 		if (!isDedicated) //no texture uploading for dedicated server
 		{
 			if (tx->type == TEXTYPE_SKY)
@@ -930,6 +948,8 @@ static void Mod_LoadLighting (lump_t *l)
 	int	bspxsize;
 
 	loadmodel->lightdata = NULL;
+	loadmodel->lightdatasamples = 0;
+	loadmodel->flags &= ~MOD_HDRLIGHTING;
 	loadmodel->litfile = false;
 	// LordHavoc: check for a .lit file
 	q_strlcpy(litfilename, loadmodel->name, sizeof(litfilename));
@@ -1033,7 +1053,7 @@ static void Mod_LoadLighting (lump_t *l)
 		in = mod_base + l->fileofs;
 		out = loadmodel->lightdata;
 
-		for (unsigned int i = 0;i < (l->filelen / 2) ;i++)
+                for (unsigned int i = 0; i < (unsigned int)(l->filelen / 2); i++)
 		{
 			q64_b0 = *in++;
 			q64_b1 = *in++;
@@ -1080,7 +1100,7 @@ static void Mod_LoadLighting (lump_t *l)
 		in = loadmodel->lightdata + l->filelen*2; // place the file at the end, so it will not be overwritten until the very last write
 		out = loadmodel->lightdata;
 		memcpy (in, mod_base + l->fileofs, l->filelen);
-		for (unsigned int i = 0;i < l->filelen;i++)
+                for (unsigned int i = 0; i < (unsigned int)l->filelen; i++)
 		{
 			d = *in++;
 			*out++ = d;
@@ -1171,6 +1191,48 @@ _load_embedded:
 	}
 	loadmodel->entities = (char *) Hunk_AllocNameNoFill ( l->filelen, loadname);
 	memcpy (loadmodel->entities, mod_base + l->fileofs, l->filelen);
+}
+
+static qboolean Mod_ParseWorldspawnKey (qmodel_t *mod, const char *key, char *value, size_t valuesize)
+{
+	const char *data;
+
+	if (!mod || !mod->entities || !key || !value || valuesize == 0)
+		return false;
+
+	data = COM_Parse (mod->entities);
+	if (!data || com_token[0] != '{')
+		return false;
+
+	while (1)
+	{
+		data = COM_Parse (data);
+		if (!data || !com_token[0])
+			return false;
+		if (com_token[0] == '}')
+			return false;
+
+		if (!strcmp (com_token, "classname"))
+		{
+			data = COM_Parse (data);
+			if (!data || strcmp (com_token, "worldspawn"))
+				return false;
+			continue;
+		}
+
+		if (!strcmp (com_token, key))
+		{
+			data = COM_Parse (data);
+			if (!data)
+				return false;
+			q_strlcpy (value, com_token, valuesize);
+			return true;
+		}
+
+		data = COM_Parse (data);
+		if (!data)
+			return false;
+	}
 }
 
 
@@ -1320,8 +1382,6 @@ static void CalcSurfaceExtents (msurface_t *s)
 	int		i,j, e;
 	mvertex_t	*v;
 	mtexinfo_t	*tex;
-	int		bmins[2], bmaxs[2];
-	int lmscale;
 	double	texvecs[2][4];
 
 	mins[0] = mins[1] = FLT_MAX;
@@ -1388,7 +1448,6 @@ static void CalcSurfaceExtents (msurface_t *s)
 		}
 	}
 
-	lmscale = 1<<lmshift;
 
 	for (i=0 ; i<2 ; i++)
 	{
@@ -1432,6 +1491,13 @@ void Mod_CalcSurfaceBounds (msurface_t *s)
 		s->maxs[1] = q_max (s->maxs[1], v->position[1]);
 		s->maxs[2] = q_max (s->maxs[2], v->position[2]);
 	}
+}
+
+static void BSPX_LightGridLoad (qmodel_t *mod, void *lump, int lumpsize)
+{
+	(void)mod;
+	(void)lump;
+	(void)lumpsize;
 }
 
 /*

--- a/Quake/gl_model.h
+++ b/Quake/gl_model.h
@@ -380,7 +380,7 @@ extern	trivertx_t			*poseverts[MAXALIASFRAMES];
 // Whole model
 //
 
-typedef enum {mod_brush, mod_alias, mod_sprite, mod_numtypes} modtype_t;
+typedef enum {mod_brush, mod_alias, mod_sprite, mod_ext_invalid, mod_numtypes} modtype_t;
 
 #define	EF_ROCKET	1			// leave a trail
 #define	EF_GRENADE	2			// leave a trail
@@ -396,6 +396,7 @@ typedef enum {mod_brush, mod_alias, mod_sprite, mod_numtypes} modtype_t;
 #define	MOD_NOLERP		256		//don't lerp when animating
 #define	MOD_NOSHADOW	512		//don't cast a shadow
 #define	MOD_FBRIGHTHACK	1024	//when fullbrights are disabled, use a hack to render this model brighter
+#define	MOD_HDRLIGHTING	2048
 //johnfitz
 
 //
@@ -490,6 +491,7 @@ typedef struct qmodel_s
 
 	byte		*visdata;
 	byte		*lightdata;
+	int			lightdatasamples;
 	char		*entities;
 
 	qboolean	litfile;


### PR DESCRIPTION
## Summary
- add missing cvars, constants, and flags needed for lightmap handling
- track lightdata sample counts and reset HDR lighting state during loading
- stub worldspawn parsing and BSPX light grid helpers to resolve missing references

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922521b9090832e9756ef39ae8d3d83)