### PR TITLE
Fix alias lightning flag string comparison

### DIFF
--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -676,7 +676,7 @@ static void R_DrawAliasModel_Real (entity_t *e, qboolean showtris)
         instance->alpha = entalpha;
         if (e == &cl.viewent)
                 instance->flags |= ALIAS_INSTANCE_FLAG_NO_MOTION_BLUR | ALIAS_INSTANCE_FLAG_VIEWMODEL;
-        if (!q_strncmp (e->model->name, "progs/bolt", 10))
+if (!Q_strncmp (e->model->name, "progs/bolt", 10))
                 instance->flags |= ALIAS_INSTANCE_FLAG_LIGHTNING;
         instance->pose1 = lerpdata.pose1;
         instance->pose2 = lerpdata.pose2;


### PR DESCRIPTION
## Summary
- replace the incorrect `q_strncmp` call with existing `Q_strncmp` in `r_alias.c`
- ensure the lightning flag check uses the proper string comparison

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930aa59d904832e945457aacfe8b573)