### PR TITLE
Fix texture atlas usage for water surfaces

### DIFF
--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -335,19 +335,25 @@ static void R_FlushBModelCalls (void)
 R_AddBModelCall
 =============
 */
-static void R_AddBModelCall (int index, int first_instance, int num_instances, texture_t *t, qboolean zfix)
+static void R_AddBModelCall (qmodel_t *model, int usedtex_index, int first_instance, int num_instances, texture_t *t, qboolean zfix)
 {
 	GLuint		flags;
 	float		alpha;
 	gltexture_t	*tx, *fb, *em;
+	int		texnum;
 
 	atlas_rect_t	atlas_rect;
 	float		atlas_uv[4];
 	float		orig_size[2];
 	float		offset[2];
 
-        if (num_bmodel_calls == MAX_BMODEL_DRAWS)
-                R_FlushBModelCalls ();
+	int		draw_index;
+
+	if (num_bmodel_calls == MAX_BMODEL_DRAWS)
+		R_FlushBModelCalls ();
+
+	draw_index = model->firstcmd + usedtex_index;
+	texnum = model->usedtextures[usedtex_index];
 
         atlas_rect.u1 = 0.f;
         atlas_rect.v1 = 0.f;
@@ -363,33 +369,52 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
         offset[0] = 0.f;
         offset[1] = 0.f;
 
-        if (t)
+        if (model && model->surfaces)
         {
-                tx = t->gltexture;
-                fb = t->fullbright;
-                em = t->emissive;
-                atlas_rect = Atlas_GetUV(t->name);
-                if (atlas_rect.exists)
+                msurface_t *surf = model->surfaces + model->firstmodelsurface;
+                for (int i = 0; i < model->nummodelsurfaces; ++i, ++surf)
                 {
-                        const gltexture_t *atlas_tex = Atlas_GetGLTextureStruct();
-                        if (atlas_tex)
-                                tx = (gltexture_t *)atlas_tex;
-                        atlas_uv[0] = atlas_rect.u1;
-                        atlas_uv[1] = atlas_rect.v1;
-                        atlas_uv[2] = atlas_rect.u2 - atlas_rect.u1;
-                        atlas_uv[3] = atlas_rect.v2 - atlas_rect.v1;
+                        if (surf->texinfo && surf->texinfo->texnum == texnum)
+                        {
+                                offset[0] = surf->texinfo->vecs[0][3];
+                                offset[1] = surf->texinfo->vecs[1][3];
+                                break;
+                        }
                 }
-                if (t->gltexture && atlas_rect.exists)
-                {
-                        gltexture_t *glt = t->gltexture;
-                        orig_size[0] = glt->source_width ? (float)glt->source_width : (float)glt->width;
-                        orig_size[1] = glt->source_height ? (float)glt->source_height : (float)glt->height;
-                }
-                if (r_lightmap_cheatsafe)
-                        tx = fb = em = NULL;
-                if (!gl_fullbrights.value && t->type != TEXTYPE_SKY)
-                        fb = NULL;
         }
+
+	if (t)
+	{
+		tx = t->gltexture;
+		fb = t->fullbright;
+		em = t->emissive;
+		atlas_rect = Atlas_GetUV(t->name);
+		if (atlas_rect.exists)
+		{
+			const gltexture_t *atlas_tex = Atlas_GetGLTextureStruct();
+			if (atlas_tex)
+				tx = (gltexture_t *)atlas_tex;
+			atlas_uv[0] = atlas_rect.u1;
+			atlas_uv[1] = atlas_rect.v1;
+			atlas_uv[2] = atlas_rect.u2;
+			atlas_uv[3] = atlas_rect.v2;
+		}
+		if (t->gltexture)
+		{
+			gltexture_t *glt = t->gltexture;
+			orig_size[0] = glt->source_width ? (float)glt->source_width : (float)glt->width;
+			orig_size[1] = glt->source_height ? (float)glt->source_height : (float)glt->height;
+		}
+		else if (tx)
+		{
+			orig_size[0] = (float)tx->width;
+			orig_size[1] = (float)tx->height;
+		}
+		if (r_lightmap_cheatsafe)
+			tx = fb = em = NULL;
+		if (!gl_fullbrights.value && t->type != TEXTYPE_SKY)
+			fb = NULL;
+	}
 	else
 	{
 		tx = fb = whitetexture;
@@ -399,44 +424,44 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
 	if (!gl_zfix.value || map_checks.value)
 		zfix = 0;
 
-        flags = zfix | ((fb != NULL) << 1) | ((r_fullbright_cheatsafe != false) << 2);
-        if (em != NULL)
-                flags |= CALLFLAG_EMISSIVE;
-        if (t && t->type == TEXTYPE_CUTOUT)
-                flags |= CALLFLAG_ALPHA_TEST;
-        alpha = t ? GL_WaterAlphaForTextureType (t->type) : 1.f;
+	flags = zfix | ((fb != NULL) << 1) | ((r_fullbright_cheatsafe != false) << 2);
+	if (em != NULL)
+		flags |= CALLFLAG_EMISSIVE;
+	if (t && t->type == TEXTYPE_CUTOUT)
+		flags |= CALLFLAG_ALPHA_TEST;
+	alpha = t ? GL_WaterAlphaForTextureType (t->type) : 1.f;
 
-        if (gl_bindless_able)
-        {
-                bmodel_bindless_gpu_call_t *call = &bmodel_calls.bindless.params[num_bmodel_calls];
-                call->flags = flags;
-                call->alpha = alpha;
-                call->texture = tx ? tx->bindless_handle : greytexture->bindless_handle;
-                call->fullbright = fb ? fb->bindless_handle : blacktexture->bindless_handle;
-                call->emissive = em ? em->bindless_handle : blacktexture->bindless_handle;
-                memcpy(call->atlas_uv, atlas_uv, sizeof(atlas_uv));
-                memcpy(call->orig_size, orig_size, sizeof(orig_size));
-                memcpy(call->offset, offset, sizeof(offset));
-        }
-        else
-        {
-                bmodel_bound_gpu_call_t *call = &bmodel_calls.bound.params[num_bmodel_calls];
-                gltexture_t **textures = bmodel_calls.bound.textures[num_bmodel_calls];
-                call->flags = flags;
-                call->alpha = alpha;
-                call->baseinstance = first_instance;
-                call->padding = 0;
-                memcpy(call->atlas_uv, atlas_uv, sizeof(atlas_uv));
-                memcpy(call->orig_size, orig_size, sizeof(orig_size));
-                memcpy(call->offset, offset, sizeof(offset));
-                textures[0] = tx ? tx : greytexture;
-                textures[1] = fb ? fb : blacktexture;
-                textures[2] = em ? em : blacktexture;
-        }
+	if (gl_bindless_able)
+	{
+		bmodel_bindless_gpu_call_t *call = &bmodel_calls.bindless.params[num_bmodel_calls];
+		call->flags = flags;
+		call->alpha = alpha;
+		call->texture = tx ? tx->bindless_handle : greytexture->bindless_handle;
+		call->fullbright = fb ? fb->bindless_handle : blacktexture->bindless_handle;
+		call->emissive = em ? em->bindless_handle : blacktexture->bindless_handle;
+		memcpy(call->atlas_uv, atlas_uv, sizeof(atlas_uv));
+		memcpy(call->orig_size, orig_size, sizeof(orig_size));
+		memcpy(call->offset, offset, sizeof(offset));
+	}
+	else
+	{
+		bmodel_bound_gpu_call_t *call = &bmodel_calls.bound.params[num_bmodel_calls];
+		gltexture_t **textures = bmodel_calls.bound.textures[num_bmodel_calls];
+		call->flags = flags;
+		call->alpha = alpha;
+		call->baseinstance = first_instance;
+		call->padding = 0;
+		memcpy(call->atlas_uv, atlas_uv, sizeof(atlas_uv));
+		memcpy(call->orig_size, orig_size, sizeof(orig_size));
+		memcpy(call->offset, offset, sizeof(offset));
+		textures[0] = tx ? tx : greytexture;
+		textures[1] = fb ? fb : blacktexture;
+		textures[2] = em ? em : blacktexture;
+	}
 
 	SDL_assert (num_instances > 0);
 	SDL_assert (num_instances <= MAX_BMODEL_INSTANCES);
-	bmodel_call_remap[num_bmodel_calls].src = index;
+	bmodel_call_remap[num_bmodel_calls].src = draw_index;
 	bmodel_call_remap[num_bmodel_calls].inst = first_instance * MAX_BMODEL_INSTANCES + (num_instances - 1);
 
 	++num_bmodel_calls;
@@ -592,7 +617,7 @@ GL_Bind (GL_TEXTURE2, skybox->cubemap);
                 for (j = model->texofs[texbegin]; j < model->texofs[texend]; j++)
                 {
                         texture_t *t = model->textures[model->usedtextures[j]];
-                        R_AddBModelCall (model->firstcmd + j, baseinst, numinst, pass != BP_SHOWTRIS ? R_TextureAnimation (t, frame) : 0, zfix);
+                        R_AddBModelCall (model, j, baseinst, numinst, pass != BP_SHOWTRIS ? R_TextureAnimation (t, frame) : 0, zfix);
                 }
 
                 baseinst += numinst;
@@ -690,8 +715,8 @@ GL_Upload (GL_SHADER_STORAGE_BUFFER, bmodel_instances, sizeof(bmodel_instances[0
 			texture_t *t = model->textures[model->usedtextures[j]];
 			if ((GL_WaterAlphaForEntityTextureType (e, t->type) < 1.f) != translucent)
 				continue;
-			R_AddBModelCall (model->firstcmd + j, baseinst, numinst, R_TextureAnimation (t, frame), !isworld);
-		}
+                        R_AddBModelCall (model, j, baseinst, numinst, R_TextureAnimation (t, frame), !isworld);
+                }
 
 		baseinst += numinst;
 	}

--- a/Quake/shaders/water.frag
+++ b/Quake/shaders/water.frag
@@ -84,6 +84,9 @@ layout(location=3) in vec3 in_pos;
 #endif
 layout(location=6) noperspective in vec4 in_curr_clip;
 layout(location=7) noperspective in vec4 in_prev_clip;
+layout(location=8) flat in vec4 in_atlas_uv;
+layout(location=9) flat in vec2 in_orig_size;
+layout(location=10) flat in vec2 in_offset;
 
 #define OUT_COLOR out_fragcolor
 #if OIT
@@ -128,26 +131,31 @@ void main()
 {
         vec3 fullbright = vec3(0.0);
         vec3 emissive = vec3(0.0);
-        vec2 uv = in_uv * 2.0 + 0.125 * sin(in_uv.yx * (3.14159265 * 2.0) + Time);
+        vec2 uv = in_uv;
+        uv = uv * 2.0 + 0.125 * sin(uv.yx * (3.14159265 * 2.0) + Time);
+        uv += in_offset;
+        vec2 atlas_size = max(in_orig_size, vec2(1.0));
+        vec2 texnorm = uv / atlas_size;
+        vec2 atlas_uv = in_atlas_uv.xy + texnorm * in_atlas_uv.zw;
 #if BINDLESS
         sampler2D Tex = sampler2D(in_samplers0.xy);
         if ((in_flags & CF_USE_FULLBRIGHT) != 0u)
         {
                 sampler2D FullbrightTex = sampler2D(in_samplers0.zw);
-                fullbright = texture(FullbrightTex, uv).rgb;
+                fullbright = texture(FullbrightTex, atlas_uv).rgb;
         }
         if ((in_flags & CF_USE_EMISSIVE) != 0u)
         {
                 sampler2D EmissiveSampler = sampler2D(in_samplers1.xy);
-                emissive = texture(EmissiveSampler, uv).rgb;
+                emissive = texture(EmissiveSampler, atlas_uv).rgb;
         }
 #else
         if ((in_flags & CF_USE_FULLBRIGHT) != 0u)
-                fullbright = texture(FullbrightTex, uv).rgb;
+                fullbright = texture(FullbrightTex, atlas_uv).rgb;
         if ((in_flags & CF_USE_EMISSIVE) != 0u)
-                emissive = texture(EmissiveTex, uv).rgb;
+                emissive = texture(EmissiveTex, atlas_uv).rgb;
 #endif
-        vec4 result = texture(Tex, uv);
+        vec4 result = texture(Tex, atlas_uv);
         result.rgb += fullbright;
         result.rgb += emissive;
         result.rgb = clamp(result.rgb, 0.0, 1.0);

--- a/Quake/shaders/water.vert
+++ b/Quake/shaders/water.vert
@@ -96,6 +96,9 @@ layout(location=3) out vec3 out_pos;
 #endif
 layout(location=6) noperspective out vec4 out_curr_clip;
 layout(location=7) noperspective out vec4 out_prev_clip;
+layout(location=8) flat out vec4 out_atlas_uv;
+layout(location=9) flat out vec2 out_orig_size;
+layout(location=10) flat out vec2 out_offset;
 
 void main()
 {
@@ -121,4 +124,7 @@ void main()
                 out_samplers0.zw = out_samplers0.xy;
         out_samplers1.xy = call.emhandle;
 #endif
+        out_atlas_uv = call.atlas_uv;
+        out_orig_size = call.orig_size;
+        out_offset = call.offset;
 }

--- a/Quake/texture_atlas.c
+++ b/Quake/texture_atlas.c
@@ -47,6 +47,7 @@ static void Atlas_NormalizeTextureName(const char *name, char *out, size_t out_s
 {
     size_t len;
     const char *start;
+    const char *slash;
 
     if (!name)
     {
@@ -59,6 +60,15 @@ static void Atlas_NormalizeTextureName(const char *name, char *out, size_t out_s
         ;
 
     q_strlcpy(out, start, out_size);
+
+    // strip leading special characters like *water, +anim, -alternate
+    while (out[0] == '*' || out[0] == '+' || out[0] == '-')
+        memmove(out, out + 1, strlen(out));
+
+    // strip directory components so atlas entries match basename
+    slash = strrchr(out, '/');
+    if (slash)
+        memmove(out, slash + 1, strlen(slash + 1) + 1);
 
     // trim trailing whitespace
     len = strlen(out);
@@ -371,8 +381,8 @@ static qboolean Atlas_ParseJSON(const char *json, size_t len)
         Atlas_NormalizeTextureName(name, entry->name, sizeof(entry->name));
         entry->rect.u1 = (float)x / (float)atlas_width;
         entry->rect.v1 = (float)y / (float)atlas_height;
-        entry->rect.u2 = (float)(x + w) / (float)atlas_width;
-        entry->rect.v2 = (float)(y + h) / (float)atlas_height;
+        entry->rect.u2 = (float)w / (float)atlas_width;
+        entry->rect.v2 = (float)h / (float)atlas_height;
         entry->rect.exists = 1;
         entry->logged = false;
 
@@ -890,17 +900,6 @@ atlas_rect_t Atlas_GetUV(const char *name)
         return atlas_null_rect;
 
     Atlas_NormalizeTextureName(name, normalized, sizeof(normalized));
-    // remove leading special chars for better matching
-    if (normalized[0] == '*' || normalized[0] == '+' || normalized[0] == '-')
-        memmove(normalized, normalized + 1, strlen(normalized));
-
-    // strip directory components
-    {
-        char *slash = strrchr(normalized, '/');
-        if (slash)
-            memmove(normalized, slash + 1, strlen(slash + 1) + 1);
-    }
-
     if (!normalized[0])
         return atlas_null_rect;
 


### PR DESCRIPTION
## Summary
- normalize atlas texture names and store atlas rectangle sizes when parsing atlas metadata
- populate brush model calls with atlas UVs, original texture dimensions, and texture offsets and forward them to the water shaders
- update water shaders to apply atlas-aware UV normalization for base, fullbright, and emissive sampling

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69279bcca50c832ea77d91ac97426eb4)