### PR TITLE
Fix brush atlas fallback reading base pixels

### DIFF
--- a/Quake/texture_atlas.c
+++ b/Quake/texture_atlas.c
@@ -1030,11 +1030,25 @@ static byte *Atlas_ReadTextureSource(const gltexture_t *glt, int *width, int *he
     }
     else if (glt->source_offset)
     {
+        const byte *src = (const byte *)glt->source_offset;
+
+        /*
+         * Brush textures keep their miptex header and mip levels together in
+         * memory.  The base pixel data starts at offsets[0], so copy from that
+         * location instead of the beginning of the struct to avoid treating
+         * the header as image data.
+         */
+        if (glt->source_format == SRC_INDEXED)
+        {
+            const miptex_t *mt = (const miptex_t *)glt->source_offset;
+            src += mt->offsets[0];
+        }
+
         if (expected_size > 0)
         {
             raw = (byte *)malloc(expected_size);
             if (raw)
-                memcpy(raw, (const void *)glt->source_offset, expected_size);
+                memcpy(raw, src, expected_size);
         }
     }
 


### PR DESCRIPTION
## Summary
- copy miptex pixel data from the correct offset when building atlas fallbacks so headers are not treated as texture data

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cbea80910832e87d369c85dcbf749)