### PR TITLE
Pause playback during asset loading

### DIFF
--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -292,6 +292,8 @@ void CL_ParseServerInfo (void)
 
 	Con_DPrintf ("Serverinfo packet received.\n");
 
+	Host_BeginAssetLoading ();
+
 // ericw -- bring up loading plaque for map changes within a demo.
 //          it will be hidden in CL_SignonReply.
 	if (cls.demoplayback)
@@ -434,6 +436,8 @@ void CL_ParseServerInfo (void)
 	noclip_anglehack = false;		// noclip is turned off at start
 
 	warn_about_nehahra_protocol = true; //johnfitz -- warn about nehahra protocol hack once per server connection
+
+	Host_EndAssetLoading ();
 
 //johnfitz -- reset developer stats
 	memset(&dev_stats, 0, sizeof(dev_stats));

--- a/Quake/gl_screen.c
+++ b/Quake/gl_screen.c
@@ -1891,6 +1891,8 @@ void SCR_BeginLoadingPlaque (void)
 	if (cls.signon != SIGNONS)
 		return;
 
+	Host_BeginAssetLoading ();
+
 // redraw with no console and the loading plaque
 	if (key_dest != key_console)
 	{
@@ -1918,6 +1920,7 @@ SCR_EndLoadingPlaque
 */
 void SCR_EndLoadingPlaque (void)
 {
+	Host_EndAssetLoading ();
 	scr_disabled_for_loading = false;
 	Con_ClearNotify ();
 }

--- a/Quake/gl_texmgr.c
+++ b/Quake/gl_texmgr.c
@@ -561,6 +561,8 @@ void TexMgr_CompressTextures_f (cvar_t *var)
 {
 	gltexture_t	*glt;
 
+	Host_BeginAssetLoading ();
+
 	Con_SafePrintf ("Using %s textures\n", var->value ? "compressed" : "uncompressed");
 
 	// In an attempt to reduce VRAM fragmentation, instead of unloading and reloading
@@ -572,6 +574,8 @@ void TexMgr_CompressTextures_f (cvar_t *var)
 	for (glt = active_gltextures; glt; glt = glt->next)
 		if (TexMgr_CanCompress (glt))
 			TexMgr_ReloadImage (glt, -1, -1);
+
+	Host_EndAssetLoading ();
 }
 
 /*

--- a/Quake/host.c
+++ b/Quake/host.c
@@ -51,6 +51,11 @@ int		host_framecount;
 
 int		host_hunklevel;
 
+static int		host_assetloading_depth;
+static qboolean	host_assetloading_sound_blocked;
+static qboolean	host_assetloading_was_demopaused;
+static qboolean	host_assetloading_was_demoplayback;
+
 int		minimum_memory;
 
 client_t	*host_client;			// current client
@@ -97,6 +102,49 @@ cvar_t	sv_autosave_interval = {"sv_autosave_interval", "30", CVAR_ARCHIVE};
 
 devstats_t dev_stats, dev_peakstats;
 overflowtimes_t dev_overflows; //this stores the last time overflow messages were displayed, not the last time overflows occured
+
+
+/*
+================
+Host_BeginAssetLoading
+================
+*/
+void Host_BeginAssetLoading (void)
+{
+	if (host_assetloading_depth++ > 0)
+		return;
+
+	host_assetloading_sound_blocked = S_IsSoundBlocked ();
+	host_assetloading_was_demoplayback = cls.demoplayback;
+	host_assetloading_was_demopaused = cls.demopaused;
+
+	if (!host_assetloading_sound_blocked)
+		S_BlockSound ();
+
+	if (cls.demoplayback)
+		cls.demopaused = true;
+}
+
+/*
+================
+Host_EndAssetLoading
+================
+*/
+void Host_EndAssetLoading (void)
+{
+	if (host_assetloading_depth == 0)
+		return;
+
+	host_assetloading_depth--;
+	if (host_assetloading_depth > 0)
+		return;
+
+	if (!host_assetloading_sound_blocked)
+		S_UnblockSound ();
+
+	if (host_assetloading_was_demoplayback && cls.demoplayback)
+		cls.demopaused = host_assetloading_was_demopaused;
+}
 
 /*
 ================

--- a/Quake/q_sound.h
+++ b/Quake/q_sound.h
@@ -102,6 +102,7 @@ void S_ExtraUpdate (void);
 
 void S_BlockSound (void);
 void S_UnblockSound (void);
+qboolean S_IsSoundBlocked (void);
 
 sfx_t *S_PrecacheSound (const char *sample);
 void S_TouchSound (const char *sample);

--- a/Quake/quakedef.h
+++ b/Quake/quakedef.h
@@ -411,6 +411,8 @@ void Host_Frame (double time);
 void Host_Quit_f (void);
 void Host_ClientCommands (const char *fmt, ...) FUNC_PRINTF(1,2);
 void Host_ShutdownServer (qboolean crash);
+void Host_BeginAssetLoading (void);
+void Host_EndAssetLoading (void);
 void Host_WriteConfiguration (void);
 void Host_Resetdemos (void);
 

--- a/Quake/snd_dma.c
+++ b/Quake/snd_dma.c
@@ -1009,6 +1009,12 @@ void S_UnblockSound (void)
 	}
 }
 
+qboolean S_IsSoundBlocked (void)
+{
+	return snd_blocked > 0;
+}
+
+
 /*
 ===============================================================================
 


### PR DESCRIPTION
## Summary
- pause demos and block audio while server info precaching and loading screens run
- wrap texture compression passes in the same loading pause to avoid stuttering
- add sound block query helper to safely restore previous state when unblocking

## Testing
- Not run (not requested).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f780624c0832ebaa0e3ea1285d97c)