### PR TITLE
Add null renderer backend

### DIFF
--- a/Quake/null_backend.c
+++ b/Quake/null_backend.c
@@ -1,0 +1,117 @@
+#include "renderer_backend.h"
+
+static qboolean Null_Init(void)
+{
+    return true;
+}
+
+static void Null_Shutdown(void)
+{
+}
+
+static void Null_BeginFrame(void)
+{
+}
+
+static void Null_EndFrame(void)
+{
+}
+
+static texture_handle_t Null_CreateTexture(int width, int height, const void *pixels)
+{
+    (void)width;
+    (void)height;
+    (void)pixels;
+
+    return 0;
+}
+
+static void Null_DestroyTexture(texture_handle_t handle)
+{
+    (void)handle;
+}
+
+static shader_handle_t Null_CreateShader(const char *vertex_source, const char *fragment_source)
+{
+    (void)vertex_source;
+    (void)fragment_source;
+
+    return 0;
+}
+
+static void Null_DestroyShader(shader_handle_t handle)
+{
+    (void)handle;
+}
+
+static mesh_handle_t Null_CreateMesh(const void *vertex_data, size_t vertex_count, const void *index_data, size_t index_count)
+{
+    (void)vertex_data;
+    (void)vertex_count;
+    (void)index_data;
+    (void)index_count;
+
+    return 0;
+}
+
+static void Null_DestroyMesh(mesh_handle_t handle)
+{
+    (void)handle;
+}
+
+static void Null_BeginPass(struct render_pass_s *pass)
+{
+    (void)pass;
+}
+
+static void Null_EndPass(struct render_pass_s *pass)
+{
+    (void)pass;
+}
+
+static void Null_SetMaterial(struct material_s *material)
+{
+    (void)material;
+}
+
+static void Null_SetViewport(int x, int y, int width, int height)
+{
+    (void)x;
+    (void)y;
+    (void)width;
+    (void)height;
+}
+
+static void Null_DrawSurface(mesh_handle_t mesh)
+{
+    (void)mesh;
+}
+
+static render_backend_t null_backend = {
+    Null_Init,
+    Null_Shutdown,
+    Null_BeginFrame,
+    Null_EndFrame,
+
+    Null_CreateTexture,
+    Null_DestroyTexture,
+
+    Null_CreateShader,
+    Null_DestroyShader,
+
+    Null_CreateMesh,
+    Null_DestroyMesh,
+
+    Null_BeginPass,
+    Null_EndPass,
+
+    Null_SetMaterial,
+    Null_SetViewport,
+
+    Null_DrawSurface,
+};
+
+render_backend_t *Null_GetBackend(void)
+{
+    return &null_backend;
+}

--- a/Quake/renderer_backend.h
+++ b/Quake/renderer_backend.h
@@ -10,6 +10,8 @@ typedef uint32_t mesh_handle_t;
 struct material_s;
 struct render_pass_s;
 
+typedef struct render_backend_s render_backend_t;
+
 struct render_backend_s {
     qboolean (*Init)(void);
     void (*Shutdown)(void);
@@ -35,5 +37,7 @@ struct render_backend_s {
 };
 
 extern struct render_backend_s *rb;
+
+render_backend_t *Null_GetBackend(void);
 
 #endif // RENDERER_BACKEND_H


### PR DESCRIPTION
## Summary
- add a null renderer backend that provides no-op implementations for the renderer interface
- expose a render_backend_t typedef and accessor for retrieving the null backend

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ccc5fc41c832ea65c11d8b51f8c35)