### PR TITLE
Add dynamic afterglow to dynamic lights

### DIFF
--- a/Quake/cl_main.c
+++ b/Quake/cl_main.c
@@ -360,31 +360,33 @@ dlight_t *CL_AllocDlight (int key)
 	if (key)
 	{
 		dl = cl_dlights;
-		for (i=0 ; i<MAX_DLIGHTS ; i++, dl++)
-		{
-			if (dl->key == key)
-			{
-				memset (dl, 0, sizeof(*dl));
-				dl->key = key;
+                for (i=0 ; i<MAX_DLIGHTS ; i++, dl++)
+                {
+                        if (dl->key == key)
+                        {
+                                memset (dl, 0, sizeof(*dl));
+                                dl->key = key;
                                 dl->color[0] = dl->color[1] = dl->color[2] = 1; //johnfitz -- lit support via lordhavoc
                                 dl->type = DLIGHT_DEFAULT;
                                 dl->spawn = cl.time - 0.001;
+                                dl->flicker_seed = (float) rand ();
                                 return dl;
                         }
-		}
-	}
+                }
+        }
 
 // then look for anything else
 	dl = cl_dlights;
 	for (i=0 ; i<MAX_DLIGHTS ; i++, dl++)
 	{
-		if (dl->die < cl.time || dl->spawn > cl.time)
+                if (dl->die < cl.time || dl->spawn > cl.time)
                 {
                         memset (dl, 0, sizeof(*dl));
                         dl->key = key;
                         dl->color[0] = dl->color[1] = dl->color[2] = 1; //johnfitz -- lit support via lordhavoc
                         dl->type = DLIGHT_DEFAULT;
                         dl->spawn = cl.time - 0.001;
+                        dl->flicker_seed = (float) rand ();
                         return dl;
                 }
         }
@@ -395,6 +397,7 @@ dlight_t *CL_AllocDlight (int key)
         dl->color[0] = dl->color[1] = dl->color[2] = 1; //johnfitz -- lit support via lordhavoc
         dl->type = DLIGHT_DEFAULT;
         dl->spawn = cl.time - 0.001;
+        dl->flicker_seed = (float) rand ();
         return dl;
 }
 
@@ -413,16 +416,20 @@ void CL_DecayLights (void)
 
 	time = cl.time - cl.oldtime;
 
-	dl = cl_dlights;
-	for (i=0 ; i<MAX_DLIGHTS ; i++, dl++)
-	{
-		if (dl->die < cl.time || dl->spawn > cl.time || !dl->radius)
-			continue;
+        dl = cl_dlights;
+        for (i=0 ; i<MAX_DLIGHTS ; i++, dl++)
+        {
+                if (dl->die < cl.time || dl->spawn > cl.time || !dl->baseradius)
+                        continue;
 
-		dl->radius -= time*dl->decay;
-		if (dl->radius < 0)
-			dl->radius = 0;
-	}
+                dl->baseradius -= time*dl->decay;
+                if (dl->baseradius < 0)
+                        dl->baseradius = 0;
+
+                dl->radius = dl->baseradius * (1.0f + 0.1f * (float) sin (cl.time * 9.0 + dl->flicker_seed));
+                if (dl->radius < 0)
+                        dl->radius = 0;
+        }
 }
 
 
@@ -691,12 +698,13 @@ void CL_RelinkEntities (void)
 			dl->origin[2] += 16;
 			AngleVectors (ent->angles, fv, rv, uv);
 
-			VectorMA (dl->origin, 18, fv, dl->origin);
-			dl->radius = 200 + (rand()&31);
-			dl->minlight = 32;
-			dl->die = cl.time + 0.1;
-			dl->color[0] = 1.00f; dl->color[1] = 0.70f; dl->color[2] = 0.30f;
-			CL_SetDlightColorForEntity (dl, ent);
+                        VectorMA (dl->origin, 18, fv, dl->origin);
+                        dl->radius = 200 + (rand()&31);
+                        dl->baseradius = dl->radius;
+                        dl->minlight = 32;
+                        dl->die = cl.time + 0.1;
+                        dl->color[0] = 1.00f; dl->color[1] = 0.70f; dl->color[2] = 0.30f;
+                        CL_SetDlightColorForEntity (dl, ent);
 
 			//johnfitz -- assume muzzle flash accompanied by muzzle flare, which looks bad when lerped
 			if (r_lerpmodels.value != 2)
@@ -708,12 +716,13 @@ void CL_RelinkEntities (void)
 			}
 			//johnfitz
 		}
-		if (ent->effects & EF_BRIGHTLIGHT)
-		{
-			dl = CL_AllocDlight (i);
+                if (ent->effects & EF_BRIGHTLIGHT)
+                {
+                        dl = CL_AllocDlight (i);
                         VectorCopy (ent->origin,  dl->origin);
                         dl->origin[2] += 16;
                         dl->radius = 400 + (rand()&31);
+                        dl->baseradius = dl->radius;
                         dl->die = cl.time + 0.001;
                         CL_SetDlightColorForEntity (dl, ent);
                 }
@@ -722,29 +731,32 @@ void CL_RelinkEntities (void)
                         dl = CL_AllocDlight (i);
                         VectorCopy (ent->origin,  dl->origin);
                         dl->radius = 200 + (rand()&31);
+                        dl->baseradius = dl->radius;
                         dl->die = cl.time + 0.001;
                         CL_SetDlightColorForEntity (dl, ent);
                 }
-		if (ent->effects & EF_QEX_QUADLIGHT)
-		{
-			dl = CL_AllocDlight (i);
-			VectorCopy (ent->origin,  dl->origin);
-			dl->radius = 200 + (rand()&31);
-			dl->die = cl.time + 0.001;
-			dl->color[0] = 0.25f;
-			dl->color[1] = 0.25f;
-			dl->color[2] = 1.0f;
-		}
-		if (ent->effects & EF_QEX_PENTALIGHT)
-		{
-			dl = CL_AllocDlight (i);
-			VectorCopy (ent->origin,  dl->origin);
-			dl->radius = 200 + (rand()&31);
-			dl->die = cl.time + 0.001;
-			dl->color[0] = 1.0f;
-			dl->color[1] = 0.25f;
-			dl->color[2] = 0.25f;
-		}
+                if (ent->effects & EF_QEX_QUADLIGHT)
+                {
+                        dl = CL_AllocDlight (i);
+                        VectorCopy (ent->origin,  dl->origin);
+                        dl->radius = 200 + (rand()&31);
+                        dl->baseradius = dl->radius;
+                        dl->die = cl.time + 0.001;
+                        dl->color[0] = 0.25f;
+                        dl->color[1] = 0.25f;
+                        dl->color[2] = 1.0f;
+                }
+                if (ent->effects & EF_QEX_PENTALIGHT)
+                {
+                        dl = CL_AllocDlight (i);
+                        VectorCopy (ent->origin,  dl->origin);
+                        dl->radius = 200 + (rand()&31);
+                        dl->baseradius = dl->radius;
+                        dl->die = cl.time + 0.001;
+                        dl->color[0] = 1.0f;
+                        dl->color[1] = 0.25f;
+                        dl->color[2] = 0.25f;
+                }
 
 		if (ent->model->flags & EF_GIB)
 			CL_RocketTrail (ent, 2);
@@ -754,12 +766,13 @@ void CL_RelinkEntities (void)
 			CL_RocketTrail (ent, 3);
 		else if (ent->model->flags & EF_TRACER2)
 			CL_RocketTrail (ent, 5);
-		else if (ent->model->flags & EF_ROCKET)
-		{
+                else if (ent->model->flags & EF_ROCKET)
+                {
                         CL_RocketTrail (ent, 0);
                         dl = CL_AllocDlight (i);
                         VectorCopy (ent->origin, dl->origin);
                         dl->radius = 200;
+                        dl->baseradius = dl->radius;
                         dl->die = cl.time + 0.01;
                         dl->type = DLIGHT_ROCKET;
                         CL_SetDlightColorForEntity (dl, ent);
@@ -848,10 +861,10 @@ int CL_ReadFromServer (void)
 	dev_stats.beams = num_beams;
 	dev_peakstats.beams = q_max(num_beams, dev_peakstats.beams);
 
-	//dlights
-	for (i=0, l=cl_dlights ; i<MAX_DLIGHTS ; i++, l++)
-		if (l->die >= cl.time && l->spawn <= cl.time && l->radius)
-			num_dlights++;
+        //dlights
+        for (i=0, l=cl_dlights ; i<MAX_DLIGHTS ; i++, l++)
+                if (l->die >= cl.time && l->spawn <= cl.time && l->baseradius)
+                        num_dlights++;
 	if (num_dlights > 32 && dev_peakstats.dlights <= 32)
 		Con_DWarning ("%i dlights exceeded standard limit of 32 (max = %d).\n", num_dlights, MAX_DLIGHTS);
 	dev_stats.dlights = num_dlights;

--- a/Quake/cl_tent.c
+++ b/Quake/cl_tent.c
@@ -191,10 +191,11 @@ void CL_ParseTEnt (void)
 		pos[0] = MSG_ReadCoord (cl.protocolflags);
 		pos[1] = MSG_ReadCoord (cl.protocolflags);
 		pos[2] = MSG_ReadCoord (cl.protocolflags);
-		R_ParticleExplosion (pos);
+                R_ParticleExplosion (pos);
                 dl = CL_AllocDlight (0);
                 VectorCopy (pos, dl->origin);
                 dl->radius = 350;
+                dl->baseradius = dl->radius;
                 dl->color[0] = 1.00f; dl->color[1] = 0.50f; dl->color[2] = 0.25f;
                 dl->die = cl.time + 0.5;
                 dl->decay = 300;
@@ -206,10 +207,10 @@ void CL_ParseTEnt (void)
 		pos[0] = MSG_ReadCoord (cl.protocolflags);
 		pos[1] = MSG_ReadCoord (cl.protocolflags);
 		pos[2] = MSG_ReadCoord (cl.protocolflags);
-		R_BlobExplosion (pos);
+                R_BlobExplosion (pos);
 
-		S_StartSound (-1, 0, cl_sfx_r_exp3, pos, 1, 1);
-		break;
+                S_StartSound (-1, 0, cl_sfx_r_exp3, pos, 1, 1);
+                break;
 
 	case TE_LIGHTNING1:				// lightning bolts
 		CL_ParseBeam (Mod_ForName("progs/bolt.mdl", true));
@@ -249,10 +250,11 @@ void CL_ParseTEnt (void)
 		pos[2] = MSG_ReadCoord (cl.protocolflags);
 		colorStart = MSG_ReadByte ();
 		colorLength = MSG_ReadByte ();
-		R_ParticleExplosion2 (pos, colorStart, colorLength);
+                R_ParticleExplosion2 (pos, colorStart, colorLength);
                 dl = CL_AllocDlight (0);
                 VectorCopy (pos, dl->origin);
                 dl->radius = 350;
+                dl->baseradius = dl->radius;
                 dl->die = cl.time + 0.5;
                 dl->decay = 300;
                 dl->type = DLIGHT_EXPLOSION;

--- a/Quake/client.h
+++ b/Quake/client.h
@@ -81,12 +81,14 @@ typedef struct
 {
 	vec3_t	origin;
 	float	radius;
+	float	baseradius;
 	float	spawn;				// stop lighting before this time
 	float	die;				// stop lighting after this time
 	float	decay;				// drop this each second
 	float	minlight;			// don't add when contributing less
 	int		key;
 	vec3_t	color;				//johnfitz -- lit support via lordhavoc
+	float	flicker_seed;
 	dlighttype_t type;
 } dlight_t;
 

--- a/Quake/gl_rlight.c
+++ b/Quake/gl_rlight.c
@@ -168,32 +168,37 @@ void R_PushDlights (void)
 		for (i = 0, l = cl_dlights; i < MAX_DLIGHTS; i++, l++)
 		{
 			gpulight_t *out;
-			qboolean cull = false;
+                        qboolean cull = false;
+                        float radius;
 
-			if (l->spawn > cl.time)
-			{
-				l->die = 0.f;
-				continue;
-			}
+                        if (l->spawn > cl.time)
+                        {
+                                l->die = 0.f;
+                                continue;
+                        }
 
-			if (l->die < cl.time || !l->radius)
-				continue;
+                        if (l->die < cl.time || !l->baseradius)
+                                continue;
 
-			for (j = 0; j < 4; j++)
-			{
-				mplane_t *p = &frustum[j];
-				if (DotProduct (p->normal, l->origin) - p->dist + l->radius < 0.f)
-				{
-					cull = true;
-					break;
-				}
-			}
+                        radius = l->baseradius * (1.f + 0.1f * (float) sin (cl.time * 9.0 + l->flicker_seed));
+                        radius = q_max (radius, 0.f);
+                        l->radius = radius;
+
+                        for (j = 0; j < 4; j++)
+                        {
+                                mplane_t *p = &frustum[j];
+                                if (DotProduct (p->normal, l->origin) - p->dist + radius < 0.f)
+                                {
+                                        cull = true;
+                                        break;
+                                }
+                        }
                         if (cull)
                                 continue;
 
                         out = &r_lightbuffer.lights[r_framedata.numlights++];
                         const vec3_t *temp = R_GetDynamicLightTemperature (l->type);
-                        float radiusFactor = q_min (1.f, q_max (l->radius / 350.f, 0.2f));
+                        float radiusFactor = q_min (1.f, q_max (radius / 350.f, 0.2f));
                         float flicker = 1.f + (float)sin (cl.time * 15.0 + l->key) * 0.1f;
                         vec3_t finalcolor;
                         finalcolor[0] = l->color[0] * (*temp)[0] * radiusFactor;
@@ -211,7 +216,7 @@ void R_PushDlights (void)
                         out->pos[0]   = l->origin[0];
                         out->pos[1]   = l->origin[1];
                         out->pos[2]   = l->origin[2];
-                        out->radius   = l->radius;
+                        out->radius   = radius;
                         out->color[0] = finalcolor[0];
                         out->color[1] = finalcolor[1];
                         out->color[2] = finalcolor[2];


### PR DESCRIPTION
## Summary
- add base radius tracking and per-light flicker seeds to dynamic lights
- animate dynamic light radii with a subtle sinusoidal afterglow that persists as they decay
- apply the animated radii when spawning explosions and during rendering/culling for more pronounced effects

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ff727c968832e94e25e9ff3d7098b)