### PR TITLE
Add teleport visual effect

### DIFF
--- a/Quake/cl_main.c
+++ b/Quake/cl_main.c
@@ -245,6 +245,7 @@ void CL_SignonReply (void)
 		SCR_EndLoadingPlaque ();		// allow normal screen updates
 		break;
 	}
+
 }
 
 /*
@@ -570,6 +571,7 @@ void CL_RelinkEntities (void)
 	vec3_t		delta;
 	float		bobjrotate;
 	dlight_t	*dl;
+	qboolean		viewentity_teleported = false;
 
 // determine partial update time
 	frac = CL_LerpPoint ();
@@ -604,6 +606,8 @@ void CL_RelinkEntities (void)
 // start on the entity after the world
 	for (i=1,ent=cl_entities+1 ; i<cl.num_entities ; i++,ent++)
 	{
+		qboolean teleported = false;
+
 		if (!ent->model)
 		{	// empty slot
 			
@@ -638,6 +642,7 @@ void CL_RelinkEntities (void)
 				{
 					f = 1;		// assume a teleportation, not a motion
 					ent->lerpflags |= LERP_RESETMOVE; //johnfitz -- don't lerp teleports
+					teleported = true;
 				}
 			}
 
@@ -662,6 +667,9 @@ void CL_RelinkEntities (void)
 
 		if (ent->forcelink || ent->lerpflags & LERP_RESETMOVE)
 			CL_ResetTrail (ent);
+
+		if (ent == &cl_entities[cl.viewentity] && teleported)
+			viewentity_teleported = true;
 
 // rotate binary objects locally
 		if (ent->model->flags & EF_ROTATE)
@@ -769,6 +777,9 @@ void CL_RelinkEntities (void)
 			cl_numvisedicts++;
 		}
 	}
+
+	if (viewentity_teleported)
+		cl.teleport_fx_time = cl.time;
 }
 
 

--- a/Quake/client.h
+++ b/Quake/client.h
@@ -201,6 +201,7 @@ typedef struct
 
 	float		viewheight;
 	float		crouch;			// local amount for smoothing stepups
+	double		teleport_fx_time;		// time when the last teleport effect should start
 
 	qboolean	paused;			// send over by server
 	qboolean	onground;

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -233,6 +233,8 @@ cvar_t	r_vignette_noise = { "r_vignette_noise", "0.0", CVAR_ARCHIVE };
 cvar_t	r_chromatic_aberration = { "r_chromatic_aberration", "0", CVAR_ARCHIVE };
 cvar_t	r_screendarken = { "r_screendarken", "0", CVAR_ARCHIVE };
 cvar_t	r_screendarken_depth = { "r_screendarken_depth", "0.4", CVAR_ARCHIVE };
+cvar_t	r_teleportfx = { "r_teleportfx", "1", CVAR_ARCHIVE };
+cvar_t	r_teleportfx_time = { "r_teleportfx_time", "0.35", CVAR_ARCHIVE };
 
 cvar_t	r_overbrightbits = { "r_overbrightbits", "1", CVAR_ARCHIVE };
 
@@ -693,6 +695,8 @@ void GL_PostProcess (void)
         qboolean screen_darken_enabled;
         float screen_darken_strength;
         float screen_darken_depth;
+        float teleport_fade;
+        float teleport_blur;
         if (!GL_NeedsPostprocess ())
                 return;
 
@@ -707,6 +711,20 @@ void GL_PostProcess (void)
         screen_darken_strength = q_min (1.f, q_max (0.f, r_screendarken.value));
         screen_darken_depth = q_max (0.f, r_screendarken_depth.value);
         screen_darken_enabled = (screen_darken_strength > 0.f);
+        teleport_fade = 0.f;
+        teleport_blur = 0.f;
+        {
+                float teleport_duration = q_max (0.f, r_teleportfx_time.value);
+                if (r_teleportfx.value > 0.f && teleport_duration > 0.f && cl.teleport_fx_time > 0.0)
+                {
+                        double teleport_elapsed = cl.time - cl.teleport_fx_time;
+                        if (teleport_elapsed >= 0.0 && teleport_elapsed < teleport_duration)
+                        {
+                                teleport_fade = 1.f - (float)(teleport_elapsed / teleport_duration);
+                                teleport_blur = teleport_fade * 2.f;
+                        }
+                }
+        }
         GLuint bloom_texture = framebufs.bloom.extract_tex ? framebufs.bloom.extract_tex : 0;
         if (framebufs.bloom.pingpong_tex[0])
                 bloom_texture = framebufs.bloom.pingpong_tex[0];
@@ -781,6 +799,7 @@ void GL_PostProcess (void)
                 q_max (0.f, r_chromatic_aberration.value),
                 screen_darken_strength,
                 screen_darken_depth);
+        GL_Uniform4fFunc (11, teleport_fade, teleport_blur, 0.f, 0.f);
 
         dof_enabled = R_DoFEnabled ();
 

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -83,6 +83,8 @@ extern cvar_t r_vignette_noise;
 extern cvar_t r_chromatic_aberration;
 extern cvar_t r_screendarken;
 extern cvar_t r_screendarken_depth;
+extern cvar_t r_teleportfx;
+extern cvar_t r_teleportfx_time;
 
 #if defined(USE_SIMD)
 extern cvar_t r_simd;
@@ -389,7 +391,9 @@ Cvar_RegisterVariable (&r_drawviewmodel);
 	Cvar_RegisterVariable (&r_chromatic_aberration);
 	Cvar_RegisterVariable (&r_screendarken);
 	Cvar_RegisterVariable (&r_screendarken_depth);
-	Cvar_RegisterVariable (&r_overbrightbits);
+	Cvar_RegisterVariable (&r_teleportfx);
+	Cvar_RegisterVariable (&r_teleportfx_time);
+        Cvar_RegisterVariable (&r_overbrightbits);
         Cvar_SetCallback (&r_overbrightbits, R_OverbrightBits_f);
 
 	Cvar_RegisterVariable (&gl_finish);

--- a/Quake/shaders/postprocess.frag
+++ b/Quake/shaders/postprocess.frag
@@ -115,6 +115,7 @@ layout(location=7) uniform vec4 MotionParams1; // x: max blur radius (pixels), y
 layout(location=8) uniform vec4 PostFXParams0; // x: vignette strength, y: inner radius, z: outer radius, w: falloff
 layout(location=9) uniform vec4 PostFXParams1; // xyz: vignette color, w: blend mode
 layout(location=10) uniform vec4 PostFXParams2; // x: vignette noise amount, y: chromatic aberration (pixels), z: screen-space darken strength, w: screen-space darken depth range
+layout(location=11) uniform vec4 TeleportParams; // x: teleport fade, y: blur radius (pixels)
 
 const int MOTION_MAX_SAMPLES = 64;
 const float OPAQUE_ALPHA_THRESHOLD = 0.999;
@@ -406,6 +407,23 @@ void main()
                                 float blend = clamp(chromaticAmount * lenDir, 0.0, 1.0);
                                 color.rgb = mix(color.rgb, aberrated, blend);
                         }
+                }
+
+                float teleportFade = clamp(TeleportParams.x, 0.0, 1.0);
+                float teleportBlur = max(TeleportParams.y, 0.0);
+                if (teleportFade > 0.0)
+                {
+                        if (teleportBlur > 0.0)
+                        {
+                                vec2 blurOffset = teleportBlur * invTexSize;
+                                vec3 blurAccum = color.rgb;
+                                blurAccum += texture(GammaTexture, clamp(uv + vec2(blurOffset.x, 0.0), viewMin, viewMax)).rgb;
+                                blurAccum += texture(GammaTexture, clamp(uv - vec2(blurOffset.x, 0.0), viewMin, viewMax)).rgb;
+                                blurAccum += texture(GammaTexture, clamp(uv + vec2(0.0, blurOffset.y), viewMin, viewMax)).rgb;
+                                blurAccum += texture(GammaTexture, clamp(uv - vec2(0.0, blurOffset.y), viewMin, viewMax)).rgb;
+                                color.rgb = blurAccum * 0.2;
+                        }
+                        color.rgb += vec3(0.5, 0.3, 1.0) * teleportFade;
                 }
         }
 


### PR DESCRIPTION
## Summary
- track player teleports to trigger a short screen effect
- add cvars for enabling and tuning a teleport flash
- render a purple teleport flash with a brief blur during post-processing

## Testing
- Not run (not requested).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f280e091c832e9273bc68b6e290c4)