### PR TITLE
Fix atlas PNG export for Windows build

### DIFF
--- a/Quake/Makefile
+++ b/Quake/Makefile
@@ -263,12 +263,13 @@ OBJS = strlcat.o \
         common.o \
         q3shader.o \
         steam.o \
-	json.o \
-	miniz.o \
-	crc.o \
-	cvar.o \
-	cfgfile.o \
-	host.o \
+        json.o \
+        texture_atlas.o \
+        miniz.o \
+        crc.o \
+        cvar.o \
+        cfgfile.o \
+        host.o \
 	host_cmd.o \
 	mathlib.o \
 	pr_cmds.o \

--- a/Quake/host.c
+++ b/Quake/host.c
@@ -25,6 +25,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "quakedef.h"
 #include "bgmusic.h"
 #include "steam.h"
+#include "texture_atlas.h"
 #include <setjmp.h>
 
 /*
@@ -1421,13 +1422,14 @@ void Host_Init (void)
 		if (!host_colormap)
 			Sys_Error ("Couldn't load gfx/colormap.lmp");
 
-		V_Init ();
-		Chase_Init ();
-		M_Init ();
-		VID_Init ();
-		IN_Init ();
-		TexMgr_Init (); //johnfitz
-		Draw_Init ();
+                V_Init ();
+                Chase_Init ();
+                M_Init ();
+                VID_Init ();
+                IN_Init ();
+                TexMgr_Init (); //johnfitz
+                Atlas_Init ();
+                Draw_Init ();
 		SCR_Init ();
 		R_Init ();
 		S_Init ();

--- a/Quake/texture_atlas.c
+++ b/Quake/texture_atlas.c
@@ -4,7 +4,7 @@
 
 #include "quakedef.h"
 #include "texture_atlas.h"
-#include "stb_image_write.h"
+#include "image.h"
 
 static world_atlas_t g_world_atlas;
 
@@ -96,16 +96,23 @@ void Atlas_RegisterTexture(const char *name, int w, int h, const unsigned char *
 
 void Atlas_Build(const char *mapname)
 {
-	int i;
-	int x = 0, y = 0, row_h = 0;
+        int i;
+        int x = 0, y = 0, row_h = 0;
 
-	if (g_world_atlas.texture_count == 0)
-		return;
+        if (g_world_atlas.texture_count == 0)
+                return;
 
-	if (g_world_atlas.pixels)
-	{
-		free(g_world_atlas.pixels);
-		g_world_atlas.pixels = NULL;
+        g_world_atlas.built = 0;
+
+        if (g_world_atlas.atlas_w <= 0)
+                g_world_atlas.atlas_w = ATLAS_SIZE;
+        if (g_world_atlas.atlas_h <= 0)
+                g_world_atlas.atlas_h = ATLAS_SIZE;
+
+        if (g_world_atlas.pixels)
+        {
+                free(g_world_atlas.pixels);
+                g_world_atlas.pixels = NULL;
 	}
 
 	g_world_atlas.pixels = (unsigned char *) calloc(1, g_world_atlas.atlas_w * g_world_atlas.atlas_h * 4);
@@ -166,7 +173,7 @@ void Atlas_SavePNG(const char *mapname)
 
 	q_snprintf(filename, sizeof(filename), "%s/%s_atlas.png", dirname, mapname ? mapname : "map");
 
-	stbi_write_png(filename, g_world_atlas.atlas_w, g_world_atlas.atlas_h, 4, g_world_atlas.pixels, g_world_atlas.atlas_w * 4);
+        Image_WritePNG(filename, g_world_atlas.pixels, g_world_atlas.atlas_w, g_world_atlas.atlas_h, 32, false);
 	Con_Printf("Atlas_SavePNG: wrote %s\n", filename);
 }
 
@@ -235,4 +242,8 @@ void Atlas_OnMapStart(const char *mapname)
  * In Mod_LoadBrushModel():
  * // === Build CPU Atlas for this map ===
  * // Atlas_OnMapStart(loadmodel->name);
+ *
+ * In R_LoadExternalTexture():
+ * // === Texture Atlas Hook ===
+ * // Atlas_RegisterTexture(texture_name, width, height, rgba);
  */

--- a/Windows/VisualStudio/ironwail.vcxproj
+++ b/Windows/VisualStudio/ironwail.vcxproj
@@ -344,6 +344,7 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\Quake\sys_sdl_win.c" />
+    <ClCompile Include="..\..\Quake\texture_atlas.c" />
     <ClCompile Include="..\..\Quake\view.c" />
     <ClCompile Include="..\..\Quake\wad.c" />
     <ClCompile Include="..\..\Quake\world.c" />
@@ -422,6 +423,7 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
     <ClInclude Include="..\..\Quake\world.h" />
     <ClInclude Include="..\..\Quake\wsaerror.h" />
     <ClInclude Include="..\..\Quake\zone.h" />
+    <ClInclude Include="..\..\Quake\texture_atlas.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\QuakeSpasm.rc" />

--- a/Windows/VisualStudio/ironwail.vcxproj.filters
+++ b/Windows/VisualStudio/ironwail.vcxproj.filters
@@ -273,6 +273,9 @@
     <ClCompile Include="..\..\Quake\snd_mpg123.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Quake\texture_atlas.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Quake\anorm_dots.h">
@@ -474,6 +477,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Quake\zone.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Quake\texture_atlas.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Quake\gl_shaders.h">


### PR DESCRIPTION
## Summary
- switch texture atlas PNG writing to the existing Image_WritePNG helper
- include the proper header so the atlas uses the engine's PNG writer instead of the missing stb symbol

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692636d50440832e95996c72b9368293)