### PR TITLE
Add rim lighting controls for world and models

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -197,6 +197,8 @@ cvar_t	r_simd = { "r_simd","1",CVAR_ARCHIVE };
 cvar_t	r_alphasort = { "r_alphasort","1",CVAR_ARCHIVE };
 cvar_t	r_oit = { "r_oit","1",CVAR_ARCHIVE };
 cvar_t	r_dither = { "r_dither", "1.0", CVAR_ARCHIVE };
+cvar_t	r_rim_world = { "r_rim_world", "0", CVAR_ARCHIVE };
+cvar_t	r_rim_models = { "r_rim_models", "0", CVAR_ARCHIVE };
 cvar_t	r_dof = { "r_dof", "0", CVAR_ARCHIVE };
 cvar_t	r_dof_focus = { "r_dof_focus", "64", CVAR_ARCHIVE };
 cvar_t	r_dof_range = { "r_dof_range", "48", CVAR_ARCHIVE };
@@ -1533,7 +1535,11 @@ void R_SetupView (void)
 
 
 		r_framedata.overbright = overbright;
-		r_framedata._padding0 = 0.f;
+		r_framedata.rim_world = q_max (0.f, r_rim_world.value);
+		r_framedata.rim_models = q_max (0.f, r_rim_models.value);
+		r_framedata._padding0[0] = 0.f;
+		r_framedata._padding0[1] = 0.f;
+		r_framedata._padding0[2] = 0.f;
 	}
 
 	r_framecount++;

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -52,6 +52,8 @@ extern cvar_t gl_zfix; // QuakeSpasm z-fighting fix
 extern cvar_t r_alphasort;
 extern cvar_t r_oit;
 extern cvar_t r_dither;
+extern cvar_t r_rim_world;
+extern cvar_t r_rim_models;
 extern cvar_t r_dof;
 extern cvar_t r_dof_autofocus;
 extern cvar_t r_dof_focus;
@@ -349,12 +351,14 @@ void R_Init (void)
 #endif
 	Cvar_RegisterVariable (&r_speeds);
 	Cvar_RegisterVariable (&r_pos);
-	Cvar_RegisterVariable (&r_alphasort);
-	Cvar_RegisterVariable (&r_oit);
-	Cvar_RegisterVariable (&r_dither);
-	Cvar_RegisterVariable (&r_dof);
+        Cvar_RegisterVariable (&r_alphasort);
+        Cvar_RegisterVariable (&r_oit);
+        Cvar_RegisterVariable (&r_dither);
+        Cvar_RegisterVariable (&r_rim_world);
+        Cvar_RegisterVariable (&r_rim_models);
+        Cvar_RegisterVariable (&r_dof);
         Cvar_RegisterVariable (&r_dof_autofocus);
-	Cvar_RegisterVariable (&r_dof_focus);
+        Cvar_RegisterVariable (&r_dof_focus);
 	Cvar_RegisterVariable (&r_dof_range);
 	Cvar_RegisterVariable (&r_dof_strength);
         Cvar_RegisterVariable (&r_motionblur);

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -427,7 +427,9 @@ typedef struct gpuframedata_s {
 	float	screendither;
 	float	texturedither;
 	float	overbright;
-	float	_padding0;
+	float	rim_world;
+	float	rim_models;
+	float	_padding0[3];
 	vec3_t	eyepos;
 	float	time;
 	vec3_t	prev_eyepos;

--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -76,7 +76,9 @@ struct ibuf_s {
 		float	_pad;
 		vec4_t	fog;
 		float	dither;
-		float	_padding[3];
+		float	rim_world;
+		float	rim_models;
+		float	_padding;
 	} global;
 	aliasinstance_t inst[MAX_ALIAS_INSTANCES];
 } ibuf;
@@ -358,10 +360,13 @@ void R_FlushAliasInstances (qboolean showtris)
 	// use fog density sign bit as overbright flag
 	ibuf.global.fog[3] =
 		gl_overbright_models.value ?
-			-fabs (r_framedata.fogdata[3]) :
-			 fabs (r_framedata.fogdata[3])
+				-fabs (r_framedata.fogdata[3]) :
+				fabs (r_framedata.fogdata[3])
 	;
 	ibuf.global.dither = r_framedata.screendither;
+	ibuf.global.rim_world = r_framedata.rim_world;
+	ibuf.global.rim_models = r_framedata.rim_models;
+	ibuf.global._padding = 0.f;
 
 	ibuf_size = sizeof(ibuf.global) + sizeof(ibuf.inst[0]) * ibuf.count;
 	GL_Upload (GL_SHADER_STORAGE_BUFFER, &ibuf.global, ibuf_size, &buf, &ofs);

--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -17,9 +17,9 @@ layout(std430, binding=1) restrict readonly buffer InstanceBuffer
 	float	_Pad0;
 	vec4	Fog;
 	float	ScreenDither;
+	float	RimWorld;
+	float	RimModels;
 	float	_Pad1;
-	float	_Pad2;
-	float	_Pad3;
 	InstanceData instances[];
 };
 // ALU-only 16x16 Bayer matrix
@@ -96,6 +96,7 @@ layout(location=2) in vec3 in_pos;
 layout(location=3) noperspective in vec4 in_curr_clip;
 layout(location=4) noperspective in vec4 in_prev_clip;
 layout(location=5) flat in int in_flags;
+layout(location=6) in vec3 in_normal;
 
 #define OUT_COLOR out_fragcolor
 #if OIT
@@ -164,6 +165,22 @@ void main()
 #endif
         result.rgb += fullbright;
         result.rgb += emissive;
+        if (RimModels > 0.0)
+        {
+                vec3 normal = in_normal;
+                float normal_len = length(normal);
+                if (normal_len > 0.0)
+                        normal /= normal_len;
+                vec3 view_dir = -in_pos;
+                float view_len = length(view_dir);
+                if (view_len > 0.0)
+                        view_dir /= view_len;
+                else
+                        view_dir = vec3(0.0, 0.0, 1.0);
+                float rim = 1.0 - max(dot(normal, view_dir), 0.0);
+                rim *= rim;
+                result.rgb += rim * RimModels * result.rgb;
+        }
         result.rgb = clamp(result.rgb, 0.0, 1.0);
         float fog = exp2(abs(Fog.w) * -dot(in_pos, in_pos));
 	fog = clamp(fog, 0.0, 1.0);

--- a/Quake/shaders/alias.vert
+++ b/Quake/shaders/alias.vert
@@ -17,9 +17,9 @@ layout(std430, binding=1) restrict readonly buffer InstanceBuffer
 	float	_Pad0;
 	vec4	Fog;
 	float	ScreenDither;
+	float	RimWorld;
+	float	RimModels;
 	float	_Pad1;
-	float	_Pad2;
-	float	_Pad3;
 	InstanceData instances[];
 };
 
@@ -90,6 +90,7 @@ layout(location=2) out vec3 out_pos;
 layout(location=3) noperspective out vec4 out_curr_clip;
 layout(location=4) noperspective out vec4 out_prev_clip;
 layout(location=5) flat out int out_flags;
+layout(location=6) out vec3 out_normal;
 
 void main()
 {
@@ -102,6 +103,7 @@ void main()
 	mat4x3 prev_worldmatrix = transpose(mat3x4(inst.PrevWorldMatrix[0], inst.PrevWorldMatrix[1], inst.PrevWorldMatrix[2]));
 	vec3 world_vert = (worldmatrix * vec4(local_vert, 1.0)).xyz;
 	vec3 prev_world_vert = (prev_worldmatrix * vec4(local_vert, 1.0)).xyz;
+	vec3 blended_normal = normalize(mat3(worldmatrix) * mix(pose1.nor, pose2.nor, inst.Blend));
 	vec4 curr_clip = ViewProj * vec4(world_vert, 1.0);
 	vec4 prev_clip = PrevViewProj * vec4(prev_world_vert, 1.0);
 	gl_Position = curr_clip;
@@ -109,6 +111,7 @@ void main()
 	out_prev_clip = prev_clip;
 	out_flags = inst.Flags;
 	out_pos = world_vert - EyePos;
+	out_normal = blended_normal;
 	// transform world X and Z axes to local space
 	mat3 orientation = mat3(normalize(worldmatrix[0].xyz), normalize(worldmatrix[1].xyz), normalize(worldmatrix[2].xyz));
 	orientation = transpose(orientation);

--- a/Quake/shaders/frame_uniforms.glsl
+++ b/Quake/shaders/frame_uniforms.glsl
@@ -12,7 +12,12 @@ layout(std140, binding=0) uniform FrameDataUBO
         float   ScreenDither;
         float   TextureDither;
         float   Overbright;
+        float   RimWorld;
+        float   RimModels;
         float   _Pad0;
+        float   _Pad1;
+        float   _Pad2;
+        float   _Pad3;
         vec3    EyePos;
         float   Time;
         vec3    PrevEyePos;
@@ -21,8 +26,8 @@ layout(std140, binding=0) uniform FrameDataUBO
         float   ZLogBias;
         uint    NumLights;
         uint    PrevFrameValid;
-        uint    _Pad1;
-        uint    _Pad2;
+        uint    _Pad4;
+        uint    _Pad5;
 };
 
 #endif // FRAME_UNIFORMS_GLSL

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -419,6 +419,12 @@ void main()
         result.rgb += emissive;
         vec3 spec_clamped = clamp(specular_light, vec3(0.0), vec3(Overbright));
         result.rgb += spec_clamped * clamp(result.a, 0.0, 1.0);
+        if (RimWorld > 0.0)
+        {
+                float rim = 1.0 - max(dot(surface_normal, view_dir), 0.0);
+                rim *= rim;
+                result.rgb += rim * RimWorld * result.rgb;
+        }
         result = clamp(result, 0.0, 1.0);
         result.rgb = ApplyFog(result.rgb, in_pos - EyePos);
 


### PR DESCRIPTION
## Summary
- add controllable rim-lighting cvars for world surfaces and models and upload them with frame data
- apply rim lighting in world and alias shaders, including normal-based rim shading for models
- pass rim parameters through alias draw buffers alongside rim-safe normal handling

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923a836db88832e94f1823587d04907)