### PR TITLE
Add camera vibration for nearby explosions

### DIFF
--- a/Quake/cl_tent.c
+++ b/Quake/cl_tent.c
@@ -187,40 +187,42 @@ void CL_ParseTEnt (void)
 		R_RunParticleEffect (pos, vec3_origin, 0, 20);
 		break;
 
-	case TE_EXPLOSION:			// rocket explosion
+	case TE_EXPLOSION:                      // rocket explosion
 		pos[0] = MSG_ReadCoord (cl.protocolflags);
 		pos[1] = MSG_ReadCoord (cl.protocolflags);
 		pos[2] = MSG_ReadCoord (cl.protocolflags);
-                R_ParticleExplosion (pos);
-                dl = CL_AllocDlight (0);
-                VectorCopy (pos, dl->origin);
-                dl->radius = 350;
-                dl->baseradius = dl->radius;
-                dl->color[0] = 1.00f; dl->color[1] = 0.50f; dl->color[2] = 0.25f;
-                dl->die = cl.time + 0.5;
-                dl->decay = 300;
-                dl->type = DLIGHT_EXPLOSION;
-                S_StartSound (-1, 0, cl_sfx_r_exp3, pos, 1, 1);
-                break;
+		V_AddExplosionVibration (pos);
+		R_ParticleExplosion (pos);
+		dl = CL_AllocDlight (0);
+		VectorCopy (pos, dl->origin);
+		dl->radius = 350;
+		dl->baseradius = dl->radius;
+		dl->color[0] = 1.00f; dl->color[1] = 0.50f; dl->color[2] = 0.25f;
+		dl->die = cl.time + 0.5;
+		dl->decay = 300;
+		dl->type = DLIGHT_EXPLOSION;
+		S_StartSound (-1, 0, cl_sfx_r_exp3, pos, 1, 1);
+		break;
 
-	case TE_TAREXPLOSION:			// tarbaby explosion
+	case TE_TAREXPLOSION:                   // tarbaby explosion
 		pos[0] = MSG_ReadCoord (cl.protocolflags);
 		pos[1] = MSG_ReadCoord (cl.protocolflags);
 		pos[2] = MSG_ReadCoord (cl.protocolflags);
-                R_BlobExplosion (pos);
+		V_AddExplosionVibration (pos);
+		R_BlobExplosion (pos);
 
-                S_StartSound (-1, 0, cl_sfx_r_exp3, pos, 1, 1);
-                break;
+		S_StartSound (-1, 0, cl_sfx_r_exp3, pos, 1, 1);
+		break;
 
-	case TE_LIGHTNING1:				// lightning bolts
+	case TE_LIGHTNING1:			     // lightning bolts
 		CL_ParseBeam (Mod_ForName("progs/bolt.mdl", true));
 		break;
 
-	case TE_LIGHTNING2:				// lightning bolts
+	case TE_LIGHTNING2:			     // lightning bolts
 		CL_ParseBeam (Mod_ForName("progs/bolt2.mdl", true));
 		break;
 
-	case TE_LIGHTNING3:				// lightning bolts
+	case TE_LIGHTNING3:			     // lightning bolts
 		CL_ParseBeam (Mod_ForName("progs/bolt3.mdl", true));
 		break;
 
@@ -248,6 +250,7 @@ void CL_ParseTEnt (void)
 		pos[0] = MSG_ReadCoord (cl.protocolflags);
 		pos[1] = MSG_ReadCoord (cl.protocolflags);
 		pos[2] = MSG_ReadCoord (cl.protocolflags);
+		V_AddExplosionVibration (pos);
 		colorStart = MSG_ReadByte ();
 		colorLength = MSG_ReadByte ();
                 R_ParticleExplosion2 (pos, colorStart, colorLength);

--- a/Quake/client.h
+++ b/Quake/client.h
@@ -412,6 +412,7 @@ void V_StopPitchDrift (void);
 
 void V_RenderView (void);
 void V_ParseDamage (void);
+void V_AddExplosionVibration (const vec3_t origin);
 void V_SetContentsColor (int contents);
 
 //

--- a/Quake/view.c
+++ b/Quake/view.c
@@ -49,6 +49,8 @@ cvar_t	v_kickpitch = {"v_kickpitch", "0.6", CVAR_NONE};
 cvar_t	v_gunkick = {"v_gunkick", "2", CVAR_ARCHIVE}; //johnfitz
 cvar_t	v_gunsway = {"v_gunsway", "0", CVAR_ARCHIVE};
 
+cvar_t	v_explosionvibration = {"v_explosionvibration", "1", CVAR_ARCHIVE};
+
 cvar_t	v_iyaw_cycle = {"v_iyaw_cycle", "2", CVAR_NONE};
 cvar_t	v_iroll_cycle = {"v_iroll_cycle", "0.5", CVAR_NONE};
 cvar_t	v_ipitch_cycle = {"v_ipitch_cycle", "1", CVAR_NONE};
@@ -257,6 +259,11 @@ static cshift_t cshift_slime = { {0,25,5}, 150 };
 static cshift_t cshift_lava = { {255,80,0}, 150 };
 
 static float v_dmg_time, v_dmg_roll, v_dmg_pitch;
+static float v_explosion_vibration_time;
+static float v_explosion_vibration_strength;
+
+static const float V_EXPLOSION_VIBRATION_DURATION = 0.25f;
+static const float V_EXPLOSION_VIBRATION_FREQUENCY = 40.0f;
 
 float		v_blend[4];		// rgba 0.0 - 1.0; see note in V_PolyBlend for more info
 
@@ -274,6 +281,8 @@ void V_ResetEffects (void)
 	v_dmg_time = 0.f;
 	v_dmg_roll = 0.f;
 	v_dmg_pitch = 0.f;
+	v_explosion_vibration_time = 0.f;
+	v_explosion_vibration_strength = 0.f;
 }
 
 /*
@@ -345,6 +354,33 @@ void V_ParseDamage (void)
 
 	v_dmg_time = v_kicktime.value;
 }
+
+
+void V_AddExplosionVibration (const vec3_t origin)
+{
+	vec3_t delta;
+	float distance;
+	float strength;
+	entity_t *ent;
+
+	if (!v_explosionvibration.value)
+		return;
+
+	ent = &cl_entities[cl.viewentity];
+
+	VectorCopy (ent->origin, delta);
+	delta[2] += cl.viewheight;
+	VectorSubtract (origin, delta, delta);
+
+	distance = VectorLength (delta);
+	strength = 2.0f * expf (-distance * 0.01f);
+	if (strength < 0.01f)
+		return;
+
+	v_explosion_vibration_strength = q_max (v_explosion_vibration_strength, strength);
+	v_explosion_vibration_time = V_EXPLOSION_VIBRATION_DURATION;
+}
+
 
 
 /*
@@ -895,6 +931,19 @@ void V_CalcRefdef (void)
 	}
 	//johnfitz
 
+	if (v_explosion_vibration_time > 0.f)
+	{
+		float decay = v_explosion_vibration_time / V_EXPLOSION_VIBRATION_DURATION;
+		float pitch_vibration = sinf (cl.time * V_EXPLOSION_VIBRATION_FREQUENCY) * v_explosion_vibration_strength * decay;
+		r_refdef.viewangles[PITCH] -= pitch_vibration;
+		v_explosion_vibration_time -= cl.time - cl.oldtime;
+		if (v_explosion_vibration_time < 0.f)
+		{
+			v_explosion_vibration_time = 0.f;
+			v_explosion_vibration_strength = 0.f;
+		}
+	}
+
 	V_AddGunSway (view);
 
 	// smooth out stair step ups
@@ -1042,6 +1091,7 @@ void V_Init (void)
 	Cvar_RegisterVariable (&v_kickpitch);
 	Cvar_RegisterVariable (&v_gunkick); //johnfitz
 	Cvar_RegisterVariable (&v_gunsway);
+	Cvar_RegisterVariable (&v_explosionvibration);
 
 	Cvar_RegisterVariable (&r_viewmodel_quake); //MarkV
 }


### PR DESCRIPTION
## Summary
- add a configurable v_explosionvibration cvar to drive camera vibration from nearby explosions
- trigger the vibration effect when parsing explosion temp entities
- decay the vibration over time when rendering the view

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69300ccf29d4832ea89c995bc74df6b9)