### PR TITLE
Remove unused gl_local include from KTX2 loader

### DIFF
--- a/Quake/gl_ktx2.c
+++ b/Quake/gl_ktx2.c
@@ -1,5 +1,4 @@
 #include "quakedef.h"
-#include "gl_local.h"
 #include "gl_ktx2.h"
 #include "gl_texmgr.h"
 #include "basisu_transcoder.h"


### PR DESCRIPTION
## Summary
- remove the gl_local.h include from gl_ktx2.c to match available headers and fix Windows build

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f238f6168832ea347e0ff2cf817e2)