### PR TITLE
Route debug draw calls through draw surface submission

### DIFF
--- a/Quake/draw_surface.h
+++ b/Quake/draw_surface.h
@@ -3,11 +3,10 @@
 
 #include "renderer_backend.h"
 
-typedef struct material_s material_t;
 typedef float matrix4x4_t[16];
 
 typedef struct draw_surf_s {
-    material_t *material;
+    shader_handle_t shader;
     mesh_handle_t mesh;
     matrix4x4_t model_matrix;
     int first_index;

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -22,6 +22,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // r_main.c
 
 #include "quakedef.h"
+#include "draw_surface.h"
 
 #define NOISESCALE     (1.0f / 127.0f)
 
@@ -1816,45 +1817,132 @@ static uint16_t		debugidx[MAX_DEBUG_IDX];
 static int			numdebugverts = 0;
 static int			numdebugidx = 0;
 static qboolean		debugztest = false;
+static shader_handle_t	debug_shader = 0;
 
-/*
-================
-R_FlushDebugGeometry
-================
-*/
-static void R_FlushDebugGeometry (void)
+static const char *debug_vert_src =
+		"#version 330 core\n"
+		"layout(location = 0) in vec3 in_pos;\n"
+		"layout(location = 1) in vec3 in_color;\n"
+		"uniform mat4 u_model;\n"
+		"uniform mat4 u_viewproj;\n"
+		"out vec3 v_color;\n"
+		"void main() {\n"
+		"    v_color = in_color;\n"
+		"    gl_Position = u_viewproj * u_model * vec4(in_pos, 1.0);\n"
+		"}\n";
+
+static const char *debug_frag_src =
+"#version 330 core\n"
+"in vec3 v_color;\n"
+"out vec4 frag_color;\n"
+"void main() {\n"
+"    frag_color = vec4(v_color, 1.0);\n"
+"}\n";
+
+static void R_InitDebugShader (void)
 {
-	if (numdebugverts && numdebugidx)
-	{
-		GLuint	buf;
-		GLbyte* ofs;
-		unsigned int state;
+		shader_desc_t desc;
+		static const shader_uniform_def_t uniforms[] = {
+				{ "u_model", 0 },
+				{ "u_viewproj", 0 }
+		};
 
-		GL_UseProgram (glprogs.debug3d);
-		state = GLS_BLEND_ALPHA | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (2);
-		if (!debugztest)
-			state |= GLS_NO_ZTEST;
-		GL_SetState (state);
+		if (debug_shader || !rb || !rb->CreateShader)
+				return;
 
-		GL_Upload (GL_ARRAY_BUFFER, debugverts, sizeof (debugverts[0]) * numdebugverts, &buf, &ofs);
-		GL_BindBuffer (GL_ARRAY_BUFFER, buf);
-		GL_VertexAttribPointerFunc (0, 3, GL_FLOAT, GL_FALSE, sizeof (debugverts[0]), ofs + offsetof (debugvert_t, pos));
-		GL_VertexAttribPointerFunc (1, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof (debugverts[0]), ofs + offsetof (debugvert_t, color));
+		memset (&desc, 0, sizeof (desc));
+		desc.vertex_source = debug_vert_src;
+		desc.fragment_source = debug_frag_src;
+		desc.uniforms = uniforms;
+		desc.uniform_count = countof (uniforms);
 
-		GL_Upload (GL_ELEMENT_ARRAY_BUFFER, debugidx, sizeof (debugidx[0]) * numdebugidx, &buf, &ofs);
-		GL_BindBuffer (GL_ELEMENT_ARRAY_BUFFER, buf);
-		glDrawElements (GL_LINES, numdebugidx, GL_UNSIGNED_SHORT, ofs);
-	}
-
-	numdebugverts = 0;
-	numdebugidx = 0;
+		debug_shader = rb->CreateShader (&desc);
 }
 
-/*
-================
-R_SetDebugGeometryZTest
-================
-*/
+static mesh_handle_t R_CreateDebugMesh (void)
+{
+		float *positions;
+		float *colors;
+		int *indices;
+		mesh_handle_t mesh;
+		int i;
+
+		if (!rb || !rb->CreateMesh || numdebugverts <= 0 || numdebugidx <= 0)
+				return 0;
+
+		positions = (float *) malloc ((size_t)numdebugverts * 3 * sizeof (float));
+		colors = (float *) malloc ((size_t)numdebugverts * 3 * sizeof (float));
+		indices = (int *) malloc ((size_t)numdebugidx * sizeof (int));
+		if (!positions || !colors || !indices)
+		{
+				free (positions);
+				free (colors);
+				free (indices);
+				return 0;
+		}
+
+		for (i = 0; i < numdebugverts; ++i)
+		{
+				uint32_t color = debugverts[i].color;
+				positions[i * 3 + 0] = debugverts[i].pos[0];
+				positions[i * 3 + 1] = debugverts[i].pos[1];
+				positions[i * 3 + 2] = debugverts[i].pos[2];
+
+				colors[i * 3 + 0] = (float)(color & 0xff) / 255.f;
+				colors[i * 3 + 1] = (float)((color >> 8) & 0xff) / 255.f;
+				colors[i * 3 + 2] = (float)((color >> 16) & 0xff) / 255.f;
+		}
+
+		for (i = 0; i < numdebugidx; ++i)
+				indices[i] = (int)debugidx[i];
+
+		{
+				mesh_desc_t desc = { 0 };
+
+				desc.positions = positions;
+				desc.normals = colors;
+				desc.uvs = NULL;
+				desc.indices = indices;
+				desc.vertex_count = numdebugverts;
+				desc.index_count = numdebugidx;
+
+				mesh = rb->CreateMesh (&desc);
+		}
+
+		free (positions);
+		free (colors);
+		free (indices);
+
+		return mesh;
+}
+
+static void R_FlushDebugGeometry (void)
+{
+                if (numdebugverts && numdebugidx && rb)
+                {
+                                mesh_handle_t mesh;
+                                draw_surf_t ds = { 0 };
+
+                                R_InitDebugShader ();
+                                mesh = R_CreateDebugMesh ();
+                                if (mesh)
+                                {
+                                                ds.shader = debug_shader;
+                                                ds.mesh = mesh;
+                                                memcpy (ds.model_matrix, r_identity_mat4, sizeof (ds.model_matrix));
+                                                ds.first_index = 0;
+                                                ds.index_count = numdebugidx;
+                                                R_SubmitDrawSurface (&ds);
+                                                R_FlushDrawSurfaces ();
+                                                if (rb->DestroyMesh)
+                                                                rb->DestroyMesh (mesh);
+                                }
+                }
+
+                numdebugverts = 0;
+                numdebugidx = 0;
+}
+
 static void R_SetDebugGeometryZTest (qboolean ztest)
 {
 	if (debugztest == ztest)


### PR DESCRIPTION
## Summary
- update draw surface definition to carry shader handles alongside mesh/index data
- replace immediate debug geometry GL calls with backend draw-surface submission using generated shader and mesh data

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cd91ead28832e85de99ead6f7ade0)