### PR TITLE
Bind deferred composite textures to correct units

### DIFF
--- a/Quake/gl_deferred.c
+++ b/Quake/gl_deferred.c
@@ -473,8 +473,11 @@ void R_Deferred_Composite(void)
     glUseProgram(composite_program);
     glBindVertexArray(composite_vao);
 
+    const qboolean msaa = framebufs.scene.samples > 1;
+    GLuint forward_color = msaa ? framebufs.resolved_scene.color_tex : framebufs.scene.color_tex;
+
     glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_2D, R_GBuffer_GetAlbedoTexture());
+    glBindTexture(GL_TEXTURE_2D, forward_color);
     glActiveTexture(GL_TEXTURE1);
     glBindTexture(GL_TEXTURE_2D, framebufs.composite.color_tex);
 


### PR DESCRIPTION
## Summary
- bind the forward color and deferred light textures to texture units 0 and 1 in the composite pass

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692deb93e784832eb3558f0111a1ddc2)