### PR TITLE
Add minimal OpenGL G-buffer implementation

### DIFF
--- a/Quake/gl_gbuffer.c
+++ b/Quake/gl_gbuffer.c
@@ -1,0 +1,96 @@
+/*
+Copyright (C) 2024
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+*/
+
+#include "quakedef.h"
+#include "gl_gbuffer.h"
+
+static GLuint gbuffer_fbo = 0;
+static GLuint gbuffer_albedo = 0;
+static GLuint gbuffer_normal_spec = 0;
+static GLuint gbuffer_depth = 0;
+
+static GLuint R_GBuffer_CreateTexture(int width, int height, GLenum internal_format, GLenum format, GLenum type)
+{
+    GLuint texture = 0;
+
+    glGenTextures(1, &texture);
+    glBindTexture(GL_TEXTURE_2D, texture);
+    glTexImage2D(GL_TEXTURE_2D, 0, internal_format, width, height, 0, format, type, NULL);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glBindTexture(GL_TEXTURE_2D, 0);
+
+    return texture;
+}
+
+void R_GBuffer_Shutdown(void)
+{
+    if (gbuffer_albedo)
+    {
+        glDeleteTextures(1, &gbuffer_albedo);
+        gbuffer_albedo = 0;
+    }
+
+    if (gbuffer_normal_spec)
+    {
+        glDeleteTextures(1, &gbuffer_normal_spec);
+        gbuffer_normal_spec = 0;
+    }
+
+    if (gbuffer_depth)
+    {
+        glDeleteTextures(1, &gbuffer_depth);
+        gbuffer_depth = 0;
+    }
+
+    if (gbuffer_fbo)
+    {
+        glDeleteFramebuffers(1, &gbuffer_fbo);
+        gbuffer_fbo = 0;
+    }
+}
+
+void R_GBuffer_Init(int width, int height)
+{
+    GLenum status;
+    GLenum draw_buffers[2] = { GL_COLOR_ATTACHMENT0, GL_COLOR_ATTACHMENT1 };
+
+    R_GBuffer_Shutdown();
+
+    gbuffer_albedo = R_GBuffer_CreateTexture(width, height, GL_RGB8, GL_RGB, GL_UNSIGNED_BYTE);
+    gbuffer_normal_spec = R_GBuffer_CreateTexture(width, height, GL_RGBA16F, GL_RGBA, GL_FLOAT);
+    gbuffer_depth = R_GBuffer_CreateTexture(width, height, GL_DEPTH_COMPONENT24, GL_DEPTH_COMPONENT, GL_UNSIGNED_INT);
+
+    glGenFramebuffers(1, &gbuffer_fbo);
+    glBindFramebuffer(GL_FRAMEBUFFER, gbuffer_fbo);
+
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, gbuffer_albedo, 0);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT1, GL_TEXTURE_2D, gbuffer_normal_spec, 0);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, gbuffer_depth, 0);
+
+    glDrawBuffers(2, draw_buffers);
+
+    status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+    if (status != GL_FRAMEBUFFER_COMPLETE)
+        Sys_Error("R_GBuffer_Init: framebuffer incomplete (0x%X)", status);
+
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+}

--- a/Quake/gl_gbuffer.h
+++ b/Quake/gl_gbuffer.h
@@ -1,0 +1,26 @@
+/*
+Copyright (C) 2024
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+*/
+
+#ifndef GL_GBUFFER_H
+#define GL_GBUFFER_H
+
+void R_GBuffer_Init(int width, int height);
+void R_GBuffer_Shutdown(void);
+
+#endif /* GL_GBUFFER_H */


### PR DESCRIPTION
## Summary
- add header/source for initializing and shutting down a minimal OpenGL G-buffer
- create albedo, normal/specular, and depth attachments with framebuffer completeness checks

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692da6289008832eba601143ebf896ca)