### PR TITLE
Fix COM_LoadMallocFile cleanup in gl_texmgr

### DIFF
--- a/Quake/gl_texmgr.c
+++ b/Quake/gl_texmgr.c
@@ -2446,7 +2446,7 @@ GLuint GL_LoadDDS (const char *path, int *w, int *h, int *has_mips)
 	len = (size_t)com_filesize;
 
 	texnum = GL_LoadDDS_Memory ((const uint8_t *)filebuf, (size_t)len, w, h, has_mips);
-	COM_FreeFile (filebuf);
+        free (filebuf);
 	return texnum;
 }
 
@@ -2502,7 +2502,7 @@ GLuint GL_LoadTexture (const char *filename, int *w, int *h, int *has_mips)
 	len = (size_t)com_filesize;
 
 	pixels = stbi_load_from_memory (filebuf, (int)len, &width, &height, NULL, 4);
-	COM_FreeFile (filebuf);
+        free (filebuf);
 	if (!pixels)
 		return 0;
 


### PR DESCRIPTION
## Summary
- replace undefined COM_FreeFile usage with free when releasing COM_LoadMallocFile buffers
- prevent build failures from missing COM_FreeFile symbol

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cb43cd018832ead2c13db26aa3366)