### PR TITLE
Remove rim lighting from alias shader

### DIFF
--- a/Quake/gl_shaders.c
+++ b/Quake/gl_shaders.c
@@ -547,13 +547,8 @@ void GL_CreateShaders (void)
                                         glprogs.alias[oit][mode][alphatest][md5] =
                                                 GL_CreateProgram (GLSL_PATH("alias.vert"), GLSL_PATH("alias.frag"), "alias|OIT %d; MODE %d; ALPHATEST %d; MD5 %d", oit, mode, alphatest, md5);
 
-        memset (&model_program, 0, sizeof (model_program));
-        model_program.u_rimColor = GL_GetUniformLocationFunc (glprogs.alias[0][ALIASSHADER_STANDARD][0][0], "rimColor");
-        model_program.u_rimStrength = GL_GetUniformLocationFunc (glprogs.alias[0][ALIASSHADER_STANDARD][0][0], "rimStrength");
-        model_program.u_halfLambertStrength = GL_GetUniformLocationFunc (glprogs.alias[0][ALIASSHADER_STANDARD][0][0], "halfLambertStrength");
-        model_program.u_viewmodelRimColor = GL_GetUniformLocationFunc (glprogs.alias[0][ALIASSHADER_STANDARD][0][0], "viewmodelRimColor");
-        model_program.u_viewmodelRimStrength = GL_GetUniformLocationFunc (glprogs.alias[0][ALIASSHADER_STANDARD][0][0], "viewmodelRimStrength");
-        model_program.u_isViewmodel = GL_GetUniformLocationFunc (glprogs.alias[0][ALIASSHADER_STANDARD][0][0], "isViewmodel");
+memset (&model_program, 0, sizeof (model_program));
+model_program.u_halfLambertStrength = GL_GetUniformLocationFunc (glprogs.alias[0][ALIASSHADER_STANDARD][0][0], "halfLambertStrength");
 
         glprogs.debug3d = GL_CreateProgram (GLSL_PATH("debug3d.vert"), GLSL_PATH("debug3d.frag"), "debug3d");
 

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -566,12 +566,7 @@ typedef struct glprogs_s {
 extern glprogs_t glprogs;
 
 typedef struct model_program_s {
-        int                     u_rimColor;
-        int                     u_rimStrength;
-        int                     u_halfLambertStrength;
-        int                     u_viewmodelRimColor;
-        int                     u_viewmodelRimStrength;
-        int                     u_isViewmodel;
+	int                     u_halfLambertStrength;
 } model_program_t;
 
 extern model_program_t model_program;

--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -36,9 +36,7 @@ const float	r_avertexnormals[NUMVERTEXNORMALS][3] = {
 };
 
 extern vec3_t	lightcolor; //johnfitz -- replaces "float shadelight" for lit support
-static const float rimStrength = 0.25f;
 static const float halfLambertStrength = 1.0f;
-static const float viewmodelRimStrength = 0.35f;
 
 static float	entalpha; //johnfitz
 
@@ -401,36 +399,8 @@ void R_FlushAliasInstances (qboolean showtris)
         GL_UseProgram (glprogs.alias[oit][mode][alphatest][md5]);
 
         {
-                vec3 ambient = R_ComputeSceneAmbient ();
-                vec3_t rimColor;
-                vec3_t viewmodelRimColor;
-                qboolean is_viewmodel = (ibuf.inst[0].flags & ALIAS_INSTANCE_FLAG_VIEWMODEL) != 0;
-
-                rimColor[0] = ambient.x * 0.7f + 0.3f;
-                rimColor[1] = ambient.y * 0.7f + 0.3f;
-                rimColor[2] = ambient.z * 0.7f + 0.3f;
-                VectorCopy (rimColor, viewmodelRimColor);
-
-                if (model_program.u_rimColor >= 0)
-                        GL_Uniform3fvFunc (model_program.u_rimColor, 1, rimColor);
-                if (model_program.u_rimStrength >= 0)
-                        GL_Uniform1fFunc (model_program.u_rimStrength, rimStrength);
                 if (model_program.u_halfLambertStrength >= 0)
                         GL_Uniform1fFunc (model_program.u_halfLambertStrength, halfLambertStrength);
-
-                if (is_viewmodel)
-                {
-                        if (model_program.u_isViewmodel >= 0)
-                                GL_Uniform1iFunc (model_program.u_isViewmodel, 1);
-                        if (model_program.u_viewmodelRimColor >= 0)
-                                GL_Uniform3fvFunc (model_program.u_viewmodelRimColor, 1, viewmodelRimColor);
-                        if (model_program.u_viewmodelRimStrength >= 0)
-                                GL_Uniform1fFunc (model_program.u_viewmodelRimStrength, viewmodelRimStrength);
-                }
-                else if (model_program.u_isViewmodel >= 0)
-                {
-                        GL_Uniform1iFunc (model_program.u_isViewmodel, 0);
-                }
         }
 
         if (md5)
@@ -438,25 +408,25 @@ void R_FlushAliasInstances (qboolean showtris)
         else
                 state = GLS_CULL_BACK | GLS_ATTRIBS(1);
 
-	if (!translucent)
-		state |= GLS_BLEND_OPAQUE;
-	else
-		state |= GLS_BLEND_ALPHA_OIT | GLS_NO_ZWRITE;
-	GL_SetState (state);
+        if (!translucent)
+                state |= GLS_BLEND_OPAQUE;
+        else
+                state |= GLS_BLEND_ALPHA_OIT | GLS_NO_ZWRITE;
+        GL_SetState (state);
 
-memcpy (ibuf.global.matviewproj, r_matviewproj, sizeof (r_matviewproj));
-memcpy (ibuf.global.prev_matviewproj, r_framedata.prev_viewproj, sizeof (r_framedata.prev_viewproj));
-memcpy (ibuf.global.eyepos, r_refdef.vieworg, sizeof (r_refdef.vieworg));
-memcpy (ibuf.global.fog, r_framedata.fogdata, 3 * sizeof (float));
-// use fog density sign bit as overbright flag
-ibuf.global.fog[3] =
-gl_overbright_models.value ?
--fabs (r_framedata.fogdata[3]) :
- fabs (r_framedata.fogdata[3])
-;
-ibuf.global.overbright = gl_overbright_models.value > 0.f ? r_framedata.dither[2] : 1.f;
-ibuf.global.dither = r_framedata.dither[0];
-ibuf.global.half_lambert = r_model_halflambert.value > 0.f ? 1.f : 0.f;
+        memcpy (ibuf.global.matviewproj, r_matviewproj, sizeof (r_matviewproj));
+        memcpy (ibuf.global.prev_matviewproj, r_framedata.prev_viewproj, sizeof (r_framedata.prev_viewproj));
+        memcpy (ibuf.global.eyepos, r_refdef.vieworg, sizeof (r_refdef.vieworg));
+        memcpy (ibuf.global.fog, r_framedata.fogdata, 3 * sizeof (float));
+        // use fog density sign bit as overbright flag
+        ibuf.global.fog[3] =
+                gl_overbright_models.value ?
+                        -fabs (r_framedata.fogdata[3]) :
+                         fabs (r_framedata.fogdata[3])
+                ;
+        ibuf.global.overbright = gl_overbright_models.value > 0.f ? r_framedata.dither[2] : 1.f;
+        ibuf.global.dither = r_framedata.dither[0];
+        ibuf.global.half_lambert = r_model_halflambert.value > 0.f ? 1.f : 0.f;
 
 	ibuf_size = sizeof(ibuf.global) + sizeof(ibuf.inst[0]) * ibuf.count;
 	GL_Upload (GL_SHADER_STORAGE_BUFFER, &ibuf.global, ibuf_size, &buf, &ofs);

--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -89,18 +89,12 @@ vec2 ComputeVelocity(vec4 curr_clip, vec4 prev_clip)
 }
 
 const int ALIAS_FLAG_NO_MOTION_BLUR = 1;
-const int ALIAS_FLAG_VIEWMODEL = 2;
 const int ALIAS_FLAG_LIGHTNING = 4;
 
 layout(binding=0) uniform sampler2D Tex;
 layout(binding=1) uniform sampler2D FullbrightTex;
 layout(binding=2) uniform sampler2D EmissiveTex;
 uniform vec3 lightDir;
-uniform vec3 rimColor;
-uniform float rimStrength;
-uniform bool isViewmodel;
-uniform vec3 viewmodelRimColor;
-uniform float viewmodelRimStrength;
 
 #if MODE == 2
         layout(location=0) noperspective in vec2 in_texcoord;
@@ -113,7 +107,6 @@ layout(location=3) noperspective in vec4 in_curr_clip;
 layout(location=4) noperspective in vec4 in_prev_clip;
 layout(location=5) flat in int in_flags;
 layout(location=6) in vec3 vNormal;
-layout(location=7) in vec3 vViewDir;
 
 #define OUT_COLOR out_fragcolor
 #if OIT
@@ -181,7 +174,6 @@ void main()
         emissive = texture(EmissiveTex, uv).rgb;
 #endif
         vec3 normal = normalize(vNormal);
-        vec3 viewDir = normalize(vViewDir);
         vec3 diffuse = result.rgb;
         float ndotl = max(dot(normal, lightDir), 0.0);
         float hLambert = pow(ndotl * 0.5 + 0.5, 1.3);
@@ -196,15 +188,6 @@ void main()
                 float ghost = pow(1.0 - d, 3.0) * 0.2;
                 result.rgb += ghost * vec3(0.5, 0.7, 1.3);
         }
-        float ndv = max(dot(normal, viewDir), 0.0);
-        float viewFacing = clamp(1.0 - ndv, 0.0, 1.0);
-        float rimMask = smoothstep(0.05, 0.65, viewFacing);
-        float rim = pow(viewFacing, 2.0) * rimMask;
-        rim *= (1.0 - ndotl * 0.4);
-        if (isViewmodel)
-                result.rgb += viewmodelRimColor * rim * viewmodelRimStrength;
-        else
-                result.rgb += rimColor * rim * rimStrength;
         result.rgb = clamp(result.rgb, 0.0, 1.0);
         result.rgb = ApplyFog(result.rgb, in_pos);
         out_fragcolor = result;

--- a/Quake/shaders/alias.vert
+++ b/Quake/shaders/alias.vert
@@ -94,7 +94,6 @@ layout(location=3) noperspective out vec4 out_curr_clip;
 layout(location=4) noperspective out vec4 out_prev_clip;
 layout(location=5) flat out int out_flags;
 layout(location=6) out vec3 vNormal;
-layout(location=7) out vec3 vViewDir;
 
 const int ALIAS_FLAG_VIEWMODEL = 2;
 
@@ -125,18 +124,11 @@ void main()
         float lighting = mix(dot1, dot2, inst.Blend);
         vec3 blended_normal = normalize(mix(pose1.nor, pose2.nor, inst.Blend));
         mat3 world_orientation = mat3(worldmatrix[0].xyz, worldmatrix[1].xyz, worldmatrix[2].xyz);
-        vec3 world_normal = normalize(world_orientation * blended_normal);
-        vec3 view_dir = normalize(-out_pos);
-        float ndv = max(dot(world_normal, view_dir), 0.0);
-        float viewFacing = clamp(1.0 - ndv, 0.0, 1.0);
-        float rimMask = smoothstep(0.05, 0.65, viewFacing);
-        float rim = pow(viewFacing, 2.0) * rimMask * 0.2;
         mat3 normalMatrix = world_orientation;
         vNormal = normalize(normalMatrix * blended_normal);
-        vViewDir = normalize(EyePos - world_vert);
         vec3 dlight = inst.DLightColor.rgb * (lighting * Overbright);
         vec3 ambient = max(inst.LightColor.rgb - inst.DLightColor.rgb, vec3(0.0)) * (lighting * (Overbright * 0.5));
-        vec3 viewmodel_color = ambient + dlight + vec3(rim);
+        vec3 viewmodel_color = ambient + dlight;
         bool is_viewmodel = (inst.Flags & ALIAS_FLAG_VIEWMODEL) != 0;
         vec3 final_color = is_viewmodel ? viewmodel_color : inst.LightColor.rgb * (lighting * Overbright);
         out_color = clamp(vec4(final_color, inst.LightColor.a), 0.0, Overbright);


### PR DESCRIPTION
## Summary
- remove rim lighting calculations and uniforms from the alias vertex and fragment shaders
- drop related rim lighting uniform plumbing in the renderer
- retain only half-Lambert configuration for alias program setup

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69308ece81e4832eb47468d555c91693)