### PR TITLE
Include q_ctype for texture atlas normalization

### DIFF
--- a/Quake/texture_atlas.c
+++ b/Quake/texture_atlas.c
@@ -3,6 +3,7 @@
  */
 
 #include "quakedef.h"
+#include "q_ctype.h"
 #include "texture_atlas.h"
 
 #define STB_IMAGE_IMPLEMENTATION


### PR DESCRIPTION
## Summary
- include q_ctype.h in texture_atlas.c so q_tolower is declared

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692767de9ba4832e9c6ad3e70f08b929)