### PR TITLE
Fix clamp usage in world shader

### DIFF
--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -471,13 +471,13 @@ void main()
 				}
 			}
 			
-			total_light += clamp(dynamic_light, 0.0, 1.0 - total_light);
-		}
-	}
+                        total_light += clamp(dynamic_light, vec3(0.0), 1.0 - total_light);
+                }
+        }
 
-	// Sun Light
-	vec3 sun_light = ComputeSunLight(in_pos, surface_normal);
-	total_light += clamp(sun_light, 0.0, 1.0 - total_light);
+        // Sun Light
+        vec3 sun_light = ComputeSunLight(in_pos, surface_normal);
+        total_light += clamp(sun_light, vec3(0.0), 1.0 - total_light);
 
 	// ========================================================================
 	// FINAL LIGHTING COMPOSITION


### PR DESCRIPTION
## Summary
- fix clamp calls in world fragment shader to use consistent vec3 arguments
- prevent GLSL compilation errors when applying dynamic and sun lighting

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693099377c94832e9117b1922be7e329)