### PR TITLE
Fix sound loading to free zone allocations correctly

### DIFF
--- a/Quake/snd_mem.c
+++ b/Quake/snd_mem.c
@@ -149,12 +149,12 @@ sfxcache_t *S_LoadSound (sfx_t *s)
                 return NULL;
         }
 
-	sc = (sfxcache_t *) Cache_Alloc ( &s->cache, len + sizeof(sfxcache_t), s->name);
-	if (!sc)
-	{
-		free (data);
-		return NULL;
-	}
+        sc = (sfxcache_t *) Cache_Alloc ( &s->cache, len + sizeof(sfxcache_t), s->name);
+        if (!sc)
+        {
+                Z_Free (data);
+                return NULL;
+        }
 
 	sc->length = info.samples;
 	sc->loopstart = info.loopstart;
@@ -164,7 +164,7 @@ sfxcache_t *S_LoadSound (sfx_t *s)
 
 	ResampleSfx (s, sc->speed, sc->width, data + info.dataofs);
 
-	free (data);
+        Z_Free (data);
 
 	return sc;
 }


### PR DESCRIPTION
## Summary
- ensure sound loading frees zone-allocated wav data with Z_Free
- avoid mixing standard free with zone allocator to prevent heap corruption

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dfdf26a98832ebf0ec5a928501777)