### PR TITLE
Add lightning gun afterimage trail shader

### DIFF
--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -64,9 +64,10 @@ typedef struct aliasinstance_s {
 	int32_t		flags;
 } aliasinstance_t;
 
-#define ALIAS_INSTANCE_FLAG_NONE          0
+#define ALIAS_INSTANCE_FLAG_NONE           0
 #define ALIAS_INSTANCE_FLAG_NO_MOTION_BLUR (1 << 0)
-#define ALIAS_INSTANCE_FLAG_VIEWMODEL     (1 << 1)
+#define ALIAS_INSTANCE_FLAG_VIEWMODEL      (1 << 1)
+#define ALIAS_INSTANCE_FLAG_LIGHTNING      (1 << 2)
 
 struct ibuf_s {
 	int			count;
@@ -670,14 +671,16 @@ static void R_DrawAliasModel_Real (entity_t *e, qboolean showtris)
 	e->motion_blur_prev_frame = r_framecount;
 	e->motion_blur_prev_valid = true;
 
-	VectorCopy (lightcolor, instance->lightcolor);
-	VectorCopy (e->lightcache.dlightcolor, instance->dlightcolor);
-	instance->alpha = entalpha;
-	if (e == &cl.viewent)
-		instance->flags |= ALIAS_INSTANCE_FLAG_NO_MOTION_BLUR | ALIAS_INSTANCE_FLAG_VIEWMODEL;
-	instance->pose1 = lerpdata.pose1;
-	instance->pose2 = lerpdata.pose2;
-	instance->blend = lerpdata.blend;
+        VectorCopy (lightcolor, instance->lightcolor);
+        VectorCopy (e->lightcache.dlightcolor, instance->dlightcolor);
+        instance->alpha = entalpha;
+        if (e == &cl.viewent)
+                instance->flags |= ALIAS_INSTANCE_FLAG_NO_MOTION_BLUR | ALIAS_INSTANCE_FLAG_VIEWMODEL;
+        if (!q_strncmp (e->model->name, "progs/bolt", 10))
+                instance->flags |= ALIAS_INSTANCE_FLAG_LIGHTNING;
+        instance->pose1 = lerpdata.pose1;
+        instance->pose2 = lerpdata.pose2;
+        instance->blend = lerpdata.blend;
 
 	if (paliashdr->poseverttype == PV_QUAKE1)
 	{

--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -90,6 +90,7 @@ vec2 ComputeVelocity(vec4 curr_clip, vec4 prev_clip)
 
 const int ALIAS_FLAG_NO_MOTION_BLUR = 1;
 const int ALIAS_FLAG_VIEWMODEL = 2;
+const int ALIAS_FLAG_LIGHTNING = 4;
 
 layout(binding=0) uniform sampler2D Tex;
 layout(binding=1) uniform sampler2D FullbrightTex;
@@ -173,6 +174,13 @@ void main()
 #endif
         result.rgb += fullbright;
         result.rgb += emissive;
+
+        if ((in_flags & ALIAS_FLAG_LIGHTNING) != 0)
+        {
+                float d = clamp(length(in_texcoord - 0.5) * 2.0, 0.0, 1.0);
+                float ghost = pow(1.0 - d, 3.0) * 0.2;
+                result.rgb += ghost * vec3(0.5, 0.7, 1.3);
+        }
         result.rgb = clamp(result.rgb, 0.0, 1.0);
         result.rgb = ApplyFog(result.rgb, in_pos);
         out_fragcolor = result;


### PR DESCRIPTION
## Summary
- flag lightning bolt models in the alias instance data
- apply a blue ghost overlay in the alias fragment shader to create an afterimage look

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69302a23e1b8832ebbf3aa738043a337)