### PR TITLE
Add draw surface queue and backend updates

### DIFF
--- a/Quake/Makefile
+++ b/Quake/Makefile
@@ -229,9 +229,10 @@ GLOBJS = \
 	$(SYSOBJ_GL_VID) \
 	gl_draw.o \
 	image.o \
-	gl_texmgr.o \
-	gl_mesh.o \
-	r_sprite.o \
+        gl_texmgr.o \
+        gl_mesh.o \
+        draw_surface.o \
+        r_sprite.o \
 	r_alias.o \
 	r_brush.o \
 	gl_model.o

--- a/Quake/draw_surface.c
+++ b/Quake/draw_surface.c
@@ -1,0 +1,34 @@
+#include "draw_surface.h"
+
+#define MAX_DRAW_SURFACES 8192
+
+render_backend_t *rb;
+
+static draw_surf_t draw_surfaces[MAX_DRAW_SURFACES];
+static size_t draw_surface_count = 0;
+
+void R_SubmitDrawSurface(const draw_surf_t *surf)
+{
+    if (!surf)
+        return;
+
+    if (draw_surface_count == MAX_DRAW_SURFACES)
+        R_FlushDrawSurfaces();
+
+    draw_surfaces[draw_surface_count++] = *surf;
+}
+
+void R_FlushDrawSurfaces(void)
+{
+    if (!rb || !rb->DrawSurface)
+    {
+        draw_surface_count = 0;
+        return;
+    }
+
+    for (size_t i = 0; i < draw_surface_count; ++i)
+        rb->DrawSurface(&draw_surfaces[i]);
+
+    draw_surface_count = 0;
+}
+

--- a/Quake/draw_surface.h
+++ b/Quake/draw_surface.h
@@ -6,7 +6,7 @@
 typedef struct material_s material_t;
 typedef float matrix4x4_t[16];
 
-typedef struct {
+typedef struct draw_surf_s {
     material_t *material;
     mesh_handle_t mesh;
     matrix4x4_t model_matrix;
@@ -15,5 +15,6 @@ typedef struct {
 } draw_surf_t;
 
 void R_SubmitDrawSurface(const draw_surf_t *surf);
+void R_FlushDrawSurfaces(void);
 
 #endif // DRAW_SURFACE_H

--- a/Quake/gl_backend.c
+++ b/Quake/gl_backend.c
@@ -107,9 +107,9 @@ void RB_SetViewport(int x, int y, int width, int height)
     printf("set viewport placeholder\n");
 }
 
-void RB_DrawSurface(mesh_handle_t mesh)
+void RB_DrawSurface(const draw_surf_t *surface)
 {
-    (void)mesh;
+    (void)surface;
 
     printf("draw surface placeholder\n");
 }

--- a/Quake/null_backend.c
+++ b/Quake/null_backend.c
@@ -82,9 +82,9 @@ static void Null_SetViewport(int x, int y, int width, int height)
     (void)height;
 }
 
-static void Null_DrawSurface(mesh_handle_t mesh)
+static void Null_DrawSurface(const draw_surf_t *surface)
 {
-    (void)mesh;
+    (void)surface;
 }
 
 static render_backend_t null_backend = {

--- a/Quake/renderer_backend.h
+++ b/Quake/renderer_backend.h
@@ -7,6 +7,9 @@ typedef uint32_t texture_handle_t;
 typedef uint32_t shader_handle_t;
 typedef uint32_t mesh_handle_t;
 
+struct draw_surf_s;
+typedef struct draw_surf_s draw_surf_t;
+
 struct material_s;
 struct render_pass_s;
 
@@ -33,7 +36,7 @@ struct render_backend_s {
     void (*SetMaterial)(struct material_s *material);
     void (*SetViewport)(int x, int y, int width, int height);
 
-    void (*DrawSurface)(mesh_handle_t mesh);
+    void (*DrawSurface)(const draw_surf_t *surface);
 };
 
 extern struct render_backend_s *rb;


### PR DESCRIPTION
## Summary
- add a queue implementation for submitted draw surfaces with flush support
- update renderer backend draw callback to accept full draw surface data
- register the new draw surface module in the build

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ccf52be5c832e912090d8478721b5)