### PR TITLE
Improve dynamic light falloff

### DIFF
--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -404,15 +404,17 @@ void main()
                                         if (rad < minlight)
                                                 continue;
                                         vec3 local_pos = l.origin - plane.xyz * dist;
-                                        minlight = rad - minlight;
                                         vec3 light_vec = local_pos - in_pos;
                                         float surface_dist = length(light_vec);
-                                        float attenuation = clamp((minlight - surface_dist) / 16.0, 0.0, 1.0);
-                                        float normalized_dist = surface_dist / rad;
-                                        float falloff = pow(1.0 - clamp(normalized_dist, 0.0, 1.0), 1.5);
-                                        vec3 light_contrib = attenuation * falloff * l.color;
+
+                                        float effective_radius = max(rad - minlight, 0.0);
+                                        float normalized_dist = effective_radius > 0.0 ?
+                                                clamp((surface_dist - minlight) / effective_radius, 0.0, 1.0) :
+                                                1.0;
+                                        float attenuation = pow(1.0 - normalized_dist, 2.0);
+                                        vec3 light_contrib = attenuation * l.color;
                                         dynamic_light += light_contrib;
-                                        if (attenuation > 0.0 && falloff > 0.0 && surface_dist > 0.0)
+                                        if (attenuation > 0.0 && surface_dist > 0.0)
                                         {
                                                 vec3 light_dir = light_vec / surface_dist;
                                                 float ndotl = max(dot(surface_normal, light_dir), 0.0);


### PR DESCRIPTION
## Summary
- adjust dynamic light attenuation to smoothly fall off toward light boundaries

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f57b9c1b0832ebf5ee23d79efc6c3)