### PR TITLE
Add extension helper and guard RGTC2 constant

### DIFF
--- a/Quake/common.c
+++ b/Quake/common.c
@@ -1164,6 +1164,28 @@ const char *COM_FileGetExtension (const char *in)
 
 /*
 ============
+COM_HasExtension
+============
+*/
+qboolean COM_HasExtension (const char *path, const char *extension)
+{
+	const char *path_ext;
+
+	if (!path || !extension)
+		return false;
+
+	path_ext = COM_FileGetExtension (path);
+	if (!*path_ext)
+		return false;
+
+	if (*extension == '.')
+		++extension;
+
+	return !q_strcasecmp (path_ext, extension);
+}
+
+/*
+============
 COM_ExtractExtension
 ============
 */

--- a/Quake/common.h
+++ b/Quake/common.h
@@ -331,6 +331,7 @@ void COM_AddExtension (char *path, const char *extension, size_t len);
 void COM_DefaultExtension (char *path, const char *extension, size_t len);
 #endif
 const char *COM_FileGetExtension (const char *in); /* doesn't return NULL */
+qboolean COM_HasExtension (const char *path, const char *extension);
 void COM_ExtractExtension (const char *in, char *out, size_t outsize);
 char *COM_TempSuffix (unsigned seq);
 void COM_CreatePath (char *path);

--- a/Quake/gl_texmgr.c
+++ b/Quake/gl_texmgr.c
@@ -25,6 +25,10 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "quakedef.h"
 #include "glquake.h"
 
+#ifndef GL_COMPRESSED_RED_GREEN_RGTC2
+#define GL_COMPRESSED_RED_GREEN_RGTC2 0x8DBD
+#endif
+
 extern cvar_t r_lightmap_mipmaps;
 extern cvar_t r_lightmap16f;
 extern cvar_t r_lightmap_linear;


### PR DESCRIPTION
## Summary
- add a COM_HasExtension helper to centralize extension checks
- define GL_COMPRESSED_RED_GREEN_RGTC2 when missing so DDS decoding builds against older headers

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f21c23908832eb793181aa982d26d)