### PR TITLE
Add missing deferred renderer files to VS project

### DIFF
--- a/Windows/VisualStudio/ironwail.vcxproj
+++ b/Windows/VisualStudio/ironwail.vcxproj
@@ -239,7 +239,9 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
     <ClCompile Include="..\..\Quake\cvar.c" />
     <ClCompile Include="..\..\Quake\draw_surface.c" />
     <ClCompile Include="..\..\Quake\gl_draw.c" />
+    <ClCompile Include="..\..\Quake\gl_gbuffer.c" />
     <ClCompile Include="..\..\Quake\gl_fog.c" />
+    <ClCompile Include="..\..\Quake\gl_deferred.c" />
     <ClCompile Include="..\..\Quake\gl_mesh.c" />
     <ClCompile Include="..\..\Quake\gl_model.c" />
     <ClCompile Include="..\..\Quake\gl_refrag.c" />
@@ -366,6 +368,8 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
     <ClInclude Include="..\..\Quake\cvar.h" />
     <ClInclude Include="..\..\Quake\draw.h" />
     <ClInclude Include="..\..\Quake\draw_surface.h" />
+    <ClInclude Include="..\..\Quake\gl_deferred.h" />
+    <ClInclude Include="..\..\Quake\gl_gbuffer.h" />
     <ClInclude Include="..\..\Quake\glquake.h" />
     <ClInclude Include="..\..\Quake\gl_model.h" />
     <ClInclude Include="..\..\Quake\gl_shaders.h" />

--- a/Windows/VisualStudio/ironwail.vcxproj.filters
+++ b/Windows/VisualStudio/ironwail.vcxproj.filters
@@ -60,7 +60,13 @@
     <ClCompile Include="..\..\Quake\gl_draw.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Quake\gl_gbuffer.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\Quake\gl_fog.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Quake\gl_deferred.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\Quake\gl_mesh.c">
@@ -321,6 +327,12 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Quake\draw_surface.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Quake\gl_deferred.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Quake\gl_gbuffer.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Quake\gl_model.h">


### PR DESCRIPTION
## Summary
- include gl_gbuffer and gl_deferred source files in the Visual Studio project
- add associated headers to the project so deferred rendering symbols are linked

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ded4a58cc832e8e745b2db40ee03c)