### PR TITLE
Fix frame uniform struct layout

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -1385,9 +1385,9 @@ void R_SetFrustum (void)
 
 	logznear = log2f (znear);
 	logzfar = log2f (zfar);
-	memcpy (r_framedata.viewproj, r_matviewproj, 16 * sizeof (float));
-	r_framedata.zlogscale = LIGHT_TILES_Z / (logzfar - logznear);
-	r_framedata.zlogbias = -r_framedata.zlogscale * logznear;
+        memcpy (r_framedata.viewproj, r_matviewproj, 16 * sizeof (float));
+        r_framedata.zparams[0] = LIGHT_TILES_Z / (logzfar - logznear);
+        r_framedata.zparams[1] = -r_framedata.zparams[0] * logznear;
 }
 
 /*
@@ -1537,16 +1537,15 @@ void R_SetupView (void)
 			}
 		}
 
-
-r_framedata.overbright = overbright;
-r_framedata._padding0 = 0.f;
+        r_framedata.dither[2] = overbright;
+        r_framedata.dither[3] = 0.f;
 }
 
 	r_framecount++;
-	r_framedata.eyepos[0] = r_refdef.vieworg[0];
-	r_framedata.eyepos[1] = r_refdef.vieworg[1];
-	r_framedata.eyepos[2] = r_refdef.vieworg[2];
-	r_framedata.time = cl.time;
+        r_framedata.eye[0] = r_refdef.vieworg[0];
+        r_framedata.eye[1] = r_refdef.vieworg[1];
+        r_framedata.eye[2] = r_refdef.vieworg[2];
+        r_framedata.eye[3] = cl.time;
 	r_framedata.lightmap_params[0] = r_lightmap_linear.value > 0.f ? 1.f : 0.f;
 	r_framedata.lightmap_params[1] = r_tonemap.value > 0.f ? 1.f : 0.f;
 	r_framedata.lightmap_params[2] = (r_lightingdir.value > 0.f && lightmap_dir_texture) ? 1.f : 0.f;
@@ -1558,44 +1557,44 @@ r_framedata._padding0 = 0.f;
 	if (prev_valid)
 	{
 		memcpy (r_framedata.prev_viewproj, r_prev_matviewproj, sizeof (r_prev_matviewproj));
-		r_framedata.prev_eyepos[0] = r_prev_vieworg[0];
-		r_framedata.prev_eyepos[1] = r_prev_vieworg[1];
-		r_framedata.prev_eyepos[2] = r_prev_vieworg[2];
-		r_framedata.delta_time = (float)prev_delta;
+                r_framedata.prev_eye[0] = r_prev_vieworg[0];
+                r_framedata.prev_eye[1] = r_prev_vieworg[1];
+                r_framedata.prev_eye[2] = r_prev_vieworg[2];
+                r_framedata.prev_eye[3] = (float)prev_delta;
 		r_framedata.prev_frame_valid = 1;
 	}
 	else
 	{
 		memcpy (r_framedata.prev_viewproj, r_identity_mat4, sizeof (r_identity_mat4));
-		r_framedata.prev_eyepos[0] = r_refdef.vieworg[0];
-		r_framedata.prev_eyepos[1] = r_refdef.vieworg[1];
-		r_framedata.prev_eyepos[2] = r_refdef.vieworg[2];
-		r_framedata.delta_time = 0.f;
+                r_framedata.prev_eye[0] = r_refdef.vieworg[0];
+                r_framedata.prev_eye[1] = r_refdef.vieworg[1];
+                r_framedata.prev_eye[2] = r_refdef.vieworg[2];
+                r_framedata.prev_eye[3] = 0.f;
 		r_framedata.prev_frame_valid = 0;
 		r_prev_frame_valid = false;
 	}
 
 	if (softemu == SOFTEMU_COARSE)
 	{
-		r_framedata.screendither = NOISESCALE * r_dither.value * r_softemu_dither_screen.value;
-		r_framedata.texturedither = NOISESCALE * r_dither.value * r_softemu_dither_texture.value;
+                r_framedata.dither[0] = NOISESCALE * r_dither.value * r_softemu_dither_screen.value;
+                r_framedata.dither[1] = NOISESCALE * r_dither.value * r_softemu_dither_texture.value;
 
 		// r_fullbright replaces the actual lightmap texture with a 2x2 50% grey one.
 		// Since texture-space dithering is applied on a scale of 1/16 of a lightmap texel,
 		// this would lead to massively overscaled dithering patterns, so we disable
 		// texture-space dithering in this case.
-		if (r_fullbright_cheatsafe)
-			r_framedata.texturedither = 0.f;
+                if (r_fullbright_cheatsafe)
+                        r_framedata.dither[1] = 0.f;
 	}
 	else if (softemu == SOFTEMU_OFF)
 	{
-		r_framedata.screendither = r_dither.value * (1.f / 255.f);
-		r_framedata.texturedither = 0.f;
+                r_framedata.dither[0] = r_dither.value * (1.f / 255.f);
+                r_framedata.dither[1] = 0.f;
 	}
 	else // FINE (screen-space dithering applied during postprocessing), or BANDED (no dithering)
 	{
-		r_framedata.screendither = 0.f;
-		r_framedata.texturedither = 0.f;
+                r_framedata.dither[0] = 0.f;
+                r_framedata.dither[1] = 0.f;
 	}
 
 	Fog_SetupFrame (); //johnfitz

--- a/Quake/gl_sky.c
+++ b/Quake/gl_sky.c
@@ -722,9 +722,9 @@ void Sky_DrawSkyBox (void)
 	GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS(2));
 
 	GL_UniformMatrix4fvFunc (0, 1, GL_FALSE, r_matviewproj);
-	GL_Uniform3fvFunc (1, 1, r_refdef.vieworg);
-	GL_Uniform4fvFunc (2, 1, fog);
-	GL_Uniform1fFunc (3, r_framedata.screendither);
+        GL_Uniform3fvFunc (1, 1, r_refdef.vieworg);
+        GL_Uniform4fvFunc (2, 1, fog);
+        GL_Uniform1fFunc (3, r_framedata.dither[0]);
 
 	for (i = 0; i < 6; i++)
 	{
@@ -826,8 +826,8 @@ void Sky_SetupFrame (void)
 
 	phase -= floor (phase) + 0.5; // [-0.5, 0.5)
 
-	r_framedata.winddir[0] =  dist * cp * sy;
-	r_framedata.winddir[1] =  dist * sp;
-	r_framedata.winddir[2] = -dist * cp * cy;
-	r_framedata.windphase = phase;
+        r_framedata.wind[0] =  dist * cp * sy;
+        r_framedata.wind[1] =  dist * sp;
+        r_framedata.wind[2] = -dist * cp * cy;
+        r_framedata.wind[3] = phase;
 }

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -418,27 +418,21 @@ typedef struct gpulightbuffer_s {
 } gpulightbuffer_t;
 
 typedef struct gpuframedata_s {
-	float	viewproj[16];
-	float	prev_viewproj[16];
-	float	fogdata[4];
-	float	skyfogdata[4];
-	vec3_t	winddir;
-	float	windphase;
-	float	screendither;
-	float	texturedither;
-	float	overbright;
-	float	_padding0;
-	vec3_t	eyepos;
-	float	time;
-	vec3_t	prev_eyepos;
-	float	delta_time;
-	float	zlogscale;
-	float	zlogbias;
-	float	lightmap_params[4];
-	int			numlights;
-	int			prev_frame_valid;
-	int			_padding1;
-	int			_padding2;
+        // Fields are grouped into vec4-aligned blocks to match the std140 layout in frame_uniforms.glsl.
+        float           viewproj[16];
+        float           prev_viewproj[16];
+        float           fogdata[4];
+        float           skyfogdata[4];
+        vec4_t          wind;           // xyz: winddir, w: windphase
+        vec4_t          dither;         // x: screen, y: texture, z: overbright, w: padding
+        vec4_t          eye;            // xyz: eyepos, w: time
+        vec4_t          prev_eye;       // xyz: prev_eyepos, w: delta_time
+        vec4_t          zparams;        // x: zlogscale, y: zlogbias, zw: padding
+        float           lightmap_params[4];
+        unsigned int    numlights;
+        unsigned int    prev_frame_valid;
+        unsigned int    _padding1;
+        unsigned int    _padding2;
 } gpuframedata_t;
 
 extern gpulightbuffer_t r_lightbuffer;

--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -361,7 +361,7 @@ void R_FlushAliasInstances (qboolean showtris)
 			-fabs (r_framedata.fogdata[3]) :
 			 fabs (r_framedata.fogdata[3])
 	;
-	ibuf.global.dither = r_framedata.screendither;
+    ibuf.global.dither = r_framedata.dither[0];
 
 	ibuf_size = sizeof(ibuf.global) + sizeof(ibuf.inst[0]) * ibuf.count;
 	GL_Upload (GL_SHADER_STORAGE_BUFFER, &ibuf.global, ibuf_size, &buf, &ofs);


### PR DESCRIPTION
## Summary
- reorganize the frame data UBO layout to use vec4-aligned groups that match the shader's std140 layout
- update frame data writes and consumers to use the new packed fields for wind, dithering, view position, and timing

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925efcef958832e9d6854d2d821d6de)