### PR TITLE
Fix atlas UV normalization for world shaders

### DIFF
--- a/Quake/shaders/water.frag
+++ b/Quake/shaders/water.frag
@@ -131,11 +131,10 @@ void main()
 {
         vec3 fullbright = vec3(0.0);
         vec3 emissive = vec3(0.0);
-        vec2 uv = in_uv;
-        uv = uv * 2.0 + 0.125 * sin(uv.yx * (3.14159265 * 2.0) + Time);
-        uv += in_offset;
-        vec2 atlas_size = max(in_orig_size, vec2(1.0));
-        vec2 texnorm = uv / atlas_size;
+        vec2 world_uv = in_uv;
+        world_uv = world_uv * 2.0 + 0.125 * sin(world_uv.yx * (3.14159265 * 2.0) + Time);
+        world_uv += in_offset;
+        vec2 texnorm = world_uv / in_orig_size;
         vec2 atlas_uv = in_atlas_uv.xy + texnorm * in_atlas_uv.zw;
 #if BINDLESS
         sampler2D Tex = sampler2D(in_samplers0.xy);

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -269,14 +269,13 @@ void main()
 #endif
         vec3 fullbright = vec3(0.);
         vec3 emissive = vec3(0.);
-        vec2 uv = in_uv;
+        vec2 world_uv = in_uv;
 #if MODE == 2
-        uv = uv * 2.0 + 0.125 * sin(uv.yx * (3.14159265 * 2.0) + Time);
+        world_uv = world_uv * 2.0 + 0.125 * sin(world_uv.yx * (3.14159265 * 2.0) + Time);
 #endif
 
-        uv += in_offset;
-        vec2 atlas_size = max(in_orig_size, vec2(1.0));
-        vec2 texnorm = uv / atlas_size;
+        world_uv += in_offset;
+        vec2 texnorm = world_uv / in_orig_size;
         vec2 atlas_uv = in_atlas_uv.xy + texnorm * in_atlas_uv.zw;
 #if BINDLESS
         sampler2D Tex = sampler2D(in_samplers0.xy);


### PR DESCRIPTION
## Summary
- normalize atlas coordinates in world fragment shader using original size and offset
- normalize atlas coordinates in water fragment shader using original size and offset

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927a22f485c832e8ddab0eb2e9e0fe0)