### PR TITLE
Adjust dynamic light colors for projectiles and effects

### DIFF
--- a/Quake/cl_main.c
+++ b/Quake/cl_main.c
@@ -500,7 +500,7 @@ static void CL_RocketTrail (entity_t *ent, int type)
 
 /*
 ===============
-CL_SetDlightColorForEntity
+			CL_SetDlightColorForEntity
 
 Tint dynamic lights to better match their source.
 ===============
@@ -532,15 +532,21 @@ static void CL_SetDlightColorForEntity (dlight_t *dl, const entity_t *ent)
                 return;
         }
 
+        if (name && (q_strcasestr (name, "acid") || q_strcasestr (name, "spit")))
+        {
+                dl->color[0] = 0.20f; dl->color[1] = 0.95f; dl->color[2] = 0.20f;
+                return;
+        }
+
         if (name && q_strcasestr (name, "lava"))
         {
-                dl->color[0] = 1.00f; dl->color[1] = 0.40f; dl->color[2] = 0.10f;
+                dl->color[0] = 1.00f; dl->color[1] = 0.15f; dl->color[2] = 0.05f;
                 return;
         }
 
         if (name && q_strcasestr (name, "wiz"))
         {
-                dl->color[0] = 0.30f; dl->color[1] = 0.85f; dl->color[2] = 0.30f;
+                dl->color[0] = 0.20f; dl->color[1] = 0.95f; dl->color[2] = 0.20f;
                 return;
         }
 
@@ -673,11 +679,12 @@ void CL_RelinkEntities (void)
 			dl->origin[2] += 16;
 			AngleVectors (ent->angles, fv, rv, uv);
 
-                        VectorMA (dl->origin, 18, fv, dl->origin);
-                        dl->radius = 200 + (rand()&31);
-                        dl->minlight = 32;
-                        dl->die = cl.time + 0.1;
-                        CL_SetDlightColorForEntity (dl, ent);
+			VectorMA (dl->origin, 18, fv, dl->origin);
+			dl->radius = 200 + (rand()&31);
+			dl->minlight = 32;
+			dl->die = cl.time + 0.1;
+			dl->color[0] = 1.00f; dl->color[1] = 0.70f; dl->color[2] = 0.30f;
+			CL_SetDlightColorForEntity (dl, ent);
 
 			//johnfitz -- assume muzzle flash accompanied by muzzle flare, which looks bad when lerped
 			if (r_lerpmodels.value != 2)

--- a/Quake/cl_tent.c
+++ b/Quake/cl_tent.c
@@ -192,12 +192,13 @@ void CL_ParseTEnt (void)
 		pos[1] = MSG_ReadCoord (cl.protocolflags);
 		pos[2] = MSG_ReadCoord (cl.protocolflags);
 		R_ParticleExplosion (pos);
-		dl = CL_AllocDlight (0);
-		VectorCopy (pos, dl->origin);
-		dl->radius = 350;
-		dl->die = cl.time + 0.5;
-		dl->decay = 300;
-		S_StartSound (-1, 0, cl_sfx_r_exp3, pos, 1, 1);
+                dl = CL_AllocDlight (0);
+                VectorCopy (pos, dl->origin);
+                dl->radius = 350;
+                dl->color[0] = 1.00f; dl->color[1] = 0.50f; dl->color[2] = 0.25f;
+                dl->die = cl.time + 0.5;
+                dl->decay = 300;
+                S_StartSound (-1, 0, cl_sfx_r_exp3, pos, 1, 1);
 		break;
 
 	case TE_TAREXPLOSION:			// tarbaby explosion


### PR DESCRIPTION
## Summary
- tint acid and lava-based projectiles toward green and red to match their visuals
- color rocket explosions and muzzle flashes with warm tones for better readability

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69262724117c832e8f2f128f0f8a4167)