### PR TITLE
Add DDS texture loader support

### DIFF
--- a/Quake/gl_texmgr.c
+++ b/Quake/gl_texmgr.c
@@ -104,7 +104,7 @@ static qboolean TexMgr_ReadImageHeader (const char *filename, unsigned int *widt
 {
         FILE *f;
         const char *ext;
-        unsigned char header[40];
+        unsigned char header[128];
         unsigned int w = 0, h = 0;
 
         if (!filename || !*filename)
@@ -138,9 +138,21 @@ static qboolean TexMgr_ReadImageHeader (const char *filename, unsigned int *widt
                         h = (unsigned int)(header[14] | (header[15] << 8));
                 }
         }
+        else if (!q_strcasecmp(ext, "dds"))
+        {
+                if (fread(header, 1, 128, f) == 128)
+                {
+                        static const unsigned char sig[4] = {'D', 'D', 'S', ' '};
+                        if (!memcmp(header, sig, sizeof(sig)))
+                        {
+                                w = (unsigned int)(header[16] | (header[17] << 8) | (header[18] << 16) | (header[19] << 24));
+                                h = (unsigned int)(header[12] | (header[13] << 8) | (header[14] << 16) | (header[15] << 24));
+                        }
+                }
+        }
         else if (!q_strcasecmp(ext, "wal"))
         {
-                if (fread(header, 1, sizeof(header), f) == sizeof(header))
+                if (fread(header, 1, 40, f) == 40)
                 {
                         w = (unsigned int)(header[32] | (header[33] << 8) | (header[34] << 16) | (header[35] << 24));
                         h = (unsigned int)(header[36] | (header[37] << 8) | (header[38] << 16) | (header[39] << 24));

--- a/Quake/image.c
+++ b/Quake/image.c
@@ -105,7 +105,7 @@ returns a pointer to hunk allocated RGBA data
 */
 byte *Image_LoadImage (const char *name, int *width, int *height, enum srcformat *fmt)
 {
-	static const char *const stbi_formats[] = {"png", "tga", "jpg", NULL};
+        static const char *const stbi_formats[] = {"dds", "png", "tga", "jpg", NULL};
 	FILE	*f;
 	int		i;
 
@@ -124,9 +124,9 @@ byte *Image_LoadImage (const char *name, int *width, int *height, enum srcformat
 				memcpy (hunkdata, data, numbytes);
 				free (data);
 				data = hunkdata;
-				*fmt = SRC_RGBA;
-				if ((developer.value || map_checks.value) && strcmp (ext, "tga") != 0)
-					Con_Warning ("%s not supported by QS, consider tga\n", loadfilename);
+                                *fmt = SRC_RGBA;
+                                if ((developer.value || map_checks.value) && strcmp (ext, "tga") != 0 && strcmp (ext, "dds") != 0)
+                                        Con_Warning ("%s not supported by QS, consider tga\n", loadfilename);
 			}
 			else
 				Con_Warning ("couldn't load %s (%s)\n", loadfilename, stbi_failure_reason ());


### PR DESCRIPTION
## Summary
- add DDS to the list of image formats loaded via stb_image and suppress false warnings
- read DDS headers when gathering texture dimensions to avoid full loads

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928609f0484832eac8e8526e0382c1b)