### PR TITLE
Soften rim lighting effect

### DIFF
--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -36,7 +36,7 @@ const float	r_avertexnormals[NUMVERTEXNORMALS][3] = {
 };
 
 extern vec3_t	lightcolor; //johnfitz -- replaces "float shadelight" for lit support
-static const float rimStrength = 0.35f;
+static const float rimStrength = 0.2f;
 static const float halfLambertStrength = 1.0f;
 static const float viewmodelRimStrength = 0.45f;
 

--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -196,7 +196,9 @@ void main()
                 float ghost = pow(1.0 - d, 3.0) * 0.2;
                 result.rgb += ghost * vec3(0.5, 0.7, 1.3);
         }
-        float rim = pow(1.0 - max(dot(normal, viewDir), 0.0), 3.0);
+        float ndv = max(dot(normal, viewDir), 0.0);
+        float rim = smoothstep(0.2, 0.8, 1.0 - ndv);
+        rim *= rim;
         if (isViewmodel)
                 result.rgb += viewmodelRimColor * rim * viewmodelRimStrength;
         else

--- a/Quake/shaders/alias.vert
+++ b/Quake/shaders/alias.vert
@@ -127,7 +127,8 @@ void main()
         mat3 world_orientation = mat3(worldmatrix[0].xyz, worldmatrix[1].xyz, worldmatrix[2].xyz);
         vec3 world_normal = normalize(world_orientation * blended_normal);
         vec3 view_dir = normalize(-out_pos);
-        float rim = pow(max(1.0 - dot(world_normal, view_dir), 0.0), 3.0) * 0.3;
+        float ndv = max(dot(world_normal, view_dir), 0.0);
+        float rim = smoothstep(0.2, 0.8, 1.0 - ndv) * 0.25;
         mat3 normalMatrix = world_orientation;
         vNormal = normalize(normalMatrix * blended_normal);
         vViewDir = normalize(EyePos - world_vert);


### PR DESCRIPTION
## Summary
- reduce default rim lighting strength and adjust rim falloff to emphasize silhouettes
- refine viewmodel rim calculation to match the softer appearance

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693077ad325c832eac00190f41d3c54f)