### PR TITLE
Normalize world shader UV mapping

### DIFF
--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -269,13 +269,11 @@ void main()
 #endif
         vec3 fullbright = vec3(0.);
         vec3 emissive = vec3(0.);
-        vec2 world_uv = in_uv;
-#if MODE == 2
-        world_uv = world_uv * 2.0 + 0.125 * sin(world_uv.yx * (3.14159265 * 2.0) + Time);
-#endif
-
+        vec2 world_uv = in_uv.xy;
         world_uv += in_offset;
+
         vec2 texnorm = world_uv / in_orig_size;
+
         vec2 atlas_uv = in_atlas_uv.xy + texnorm * in_atlas_uv.zw;
 #if BINDLESS
         sampler2D Tex = sampler2D(in_samplers0.xy);


### PR DESCRIPTION
## Summary
- standardize world fragment shader UV calculation using orig_size and atlas_uv
- remove mode-specific UV warping to ensure consistent atlas sampling

## Testing
- not run (shader logic change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927a56c7e58832e992da13c4921f0ad)