### PR TITLE
Fix Host_BotSpawn self pointer evaluation

### DIFF
--- a/Quake/host_cmd.c
+++ b/Quake/host_cmd.c
@@ -2984,6 +2984,7 @@ Host_BotSpawn_f
 static void Host_BotSpawn_f (void)
 {
 	dfunction_t *func;
+	edict_t *self;
 
 	if (!sv.active || sv.state != ss_active)
 	{
@@ -2999,7 +3000,8 @@ static void Host_BotSpawn_f (void)
 	}
 
 	pr_global_struct->time = qcvm->time;
-	pr_global_struct->self = EDICT_TO_PROG(cmd_source == src_command ? qcvm->edicts : sv_player);
+	self = (cmd_source == src_command) ? qcvm->edicts : sv_player;
+	pr_global_struct->self = EDICT_TO_PROG(self);
 
 	PR_ExecuteProgram (func - qcvm->functions);
 }


### PR DESCRIPTION
## Summary
- add a temporary edict pointer before calling `EDICT_TO_PROG` in `Host_BotSpawn_f` to avoid incorrect cast precedence

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932125830b4832e8524ca9978eefefb)