### PR TITLE
Include quakedef header in draw_surface

### DIFF
--- a/Quake/draw_surface.c
+++ b/Quake/draw_surface.c
@@ -1,3 +1,5 @@
+#include "quakedef.h"
+
 #include "draw_surface.h"
 
 #define MAX_DRAW_SURFACES 8192


### PR DESCRIPTION
## Summary
- include `quakedef.h` in `draw_surface.c` so the file builds with the expected precompiled header

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cdc473ae0832e815eed07d515ac6d)