### PR TITLE
Fix Visual Studio OpenGL warnings in deferred renderer

### DIFF
--- a/Quake/gl_deferred.c
+++ b/Quake/gl_deferred.c
@@ -17,18 +17,12 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 */
 
-#define GL_GLEXT_PROTOTYPES 1
-#if defined(SDL_FRAMEWORK) || defined(NO_SDL_CONFIG)
-#include <SDL2/SDL_opengl.h>
-#else
-#include "SDL_opengl.h"
-#endif
+#include "quakedef.h"
 
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>
 
-#include "quakedef.h"
 #include "gl_deferred.h"
 #include "gl_gbuffer.h"
 

--- a/Quake/gl_gbuffer.c
+++ b/Quake/gl_gbuffer.c
@@ -17,13 +17,6 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 */
 
-#define GL_GLEXT_PROTOTYPES 1
-#if defined(SDL_FRAMEWORK) || defined(NO_SDL_CONFIG)
-#include <SDL2/SDL_opengl.h>
-#else
-#include "SDL_opengl.h"
-#endif
-
 #include "quakedef.h"
 #include "gl_gbuffer.h"
 
@@ -71,7 +64,7 @@ void R_GBuffer_Shutdown(void)
 
     if (gbuffer_fbo)
     {
-        glDeleteFramebuffers(1, &gbuffer_fbo);
+        GL_DeleteFramebuffersFunc(1, &gbuffer_fbo);
         gbuffer_fbo = 0;
     }
 }


### PR DESCRIPTION
## Summary
- include the precompiled header before OpenGL usage in deferred rendering sources to avoid GL_GLEXT macro warnings on MSVC
- swap direct framebuffer deletion for the loaded GL function pointer to avoid missing prototype errors

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692df2d37ae8832ea9d3975ae9c189d4)