### PR TITLE
Fix alias instance buffer alignment

### DIFF
--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -78,10 +78,12 @@ struct ibuf_s {
 		float	dither;
 		float	overbright;
 		float	half_lambert;
-		float	_padding[2]; // keep std430 layout in sync with InstanceBuffer in alias shaders
+		float	_padding[5]; // keep std430 layout in sync with InstanceBuffer in alias shaders
 	} global;
 	aliasinstance_t inst[MAX_ALIAS_INSTANCES];
 } ibuf;
+
+COMPILE_TIME_ASSERT (alias_global_size_matches_std430, sizeof (ibuf.global) % 16 == 0);
 
 /*
 =================

--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -19,8 +19,7 @@ layout(std430, binding=1) restrict readonly buffer InstanceBuffer
 	float	ScreenDither;
 	float	Overbright;
 	float	ModelHalfLambert;
-	float	_Pad1;
-	float	_Pad2;
+	float   _Pad[5];
 	InstanceData instances[];
 };
 // ALU-only 16x16 Bayer matrix

--- a/Quake/shaders/alias.vert
+++ b/Quake/shaders/alias.vert
@@ -19,8 +19,7 @@ layout(std430, binding=1) restrict readonly buffer InstanceBuffer
 	float	ScreenDither;
 	float	Overbright;
 	float	ModelHalfLambert;
-	float	_Pad1;
-	float	_Pad2;
+	float   _Pad[5];
 	InstanceData instances[];
 };
 


### PR DESCRIPTION
## Summary
- add sufficient padding and a compile-time check so the alias instance buffer matches std430 alignment
- adjust alias shaders to mirror the revised InstanceBuffer padding

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f3161bd78832ebe5478e8d77830b7)