### PR TITLE
Fix signed/unsigned comparison warning in alias lighting

### DIFF
--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -160,9 +160,9 @@ R_SetupEntityTransform -- johnfitz -- set up transform part of lerpdata
 */
 void R_SetupEntityTransform (entity_t *e, lerpdata_t *lerpdata)
 {
-	float blend;
-	vec3_t d;
-	int i;
+	float           blend;
+	vec3_t          d;
+	unsigned int    i;
 
 	// if LERP_RESETMOVE, kill any lerps in progress
 	if (e->lerpflags & LERP_RESETMOVE)
@@ -229,7 +229,7 @@ void R_SetupAliasLighting (entity_t	*e)
 {
 	vec3_t		dist;
 	float		add;
-	int			i;
+	unsigned int	 i;
 
 	// if the initial trace is completely black, try again from above
 	// this helps with models whose origin is slightly below ground level


### PR DESCRIPTION
## Summary
- align alias rendering loop counters with unsigned light counts to resolve signed/unsigned comparison warnings
- use consistent unsigned loop index declarations in entity transform setup

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69260147b5c4832e844bfbd26f99aed1)