### PR TITLE
Declare SV_FatPVS prototype in gl_rlight

### DIFF
--- a/Quake/gl_rlight.c
+++ b/Quake/gl_rlight.c
@@ -26,6 +26,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 extern cvar_t r_flatlightstyles; //johnfitz
 extern cvar_t r_lerplightstyles;
 extern cvar_t r_dynamic;
+extern byte *SV_FatPVS (vec3_t org, qmodel_t *worldmodel);
 
 gpulightbuffer_t r_lightbuffer;
 float r_lightstyle_framefrac;


### PR DESCRIPTION
## Summary
- declare SV_FatPVS in gl_rlight to avoid implicit function warnings when building

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f76256148832e85c6ba369cb9caad)