### PR TITLE
Ensure frame data is uploaded after fog setup

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -2591,9 +2591,13 @@ void R_RenderScene (void)
 
 	R_Clear ();
 
-	Fog_EnableGFog (); //johnfitz
+Fog_EnableGFog (); //johnfitz
 
-	R_DrawViewModel (); //johnfitz -- moved here from R_RenderView
+// Upload frame data after fog has been set up to ensure fog parameters
+// are available to all draw calls, even when light clustering is skipped.
+R_UploadFrameData ();
+
+R_DrawViewModel (); //johnfitz -- moved here from R_RenderView
 
 	S_ExtraUpdate (); // don't let sound get messed up if going slow
 


### PR DESCRIPTION
## Summary
- upload frame uniform data immediately after fog is configured so fog uniforms are available for all draw calls

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926242f9c7c832eb1a49d1cbbdb2e61)