### PR TITLE
Fix fog application on water surfaces

### DIFF
--- a/Quake/shaders/water.frag
+++ b/Quake/shaders/water.frag
@@ -158,7 +158,7 @@ void main()
         result.rgb += fullbright;
         result.rgb += emissive;
         result.rgb = clamp(result.rgb, 0.0, 1.0);
-        result.rgb = ApplyFog(result.rgb, in_pos);
+        result.rgb = ApplyFog(result.rgb, in_pos - EyePos);
         result.a *= in_alpha;
         out_fragcolor = result;
 #if !OIT

--- a/Quake/shaders/water.vert
+++ b/Quake/shaders/water.vert
@@ -108,7 +108,7 @@ void main()
         out_prev_clip = prev_clip;
         out_flags = call.flags;
         out_uv = in_uv.xy;
-        out_pos = world_pos - EyePos;
+        out_pos = world_pos;
         out_alpha = instance.alpha < 0.0 ? call.wateralpha : instance.alpha;
 #if BINDLESS
         out_samplers0.xy = call.txhandle;


### PR DESCRIPTION
## Summary
- compute fog in the water shader using camera-relative positions so liquids properly respect fog
- align vertex output with fragment fog calculations for water and portal surfaces

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692629fd9838832ebf4d1a0ef9dd3105)