### PR TITLE
Implement render pass begin and end

### DIFF
--- a/Quake/gl_backend.c
+++ b/Quake/gl_backend.c
@@ -385,18 +385,16 @@ void RB_DestroyMesh(mesh_handle_t handle)
     mesh->used = false;
 }
 
-void RB_BeginPass(struct render_pass_s *pass)
+void RB_BeginPass(const pass_info_t *info)
 {
-    (void)pass;
+    glBindFramebuffer(GL_FRAMEBUFFER, (GLuint)info->target);
 
-    printf("begin pass placeholder\n");
+    glClearColor(info->clear_color[0], info->clear_color[1], info->clear_color[2], info->clear_color[3]);
+    glClear(info->clear_flags);
 }
 
-void RB_EndPass(struct render_pass_s *pass)
+void RB_EndPass(void)
 {
-    (void)pass;
-
-    printf("end pass placeholder\n");
 }
 
 void RB_SetMaterial(struct material_s *material)

--- a/Quake/null_backend.c
+++ b/Quake/null_backend.c
@@ -53,14 +53,13 @@ static void Null_DestroyMesh(mesh_handle_t handle)
     (void)handle;
 }
 
-static void Null_BeginPass(struct render_pass_s *pass)
+static void Null_BeginPass(const pass_info_t *info)
 {
-    (void)pass;
+    (void)info;
 }
 
-static void Null_EndPass(struct render_pass_s *pass)
+static void Null_EndPass(void)
 {
-    (void)pass;
 }
 
 static void Null_SetMaterial(struct material_s *material)

--- a/Quake/renderer_backend.h
+++ b/Quake/renderer_backend.h
@@ -3,9 +3,24 @@
 
 #include "q_stdinc.h"
 
+#if defined(SDL_FRAMEWORK) || defined(NO_SDL_CONFIG)
+#include <SDL2/SDL_opengl.h>
+#else
+#include "SDL_opengl.h"
+#endif
+
 typedef uint32_t texture_handle_t;
 typedef uint32_t shader_handle_t;
 typedef uint32_t mesh_handle_t;
+typedef uint32_t framebuffer_handle_t;
+
+typedef vec4_t vec4;
+
+typedef struct pass_info_s {
+    GLenum clear_flags;
+    vec4 clear_color;
+    framebuffer_handle_t target;
+} pass_info_t;
 
 typedef struct shader_uniform_def_s {
     const char *name;
@@ -46,8 +61,6 @@ struct draw_surf_s;
 typedef struct draw_surf_s draw_surf_t;
 
 struct material_s;
-struct render_pass_s;
-
 typedef struct render_backend_s render_backend_t;
 
 struct render_backend_s {
@@ -65,8 +78,8 @@ struct render_backend_s {
     mesh_handle_t (*CreateMesh)(const mesh_desc_t *desc);
     void (*DestroyMesh)(mesh_handle_t handle);
 
-    void (*BeginPass)(struct render_pass_s *pass);
-    void (*EndPass)(struct render_pass_s *pass);
+    void (*BeginPass)(const pass_info_t *info);
+    void (*EndPass)(void);
 
     void (*SetMaterial)(struct material_s *material);
     void (*SetViewport)(int x, int y, int width, int height);


### PR DESCRIPTION
## Summary
- add render pass info structure and framebuffer handle definitions to renderer backend API
- update backend interfaces to use pass information and adjust null backend stubs
- implement OpenGL render pass begin to bind framebuffers and clear with supplied color and flags

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cd4b23ee4832eaafe18f83576288f)