### PR TITLE
Ensure texture names are null-terminated for atlas lookup

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -1004,7 +1004,8 @@ static void Mod_LoadTextures (lump_t *l)
 		memset (tx, 0, sizeof (*tx));
 		loadmodel->textures[i] = tx;
 
-		memcpy (tx->name, mt->name, sizeof(tx->name));
+                // ensure texture names are always null-terminated so atlas lookups work
+                q_strlcpy (tx->name, mt->name, sizeof(tx->name));
 		if (!tx->name[0])
 		{
 			q_snprintf (tx->name, sizeof(tx->name), "unnamed%d", i);


### PR DESCRIPTION
## Summary
- ensure BSP texture names are copied with an explicit terminator so atlas lookups succeed

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692758b9efd4832e8fa9f063d7556393)