### PR TITLE
Add default bright red emissive map for lava

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -1079,7 +1079,9 @@ static void Mod_LoadTextures (lump_t *l)
                                                 SRC_INDEXED, (byte *)(tx+1), loadmodel->name, offset, TEXPREF_MIPMAP | TEXPREF_BINDLESS);
                                 }
 
-                                tx->emissive = Mod_LoadEmissiveMap (loadmodel, filename, TEXPREF_MIPMAP | TEXPREF_BINDLESS);
+					tx->emissive = Mod_LoadEmissiveMap (loadmodel, filename, TEXPREF_MIPMAP | TEXPREF_BINDLESS);
+					if (!tx->emissive && tx->type == TEXTYPE_LAVA)
+						tx->emissive = lavaemissivetexture;
 
                                 Hunk_FreeToLowMark (mark);
                                 if (malloced)

--- a/Quake/gl_texmgr.c
+++ b/Quake/gl_texmgr.c
@@ -63,6 +63,7 @@ softemu_t		softemu;
 static int numgltextures;
 static gltexture_t	*active_gltextures, *free_gltextures;
 gltexture_t		*notexture, *nulltexture, *whitetexture, *greytexture, *blacktexture;
+gltexture_t		*lavaemissivetexture;
 
 unsigned int d_8to24table_opaque[256];			//standard palette with alpha 255 for all colors
 unsigned int d_8to24table[256];					//standard palette, 255 is transparent
@@ -846,6 +847,7 @@ void TexMgr_Init (void)
 	static byte whitetexture_data[16] = {255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255}; //white
 	static byte greytexture_data[16] = {127,127,127,255,127,127,127,255,127,127,127,255,127,127,127,255}; //50% grey
 	static byte blacktexture_data[16] = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}; //black
+	static byte lavaemissive_data[16] = {255,0,0,255,255,0,0,255,255,0,0,255,255,0,0,255}; //bright red
 	extern texture_t *r_notexture_mip, *r_notexture_mip2;
 	cmd_function_t	*cmd;
 
@@ -896,6 +898,7 @@ void TexMgr_Init (void)
 	whitetexture = TexMgr_LoadImage (NULL, "whitetexture", 2, 2, SRC_RGBA, whitetexture_data, "", (src_offset_t)whitetexture_data, TEXPREF_NEAREST | TEXPREF_PERSIST | TEXPREF_NOPICMIP | TEXPREF_BINDLESS);
 	greytexture = TexMgr_LoadImage (NULL, "greytexture", 2, 2, SRC_RGBA, greytexture_data, "", (src_offset_t)greytexture_data, TEXPREF_NEAREST | TEXPREF_PERSIST | TEXPREF_NOPICMIP | TEXPREF_BINDLESS);
 	blacktexture = TexMgr_LoadImage (NULL, "blacktexture", 2, 2, SRC_RGBA, blacktexture_data, "", (src_offset_t)blacktexture_data, TEXPREF_NEAREST | TEXPREF_PERSIST | TEXPREF_NOPICMIP | TEXPREF_BINDLESS);
+	lavaemissivetexture = TexMgr_LoadImage (NULL, "lavaemissive", 2, 2, SRC_RGBA, lavaemissive_data, "", (src_offset_t)lavaemissive_data, TEXPREF_NEAREST | TEXPREF_PERSIST | TEXPREF_NOPICMIP | TEXPREF_BINDLESS);
 
 	//have to assign these here becuase Mod_Init is called before TexMgr_Init
 	r_notexture_mip->gltexture = r_notexture_mip2->gltexture = notexture;

--- a/Quake/gl_texmgr.h
+++ b/Quake/gl_texmgr.h
@@ -83,6 +83,7 @@ extern gltexture_t *nulltexture;
 extern gltexture_t *whitetexture;
 extern gltexture_t *greytexture;
 extern gltexture_t *blacktexture;
+extern gltexture_t *lavaemissivetexture;
 
 extern GLuint gl_palette_lut;
 extern GLuint gl_palette_buffer[2];


### PR DESCRIPTION
## Summary
- add a persistent bright red emissive texture for lava surfaces
- fall back to the default emissive map when lava textures lack a dedicated glow map

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e2a71f374832eb67b68af6f03d25f)