### PR TITLE
Fix lightmap linear mode and post effects handling

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -1404,6 +1404,9 @@ qboolean GL_NeedsSceneEffects (void)
         if (GL_ShouldApplyMotionBlur ())
                 return true;
 
+        if (R_DoFEnabled ())
+                return true;
+
         return false;
 }
 

--- a/Quake/gl_texmgr.c
+++ b/Quake/gl_texmgr.c
@@ -1485,8 +1485,8 @@ static void TexMgr_LoadLightmap (gltexture_t *glt, byte *data)
 	}
 
 #ifdef GL_EXT_texture_sRGB_decode
-	if (r_lightmap_linear.value > 0.f)
-		glTexParameteri (glt->target, GL_TEXTURE_SRGB_DECODE_EXT, GL_DECODE_EXT);
+        glTexParameteri (glt->target, GL_TEXTURE_SRGB_DECODE_EXT,
+                        r_lightmap_linear.value > 0.f ? GL_SKIP_DECODE_EXT : GL_DECODE_EXT);
 #endif
 
 	// set filter modes

--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -37,7 +37,14 @@ float bayer01(ivec2 coord)
 
 float bayer(ivec2 coord)
 {
-	return bayer01(coord) - 0.5;
+        return bayer01(coord) - 0.5;
+}
+
+vec3 ApplyFog(vec3 clr, vec3 p)
+{
+        float fog = exp2(-Fog.w * dot(p, p));
+        fog = clamp(fog, 0.0, 1.0);
+        return mix(Fog.rgb, clr, fog);
 }
 
 // Hash without Sine
@@ -165,10 +172,8 @@ void main()
         result.rgb += fullbright;
         result.rgb += emissive;
         result.rgb = clamp(result.rgb, 0.0, 1.0);
-        float fog = exp2(abs(Fog.w) * -dot(in_pos, in_pos));
-	fog = clamp(fog, 0.0, 1.0);
-	result.rgb = mix(Fog.rgb, result.rgb, fog);
-	out_fragcolor = result;
+        result.rgb = ApplyFog(result.rgb, in_pos);
+        out_fragcolor = result;
 #if !OIT
         vec2 velocity = ComputeVelocity(in_curr_clip, in_prev_clip);
         float viewModelMask = ((in_flags & ALIAS_FLAG_NO_MOTION_BLUR) != 0) ? 1.0 : 0.0;

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -297,13 +297,13 @@ void main()
 		discard;
 #endif
 
-	bool linear_lightmaps = LightmapParams.x > 0.5;
-	if (linear_lightmaps)
-	{
-		result.rgb = pow(result.rgb, vec3(2.2));
-		fullbright = pow(fullbright, vec3(2.2));
-		emissive = pow(emissive, vec3(2.2));
-	}
+        bool linear_lightmaps = LightmapParams.x > 0.5;
+        if (!linear_lightmaps)
+        {
+                result.rgb = pow(result.rgb, vec3(2.2));
+                fullbright = pow(fullbright, vec3(2.2));
+                emissive = pow(emissive, vec3(2.2));
+        }
 
 	vec2 lmuv = in_lmuv;
 #if DITHER
@@ -454,7 +454,7 @@ void main()
         result = clamp(result, 0.0, 1.0);
         result.rgb = ApplyFog(result.rgb, in_pos - EyePos);
 
-        if (linear_lightmaps)
+        if (!linear_lightmaps)
                 result.rgb = pow(result.rgb, vec3(1.0 / 2.2));
 
         result.a = in_alpha; // FIXME: This will make almost transparent things cut holes though heavy fog


### PR DESCRIPTION
## Summary
- correct lightmap gamma handling by disabling sRGB decode when r_lightmap_linear is enabled and matching shader conversions
- ensure depth of field rendering keeps velocity data so the viewmodel mask can exclude player weapons
- apply the standard fog calculation to alias models

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692617e4bf4c832e82456bf206eff6bd)