### PR TITLE
Implement texture atlas sampling updates

### DIFF
--- a/Quake/r_brush.c
+++ b/Quake/r_brush.c
@@ -798,8 +798,8 @@ void GL_BuildBModelVertexBuffer (void)
                         atlas_rect = Atlas_GetUV(texture ? texture->name : NULL);
                         use_atlas = atlas_rect.exists != 0;
 
-			if (fa->flags & SURF_DRAWTILED)
-			{
+                        if (fa->flags & SURF_DRAWTILED)
+                        {
 				// match old Mod_PolyForUnlitSurface
 				if (fa->flags & (SURF_DRAWTURB | SURF_DRAWSKY))
 					texscalex = 1.f / 128.f; //warp animation repeats every 128
@@ -823,9 +823,16 @@ void GL_BuildBModelVertexBuffer (void)
 					texscaley = 1.f / texture->height;
 					useofs = 1.f;
 				}
-				lm = &lightmaps[fa->lightmaptexturenum];
-				lmofs = ((fa->extents[0]>>4)+1) / (float)lightmap_width;
-			}
+                                lm = &lightmaps[fa->lightmaptexturenum];
+                                lmofs = ((fa->extents[0]>>4)+1) / (float)lightmap_width;
+                        }
+
+                        if (use_atlas)
+                        {
+                                texscalex = 1.f;
+                                texscaley = 1.f;
+                                useofs = 1.f;
+                        }
 
 			fa->vbo_firstvert = varray_index;
 			varray_index += fa->numedges;
@@ -913,13 +920,6 @@ void GL_BuildBModelVertexBuffer (void)
                                 vert->styles = ~0u;
                         }
 
-                        if (use_atlas)
-                        {
-                                const float du = atlas_rect.u2 - atlas_rect.u1;
-                                const float dv = atlas_rect.v2 - atlas_rect.v1;
-                                vert->st[0] = atlas_rect.u1 + vert->st[0] * du;
-                                vert->st[1] = atlas_rect.v1 + vert->st[1] * dv;
-                        }
                 }
                 }
         }

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -168,6 +168,9 @@ typedef struct bmodel_bindless_gpu_call_s {
 	GLuint64	texture;
 	GLuint64	fullbright;
 	GLuint64	emissive;
+	GLfloat	atlas_uv[4];
+	GLfloat	orig_size[2];
+	GLfloat	offset[2];
 } bmodel_bindless_gpu_call_t;
 
 typedef struct bmodel_bound_gpu_call_s {
@@ -175,6 +178,9 @@ typedef struct bmodel_bound_gpu_call_s {
 	GLfloat		alpha;
 	GLint		baseinstance;
 	GLint		padding;
+	GLfloat		atlas_uv[4];
+	GLfloat		orig_size[2];
+	GLfloat		offset[2];
 } bmodel_bound_gpu_call_t;
 
 typedef struct bmodel_gpu_call_remap_s {
@@ -335,19 +341,45 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
 	float		alpha;
 	gltexture_t	*tx, *fb, *em;
 
-	if (num_bmodel_calls == MAX_BMODEL_DRAWS)
-		R_FlushBModelCalls ();
+	atlas_rect_t	atlas_rect;
+	float		atlas_uv[4];
+	float		orig_size[2];
+	float		offset[2];
+
+        if (num_bmodel_calls == MAX_BMODEL_DRAWS)
+                R_FlushBModelCalls ();
+
+        atlas_rect = atlas_null_rect;
+        atlas_uv[0] = 0.f;
+        atlas_uv[1] = 0.f;
+        atlas_uv[2] = 1.f;
+        atlas_uv[3] = 1.f;
+        orig_size[0] = 1.f;
+        orig_size[1] = 1.f;
+        offset[0] = 0.f;
+        offset[1] = 0.f;
 
         if (t)
         {
                 tx = t->gltexture;
                 fb = t->fullbright;
                 em = t->emissive;
-                if (Atlas_TextureExists(t->name))
+                atlas_rect = Atlas_GetUV(t->name);
+                if (atlas_rect.exists)
                 {
                         const gltexture_t *atlas_tex = Atlas_GetGLTextureStruct();
                         if (atlas_tex)
                                 tx = (gltexture_t *)atlas_tex;
+                        atlas_uv[0] = atlas_rect.u1;
+                        atlas_uv[1] = atlas_rect.v1;
+                        atlas_uv[2] = atlas_rect.u2 - atlas_rect.u1;
+                        atlas_uv[3] = atlas_rect.v2 - atlas_rect.v1;
+                }
+                if (t->gltexture && atlas_rect.exists)
+                {
+                        gltexture_t *glt = t->gltexture;
+                        orig_size[0] = glt->source_width ? (float)glt->source_width : (float)glt->width;
+                        orig_size[1] = glt->source_height ? (float)glt->source_height : (float)glt->height;
                 }
                 if (r_lightmap_cheatsafe)
                         tx = fb = em = NULL;
@@ -370,27 +402,33 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
                 flags |= CALLFLAG_ALPHA_TEST;
         alpha = t ? GL_WaterAlphaForTextureType (t->type) : 1.f;
 
-	if (gl_bindless_able)
-	{
-		bmodel_bindless_gpu_call_t *call = &bmodel_calls.bindless.params[num_bmodel_calls];
-		call->flags = flags;
-		call->alpha = alpha;
-		call->texture = tx ? tx->bindless_handle : greytexture->bindless_handle;
-		call->fullbright = fb ? fb->bindless_handle : blacktexture->bindless_handle;
-		call->emissive = em ? em->bindless_handle : blacktexture->bindless_handle;
-	}
-	else
-	{
-		bmodel_bound_gpu_call_t *call = &bmodel_calls.bound.params[num_bmodel_calls];
-		gltexture_t **textures = bmodel_calls.bound.textures[num_bmodel_calls];
-		call->flags = flags;
-		call->alpha = alpha;
-		call->baseinstance = first_instance;
-		call->padding = 0;
-		textures[0] = tx ? tx : greytexture;
-		textures[1] = fb ? fb : blacktexture;
-		textures[2] = em ? em : blacktexture;
-	}
+        if (gl_bindless_able)
+        {
+                bmodel_bindless_gpu_call_t *call = &bmodel_calls.bindless.params[num_bmodel_calls];
+                call->flags = flags;
+                call->alpha = alpha;
+                call->texture = tx ? tx->bindless_handle : greytexture->bindless_handle;
+                call->fullbright = fb ? fb->bindless_handle : blacktexture->bindless_handle;
+                call->emissive = em ? em->bindless_handle : blacktexture->bindless_handle;
+                memcpy(call->atlas_uv, atlas_uv, sizeof(atlas_uv));
+                memcpy(call->orig_size, orig_size, sizeof(orig_size));
+                memcpy(call->offset, offset, sizeof(offset));
+        }
+        else
+        {
+                bmodel_bound_gpu_call_t *call = &bmodel_calls.bound.params[num_bmodel_calls];
+                gltexture_t **textures = bmodel_calls.bound.textures[num_bmodel_calls];
+                call->flags = flags;
+                call->alpha = alpha;
+                call->baseinstance = first_instance;
+                call->padding = 0;
+                memcpy(call->atlas_uv, atlas_uv, sizeof(atlas_uv));
+                memcpy(call->orig_size, orig_size, sizeof(orig_size));
+                memcpy(call->offset, offset, sizeof(offset));
+                textures[0] = tx ? tx : greytexture;
+                textures[1] = fb ? fb : blacktexture;
+                textures[2] = em ? em : blacktexture;
+        }
 
 	SDL_assert (num_instances > 0);
 	SDL_assert (num_instances <= MAX_BMODEL_INSTANCES);

--- a/Quake/shaders/sky_cubemap.vert
+++ b/Quake/shaders/sky_cubemap.vert
@@ -27,6 +27,9 @@ struct Call
 	int		baseinstance;
 	int		padding;
 #endif // BINDLESS
+	vec4	atlas_uv;
+	vec2	orig_size;
+	vec2	offset;
 };
 const uint
 	CF_USE_POLYGON_OFFSET = 1u,

--- a/Quake/shaders/sky_layers.vert
+++ b/Quake/shaders/sky_layers.vert
@@ -27,6 +27,9 @@ struct Call
 	int		baseinstance;
 	int		padding;
 #endif // BINDLESS
+	vec4	atlas_uv;
+	vec2	orig_size;
+	vec2	offset;
 };
 const uint
 	CF_USE_POLYGON_OFFSET = 1u,

--- a/Quake/shaders/skystencil.vert
+++ b/Quake/shaders/skystencil.vert
@@ -27,6 +27,9 @@ struct Call
 	int		baseinstance;
 	int		padding;
 #endif // BINDLESS
+	vec4	atlas_uv;
+	vec2	orig_size;
+	vec2	offset;
 };
 const uint
 	CF_USE_POLYGON_OFFSET = 1u,

--- a/Quake/shaders/water.vert
+++ b/Quake/shaders/water.vert
@@ -27,6 +27,9 @@ struct Call
 	int		baseinstance;
 	int		padding;
 #endif // BINDLESS
+	vec4	atlas_uv;
+	vec2	orig_size;
+	vec2	offset;
 };
 const uint
 	CF_USE_POLYGON_OFFSET = 1u,

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -58,6 +58,9 @@ struct Call
 	int		baseinstance;
 	int		padding;
 #endif // BINDLESS
+        vec4    atlas_uv;
+        vec2    orig_size;
+        vec2    offset;
 };
 const uint
 	CF_USE_POLYGON_OFFSET = 1u,
@@ -128,6 +131,9 @@ layout(location=8) flat in float in_lmofs;
 layout(location=11) noperspective in vec4 in_curr_clip;
 layout(location=12) noperspective in vec4 in_prev_clip;
 layout(location=13) in vec3 in_normal;
+layout(location=14) flat in vec4 in_atlas_uv;
+layout(location=15) flat in vec2 in_orig_size;
+layout(location=16) flat in vec2 in_offset;
 
 // ALU-only 16x16 Bayer matrix
 float bayer01(ivec2 coord)
@@ -261,36 +267,41 @@ void main()
 	out_fragcolor = vec4(0.5 + 0.5 * normalize(cross(dFdx(in_pos), dFdy(in_pos))), 0.75);
 	return;
 #endif
-	vec3 fullbright = vec3(0.);
+        vec3 fullbright = vec3(0.);
         vec3 emissive = vec3(0.);
-	vec2 uv = in_uv;
+        vec2 uv = in_uv;
 #if MODE == 2
-	uv = uv * 2.0 + 0.125 * sin(uv.yx * (3.14159265 * 2.0) + Time);
+        uv = uv * 2.0 + 0.125 * sin(uv.yx * (3.14159265 * 2.0) + Time);
 #endif
+
+        uv += in_offset;
+        vec2 atlas_size = max(in_orig_size, vec2(1.0));
+        vec2 texnorm = uv / atlas_size;
+        vec2 atlas_uv = in_atlas_uv.xy + texnorm * in_atlas_uv.zw;
 #if BINDLESS
         sampler2D Tex = sampler2D(in_samplers0.xy);
         if ((in_flags & CF_USE_FULLBRIGHT) != 0u)
         {
                 sampler2D FullbrightTex = sampler2D(in_samplers0.zw);
-                fullbright = texture(FullbrightTex, uv).rgb;
+                fullbright = texture(FullbrightTex, atlas_uv).rgb;
         }
         if ((in_flags & CF_USE_EMISSIVE) != 0u)
         {
                 sampler2D EmissiveSampler = sampler2D(in_samplers1.xy);
-                emissive = texture(EmissiveSampler, uv).rgb;
+                emissive = texture(EmissiveSampler, atlas_uv).rgb;
         }
 #else
         if ((in_flags & CF_USE_FULLBRIGHT) != 0u)
-                fullbright = texture(FullbrightTex, uv).rgb;
+                fullbright = texture(FullbrightTex, atlas_uv).rgb;
         if ((in_flags & CF_USE_EMISSIVE) != 0u)
-                emissive = texture(EmissiveTex, uv).rgb;
+                emissive = texture(EmissiveTex, atlas_uv).rgb;
 #endif
 #if DITHER >= 2
-	vec4 result = texture(Tex, uv, -1.0);
+        vec4 result = texture(Tex, atlas_uv, -1.0);
 #elif DITHER
-	vec4 result = texture(Tex, uv, -0.5);
+        vec4 result = texture(Tex, atlas_uv, -0.5);
 #else
-	vec4 result = texture(Tex, uv);
+        vec4 result = texture(Tex, atlas_uv);
 #endif
 #if MODE == 1
 	if (result.a < 0.666)

--- a/Quake/shaders/world.vert
+++ b/Quake/shaders/world.vert
@@ -56,6 +56,9 @@ struct Call
 	int		baseinstance;
 	int		padding;
 #endif // BINDLESS
+        vec4    atlas_uv;
+        vec2    orig_size;
+        vec2    offset;
 };
 const uint
 	CF_USE_POLYGON_OFFSET = 1u,
@@ -133,12 +136,15 @@ layout(location=6) noperspective out vec2 out_coord;
 layout(location=7) flat out vec4 out_styles;
 layout(location=8) flat out float out_lmofs;
 #if BINDLESS
-	layout(location=9) flat out uvec4 out_samplers0;
+layout(location=9) flat out uvec4 out_samplers0;
         layout(location=10) flat out uvec2 out_samplers1;
 #endif
 layout(location=11) noperspective out vec4 out_curr_clip;
 layout(location=12) noperspective out vec4 out_prev_clip;
 layout(location=13) out vec3 out_normal;
+layout(location=14) flat out vec4 out_atlas_uv;
+layout(location=15) flat out vec2 out_orig_size;
+layout(location=16) flat out vec2 out_offset;
 
 void main()
 {
@@ -191,11 +197,14 @@ void main()
 		out_styles.xy = vec2(1., -1.);
 	out_lmofs = in_lmofs;
 #if BINDLESS
-	out_samplers0.xy = call.txhandle;
-	if ((call.flags & CF_USE_FULLBRIGHT) != 0u)
-		out_samplers0.zw = call.fbhandle;
-	else
-		out_samplers0.zw = out_samplers0.xy;
-	out_samplers1.xy = call.emhandle;
+        out_samplers0.xy = call.txhandle;
+        if ((call.flags & CF_USE_FULLBRIGHT) != 0u)
+                out_samplers0.zw = call.fbhandle;
+        else
+                out_samplers0.zw = out_samplers0.xy;
+        out_samplers1.xy = call.emhandle;
 #endif
+        out_atlas_uv = call.atlas_uv;
+        out_orig_size = call.orig_size;
+        out_offset = call.offset;
 }

--- a/Quake/texture_atlas.c
+++ b/Quake/texture_atlas.c
@@ -22,6 +22,8 @@ typedef struct atlas_entry_s {
     char name[64];
     atlas_rect_t rect;
     qboolean logged;
+    int offset_x;
+    int offset_y;
 } atlas_entry_t;
 
 static atlas_entry_t atlas_entries[ATLAS_MAX_TEXTURES];
@@ -374,6 +376,11 @@ static qboolean Atlas_ParseJSON(const char *json, size_t len)
         entry->rect.exists = 1;
         entry->logged = false;
 
+        entry->offset_x = 0;
+        entry->offset_y = 0;
+        Atlas_ParseIntField(obj_start, obj_end, "ox", &entry->offset_x);
+        Atlas_ParseIntField(obj_start, obj_end, "oy", &entry->offset_y);
+
         cursor = obj_end + 1;
     }
 
@@ -531,6 +538,7 @@ typedef struct atlas_build_entry_s
     char name[64];
     int width, height;
     int x, y;
+    int offset_x, offset_y;
     byte *rgba;
 } atlas_build_entry_t;
 
@@ -711,8 +719,9 @@ static qboolean Atlas_WriteJSON(const char *path, const atlas_build_entry_t *ent
     for (i = 0; i < count; ++i)
     {
         const atlas_build_entry_t *e = &entries[i];
-        fprintf(f, "        {\"name\":\"%s\",\"x\":%d,\"y\":%d,\"w\":%d,\"h\":%d}%s\n",
-            e->name, e->x, e->y, e->width, e->height, (i == count - 1) ? "" : ",");
+        fprintf(f,
+            "        {\"name\":\"%s\",\"x\":%d,\"y\":%d,\"w\":%d,\"h\":%d,\"ox\":%d,\"oy\":%d}%s\n",
+            e->name, e->x, e->y, e->width, e->height, e->offset_x, e->offset_y, (i == count - 1) ? "" : ",");
     }
 
     fprintf(f, "    ]\n");
@@ -881,6 +890,17 @@ atlas_rect_t Atlas_GetUV(const char *name)
         return atlas_null_rect;
 
     Atlas_NormalizeTextureName(name, normalized, sizeof(normalized));
+    // remove leading special chars for better matching
+    if (normalized[0] == '*' || normalized[0] == '+' || normalized[0] == '-')
+        memmove(normalized, normalized + 1, strlen(normalized));
+
+    // strip directory components
+    {
+        char *slash = strrchr(normalized, '/');
+        if (slash)
+            memmove(normalized, slash + 1, strlen(slash + 1) + 1);
+    }
+
     if (!normalized[0])
         return atlas_null_rect;
 
@@ -894,6 +914,15 @@ atlas_rect_t Atlas_GetUV(const char *name)
                 atlas_entries[i].logged = true;
             }
             return atlas_entries[i].rect;
+        }
+    }
+
+    {
+        static qboolean warned = false;
+        if (!warned)
+        {
+            Con_Printf("Atlas: WARNING: texture '%s' missing in atlas\n", normalized);
+            warned = true;
         }
     }
 


### PR DESCRIPTION
## Summary
- add atlas UV, original size, and offset data to call buffers and propagate through world and related shaders
- normalize brush vertex UVs for atlas sampling and upload atlas metadata for sampling in the fragment stage
- enhance atlas JSON handling with optional offsets, stronger name matching, and improved warnings/output

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692790bbe29c832eaa25b2317854f576)