### PR TITLE
Add deferred lighting pass

### DIFF
--- a/Quake/Makefile
+++ b/Quake/Makefile
@@ -219,14 +219,16 @@ GLOBJS = \
 	gl_rlight.o \
 	gl_rmain.o \
 	gl_fog.o \
-	gl_rmisc.o \
-	r_part.o \
-	r_world.o \
-	gl_screen.o \
-	gl_shaders.o \
-	gl_sky.o \
-	gl_warp.o \
-	$(SYSOBJ_GL_VID) \
+gl_rmisc.o \
+r_part.o \
+r_world.o \
+gl_screen.o \
+gl_gbuffer.o \
+gl_deferred.o \
+gl_shaders.o \
+gl_sky.o \
+gl_warp.o \
+$(SYSOBJ_GL_VID) \
 	gl_draw.o \
 	image.o \
         gl_texmgr.o \

--- a/Quake/gl_deferred.c
+++ b/Quake/gl_deferred.c
@@ -1,0 +1,383 @@
+/*
+Copyright (C) 2024
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+*/
+
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "quakedef.h"
+#include "gl_deferred.h"
+#include "gl_gbuffer.h"
+
+#define DEFERRED_SPHERE_SECTORS 24
+#define DEFERRED_SPHERE_STACKS  16
+
+extern cvar_t r_dynamic;
+extern dlight_t cl_dlights[MAX_DLIGHTS];
+
+static GLuint deferred_program;
+static GLuint deferred_vao;
+static GLuint deferred_vbo;
+static GLuint deferred_ebo;
+static GLsizei deferred_index_count;
+
+static GLint loc_viewproj;
+static GLint loc_inv_viewproj;
+static GLint loc_light_pos;
+static GLint loc_light_color;
+static GLint loc_light_radius;
+static GLint loc_camera_pos;
+static GLint loc_screen_size;
+static GLint loc_spec_power;
+
+static void R_Deferred_LogShader(GLuint object, qboolean is_program)
+{
+    GLint status = 0;
+
+    if (is_program)
+        glGetProgramiv(object, GL_LINK_STATUS, &status);
+    else
+        glGetShaderiv(object, GL_COMPILE_STATUS, &status);
+
+    if (status)
+        return;
+
+    GLint log_length = 0;
+    if (is_program)
+        glGetProgramiv(object, GL_INFO_LOG_LENGTH, &log_length);
+    else
+        glGetShaderiv(object, GL_INFO_LOG_LENGTH, &log_length);
+
+    if (log_length > 1)
+    {
+        char *log = (char *)malloc((size_t)log_length);
+        if (log)
+        {
+            if (is_program)
+                glGetProgramInfoLog(object, log_length, NULL, log);
+            else
+                glGetShaderInfoLog(object, log_length, NULL, log);
+            Con_Printf("Deferred shader error: %s\n", log);
+            free(log);
+        }
+    }
+}
+
+static GLuint R_Deferred_Compile(GLenum type, const char *source)
+{
+    GLuint shader = glCreateShader(type);
+    glShaderSource(shader, 1, &source, NULL);
+    glCompileShader(shader);
+    R_Deferred_LogShader(shader, false);
+    return shader;
+}
+
+static qboolean R_Deferred_CreateProgram(void)
+{
+    const char *vs_source =
+        "#version 330 core\n"
+        "layout(location = 0) in vec3 aPosition;\n"
+        "uniform mat4 uViewProj;\n"
+        "uniform vec3 uLightPos;\n"
+        "uniform float uLightRadius;\n"
+        "void main() {\n"
+        "    vec3 world = aPosition * uLightRadius + uLightPos;\n"
+        "    gl_Position = uViewProj * vec4(world, 1.0);\n"
+        "}\n";
+
+    const char *fs_source =
+        "#version 330 core\n"
+        "uniform sampler2D uAlbedo;\n"
+        "uniform sampler2D uNormalSpec;\n"
+        "uniform sampler2D uDepth;\n"
+        "uniform mat4 uInvViewProj;\n"
+        "uniform vec3 uLightPos;\n"
+        "uniform vec3 uLightColor;\n"
+        "uniform float uLightRadius;\n"
+        "uniform vec3 uCameraPos;\n"
+        "uniform vec2 uScreenSize;\n"
+        "uniform float uSpecPower;\n"
+        "out vec4 FragColor;\n"
+        "vec3 DecodeNormal(vec3 n) { return normalize(n); }\n"
+        "void main() {\n"
+        "    vec2 uv = gl_FragCoord.xy / uScreenSize;\n"
+        "    float depth = texture(uDepth, uv).r;\n"
+        "    if (depth >= 1.0) discard;\n"
+        "    vec4 ndc = vec4(uv * 2.0 - 1.0, depth * 2.0 - 1.0, 1.0);\n"
+        "    vec4 world = uInvViewProj * ndc;\n"
+        "    world /= world.w;\n"
+        "    vec3 pos = world.xyz;\n"
+        "    vec4 normalSpec = texture(uNormalSpec, uv);\n"
+        "    vec3 normal = DecodeNormal(normalSpec.xyz);\n"
+        "    float specPow = normalSpec.w;\n"
+        "    if (specPow <= 0.0) specPow = uSpecPower;\n"
+        "    vec3 albedo = texture(uAlbedo, uv).rgb;\n"
+        "    vec3 L = uLightPos - pos;\n"
+        "    float dist = length(L);\n"
+        "    if (dist > uLightRadius) discard;\n"
+        "    vec3 Ldir = L / max(dist, 0.0001);\n"
+        "    float atten = max(1.0 - dist / uLightRadius, 0.0);\n"
+        "    float diffuse = max(dot(normal, Ldir), 0.0);\n"
+        "    vec3 V = normalize(uCameraPos - pos);\n"
+        "    vec3 R = reflect(-Ldir, normal);\n"
+        "    float specular = pow(max(dot(R, V), 0.0), specPow);\n"
+        "    vec3 lighting = (diffuse * albedo + specular) * uLightColor * atten;\n"
+        "    FragColor = vec4(lighting, 1.0);\n"
+        "}\n";
+
+    GLuint vs = R_Deferred_Compile(GL_VERTEX_SHADER, vs_source);
+    GLuint fs = R_Deferred_Compile(GL_FRAGMENT_SHADER, fs_source);
+
+    deferred_program = glCreateProgram();
+    glAttachShader(deferred_program, vs);
+    glAttachShader(deferred_program, fs);
+    glLinkProgram(deferred_program);
+    R_Deferred_LogShader(deferred_program, true);
+
+    glDeleteShader(vs);
+    glDeleteShader(fs);
+
+    if (!deferred_program)
+        return false;
+
+    glUseProgram(deferred_program);
+    glUniform1i(glGetUniformLocation(deferred_program, "uAlbedo"), 0);
+    glUniform1i(glGetUniformLocation(deferred_program, "uNormalSpec"), 1);
+    glUniform1i(glGetUniformLocation(deferred_program, "uDepth"), 2);
+
+    loc_viewproj = glGetUniformLocation(deferred_program, "uViewProj");
+    loc_inv_viewproj = glGetUniformLocation(deferred_program, "uInvViewProj");
+    loc_light_pos = glGetUniformLocation(deferred_program, "uLightPos");
+    loc_light_color = glGetUniformLocation(deferred_program, "uLightColor");
+    loc_light_radius = glGetUniformLocation(deferred_program, "uLightRadius");
+    loc_camera_pos = glGetUniformLocation(deferred_program, "uCameraPos");
+    loc_screen_size = glGetUniformLocation(deferred_program, "uScreenSize");
+    loc_spec_power = glGetUniformLocation(deferred_program, "uSpecPower");
+
+    return true;
+}
+
+static void R_Deferred_CreateSphere(void)
+{
+    const int sectors = DEFERRED_SPHERE_SECTORS;
+    const int stacks = DEFERRED_SPHERE_STACKS;
+    const int vertex_count = (sectors + 1) * (stacks + 1);
+    const int index_count = sectors * stacks * 6;
+    float *vertices = (float *)malloc((size_t)vertex_count * 3 * sizeof(float));
+    GLuint *indices = (GLuint *)malloc((size_t)index_count * sizeof(GLuint));
+
+    if (!vertices || !indices)
+    {
+        free(vertices);
+        free(indices);
+        return;
+    }
+
+    for (int i = 0; i <= stacks; ++i)
+    {
+        float v = (float)i / (float)stacks;
+        float phi = (float)M_PI * v;
+        float sin_phi = sinf(phi);
+        float cos_phi = cosf(phi);
+
+        for (int j = 0; j <= sectors; ++j)
+        {
+            float u = (float)j / (float)sectors;
+            float theta = 2.0f * (float)M_PI * u;
+            float sin_theta = sinf(theta);
+            float cos_theta = cosf(theta);
+
+            int index = (i * (sectors + 1) + j) * 3;
+            vertices[index + 0] = sin_phi * cos_theta;
+            vertices[index + 1] = cos_phi;
+            vertices[index + 2] = sin_phi * sin_theta;
+        }
+    }
+
+    GLuint *idx = indices;
+    for (int i = 0; i < stacks; ++i)
+    {
+        for (int j = 0; j < sectors; ++j)
+        {
+            int first = i * (sectors + 1) + j;
+            int second = first + sectors + 1;
+
+            *idx++ = (GLuint)first;
+            *idx++ = (GLuint)second;
+            *idx++ = (GLuint)(first + 1);
+
+            *idx++ = (GLuint)(first + 1);
+            *idx++ = (GLuint)second;
+            *idx++ = (GLuint)(second + 1);
+        }
+    }
+
+    deferred_index_count = (GLsizei)index_count;
+
+    glGenVertexArrays(1, &deferred_vao);
+    glBindVertexArray(deferred_vao);
+
+    glGenBuffers(1, &deferred_vbo);
+    glBindBuffer(GL_ARRAY_BUFFER, deferred_vbo);
+    glBufferData(GL_ARRAY_BUFFER, (size_t)vertex_count * 3 * sizeof(float), vertices, GL_STATIC_DRAW);
+
+    glGenBuffers(1, &deferred_ebo);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, deferred_ebo);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, (size_t)index_count * sizeof(GLuint), indices, GL_STATIC_DRAW);
+
+    glEnableVertexAttribArray(0);
+    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float), (void *)(uintptr_t)0);
+
+    glBindVertexArray(0);
+
+    free(vertices);
+    free(indices);
+}
+
+static qboolean R_Deferred_EnsureResources(void)
+{
+    if (!deferred_program)
+    {
+        if (!R_Deferred_CreateProgram())
+            return false;
+    }
+
+    if (!deferred_vao)
+        R_Deferred_CreateSphere();
+
+    return deferred_program != 0 && deferred_vao != 0;
+}
+
+static qboolean R_Deferred_Invert(const float m[16], float out[16])
+{
+    float inv[16];
+    float det;
+
+    inv[0] = m[5] * m[10] * m[15] - m[5] * m[11] * m[14] - m[9] * m[6] * m[15] +
+             m[9] * m[7] * m[14] + m[13] * m[6] * m[11] - m[13] * m[7] * m[10];
+    inv[4] = -m[4] * m[10] * m[15] + m[4] * m[11] * m[14] + m[8] * m[6] * m[15]
+             - m[8] * m[7] * m[14] - m[12] * m[6] * m[11] + m[12] * m[7] * m[10];
+    inv[8] = m[4] * m[9] * m[15] - m[4] * m[11] * m[13] - m[8] * m[5] * m[15]
+             + m[8] * m[7] * m[13] + m[12] * m[5] * m[11] - m[12] * m[7] * m[9];
+    inv[12] = -m[4] * m[9] * m[14] + m[4] * m[10] * m[13] + m[8] * m[5] * m[14]
+              - m[8] * m[6] * m[13] - m[12] * m[5] * m[10] + m[12] * m[6] * m[9];
+
+    inv[1] = -m[1] * m[10] * m[15] + m[1] * m[11] * m[14] + m[9] * m[2] * m[15]
+             - m[9] * m[3] * m[14] - m[13] * m[2] * m[11] + m[13] * m[3] * m[10];
+    inv[5] = m[0] * m[10] * m[15] - m[0] * m[11] * m[14] - m[8] * m[2] * m[15]
+             + m[8] * m[3] * m[14] + m[12] * m[2] * m[11] - m[12] * m[3] * m[10];
+    inv[9] = -m[0] * m[9] * m[15] + m[0] * m[11] * m[13] + m[8] * m[1] * m[15]
+             - m[8] * m[3] * m[13] - m[12] * m[1] * m[11] + m[12] * m[3] * m[9];
+    inv[13] = m[0] * m[9] * m[14] - m[0] * m[10] * m[13] - m[8] * m[1] * m[14]
+              + m[8] * m[2] * m[13] + m[12] * m[1] * m[10] - m[12] * m[2] * m[9];
+
+    inv[2] = m[1] * m[6] * m[15] - m[1] * m[7] * m[14] - m[5] * m[2] * m[15]
+             + m[5] * m[3] * m[14] + m[13] * m[2] * m[7] - m[13] * m[3] * m[6];
+    inv[6] = -m[0] * m[6] * m[15] + m[0] * m[7] * m[14] + m[4] * m[2] * m[15]
+             - m[4] * m[3] * m[14] - m[12] * m[2] * m[7] + m[12] * m[3] * m[6];
+    inv[10] = m[0] * m[5] * m[15] - m[0] * m[7] * m[13] - m[4] * m[1] * m[15]
+              + m[4] * m[3] * m[13] + m[12] * m[1] * m[7] - m[12] * m[3] * m[5];
+    inv[14] = -m[0] * m[5] * m[14] + m[0] * m[6] * m[13] + m[4] * m[1] * m[14]
+              - m[4] * m[2] * m[13] - m[12] * m[1] * m[6] + m[12] * m[2] * m[5];
+
+    inv[3] = -m[1] * m[6] * m[11] + m[1] * m[7] * m[10] + m[5] * m[2] * m[11]
+             - m[5] * m[3] * m[10] - m[9] * m[2] * m[7] + m[9] * m[3] * m[6];
+    inv[7] = m[0] * m[6] * m[11] - m[0] * m[7] * m[10] - m[4] * m[2] * m[11]
+             + m[4] * m[3] * m[10] + m[8] * m[2] * m[7] - m[8] * m[3] * m[6];
+    inv[11] = -m[0] * m[5] * m[11] + m[0] * m[7] * m[9] + m[4] * m[1] * m[11]
+              - m[4] * m[3] * m[9] - m[8] * m[1] * m[7] + m[8] * m[3] * m[5];
+    inv[15] = m[0] * m[5] * m[10] - m[0] * m[6] * m[9] - m[4] * m[1] * m[10]
+              + m[4] * m[2] * m[9] + m[8] * m[1] * m[6] - m[8] * m[2] * m[5];
+
+    det = m[0] * inv[0] + m[1] * inv[4] + m[2] * inv[8] + m[3] * inv[12];
+    if (det == 0.0f)
+        return false;
+
+    det = 1.0f / det;
+
+    for (int i = 0; i < 16; i++)
+        out[i] = inv[i] * det;
+
+    return true;
+}
+
+static void R_Deferred_SetMatrices(void)
+{
+    float inv_viewproj[16];
+    float viewproj[16];
+
+    memcpy(viewproj, r_matviewproj, sizeof(viewproj));
+
+    if (!R_Deferred_Invert(viewproj, inv_viewproj))
+        memcpy(inv_viewproj, r_identity_mat4, sizeof(inv_viewproj));
+
+    glUniformMatrix4fv(loc_viewproj, 1, GL_FALSE, viewproj);
+    glUniformMatrix4fv(loc_inv_viewproj, 1, GL_FALSE, inv_viewproj);
+}
+
+void R_Deferred_LightPass(void)
+{
+    if (!r_dynamic.value)
+        return;
+
+    if (!R_Deferred_EnsureResources())
+        return;
+
+    glUseProgram(deferred_program);
+    glBindVertexArray(deferred_vao);
+
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, R_GBuffer_GetAlbedoTexture());
+    glActiveTexture(GL_TEXTURE1);
+    glBindTexture(GL_TEXTURE_2D, R_GBuffer_GetNormalSpecTexture());
+    glActiveTexture(GL_TEXTURE2);
+    glBindTexture(GL_TEXTURE_2D, R_GBuffer_GetDepthTexture());
+
+    glUniform2f(loc_screen_size, (float)glwidth, (float)glheight);
+    glUniform3fv(loc_camera_pos, 1, r_origin);
+    glUniform1f(loc_spec_power, 32.0f);
+    R_Deferred_SetMatrices();
+
+    glEnable(GL_BLEND);
+    glBlendFunc(GL_ONE, GL_ONE);
+    glEnable(GL_CULL_FACE);
+    glCullFace(GL_FRONT);
+    glEnable(GL_DEPTH_TEST);
+    glDepthMask(GL_FALSE);
+    glDepthFunc(GL_LEQUAL);
+
+    for (int i = 0; i < MAX_DLIGHTS; ++i)
+    {
+        dlight_t *dl = &cl_dlights[i];
+
+        if (dl->die < cl.time || dl->radius <= 0.0f)
+            continue;
+
+        glUniform3fv(loc_light_pos, 1, dl->origin);
+        glUniform3fv(loc_light_color, 1, dl->color);
+        glUniform1f(loc_light_radius, dl->radius);
+        glDrawElements(GL_TRIANGLES, deferred_index_count, GL_UNSIGNED_INT, (void *)(uintptr_t)0);
+    }
+
+    glDepthMask(GL_TRUE);
+    glDisable(GL_CULL_FACE);
+    glDisable(GL_BLEND);
+    glUseProgram(0);
+    glBindVertexArray(0);
+}

--- a/Quake/gl_deferred.h
+++ b/Quake/gl_deferred.h
@@ -17,18 +17,9 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 */
 
-#ifndef GL_GBUFFER_H
-#define GL_GBUFFER_H
+#ifndef GL_DEFERRED_H
+#define GL_DEFERRED_H
 
-#include "glquake.h"
+void R_Deferred_LightPass(void);
 
-void R_GBuffer_Init(int width, int height);
-void R_GBuffer_Shutdown(void);
-void R_GBuffer_Begin(void);
-void R_GBuffer_End(void);
-
-GLuint R_GBuffer_GetAlbedoTexture(void);
-GLuint R_GBuffer_GetNormalSpecTexture(void);
-GLuint R_GBuffer_GetDepthTexture(void);
-
-#endif /* GL_GBUFFER_H */
+#endif /* GL_DEFERRED_H */

--- a/Quake/gl_gbuffer.c
+++ b/Quake/gl_gbuffer.c
@@ -116,3 +116,18 @@ void R_GBuffer_End(void)
 {
     glBindFramebuffer(GL_FRAMEBUFFER, forward_fbo);
 }
+
+GLuint R_GBuffer_GetAlbedoTexture(void)
+{
+    return gbuffer_albedo;
+}
+
+GLuint R_GBuffer_GetNormalSpecTexture(void)
+{
+    return gbuffer_normal_spec;
+}
+
+GLuint R_GBuffer_GetDepthTexture(void)
+{
+    return gbuffer_depth;
+}


### PR DESCRIPTION
## Summary
- add deferred lighting pass rendering dynamic lights as sphere volumes
- expose G-buffer textures for use by the deferred shader
- include new objects in the build configuration

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692de0215b4c832ea2b9a0dc06ed7e07)