### PR TITLE
Add modern weapon kick option

### DIFF
--- a/Quake/menu.c
+++ b/Quake/menu.c
@@ -3775,7 +3775,7 @@ void M_AdjustSliders (int dir)
 		break;
 
 	case OPT_RECOIL:	// gun kick
-		Cvar_SetValueQuick (&v_gunkick, ((int) q_max (v_gunkick.value, 0.f) + 3 + dir) % 3);
+		Cvar_SetValueQuick (&v_gunkick, ((int) q_max (v_gunkick.value, 0.f) + 4 + dir) % 4);
 		break;
 
 	case OPT_FLASHALPHA:	// flash intensity
@@ -4381,7 +4381,9 @@ static void M_Options_DrawItem (int y, int item)
 		break;
 
 	case OPT_RECOIL:
-		if ((int)v_gunkick.value == 2)
+		if ((int)v_gunkick.value == 3)
+			M_Print (x, y, "Modern");
+		else if ((int)v_gunkick.value == 2)
 			M_Print (x, y, "Smooth");
 		else if ((int)v_gunkick.value == 1)
 			M_Print (x, y, "Classic");

--- a/Quake/view.c
+++ b/Quake/view.c
@@ -851,7 +851,7 @@ void V_CalcRefdef (void)
 	view->colormap = vid.colormap;
 	view->scale = ENTSCALE_DEFAULT;
 
-//johnfitz -- v_gunkick
+	//johnfitz -- v_gunkick
 	if (v_gunkick.value == 1) //original quake kick
 		VectorAdd (r_refdef.viewangles, cl.punchangle, r_refdef.viewangles);
 	if (v_gunkick.value == 2) //lerped kick
@@ -865,7 +865,16 @@ void V_CalcRefdef (void)
 		r_refdef.viewangles[1] += v_punchangles[1][1] + (v_punchangles[0][1] - v_punchangles[1][1]) * punchblend;
 		r_refdef.viewangles[2] += v_punchangles[1][2] + (v_punchangles[0][2] - v_punchangles[1][2]) * punchblend;
 	}
-//johnfitz
+	if (v_gunkick.value == 3) //modern style kick
+	{
+		float recoil = cl.punchangle[PITCH];
+		float recoil_bob = recoil * 0.3f;
+
+		r_refdef.viewangles[PITCH] -= recoil * 0.5f;
+		r_refdef.vieworg[2] += recoil_bob;
+		view->origin[2] += recoil_bob;
+	}
+	//johnfitz
 
 // smooth out stair step ups
 	if (!noclip_anglehack && cl.onground && ent->origin[2] - oldz > 0) //johnfitz -- added exception for noclip


### PR DESCRIPTION
## Summary
- add a modern weapon kick mode that applies recoil to pitch and weapon bob
- expose the new recoil option in the in-game menu

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f5147a034832ebc9b01625d775bf3)