### PR TITLE
Enhance lightmap rendering

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -68,7 +68,7 @@ R_MD5_f -- called when r_md5 changes
 ===============
 */
 static void R_MD5_f (cvar_t *cvar)
-{
+			{
 	int			i;
 	qmodel_t	*mod;
 
@@ -100,7 +100,7 @@ Mod_Init
 ===============
 */
 void Mod_Init (void)
-{
+				{
         Cvar_RegisterVariable (&external_vis);
         Cvar_RegisterVariable (&external_ents);
         Cvar_RegisterVariable (&gl_loadlitfiles);
@@ -130,7 +130,7 @@ Caches the data if needed
 ===============
 */
 void *Mod_Extradata (qmodel_t *mod)
-{
+				{
 	void	*r;
 
 	r = Cache_Check (&mod->cache);
@@ -1491,14 +1491,13 @@ loadlightdir:
 				sample_count_ok = false;
 			}
 
-                        if (sample_count_ok)
-                        {
-                                // QuakeSpasm-like: ignore LIGHTINGDIR completely
-                                loadmodel->lightdirdata = NULL;
-                                loadmodel->lightdirsamples = 0;
-                                Q1BSPX_MarkUsed("LIGHTINGDIR");
-                                Con_DPrintf("LIGHTINGDIR ignored (QS mode)\n");
-                        }
+			if (sample_count_ok)
+			{
+				loadmodel->lightdirdata = (byte *) Hunk_AllocNameNoFill (bspxsize, litfilename);
+				loadmodel->lightdirsamples = samples;
+				memcpy (loadmodel->lightdirdata, in, bspxsize);
+				Q1BSPX_MarkUsed("LIGHTINGDIR");
+			}
 			else
 				Q1BSPX_MarkUnsupported("LIGHTINGDIR");
 		}
@@ -2127,25 +2126,29 @@ static void Mod_LoadFaces (lump_t *l)
                         out->samples = NULL;
                         out->luxsamples = NULL;
                 }
-                else
-                {
-                        int smax = (out->extents[0] >> 4) + 1;
-                        int tmax = (out->extents[1] >> 4) + 1;
-                        int facesamples = facestyles * smax * tmax;
+			else
+			{
+				int smax = (out->extents[0] >> 4) + 1;
+				int tmax = (out->extents[1] >> 4) + 1;
+				int facesamples = facestyles * smax * tmax;
 
-                        out->luxsamples = NULL; // LIGHTINGDIR is loaded but intentionally unused
+				// use the same dimensions as R_BuildLightMap to avoid rejecting valid faces
+				if (lofs + facesamples > loadmodel->lightdatasamples)
+				out->samples = NULL; //corrupt...
+				else if (loadmodel->flags & MOD_HDRLIGHTING)
+				out->samples = loadmodel->lightdata + (lofs * 4); //spike -- hdr lighting data is 4-aligned
+				else
+				out->samples = loadmodel->lightdata + (lofs * 3); //johnfitz -- lit support via lordhavoc (was "+ i")
 
-                        // use the same dimensions as R_BuildLightMap to avoid rejecting valid faces
-                        if (lofs + facesamples > loadmodel->lightdatasamples)
-                                out->samples = NULL; //corrupt...
-                        else if (loadmodel->flags & MOD_HDRLIGHTING)
-                                out->samples = loadmodel->lightdata + (lofs * 4); //spike -- hdr lighting data is 4-aligned
-                        else
-                                out->samples = loadmodel->lightdata + (lofs * 3); //johnfitz -- lit support via lordhavoc (was "+ i")
-
-                        if (loadmodel->lightdirdata && lofs + facesamples > loadmodel->lightdirsamples)
-                                Con_DWarning("LIGHTINGDIR data too small for face %d\n", surfnum);
-                }
+				out->luxsamples = NULL;
+				if (loadmodel->lightdirdata)
+				{
+					if (lofs + facesamples > loadmodel->lightdirsamples)
+						Con_DWarning("LIGHTINGDIR data too small for face %d\n", surfnum);
+					else
+						out->luxsamples = loadmodel->lightdirdata + (lofs * 3);
+				}
+			}
 
                 texture = loadmodel->textures[out->texinfo->texnum];
 

--- a/Quake/gl_rlight.c
+++ b/Quake/gl_rlight.c
@@ -28,6 +28,7 @@ extern cvar_t r_lerplightstyles;
 extern cvar_t r_dynamic;
 
 gpulightbuffer_t r_lightbuffer;
+float r_lightstyle_framefrac;
 
 /*
 ==================
@@ -45,18 +46,20 @@ void R_AnimateLight (void)
 	f = cl.time * 10.0;
 	base = floor(f);
 	i = (int)base;
-	f -= base;
-	if (!r_lerplightstyles.value)
-		f = 0.0;
+        f -= base;
+        if (!r_lerplightstyles.value)
+                f = 0.0;
+        r_lightstyle_framefrac = (float)f;
 
 	for (j=0 ; j<MAX_LIGHTSTYLES ; j++)
 	{
 		if (!cl_lightstyle[j].length)
 		{
-			d_lightstylevalue[j] = 256;
-			r_lightbuffer.lightstyles[j] = 1.f;
-			continue;
-		}
+                        d_lightstylevalue[j] = 256;
+                        r_lightbuffer.lightstyles[j * 2 + 0] = 1.f;
+                        r_lightbuffer.lightstyles[j * 2 + 1] = 1.f;
+                        continue;
+                }
 		//johnfitz -- r_flatlightstyles
 		if (r_flatlightstyles.value == 2)
 			k = n = cl_lightstyle[j].peak - 'a';
@@ -74,10 +77,11 @@ void R_AnimateLight (void)
 		// only interpolate abrupt changes (e.g. flickering light in e1m1) if r_lerplightstyles >= 2
 		if (r_lerplightstyles.value < 2.f && abs(n - k) >= ('m' - 'a') / 2)
 			n = k;
-		d_lightstylevalue[j] = (int)(k*22 + (n-k)*22*f);
-		r_lightbuffer.lightstyles[j] = (k + (n-k)*f) * (22.f/256.f);
-		//johnfitz
-	}
+                d_lightstylevalue[j] = (int)(k*22 + (n-k)*22*f);
+                r_lightbuffer.lightstyles[j * 2 + 0] = k * (22.f/256.f);
+                r_lightbuffer.lightstyles[j * 2 + 1] = n * (22.f/256.f);
+                //johnfitz
+        }
 
 	if (r_fullbright_cheatsafe)
 		r_lightbuffer.lightstyles[0] = 1.f;

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -25,6 +25,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #define NOISESCALE     (1.0f / 127.0f)
 
+extern gltexture_t *lightmap_dir_texture;
+
 qboolean	r_cache_thrash;		// compatability
 
 gpuframedata_t r_framedata;
@@ -187,6 +189,10 @@ cvar_t	r_speeds = { "r_speeds","0",CVAR_NONE };
 cvar_t	r_pos = { "r_pos","0",CVAR_NONE };
 cvar_t	r_fullbright = { "r_fullbright","0",CVAR_NONE };
 cvar_t	r_lightmap = { "r_lightmap","0",CVAR_NONE };
+cvar_t	r_lightmap_linear = { "r_lightmap_linear", "1", CVAR_ARCHIVE };
+cvar_t	r_lightmap_mipmaps = { "r_lightmap_mipmaps", "1", CVAR_ARCHIVE };
+cvar_t	r_lightmap16f = { "r_lightmap16f", "0", CVAR_ARCHIVE };
+cvar_t	r_lightingdir = { "r_lightingdir", "0", CVAR_ARCHIVE };
 cvar_t	r_wateralpha = { "r_wateralpha","1",CVAR_ARCHIVE };
 cvar_t	r_litwater = { "r_litwater","1",CVAR_NONE };
 cvar_t	r_dynamic = { "r_dynamic","1",CVAR_ARCHIVE };
@@ -1532,15 +1538,19 @@ void R_SetupView (void)
 		}
 
 
-		r_framedata.overbright = overbright;
-		r_framedata._padding0 = 0.f;
-	}
+r_framedata.overbright = overbright;
+r_framedata._padding0 = 0.f;
+}
 
 	r_framecount++;
 	r_framedata.eyepos[0] = r_refdef.vieworg[0];
 	r_framedata.eyepos[1] = r_refdef.vieworg[1];
 	r_framedata.eyepos[2] = r_refdef.vieworg[2];
 	r_framedata.time = cl.time;
+	r_framedata.lightmap_params[0] = r_lightmap_linear.value > 0.f ? 1.f : 0.f;
+	r_framedata.lightmap_params[1] = r_tonemap.value > 0.f ? 1.f : 0.f;
+	r_framedata.lightmap_params[2] = (r_lightingdir.value > 0.f && lightmap_dir_texture) ? 1.f : 0.f;
+	r_framedata.lightmap_params[3] = r_lightstyle_framefrac;
 
 	double prev_delta = cl.time - r_prev_frame_time;
 	qboolean prev_valid = r_prev_frame_valid && prev_delta > 0.0;

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -47,6 +47,10 @@ extern cvar_t r_lerpmodels;
 extern cvar_t r_lerpmove;
 extern cvar_t r_nolerp_list;
 extern cvar_t r_noshadow_list;
+extern cvar_t r_lightmap_linear;
+extern cvar_t r_lightmap_mipmaps;
+extern cvar_t r_lightmap16f;
+extern cvar_t r_lightingdir;
 //johnfitz
 extern cvar_t gl_zfix; // QuakeSpasm z-fighting fix
 extern cvar_t r_alphasort;
@@ -332,11 +336,15 @@ void R_Init (void)
 		cmd->completion = R_ShowbboxesFilter_Completion_f;
 	Cmd_AddCommand ("r_showbboxes_filter_clear", R_ShowbboxesFilterClear_f);
 
-        Cvar_RegisterVariable (&r_norefresh);
-        Cvar_RegisterVariable (&r_lightmap);
-        Cvar_RegisterVariable (&r_fullbright);
-        Cvar_RegisterVariable (&r_drawentities);
-        Cvar_RegisterVariable (&r_drawviewmodel);
+Cvar_RegisterVariable (&r_norefresh);
+Cvar_RegisterVariable (&r_lightmap);
+Cvar_RegisterVariable (&r_lightmap_linear);
+Cvar_RegisterVariable (&r_lightmap_mipmaps);
+Cvar_RegisterVariable (&r_lightmap16f);
+Cvar_RegisterVariable (&r_lightingdir);
+Cvar_RegisterVariable (&r_fullbright);
+Cvar_RegisterVariable (&r_drawentities);
+Cvar_RegisterVariable (&r_drawviewmodel);
 	Cvar_RegisterVariable (&r_wateralpha);
 	Cvar_SetCallback (&r_wateralpha, R_SetWateralpha_f);
 	Cvar_RegisterVariable (&r_litwater);

--- a/Quake/gl_texmgr.c
+++ b/Quake/gl_texmgr.c
@@ -25,6 +25,10 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "quakedef.h"
 #include "glquake.h"
 
+extern cvar_t r_lightmap_mipmaps;
+extern cvar_t r_lightmap16f;
+extern cvar_t r_lightmap_linear;
+
 typedef struct {
 	GLenum		id;
 	int			ratio;
@@ -1458,13 +1462,47 @@ TexMgr_LoadLightmap -- handles lightmap data
 */
 static void TexMgr_LoadLightmap (gltexture_t *glt, byte *data)
 {
+	qboolean use_mipmaps = (r_lightmap_mipmaps.value > 0.f) && (glt->flags & TEXPREF_MIPMAP);
+	qboolean use_half = (r_lightmap16f.value > 0.f) && (!strstr(glt->name, "lightmap_dir"));
+
 	// upload it
 	glt->compression = 1;
 	GL_Bind (GL_TEXTURE0, glt);
-	GL_TexImage (glt, 0, GL_RGBA8, glt->width, glt->height, gl_lightmap_format, GL_UNSIGNED_BYTE, data);
+	if (use_half)
+	{
+		size_t pixels = (size_t)glt->width * glt->height * 4;
+		GLfloat *float_data = (GLfloat *) malloc (pixels * sizeof (*float_data));
+		if (!float_data)
+			Sys_Error ("TexMgr_LoadLightmap: out of memory on %" SDL_PRIu64 " bytes", (uint64_t)(pixels * sizeof (*float_data)));
+		for (size_t idx = 0; idx < pixels; idx++)
+			float_data[idx] = data[idx] * (1.0f / 255.0f);
+		GL_TexImage (glt, 0, GL_RGBA16F, glt->width, glt->height, GL_RGBA, GL_FLOAT, float_data);
+		free (float_data);
+	}
+	else
+	{
+		GL_TexImage (glt, 0, GL_RGBA8, glt->width, glt->height, gl_lightmap_format, GL_UNSIGNED_BYTE, data);
+	}
+
+#ifdef GL_EXT_texture_sRGB_decode
+	if (r_lightmap_linear.value > 0.f)
+		glTexParameteri (glt->target, GL_TEXTURE_SRGB_DECODE_EXT, GL_DECODE_EXT);
+#endif
 
 	// set filter modes
 	TexMgr_SetFilterModes (glt);
+
+	if (use_mipmaps)
+	{
+		GL_GenerateMipmapFunc (glt->target);
+		glTexParameteri (glt->target, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+		glTexParameteri (glt->target, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+	}
+	else
+	{
+		glTexParameteri (glt->target, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+		glTexParameteri (glt->target, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+	}
 }
 
 /*

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -413,7 +413,7 @@ typedef struct gpulight_s {
 } gpulight_t;
 
 typedef struct gpulightbuffer_s {
-	float		lightstyles[MAX_LIGHTSTYLES];
+	float		lightstyles[MAX_LIGHTSTYLES * 2];
 	gpulight_t	lights[MAX_DLIGHTS];
 } gpulightbuffer_t;
 
@@ -434,6 +434,7 @@ typedef struct gpuframedata_s {
 	float	delta_time;
 	float	zlogscale;
 	float	zlogbias;
+	float	lightmap_params[4];
 	int			numlights;
 	int			prev_frame_valid;
 	int			_padding1;
@@ -442,6 +443,7 @@ typedef struct gpuframedata_s {
 
 extern gpulightbuffer_t r_lightbuffer;
 extern gpuframedata_t r_framedata;
+extern float r_lightstyle_framefrac;
 
 void R_AnimateLight (void);
 void R_MarkSurfaces (void);

--- a/Quake/r_brush.c
+++ b/Quake/r_brush.c
@@ -27,6 +27,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "quakedef.h"
 
 extern cvar_t gl_fullbrights, gl_overbright; //johnfitz
+extern cvar_t r_lightmap_mipmaps;
+extern cvar_t r_lightingdir;
 
 cvar_t gl_lightmap_atlas_size = { "gl_lightmap_atlas_size", "1024", CVAR_ARCHIVE };
 
@@ -35,6 +37,7 @@ int     lightmap_block_height = 256;
 
 int		gl_lightmap_format;
 int		lightmap_bytes;
+static const int	lightmap_padding = 2;
 
 typedef struct {
 	qboolean		reverse;
@@ -52,6 +55,8 @@ int				*lit_surf_order[2];
 int				num_lightmap_samples;
 unsigned		*lightmap_data;
 gltexture_t		*lightmap_texture;
+unsigned		*lightmap_dir_data;
+gltexture_t		*lightmap_dir_texture;
 int				lightmap_width;
 int				lightmap_height;
 
@@ -255,69 +260,143 @@ static int GL_NumLightmapTaps (const msurface_t *surf)
 
 /*
 ========================
+	GL_ExtendLightmapBorders
+========================
+*/
+static void GL_ExtendLightmapBorders (unsigned *dst, int stride, int width, int height)
+{
+	int t, p;
+	unsigned *row0 = dst;
+	unsigned *rowN = dst + (height - 1) * stride;
+
+	for (p = 1; p <= lightmap_padding; p++)
+	{
+		memcpy (row0 - p * stride, row0, width * sizeof (*row0));
+		memcpy (rowN + p * stride, rowN, width * sizeof (*rowN));
+	}
+
+	for (t = -lightmap_padding; t < height + lightmap_padding; t++)
+	{
+		unsigned *row = dst + t * stride;
+		unsigned left = row[0];
+		unsigned right = row[width - 1];
+
+		for (p = 1; p <= lightmap_padding; p++)
+		{
+			row[-p] = left;
+			row[width - 1 + p] = right;
+		}
+}
+}
+
+/*
+========================
 GL_FillSurfaceLightmap
 ========================
 */
 static void GL_FillSurfaceLightmap (msurface_t *surf)
 {
-	lightmap_t	*lm;
-	int			smax, tmax;
-	int			xofs, yofs;
-	int			map;
-	byte		*src;
-	unsigned	*dst;
-	int			s, t, facesize;
-
-	if (!cl.worldmodel->lightdata || !surf->samples || surf->styles[0] == INVALID_LIGHTSTYLE)
-		return;
+	const byte		*samples, *luxsamples;
+	lightmap_t		*lm;
+	int			smax, tmax, taps, style_count;
+	int			xofs, yofs, rowstride;
+	unsigned	*dst, *luxdst;
+	int			s, t;
+	int			facesize;
 
 	lm = &lightmaps[surf->lightmaptexturenum];
 	smax = (surf->extents[0]>>4)+1;
 	tmax = (surf->extents[1]>>4)+1;
+	taps = GL_NumLightmapTaps (surf);
 	xofs = lm->xofs + surf->light_s;
 	yofs = lm->yofs + surf->light_t;
+	rowstride = lightmap_width;
 	facesize = smax * tmax * 3;
 
-	src = surf->samples;
-	dst = lightmap_data + yofs * lightmap_width + xofs;
+	samples = surf->samples;
+	luxsamples = surf->luxsamples;
+	dst = lightmap_data + yofs * rowstride + xofs;
+	luxdst = lightmap_dir_data ? lightmap_dir_data + yofs * rowstride + xofs : NULL;
 
-	if (surf->styles[1] == INVALID_LIGHTSTYLE) // single lightstyle
+	if (!cl.worldmodel->lightdata || !samples || surf->styles[0] == INVALID_LIGHTSTYLE)
 	{
-		for (t = 0; t < tmax; t++, dst += lightmap_width)
-			for (s = 0; s < smax; s++, src += 3)
-				dst[s] = src[0] | (src[1] << 8) | (src[2] << 16) | 0xff000000u;
-	}
-	else if (surf->styles[2] == INVALID_LIGHTSTYLE) // 2 lightstyles
-	{
-		for (t = 0; t < tmax; t++, dst += lightmap_width)
+		if (luxdst)
 		{
-			for (s = 0; s < smax; s++, src += 3)
+			unsigned dir = 0x7f7f7fff;
+			for (t = 0; t < tmax; t++)
 			{
-				dst[s       ] = src[0           ] | (src[1           ] << 8) | (src[2           ] << 16) | 0xff000000u;
-				dst[s + smax] = src[0 + facesize] | (src[1 + facesize] << 8) | (src[2 + facesize] << 16) | 0xff000000u;
+				unsigned *luxrow = luxdst + t * rowstride;
+				for (s = 0; s < smax; s++)
+					for (int tap = 0; tap < taps; tap++)
+						luxrow[s + tap * smax] = dir;
 			}
+			GL_ExtendLightmapBorders (luxdst, rowstride, smax * taps, tmax);
 		}
+		return;
 	}
-	else // 3 or 4 lightstyles
+
+	style_count = 0;
+	while (style_count < 4 && surf->styles[style_count] != INVALID_LIGHTSTYLE)
+		style_count++;
+
+	for (t = 0; t < tmax; t++)
 	{
-		for (t = 0; t < tmax; t++, dst += lightmap_width)
+		unsigned *row = dst + t * rowstride;
+		unsigned *luxrow = luxdst ? luxdst + t * rowstride : NULL;
+		for (s = 0; s < smax; s++)
 		{
-			for (s = 0; s < smax; s++, src += 3)
+			int idx = (t * smax + s) * 3;
+			const byte *pix = samples + idx;
+
+			switch (taps)
 			{
-				const byte *mapsrc = src;
+			case 1:
+				row[s] = pix[0] | (pix[1] << 8) | (pix[2] << 16) | 0xff000000u;
+				break;
+
+			case 2:
+			{
+				const byte *pix1 = samples + facesize + idx;
+				row[s] = pix[0] | (pix[1] << 8) | (pix[2] << 16) | 0xff000000u;
+				row[s + smax] = pix1[0] | (pix1[1] << 8) | (pix1[2] << 16) | 0xff000000u;
+				break;
+			}
+
+			default:
+			{
 				unsigned r = 0, g = 0, b = 0;
-				for (map = 0; map < 4 && surf->styles[map] != INVALID_LIGHTSTYLE; map++, mapsrc += facesize)
+				int map;
+				for (map = 0; map < style_count; map++)
 				{
+					const byte *mapsrc = samples + map * facesize + idx;
 					r |= mapsrc[0] << (map << 3);
 					g |= mapsrc[1] << (map << 3);
 					b |= mapsrc[2] << (map << 3);
 				}
-				dst[s           ] = r;
-				dst[s + smax    ] = g;
-				dst[s + smax * 2] = b;
+				row[s] = r;
+				row[s + smax] = g;
+				row[s + smax * 2] = b;
+				break;
+			}
+			}
+
+			if (luxrow)
+			{
+				unsigned dir = 0x7f7f7fff;
+				if (luxsamples)
+				{
+					const byte *lux = luxsamples + idx;
+					dir = lux[0] | (lux[1] << 8) | (lux[2] << 16) | 0xff000000u;
+				}
+				for (int tap = 0; tap < taps; tap++)
+					luxrow[s + tap * smax] = dir;
 			}
 		}
 	}
+
+	GL_ExtendLightmapBorders (dst, rowstride, smax * taps, tmax);
+	if (luxdst)
+		GL_ExtendLightmapBorders (luxdst, rowstride, smax * taps, tmax);
 }
 
 /*
@@ -327,23 +406,29 @@ GL_FreeLightmapData
 */
 static void GL_FreeLightmapData (void)
 {
-	if (lightmap_data)
-	{
-		free (lightmap_data);
-		lightmap_data = NULL;
-	}
-	if (lightmaps)
-	{
-		free (lightmaps);
-		lightmaps = NULL;
-	}
+        if (lightmap_data)
+        {
+                free (lightmap_data);
+                lightmap_data = NULL;
+        }
+        if (lightmap_dir_data)
+        {
+                free (lightmap_dir_data);
+                lightmap_dir_data = NULL;
+        }
+        if (lightmaps)
+        {
+                free (lightmaps);
+                lightmaps = NULL;
+        }
 
-	VEC_CLEAR (lit_surfs);
+        VEC_CLEAR (lit_surfs);
 
-	lightmap_texture = NULL; // freed by the texture manager
-	last_lightmap_allocated = 0;
-	lightmap_count = 0;
-	lightmap_width = 0;
+        lightmap_texture = NULL; // freed by the texture manager
+        lightmap_dir_texture = NULL;
+        last_lightmap_allocated = 0;
+        lightmap_count = 0;
+        lightmap_width = 0;
 	lightmap_height = 0;
 	num_lightmap_samples = 0;
 }
@@ -391,7 +476,11 @@ static void GL_PackLitSurfaces (void)
 		}
 	}
 
-	blacklm = AllocBlock (maxblack[0]+1, maxblack[1]+1, &blackofs[0], &blackofs[1]);
+	int black_w = maxblack[0] + 1 + lightmap_padding * 2;
+	int black_h = maxblack[1] + 1 + lightmap_padding * 2;
+	blacklm = AllocBlock (black_w, black_h, &blackofs[0], &blackofs[1]);
+	blackofs[0] += lightmap_padding;
+	blackofs[1] += lightmap_padding;
 
 	if (VEC_SIZE (lit_surfs) == 0)
 		return;
@@ -441,17 +530,22 @@ static void GL_PackLitSurfaces (void)
 	// pack surfaces in sort order
 	for (i = 0, j = VEC_SIZE (lit_surfs); i < j; i++)
 	{
-		int smax, tmax;
+		int smax, tmax, taps, data_width, alloc_w, alloc_h;
 
 		surf = lit_surfs[lit_surf_order[0][i]];
 		smax = (surf->extents[0]>>4)+1;
 		tmax = (surf->extents[1]>>4)+1;
-		smax *= GL_NumLightmapTaps (surf);
-		num_lightmap_samples += smax * tmax;
+		taps = GL_NumLightmapTaps (surf);
+		data_width = smax * taps;
+		alloc_w = data_width + lightmap_padding * 2;
+		alloc_h = tmax + lightmap_padding * 2;
+		num_lightmap_samples += data_width * tmax;
 
 		if (surf->samples)
 		{
-			surf->lightmaptexturenum = AllocBlock (smax, tmax, &surf->light_s, &surf->light_t);
+			surf->lightmaptexturenum = AllocBlock (alloc_w, alloc_h, &surf->light_s, &surf->light_t);
+			surf->light_s += lightmap_padding;
+			surf->light_t += lightmap_padding;
 		}
 		else
 		{
@@ -474,12 +568,15 @@ void GL_BuildLightmaps (void)
 {
 	int			i, j, xblocks, yblocks, lmsize;
 	lightmap_t	*lm;
+	qboolean	use_lightdir;
+	unsigned	tex_flags;
 
 	r_framecount = 1; // no dlightcache
 
 	//Spike -- wipe out all the lightmap data (johnfitz -- the gltexture objects were already freed by Mod_ClearAll)
 	GL_FreeLightmapData ();
 
+	use_lightdir = (r_lightingdir.value > 0.f) && cl.worldmodel->lightdirdata;
 	gl_lightmap_format = GL_RGBA;//FIXME: hardcoded for now!
 
 	switch (gl_lightmap_format)
@@ -524,6 +621,13 @@ void GL_BuildLightmaps (void)
 	if (!lightmap_data)
 		Sys_Error ("GL_BuildLightmaps: out of memory on %" SDL_PRIu64 " bytes", (uint64_t)(lmsize * sizeof (*lightmap_data)));
 
+	if (use_lightdir)
+	{
+		lightmap_dir_data = (unsigned *) calloc (lmsize, sizeof (*lightmap_dir_data));
+		if (!lightmap_dir_data)
+			Sys_Error ("GL_BuildLightmaps: out of memory on %" SDL_PRIu64 " bytes", (uint64_t)(lmsize * sizeof (*lightmap_dir_data)));
+	}
+
 	// compute offsets for each lightmap block
 	for (i=0; i<lightmap_count; i++)
 	{
@@ -534,21 +638,46 @@ void GL_BuildLightmaps (void)
 
 	// fill reserved texel
 	lightmap_data[0] = 0xff808080u;
+	if (lightmap_dir_data)
+		lightmap_dir_data[0] = 0x7f7f7fff;
 
 	// unlit map? fill with 50% grey
 	if (!cl.worldmodel->lightdata)
+	{
 		for (i = 1; i < lmsize; i++)
+		{
 			lightmap_data[i] = 0xff808080u;
+			if (lightmap_dir_data)
+				lightmap_dir_data[i] = 0x7f7f7fff;
+		}
+	}
 
 	// fill lightmap samples
 	for (i = 0, j = VEC_SIZE (lit_surfs); i < j; i++)
 		GL_FillSurfaceLightmap (lit_surfs[i]);
 
+	tex_flags = TEXPREF_ALPHA | TEXPREF_LINEAR;
+	if (r_lightmap_mipmaps.value > 0.f)
+		tex_flags |= TEXPREF_MIPMAP;
+	else
+		tex_flags |= TEXPREF_NOPICMIP;
+
 	lightmap_texture =
 		TexMgr_LoadImage (cl.worldmodel, "lightmap", lightmap_width, lightmap_height,
 			SRC_LIGHTMAP, (byte *)lightmap_data, "", (src_offset_t)lightmap_data,
-			TEXPREF_ALPHA | TEXPREF_LINEAR | TEXPREF_NOPICMIP
+			tex_flags
 		);
+
+	if (lightmap_dir_data)
+	{
+		lightmap_dir_texture =
+			TexMgr_LoadImage (cl.worldmodel, "lightmap_dir", lightmap_width, lightmap_height,
+				SRC_LIGHTMAP, (byte *)lightmap_dir_data, "", (src_offset_t)lightmap_dir_data,
+				tex_flags
+			);
+	}
+	else
+		lightmap_dir_texture = NULL;
 
 	//johnfitz -- warn about exceeding old limits
 	//GLQuake limit was 64 textures of 128x128. Estimate how many 128x128 textures we would need

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -29,6 +29,8 @@ extern cvar_t gl_zfix; // QuakeSpasm z-fighting fix
 extern cvar_t r_oit;
 
 extern gltexture_t *lightmap_texture;
+extern gltexture_t *lightmap_dir_texture;
+extern cvar_t r_lightingdir;
 
 extern GLuint gl_bmodel_vbo;
 extern size_t gl_bmodel_vbo_size;
@@ -510,12 +512,13 @@ static void R_DrawBrushModels_Real (entity_t **ents, int count, brushpass_t pass
 
         R_ResetBModelCalls (program);
         GL_SetState (state);
-        if (pass <= BP_ALPHATEST)
-        {
-                GL_Bind (GL_TEXTURE2, r_fullbright_cheatsafe ? greytexture : lightmap_texture);
-        }
-        else if (pass == BP_SKYCUBEMAP)
-                GL_Bind (GL_TEXTURE2, skybox->cubemap);
+if (pass <= BP_ALPHATEST)
+{
+GL_Bind (GL_TEXTURE2, r_fullbright_cheatsafe ? greytexture : lightmap_texture);
+GL_Bind (GL_TEXTURE3, (r_lightingdir.value > 0.f && lightmap_dir_texture) ? lightmap_dir_texture : greytexture);
+}
+else if (pass == BP_SKYCUBEMAP)
+GL_Bind (GL_TEXTURE2, skybox->cubemap);
 
         GL_Upload (GL_SHADER_STORAGE_BUFFER, bmodel_instances, sizeof(bmodel_instances[0]) * totalinst, &buf, &ofs);
         GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 2, buf, (GLintptr)ofs, sizeof(bmodel_instances[0]) * totalinst);
@@ -610,11 +613,12 @@ void R_DrawBrushModels_Water (entity_t **ents, int count, qboolean translucent)
 	else
 		program = glprogs.water[oit][softemu == SOFTEMU_COARSE];
 
-	R_ResetBModelCalls (program);
-	GL_SetState (state);
-	GL_Bind (GL_TEXTURE2, r_fullbright_cheatsafe ? greytexture : lightmap_texture);
+R_ResetBModelCalls (program);
+GL_SetState (state);
+GL_Bind (GL_TEXTURE2, r_fullbright_cheatsafe ? greytexture : lightmap_texture);
+GL_Bind (GL_TEXTURE3, (r_lightingdir.value > 0.f && lightmap_dir_texture) ? lightmap_dir_texture : greytexture);
 
-	GL_Upload (GL_SHADER_STORAGE_BUFFER, bmodel_instances, sizeof(bmodel_instances[0]) * totalinst, &buf, &ofs);
+GL_Upload (GL_SHADER_STORAGE_BUFFER, bmodel_instances, sizeof(bmodel_instances[0]) * totalinst, &buf, &ofs);
 	GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 2, buf, (GLintptr)ofs, sizeof(bmodel_instances[0]) * count);
 
 	// generate drawcalls

--- a/Quake/shaders/cluster_lights.comp
+++ b/Quake/shaders/cluster_lights.comp
@@ -24,7 +24,7 @@ struct Light
 
 layout(std430, binding=0) restrict readonly buffer LightBuffer
 {
-	float	LightStyles[64];
+	vec2	LightStyles[64];
 	Light	Lights[];
 };
 
@@ -32,7 +32,7 @@ float GetLightStyle(int index)
 {
 	float result;
 	if (index < 64)
-		result = LightStyles[index];
+		result = mix(LightStyles[index].x, LightStyles[index].y, LightmapParams.w);
 	else
 		result = 1.0;
 	return result;

--- a/Quake/shaders/frame_uniforms.glsl
+++ b/Quake/shaders/frame_uniforms.glsl
@@ -19,6 +19,7 @@ layout(std140, binding=0) uniform FrameDataUBO
         float   DeltaTime;
         float   ZLogScale;
         float   ZLogBias;
+        vec4    LightmapParams;
         uint    NumLights;
         uint    PrevFrameValid;
         uint    _Pad1;

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -1,11 +1,12 @@
 #if BINDLESS
 	#extension GL_ARB_bindless_texture : require
 #else
-	layout(binding=0) uniform sampler2D Tex;
-	layout(binding=1) uniform sampler2D FullbrightTex;
+        layout(binding=0) uniform sampler2D Tex;
+        layout(binding=1) uniform sampler2D FullbrightTex;
         layout(binding=4) uniform sampler2D EmissiveTex;
 #endif
 layout(binding=2) uniform sampler2D LMTex;
+layout(binding=3) uniform sampler2D LMTexDir;
 #include "frame_uniforms.glsl"
 
 vec3 ApplyFog(vec3 clr, vec3 p)
@@ -30,7 +31,7 @@ struct Light
 
 layout(std430, binding=0) restrict readonly buffer LightBuffer
 {
-	float	LightStyles[64];
+	vec2	LightStyles[64];
 	Light	Lights[];
 };
 
@@ -38,7 +39,7 @@ float GetLightStyle(int index)
 {
 	float result;
 	if (index < 64)
-		result = LightStyles[index];
+		result = mix(LightStyles[index].x, LightStyles[index].y, LightmapParams.w);
 	else
 		result = 1.0;
 	return result;
@@ -176,6 +177,20 @@ float tri(float x)
 #define SCREEN_SPACE_NOISE() DITHER_NOISE(floor(gl_FragCoord.xy)+0.5)
 #define SUPPRESS_BANDING() bayer(ivec2(gl_FragCoord.xy))
 
+vec4 SampleLightmap(vec2 uv)
+{
+	vec4 lm = texture(LMTex, uv);
+	if (LightmapParams.x > 0.5)
+		lm = pow(lm, vec4(2.2));
+	return lm;
+}
+
+vec3 SampleLightmapDir(vec2 uv)
+{
+	vec3 dir = texture(LMTexDir, uv).xyz * 2.0 - 1.0;
+	return normalize(dir);
+}
+
 vec2 ComputeVelocity(vec4 curr_clip, vec4 prev_clip)
 {
 	const float EPS = 1e-6;
@@ -287,13 +302,13 @@ void main()
 	vec2 lmsize = vec2(textureSize(LMTex, 0).xy) * 16.;
 	lmuv = (floor(lmuv * lmsize) + 0.5) / lmsize;
 #endif // DITHER
-	vec4 lm0 = textureLod(LMTex, lmuv, 0.);
+        vec4 lm0 = SampleLightmap(lmuv);
         vec3 static_light;
         if (in_styles.y < 0.) // single style fast path
                 static_light = in_styles.x * lm0.xyz;
         else
         {
-                vec4 lm1 = textureLod(LMTex, vec2(lmuv.x + in_lmofs, lmuv.y), 0.);
+                vec4 lm1 = SampleLightmap(vec2(lmuv.x + in_lmofs, lmuv.y));
                 if (in_styles.z < 0.) // 2 styles
                 {
                         static_light =
@@ -302,7 +317,7 @@ void main()
                 }
                 else // 3 or 4 lightstyles
                 {
-                        vec4 lm2 = textureLod(LMTex, vec2(lmuv.x + in_lmofs * 2., lmuv.y), 0.);
+                        vec4 lm2 = SampleLightmap(vec2(lmuv.x + in_lmofs * 2., lmuv.y));
                         static_light = vec3
                         (
                                 dot(in_styles, lm0),
@@ -310,6 +325,13 @@ void main()
                                 dot(in_styles, lm2)
                         );
                 }
+        }
+
+        if (LightmapParams.z > 0.5)
+        {
+                vec3 dir = SampleLightmapDir(lmuv);
+                float ndl = max(dot(dir, vec3(0.0, 0.0, 1.0)), 0.0);
+                static_light *= ndl;
         }
 
         vec3 surface_normal = in_normal;
@@ -419,6 +441,8 @@ void main()
         result.rgb += emissive;
         vec3 spec_clamped = clamp(specular_light, vec3(0.0), vec3(Overbright));
         result.rgb += spec_clamped * clamp(result.a, 0.0, 1.0);
+        if (LightmapParams.y > 0.5)
+                result.rgb = result.rgb / (vec3(1.0) + result.rgb);
         result = clamp(result, 0.0, 1.0);
         result.rgb = ApplyFog(result.rgb, in_pos - EyePos);
 

--- a/Quake/shaders/world.vert
+++ b/Quake/shaders/world.vert
@@ -30,7 +30,7 @@ struct Light
 
 layout(std430, binding=0) restrict readonly buffer LightBuffer
 {
-	float	LightStyles[64];
+	vec2	LightStyles[64];
 	Light	Lights[];
 };
 
@@ -38,7 +38,7 @@ float GetLightStyle(int index)
 {
 	float result;
 	if (index < 64)
-		result = LightStyles[index];
+		result = mix(LightStyles[index].x, LightStyles[index].y, LightmapParams.w);
 	else
 		result = 1.0;
 	return result;


### PR DESCRIPTION
## Summary
- add padding, gutters, and optional directional data when building lightmap atlases and upload trilinear/mipmapped lightmaps
- support 16F uploads, SRGB decode, and shader-side linear sampling with optional tonemapping and directional modulation
- smooth lightstyle blending on GPU by mixing previous/next values via new frame parameters

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692583c04164832e81bffc7b4d9de638)