### PR TITLE
Add color-shift flicker for torch lights

### DIFF
--- a/Quake/gl_rlight.c
+++ b/Quake/gl_rlight.c
@@ -202,6 +202,12 @@ void R_PushDlights (void)
                         finalcolor[0] *= flicker;
                         finalcolor[1] *= flicker;
                         finalcolor[2] *= flicker;
+                        if (l->type == DLIGHT_TORCH)
+                        {
+                                float colorshift = (float)sin (cl.time * 11.0 + l->key) * 0.1f;
+                                finalcolor[0] *= 1.0f + colorshift;
+                                finalcolor[1] *= 1.0f - colorshift;
+                        }
                         out->pos[0]   = l->origin[0];
                         out->pos[1]   = l->origin[1];
                         out->pos[2]   = l->origin[2];


### PR DESCRIPTION
## Summary
- add a hue-shifting flicker to torch dynamic lights for a more natural fire effect

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ff665428c832ea2545c59a2a12ba5)