### PR TITLE
Add saturation control to rendering

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -781,8 +781,9 @@ void GL_PostProcess (void)
         GL_BindNative (GL_TEXTURE3, GL_TEXTURE_2D, bloom_texture);
         GL_BindNative (GL_TEXTURE4, GL_TEXTURE_2D, velocity_texture);
         GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 0, gl_palette_buffer[palidx], 0, 256 * sizeof (GLuint));
-	if (variant != 2) // some AMD drivers optimize out the uniform in variant #2
-		GL_Uniform4fFunc (0, vid_gamma.value, q_min (2.0f, q_max (1.0f, vid_contrast.value)), 1.f / r_refdef.scale, dither);
+        if (variant != 2) // some AMD drivers optimize out the uniform in variant #2
+                GL_Uniform4fFunc (0, vid_gamma.value, q_min (2.0f, q_max (1.0f, vid_contrast.value)), 1.f / r_refdef.scale, dither);
+        GL_Uniform1fFunc (12, q_min (2.f, q_max (0.f, vid_saturation.value)));
         GL_Uniform3fFunc (5, bloom_intensity, exposure, tonemap_mode);
         GL_Uniform4fFunc (6, motion_enabled ? 1.f : 0.f, motion_effective_shutter, motion_min_velocity, motion_depth_threshold);
         GL_Uniform4fFunc (7, motion_max_radius, (float)motion_max_samples, velocity_texture ? 1.f : 0.f, 0.f);
@@ -1446,7 +1447,7 @@ GL_NeedsPostprocess
 */
 qboolean GL_NeedsPostprocess (void)
 {
-        if (vid_gamma.value != 1.f || vid_contrast.value != 1.f || softemu || R_GetEffectiveAlphaMode () == ALPHAMODE_OIT || R_DoFEnabled ())
+        if (vid_gamma.value != 1.f || vid_contrast.value != 1.f || vid_saturation.value != 1.f || softemu || R_GetEffectiveAlphaMode () == ALPHAMODE_OIT || R_DoFEnabled ())
                 return true;
         if (r_tonemap.value > 0.f || r_bloom.value > 0.f || GL_ShouldApplyMotionBlur ())
                 return true;

--- a/Quake/gl_texmgr.c
+++ b/Quake/gl_texmgr.c
@@ -2524,6 +2524,7 @@ static unsigned int cached_palette[256];
 static softemu_metric_t cached_softemu_metric = SOFTEMU_METRIC_INVALID;
 static float cached_gamma;
 static float cached_contrast;
+static float cached_saturation;
 static vec4_t cached_blendcolor;
 
 /*
@@ -2533,11 +2534,12 @@ GLPalette_DeleteResources
 */
 static void GLPalette_InvalidateRemapped (void)
 {
-	int i;
-	cached_gamma = -1.f;
-	cached_contrast = -1.f;
-	for (i = 0; i < 4; i++)
-		cached_blendcolor[i] = -1.f;
+        int i;
+        cached_gamma = -1.f;
+        cached_contrast = -1.f;
+        cached_saturation = -1.f;
+        for (i = 0; i < 4; i++)
+                cached_blendcolor[i] = -1.f;
 }
 
 /*
@@ -2656,27 +2658,33 @@ Returns index of palette buffer to use:
 	blend = (v_blend[3] && gl_polyblend.value) ? v_blend : vec4_origin;
 
 	/* can we use the original palette? */
-	if (vid_gamma.value == 1.f &&
-		vid_contrast.value == 1.f &&
-		blend[3] == 0.f)
-		return 0;
+        if (vid_gamma.value == 1.f &&
+                vid_contrast.value == 1.f &&
+                vid_saturation.value == 1.f &&
+                blend[3] == 0.f)
+                return 0;
 
 	/* no change since last time? */
-	if (cached_gamma == vid_gamma.value &&
-		cached_contrast == vid_contrast.value &&
-		memcmp (cached_blendcolor, blend, 4 * sizeof (float)) == 0)
-		return 1;
+        if (cached_gamma == vid_gamma.value &&
+                cached_contrast == vid_contrast.value &&
+                cached_saturation == vid_saturation.value &&
+                memcmp (cached_blendcolor, blend, 4 * sizeof (float)) == 0)
+                return 1;
 
-	cached_gamma = vid_gamma.value;
-	cached_contrast = vid_contrast.value;
-	memcpy (cached_blendcolor, blend, 4 * sizeof (float));
+        cached_gamma = vid_gamma.value;
+        cached_contrast = vid_contrast.value;
+        cached_saturation = vid_saturation.value;
+        memcpy (cached_blendcolor, blend, 4 * sizeof (float));
 
 	GL_BeginGroup ("Postprocess palette");
 
 	GL_UseProgram (glprogs.palette_postprocess);
 	GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 0, gl_palette_buffer[0], 0, 256 * sizeof (GLuint));
 	GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 1, gl_palette_buffer[1], 0, 256 * sizeof (GLuint));
-	GL_Uniform2fFunc (0, vid_gamma.value, CLAMP (1.0f, vid_contrast.value, 2.0f));
+        GL_Uniform3fFunc (0,
+                vid_gamma.value,
+                CLAMP (1.0f, vid_contrast.value, 2.0f),
+                CLAMP (0.0f, vid_saturation.value, 2.0f));
 	GL_Uniform4fvFunc (1, 1, blend);
 	GL_DispatchComputeFunc (256/64, 1, 1);
 	GL_MemoryBarrierFunc (GL_SHADER_STORAGE_BARRIER_BIT);

--- a/Quake/gl_vidsdl.c
+++ b/Quake/gl_vidsdl.c
@@ -153,6 +153,7 @@ cvar_t		vid_saveresize = {"vid_saveresize", "0", CVAR_ARCHIVE};
 
 cvar_t		vid_gamma = {"gamma", "1", CVAR_ARCHIVE}; //johnfitz -- moved here from view.c
 cvar_t		vid_contrast = {"contrast", "1", CVAR_ARCHIVE}; //QuakeSpasm, MarkV
+cvar_t		vid_saturation = {"saturation", "1", CVAR_ARCHIVE};
 
 void TexMgr_Anisotropy_f (cvar_t *var);
 void TexMgr_CompressTextures_f (cvar_t *var);
@@ -246,9 +247,10 @@ VID_Gamma_Init -- call on init
 */
 static void VID_Gamma_Init (void)
 {
-	Cvar_RegisterVariable (&vid_gamma);
-	Cvar_SetCallback (&vid_gamma, VID_Gamma_f);
-	Cvar_RegisterVariable (&vid_contrast);
+        Cvar_RegisterVariable (&vid_gamma);
+        Cvar_SetCallback (&vid_gamma, VID_Gamma_f);
+        Cvar_RegisterVariable (&vid_contrast);
+        Cvar_RegisterVariable (&vid_saturation);
 }
 
 /*

--- a/Quake/menu.c
+++ b/Quake/menu.c
@@ -3133,6 +3133,7 @@ void M_Menu_Gamepad_f (void)
 		item (OPT_PREVIEW,				"Live Preview")					\
 		item (OPT_GAMMA,				"Brightness")					\
 		item (OPT_CONTRAST,				"Contrast")						\
+                item (OPT_SATURATION,                           "Saturation")                                   \
 		item (OPT_VIDEO,				"Display")						\
 		item (OPT_GRAPHICS,				"Graphics")						\
 		item (OPT_INTERFACE,			"Interface")					\
@@ -3471,12 +3472,13 @@ static void M_Options_Preview (int id)
 	{
 		if (id < GRAPHICS_OPTIONS_BEGIN || id >= GRAPHICS_OPTIONS_END)
 		{
-			switch (id)
-			{
-			case OPT_GAMMA:
-			case OPT_CONTRAST:
-			case OPT_UISCALE:
-			case OPT_HUDSTYLE:
+                        switch (id)
+                        {
+                        case OPT_GAMMA:
+                        case OPT_CONTRAST:
+                        case OPT_SATURATION:
+                        case OPT_UISCALE:
+                        case OPT_HUDSTYLE:
 			case OPT_SBALPHA:
 			case OPT_HUDLEVEL:
 			case OPT_CONALPHA:
@@ -3678,6 +3680,12 @@ void M_AdjustSliders (int dir)
 		if (f < 1)	f = 1;
 		else if (f > 2)	f = 2;
 		Cvar_SetValue ("contrast", f);
+		break;
+	case OPT_SATURATION:	// saturation
+		f = vid_saturation.value + dir * 0.1f;
+		if (f < 0)	f = 0;
+		else if (f > 2)	f = 2;
+		Cvar_SetValue ("saturation", f);
 		break;
 	case OPT_MOUSESPEED:	// mouse speed
 		f = sensitivity.value + dir * 0.5;
@@ -4075,6 +4083,9 @@ qboolean M_SetSliderValue (int option, float f)
 		f += 1.f;
 		Cvar_SetValue ("contrast", f);
 		return true;
+	case OPT_SATURATION:	// saturation
+		Cvar_SetValue ("saturation", f * 2.f);
+		return true;
 	case OPT_RENDERSCALE:
 		f = floor (1 + f * (vid.maxscale - 1) + 0.5);
 		Cvar_SetValueQuick (&r_scale, f);
@@ -4319,15 +4330,20 @@ static void M_Options_DrawItem (int y, int item)
 		M_DrawSlider (x, y, r, va ("%.0f", 10.f * r));
 		break;
 
-	case OPT_CONTRAST:
-		r = vid_contrast.value - 1.0;
-		M_DrawSlider (x, y, r, va ("%.0f", 10.f * r));
-		break;
-	
-	case OPT_MOUSESPEED:
-		r = (sensitivity.value - 1)/10;
-		M_DrawSlider (x, y, r, va ("%.1f", sensitivity.value));
-		break;
+        case OPT_CONTRAST:
+                r = vid_contrast.value - 1.0;
+                M_DrawSlider (x, y, r, va ("%.0f", 10.f * r));
+                break;
+
+        case OPT_SATURATION:
+                r = vid_saturation.value * 0.5f;
+                M_DrawSlider (x, y, r, va ("%.0f%%", vid_saturation.value * 100.f));
+                break;
+
+        case OPT_MOUSESPEED:
+                r = (sensitivity.value - 1)/10;
+                M_DrawSlider (x, y, r, va ("%.1f", sensitivity.value));
+                break;
 
 	case OPT_SBALPHA:
 		r = (1.0 - scr_sbaralpha.value) ; // scr_sbaralpha range is 1.0 to 0.0

--- a/Quake/shaders/palette_postprocess.comp
+++ b/Quake/shaders/palette_postprocess.comp
@@ -1,6 +1,6 @@
 layout(local_size_x=64) in;
 
-layout(location=0) uniform vec2 GammmaContrast;
+layout(location=0) uniform vec3 GammaContrastSaturation;
 layout(location=1) uniform vec4 BlendColor;
 
 layout(std430, binding=0) restrict readonly buffer PaletteBuffer
@@ -21,15 +21,18 @@ layout(std430, binding=1) restrict writeonly buffer DstPaletteBuffer
 
 void main()
 {
-	float gamma = GammmaContrast.x;
-	float contrast = GammmaContrast.y;
-	uint idx = gl_GlobalInvocationID.x;
-	if (idx >= 256u)
-		return;
-	vec3 color = vec3(UnpackRGB8(Palette[idx])) * (1./255.);
-	color = mix(color, BlendColor.rgb, BlendColor.a);
-	color *= contrast;
-	color = pow(color, vec3(gamma));
+        float gamma = GammaContrastSaturation.x;
+        float contrast = GammaContrastSaturation.y;
+        float saturation = GammaContrastSaturation.z;
+        uint idx = gl_GlobalInvocationID.x;
+        if (idx >= 256u)
+                return;
+        vec3 color = vec3(UnpackRGB8(Palette[idx])) * (1./255.);
+        color = mix(color, BlendColor.rgb, BlendColor.a);
+        float luma = dot(color, vec3(0.2126, 0.7152, 0.0722));
+        color = mix(vec3(luma), color, clamp(saturation, 0.0, 2.0));
+        color *= contrast;
+        color = pow(color, vec3(gamma));
 	uvec3 dst = uvec3(clamp(color, 0., 1.) * 255. + .5);
 	DstPalette[idx] = dst.r | (dst.g << 8) | (dst.b << 16) | 0xff000000u;
 }

--- a/Quake/shaders/postprocess.frag
+++ b/Quake/shaders/postprocess.frag
@@ -116,6 +116,7 @@ layout(location=8) uniform vec4 PostFXParams0; // x: vignette strength, y: inner
 layout(location=9) uniform vec4 PostFXParams1; // xyz: vignette color, w: blend mode
 layout(location=10) uniform vec4 PostFXParams2; // x: vignette noise amount, y: chromatic aberration (pixels), z: screen-space darken strength, w: screen-space darken depth range
 layout(location=11) uniform vec4 TeleportParams; // x: teleport fade, y: blur radius (pixels)
+layout(location=12) uniform float Saturation;
 
 const int MOTION_MAX_SAMPLES = 64;
 const float OPAQUE_ALPHA_THRESHOLD = 0.999;
@@ -449,6 +450,8 @@ void main()
         float exposure = max(HDRParams.y, 0.0);
         float tonemapMode = HDRParams.z;
         vec3 combined = (hdrColor + bloomColor) * exposure * contrast;
+        float luma = dot(combined, vec3(0.2126, 0.7152, 0.0722));
+        combined = mix(vec3(luma), combined, clamp(Saturation, 0.0, 2.0));
         combined = max(combined, vec3(0.0));
         vec3 mapped;
         if (tonemapMode > 0.5)

--- a/Quake/view.h
+++ b/Quake/view.h
@@ -25,6 +25,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 extern	cvar_t		vid_gamma;
 extern	cvar_t		vid_contrast;
+extern	cvar_t		vid_saturation;
 
 extern float v_blend[4];
 


### PR DESCRIPTION
## Summary
- add a new `saturation` cvar and register it for rendering settings
- apply saturation to both shader-based postprocessing and software palette paths
- expose saturation adjustment with a slider in the main options menu

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69309a79b988832ea3b4d6467c5749e5)