### PR TITLE
Fix Windows build for compressed textures

### DIFF
--- a/Quake/gl_texmgr.c
+++ b/Quake/gl_texmgr.c
@@ -1634,7 +1634,7 @@ GLuint TexMgr_LoadDDS (const char *path)
 	for (level = 0; level < mip_levels; level++)
 	{
 	size_t level_size = Dds_CalcLevelSize(&format, level_width, level_height);
-	glCompressedTexImage2D (GL_TEXTURE_2D, level, format.internal_format, level_width, level_height, 0, (GLsizei) level_size, file_buffer + offset);
+        GL_CompressedTexImage2DFunc (GL_TEXTURE_2D, level, format.internal_format, level_width, level_height, 0, (GLsizei) level_size, file_buffer + offset);
 
 	offset += level_size;
 	if (level_width > 1)

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -198,6 +198,7 @@ extern	const char	*gl_version;
 	x(const GLubyte*,GetStringi, (GLenum name, GLuint index))\
 	x(void,			TexStorage2D, (GLenum target, GLsizei levels, GLenum internalFormat, GLsizei width, GLsizei height))\
 	x(void,			TexStorage3D, (GLenum target, GLsizei levels, GLenum internalFormat, GLsizei width, GLsizei height, GLsizei depth))\
+	x(void,			CompressedTexImage2D, (GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLint border, GLsizei imageSize, const GLvoid *data))\
 	x(void,			TexStorage2DMultisample, (GLenum target, GLsizei samples, GLenum internalFormat, GLsizei width, GLsizei height, GLboolean fixedsamplelocations))\
 	x(void,			MinSampleShading, (GLfloat value))\
 	x(void,			TexImage3D, (GLenum target, GLint level, GLint internalFormat, GLsizei width, GLsizei height, GLsizei depth, GLint border, GLenum format, GLenum type, const GLvoid *pixels))\

--- a/Windows/VisualStudio/ironwail.vcxproj
+++ b/Windows/VisualStudio/ironwail.vcxproj
@@ -249,6 +249,7 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
     <ClCompile Include="..\..\Quake\gl_shaders.c" />
     <ClCompile Include="..\..\Quake\gl_sky.c" />
     <ClCompile Include="..\..\Quake\gl_texmgr.c" />
+    <ClCompile Include="..\..\Quake\gl_ktx2.c" />
     <ClCompile Include="..\..\Quake\gl_vidsdl.c" />
     <ClCompile Include="..\..\Quake\gl_warp.c" />
     <ClCompile Include="..\..\Quake\host.c" />

--- a/Windows/VisualStudio/ironwail.vcxproj.filters
+++ b/Windows/VisualStudio/ironwail.vcxproj.filters
@@ -87,6 +87,9 @@
     <ClCompile Include="..\..\Quake\gl_texmgr.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Quake\gl_ktx2.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\Quake\gl_vidsdl.c">
       <Filter>Source Files</Filter>
     </ClCompile>


### PR DESCRIPTION
## Summary
- load OpenGL compressed texture upload via function pointer to avoid missing import on Windows
- add KTX2 loader source file to the Visual Studio project and filters

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f2265f778832e91cb18fb512eb86c)