### PR TITLE
Add noise-based variation to fog calculations

### DIFF
--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -40,11 +40,18 @@ float bayer(ivec2 coord)
         return bayer01(coord) - 0.5;
 }
 
+float FogNoise(vec2 worldPos)
+{
+	return fract(sin(dot(worldPos, vec2(12.9898, 78.233))) * 43758.5453);
+}
+
 vec3 ApplyFog(vec3 clr, vec3 p)
 {
-        float fog = exp2(-abs(Fog.w) * dot(p, p));
-        fog = clamp(fog, 0.0, 1.0);
-        return mix(Fog.rgb, clr, fog);
+	float fog = exp2(-abs(Fog.w) * dot(p, p));
+	float noise = FogNoise((p + EyePos).xy);
+	fog *= mix(0.8, 1.2, noise);
+	fog = clamp(fog, 0.0, 1.0);
+	return mix(Fog.rgb, clr, fog);
 }
 
 // Hash without Sine

--- a/Quake/shaders/cluster_lights.comp
+++ b/Quake/shaders/cluster_lights.comp
@@ -2,9 +2,16 @@ layout(local_size_x=8, local_size_y=8, local_size_z=1) in;
 
 #include "frame_uniforms.glsl"
 
+float FogNoise(vec2 worldPos)
+{
+	return fract(sin(dot(worldPos, vec2(12.9898, 78.233))) * 43758.5453);
+}
+
 vec3 ApplyFog(vec3 clr, vec3 p)
 {
 	float fog = exp2(-Fog.w * dot(p, p));
+	float noise = FogNoise((p + EyePos).xy);
+	fog *= mix(0.8, 1.2, noise);
 	fog = clamp(fog, 0.0, 1.0);
 	return mix(Fog.rgb, clr, fog);
 }

--- a/Quake/shaders/debug3d.vert
+++ b/Quake/shaders/debug3d.vert
@@ -1,8 +1,15 @@
 #include "frame_uniforms.glsl"
 
+float FogNoise(vec2 worldPos)
+{
+	return fract(sin(dot(worldPos, vec2(12.9898, 78.233))) * 43758.5453);
+}
+
 vec3 ApplyFog(vec3 clr, vec3 p)
 {
 	float fog = exp2(-Fog.w * dot(p, p));
+	float noise = FogNoise((p + EyePos).xy);
+	fog *= mix(0.8, 1.2, noise);
 	fog = clamp(fog, 0.0, 1.0);
 	return mix(Fog.rgb, clr, fog);
 }

--- a/Quake/shaders/particles.frag
+++ b/Quake/shaders/particles.frag
@@ -1,8 +1,15 @@
 #include "frame_uniforms.glsl"
 
+float FogNoise(vec2 worldPos)
+{
+	return fract(sin(dot(worldPos, vec2(12.9898, 78.233))) * 43758.5453);
+}
+
 vec3 ApplyFog(vec3 clr, vec3 p)
 {
 	float fog = exp2(-Fog.w * dot(p, p));
+	float noise = FogNoise((p + EyePos).xy);
+	fog *= mix(0.8, 1.2, noise);
 	fog = clamp(fog, 0.0, 1.0);
 	return mix(Fog.rgb, clr, fog);
 }

--- a/Quake/shaders/particles.vert
+++ b/Quake/shaders/particles.vert
@@ -1,8 +1,15 @@
 #include "frame_uniforms.glsl"
 
+float FogNoise(vec2 worldPos)
+{
+	return fract(sin(dot(worldPos, vec2(12.9898, 78.233))) * 43758.5453);
+}
+
 vec3 ApplyFog(vec3 clr, vec3 p)
 {
 	float fog = exp2(-Fog.w * dot(p, p));
+	float noise = FogNoise((p + EyePos).xy);
+	fog *= mix(0.8, 1.2, noise);
 	fog = clamp(fog, 0.0, 1.0);
 	return mix(Fog.rgb, clr, fog);
 }

--- a/Quake/shaders/sky_cubemap.frag
+++ b/Quake/shaders/sky_cubemap.frag
@@ -1,8 +1,15 @@
 #include "frame_uniforms.glsl"
 
+float FogNoise(vec2 worldPos)
+{
+	return fract(sin(dot(worldPos, vec2(12.9898, 78.233))) * 43758.5453);
+}
+
 vec3 ApplyFog(vec3 clr, vec3 p)
 {
 	float fog = exp2(-Fog.w * dot(p, p));
+	float noise = FogNoise((p + EyePos).xy);
+	fog *= mix(0.8, 1.2, noise);
 	fog = clamp(fog, 0.0, 1.0);
 	return mix(Fog.rgb, clr, fog);
 }

--- a/Quake/shaders/sky_cubemap.vert
+++ b/Quake/shaders/sky_cubemap.vert
@@ -8,9 +8,16 @@
 
 #include "frame_uniforms.glsl"
 
+float FogNoise(vec2 worldPos)
+{
+	return fract(sin(dot(worldPos, vec2(12.9898, 78.233))) * 43758.5453);
+}
+
 vec3 ApplyFog(vec3 clr, vec3 p)
 {
 	float fog = exp2(-Fog.w * dot(p, p));
+	float noise = FogNoise((p + EyePos).xy);
+	fog *= mix(0.8, 1.2, noise);
 	fog = clamp(fog, 0.0, 1.0);
 	return mix(Fog.rgb, clr, fog);
 }

--- a/Quake/shaders/sky_layers.frag
+++ b/Quake/shaders/sky_layers.frag
@@ -7,9 +7,16 @@
 
 #include "frame_uniforms.glsl"
 
+float FogNoise(vec2 worldPos)
+{
+	return fract(sin(dot(worldPos, vec2(12.9898, 78.233))) * 43758.5453);
+}
+
 vec3 ApplyFog(vec3 clr, vec3 p)
 {
 	float fog = exp2(-Fog.w * dot(p, p));
+	float noise = FogNoise((p + EyePos).xy);
+	fog *= mix(0.8, 1.2, noise);
 	fog = clamp(fog, 0.0, 1.0);
 	return mix(Fog.rgb, clr, fog);
 }

--- a/Quake/shaders/sky_layers.vert
+++ b/Quake/shaders/sky_layers.vert
@@ -8,9 +8,16 @@
 
 #include "frame_uniforms.glsl"
 
+float FogNoise(vec2 worldPos)
+{
+	return fract(sin(dot(worldPos, vec2(12.9898, 78.233))) * 43758.5453);
+}
+
 vec3 ApplyFog(vec3 clr, vec3 p)
 {
 	float fog = exp2(-Fog.w * dot(p, p));
+	float noise = FogNoise((p + EyePos).xy);
+	fog *= mix(0.8, 1.2, noise);
 	fog = clamp(fog, 0.0, 1.0);
 	return mix(Fog.rgb, clr, fog);
 }

--- a/Quake/shaders/skystencil.vert
+++ b/Quake/shaders/skystencil.vert
@@ -8,9 +8,16 @@
 
 #include "frame_uniforms.glsl"
 
+float FogNoise(vec2 worldPos)
+{
+	return fract(sin(dot(worldPos, vec2(12.9898, 78.233))) * 43758.5453);
+}
+
 vec3 ApplyFog(vec3 clr, vec3 p)
 {
 	float fog = exp2(-Fog.w * dot(p, p));
+	float noise = FogNoise((p + EyePos).xy);
+	fog *= mix(0.8, 1.2, noise);
 	fog = clamp(fog, 0.0, 1.0);
 	return mix(Fog.rgb, clr, fog);
 }

--- a/Quake/shaders/sprites.frag
+++ b/Quake/shaders/sprites.frag
@@ -1,8 +1,15 @@
 #include "frame_uniforms.glsl"
 
+float FogNoise(vec2 worldPos)
+{
+	return fract(sin(dot(worldPos, vec2(12.9898, 78.233))) * 43758.5453);
+}
+
 vec3 ApplyFog(vec3 clr, vec3 p)
 {
 	float fog = exp2(-Fog.w * dot(p, p));
+	float noise = FogNoise((p + EyePos).xy);
+	fog *= mix(0.8, 1.2, noise);
 	fog = clamp(fog, 0.0, 1.0);
 	return mix(Fog.rgb, clr, fog);
 }

--- a/Quake/shaders/sprites.vert
+++ b/Quake/shaders/sprites.vert
@@ -1,8 +1,15 @@
 #include "frame_uniforms.glsl"
 
+float FogNoise(vec2 worldPos)
+{
+	return fract(sin(dot(worldPos, vec2(12.9898, 78.233))) * 43758.5453);
+}
+
 vec3 ApplyFog(vec3 clr, vec3 p)
 {
 	float fog = exp2(-Fog.w * dot(p, p));
+	float noise = FogNoise((p + EyePos).xy);
+	fog *= mix(0.8, 1.2, noise);
 	fog = clamp(fog, 0.0, 1.0);
 	return mix(Fog.rgb, clr, fog);
 }

--- a/Quake/shaders/water.frag
+++ b/Quake/shaders/water.frag
@@ -31,11 +31,16 @@ float bayer01(ivec2 coord)
 
 float bayer(ivec2 coord)
 {
-	return bayer01(coord) - 0.5;
+        return bayer01(coord) - 0.5;
+}
+
+float FogNoise(vec2 worldPos)
+{
+	return fract(sin(dot(worldPos, vec2(12.9898, 78.233))) * 43758.5453);
 }
 
 // Hash without Sine
-// https://www.shadertoy.com/view/4djSRW 
+// https://www.shadertoy.com/view/4djSRW
 float whitenoise01(vec2 p)
 {
 	vec3 p3 = fract(vec3(p.xyx) * .1031);
@@ -151,8 +156,10 @@ void main()
         result.rgb += fullbright;
         result.rgb += emissive;
         result.rgb = clamp(result.rgb, 0.0, 1.0);
-        float fog = exp2(-Fog.w * dot(in_pos - EyePos, in_pos - EyePos));
-        fog = clamp(fog, 0.0, 1.0);
+	float fog = exp2(-Fog.w * dot(in_pos - EyePos, in_pos - EyePos));
+	float noise = FogNoise(in_pos.xy);
+	fog *= mix(0.8, 1.2, noise);
+	fog = clamp(fog, 0.0, 1.0);
 
         result.rgb = mix(Fog.rgb, result.rgb, fog);
         result.a *= in_alpha * fog;

--- a/Quake/shaders/water.vert
+++ b/Quake/shaders/water.vert
@@ -8,9 +8,16 @@
 
 #include "frame_uniforms.glsl"
 
+float FogNoise(vec2 worldPos)
+{
+	return fract(sin(dot(worldPos, vec2(12.9898, 78.233))) * 43758.5453);
+}
+
 vec3 ApplyFog(vec3 clr, vec3 p)
 {
 	float fog = exp2(-Fog.w * dot(p, p));
+	float noise = FogNoise((p + EyePos).xy);
+	fog *= mix(0.8, 1.2, noise);
 	fog = clamp(fog, 0.0, 1.0);
 	return mix(Fog.rgb, clr, fog);
 }

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -9,11 +9,18 @@ layout(binding=2) uniform sampler2D LMTex;
 layout(binding=3) uniform sampler2D LMTexDir;
 #include "frame_uniforms.glsl"
 
+float FogNoise(vec2 worldPos)
+{
+	return fract(sin(dot(worldPos, vec2(12.9898, 78.233))) * 43758.5453);
+}
+
 vec3 ApplyFog(vec3 clr, vec3 p)
 {
-        float fog = exp2(-abs(Fog.w) * dot(p, p));
-        fog = clamp(fog, 0.0, 1.0);
-        return mix(Fog.rgb, clr, fog);
+	float fog = exp2(-abs(Fog.w) * dot(p, p));
+	float noise = FogNoise((p + EyePos).xy);
+	fog *= mix(0.8, 1.2, noise);
+	fog = clamp(fog, 0.0, 1.0);
+	return mix(Fog.rgb, clr, fog);
 }
 
 #define LIGHT_TILES_X 32

--- a/Quake/shaders/world.vert
+++ b/Quake/shaders/world.vert
@@ -8,9 +8,16 @@
 
 #include "frame_uniforms.glsl"
 
+float FogNoise(vec2 worldPos)
+{
+	return fract(sin(dot(worldPos, vec2(12.9898, 78.233))) * 43758.5453);
+}
+
 vec3 ApplyFog(vec3 clr, vec3 p)
 {
 	float fog = exp2(-Fog.w * dot(p, p));
+	float noise = FogNoise((p + EyePos).xy);
+	fog *= mix(0.8, 1.2, noise);
 	fog = clamp(fog, 0.0, 1.0);
 	return mix(Fog.rgb, clr, fog);
 }


### PR DESCRIPTION
## Summary
- add a reusable noise helper to fog calculations to vary density per pixel
- apply the fog modulation to world geometry, models, particles, skies, sprites, and water shaders

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f66caad24832e94229febbc7fdae4)