### PR TITLE
Add GLSL 120 alias shaders with half-Lambert rim lighting

### DIFF
--- a/Quake/shaders/alias_legacy.frag
+++ b/Quake/shaders/alias_legacy.frag
@@ -1,0 +1,58 @@
+#version 120
+
+uniform vec3 ambientColor;
+uniform vec3 lightColor;
+uniform vec4 Fog; // rgb = fog color, w = density
+
+uniform sampler2D baseTexture;
+uniform sampler2D fullbrightTexture;
+
+uniform vec3 rimColor;
+uniform float rimStrength;
+uniform float halfLambertStrength;
+uniform vec3 viewmodelRimColor;
+uniform float viewmodelRimStrength;
+uniform bool isViewmodel;
+
+varying vec2 vTexCoord;
+varying vec3 vNormal;
+varying vec3 vViewDir;
+varying vec3 vLightDir;
+varying vec3 vFogVector;
+
+vec3 ApplyFog(vec3 color)
+{
+        float fog = exp2(-abs(Fog.w) * dot(vFogVector, vFogVector));
+        fog = clamp(fog, 0.0, 1.0);
+        return mix(Fog.rgb, color, fog);
+}
+
+void main()
+{
+        vec4 albedo = texture2D(baseTexture, vTexCoord);
+#ifdef ALPHATEST
+        if (albedo.a < 0.666)
+                discard;
+#endif
+
+        vec3 normal = normalize(vNormal);
+        vec3 viewDir = normalize(vViewDir);
+        vec3 lightDir = normalize(vLightDir);
+
+        float ndotl = max(dot(normal, lightDir), 0.0);
+        float hLambert = pow(ndotl * 0.5 + 0.5, 1.3);
+        vec3 diffuseLight = lightColor * (hLambert * halfLambertStrength);
+
+        float rim = pow(1.0 - max(dot(normal, viewDir), 0.0), 3.0);
+        vec3 rimLight = rimColor * rim * rimStrength;
+        if (isViewmodel)
+                rimLight = viewmodelRimColor * rim * viewmodelRimStrength;
+
+        vec3 fullbright = texture2D(fullbrightTexture, vTexCoord).rgb;
+
+        vec3 litColor = (ambientColor + diffuseLight) * albedo.rgb + rimLight;
+        litColor += fullbright;
+        litColor = ApplyFog(litColor);
+
+        gl_FragColor = vec4(litColor, albedo.a);
+}

--- a/Quake/shaders/alias_legacy.vert
+++ b/Quake/shaders/alias_legacy.vert
@@ -1,0 +1,30 @@
+#version 120
+
+uniform mat4 uModel;
+uniform mat4 uViewProj;
+uniform vec3 cameraPos;
+uniform vec3 primaryLightDir;
+
+attribute vec3 aPosition;
+attribute vec3 aNormal;
+attribute vec2 aTexCoord;
+
+varying vec2 vTexCoord;
+varying vec3 vNormal;
+varying vec3 vViewDir;
+varying vec3 vLightDir;
+varying vec3 vFogVector;
+
+void main()
+{
+        vec4 worldPos = uModel * vec4(aPosition, 1.0);
+        vec3 worldNormal = normalize((uModel * vec4(aNormal, 0.0)).xyz);
+
+        vTexCoord = aTexCoord;
+        vNormal = worldNormal;
+        vViewDir = normalize(cameraPos - worldPos.xyz);
+        vLightDir = normalize(primaryLightDir);
+        vFogVector = worldPos.xyz - cameraPos;
+
+        gl_Position = uViewProj * worldPos;
+}


### PR DESCRIPTION
## Summary
- add a GLSL 120 vertex shader that outputs normals, view direction, light direction, and fog vector
- add a GLSL 120 fragment shader with Half-Lambert diffuse lighting and colored rim lighting including a viewmodel mode
- preserve alpha testing, fog application, and fullbright additions in the new model shader pair

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69303c4b5804832eb03e7de97e939040)