### PR TITLE
Add BSPX vertex normal support

### DIFF
--- a/Quake/bspfile.h
+++ b/Quake/bspfile.h
@@ -257,6 +257,7 @@ typedef struct texinfo_s
 } texinfo_t;
 #define	TEX_SPECIAL		1		// sky or slime, no lightmap or 256 subdivision
 #define TEX_MISSING		2		// johnfitz -- this texinfo does not have a texture
+#define     TEX_VERTEXNORMALS       0x800   // bspx smooth shading
 
 // note that edge 0 is never used, because negative edge nums are used for
 // counterclockwise use of the edge in a face

--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -486,11 +486,11 @@ static int bspx_lump_usage_count;
 //LMOFFSET (LMSHIFT helper)
 //LMSTYLE (LMSHIFT helper)
 //LIGHTINGDIR (.lux)
+//VERTEXNORMALS (smooth shading with dlights/rtlights)
 
 //unsupported lumps ('documented' elsewhere):
 //BRUSHLIST (because hulls suck)
 //LIGHTING_E5BGR9 (hdr lighting)
-//VERTEXNORMALS (smooth shading with dlights/rtlights)
 static void Q1BSPX_ResetUsage(void)
 {
         bspx_lump_usage_count = 0;
@@ -1345,9 +1345,13 @@ Mod_LoadVertexes
 */
 static void Mod_LoadVertexes (lump_t *l)
 {
-	dvertex_t	*in;
-	mvertex_t	*out;
+	dvertex_t		*in;
+	mvertex_t		*out;
 	int			i, count;
+	int			bspxsize;
+	const float	*normal_in = NULL;
+
+	loadmodel->vertexes = NULL;
 
 	in = (dvertex_t *)(mod_base + l->fileofs);
 	if (l->filelen % sizeof(*in))
@@ -1358,11 +1362,34 @@ static void Mod_LoadVertexes (lump_t *l)
 	loadmodel->vertexes = out;
 	loadmodel->numvertexes = count;
 
+	{
+		void *normal_lump = Q1BSPX_FindLump("VERTEXNORMALS", &bspxsize);
+		if (normal_lump)
+		{
+			if (bspxsize == count * sizeof(vec3_t))
+			{
+				Q1BSPX_MarkUsed("VERTEXNORMALS");
+				normal_in = (const float *)normal_lump;
+			}
+			else
+				Q1BSPX_MarkUnsupported("VERTEXNORMALS");
+		}
+	}
+
 	for (i=0 ; i<count ; i++, in++, out++)
 	{
 		out->position[0] = LittleFloat (in->point[0]);
 		out->position[1] = LittleFloat (in->point[1]);
 		out->position[2] = LittleFloat (in->point[2]);
+
+		if (normal_in)
+		{
+			out->normal[0] = LittleFloat (*normal_in++);
+			out->normal[1] = LittleFloat (*normal_in++);
+			out->normal[2] = LittleFloat (*normal_in++);
+		}
+		else
+			VectorClear(out->normal);
 	}
 }
 

--- a/Quake/gl_model.h
+++ b/Quake/gl_model.h
@@ -49,6 +49,7 @@ BRUSH MODELS
 typedef struct
 {
 	vec3_t		position;
+	vec3_t		normal;
 } mvertex_t;
 
 #define	SIDE_FRONT	0
@@ -132,6 +133,7 @@ typedef struct
 
 typedef struct glvert_s {
 	vec3_t		pos;
+	vec3_t		normal;
 	float		st[4];
 	float		lmofs;
 	unsigned	styles;

--- a/Quake/r_brush.c
+++ b/Quake/r_brush.c
@@ -646,16 +646,22 @@ void GL_BuildBModelVertexBuffer (void)
 	{
 		m = cl.model_precache[j];
 		if (!m || m->name[0] == '*' || m->type != mod_brush)
-			continue;
+		continue;
 
 		for (i = 0; i < m->numsurfaces; i++)
 		{
-			msurface_t	*fa = &m->surfaces[i];
-			texture_t	*texture = m->textures[fa->texinfo->texnum];
-			glvert_t	*vert = &varray[varray_index];
-			float		texscalex, texscaley, useofs, lmofs;
-			medge_t		*r_pedge;
-			lightmap_t	*lm;
+			msurface_t      *fa = &m->surfaces[i];
+			texture_t       *texture = m->textures[fa->texinfo->texnum];
+			glvert_t        *vert = &varray[varray_index];
+			float           texscalex, texscaley, useofs, lmofs;
+			medge_t         *r_pedge;
+			lightmap_t      *lm;
+			vec3_t          surfnormal;
+
+			if (fa->flags & SURF_PLANEBACK)
+				VectorNegate(fa->plane->normal, surfnormal);
+			else
+				VectorCopy(fa->plane->normal, surfnormal);
 
 			if (fa->flags & SURF_DRAWTILED)
 			{
@@ -691,21 +697,29 @@ void GL_BuildBModelVertexBuffer (void)
 
 			for (k = 0; k < fa->numedges; k++, vert++)
 			{
-				float	*vec;
-				float	s, t;
-				int		lindex;
+				float   *vec;
+				float   s, t;
+				int             lindex;
+				int             vertindex;
 
 				lindex = m->surfedges[fa->firstedge + k];
 				if (lindex > 0)
 				{
 					r_pedge = &m->edges[lindex];
-					vec = m->vertexes[r_pedge->v[0]].position;
+					vertindex = r_pedge->v[0];
+					vec = m->vertexes[vertindex].position;
 				}
 				else
 				{
 					r_pedge = &m->edges[-lindex];
-					vec = m->vertexes[r_pedge->v[1]].position;
+					vertindex = r_pedge->v[1];
+					vec = m->vertexes[vertindex].position;
 				}
+
+				VectorCopy (vec, vert->pos);
+				VectorCopy (surfnormal, vert->normal);
+				if ((fa->texinfo->flags & TEX_VERTEXNORMALS) && (m->vertexes[vertindex].normal[0] || m->vertexes[vertindex].normal[1] || m->vertexes[vertindex].normal[2]))
+					VectorCopy (m->vertexes[vertindex].normal, vert->normal);
 
 				s = DotProduct (vec, fa->texinfo->vecs[0]) + fa->texinfo->vecs[0][3] * useofs;
 				s *= texscalex;
@@ -713,35 +727,34 @@ void GL_BuildBModelVertexBuffer (void)
 				t = DotProduct (vec, fa->texinfo->vecs[1]) + fa->texinfo->vecs[1][3] * useofs;
 				t *= texscaley;
 
-				VectorCopy (vec, vert->pos);
 				vert->st[0] = s;
 				vert->st[1] = t;
 
-				if (!(fa->flags & SURF_DRAWTILED))
+			if (!(fa->flags & SURF_DRAWTILED))
+			{
+				// match old BuildSurfaceDisplayList
+
+				// Q64 RERELEASE texture shift
+				if (texture->shift > 0)
 				{
-					// match old BuildSurfaceDisplayList
+					vert->st[0] /= (2 * texture->shift);
+					vert->st[1] /= (2 * texture->shift);
+				}
 
-					// Q64 RERELEASE texture shift
-					if (texture->shift > 0)
-					{
-						vert->st[0] /= (2 * texture->shift);
-						vert->st[1] /= (2 * texture->shift);
-					}
+				//
+				// lightmap texture coordinates
+				//
+				s = DotProduct (vec, fa->texinfo->vecs[0]) + fa->texinfo->vecs[0][3];
+				s -= fa->texturemins[0];
+				s += (fa->light_s + lm->xofs) * 16;
+				s += 8;
+				s *= lmscalex;
 
-					//
-					// lightmap texture coordinates
-					//
-					s = DotProduct (vec, fa->texinfo->vecs[0]) + fa->texinfo->vecs[0][3];
-					s -= fa->texturemins[0];
-					s += (fa->light_s + lm->xofs) * 16;
-					s += 8;
-					s *= lmscalex;
-
-					t = DotProduct (vec, fa->texinfo->vecs[1]) + fa->texinfo->vecs[1][3];
-					t -= fa->texturemins[1];
-					t += (fa->light_t + lm->yofs) * 16;
-					t += 8;
-					t *= lmscaley;
+				t = DotProduct (vec, fa->texinfo->vecs[1]) + fa->texinfo->vecs[1][3];
+				t -= fa->texturemins[1];
+				t += (fa->light_t + lm->yofs) * 16;
+				t += 8;
+				t *= lmscaley;
 
                                         vert->st[2] = s;
                                         vert->st[3] = t;
@@ -759,12 +772,12 @@ void GL_BuildBModelVertexBuffer (void)
                                 else
                                 {
                                         // first lightmap texel is fullbright
-					vert->st[2] = 0.5f / lightmap_width;
-					vert->st[3] = 0.5f / lightmap_height;
-					vert->lmofs = 0.f;
-					vert->styles = ~0u;
-				}
+				vert->st[2] = 0.5f / lightmap_width;
+				vert->st[3] = 0.5f / lightmap_height;
+				vert->lmofs = 0.f;
+				vert->styles = ~0u;
 			}
+		}
 		}
 	}
 

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -291,6 +291,7 @@ static void R_FlushBModelCalls (void)
 	GL_VertexAttribPointerFunc (1, 4, GL_FLOAT, GL_FALSE, sizeof (glvert_t), (void *) offsetof (glvert_t, st));
 	GL_VertexAttribPointerFunc (2, 1, GL_FLOAT, GL_FALSE, sizeof (glvert_t), (void *) offsetof (glvert_t, lmofs));
 	GL_VertexAttribIPointerFunc (3, 4, GL_UNSIGNED_BYTE, sizeof (glvert_t), (void *) offsetof (glvert_t, styles));
+        GL_VertexAttribPointerFunc (4, 3, GL_FLOAT, GL_FALSE, sizeof (glvert_t), (void *) offsetof (glvert_t, normal));
 
 	if (gl_bindless_able)
 	{
@@ -501,7 +502,7 @@ static void R_DrawBrushModels_Real (entity_t **ents, int count, brushpass_t pass
         if (!totalinst)
                 return;
 
-        state = GLS_CULL_BACK | GLS_ATTRIBS(4);
+        state = GLS_CULL_BACK | GLS_ATTRIBS(5);
         if (!translucent)
                 state |= GLS_BLEND_OPAQUE;
         else
@@ -597,7 +598,7 @@ void R_DrawBrushModels_Water (entity_t **ents, int count, qboolean translucent)
 	GL_BeginGroup (translucent ? "Water (translucent)" : "Water (opaque)");
 
 	// setup state
-	state = GLS_CULL_BACK | GLS_ATTRIBS(4);
+	state = GLS_CULL_BACK | GLS_ATTRIBS(5);
 	if (translucent)
 		state |= GLS_BLEND_ALPHA_OIT | GLS_NO_ZWRITE;
 	else

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -126,6 +126,7 @@ layout(location=8) flat in float in_lmofs;
 #endif
 layout(location=11) noperspective in vec4 in_curr_clip;
 layout(location=12) noperspective in vec4 in_prev_clip;
+layout(location=13) in vec3 in_normal;
 
 // ALU-only 16x16 Bayer matrix
 float bayer01(ivec2 coord)
@@ -311,11 +312,21 @@ void main()
                 }
         }
 
-        vec3 surface_normal = vec3(0.0, 0.0, 1.0);
-        vec3 surface_normal_vec = cross(dFdx(in_pos), dFdy(in_pos));
-        float surface_normal_len = length(surface_normal_vec);
+        vec3 surface_normal = in_normal;
+        float surface_normal_len = length(surface_normal);
         if (surface_normal_len > 0.0)
-                surface_normal = surface_normal_vec / surface_normal_len;
+                surface_normal /= surface_normal_len;
+        else
+        {
+                vec3 surface_normal_vec = cross(dFdx(in_pos), dFdy(in_pos));
+                float geom_len = length(surface_normal_vec);
+                if (geom_len > 0.0)
+                        surface_normal = surface_normal_vec / geom_len;
+                else
+                        surface_normal = vec3(0.0, 0.0, 1.0);
+        }
+        if (!gl_FrontFacing)
+                surface_normal = -surface_normal;
         vec3 total_light = clamp(static_light, 0.0, 1.0);
         vec3 specular_light = vec3(0.0);
         vec3 to_eye = EyePos - in_pos;

--- a/Quake/shaders/world.vert
+++ b/Quake/shaders/world.vert
@@ -105,11 +105,18 @@ vec3 TransformPrev(vec3 p, Instance instance)
 {
 	return TransformPosition(p, instance.prev_mat);
 }
+vec3 TransformDirection(vec3 n, Instance instance)
+{
+        mat4x3 world = transpose(mat3x4(instance.mat[0], instance.mat[1], instance.mat[2]));
+        return (world * vec4(n, 0.0)).xyz;
+}
+
 
 layout(location=0) in vec3 in_pos;
 layout(location=1) in vec4 in_uv;
 layout(location=2) in float in_lmofs;
 layout(location=3) in ivec4 in_styles;
+layout(location=4) in vec3 in_normal;
 
 
 layout(location=0) flat out uint out_flags;
@@ -131,6 +138,7 @@ layout(location=8) flat out float out_lmofs;
 #endif
 layout(location=11) noperspective out vec4 out_curr_clip;
 layout(location=12) noperspective out vec4 out_prev_clip;
+layout(location=13) out vec3 out_normal;
 
 void main()
 {
@@ -138,6 +146,7 @@ void main()
 	int instance_id = GET_INSTANCE_ID(call);
 	Instance instance = instance_data[instance_id];
 	vec3 world_pos = Transform(in_pos, instance);
+        vec3 world_normal = TransformDirection(in_normal, instance);
 	vec3 prev_world_pos = TransformPrev(in_pos, instance);
 	vec4 curr_clip = ViewProj * vec4(world_pos, 1.0);
 	vec4 prev_clip = PrevViewProj * vec4(prev_world_pos, 1.0);
@@ -155,6 +164,7 @@ void main()
 	out_curr_clip = curr_clip;
 	out_prev_clip = prev_clip;
 	out_pos = world_pos;
+        out_normal = normalize(world_normal);
 	out_uv = in_uv.xy;
 	out_lmuv = in_uv.zw;
 	out_depth = gl_Position.w;


### PR DESCRIPTION
## Summary
- load BSPX VERTEXNORMALS data and store per-vertex normals for brush models
- emit vertex normals into brush model buffers and GLS shaders, using TEX_VERTEXNORMALS surfaces for smooth lighting
- fall back to plane normals when BSPX data is absent while keeping existing lightmapping paths

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692278cc17bc832e92feab8329eb9ea3)