### PR TITLE
Fix OpenGL prototypes for deferred renderer

### DIFF
--- a/Quake/gl_deferred.c
+++ b/Quake/gl_deferred.c
@@ -17,6 +17,12 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 */
 
+#if defined(SDL_FRAMEWORK) || defined(NO_SDL_CONFIG)
+#include <SDL2/SDL_opengl.h>
+#else
+#include "SDL_opengl.h"
+#endif
+
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>

--- a/Quake/gl_gbuffer.c
+++ b/Quake/gl_gbuffer.c
@@ -17,6 +17,12 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 */
 
+#if defined(SDL_FRAMEWORK) || defined(NO_SDL_CONFIG)
+#include <SDL2/SDL_opengl.h>
+#else
+#include "SDL_opengl.h"
+#endif
+
 #include "quakedef.h"
 #include "gl_gbuffer.h"
 

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -68,7 +68,7 @@ typedef struct framesetup_s
 
 static framesetup_t framesetup;
 
-static const float r_identity_mat4[16] = {
+const float r_identity_mat4[16] = {
 		1.f, 0.f, 0.f, 0.f,
 		0.f, 1.f, 0.f, 0.f,
 		0.f, 0.f, 1.f, 0.f,

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -398,6 +398,7 @@ void Fog_Init (void);
 extern float r_matview[16];
 extern float r_matproj[16];
 extern float r_matviewproj[16];
+extern const float r_identity_mat4[16];
 
 void R_NewGame (void);
 


### PR DESCRIPTION
## Summary
- include the SDL OpenGL headers in deferred rendering sources to provide GL3 prototypes
- export the identity matrix constant so deferred rendering can use it without warnings

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dee32ac80832e997fe67e89853cb8)