### PR TITLE
Generate texture atlases on map load

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -25,6 +25,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // on the same machine.
 
 #include "quakedef.h"
+#include "texture_atlas.h"
 
 #define INVALID_LIGHTSTYLE_OLD 255
 
@@ -54,6 +55,44 @@ static int	mod_novis_capacity;
 
 static byte	*mod_decompressed;
 static int	mod_decompressed_capacity;
+
+static void Mod_RegisterTextureAtlasEntry (const char *name, int width, int height, enum srcformat fmt, const byte *data)
+{
+        size_t i, pixels;
+        unsigned char *rgba;
+
+        if (isDedicated || !name || !data || width <= 0 || height <= 0)
+                return;
+
+        if (fmt == SRC_RGBA)
+        {
+                Atlas_RegisterTexture(name, width, height, data);
+                return;
+        }
+
+        if (fmt != SRC_INDEXED)
+                return;
+
+        pixels = (size_t) width * (size_t) height;
+        rgba = (unsigned char *) malloc(pixels * 4);
+        if (!rgba)
+        {
+                Con_Printf("Mod_RegisterTextureAtlasEntry: out of memory registering %s\n", name);
+                return;
+        }
+
+        for (i = 0; i < pixels; i++)
+        {
+                unsigned int color = d_8to24table[data[i]];
+                rgba[i * 4 + 0] = ((byte *) &color)[0];
+                rgba[i * 4 + 1] = ((byte *) &color)[1];
+                rgba[i * 4 + 2] = ((byte *) &color)[2];
+                rgba[i * 4 + 3] = ((byte *) &color)[3];
+        }
+
+        Atlas_RegisterTexture(name, width, height, rgba);
+        free(rgba);
+}
 
 #define	MAX_MOD_KNOWN	4096 /*johnfitz -- was 512 */
 static qmodel_t	mod_known[MAX_MOD_KNOWN];
@@ -257,7 +296,6 @@ byte *Mod_NoVisPVS (qmodel_t *model)
 		mod_novis = (byte *) realloc (mod_novis, mod_novis_capacity);
 		if (!mod_novis)
 			Sys_Error ("Mod_NoVisPVS: realloc() failed on %d bytes", mod_novis_capacity);
-		
 		memset(mod_novis, 0xff, mod_novis_capacity);
 	}
 	return mod_novis;
@@ -1070,12 +1108,13 @@ static void Mod_LoadTextures (lump_t *l)
                                         q_strlcpy (texturename, filename, sizeof(texturename));
                                         tx->gltexture = TexMgr_LoadImage (loadmodel, texturename, fwidth, fheight,
                                                 fmt, data, filename, 0, TEXPREF_MIPMAP | TEXPREF_BINDLESS);
+                                        Mod_RegisterTextureAtlasEntry(tx->name, fwidth, fheight, fmt, data);
                                 }
                                 else //use the texture from the bsp file
-				{
-					q_snprintf (texturename, sizeof(texturename), "%s:%s", loadmodel->name, tx->name);
-					offset = (src_offset_t)(mt+1) - (src_offset_t)mod_base;
-					tx->gltexture = TexMgr_LoadImage (loadmodel, texturename, tx->width, tx->height,
+                                {
+                                        q_snprintf (texturename, sizeof(texturename), "%s:%s", loadmodel->name, tx->name);
+                                        offset = (src_offset_t)(mt+1) - (src_offset_t)mod_base;
+                                        tx->gltexture = TexMgr_LoadImage (loadmodel, texturename, tx->width, tx->height,
                                                 SRC_INDEXED, (byte *)(tx+1), loadmodel->name, offset, TEXPREF_MIPMAP | TEXPREF_BINDLESS);
                                 }
 
@@ -1108,6 +1147,7 @@ static void Mod_LoadTextures (lump_t *l)
                                 {
                                         tx->gltexture = TexMgr_LoadImage (loadmodel, filename, fwidth, fheight,
                                                 fmt, data, filename, 0, TEXPREF_MIPMAP | extraflags );
+					Mod_RegisterTextureAtlasEntry(tx->name, fwidth, fheight, fmt, data);
                                 }
                                 else //use the texture from the bsp file
                                 {
@@ -1134,6 +1174,7 @@ static void Mod_LoadTextures (lump_t *l)
 						tx->gltexture = TexMgr_LoadImage (loadmodel, texturename, tx->width, tx->height,
 							SRC_INDEXED, (byte *)(tx+1), loadmodel->name, offset, TEXPREF_MIPMAP | extraflags);
                                         }
+					Mod_RegisterTextureAtlasEntry(tx->name, tx->width, tx->height, SRC_INDEXED, (byte *)(tx+1));
                                 }
                                 tx->emissive = Mod_LoadEmissiveMap (loadmodel, filename, TEXPREF_MIPMAP | extraflags);
                                 if (malloced)
@@ -3141,8 +3182,11 @@ static void Mod_LoadBrushModel (qmodel_t *mod, void *buffer)
 	dmodel_t 	*bm;
 	float		radius; //johnfitz
 	bsp_header_info_t header;
+	char		mapbase[MAX_QPATH];
 
 	loadmodel->type = mod_brush;
+	if (!isDedicated && loadmodel->name[0] != "*")
+		Atlas_Reset();
 
 	mod_base = (byte *)buffer;
 
@@ -3230,6 +3274,12 @@ visdone:
 
 	Mod_DispatchBSPXLumps(mod);
 	Q1BSPX_LogUsage(mod->name);
+	if (!isDedicated && loadmodel->name[0] != "*")
+	{
+		COM_FileBase (loadmodel->name, mapbase, sizeof(mapbase));
+		Atlas_OnMapStart(mapbase);
+	}
+
 
 //
 // set up the submodels (FIXME: this is confusing)


### PR DESCRIPTION
## Summary
- register BSP textures in the CPU texture atlas during map loading
- reset and build texture atlases per map and save atlas outputs once textures are loaded

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692642b54a6c832ea8bd2ffe48be26ef)