### PR TITLE
Include quakedef header in GL backend

### DIFF
--- a/Quake/gl_backend.c
+++ b/Quake/gl_backend.c
@@ -1,3 +1,5 @@
+#include "quakedef.h"
+
 #if defined(SDL_FRAMEWORK) || defined(NO_SDL_CONFIG)
 #include <SDL2/SDL_opengl.h>
 #else


### PR DESCRIPTION
## Summary
- include `quakedef.h` in the OpenGL backend to satisfy precompiled header requirements on Windows

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e09b9c78c832eaffb078d946eb761)