### PR TITLE
Enable sRGB alias lighting

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -3775,7 +3775,7 @@ static void *Mod_LoadAllSkins (int numskins, daliasskintype_t *pskintype)
 	daliasskininterval_t	*pinskinintervals;
 	char			fbr_mask_name[MAX_QPATH]; //johnfitz -- added for fullbright support
 	src_offset_t		offset; //johnfitz
-	unsigned int		texflags = TEXPREF_PAD;
+	unsigned int		texflags = TEXPREF_PAD | TEXPREF_SRGB;
 
 	skin = (byte *)(pskintype + 1);
 

--- a/Quake/gl_texmgr.c
+++ b/Quake/gl_texmgr.c
@@ -1353,10 +1353,22 @@ static void TexMgr_LoadImage32 (gltexture_t *glt, unsigned *data)
 
 	// upload
 	compress = gl_compress_textures.value && TexMgr_CanCompress (glt);
-	internalformat = (glt->flags & TEXPREF_HASALPHA) ? glformats[compress].alpha : glformats[compress].solid;
-	glt->compression = internalformat.ratio;
-	GL_Bind (GL_TEXTURE0, glt);
-	GL_TexImage (glt, 0, internalformat.id, glt->width, glt->height, GL_RGBA, GL_UNSIGNED_BYTE, data);
+        internalformat = (glt->flags & TEXPREF_HASALPHA) ? glformats[compress].alpha : glformats[compress].solid;
+
+#ifdef GL_SRGB8
+        if (glt->flags & TEXPREF_SRGB)
+                internalformat.id = (glt->flags & TEXPREF_HASALPHA) ? GL_SRGB8_ALPHA8 : GL_SRGB8;
+#endif
+
+        glt->compression = internalformat.ratio;
+        glt->internal_format = internalformat.id;
+        GL_Bind (GL_TEXTURE0, glt);
+        GL_TexImage (glt, 0, internalformat.id, glt->width, glt->height, GL_RGBA, GL_UNSIGNED_BYTE, data);
+
+#ifdef GL_EXT_texture_sRGB_decode
+        if (glt->flags & TEXPREF_SRGB)
+                glTexParameteri (glt->target, GL_TEXTURE_SRGB_DECODE_EXT, GL_DECODE_EXT);
+#endif
 
 	// upload mipmaps
 	if (glt->flags & TEXPREF_MIPMAP)

--- a/Quake/gl_texmgr.h
+++ b/Quake/gl_texmgr.h
@@ -45,6 +45,8 @@ typedef enum
 	TEXPREF_ALPHABRIGHT		= 0x4000,	// use palette with lighting mask in alpha channel (0=fullbright, 1=lit)
 	TEXPREF_CLAMP			= 0x8000,	// clamp UVs
 
+	TEXPREF_SRGB			= 0x10000,	// upload texture in sRGB format
+
 	TEXPREF_HASALPHA		= (TEXPREF_ALPHA|TEXPREF_ALPHABRIGHT), // texture has alpha channel
 } textureflags_t;
 

--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -277,22 +277,23 @@ void R_SetupAliasLighting (entity_t	*e)
 		}
 	}
 
-	// clamp lighting so it doesn't overbright as much (96)
-	if (gl_overbright_models.value)
-	{
-		add = lightcolor[0] + lightcolor[1] + lightcolor[2];
-		if (add > 288.0f)
-			VectorScale(lightcolor, 288.0f / add, lightcolor);
-	}
-	//hack up the brightness when fullbrights but no overbrights (256)
-	else if (e->model->flags & MOD_FBRIGHTHACK && gl_fullbrights.value)
-	{
-		lightcolor[0] = 256.0f;
-		lightcolor[1] = 256.0f;
-		lightcolor[2] = 256.0f;
-	}
+        //hack up the brightness when fullbrights but no overbrights (256)
+        if (!gl_overbright_models.value && (e->model->flags & MOD_FBRIGHTHACK) && gl_fullbrights.value)
+        {
+                lightcolor[0] = 256.0f;
+                lightcolor[1] = 256.0f;
+                lightcolor[2] = 256.0f;
+        }
 
-        VectorScale (lightcolor, 1.0f / 200.0f, lightcolor);
+        const float overbright = gl_overbright_models.value ? 2.0f : 1.0f;
+
+        for (i = 0; i < 3; i++)
+        {
+                float L = lightcolor[i] * (1.0f / 256.0f);
+                L = fminf(L * overbright, 1.0f);
+                L = powf(L, 1.0f / 2.2f);
+                lightcolor[i] = L;
+        }
 }
 
 /*


### PR DESCRIPTION
## Summary
- upload alias model skins as sRGB textures and keep sRGB decoding enabled
- apply linear-space overbright scaling with gamma-corrected alias lighting

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f38499000832e81f2695419a3127c)