### PR TITLE
Initialize surface styles before parsing faces

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -1602,6 +1602,10 @@ static void Mod_LoadFaces (lump_t *l, qboolean bsp2)
 	for (surfnum=0 ; surfnum<count ; surfnum++, out++)
 	{
 		texture_t *texture;
+
+		// initialize to avoid garbage when a BSP provides fewer than MAXLIGHTMAPS styles
+		for (i=0 ; i<MAXLIGHTMAPS ; i++)
+			out->styles[i] = INVALID_LIGHTSTYLE;
 		if (bsp2)
 		{	//32bit datatypes
 			out->firstedge = LittleLong(inl->firstedge);


### PR DESCRIPTION
## Summary
- initialize surface light style arrays before processing face data to avoid garbage style counts

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69226111e618832e80ca9ea2430951fb)