### PR TITLE
Use zone allocator for COM_LoadMallocFile buffers

### DIFF
--- a/Quake/common.c
+++ b/Quake/common.c
@@ -2068,9 +2068,9 @@ byte *COM_LoadFile (const char *path, int usehunk, unsigned int *path_id)
 	case LOADFILE_HUNK:
 		buf = (byte *) Hunk_AllocNameNoFill (len+1, base);
 		break;
-	case LOADFILE_MALLOC:
-		buf = (byte *) malloc (len+1);
-		break;
+        case LOADFILE_MALLOC:
+                buf = (byte *) Z_Malloc (len+1);
+                break;
 	default:
 		Sys_Error ("COM_LoadFile: bad usehunk");
 	}

--- a/Quake/common.h
+++ b/Quake/common.h
@@ -420,9 +420,9 @@ void COM_CloseFile (int h);
 // buffer. the buffer is allocated with a total size of com_filesize + 1. the
 // procedures differ by their buffer allocation method.
 byte *COM_LoadHunkFile (const char *path, unsigned int *path_id);
-	// allocates the buffer on the hunk.
+        // allocates the buffer on the hunk.
 byte *COM_LoadMallocFile (const char *path, unsigned int *path_id);
-	// allocates the buffer on the system mem (malloc).
+        // allocates the buffer using Z_Malloc; free with Z_Free.
 
 // Opens the given path directly, ignoring search paths.
 // Returns NULL on failure, or else a '\0'-terminated malloc'ed buffer.

--- a/Quake/gl_deferred.c
+++ b/Quake/gl_deferred.c
@@ -440,7 +440,7 @@ static qboolean R_Deferred_CreateCompositeProgram(void)
     GLuint vs = R_Deferred_Compile(GL_VERTEX_SHADER, vs_source);
     if (!vs)
     {
-        free(fs_source);
+        Z_Free(fs_source);
         return false;
     }
 
@@ -448,7 +448,7 @@ static qboolean R_Deferred_CreateCompositeProgram(void)
     if (!fs)
     {
         GL_DeleteShaderFunc(vs);
-        free(fs_source);
+        Z_Free(fs_source);
         return false;
     }
 
@@ -457,7 +457,7 @@ static qboolean R_Deferred_CreateCompositeProgram(void)
     {
         GL_DeleteShaderFunc(vs);
         GL_DeleteShaderFunc(fs);
-        free(fs_source);
+        Z_Free(fs_source);
         return false;
     }
     GL_AttachShaderFunc(composite_program, vs);
@@ -473,13 +473,13 @@ static qboolean R_Deferred_CreateCompositeProgram(void)
         composite_program = 0;
         GL_DeleteShaderFunc(vs);
         GL_DeleteShaderFunc(fs);
-        free(fs_source);
+        Z_Free(fs_source);
         return false;
     }
 
     GL_DeleteShaderFunc(vs);
     GL_DeleteShaderFunc(fs);
-    free(fs_source);
+    Z_Free(fs_source);
 
     GL_UseProgramFunc(composite_program);
     GL_Uniform1iFunc(GL_GetUniformLocationFunc(composite_program, "u_ForwardColor"), 0);

--- a/Quake/gl_draw.c
+++ b/Quake/gl_draw.c
@@ -404,8 +404,8 @@ qpic_t	*Draw_TryCachePic (const char *path, unsigned int texflags)
 		gl.th = (float)dat->height/(float)TexMgr_PadConditional(dat->height); //johnfitz
 	}
 
-	free (dat);
-	memcpy (pic->pic.data, &gl, sizeof(glpic_t));
+        Z_Free (dat);
+        memcpy (pic->pic.data, &gl, sizeof(glpic_t));
 
 	return &pic->pic;
 }

--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -433,7 +433,7 @@ static qmodel_t *Mod_LoadModel (qmodel_t *mod, qboolean crash)
 		break;
 	}
 
-	free (buf);
+        Z_Free (buf);
 
 	return mod;
 }
@@ -4076,10 +4076,10 @@ static void Mod_LoadAliasModel (qmodel_t *mod, void *buffer)
 			if (md5buffer)
 			{
 				Mod_LoadMD5MeshModel (mod, md5buffer);
-				free (md5buffer);
-				return;
-			}
-		}
+                                Z_Free (md5buffer);
+                                return;
+                        }
+                }
 	}
 
 //
@@ -4789,7 +4789,7 @@ static void MD5Anim_Load(md5animctx_t *ctx, boneinfo_t *bones, size_t numbones)
 
 	if (!buffer)
 	{
-		free(ctx->animfile);
+                Z_Free(ctx->animfile);
 		return;
 	}
 
@@ -4906,7 +4906,7 @@ static void MD5Anim_Load(md5animctx_t *ctx, boneinfo_t *bones, size_t numbones)
 	Z_Free(raw);
 	Z_Free(ab);
 	free(frameposes);
-	free(ctx->animfile);
+        Z_Free(ctx->animfile);
 }
 static void Mod_LoadMD5MeshModel (qmodel_t *mod, const char *buffer)
 {

--- a/Quake/gl_shaders.c
+++ b/Quake/gl_shaders.c
@@ -256,7 +256,7 @@ static char *GL_LoadShaderFile_Internal (const char *path, int depth)
                         if (!_newbuf)                                                  \
                         {                                                              \
                                 free (result);                                         \
-                                free (source);                                         \
+                                Z_Free (source);                                       \
                                 Sys_Error ("GL_LoadShaderFile: realloc failed for %s", path); \
                         }                                                              \
                         result = _newbuf;                                              \
@@ -308,7 +308,7 @@ static char *GL_LoadShaderFile_Internal (const char *path, int depth)
                                         if (include_len >= sizeof (include_path))
                                         {
                                                 free (result);
-                                                free (source);
+                                                Z_Free (source);
                                                 Sys_Error ("GL_LoadShaderFile: include path too long in %s", path);
                                         }
 
@@ -330,7 +330,7 @@ static char *GL_LoadShaderFile_Internal (const char *path, int depth)
                                         if (q_strlcat (full_path, include_path, sizeof (full_path)) >= sizeof (full_path))
                                         {
                                                 free (result);
-                                                free (source);
+                                                Z_Free (source);
                                                 Sys_Error ("GL_LoadShaderFile: include path overflow in %s", path);
                                         }
 
@@ -354,7 +354,7 @@ static char *GL_LoadShaderFile_Internal (const char *path, int depth)
 
 #undef APPEND_STR
 
-        free (source);
+        Z_Free (source);
 
         shader_cache[shader_cache_count].data = result;
         q_strlcpy (shader_cache[shader_cache_count].path, path, sizeof (shader_cache[shader_cache_count].path));

--- a/Quake/gl_sky.c
+++ b/Quake/gl_sky.c
@@ -247,7 +247,7 @@ static void Skywind_Load_f (void)
 		skybox->wind_pitch = fmod (atof (com_token) + 90.0, 180.0) - 90.0;
 
 done:
-	free (buf);
+        Z_Free (buf);
 }
 
 /*

--- a/Quake/host_cmd.c
+++ b/Quake/host_cmd.c
@@ -1138,8 +1138,8 @@ static void Modlist_Add (const char *name)
 		if (mapdb)
 		{
 			qboolean is_base_mapdb = !com_searchpaths || path_id < com_searchpaths->path_id;
-			json_t *json = JSON_Parse (mapdb);
-			free (mapdb);
+                        json_t *json = JSON_Parse (mapdb);
+                        Z_Free (mapdb);
 			if (json)
 			{
 				const jsonentry_t *episodes = JSON_Find (json->root, "episodes", JSON_ARRAY);

--- a/Quake/q3shader.c
+++ b/Quake/q3shader.c
@@ -181,7 +181,7 @@ int Q3Shader_LoadFile (const char *path)
                 count++;
         }
 
-        free (buffer);
+        Z_Free (buffer);
         return count;
 }
 

--- a/Quake/snd_mem.c
+++ b/Quake/snd_mem.c
@@ -123,31 +123,31 @@ sfxcache_t *S_LoadSound (sfx_t *s)
 	}
 
 	info = GetWavinfo (s->name, data, com_filesize);
-	if (info.channels != 1)
-	{
-		free (data);
-		Con_Printf ("%s is a stereo sample\n",s->name);
-		return NULL;
-	}
+        if (info.channels != 1)
+        {
+                Z_Free (data);
+                Con_Printf ("%s is a stereo sample\n",s->name);
+                return NULL;
+        }
 
-	if (info.width != 1 && info.width != 2)
-	{
-		free (data);
-		Con_Printf("%s is not 8 or 16 bit\n", s->name);
-		return NULL;
-	}
+        if (info.width != 1 && info.width != 2)
+        {
+                Z_Free (data);
+                Con_Printf("%s is not 8 or 16 bit\n", s->name);
+                return NULL;
+        }
 
 	stepscale = (float)info.rate / shm->speed;
 	len = info.samples / stepscale;
 
 	len = len * info.width * info.channels;
 
-	if (info.samples == 0 || len == 0)
-	{
-		free (data);
-		Con_Printf("%s has zero samples\n", s->name);
-		return NULL;
-	}
+        if (info.samples == 0 || len == 0)
+        {
+                Z_Free (data);
+                Con_Printf("%s has zero samples\n", s->name);
+                return NULL;
+        }
 
 	sc = (sfxcache_t *) Cache_Alloc ( &s->cache, len + sizeof(sfxcache_t), s->name);
 	if (!sc)

--- a/Quake/texture_atlas.c
+++ b/Quake/texture_atlas.c
@@ -636,7 +636,7 @@ static qboolean Atlas_LoadJSON(const char *path)
     ok = Atlas_ParseJSONBuffer((const char *)json, (size_t)len);
     if (!ok)
         Con_Printf("Atlas_LoadJSON: failed to parse %s\n", path);
-    free(json);
+    Z_Free(json);
     return ok;
 }
 
@@ -672,7 +672,7 @@ static qboolean Atlas_LoadPNG(const char *path)
 
     len = com_filesize;
     pixels = stbi_load_from_memory(data, (int)len, &atlas_width, &atlas_height, &channels, 4);
-    free(data);
+    Z_Free(data);
 
     if (!pixels)
     {

--- a/Quake/wad.c
+++ b/Quake/wad.c
@@ -75,8 +75,8 @@ void W_LoadWadFile (void) //johnfitz -- filename is now hard-coded for honesty
 
 	//johnfitz -- modified to use malloc
 	//TODO: use cache_alloc
-	if (wad_base)
-		free (wad_base);
+        if (wad_base)
+                Z_Free (wad_base);
 	wad_base = COM_LoadMallocFile (filename, NULL);
 	if (!wad_base)
 		Sys_Error ("W_LoadWadFile: couldn't load %s\n\n"


### PR DESCRIPTION
## Summary
- switch COM_LoadMallocFile to allocate via the zone allocator and document the expected Z_Free deallocator
- update all consumers of COM_LoadMallocFile buffers to release them with Z_Free instead of free to avoid allocator mismatches

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692df9f1a780832e858a75edfdfed4a5)