### PR TITLE
Initialize render backend

### DIFF
--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -23,6 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // r_misc.c
 
 #include "quakedef.h"
+#include "renderer_backend.h"
 
 //johnfitz -- new cvars
 extern cvar_t r_clearcolor;
@@ -335,6 +336,10 @@ void R_Init (void)
 	if (cmd)
 		cmd->completion = R_ShowbboxesFilter_Completion_f;
 	Cmd_AddCommand ("r_showbboxes_filter_clear", R_ShowbboxesFilterClear_f);
+
+	rb = GL_GetBackend ();
+	if (!rb || !rb->Init || !rb->Init ())
+		Sys_Error ("Failed to initialize render backend");
 
 Cvar_RegisterVariable (&r_norefresh);
 Cvar_RegisterVariable (&r_lightmap);

--- a/Quake/renderer_backend.h
+++ b/Quake/renderer_backend.h
@@ -90,5 +90,6 @@ struct render_backend_s {
 extern struct render_backend_s *rb;
 
 render_backend_t *Null_GetBackend(void);
+render_backend_t *GL_GetBackend(void);
 
 #endif // RENDERER_BACKEND_H

--- a/Windows/VisualStudio/ironwail.vcxproj
+++ b/Windows/VisualStudio/ironwail.vcxproj
@@ -239,6 +239,7 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
     <ClCompile Include="..\..\Quake\cvar.c" />
     <ClCompile Include="..\..\Quake\draw_surface.c" />
     <ClCompile Include="..\..\Quake\gl_draw.c" />
+    <ClCompile Include="..\..\Quake\gl_backend.c" />
     <ClCompile Include="..\..\Quake\gl_gbuffer.c" />
     <ClCompile Include="..\..\Quake\gl_fog.c" />
     <ClCompile Include="..\..\Quake\gl_deferred.c" />

--- a/Windows/VisualStudio/ironwail.vcxproj.filters
+++ b/Windows/VisualStudio/ironwail.vcxproj.filters
@@ -60,6 +60,9 @@
     <ClCompile Include="..\..\Quake\gl_draw.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Quake\gl_backend.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\Quake\gl_gbuffer.c">
       <Filter>Source Files</Filter>
     </ClCompile>


### PR DESCRIPTION
## Summary
- expose the GL backend getter in the renderer backend header
- initialize the renderer backend during renderer startup to ensure graphics rendering hooks are set up
- include gl_backend.c in the Visual Studio project so GL_GetBackend links on Windows

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e02383a90832e800f856f916cade1)