### PR TITLE
Add atlas container loader and in-memory DDS support

### DIFF
--- a/Quake/gl_texmgr.c
+++ b/Quake/gl_texmgr.c
@@ -2322,109 +2322,132 @@ static qboolean DDS_ParseFormat (uint32_t fourcc, uint32_t dxgi_format, GLenum *
                 return false;
         }
 
-        if (out_format)
-                *out_format = format;
-        if (block_size)
-                *block_size = block;
+	if (out_format)
+		*out_format = format;
+	if (block_size)
+		*block_size = block;
 
-        return block != 0;
+	return block != 0;
+}
+
+static GLuint GL_LoadDDS_Internal (const uint8_t *data, size_t size, int *w, int *h, int *has_mips)
+{
+	dds_header_t header;
+	dds_header_dxt10_t dx10;
+	uint32_t fourcc;
+	uint32_t width, height, mipmaps;
+	int block_size = 0;
+	GLenum format = GL_RGBA8;
+	GLuint texnum = 0;
+	size_t remaining = size;
+
+	if (!data || size < sizeof(header) + 4)
+		return 0;
+
+	if (memcmp (data, "DDS ", 4))
+		return 0;
+
+	data += 4;
+	remaining -= 4;
+
+	if (remaining < sizeof(header))
+		return 0;
+
+	memcpy (&header, data, sizeof(header));
+	data += sizeof(header);
+	remaining -= sizeof(header);
+
+	if (LittleLong (header.size) != sizeof(header) || LittleLong (header.ddspf.size) != sizeof(header.ddspf))
+		return 0;
+
+	width = LittleLong (header.width);
+	height = LittleLong (header.height);
+	mipmaps = LittleLong (header.mipMapCount);
+	fourcc = LittleLong (header.ddspf.fourCC);
+
+	if (!width || !height)
+		return 0;
+
+	memset (&dx10, 0, sizeof(dx10));
+	if (fourcc == DDS_FOURCC('D','X','1','0'))
+	{
+		if (remaining < sizeof(dx10))
+			return 0;
+
+		memcpy (&dx10, data, sizeof(dx10));
+		data += sizeof(dx10);
+		remaining -= sizeof(dx10);
+
+		dx10.dxgiFormat = LittleLong (dx10.dxgiFormat);
+		dx10.resourceDimension = LittleLong (dx10.resourceDimension);
+		dx10.arraySize = LittleLong (dx10.arraySize);
+
+		if (dx10.resourceDimension != 3 || dx10.arraySize != 1)
+			return 0;
+	}
+
+	if (!DDS_ParseFormat (fourcc, dx10.dxgiFormat, &format, &block_size))
+		return 0;
+
+	mipmaps = mipmaps ? mipmaps : 1;
+
+	glGenTextures (1, &texnum);
+	glBindTexture (GL_TEXTURE_2D, texnum);
+	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
+	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
+	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_BASE_LEVEL, 0);
+	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, mipmaps - 1);
+	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, mipmaps > 1 ? GL_LINEAR_MIPMAP_LINEAR : GL_LINEAR);
+
+	for (uint32_t level = 0, lw = width, lh = height; level < mipmaps; level++, lw = max (1u, lw >> 1), lh = max (1u, lh >> 1))
+	{
+		size_t level_size = ((lw + 3) / 4) * ((lh + 3) / 4) * (size_t)block_size;
+
+		if (level_size > remaining)
+			goto fail;
+
+		glCompressedTexImage2D (GL_TEXTURE_2D, level, format, lw, lh, 0, (GLsizei)level_size, data);
+		data += level_size;
+		remaining -= level_size;
+	}
+
+	if (w)
+		*w = width;
+	if (h)
+		*h = height;
+	if (has_mips)
+		*has_mips = (mipmaps > 1);
+
+	return texnum;
+
+fail:
+	if (texnum)
+		GL_DeleteTexturesFunc (1, &texnum);
+	return 0;
 }
 
 GLuint GL_LoadDDS (const char *path, int *w, int *h, int *has_mips)
 {
-        FILE *f;
-        char magic[4];
-        dds_header_t header;
-        dds_header_dxt10_t dx10;
-        uint32_t fourcc;
-        uint32_t width, height, mipmaps;
-        int block_size = 0;
-        GLenum format = GL_RGBA8;
-        GLuint texnum = 0;
+	byte *filebuf = NULL;
+	int len;
+	GLuint texnum;
 
-        if (!path || !*path)
-                return 0;
+	if (!path || !*path)
+		return 0;
 
-        if (COM_FOpenFile (path, &f, NULL) < 0 || !f)
-                return 0;
+	len = COM_LoadMallocFile (path, (void **)&filebuf);
+	if (len <= 0 || !filebuf)
+		return 0;
 
-        if (fread (magic, 1, sizeof(magic), f) != sizeof(magic) || memcmp (magic, "DDS ", sizeof(magic)))
-                goto fail;
+	texnum = GL_LoadDDS_Memory ((const uint8_t *)filebuf, (size_t)len, w, h, has_mips);
+	COM_FreeFile (filebuf);
+	return texnum;
+}
 
-        if (fread (&header, 1, sizeof(header), f) != sizeof(header))
-                goto fail;
-
-        if (LittleLong (header.size) != sizeof(header) || LittleLong (header.ddspf.size) != sizeof(header.ddspf))
-                goto fail;
-
-        width = LittleLong (header.width);
-        height = LittleLong (header.height);
-        mipmaps = LittleLong (header.mipMapCount);
-        fourcc = LittleLong (header.ddspf.fourCC);
-
-        if (!width || !height)
-                goto fail;
-
-        memset (&dx10, 0, sizeof(dx10));
-        if (fourcc == DDS_FOURCC('D','X','1','0'))
-        {
-                if (fread (&dx10, 1, sizeof(dx10), f) != sizeof(dx10))
-                        goto fail;
-
-                dx10.dxgiFormat = LittleLong (dx10.dxgiFormat);
-                dx10.resourceDimension = LittleLong (dx10.resourceDimension);
-                dx10.arraySize = LittleLong (dx10.arraySize);
-
-                if (dx10.resourceDimension != 3 || dx10.arraySize != 1)
-                        goto fail;
-        }
-
-        if (!DDS_ParseFormat (fourcc, dx10.dxgiFormat, &format, &block_size))
-                goto fail;
-
-        mipmaps = mipmaps ? mipmaps : 1;
-
-        glGenTextures (1, &texnum);
-        glBindTexture (GL_TEXTURE_2D, texnum);
-        glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
-        glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
-        glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_BASE_LEVEL, 0);
-        glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, mipmaps - 1);
-        glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-        glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, mipmaps > 1 ? GL_LINEAR_MIPMAP_LINEAR : GL_LINEAR);
-
-        for (uint32_t level = 0, lw = width, lh = height; level < mipmaps; level++, lw = max (1u, lw >> 1), lh = max (1u, lh >> 1))
-        {
-                size_t level_size = ((lw + 3) / 4) * ((lh + 3) / 4) * (size_t)block_size;
-                byte *data = (byte *)malloc (level_size);
-
-                if (!data)
-                        goto fail;
-                if (fread (data, 1, level_size, f) != level_size)
-                {
-                        free (data);
-                        goto fail;
-                }
-
-                glCompressedTexImage2D (GL_TEXTURE_2D, level, format, lw, lh, 0, (GLsizei)level_size, data);
-                free (data);
-        }
-
-        if (w)
-                *w = width;
-        if (h)
-                *h = height;
-        if (has_mips)
-                *has_mips = (mipmaps > 1);
-
-        fclose (f);
-        return texnum;
-
-fail:
-        if (texnum)
-                GL_DeleteTexturesFunc (1, &texnum);
-        fclose (f);
-        return 0;
+GLuint GL_LoadDDS_Memory (const uint8_t *data, size_t size, int *w, int *h, int *has_mips)
+{
+	return GL_LoadDDS_Internal (data, size, w, h, has_mips);
 }
 
 static int GL_CalcMipCount (int width, int height)

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -24,6 +24,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #ifndef GLQUAKE_H
 #define GLQUAKE_H
 
+#include <stddef.h>
+
 void GL_BeginRendering (int *x, int *y, int *width, int *height);
 void GL_EndRendering (void);
 void GL_Set2D (void);
@@ -651,6 +653,7 @@ void Sky_SetupFrame (void);
 qboolean Sky_IsAnimated (void);
 
 GLuint GL_LoadDDS (const char *path, int *w, int *h, int *has_mips);
+GLuint GL_LoadDDS_Memory (const uint8_t *data, size_t size, int *w, int *h, int *has_mips);
 GLuint GL_LoadTexture (const char *filename, int *w, int *h, int *has_mips);
 
 void GL_BindBuffer (GLenum target, GLuint buffer);

--- a/Quake/texture_atlas.c
+++ b/Quake/texture_atlas.c
@@ -1268,6 +1268,87 @@ fail:
     return false;
 }
 
+bool LoadAtlasContainer(const char *atlas_path, AtlasInfo *out)
+{
+    uint8_t *data = NULL;
+    uint8_t *dds_copy = NULL;
+    char *json_copy = NULL;
+    size_t size = 0;
+    uint32_t json_offset = 0;
+    uint32_t dds_offset = 0;
+    size_t json_size;
+    size_t dds_size;
+    GLuint texnum = 0;
+    int width = 0;
+    int height = 0;
+    int has_mips = 0;
+    bool ok = false;
+
+    if (!atlas_path || !out)
+        return false;
+
+    memset(out, 0, sizeof(*out));
+
+    if (!Atlas_ReadFile(atlas_path, &data, &size))
+        return false;
+
+    if (size < 16)
+        goto fail;
+
+    if (memcmp(data, "ATLAS01", 7) != 0 || data[7] != 1)
+        goto fail;
+
+    memcpy(&json_offset, data + 8, sizeof(json_offset));
+    memcpy(&dds_offset, data + 12, sizeof(dds_offset));
+
+    json_offset = LittleLong(json_offset);
+    dds_offset = LittleLong(dds_offset);
+
+    if (json_offset < 16 || json_offset > size || dds_offset > size || json_offset > dds_offset)
+        goto fail;
+
+    json_size = (size_t)(dds_offset - json_offset);
+    dds_size = size - dds_offset;
+
+    json_copy = (char *)malloc(json_size + 1);
+    if (!json_copy)
+        goto fail;
+
+    if (json_size)
+        memcpy(json_copy, data + json_offset, json_size);
+    json_copy[json_size] = '\0';
+
+    dds_copy = (uint8_t *)malloc(dds_size ? dds_size : 1);
+    if (!dds_copy)
+        goto fail;
+
+    if (dds_size)
+        memcpy(dds_copy, data + dds_offset, dds_size);
+
+    texnum = GL_LoadDDS_Memory(dds_copy, dds_size, &width, &height, &has_mips);
+
+    if (!texnum)
+        goto fail;
+
+    out->json_blob = json_copy;
+    out->json_size = json_size;
+    out->texnum = texnum;
+    out->width = width;
+    out->height = height;
+    out->has_mips = has_mips;
+    ok = true;
+
+fail:
+    free(dds_copy);
+    free(data);
+    if (!ok)
+    {
+        free(json_copy);
+    }
+
+    return ok;
+}
+
 void Atlas_CreateFromFallbacks(qmodel_t *model)
 {
     atlas_build_entry_t *entries = NULL;

--- a/Quake/texture_atlas.h
+++ b/Quake/texture_atlas.h
@@ -2,6 +2,7 @@
 #define TEXTURE_ATLAS_H
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #include "quakedef.h"
@@ -13,6 +14,15 @@ typedef struct atlas_rect_s {
     float u1, v1, u2, v2;
     int exists; // 1 = im atlas
 } atlas_rect_t;
+
+typedef struct AtlasInfo_s {
+    char *json_blob;
+    size_t json_size;
+    GLuint texnum;
+    int width;
+    int height;
+    int has_mips;
+} AtlasInfo;
 
 struct qmodel_s;
 
@@ -29,5 +39,6 @@ const gltexture_t *Atlas_GetGLTextureStruct(void);
 
 bool SaveAtlasAsDDS(const char *output_path, const uint8_t *rgba_pixels, int width, int height, bool has_alpha);
 bool PackAtlasContainer(const char *atlas_path, const char *json_path, const char *dds_path);
+bool LoadAtlasContainer(const char *atlas_path, AtlasInfo *out);
 
 #endif // TEXTURE_ATLAS_H


### PR DESCRIPTION
## Summary
- add an in-memory DDS loader and reuse it for file-based uploads
- introduce an AtlasInfo struct and API to load packed .atlas containers
- expose new atlas container loader and DDS memory loader in public headers

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69286ac508f8832e990c2091accc107b)