### PR TITLE
Implement lightgrid support and sampling

### DIFF
--- a/Quake/Makefile
+++ b/Quake/Makefile
@@ -215,11 +215,12 @@ SYSOBJ_SYS = pl_linux.o sys_sdl_unix.o
 SYSOBJ_MAIN= main_sdl.o
 
 GLOBJS = \
-	gl_refrag.o \
-	gl_rlight.o \
-	gl_rmain.o \
-	gl_fog.o \
-	gl_rmisc.o \
+gl_refrag.o \
+gl_rlight.o \
+gl_lightgrid.o \
+gl_rmain.o \
+gl_fog.o \
+gl_rmisc.o \
 	r_part.o \
 	r_world.o \
 	gl_screen.o \

--- a/Quake/gl_lightgrid.c
+++ b/Quake/gl_lightgrid.c
@@ -1,0 +1,352 @@
+/*
+Copyright (C) 2024 Ironwail developers
+*/
+
+#include "quakedef.h"
+#include "gl_lightgrid.h"
+#include "glquake.h"
+
+extern vec3_t lightcolor;
+
+static lightgrid_t current_lightgrid;
+
+cvar_t  r_lightgrid = { "r_lightgrid", "1", CVAR_ARCHIVE };
+cvar_t  r_lightgrid_debug = { "r_lightgrid_debug", "0", CVAR_NONE };
+
+void Lightgrid_Init (void)
+{
+    Cvar_RegisterVariable (&r_lightgrid);
+    Cvar_RegisterVariable (&r_lightgrid_debug);
+    Lightgrid_Clear ();
+}
+
+void Lightgrid_Shutdown (void)
+{
+    Lightgrid_Clear ();
+}
+
+void Lightgrid_Clear (void)
+{
+    if (current_lightgrid.cells)
+    {
+        Z_Free (current_lightgrid.cells);
+        current_lightgrid.cells = NULL;
+    }
+
+    current_lightgrid.nx = current_lightgrid.ny = current_lightgrid.nz = 0;
+    current_lightgrid.cellsize = 0.f;
+    VectorClear (current_lightgrid.mins);
+    VectorClear (current_lightgrid.maxs);
+    current_lightgrid.valid = false;
+}
+
+static qboolean Lightgrid_ValidateBSPX (int nx, int ny, int nz, int datasize)
+{
+    int count;
+    size_t expect;
+
+    if (nx <= 0 || ny <= 0 || nz <= 0)
+        return false;
+
+    count = nx * ny * nz;
+    expect = (size_t)(3 * sizeof(int)) + sizeof(float) + sizeof(vec3_t) * 2 + (sizeof(vec3_t) * 2 + sizeof(float)) * (size_t)count;
+
+    return expect <= (size_t)datasize;
+}
+
+qboolean Lightgrid_LoadFromBSPX (void *bspx_data, int bspx_len)
+{
+    byte *data = (byte *)bspx_data;
+    int nx, ny, nz;
+    float cellsize;
+    vec3_t mins, maxs;
+    int count, i;
+    lightgrid_cell_t *cells;
+
+    Lightgrid_Clear ();
+
+    if (!bspx_data || bspx_len <= 0)
+        return false;
+
+    if ((size_t)bspx_len < sizeof(int) * 3 + sizeof(float) + sizeof(vec3_t) * 2)
+        return false;
+
+    nx = LittleLong (((int *)data)[0]);
+    ny = LittleLong (((int *)data)[1]);
+    nz = LittleLong (((int *)data)[2]);
+
+    if (!Lightgrid_ValidateBSPX (nx, ny, nz, bspx_len))
+        return false;
+
+    cellsize = LittleFloat (*(float *)(data + sizeof(int) * 3));
+    memcpy (mins, data + sizeof(int) * 3 + sizeof(float), sizeof(vec3_t));
+    memcpy (maxs, data + sizeof(int) * 3 + sizeof(float) + sizeof(vec3_t), sizeof(vec3_t));
+    for (i = 0; i < 3; i++)
+    {
+        mins[i] = LittleFloat (mins[i]);
+        maxs[i] = LittleFloat (maxs[i]);
+    }
+
+    count = nx * ny * nz;
+    cells = (lightgrid_cell_t *)Z_Malloc (count * sizeof(lightgrid_cell_t));
+
+    data += sizeof(int) * 3 + sizeof(float) + sizeof(vec3_t) * 2;
+    for (i = 0; i < count; i++)
+    {
+        vec3_t color, dir;
+        float intensity;
+        memcpy (color, data, sizeof(vec3_t));
+        data += sizeof(vec3_t);
+        memcpy (dir, data, sizeof(vec3_t));
+        data += sizeof(vec3_t);
+        memcpy (&intensity, data, sizeof(float));
+        data += sizeof(float);
+
+        color[0] = LittleFloat (color[0]);
+        color[1] = LittleFloat (color[1]);
+        color[2] = LittleFloat (color[2]);
+        dir[0] = LittleFloat (dir[0]);
+        dir[1] = LittleFloat (dir[1]);
+        dir[2] = LittleFloat (dir[2]);
+        intensity = LittleFloat (intensity);
+
+        VectorCopy (color, cells[i].color);
+        VectorCopy (dir, cells[i].dir);
+        VectorNormalize (cells[i].dir);
+        cells[i].intensity = intensity;
+    }
+
+    current_lightgrid.nx = nx;
+    current_lightgrid.ny = ny;
+    current_lightgrid.nz = nz;
+    current_lightgrid.cellsize = cellsize;
+    VectorCopy (mins, current_lightgrid.mins);
+    VectorCopy (maxs, current_lightgrid.maxs);
+    current_lightgrid.cells = cells;
+    current_lightgrid.valid = true;
+
+    return true;
+}
+
+static void Lightgrid_ClampPos (const vec3_t pos, vec3_t out)
+{
+    VectorCopy (pos, out);
+    if (!current_lightgrid.valid)
+        return;
+
+    out[0] = CLAMP (current_lightgrid.mins[0], out[0], current_lightgrid.maxs[0]);
+    out[1] = CLAMP (current_lightgrid.mins[1], out[1], current_lightgrid.maxs[1]);
+    out[2] = CLAMP (current_lightgrid.mins[2], out[2], current_lightgrid.maxs[2]);
+}
+
+static lightgrid_cell_t *Lightgrid_At (int x, int y, int z)
+{
+    return &current_lightgrid.cells[(z * current_lightgrid.ny + y) * current_lightgrid.nx + x];
+}
+
+static void Lightgrid_DefaultSample (vec3_t out_color, vec3_t out_dir)
+{
+    out_color[0] = out_color[1] = out_color[2] = 1.f;
+    out_dir[0] = out_dir[1] = 0.f;
+    out_dir[2] = 1.f;
+}
+
+void Lightgrid_Sample (const vec3_t pos, vec3_t out_color, vec3_t out_dir)
+{
+    vec3_t p;
+    float fx, fy, fz;
+    int x0, y0, z0, x1, y1, z1;
+    lightgrid_cell_t *c000, *c100, *c010, *c110, *c001, *c101, *c011, *c111;
+    vec3_t color = {1.f, 1.f, 1.f};
+    vec3_t dir = {0.f, 0.f, 1.f};
+
+    if (!current_lightgrid.valid || !r_lightgrid.value)
+    {
+        Lightgrid_DefaultSample (out_color, out_dir);
+        return;
+    }
+
+    Lightgrid_ClampPos (pos, p);
+
+    fx = (p[0] - current_lightgrid.mins[0]) / current_lightgrid.cellsize;
+    fy = (p[1] - current_lightgrid.mins[1]) / current_lightgrid.cellsize;
+    fz = (p[2] - current_lightgrid.mins[2]) / current_lightgrid.cellsize;
+
+    x0 = CLAMP (0, (int)floorf (fx), current_lightgrid.nx - 1);
+    y0 = CLAMP (0, (int)floorf (fy), current_lightgrid.ny - 1);
+    z0 = CLAMP (0, (int)floorf (fz), current_lightgrid.nz - 1);
+
+    x1 = q_min (x0 + 1, current_lightgrid.nx - 1);
+    y1 = q_min (y0 + 1, current_lightgrid.ny - 1);
+    z1 = q_min (z0 + 1, current_lightgrid.nz - 1);
+
+    fx -= floorf (fx);
+    fy -= floorf (fy);
+    fz -= floorf (fz);
+
+    c000 = Lightgrid_At (x0, y0, z0);
+    c100 = Lightgrid_At (x1, y0, z0);
+    c010 = Lightgrid_At (x0, y1, z0);
+    c110 = Lightgrid_At (x1, y1, z0);
+    c001 = Lightgrid_At (x0, y0, z1);
+    c101 = Lightgrid_At (x1, y0, z1);
+    c011 = Lightgrid_At (x0, y1, z1);
+    c111 = Lightgrid_At (x1, y1, z1);
+
+    {
+        vec3_t c00, c10, c01, c11, c0, c1;
+        vec3_t d00, d10, d01, d11, d0, d1;
+
+        VectorLerp (c000->color, c100->color, fx, c00);
+        VectorLerp (c010->color, c110->color, fx, c10);
+        VectorLerp (c001->color, c101->color, fx, c01);
+        VectorLerp (c011->color, c111->color, fx, c11);
+
+        VectorLerp (c00, c10, fy, c0);
+        VectorLerp (c01, c11, fy, c1);
+
+        VectorLerp (c0, c1, fz, color);
+
+        VectorLerp (c000->dir, c100->dir, fx, d00);
+        VectorLerp (c010->dir, c110->dir, fx, d10);
+        VectorLerp (c001->dir, c101->dir, fx, d01);
+        VectorLerp (c011->dir, c111->dir, fx, d11);
+
+        VectorLerp (d00, d10, fy, d0);
+        VectorLerp (d01, d11, fy, d1);
+
+        VectorLerp (d0, d1, fz, dir);
+        VectorNormalize (dir);
+    }
+
+    VectorCopy (color, out_color);
+    VectorCopy (dir, out_dir);
+}
+
+static float Lightgrid_CellsizeForBounds (const vec3_t mins, const vec3_t maxs)
+{
+    vec3_t size;
+    float cellsize;
+
+    VectorSubtract (maxs, mins, size);
+    cellsize = q_max (size[0], q_max (size[1], size[2])) / 32.f;
+    if (cellsize < 16.f)
+        cellsize = 16.f;
+    return cellsize;
+}
+
+static void Lightgrid_AddDlights (const vec3_t pos, vec3_t color, vec3_t dirsum)
+{
+    int i;
+    const dlight_t *l;
+
+    for (i = 0, l = cl_dlights; i < MAX_DLIGHTS; i++, l++)
+    {
+        vec3_t delta;
+        float dist2, add, scale;
+        if (l->die <= cl.time || (!l->radius && !l->minlight))
+            continue;
+
+        VectorSubtract (pos, l->origin, delta);
+        dist2 = DotProduct (delta, delta);
+        if (dist2 >= l->radius * l->radius)
+            continue;
+
+        add = l->radius - sqrtf (dist2);
+        if (add <= l->minlight)
+            continue;
+
+        scale = add * (1.f / 256.f);
+        VectorMA (color, scale, l->color, color);
+
+        if (VectorNormalize (delta) > 0.f)
+            VectorMA (dirsum, add, delta, dirsum);
+    }
+}
+
+void Lightgrid_BuildFallback (void)
+{
+    vec3_t mins, maxs, size;
+    float cellsize;
+    int nx, ny, nz;
+    int x, y, z;
+
+    if (!cl.worldmodel)
+        return;
+
+    Con_Printf ("Lightgrid fallback: building interpolated grid...\n");
+
+    VectorCopy (cl.worldmodel->mins, mins);
+    VectorCopy (cl.worldmodel->maxs, maxs);
+    VectorSubtract (maxs, mins, size);
+
+    cellsize = Lightgrid_CellsizeForBounds (mins, maxs);
+
+    nx = q_max (1, q_min (32, (int)ceilf (size[0] / cellsize)));
+    ny = q_max (1, q_min (32, (int)ceilf (size[1] / cellsize)));
+    nz = q_max (1, q_min (32, (int)ceilf (size[2] / cellsize)));
+
+    Lightgrid_Clear ();
+
+    current_lightgrid.nx = nx;
+    current_lightgrid.ny = ny;
+    current_lightgrid.nz = nz;
+    current_lightgrid.cellsize = cellsize;
+    VectorCopy (mins, current_lightgrid.mins);
+    VectorCopy (maxs, current_lightgrid.maxs);
+    current_lightgrid.cells = (lightgrid_cell_t *)Z_Malloc ((size_t)nx * ny * nz * sizeof(lightgrid_cell_t));
+
+    for (z = 0; z < nz; z++)
+    {
+        for (y = 0; y < ny; y++)
+        {
+            for (x = 0; x < nx; x++)
+            {
+                vec3_t pos;
+                lightgrid_cell_t *cell = Lightgrid_At (x, y, z);
+                vec3_t dirsum = {0.f, 0.f, 0.f};
+                float baseintensity;
+                lightcache_t cache = {0};
+
+                pos[0] = mins[0] + (x + 0.5f) * cellsize;
+                pos[1] = mins[1] + (y + 0.5f) * cellsize;
+                pos[2] = mins[2] + (z + 0.5f) * cellsize;
+
+                R_LightPoint (pos, 0.f, &cache);
+                cell->color[0] = lightcolor[0] * (1.f / 255.f);
+                cell->color[1] = lightcolor[1] * (1.f / 255.f);
+                cell->color[2] = lightcolor[2] * (1.f / 255.f);
+
+                baseintensity = (cell->color[0] + cell->color[1] + cell->color[2]) * (1.f / 3.f);
+
+                Lightgrid_AddDlights (pos, cell->color, dirsum);
+
+                {
+                    vec3_t up = {0.f, 0.f, 1.f};
+                    VectorMA (dirsum, baseintensity, up, dirsum);
+                }
+
+                cell->intensity = baseintensity;
+                if (VectorNormalize (dirsum) == 0.f)
+                {
+                    cell->dir[0] = cell->dir[1] = 0.f;
+                    cell->dir[2] = 1.f;
+                }
+                else
+                {
+                    VectorCopy (dirsum, cell->dir);
+                }
+            }
+        }
+    }
+
+    current_lightgrid.valid = true;
+
+    Con_Printf ("Lightgrid fallback: done (%dx%dx%d)\n", nx, ny, nz);
+}
+
+const lightgrid_t *Lightgrid_Get (void)
+{
+    return current_lightgrid.valid ? &current_lightgrid : NULL;
+}
+

--- a/Quake/gl_lightgrid.h
+++ b/Quake/gl_lightgrid.h
@@ -1,0 +1,37 @@
+//
+// Copyright (C) 2024 Ironwail developers
+//
+// Lightgrid public interface
+//
+
+#pragma once
+
+#include "quakedef.h"
+
+typedef struct lightgrid_cell_s
+{
+    vec3_t  color;
+    vec3_t  dir;
+    float   intensity;
+} lightgrid_cell_t;
+
+typedef struct lightgrid_s
+{
+    int             nx, ny, nz;
+    float           cellsize;
+    vec3_t          mins, maxs;
+    lightgrid_cell_t *cells;
+    qboolean        valid;
+} lightgrid_t;
+
+extern cvar_t r_lightgrid;
+extern cvar_t r_lightgrid_debug;
+
+void Lightgrid_Init (void);
+void Lightgrid_Shutdown (void);
+void Lightgrid_Clear (void);
+qboolean Lightgrid_LoadFromBSPX (void *bspx_data, int bspx_len);
+void Lightgrid_BuildFallback (void);
+void Lightgrid_Sample (const vec3_t pos, vec3_t out_color, vec3_t out_dir);
+const lightgrid_t *Lightgrid_Get (void);
+

--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -26,6 +26,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "quakedef.h"
 #include "gl_ktx2.h"
+#include "gl_lightgrid.h"
 
 #define INVALID_LIGHTSTYLE_OLD 255
 
@@ -511,6 +512,7 @@ typedef struct
 #define MAX_BSPX_LUMP_USAGE 256
 static bspx_lump_usage_t bspx_lump_usage[MAX_BSPX_LUMP_USAGE];
 static int bspx_lump_usage_count;
+static qboolean bspx_lightgrid_found;
 //supported lumps:
 //RGBLIGHTING (.lit)
 //LIGHTING_E5BGR9 (hdr lighting)
@@ -526,6 +528,7 @@ static void Q1BSPX_ResetUsage(void)
 {
         bspx_lump_usage_count = 0;
         memset(bspx_lump_usage, 0, sizeof(bspx_lump_usage));
+        bspx_lightgrid_found = false;
 }
 static void Q1BSPX_RecordEntries(qmodel_t *mod)
 {
@@ -836,6 +839,9 @@ static void Mod_DispatchBSPXLumps(qmodel_t *mod)
                 if (!handler->handler)
                         Q1BSPX_MarkUnsupported(entry->name);
         }
+
+        if (!bspx_lightgrid_found && mod == loadmodel)
+                Con_Printf("BSPX: LIGHTGRID missing, using fallback.\\n");
 }
 
 /*
@@ -2010,9 +2016,23 @@ void Mod_CalcSurfaceBounds (msurface_t *s)
 
 static void BSPX_LightGridLoad (qmodel_t *mod, void *lump, int lumpsize)
 {
-	(void)mod;
-	(void)lump;
-	(void)lumpsize;
+        (void)mod;
+
+        bspx_lightgrid_found = true;
+
+        if (!Lightgrid_LoadFromBSPX (lump, lumpsize))
+        {
+                Con_Printf("BSPX: LIGHTGRID is corrupted, falling back.\n");
+                return;
+        }
+
+        {
+                const lightgrid_t *lg = Lightgrid_Get ();
+                if (lg)
+                        Con_Printf("BSPX: LIGHTGRID found (%dx%dx%d, cell %.1f)\n", lg->nx, lg->ny, lg->nz, lg->cellsize);
+        }
+
+        Con_Printf("BSPX: Lightgrid loaded successfully.\n");
 }
 
 /*

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -22,6 +22,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // r_main.c
 
 #include "quakedef.h"
+#include "gl_lightgrid.h"
 
 #define NOISESCALE     (1.0f / 127.0f)
 
@@ -2424,17 +2425,66 @@ R_ShowPointFile
 */
 static void R_ShowPointFile (void)
 {
-	size_t i;
+        size_t i;
 
-	if (VEC_SIZE (r_pointfile) == 0)
-		return;
+        if (VEC_SIZE (r_pointfile) == 0)
+                return;
 
-	GL_BeginGroup ("Point file");
-	R_SetDebugGeometryZTest (true);
-	for (i = 1; i < VEC_SIZE (r_pointfile); i++)
-		R_EmitArrow (r_pointfile[i - 1], r_pointfile[i], 0xff3f3f7f);
-	R_FlushDebugGeometry ();
-	GL_EndGroup ();
+        GL_BeginGroup ("Point file");
+        R_SetDebugGeometryZTest (true);
+        for (i = 1; i < VEC_SIZE (r_pointfile); i++)
+                R_EmitArrow (r_pointfile[i - 1], r_pointfile[i], 0xff3f3f7f);
+        R_FlushDebugGeometry ();
+        GL_EndGroup ();
+}
+
+static void R_ShowLightgrid (void)
+{
+        const lightgrid_t *lg;
+        int x, y, z;
+
+        if (!r_lightgrid_debug.value)
+                return;
+
+        lg = Lightgrid_Get ();
+        if (!lg)
+                return;
+
+        GL_BeginGroup ("Lightgrid");
+        R_SetDebugGeometryZTest (false);
+
+        for (z = 0; z < lg->nz; z++)
+        {
+                for (y = 0; y < lg->ny; y++)
+                {
+                        for (x = 0; x < lg->nx; x++)
+                        {
+                                const lightgrid_cell_t *cell = &lg->cells[(z * lg->ny + y) * lg->nx + x];
+                                vec3_t mins, maxs;
+                                uint32_t color;
+                                int r, g, b, a;
+
+                                mins[0] = lg->mins[0] + x * lg->cellsize;
+                                mins[1] = lg->mins[1] + y * lg->cellsize;
+                                mins[2] = lg->mins[2] + z * lg->cellsize;
+
+                                maxs[0] = mins[0] + lg->cellsize;
+                                maxs[1] = mins[1] + lg->cellsize;
+                                maxs[2] = mins[2] + lg->cellsize;
+
+                                r = CLAMP (0, (int)(cell->color[0] * 255.f), 255);
+                                g = CLAMP (0, (int)(cell->color[1] * 255.f), 255);
+                                b = CLAMP (0, (int)(cell->color[2] * 255.f), 255);
+                                a = 127;
+                                color = ((uint32_t)a << 24) | ((uint32_t)r << 16) | ((uint32_t)g << 8) | (uint32_t)b;
+
+                                R_EmitWireBox (mins, maxs, color);
+                        }
+                }
+        }
+
+        R_FlushDebugGeometry ();
+        GL_EndGroup ();
 }
 
 /*
@@ -2646,13 +2696,15 @@ void R_RenderScene (void)
 
 	R_EndTranslucency ();
 
-	R_ShowTris (); //johnfitz
+        R_ShowTris (); //johnfitz
 
-	R_ShowBoundingBoxes (); //johnfitz
+        R_ShowBoundingBoxes (); //johnfitz
 
-	R_ShowPointFile ();
+        R_ShowPointFile ();
 
-	Fog_DisableGFog (); // Leave fog disabled for 2D overlays
+        R_ShowLightgrid ();
+
+        Fog_DisableGFog (); // Leave fog disabled for 2D overlays
 }
 
 /*

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -23,6 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // r_misc.c
 
 #include "quakedef.h"
+#include "gl_lightgrid.h"
 
 //johnfitz -- new cvars
 extern cvar_t r_clearcolor;
@@ -458,10 +459,11 @@ Cvar_RegisterVariable (&r_drawviewmodel);
 	Cvar_RegisterVariable (&r_scale);
 	Cvar_SetCallback (&r_lavaalpha, R_SetLavaalpha_f);
 	Cvar_SetCallback (&r_telealpha, R_SetTelealpha_f);
-	Cvar_SetCallback (&r_slimealpha, R_SetSlimealpha_f);
+        Cvar_SetCallback (&r_slimealpha, R_SetSlimealpha_f);
 
-	R_InitParticles ();
-	R_SetClearColor_f (&r_clearcolor); //johnfitz
+        Lightgrid_Init ();
+        R_InitParticles ();
+        R_SetClearColor_f (&r_clearcolor); //johnfitz
 
 	Sky_Init (); //johnfitz
 	Fog_Init (); //johnfitz
@@ -638,6 +640,9 @@ void R_NewMap (void)
         Sky_NewMap (); //johnfitz -- skybox in worldspawn
         Fog_NewMap (); //johnfitz -- global fog in worldspawn
         R_ParseWorldspawn (); //ericw -- wateralpha, lavaalpha, telealpha, slimealpha in worldspawn
+
+        if (!Lightgrid_Get ())
+                Lightgrid_BuildFallback ();
 
 	// Load pointfile if map has no vis data and either developer mode is on or the game was started from a map editing tool
 	if (developer.value || map_checks.value)

--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -23,10 +23,12 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 //r_alias.c -- alias model rendering
 
 #include "quakedef.h"
+#include "gl_lightgrid.h"
 
 extern cvar_t gl_overbright_models, gl_fullbrights, r_lerpmodels, r_lerpmove, r_model_halflambert; //johnfitz
 extern cvar_t scr_fov, cl_gun_fovscale, cl_gun_x, cl_gun_y, cl_gun_z;
 extern cvar_t r_oit;
+extern cvar_t r_lightgrid;
 
 //up to 16 color translated skins
 gltexture_t *playertextures[MAX_SCOREBOARD]; //johnfitz -- changed to an array of pointers
@@ -242,13 +244,25 @@ void R_SetupAliasLighting (entity_t     *e)
 	vec3_t		dlightcolor = {0.f, 0.f, 0.f};
 	vec3_t		ambientcolor;
 
-	// if the initial trace is completely black, try again from above
-	// this helps with models whose origin is slightly below ground level
-	// (e.g. some of the candles in the DOTM start map)
-	if (!R_LightPoint (e->origin, 0.f, &e->lightcache))
-		R_LightPoint (e->origin, e->model->maxs[2] * 0.5f, &e->lightcache);
+        if (r_lightgrid.value && Lightgrid_Get ())
+        {
+                vec3_t sample_color, sample_dir;
+                int j;
+                Lightgrid_Sample (e->origin, sample_color, sample_dir);
+                for (j = 0; j < 3; j++)
+                        lightcolor[j] = sample_color[j] * 256.0f;
+                VectorCopy (lightcolor, ambientcolor);
+        }
+        else
+        {
+                // if the initial trace is completely black, try again from above
+                // this helps with models whose origin is slightly below ground level
+                // (e.g. some of the candles in the DOTM start map)
+                if (!R_LightPoint (e->origin, 0.f, &e->lightcache))
+                        R_LightPoint (e->origin, e->model->maxs[2] * 0.5f, &e->lightcache);
 
-	VectorCopy (lightcolor, ambientcolor);
+                VectorCopy (lightcolor, ambientcolor);
+        }
 
 	//add dlights
 	for (i=0; i<r_framedata.numlights; i++)

--- a/Quake/r_part.c
+++ b/Quake/r_part.c
@@ -22,6 +22,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 */
 
 #include "quakedef.h"
+#include "gl_lightgrid.h"
 
 #define MAX_PARTICLES			16384	// default max # of particles at one
 										//  time
@@ -725,16 +726,25 @@ static void R_DrawParticles_Real (qboolean alpha, qboolean showtris)
 		v = &partverts[numpartverts++];
 		VectorCopy (p->org, v->pos);
 
-		//johnfitz -- particle transparency and fade out
-		c = showtris ? color : (GLubyte *) &d_8to24table[(int)p->color];
-		*(uint32_t*)&v->color = *(uint32_t*)c;
-		v->color[0] = c[0];
-		v->color[1] = c[1];
-		v->color[2] = c[2];
-		//alpha = CLAMP(0, p->die + 0.5 - cl.time, 1);
-		v->color[3] = c[3]; //(int)(alpha * 255);
-		//johnfitz
-	}
+                //johnfitz -- particle transparency and fade out
+                c = showtris ? color : (GLubyte *) &d_8to24table[(int)p->color];
+                *(uint32_t*)&v->color = *(uint32_t*)c;
+                v->color[0] = c[0];
+                v->color[1] = c[1];
+                v->color[2] = c[2];
+                //alpha = CLAMP(0, p->die + 0.5 - cl.time, 1);
+                v->color[3] = c[3]; //(int)(alpha * 255);
+                //johnfitz
+
+                if (r_lightgrid.value && Lightgrid_Get ())
+                {
+                        vec3_t sample_color, sample_dir;
+                        Lightgrid_Sample (p->org, sample_color, sample_dir);
+                        v->color[0] = (GLubyte)CLAMP (0, (int)(v->color[0] * sample_color[0]), 255);
+                        v->color[1] = (GLubyte)CLAMP (0, (int)(v->color[1] * sample_color[1]), 255);
+                        v->color[2] = (GLubyte)CLAMP (0, (int)(v->color[2] * sample_color[2]), 255);
+                }
+        }
 
 	R_FlushParticleBatch ();
 


### PR DESCRIPTION
## Summary
- add lightgrid data structures, cvars, and BSPX loading for LIGHTGRID lumps
- build a fallback interpolated lightgrid and use it to shade models and particles
- add optional lightgrid debug visualization and integrate initialization into map loading

## Testing
- make -n *(fails: missing SDL development files in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69309429c684832ea227dafa12591de2)