### PR TITLE
Add botspawn command and sample QuakeC bot

### DIFF
--- a/Misc/qc/README.md
+++ b/Misc/qc/README.md
@@ -1,0 +1,5 @@
+# QuakeC additions
+
+This folder contains a lightweight QuakeC script that introduces a simple multiplayer bot.
+
+Add `Misc/qc/multiplayer_bot.qc` to your `progs.src` (ideally after the other gameplay scripts) and rebuild `progs.dat` with your preferred QuakeC compiler. The engine-side `botspawn` console command will invoke the `botspawn` function defined in that file, so it can be used from the server console or by connected players once their modded `progs.dat` is loaded.

--- a/Misc/qc/multiplayer_bot.qc
+++ b/Misc/qc/multiplayer_bot.qc
@@ -1,0 +1,76 @@
+// Simple multiplayer bot for Ironwail / Quake
+//
+// This script is designed to be appended to the stock id1 QuakeC sources. Compile
+// a new progs.dat that includes this file, then run `botspawn` from the console
+// (engine-side command) to drop a roaming bot into the current game.
+
+.float bot_nextmove;
+.entity enemy;
+
+// Pick a random yaw to keep idle bots moving.
+void() bot_pick_direction =
+{
+    self.ideal_yaw = random() * 360;
+    self.bot_nextmove = time + 0.75;
+};
+
+entity() bot_find_enemy =
+{
+    local entity candidate;
+
+    candidate = find(world, classname, "player");
+    while (candidate)
+    {
+        if (candidate.health > 0 && candidate != self)
+            return candidate;
+
+        candidate = find(candidate, classname, "player");
+    }
+
+    return world;
+};
+
+void() bot_think =
+{
+    if (self.enemy && self.enemy.health <= 0)
+        self.enemy = world;
+
+    if (!self.enemy)
+        self.enemy = bot_find_enemy();
+
+    if (self.enemy && self.enemy != world)
+        self.ideal_yaw = vectoyaw(self.enemy.origin - self.origin);
+    else if (time > self.bot_nextmove)
+        bot_pick_direction();
+
+    ChangeYaw();
+    walkmove(self.ideal_yaw, 200 * frametime);
+
+    self.nextthink = time + 0.1;
+    self.think = bot_think;
+};
+
+void() botspawn =
+{
+    local entity bot;
+
+    bot = spawn();
+    bot.classname = "bot";
+    bot.movetype = MOVETYPE_STEP;
+    bot.solid = SOLID_SLIDEBOX;
+    bot.takedamage = DAMAGE_AIM;
+    bot.health = 100;
+    bot.flags = FL_CLIENT;
+
+    setmodel(bot, "progs/player.mdl");
+    setsize(bot, VEC_HULL_MIN, VEC_HULL_MAX);
+    bot.view_ofs = '0 0 22';
+
+    if (self)
+        bot.origin = self.origin + '0 0 48';
+    else
+        bot.origin = world.origin + '0 0 48';
+
+    bot.think = bot_think;
+    bot.nextthink = time + 0.2;
+};

--- a/Quake/host_cmd.c
+++ b/Quake/host_cmd.c
@@ -2978,6 +2978,34 @@ static void Host_Kill_f (void)
 
 /*
 ==================
+Host_BotSpawn_f
+==================
+*/
+static void Host_BotSpawn_f (void)
+{
+	dfunction_t *func;
+
+	if (!sv.active || sv.state != ss_active)
+	{
+		Con_Printf ("botspawn is only available while a server is active\n");
+		return;
+	}
+
+	func = PR_FindFunction ("botspawn");
+	if (!func)
+	{
+		Con_Printf ("botspawn QC entry point not found\n");
+		return;
+	}
+
+	pr_global_struct->time = qcvm->time;
+	pr_global_struct->self = EDICT_TO_PROG(cmd_source == src_command ? qcvm->edicts : sv_player);
+
+	PR_ExecuteProgram (func - qcvm->functions);
+}
+
+/*
+==================
 Host_Pause_f
 ==================
 */
@@ -3749,10 +3777,11 @@ void Host_InitCommands (void)
         Cmd_AddCommand ("mapname", Host_Mapname_f); //johnfitz
         Cmd_AddCommand ("randmap", Host_Randmap_f); //ericw
         Cmd_AddCommand_ClientCommand ("status", Host_Status_f);
-	Cmd_AddCommand ("quit", Host_Quit_f);
-	Cmd_AddCommand_ClientCommand ("god", Host_God_f);
-	Cmd_AddCommand_ClientCommand ("notarget", Host_Notarget_f);
-	Cmd_AddCommand_ClientCommand ("fly", Host_Fly_f);
+        Cmd_AddCommand ("quit", Host_Quit_f);
+        Cmd_AddCommand_ClientCommand ("god", Host_God_f);
+        Cmd_AddCommand_ClientCommand ("notarget", Host_Notarget_f);
+        Cmd_AddCommand_ClientCommand ("fly", Host_Fly_f);
+        Cmd_AddCommand_ClientCommand ("botspawn", Host_BotSpawn_f);
 	Cmd_AddCommand ("map", Host_Map_f);
 	Cmd_AddCommand ("restart", Host_Restart_f);
 	Cmd_AddCommand ("changelevel", Host_Changelevel_f);

--- a/Quake/pr_edict.c
+++ b/Quake/pr_edict.c
@@ -386,6 +386,11 @@ static dfunction_t *ED_FindFunction (const char *fn_name)
 	return NULL;
 }
 
+dfunction_t *PR_FindFunction (const char *fn_name)
+{
+	return ED_FindFunction (fn_name);
+}
+
 /*
 ============
 GetEdictFieldValue

--- a/Quake/progs.h
+++ b/Quake/progs.h
@@ -319,6 +319,8 @@ qboolean PR_LoadProgs (const char *filename, qboolean fatal);
 void PR_EnableExtensions (void);
 void PR_AutoCvarChanged (cvar_t *var);					//updates the autocvar_ globals when their cvar is changed
 int PR_FindExtensionByName (const char *name);			//returns known extension index, or 0 for unrecognized extensions
+dfunction_t *PR_FindFunction (const char *fn_name);
+
 
 void PR_ReloadPics (qboolean purge);					//for gamedir or video changes
 


### PR DESCRIPTION
## Summary
- expose a reusable helper to find QuakeC functions and wire a new `botspawn` console command into the engine
- allow running the new command from console or clients, executing a QuakeC bot spawn routine when available
- add a reference QuakeC script and README that implement a simple roaming multiplayer bot

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693201010a98832eadb7abcb156637c7)