### PR TITLE
Add rim lighting uniforms for models

### DIFF
--- a/Quake/gl_rlight.c
+++ b/Quake/gl_rlight.c
@@ -255,10 +255,26 @@ LIGHT SAMPLING
 
 vec3_t lightcolor; //johnfitz -- lit support via lordhavoc
 
+vec3 R_ComputeSceneAmbient (void)
+{
+        vec3 ambient = {0.5f, 0.5f, 0.5f};
+
+        if (cl.worldmodel && cl.worldmodel->lightdata)
+        {
+                float level = r_lightbuffer.lightstyles[0] * (1.0f / 256.0f);
+                level = CLAMP (0.0f, level, 1.0f);
+                ambient.x = level;
+                ambient.y = level;
+                ambient.z = level;
+        }
+
+        return ambient;
+}
+
 static inline int LightStyleValue (unsigned short style)
 {
-	if (style < 256)
-		return d_lightstylevalue[style];
+        if (style < 256)
+                return d_lightstylevalue[style];
 
 	return d_lightstylevalue[0];
 }

--- a/Quake/gl_shaders.c
+++ b/Quake/gl_shaders.c
@@ -37,6 +37,7 @@ static shader_cache_t shader_cache[128];
 static int shader_cache_count;
 
 glprogs_t glprogs;
+model_program_t model_program;
 static GLuint gl_programs[128];
 static GLuint gl_current_program;
 static int gl_num_programs;
@@ -545,6 +546,14 @@ void GL_CreateShaders (void)
                                 for (md5 = 0; md5 < 2; md5++)
                                         glprogs.alias[oit][mode][alphatest][md5] =
                                                 GL_CreateProgram (GLSL_PATH("alias.vert"), GLSL_PATH("alias.frag"), "alias|OIT %d; MODE %d; ALPHATEST %d; MD5 %d", oit, mode, alphatest, md5);
+
+        memset (&model_program, 0, sizeof (model_program));
+        model_program.u_rimColor = GL_GetUniformLocationFunc (glprogs.alias[0][ALIASSHADER_STANDARD][0][0], "rimColor");
+        model_program.u_rimStrength = GL_GetUniformLocationFunc (glprogs.alias[0][ALIASSHADER_STANDARD][0][0], "rimStrength");
+        model_program.u_halfLambertStrength = GL_GetUniformLocationFunc (glprogs.alias[0][ALIASSHADER_STANDARD][0][0], "halfLambertStrength");
+        model_program.u_viewmodelRimColor = GL_GetUniformLocationFunc (glprogs.alias[0][ALIASSHADER_STANDARD][0][0], "viewmodelRimColor");
+        model_program.u_viewmodelRimStrength = GL_GetUniformLocationFunc (glprogs.alias[0][ALIASSHADER_STANDARD][0][0], "viewmodelRimStrength");
+        model_program.u_isViewmodel = GL_GetUniformLocationFunc (glprogs.alias[0][ALIASSHADER_STANDARD][0][0], "isViewmodel");
 
         glprogs.debug3d = GL_CreateProgram (GLSL_PATH("debug3d.vert"), GLSL_PATH("debug3d.frag"), "debug3d");
 

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -406,6 +406,12 @@ void R_NewGame (void);
 #define LIGHT_TILES_Y			16
 #define LIGHT_TILES_Z			32
 
+typedef struct vec3_s {
+        float   x;
+        float   y;
+        float   z;
+} vec3;
+
 typedef struct gpulight_s {
 	float	pos[3];
 	float	radius;
@@ -446,6 +452,7 @@ qboolean R_CullBox (vec3_t emins, vec3_t emaxs);
 qboolean R_CullModelForEntity (entity_t *e);
 void R_GetEntityBounds (const entity_t *e, vec3_t mins, vec3_t maxs);
 void R_EntityMatrix (float matrix[16], vec3_t origin, vec3_t angles, unsigned char scale);
+vec3 R_ComputeSceneAmbient (void);
 
 void R_InitParticles (void);
 void R_DrawParticles (qboolean alpha);
@@ -557,6 +564,17 @@ typedef struct glprogs_s {
 } glprogs_t;
 
 extern glprogs_t glprogs;
+
+typedef struct model_program_s {
+        int                     u_rimColor;
+        int                     u_rimStrength;
+        int                     u_halfLambertStrength;
+        int                     u_viewmodelRimColor;
+        int                     u_viewmodelRimStrength;
+        int                     u_isViewmodel;
+} model_program_t;
+
+extern model_program_t model_program;
 
 void GL_UseProgram (GLuint program);
 void GL_ClearCachedProgram (void);

--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -36,6 +36,9 @@ const float	r_avertexnormals[NUMVERTEXNORMALS][3] = {
 };
 
 extern vec3_t	lightcolor; //johnfitz -- replaces "float shadelight" for lit support
+static const float rimStrength = 0.35f;
+static const float halfLambertStrength = 1.0f;
+static const float viewmodelRimStrength = 0.45f;
 
 static float	entalpha; //johnfitz
 
@@ -382,25 +385,58 @@ void R_FlushAliasInstances (qboolean showtris)
 
 	alphatest = model->flags & MF_HOLEY ? 1 : 0;
 	translucent = !ENTALPHA_OPAQUE (ibuf.ent->alpha);
-	oit = translucent && R_GetEffectiveAlphaMode () == ALPHAMODE_OIT;
-	switch (softemu)
-	{
-	case SOFTEMU_BANDED:
-		mode = r_softemu_mdl_warp.value != 0.f ? ALIASSHADER_NOPERSP : ALIASSHADER_STANDARD;
+        oit = translucent && R_GetEffectiveAlphaMode () == ALPHAMODE_OIT;
+        switch (softemu)
+        {
+        case SOFTEMU_BANDED:
+                mode = r_softemu_mdl_warp.value != 0.f ? ALIASSHADER_NOPERSP : ALIASSHADER_STANDARD;
 		break;
 	case SOFTEMU_COARSE:
 		mode = r_softemu_mdl_warp.value > 0.f ? ALIASSHADER_NOPERSP : ALIASSHADER_DITHER;
 		break;
-	default:
-		mode = r_softemu_mdl_warp.value > 0.f ? ALIASSHADER_NOPERSP : ALIASSHADER_STANDARD;
-		break;
-	}
-	GL_UseProgram (glprogs.alias[oit][mode][alphatest][md5]);
+        default:
+                mode = r_softemu_mdl_warp.value > 0.f ? ALIASSHADER_NOPERSP : ALIASSHADER_STANDARD;
+                break;
+        }
+        GL_UseProgram (glprogs.alias[oit][mode][alphatest][md5]);
 
-	if (md5)
-		state = GLS_CULL_BACK | GLS_ATTRIBS(5);
-	else
-		state = GLS_CULL_BACK | GLS_ATTRIBS(1);
+        {
+                vec3 ambient = R_ComputeSceneAmbient ();
+                vec3_t rimColor;
+                vec3_t viewmodelRimColor;
+                qboolean is_viewmodel = (ibuf.inst[0].flags & ALIAS_INSTANCE_FLAG_VIEWMODEL) != 0;
+
+                rimColor[0] = ambient.x * 0.7f + 0.3f;
+                rimColor[1] = ambient.y * 0.7f + 0.3f;
+                rimColor[2] = ambient.z * 0.7f + 0.3f;
+                VectorCopy (rimColor, viewmodelRimColor);
+
+                if (model_program.u_rimColor >= 0)
+                        GL_Uniform3fvFunc (model_program.u_rimColor, 1, rimColor);
+                if (model_program.u_rimStrength >= 0)
+                        GL_Uniform1fFunc (model_program.u_rimStrength, rimStrength);
+                if (model_program.u_halfLambertStrength >= 0)
+                        GL_Uniform1fFunc (model_program.u_halfLambertStrength, halfLambertStrength);
+
+                if (is_viewmodel)
+                {
+                        if (model_program.u_isViewmodel >= 0)
+                                GL_Uniform1iFunc (model_program.u_isViewmodel, 1);
+                        if (model_program.u_viewmodelRimColor >= 0)
+                                GL_Uniform3fvFunc (model_program.u_viewmodelRimColor, 1, viewmodelRimColor);
+                        if (model_program.u_viewmodelRimStrength >= 0)
+                                GL_Uniform1fFunc (model_program.u_viewmodelRimStrength, viewmodelRimStrength);
+                }
+                else if (model_program.u_isViewmodel >= 0)
+                {
+                        GL_Uniform1iFunc (model_program.u_isViewmodel, 0);
+                }
+        }
+
+        if (md5)
+                state = GLS_CULL_BACK | GLS_ATTRIBS(5);
+        else
+                state = GLS_CULL_BACK | GLS_ATTRIBS(1);
 
 	if (!translucent)
 		state |= GLS_BLEND_OPAQUE;


### PR DESCRIPTION
## Summary
- add rim lighting and half-Lambert uniform locations to the model shader program
- compute scene ambient values and apply rim defaults when binding the alias model shader
- upload rim and viewmodel rim uniforms each frame for alias and MD5/view models

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69303d1c3d4c832eb9ad404227386912)