### PR TITLE
Fix alias and water buffer uploads

### DIFF
--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -78,7 +78,7 @@ struct ibuf_s {
 		float	dither;
 		float	overbright;
 		float	half_lambert;
-		float	_padding[1];
+		float	_padding[2]; // keep std430 layout in sync with InstanceBuffer in alias shaders
 	} global;
 	aliasinstance_t inst[MAX_ALIAS_INSTANCES];
 } ibuf;

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -619,7 +619,7 @@ GL_Bind (GL_TEXTURE2, r_fullbright_cheatsafe ? greytexture : lightmap_texture);
 GL_Bind (GL_TEXTURE3, (r_lightingdir.value > 0.f && lightmap_dir_texture) ? lightmap_dir_texture : greytexture);
 
 GL_Upload (GL_SHADER_STORAGE_BUFFER, bmodel_instances, sizeof(bmodel_instances[0]) * totalinst, &buf, &ofs);
-	GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 2, buf, (GLintptr)ofs, sizeof(bmodel_instances[0]) * count);
+	GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 2, buf, (GLintptr)ofs, sizeof(bmodel_instances[0]) * totalinst);
 
 	// generate drawcalls
 	for (i = 0, baseinst = 0; i < count; /**/)


### PR DESCRIPTION
## Summary
- align the alias instance buffer layout with the shader expectations to prevent invisible alias models
- bind the correct amount of water instance data so translucent liquids render

## Testing
- not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f2f463368832e84fc585165ce5029)