### PR TITLE
Fix alias overbright scaling and restore lava visibility

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -275,7 +275,7 @@ extern cvar_t	r_softemu_dither_texture;
 
 cvar_t	gl_zfix = { "gl_zfix", "1", CVAR_ARCHIVE }; // QuakeSpasm z-fighting fix
 
-cvar_t	r_lavaalpha = { "r_lavaalpha","0",CVAR_NONE };
+cvar_t	r_lavaalpha = { "r_lavaalpha","1",CVAR_NONE };
 cvar_t	r_telealpha = { "r_telealpha","0",CVAR_NONE };
 cvar_t	r_slimealpha = { "r_slimealpha","0",CVAR_NONE };
 

--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -76,8 +76,9 @@ struct ibuf_s {
 		float	_pad;
 		vec4_t	fog;
 		float	dither;
+		float	overbright;
 		float	half_lambert;
-		float	_padding[2];
+		float	_padding[1];
 	} global;
 	aliasinstance_t inst[MAX_ALIAS_INSTANCES];
 } ibuf;
@@ -352,18 +353,19 @@ void R_FlushAliasInstances (qboolean showtris)
 		state |= GLS_BLEND_ALPHA_OIT | GLS_NO_ZWRITE;
 	GL_SetState (state);
 
-	memcpy (ibuf.global.matviewproj, r_matviewproj, sizeof (r_matviewproj));
-	memcpy (ibuf.global.prev_matviewproj, r_framedata.prev_viewproj, sizeof (r_framedata.prev_viewproj));
-	memcpy (ibuf.global.eyepos, r_refdef.vieworg, sizeof (r_refdef.vieworg));
-	memcpy (ibuf.global.fog, r_framedata.fogdata, 3 * sizeof (float));
-	// use fog density sign bit as overbright flag
-	ibuf.global.fog[3] =
-		gl_overbright_models.value ?
-			-fabs (r_framedata.fogdata[3]) :
-			 fabs (r_framedata.fogdata[3])
-	;
-	ibuf.global.dither = r_framedata.dither[0];
-	ibuf.global.half_lambert = r_model_halflambert.value > 0.f ? 1.f : 0.f;
+memcpy (ibuf.global.matviewproj, r_matviewproj, sizeof (r_matviewproj));
+memcpy (ibuf.global.prev_matviewproj, r_framedata.prev_viewproj, sizeof (r_framedata.prev_viewproj));
+memcpy (ibuf.global.eyepos, r_refdef.vieworg, sizeof (r_refdef.vieworg));
+memcpy (ibuf.global.fog, r_framedata.fogdata, 3 * sizeof (float));
+// use fog density sign bit as overbright flag
+ibuf.global.fog[3] =
+gl_overbright_models.value ?
+-fabs (r_framedata.fogdata[3]) :
+ fabs (r_framedata.fogdata[3])
+;
+ibuf.global.overbright = gl_overbright_models.value > 0.f ? r_framedata.dither[2] : 1.f;
+ibuf.global.dither = r_framedata.dither[0];
+ibuf.global.half_lambert = r_model_halflambert.value > 0.f ? 1.f : 0.f;
 
 	ibuf_size = sizeof(ibuf.global) + sizeof(ibuf.inst[0]) * ibuf.count;
 	GL_Upload (GL_SHADER_STORAGE_BUFFER, &ibuf.global, ibuf_size, &buf, &ofs);

--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -17,6 +17,7 @@ layout(std430, binding=1) restrict readonly buffer InstanceBuffer
 	float	_Pad0;
 	vec4	Fog;
 	float	ScreenDither;
+	float	Overbright;
 	float	ModelHalfLambert;
 	float	_Pad1;
 	float	_Pad2;

--- a/Quake/shaders/alias.vert
+++ b/Quake/shaders/alias.vert
@@ -17,6 +17,7 @@ layout(std430, binding=1) restrict readonly buffer InstanceBuffer
 	float	_Pad0;
 	vec4	Fog;
 	float	ScreenDither;
+	float	Overbright;
 	float	ModelHalfLambert;
 	float	_Pad1;
 	float	_Pad2;
@@ -112,12 +113,11 @@ void main()
 	out_flags = inst.Flags;
 	out_pos = world_vert - EyePos;
 	// transform world X and Z axes to local space
-	mat3 orientation = mat3(normalize(worldmatrix[0].xyz), normalize(worldmatrix[1].xyz), normalize(worldmatrix[2].xyz));
-	orientation = transpose(orientation);
-	vec3 shadevector = (orientation[0] + orientation[2]) / sqrt(2.0);
-	float dot1 = r_avertexnormal_dot(pose1.nor, shadevector);
-	float dot2 = r_avertexnormal_dot(pose2.nor, shadevector);
-	out_color = clamp(inst.LightColor * vec4(vec3(mix(dot1, dot2, inst.Blend)), 1.0), 0.0, 1.0);
-	uint overbright = floatBitsToUint(Fog.w) >> 31;
-	out_color.rgb = ldexp(out_color.rgb, ivec3(overbright));
+        mat3 orientation = mat3(normalize(worldmatrix[0].xyz), normalize(worldmatrix[1].xyz), normalize(worldmatrix[2].xyz));
+        orientation = transpose(orientation);
+        vec3 shadevector = (orientation[0] + orientation[2]) / sqrt(2.0);
+        float dot1 = r_avertexnormal_dot(pose1.nor, shadevector);
+        float dot2 = r_avertexnormal_dot(pose2.nor, shadevector);
+        float lighting = mix(dot1, dot2, inst.Blend);
+        out_color = clamp(inst.LightColor * vec4(vec3(lighting * Overbright), 1.0), 0.0, Overbright);
 }


### PR DESCRIPTION
## Summary
- pass the computed overbright factor to alias rendering so r_overbrightbits affects models and viewmodels
- update alias shaders to use the overbright scale for lighting
- set the default lava alpha to 1 to ensure lava surfaces remain visible

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f2d5be498832eb212e69926066db0)