### PR TITLE
Tighten rim lighting to avoid plastic sheen

### DIFF
--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -36,9 +36,9 @@ const float	r_avertexnormals[NUMVERTEXNORMALS][3] = {
 };
 
 extern vec3_t	lightcolor; //johnfitz -- replaces "float shadelight" for lit support
-static const float rimStrength = 0.35f;
+static const float rimStrength = 0.25f;
 static const float halfLambertStrength = 1.0f;
-static const float viewmodelRimStrength = 0.45f;
+static const float viewmodelRimStrength = 0.35f;
 
 static float	entalpha; //johnfitz
 

--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -196,7 +196,11 @@ void main()
                 float ghost = pow(1.0 - d, 3.0) * 0.2;
                 result.rgb += ghost * vec3(0.5, 0.7, 1.3);
         }
-        float rim = pow(1.0 - max(dot(normal, viewDir), 0.0), 3.0);
+        float ndv = max(dot(normal, viewDir), 0.0);
+        float viewFacing = clamp(1.0 - ndv, 0.0, 1.0);
+        float rimMask = smoothstep(0.05, 0.65, viewFacing);
+        float rim = pow(viewFacing, 2.0) * rimMask;
+        rim *= (1.0 - ndotl * 0.4);
         if (isViewmodel)
                 result.rgb += viewmodelRimColor * rim * viewmodelRimStrength;
         else

--- a/Quake/shaders/alias.vert
+++ b/Quake/shaders/alias.vert
@@ -127,7 +127,10 @@ void main()
         mat3 world_orientation = mat3(worldmatrix[0].xyz, worldmatrix[1].xyz, worldmatrix[2].xyz);
         vec3 world_normal = normalize(world_orientation * blended_normal);
         vec3 view_dir = normalize(-out_pos);
-        float rim = pow(max(1.0 - dot(world_normal, view_dir), 0.0), 3.0) * 0.3;
+        float ndv = max(dot(world_normal, view_dir), 0.0);
+        float viewFacing = clamp(1.0 - ndv, 0.0, 1.0);
+        float rimMask = smoothstep(0.05, 0.65, viewFacing);
+        float rim = pow(viewFacing, 2.0) * rimMask * 0.2;
         mat3 normalMatrix = world_orientation;
         vNormal = normalize(normalMatrix * blended_normal);
         vViewDir = normalize(EyePos - world_vert);


### PR DESCRIPTION
## Summary
- reshape rim falloff to emphasize silhouettes while reducing highlight on lit faces
- align vertex rim prelighting with the fragment shader’s softer rim mask
- trim rim lighting strengths for world models and viewmodels to keep the effect subtle

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693077ad325c832eac00190f41d3c54f)