### PR TITLE
Fix frame uniform layout padding

### DIFF
--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -418,27 +418,34 @@ typedef struct gpulightbuffer_s {
 } gpulightbuffer_t;
 
 typedef struct gpuframedata_s {
+	// Padding fields are used to match the std140 layout in frame_uniforms.glsl.
 	float	viewproj[16];
 	float	prev_viewproj[16];
 	float	fogdata[4];
 	float	skyfogdata[4];
 	vec3_t	winddir;
+	float	_padding_winddir;
 	float	windphase;
 	float	screendither;
 	float	texturedither;
 	float	overbright;
 	float	_padding0;
+	float	_padding_eyepos[3];
 	vec3_t	eyepos;
+	float	_padding_time;
 	float	time;
+	float	_padding_preveye[3];
 	vec3_t	prev_eyepos;
+	float	_padding_delta;
 	float	delta_time;
 	float	zlogscale;
 	float	zlogbias;
+	float	_padding_lightmap;
 	float	lightmap_params[4];
-	int			numlights;
-	int			prev_frame_valid;
-	int			_padding1;
-	int			_padding2;
+	int				 numlights;
+	int				 prev_frame_valid;
+	int				 _padding1;
+	int				 _padding2;
 } gpuframedata_t;
 
 extern gpulightbuffer_t r_lightbuffer;


### PR DESCRIPTION
## Summary
- add explicit padding to the frame data struct so its layout matches the std140 uniform block
- document the padding to clarify why the extra fields are present

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925efcef958832e9d6854d2d821d6de)