### PR TITLE
Use tolerance when inverting deferred matrices

### DIFF
--- a/Quake/gl_deferred.c
+++ b/Quake/gl_deferred.c
@@ -316,10 +316,10 @@ static qboolean R_Deferred_Invert(const float m[16], float out[16])
               + m[4] * m[2] * m[9] + m[8] * m[1] * m[6] - m[8] * m[2] * m[5];
 
     det = m[0] * inv[0] + m[1] * inv[4] + m[2] * inv[8] + m[3] * inv[12];
-    if (det == 0.0f)
+    if (fabsf(det) < 1e-8f)
         return false;
 
-    det = 1.0f / det;
+    det = 1.f / det;
 
     for (int i = 0; i < 16; i++)
         out[i] = inv[i] * det;


### PR DESCRIPTION
## Summary
- use a tolerance-based determinant check in `R_Deferred_Invert` to catch nearly singular matrices
- keep the identity fallback in deferred matrix setup when inversion fails

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692df09bd6e4832ea538fa1ac4075b6f)