### PR TITLE
Fix lightmap sRGB decode handling

### DIFF
--- a/Quake/gl_texmgr.c
+++ b/Quake/gl_texmgr.c
@@ -1844,7 +1844,7 @@ static void TexMgr_LoadLightmap (gltexture_t *glt, byte *data)
 
 #ifdef GL_EXT_texture_sRGB_decode
         glTexParameteri (glt->target, GL_TEXTURE_SRGB_DECODE_EXT,
-                        r_lightmap_linear.value > 0.f ? GL_SKIP_DECODE_EXT : GL_DECODE_EXT);
+                        r_lightmap_linear.value > 0.f ? GL_DECODE_EXT : GL_SKIP_DECODE_EXT);
 #endif
 
 	// set filter modes


### PR DESCRIPTION
## Summary
- ensure lightmaps use hardware sRGB decode when linear lightmaps are enabled
- avoid double-decoding by skipping sRGB decode only when linearization is disabled

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f15e23a84832e99f84843b820dcb8)