### PR TITLE
Fix GLSL clamp overloads for Overbright values

### DIFF
--- a/Quake/shaders/alias.vert
+++ b/Quake/shaders/alias.vert
@@ -155,5 +155,5 @@ void main()
 	bool is_viewmodel = (inst.Flags & ALIAS_FLAG_VIEWMODEL) != 0;
 	vec3 final_color = is_viewmodel ? (ambient + dlight) : (inst.LightColor.rgb * lighting * Overbright);
 	
-	out_color = clamp(vec4(final_color, inst.LightColor.a), 0.0, Overbright);
+    out_color = clamp(vec4(final_color, inst.LightColor.a), vec4(0.0), vec4(Overbright));
 }

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -483,10 +483,10 @@ void main()
 	// FINAL LIGHTING COMPOSITION
 	// ========================================================================
 #if DITHER >= 2
-	vec3 clamped_light = clamp(total_light, 0.0, 1.0);
-	vec3 total_lightmap = clamp(floor(clamped_light * 63.0 + 0.5) * (Overbright / 63.0), 0.0, Overbright);
+    vec3 clamped_light = clamp(total_light, vec3(0.0), vec3(1.0));
+    vec3 total_lightmap = clamp(floor(clamped_light * 63.0 + 0.5) * (Overbright / 63.0), vec3(0.0), vec3(Overbright));
 #else
-	vec3 total_lightmap = clamp(total_light * Overbright, 0.0, Overbright);
+    vec3 total_lightmap = clamp(total_light * Overbright, vec3(0.0), vec3(Overbright));
 #endif
 
 #if MODE != 1
@@ -497,7 +497,7 @@ void main()
 
 	result.rgb += fullbright;
 	result.rgb += emissive;
-	result.rgb += clamp(specular_light, 0.0, Overbright) * clamp(result.a, 0.0, 1.0);
+    result.rgb += clamp(specular_light, vec3(0.0), vec3(Overbright)) * clamp(result.a, 0.0, 1.0);
 
 	// Tonemapping
 	if (LightmapParams.y > 0.5)


### PR DESCRIPTION
## Summary
- fix world fragment shader clamp bounds to use vector types when combining with Overbright
- update alias vertex shader clamp bounds to use vector types as well

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693098876878832e834a7c62e9311376)