### PR TITLE
Add LMSTYLE16 lightstyle support

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -27,7 +27,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "quakedef.h"
 
 #define INVALID_LIGHTSTYLE_OLD 255
-#define INVALID_LIGHTSTYLE     255
 
 
 static qmodel_t*	loadmodel;
@@ -1587,10 +1586,11 @@ static void Mod_LoadFaces (lump_t *l, qboolean bsp2)
 	int			i, count, surfnum, lofs, shift;
 	int			planenum, side, texinfon;
 
-	unsigned char *lmshift = NULL, defaultshift = 4;
-	unsigned int *lmoffset = NULL;
-	unsigned char *lmstyle8 = NULL, stylesperface = 4;
-	unsigned short *lmstyle16 = NULL;
+        unsigned char *lmshift = NULL, defaultshift = 4;
+        unsigned int *lmoffset = NULL;
+        unsigned char *lmstyle8 = NULL;
+        unsigned short *lmstyle16 = NULL;
+        int stylesperface = 4;
 	int lumpsize;
 	char scalebuf[16];
 	int facestyles;
@@ -1712,7 +1712,7 @@ static void Mod_LoadFaces (lump_t *l, qboolean bsp2)
 			side = LittleShort(ins->side);
 			texinfon = LittleShort (ins->texinfo);
 			for (i=0 ; i<MAXLIGHTMAPS ; i++)
-				out->styles[i] = ins->styles[i];
+				out->styles[i] = ((ins->styles[i]==INVALID_LIGHTSTYLE_OLD)?INVALID_LIGHTSTYLE:ins->styles[i]);
 			lofs = LittleLong(ins->lightofs);
 			ins++;
 		}
@@ -1722,18 +1722,24 @@ static void Mod_LoadFaces (lump_t *l, qboolean bsp2)
 			shift = lmshift[surfnum];
 		if (lmoffset)
 			lofs = LittleLong(lmoffset[surfnum]);
-		if (lmstyle16)
-			for (i=0 ; i<stylesperface ; i++)
-				out->styles[i] = lmstyle16[surfnum*stylesperface+i];
-		else if (lmstyle8)
-			for (i=0 ; i<stylesperface ; i++)
-			{
-				out->styles[i] = lmstyle8[surfnum*stylesperface+i];
-				if (out->styles[i] == INVALID_LIGHTSTYLE_OLD)
-					out->styles[i] = INVALID_LIGHTSTYLE;
-			}
-		for ( ; i<MAXLIGHTMAPS ; i++)
-			out->styles[i] = INVALID_LIGHTSTYLE;
+                if (lmstyle16)
+                {
+                        int copystyles = q_min(stylesperface, MAXLIGHTMAPS);
+                        for (i=0 ; i<copystyles ; i++)
+                                out->styles[i] = lmstyle16[surfnum*stylesperface+i];
+                }
+                else if (lmstyle8)
+                {
+                        int copystyles = q_min(stylesperface, MAXLIGHTMAPS);
+                        for (i=0 ; i<copystyles ; i++)
+                        {
+                                out->styles[i] = lmstyle8[surfnum*stylesperface+i];
+                                if (out->styles[i] == INVALID_LIGHTSTYLE_OLD)
+                                        out->styles[i] = INVALID_LIGHTSTYLE;
+                        }
+                }
+                for ( ; i<MAXLIGHTMAPS ; i++)
+                        out->styles[i] = INVALID_LIGHTSTYLE;
 
 		out->flags = 0;
 		if (out->numedges < 3)

--- a/Quake/gl_model.h
+++ b/Quake/gl_model.h
@@ -115,6 +115,8 @@ typedef struct texture_s
 #define SURF_DRAWTELE		0x1000
 #define SURF_DRAWWATER		0x2000
 
+#define INVALID_LIGHTSTYLE	((unsigned short)0xffff)
+
 // !!! if this is changed, it must be changed in asm_draw.h too !!!
 typedef struct
 {
@@ -150,7 +152,7 @@ typedef struct msurface_s
 	short		extents[2];
 	short		light_s, light_t;	// gl lightmap coordinates
 
-	byte		styles[MAXLIGHTMAPS];
+	unsigned short	styles[MAXLIGHTMAPS];
 	byte		*samples;			// [numstyles*surfsize]
 
 	int			texturemins[2];

--- a/Quake/gl_rlight.c
+++ b/Quake/gl_rlight.c
@@ -212,6 +212,14 @@ LIGHT SAMPLING
 
 vec3_t lightcolor; //johnfitz -- lit support via lordhavoc
 
+static inline int LightStyleValue (unsigned short style)
+{
+	if (style < 256)
+		return d_lightstylevalue[style];
+
+	return d_lightstylevalue[0];
+}
+
 static void InterpolateLightmap (vec3_t color, msurface_t *surf, int ds, int dt)
 {
 	byte *lightmap;
@@ -221,9 +229,9 @@ static void InterpolateLightmap (vec3_t color, msurface_t *surf, int ds, int dt)
 
 	lightmap = surf->samples + ((dt>>4) * ((surf->extents[0]>>4)+1) + (ds>>4))*3; // LordHavoc: *3 for color
 
-	for (maps = 0;maps < MAXLIGHTMAPS && surf->styles[maps] != 255;maps++)
+	for (maps = 0;maps < MAXLIGHTMAPS && surf->styles[maps] != INVALID_LIGHTSTYLE;maps++)
 	{
-		scale = d_lightstylevalue[surf->styles[maps]];
+		scale = LightStyleValue(surf->styles[maps]);
 		r00 += lightmap[      0] * scale; g00 += lightmap[      1] * scale; b00 += lightmap[      2] * scale;
 		r01 += lightmap[      3] * scale; g01 += lightmap[      4] * scale; b01 += lightmap[      5] * scale;
 		r10 += lightmap[line3+0] * scale; g10 += lightmap[line3+1] * scale; b10 += lightmap[line3+2] * scale;

--- a/Quake/r_brush.c
+++ b/Quake/r_brush.c
@@ -246,9 +246,9 @@ GL_NumLightmapTaps
 */
 static int GL_NumLightmapTaps (const msurface_t *surf)
 {
-	if (surf->styles[1] == 255)
+	if (surf->styles[1] == INVALID_LIGHTSTYLE)
 		return 1;
-	if (surf->styles[2] == 255)
+	if (surf->styles[2] == INVALID_LIGHTSTYLE)
 		return 2;
 	return 3;
 }
@@ -268,7 +268,7 @@ static void GL_FillSurfaceLightmap (msurface_t *surf)
 	unsigned	*dst;
 	int			s, t, facesize;
 
-	if (!cl.worldmodel->lightdata || !surf->samples || surf->styles[0] == 255)
+	if (!cl.worldmodel->lightdata || !surf->samples || surf->styles[0] == INVALID_LIGHTSTYLE)
 		return;
 
 	lm = &lightmaps[surf->lightmaptexturenum];
@@ -281,13 +281,13 @@ static void GL_FillSurfaceLightmap (msurface_t *surf)
 	src = surf->samples;
 	dst = lightmap_data + yofs * lightmap_width + xofs;
 
-	if (surf->styles[1] == 255) // single lightstyle
+	if (surf->styles[1] == INVALID_LIGHTSTYLE) // single lightstyle
 	{
 		for (t = 0; t < tmax; t++, dst += lightmap_width)
 			for (s = 0; s < smax; s++, src += 3)
 				dst[s] = src[0] | (src[1] << 8) | (src[2] << 16) | 0xff000000u;
 	}
-	else if (surf->styles[2] == 255) // 2 lightstyles
+	else if (surf->styles[2] == INVALID_LIGHTSTYLE) // 2 lightstyles
 	{
 		for (t = 0; t < tmax; t++, dst += lightmap_width)
 		{
@@ -306,7 +306,7 @@ static void GL_FillSurfaceLightmap (msurface_t *surf)
 			{
 				const byte *mapsrc = src;
 				unsigned r = 0, g = 0, b = 0;
-				for (map = 0; map < 4 && surf->styles[map] != 255; map++, mapsrc += facesize)
+				for (map = 0; map < 4 && surf->styles[map] != INVALID_LIGHTSTYLE; map++, mapsrc += facesize)
 				{
 					r |= mapsrc[0] << (map << 3);
 					g |= mapsrc[1] << (map << 3);
@@ -743,14 +743,21 @@ void GL_BuildBModelVertexBuffer (void)
 					t += 8;
 					t *= lmscaley;
 
-					vert->st[2] = s;
-					vert->st[3] = t;
-					vert->lmofs = lmofs;
-					vert->styles = fa->styles[0] | (fa->styles[1] << 8) | (fa->styles[2] << 16) | (fa->styles[3] << 24);
-				}
-				else
-				{
-					// first lightmap texel is fullbright
+                                        vert->st[2] = s;
+                                        vert->st[3] = t;
+                                        vert->lmofs = lmofs;
+                                        {
+                                                unsigned char packedstyles[4];
+
+                                                for (map = 0; map < MAXLIGHTMAPS; map++)
+                                                        packedstyles[map] = (fa->styles[map] > 255) ? 255 : fa->styles[map];
+
+                                                vert->styles = packedstyles[0] | (packedstyles[1] << 8) | (packedstyles[2] << 16) | (packedstyles[3] << 24);
+                                        }
+                                }
+                                else
+                                {
+                                        // first lightmap texel is fullbright
 					vert->st[2] = 0.5f / lightmap_width;
 					vert->st[3] = 0.5f / lightmap_height;
 					vert->lmofs = 0.f;


### PR DESCRIPTION
## Summary
- allow BSPX LMSTYLE16 lumps with variable per-face style counts to load without overflow
- expand lightstyle storage to 16-bit values and guard rendering paths accordingly
- clamp packed GPU lightstyle data to valid byte range

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922724a328c832e82c209d87c2c1999)