### PR TITLE
Integrate texture atlas support

### DIFF
--- a/Quake/Makefile
+++ b/Quake/Makefile
@@ -263,12 +263,13 @@ OBJS = strlcat.o \
         common.o \
         q3shader.o \
         steam.o \
-	json.o \
-	miniz.o \
-	crc.o \
-	cvar.o \
-	cfgfile.o \
-	host.o \
+        json.o \
+        texture_atlas.o \
+        miniz.o \
+        crc.o \
+        cvar.o \
+        cfgfile.o \
+        host.o \
 	host_cmd.o \
 	mathlib.o \
 	pr_cmds.o \

--- a/Quake/host.c
+++ b/Quake/host.c
@@ -25,6 +25,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "quakedef.h"
 #include "bgmusic.h"
 #include "steam.h"
+#include "texture_atlas.h"
 #include <setjmp.h>
 
 /*
@@ -1421,13 +1422,14 @@ void Host_Init (void)
 		if (!host_colormap)
 			Sys_Error ("Couldn't load gfx/colormap.lmp");
 
-		V_Init ();
-		Chase_Init ();
-		M_Init ();
-		VID_Init ();
-		IN_Init ();
-		TexMgr_Init (); //johnfitz
-		Draw_Init ();
+                V_Init ();
+                Chase_Init ();
+                M_Init ();
+                VID_Init ();
+                IN_Init ();
+                TexMgr_Init (); //johnfitz
+                Atlas_Init ();
+                Draw_Init ();
 		SCR_Init ();
 		R_Init ();
 		S_Init ();

--- a/Quake/texture_atlas.c
+++ b/Quake/texture_atlas.c
@@ -96,16 +96,23 @@ void Atlas_RegisterTexture(const char *name, int w, int h, const unsigned char *
 
 void Atlas_Build(const char *mapname)
 {
-	int i;
-	int x = 0, y = 0, row_h = 0;
+        int i;
+        int x = 0, y = 0, row_h = 0;
 
-	if (g_world_atlas.texture_count == 0)
-		return;
+        if (g_world_atlas.texture_count == 0)
+                return;
 
-	if (g_world_atlas.pixels)
-	{
-		free(g_world_atlas.pixels);
-		g_world_atlas.pixels = NULL;
+        g_world_atlas.built = 0;
+
+        if (g_world_atlas.atlas_w <= 0)
+                g_world_atlas.atlas_w = ATLAS_SIZE;
+        if (g_world_atlas.atlas_h <= 0)
+                g_world_atlas.atlas_h = ATLAS_SIZE;
+
+        if (g_world_atlas.pixels)
+        {
+                free(g_world_atlas.pixels);
+                g_world_atlas.pixels = NULL;
 	}
 
 	g_world_atlas.pixels = (unsigned char *) calloc(1, g_world_atlas.atlas_w * g_world_atlas.atlas_h * 4);
@@ -235,4 +242,8 @@ void Atlas_OnMapStart(const char *mapname)
  * In Mod_LoadBrushModel():
  * // === Build CPU Atlas for this map ===
  * // Atlas_OnMapStart(loadmodel->name);
+ *
+ * In R_LoadExternalTexture():
+ * // === Texture Atlas Hook ===
+ * // Atlas_RegisterTexture(texture_name, width, height, rgba);
  */


### PR DESCRIPTION
## Summary
- ensure the atlas builder initializes dimensions, rebuild flag, and documents external texture hook usage
- initialize the texture atlas subsystem during host startup
- include texture_atlas.c in the Unix Makefile build

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692636d50440832e95996c72b9368293)