### PR TITLE
Fix deferred composite shader memory free

### DIFF
--- a/Quake/gl_deferred.c
+++ b/Quake/gl_deferred.c
@@ -440,7 +440,7 @@ static qboolean R_Deferred_CreateCompositeProgram(void)
     GLuint vs = R_Deferred_Compile(GL_VERTEX_SHADER, vs_source);
     if (!vs)
     {
-        Z_Free(fs_source);
+        free(fs_source);
         return false;
     }
 
@@ -448,7 +448,7 @@ static qboolean R_Deferred_CreateCompositeProgram(void)
     if (!fs)
     {
         GL_DeleteShaderFunc(vs);
-        Z_Free(fs_source);
+        free(fs_source);
         return false;
     }
 
@@ -457,7 +457,7 @@ static qboolean R_Deferred_CreateCompositeProgram(void)
     {
         GL_DeleteShaderFunc(vs);
         GL_DeleteShaderFunc(fs);
-        Z_Free(fs_source);
+        free(fs_source);
         return false;
     }
     GL_AttachShaderFunc(composite_program, vs);
@@ -473,13 +473,13 @@ static qboolean R_Deferred_CreateCompositeProgram(void)
         composite_program = 0;
         GL_DeleteShaderFunc(vs);
         GL_DeleteShaderFunc(fs);
-        Z_Free(fs_source);
+        free(fs_source);
         return false;
     }
 
     GL_DeleteShaderFunc(vs);
     GL_DeleteShaderFunc(fs);
-    Z_Free(fs_source);
+    free(fs_source);
 
     GL_UseProgramFunc(composite_program);
     GL_Uniform1iFunc(GL_GetUniformLocationFunc(composite_program, "u_ForwardColor"), 0);


### PR DESCRIPTION
## Summary
- free the deferred composite shader source with `free` to match `COM_LoadMallocFile`
- prevent invalid `Z_Free` calls when compiling the composite shader program

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692df8b15370832ead49088ce062e5f8)