### PR TITLE
Add screen-space darkening option

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -231,6 +231,8 @@ cvar_t	r_vignette_color_b = { "r_vignette_color_b", "0.0", CVAR_ARCHIVE };
 cvar_t	r_vignette_blend_mode = { "r_vignette_blend_mode", "0", CVAR_ARCHIVE };
 cvar_t	r_vignette_noise = { "r_vignette_noise", "0.0", CVAR_ARCHIVE };
 cvar_t	r_chromatic_aberration = { "r_chromatic_aberration", "0", CVAR_ARCHIVE };
+cvar_t	r_screendarken = { "r_screendarken", "0", CVAR_ARCHIVE };
+cvar_t	r_screendarken_depth = { "r_screendarken_depth", "0.4", CVAR_ARCHIVE };
 
 cvar_t	r_overbrightbits = { "r_overbrightbits", "1", CVAR_ARCHIVE };
 
@@ -688,6 +690,9 @@ void GL_PostProcess (void)
         float motion_min_velocity;
         float motion_depth_threshold;
         int motion_max_samples;
+        qboolean screen_darken_enabled;
+        float screen_darken_strength;
+        float screen_darken_depth;
         if (!GL_NeedsPostprocess ())
                 return;
 
@@ -696,9 +701,12 @@ void GL_PostProcess (void)
 	palidx = GLPalette_Postprocess ();
 	dither = (softemu == SOFTEMU_FINE) ? NOISESCALE * r_dither.value * r_softemu_dither_screen.value : 0.f;
 
-	float bloom_intensity = q_max (0.f, r_bloom.value);
-	float exposure = q_max (0.f, r_tonemap_exposure.value);
-	float tonemap_mode = q_max (0.f, r_tonemap.value);
+        float bloom_intensity = q_max (0.f, r_bloom.value);
+        float exposure = q_max (0.f, r_tonemap_exposure.value);
+        float tonemap_mode = q_max (0.f, r_tonemap.value);
+        screen_darken_strength = q_min (1.f, q_max (0.f, r_screendarken.value));
+        screen_darken_depth = q_max (0.f, r_screendarken_depth.value);
+        screen_darken_enabled = (screen_darken_strength > 0.f);
         GLuint bloom_texture = framebufs.bloom.extract_tex ? framebufs.bloom.extract_tex : 0;
         if (framebufs.bloom.pingpong_tex[0])
                 bloom_texture = framebufs.bloom.pingpong_tex[0];
@@ -771,8 +779,8 @@ void GL_PostProcess (void)
         GL_Uniform4fFunc (10,
                 q_min (0.1f, q_max (0.f, r_vignette_noise.value)),
                 q_max (0.f, r_chromatic_aberration.value),
-                0.f,
-                0.f);
+                screen_darken_strength,
+                screen_darken_depth);
 
         dof_enabled = R_DoFEnabled ();
 
@@ -792,7 +800,7 @@ void GL_PostProcess (void)
         }
 
         depth_texture = 0;
-        if (framebufs.composite.depth_stencil_tex && (dof_enabled || (motion_enabled && motion_depth_threshold > 0.f)))
+        if (framebufs.composite.depth_stencil_tex && (dof_enabled || screen_darken_enabled || (motion_enabled && motion_depth_threshold > 0.f)))
                 depth_texture = framebufs.composite.depth_stencil_tex;
         GL_BindNative (GL_TEXTURE2, GL_TEXTURE_2D, depth_texture);
 

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -81,6 +81,8 @@ extern cvar_t r_vignette_color_b;
 extern cvar_t r_vignette_blend_mode;
 extern cvar_t r_vignette_noise;
 extern cvar_t r_chromatic_aberration;
+extern cvar_t r_screendarken;
+extern cvar_t r_screendarken_depth;
 
 #if defined(USE_SIMD)
 extern cvar_t r_simd;
@@ -385,8 +387,10 @@ Cvar_RegisterVariable (&r_drawviewmodel);
 	Cvar_RegisterVariable (&r_vignette_blend_mode);
 	Cvar_RegisterVariable (&r_vignette_noise);
 	Cvar_RegisterVariable (&r_chromatic_aberration);
+	Cvar_RegisterVariable (&r_screendarken);
+	Cvar_RegisterVariable (&r_screendarken_depth);
 	Cvar_RegisterVariable (&r_overbrightbits);
-	Cvar_SetCallback (&r_overbrightbits, R_OverbrightBits_f);
+        Cvar_SetCallback (&r_overbrightbits, R_OverbrightBits_f);
 
 	Cvar_RegisterVariable (&gl_finish);
 	Cvar_RegisterVariable (&gl_clear);

--- a/Quake/shaders/postprocess.frag
+++ b/Quake/shaders/postprocess.frag
@@ -114,7 +114,7 @@ layout(location=6) uniform vec4 MotionParams0; // x: enabled, y: shutter strengt
 layout(location=7) uniform vec4 MotionParams1; // x: max blur radius (pixels), y: max samples, z: velocity texture available, w: reserved
 layout(location=8) uniform vec4 PostFXParams0; // x: vignette strength, y: inner radius, z: outer radius, w: falloff
 layout(location=9) uniform vec4 PostFXParams1; // xyz: vignette color, w: blend mode
-layout(location=10) uniform vec4 PostFXParams2; // x: vignette noise amount, y: chromatic aberration (pixels), zw: reserved
+layout(location=10) uniform vec4 PostFXParams2; // x: vignette noise amount, y: chromatic aberration (pixels), z: screen-space darken strength, w: screen-space darken depth range
 
 const int MOTION_MAX_SAMPLES = 64;
 const float OPAQUE_ALPHA_THRESHOLD = 0.999;
@@ -332,6 +332,17 @@ void main()
         {
                 vec2 viewUV = clamp((uv - viewMin) / viewSize, vec2(0.0), vec2(1.0));
                 float aspect = texSize.y > 0.0 ? texSize.x / texSize.y : 1.0;
+
+                float screenDarkenStrength = clamp(PostFXParams2.z, 0.0, 1.0);
+                float screenDarkenDepth = max(PostFXParams2.w, 1e-4);
+                if (screenDarkenStrength > 0.0 && depthInfo.valid)
+                {
+                        float linearDepth = SampleLinearDepth(gl_FragCoord.xy, depthInfo);
+                        float depthRange = max(DoFParams1.y - DoFParams1.x, 1e-6);
+                        float normalizedDepth = clamp((linearDepth - DoFParams1.x) / depthRange, 0.0, 1.0);
+                        float screenAO = smoothstep(0.0, screenDarkenDepth, 1.0 - normalizedDepth);
+                        color.rgb *= mix(vec3(1.0), vec3(screenAO), screenDarkenStrength);
+                }
 
                 float vignetteStrength = clamp(PostFXParams0.x, 0.0, 1.0);
                 float vignetteInner = max(PostFXParams0.y, 0.0);


### PR DESCRIPTION
## Summary
- add `r_screendarken` and `r_screendarken_depth` cvars that feed new postprocess parameters
- implement a lightweight screen-space darkening effect in the postprocess shader using the depth buffer
- bind the depth buffer during postprocessing when the darkening effect is active

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f1955c1a4832e92f5dc0677361750)