### PR TITLE
Fix missing texture loader symbols on Windows

### DIFF
--- a/Quake/gl_texmgr.c
+++ b/Quake/gl_texmgr.c
@@ -2411,7 +2411,10 @@ static GLuint GL_LoadDDS_Internal (const uint8_t *data, size_t size, int *w, int
 		if (level_size > remaining)
 			goto fail;
 
-		glCompressedTexImage2D (GL_TEXTURE_2D, level, format, lw, lh, 0, (GLsizei)level_size, data);
+                if (!GL_CompressedTexImage2DFunc)
+                        goto fail;
+
+                GL_CompressedTexImage2DFunc (GL_TEXTURE_2D, level, format, lw, lh, 0, (GLsizei)level_size, data);
 		data += level_size;
 		remaining -= level_size;
 	}

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -201,6 +201,7 @@ extern	const char	*gl_version;
 	x(void,			TexStorage2D, (GLenum target, GLsizei levels, GLenum internalFormat, GLsizei width, GLsizei height))\
 	x(void,			TexStorage3D, (GLenum target, GLsizei levels, GLenum internalFormat, GLsizei width, GLsizei height, GLsizei depth))\
 	x(void,			TexStorage2DMultisample, (GLenum target, GLsizei samples, GLenum internalFormat, GLsizei width, GLsizei height, GLboolean fixedsamplelocations))\
+	x(void,			CompressedTexImage2D, (GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLint border, GLsizei imageSize, const GLvoid *data))\
 	x(void,			MinSampleShading, (GLfloat value))\
 	x(void,			TexImage3D, (GLenum target, GLint level, GLint internalFormat, GLsizei width, GLsizei height, GLsizei depth, GLint border, GLenum format, GLenum type, const GLvoid *pixels))\
 	x(void,			TexSubImage3D, (GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type, const GLvoid *pixels))\

--- a/Quake/image.c
+++ b/Quake/image.c
@@ -33,7 +33,6 @@ static byte *Image_LoadLMP (FILE *f, int *width, int *height);
 #endif
 
 #define STB_IMAGE_IMPLEMENTATION
-#define STB_IMAGE_STATIC
 #define STBI_NO_BMP
 #define STBI_NO_PSD
 #define STBI_NO_GIF


### PR DESCRIPTION
## Summary
- remove static linkage on stb_image implementation so shared loader symbols are exported
- load glCompressedTexImage2D through the existing GL function loader and guard usage

## Testing
- not run (not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cb555e978832eaaad10ff094870f9)