### PR TITLE
Implement texture descriptor and GL texture creation

### DIFF
--- a/Quake/gl_backend.c
+++ b/Quake/gl_backend.c
@@ -1,4 +1,8 @@
-#include <stdio.h>
+#if defined(SDL_FRAMEWORK) || defined(NO_SDL_CONFIG)
+#include <SDL2/SDL_opengl.h>
+#else
+#include "SDL_opengl.h"
+#endif
 
 #include "renderer_backend.h"
 
@@ -25,21 +29,22 @@ void RB_EndFrame(void)
     printf("end frame placeholder\n");
 }
 
-texture_handle_t RB_CreateTexture(int width, int height, const void *pixels)
+texture_handle_t RB_CreateTexture(const texture_desc_t *desc)
 {
-    (void)width;
-    (void)height;
-    (void)pixels;
+    GLuint texture = 0;
 
-    printf("create texture placeholder\n");
-    return 0;
+    glGenTextures(1, &texture);
+    glBindTexture(GL_TEXTURE_2D, texture);
+    glTexImage2D(GL_TEXTURE_2D, 0, desc->format, desc->width, desc->height, 0, desc->format, GL_UNSIGNED_BYTE, desc->pixels);
+
+    return (texture_handle_t)texture;
 }
 
 void RB_DestroyTexture(texture_handle_t handle)
 {
-    (void)handle;
+    GLuint texture = (GLuint)handle;
 
-    printf("destroy texture placeholder\n");
+    glDeleteTextures(1, &texture);
 }
 
 shader_handle_t RB_CreateShader(const char *vertex_source, const char *fragment_source)

--- a/Quake/null_backend.c
+++ b/Quake/null_backend.c
@@ -17,11 +17,9 @@ static void Null_EndFrame(void)
 {
 }
 
-static texture_handle_t Null_CreateTexture(int width, int height, const void *pixels)
+static texture_handle_t Null_CreateTexture(const texture_desc_t *desc)
 {
-    (void)width;
-    (void)height;
-    (void)pixels;
+    (void)desc;
 
     return 0;
 }

--- a/Quake/renderer_backend.h
+++ b/Quake/renderer_backend.h
@@ -7,6 +7,13 @@ typedef uint32_t texture_handle_t;
 typedef uint32_t shader_handle_t;
 typedef uint32_t mesh_handle_t;
 
+typedef struct texture_desc_s {
+    int width;
+    int height;
+    int format;
+    const void *pixels;
+} texture_desc_t;
+
 struct draw_surf_s;
 typedef struct draw_surf_s draw_surf_t;
 
@@ -21,7 +28,7 @@ struct render_backend_s {
     void (*BeginFrame)(void);
     void (*EndFrame)(void);
 
-    texture_handle_t (*CreateTexture)(int width, int height, const void *pixels);
+    texture_handle_t (*CreateTexture)(const texture_desc_t *desc);
     void (*DestroyTexture)(texture_handle_t handle);
 
     shader_handle_t (*CreateShader)(const char *vertex_source, const char *fragment_source);


### PR DESCRIPTION
## Summary
- add a texture descriptor structure to the renderer backend API
- implement OpenGL texture creation and destruction using glGenTextures, glTexImage2D, and glDeleteTextures
- update the null backend to the new texture creation signature

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cd10fc9a4832e973b64df77eb086e)