### PR TITLE
Fix fog density handling for moving models

### DIFF
--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -42,7 +42,7 @@ float bayer(ivec2 coord)
 
 vec3 ApplyFog(vec3 clr, vec3 p)
 {
-        float fog = exp2(-Fog.w * dot(p, p));
+        float fog = exp2(-abs(Fog.w) * dot(p, p));
         fog = clamp(fog, 0.0, 1.0);
         return mix(Fog.rgb, clr, fog);
 }

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -11,9 +11,9 @@ layout(binding=3) uniform sampler2D LMTexDir;
 
 vec3 ApplyFog(vec3 clr, vec3 p)
 {
-        float fog = exp2(-Fog.w * dot(p, p));
-	fog = clamp(fog, 0.0, 1.0);
-	return mix(Fog.rgb, clr, fog);
+        float fog = exp2(-abs(Fog.w) * dot(p, p));
+        fog = clamp(fog, 0.0, 1.0);
+        return mix(Fog.rgb, clr, fog);
 }
 
 #define LIGHT_TILES_X 32


### PR DESCRIPTION
## Summary
- ensure fog density uses absolute value so overbright flag does not disable fog
- align fog application for world and alias shaders so moving brushes and models get fogged correctly

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e247a1260832e9346e9abd2a09cf6)