### PR TITLE
Add ambient and rim lighting for viewmodels

### DIFF
--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -56,6 +56,8 @@ typedef struct aliasinstance_s {
 	float		prev_worldmatrix[12];
 	vec3_t		lightcolor;
 	float		alpha;
+	vec3_t		dlightcolor;
+	float		_pad0;
 	int32_t		pose1;
 	int32_t		pose2;
 	float		blend;
@@ -64,6 +66,7 @@ typedef struct aliasinstance_s {
 
 #define ALIAS_INSTANCE_FLAG_NONE          0
 #define ALIAS_INSTANCE_FLAG_NO_MOTION_BLUR (1 << 0)
+#define ALIAS_INSTANCE_FLAG_VIEWMODEL     (1 << 1)
 
 struct ibuf_s {
 	int			count;
@@ -229,11 +232,13 @@ void R_SetupEntityTransform (entity_t *e, lerpdata_t *lerpdata)
 R_SetupAliasLighting -- johnfitz -- broken out from R_DrawAliasModel and rewritten
 =================
 */
-void R_SetupAliasLighting (entity_t	*e)
+void R_SetupAliasLighting (entity_t     *e)
 {
 	vec3_t		dist;
 	float		add;
-	unsigned int	 i;
+	unsigned int	i;
+	vec3_t		dlightcolor = {0.f, 0.f, 0.f};
+	vec3_t		ambientcolor;
 
 	// if the initial trace is completely black, try again from above
 	// this helps with models whose origin is slightly below ground level
@@ -241,36 +246,49 @@ void R_SetupAliasLighting (entity_t	*e)
 	if (!R_LightPoint (e->origin, 0.f, &e->lightcache))
 		R_LightPoint (e->origin, e->model->maxs[2] * 0.5f, &e->lightcache);
 
+	VectorCopy (lightcolor, ambientcolor);
+
 	//add dlights
-       for (i=0; i<r_framedata.numlights; i++)
-       {
-               gpulight_t *l = &r_lightbuffer.lights[i];
-               VectorSubtract (e->origin, l->pos, dist);
-               add = DotProduct (dist, dist);
-               if (l->radius * l->radius > add)
-                       VectorMA (lightcolor, l->radius - sqrtf (add), l->color, lightcolor);
-       }
+	for (i=0; i<r_framedata.numlights; i++)
+	{
+		gpulight_t *l = &r_lightbuffer.lights[i];
+		VectorSubtract (e->origin, l->pos, dist);
+		add = DotProduct (dist, dist);
+		if (l->radius * l->radius > add)
+		{
+			const float intensity = l->radius - sqrtf (add);
+			VectorMA (lightcolor, intensity, l->color, lightcolor);
+			VectorMA (dlightcolor, intensity, l->color, dlightcolor);
+		}
+	}
 
-        // viewmodel lighting is typically darker because world lights aren't placed for a free camera
-        if (e == &cl.viewent)
-        {
-                for (i = 0; i < 3; i++)
-                {
-                        const float L = lightcolor[i];
-                        lightcolor[i] = fmaxf (L * 1.5f, L + 40.0f);
-                }
-        }
+	// viewmodel lighting is typically darker because world lights aren't placed for a free camera
+	if (e == &cl.viewent)
+	{
+		for (i = 0; i < 3; i++)
+		{
+			const float L = lightcolor[i];
+			const float new_L = fmaxf (L * 1.5f, L + 40.0f);
+			const float scale = L > 0.0f ? new_L / L : 0.0f;
+			ambientcolor[i] *= scale;
+			dlightcolor[i] *= scale;
+			lightcolor[i] = new_L;
+		}
+	}
 
-        // minimum light value on gun (24)
-        if (e == &cl.viewent)
-        {
-                add = 72.0f - (lightcolor[0] + lightcolor[1] + lightcolor[2]);
-                if (add > 0.0f)
+	// minimum light value on gun (24)
+	if (e == &cl.viewent)
+	{
+		add = 72.0f - (lightcolor[0] + lightcolor[1] + lightcolor[2]);
+		if (add > 0.0f)
 		{
 			add *= 1.0f / 3.0f;
 			lightcolor[0] += add;
 			lightcolor[1] += add;
 			lightcolor[2] += add;
+			ambientcolor[0] += add;
+			ambientcolor[1] += add;
+			ambientcolor[2] += add;
 		}
 	}
 
@@ -284,26 +302,49 @@ void R_SetupAliasLighting (entity_t	*e)
 			lightcolor[0] += add;
 			lightcolor[1] += add;
 			lightcolor[2] += add;
+			ambientcolor[0] += add;
+			ambientcolor[1] += add;
+			ambientcolor[2] += add;
 		}
 	}
 
-        //hack up the brightness when fullbrights but no overbrights (256)
-        if (!gl_overbright_models.value && (e->model->flags & MOD_FBRIGHTHACK) && gl_fullbrights.value)
-        {
-                lightcolor[0] = 256.0f;
-                lightcolor[1] = 256.0f;
-                lightcolor[2] = 256.0f;
-        }
+	//hack up the brightness when fullbrights but no overbrights (256)
+	if (!gl_overbright_models.value && (e->model->flags & MOD_FBRIGHTHACK) && gl_fullbrights.value)
+	{
+		lightcolor[0] = 256.0f;
+		lightcolor[1] = 256.0f;
+		lightcolor[2] = 256.0f;
+		VectorCopy (lightcolor, ambientcolor);
+		VectorClear (dlightcolor);
+	}
 
-        const float overbright = gl_overbright_models.value ? 2.0f : 1.0f;
+	const float overbright = gl_overbright_models.value ? 2.0f : 1.0f;
 
-        for (i = 0; i < 3; i++)
-        {
-                float L = lightcolor[i] * (1.0f / 256.0f);
-                L = fminf(L * overbright, 1.0f);
-                L = powf(L, 1.0f / 2.2f);
-                lightcolor[i] = L;
-        }
+	{
+		vec3_t pre_total;
+		vec3_t post_total;
+		VectorAdd (ambientcolor, dlightcolor, pre_total);
+		for (i = 0; i < 3; i++)
+		{
+			float L = pre_total[i] * (1.0f / 256.0f);
+			L = fminf(L * overbright, 1.0f);
+			L = powf(L, 1.0f / 2.2f);
+			post_total[i] = L;
+		}
+
+		for (i = 0; i < 3; i++)
+		{
+			const float total = pre_total[i];
+			const float ambient_ratio = total > 0.0f ? ambientcolor[i] / total : 0.0f;
+			const float dlight_ratio = total > 0.0f ? dlightcolor[i] / total : 0.0f;
+			ambientcolor[i] = post_total[i] * ambient_ratio;
+			dlightcolor[i] = post_total[i] * dlight_ratio;
+			lightcolor[i] = post_total[i];
+		}
+	}
+
+	VectorCopy (ambientcolor, e->lightcache.ambientcolor);
+	VectorCopy (dlightcolor, e->lightcache.dlightcolor);
 }
 
 /*
@@ -572,7 +613,11 @@ static void R_DrawAliasModel_Real (entity_t *e, qboolean showtris)
 	//
 
 	if (r_fullbright_cheatsafe || showtris)
+	{
 		lightcolor[0] = lightcolor[1] = lightcolor[2] = 0.5f;
+		VectorCopy (lightcolor, e->lightcache.ambientcolor);
+		VectorClear (e->lightcache.dlightcolor);
+	}
 
 	if (showtris)
 		entalpha = 1.f;
@@ -625,12 +670,11 @@ static void R_DrawAliasModel_Real (entity_t *e, qboolean showtris)
 	e->motion_blur_prev_frame = r_framecount;
 	e->motion_blur_prev_valid = true;
 
-	instance->lightcolor[0] = lightcolor[0];
-	instance->lightcolor[1] = lightcolor[1];
-	instance->lightcolor[2] = lightcolor[2];
+	VectorCopy (lightcolor, instance->lightcolor);
+	VectorCopy (e->lightcache.dlightcolor, instance->dlightcolor);
 	instance->alpha = entalpha;
 	if (e == &cl.viewent)
-		instance->flags |= ALIAS_INSTANCE_FLAG_NO_MOTION_BLUR;
+		instance->flags |= ALIAS_INSTANCE_FLAG_NO_MOTION_BLUR | ALIAS_INSTANCE_FLAG_VIEWMODEL;
 	instance->pose1 = lerpdata.pose1;
 	instance->pose2 = lerpdata.pose2;
 	instance->blend = lerpdata.blend;

--- a/Quake/render.h
+++ b/Quake/render.h
@@ -37,6 +37,8 @@ typedef struct lightcache_s {
 	vec3_t				pos;
 	short				ds;
 	short				dt;
+	vec3_t				ambientcolor;
+	vec3_t				dlightcolor;
 } lightcache_t;
 
 //johnfitz -- for lerping

--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -3,6 +3,7 @@ struct InstanceData
 	vec4	WorldMatrix[3];
 	vec4	PrevWorldMatrix[3];
 	vec4	LightColor; // xyz=LightColor w=Alpha
+	vec4	DLightColor; // xyz=DLightColor
 	int		Pose1;
 	int		Pose2;
 	float	Blend;
@@ -88,6 +89,7 @@ vec2 ComputeVelocity(vec4 curr_clip, vec4 prev_clip)
 }
 
 const int ALIAS_FLAG_NO_MOTION_BLUR = 1;
+const int ALIAS_FLAG_VIEWMODEL = 2;
 
 layout(binding=0) uniform sampler2D Tex;
 layout(binding=1) uniform sampler2D FullbrightTex;

--- a/Quake/shaders/alias.vert
+++ b/Quake/shaders/alias.vert
@@ -3,6 +3,7 @@ struct InstanceData
 	vec4	WorldMatrix[3];
 	vec4	PrevWorldMatrix[3];
 	vec4	LightColor; // xyz=LightColor w=Alpha
+	vec4	DLightColor; // xyz=DLightColor
 	int		Pose1;
 	int		Pose2;
 	float	Blend;
@@ -93,6 +94,8 @@ layout(location=3) noperspective out vec4 out_curr_clip;
 layout(location=4) noperspective out vec4 out_prev_clip;
 layout(location=5) flat out int out_flags;
 
+const int ALIAS_FLAG_VIEWMODEL = 2;
+
 void main()
 {
 	InstanceData inst = instances[gl_InstanceID];
@@ -118,5 +121,15 @@ void main()
         float dot1 = r_avertexnormal_dot(pose1.nor, shadevector);
         float dot2 = r_avertexnormal_dot(pose2.nor, shadevector);
         float lighting = mix(dot1, dot2, inst.Blend);
-        out_color = clamp(inst.LightColor * vec4(vec3(lighting * Overbright), 1.0), 0.0, Overbright);
+        vec3 blended_normal = normalize(mix(pose1.nor, pose2.nor, inst.Blend));
+        mat3 world_orientation = mat3(worldmatrix[0].xyz, worldmatrix[1].xyz, worldmatrix[2].xyz);
+        vec3 world_normal = normalize(world_orientation * blended_normal);
+        vec3 view_dir = normalize(-out_pos);
+        float rim = pow(max(1.0 - dot(world_normal, view_dir), 0.0), 3.0) * 0.3;
+        vec3 dlight = inst.DLightColor.rgb * (lighting * Overbright);
+        vec3 ambient = max(inst.LightColor.rgb - inst.DLightColor.rgb, vec3(0.0)) * (lighting * (Overbright * 0.5));
+        vec3 viewmodel_color = ambient + dlight + vec3(rim);
+        bool is_viewmodel = (inst.Flags & ALIAS_FLAG_VIEWMODEL) != 0;
+        vec3 final_color = is_viewmodel ? viewmodel_color : inst.LightColor.rgb * (lighting * Overbright);
+        out_color = clamp(vec4(final_color, inst.LightColor.a), 0.0, Overbright);
 }


### PR DESCRIPTION
## Summary
- track ambient and dynamic alias lighting separately and store them in instance data
- add viewmodel-specific shading that blends ambient, dynamic lights, and a rim term for added depth
- extend shader structures to consume the new lighting data and preserve motion blur flags

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693003dbb87c832e9766a72c2b4076e0)