### PR TITLE
Add COM_FreeFile helper for malloc-loaded files

### DIFF
--- a/Quake/common.c
+++ b/Quake/common.c
@@ -2099,6 +2099,12 @@ byte *COM_LoadMallocFile (const char *path, unsigned int *path_id)
 	return COM_LoadFile (path, LOADFILE_MALLOC, path_id);
 }
 
+void COM_FreeFile (void *buffer)
+{
+	if (buffer)
+		free (buffer);
+}
+
 byte *COM_LoadMallocFile_TextMode_OSPath (const char *path, long *len_out)
 {
 	FILE	*f;

--- a/Quake/common.h
+++ b/Quake/common.h
@@ -420,9 +420,10 @@ void COM_CloseFile (int h);
 // buffer. the buffer is allocated with a total size of com_filesize + 1. the
 // procedures differ by their buffer allocation method.
 byte *COM_LoadHunkFile (const char *path, unsigned int *path_id);
-	// allocates the buffer on the hunk.
+// allocates the buffer on the hunk.
 byte *COM_LoadMallocFile (const char *path, unsigned int *path_id);
-	// allocates the buffer on the system mem (malloc).
+// allocates the buffer on the system mem (malloc).
+void COM_FreeFile (void *buffer);
 
 // Opens the given path directly, ignoring search paths.
 // Returns NULL on failure, or else a '\0'-terminated malloc'ed buffer.


### PR DESCRIPTION
## Summary
- declare COM_FreeFile alongside COM_LoadMallocFile in the shared header
- implement COM_FreeFile to safely release malloc-backed file buffers

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cb4b8bd4c832ebb3d7082e316ffce)