### PR TITLE
Add BSPX octree lightgrid decoding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ if (WIN32)
 endif()
 
 file(GLOB IWAIL_SRC CONFIGURE_DEPENDS "Quake/*.c" "Quake/*.h" "Quake/*.cpp" "Quake/*.hpp")
+file(GLOB COMMON_SRC CONFIGURE_DEPENDS "common/*.c" "common/*.h")
 
 set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/Quake/bc7enc.c PROPERTIES LANGUAGE CXX)
 
@@ -62,7 +63,7 @@ elseif (PC_MAD_FOUND)
     list(REMOVE_ITEM IWAIL_SRC ${CMAKE_CURRENT_SOURCE_DIR}/Quake/snd_mpg123.c)
 endif()
 
-add_executable(ironwail ${IWAIL_SRC})
+add_executable(ironwail ${IWAIL_SRC} ${COMMON_SRC})
 target_compile_features(ironwail PRIVATE c_std_11 cxx_std_17)
 if (UNIX)
 	target_link_libraries(ironwail PRIVATE m)

--- a/Quake/Makefile
+++ b/Quake/Makefile
@@ -256,13 +256,14 @@ OBJS = strlcat.o \
 	cl_tent.o \
 	console.o \
 	keys.o \
-        menu.o \
-        sbar.o \
+	menu.o \
+	sbar.o \
 	view.o \
-        wad.o \
-        cmd.o \
-        common.o \
-        q3shader.o \
+	wad.o \
+	cmd.o \
+	common.o \
+	../common/lightgrid.o \
+	q3shader.o \
         steam.o \
 	json.o \
 	miniz.o \

--- a/Quake/cl_main.c
+++ b/Quake/cl_main.c
@@ -23,6 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "quakedef.h"
 #include "bgmusic.h"
+#include "../common/lightgrid.h"
 
 // we need to declare some mouse variables here, because the menu system
 // references them even when on a unix system.
@@ -74,11 +75,12 @@ extern vec3_t	v_punchangles[2];
 
 void CL_FreeState(void)
 {
-	int i;
-	for (i = 0; i < MAX_CL_STATS; i++)
-		free (cl.statss[i]);
-	PR_ClearProgs (&cl.qcvm);
-	memset (&cl, 0, sizeof(cl));
+        int i;
+        for (i = 0; i < MAX_CL_STATS; i++)
+                free (cl.statss[i]);
+        Lightgrid_Free(cl.lightgrid);
+        PR_ClearProgs (&cl.qcvm);
+        memset (&cl, 0, sizeof(cl));
 }
 
 /*

--- a/Quake/client.h
+++ b/Quake/client.h
@@ -25,6 +25,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 // client.h
 
+#include "../common/lightgrid.h"
+
 typedef struct
 {
 	int		length;
@@ -250,6 +252,7 @@ typedef struct
 
 // refresh related state
 	struct qmodel_s	*worldmodel;	// cl_entitites[0].model
+	lightgrid_t	*lightgrid;
 	int			num_efrags;
 	int			num_entities;	// held in cl_entities array
 	int			num_statics;	// held in cl_staticentities array

--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -26,6 +26,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "quakedef.h"
 #include "gl_ktx2.h"
+#include "../common/lightgrid.h"
 
 #define INVALID_LIGHTSTYLE_OLD 255
 
@@ -487,11 +488,11 @@ typedef struct {
     char lumpname[24]; // up to 23 chars, zero-padded
     int fileofs;  // from file start
     int filelen;
-} bspx_lump_t;
+} bspx_lump_disk_t;
 typedef struct {
     char id[4];  // 'BSPX'
     int numlumps;
-        bspx_lump_t lumps[1];
+        bspx_lump_disk_t lumps[1];
 } bspx_header_t;
 typedef struct
 {
@@ -504,7 +505,7 @@ typedef struct
 } bsp_header_info_t;
 typedef struct
 {
-        char lumpname[sizeof(((bspx_lump_t *)0)->lumpname) + 1];
+        char lumpname[sizeof(((bspx_lump_disk_t *)0)->lumpname) + 1];
         qboolean used;
         qboolean unsupported;
 } bspx_lump_usage_t;
@@ -543,7 +544,7 @@ static bspx_lump_usage_t *Q1BSPX_FindUsage(const char *lumpname)
 
         for (i = 0; i < bspx_lump_usage_count; i++)
         {
-                if (!strncmp(bspx_lump_usage[i].lumpname, lumpname, sizeof(((bspx_lump_t *)0)->lumpname)))
+                if (!strncmp(bspx_lump_usage[i].lumpname, lumpname, sizeof(((bspx_lump_disk_t *)0)->lumpname)))
                         return &bspx_lump_usage[i];
         }
         return NULL;
@@ -796,7 +797,7 @@ static qboolean Mod_ParseBSPXDirectory(qmodel_t *mod, const bsp_header_info_t *h
         return true;
 }
 
-typedef void (*bspx_handler_t)(qmodel_t *mod, void *data, int size);
+typedef qboolean (*bspx_handler_t)(qmodel_t *mod, void *data, int size);
 typedef struct
 {
         const char *name;
@@ -819,6 +820,7 @@ static void Mod_DispatchBSPXLumps(qmodel_t *mod)
         {
                 const bspx_entry_t *entry = &mod->bspx_entries[i];
                 const bspx_handler_reg_t *handler;
+                qboolean handled = false;
 
                 if (Q1BSPX_IsProcessed(entry->name))
                         continue;
@@ -827,13 +829,16 @@ static void Mod_DispatchBSPXLumps(qmodel_t *mod)
                 {
                         if (!strncmp(entry->name, handler->name, strlen(handler->name)))
                         {
-                                handler->handler(mod, mod_base + entry->offset, entry->size);
-                                Q1BSPX_MarkUsed(entry->name);
+                                handled = true;
+                                if (handler->handler(mod, mod_base + entry->offset, entry->size))
+                                        Q1BSPX_MarkUsed(entry->name);
+                                else
+                                        Q1BSPX_MarkUnsupported(entry->name);
                                 break;
                         }
                 }
 
-                if (!handler->handler)
+                if (!handled)
                         Q1BSPX_MarkUnsupported(entry->name);
         }
 }
@@ -874,6 +879,7 @@ static qboolean Mod_CheckAnimTextureArrayQ64(texture_t *anims[], int numTex)
 	}
 	return true;
 }
+
 
 /*
 ================
@@ -2008,12 +2014,31 @@ void Mod_CalcSurfaceBounds (msurface_t *s)
 	}
 }
 
-static void BSPX_LightGridLoad (qmodel_t *mod, void *lump, int lumpsize)
+static qboolean BSPX_LightGridLoad (qmodel_t *mod, void *lump, int lumpsize)
 {
+	lightgrid_t *lg;
+	bspx_lump_t l;
+
 	(void)mod;
-	(void)lump;
-	(void)lumpsize;
+
+	Lightgrid_Free(cl.lightgrid);
+	cl.lightgrid = NULL;
+
+	if (!lump || lumpsize <= 0)
+		return false;
+
+	l.data = lump;
+	l.size = (size_t)lumpsize;
+
+	lg = Lightgrid_LoadFromBSPX_Octree(&l);
+	if (!lg)
+		return false;
+
+	cl.lightgrid = lg;
+
+	return true;
 }
+
 
 /*
 =================
@@ -4486,6 +4511,7 @@ static qboolean MD5_ParseCheck(const char *s, const char **buffer)
 	*buffer = COM_Parse(*buffer);
 	return true;
 }
+
 static size_t MD5_ParseUInt(const char **buffer)
 {
 	size_t i = strtoull(com_token, NULL, 0);

--- a/Quake/gl_rlight.c
+++ b/Quake/gl_rlight.c
@@ -22,6 +22,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // r_light.c
 
 #include "quakedef.h"
+#include "../common/lightgrid.h"
 
 extern cvar_t r_flatlightstyles; //johnfitz
 extern cvar_t r_lerplightstyles;
@@ -444,4 +445,23 @@ int R_LightPoint (vec3_t p, float ofs, lightcache_t *cache)
 		InterpolateLightmap (lightcolor, cl.worldmodel->surfaces + cache->surfidx - 1, cache->ds, cache->dt);
 
 	return ((lightcolor[0] + lightcolor[1] + lightcolor[2]) * (1.0f / 3.0f));
+}
+
+const lightgrid_probe_t *R_GetLightgridSample (const vec3_t pos)
+{
+        lightgrid_t *lg = cl.lightgrid;
+        int x, y, z;
+
+        if (!lg || !lg->probes || lg->cellsize <= 0.f)
+                return NULL;
+
+        x = (int)floorf((pos[0] - lg->mins[0]) / lg->cellsize);
+        y = (int)floorf((pos[1] - lg->mins[1]) / lg->cellsize);
+        z = (int)floorf((pos[2] - lg->mins[2]) / lg->cellsize);
+
+        x = CLAMP(0, x, lg->nx - 1);
+        y = CLAMP(0, y, lg->ny - 1);
+        z = CLAMP(0, z, lg->nz - 1);
+
+        return &lg->probes[(z * lg->ny + y) * lg->nx + x];
 }

--- a/Quake/render.h
+++ b/Quake/render.h
@@ -32,6 +32,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 //=============================================================================
 
+typedef struct lightgrid_probe_s lightgrid_probe_t;
+typedef struct lightgrid_s lightgrid_t;
+
 typedef struct lightcache_s {
 	int					surfidx; // < 0: black surface; == 0: no cache; > 0: 1+index of surface
 	vec3_t				pos;
@@ -141,6 +144,8 @@ void R_ParticleExplosion (vec3_t org);
 void R_ParticleExplosion2 (vec3_t org, int colorStart, int colorLength);
 void R_LavaSplash (vec3_t org);
 void R_TeleportSplash (vec3_t org);
+const lightgrid_probe_t *R_GetLightgridSample (const vec3_t pos);
+
 
 void R_PushDlights (void);
 

--- a/common/lightgrid.c
+++ b/common/lightgrid.c
@@ -1,0 +1,274 @@
+#include "lightgrid.h"
+
+#define LIGHTGRID_MAGIC 0x4c475244u /* 'LGRD' */
+#define LIGHTGRID_VERSION 1u
+#define LIGHTGRID_MAX_DEPTH 32
+
+#define NODE_STRIDE 4
+#define LEAF_FLOATS 7
+
+typedef struct lightgrid_decode_state_s {
+    const byte *nodes;
+    size_t node_count;
+    size_t node_index;
+
+    const float *leaves;
+    size_t leaf_count;
+    size_t leaf_index;
+
+    lightgrid_t *grid;
+    float cellsize;
+    vec3_t mins;
+    vec3_t maxs;
+} lightgrid_decode_state_t;
+
+static void Lightgrid_FillLeaf(lightgrid_decode_state_t *state, const vec3_t bmins, const vec3_t bmaxs, const float *leaf)
+{
+    vec3_t dir;
+    int x0, y0, z0, x1, y1, z1;
+    const lightgrid_t *grid = state->grid;
+
+    dir[0] = LittleFloat(leaf[3]);
+    dir[1] = LittleFloat(leaf[4]);
+    dir[2] = LittleFloat(leaf[5]);
+
+    x0 = (int)ceilf(((bmins[0] - state->mins[0]) / state->cellsize) - 0.5f);
+    y0 = (int)ceilf(((bmins[1] - state->mins[1]) / state->cellsize) - 0.5f);
+    z0 = (int)ceilf(((bmins[2] - state->mins[2]) / state->cellsize) - 0.5f);
+
+    x1 = (int)floorf(((bmaxs[0] - state->mins[0]) / state->cellsize) - 0.5f);
+    y1 = (int)floorf(((bmaxs[1] - state->mins[1]) / state->cellsize) - 0.5f);
+    z1 = (int)floorf(((bmaxs[2] - state->mins[2]) / state->cellsize) - 0.5f);
+
+    x0 = CLAMP(0, x0, grid->nx - 1);
+    y0 = CLAMP(0, y0, grid->ny - 1);
+    z0 = CLAMP(0, z0, grid->nz - 1);
+
+    x1 = CLAMP(0, x1, grid->nx - 1);
+    y1 = CLAMP(0, y1, grid->ny - 1);
+    z1 = CLAMP(0, z1, grid->nz - 1);
+
+    if (x1 < x0 || y1 < y0 || z1 < z0)
+        return;
+
+    if (VectorNormalize(dir) == 0.f)
+    {
+        dir[0] = dir[1] = 0.f;
+        dir[2] = 1.f;
+    }
+
+    for (int z = z0; z <= z1; z++)
+    {
+        for (int y = y0; y <= y1; y++)
+        {
+            for (int x = x0; x <= x1; x++)
+            {
+                lightgrid_probe_t *probe = &grid->probes[(z * grid->ny + y) * grid->nx + x];
+
+                probe->rgb[0] = LittleFloat(leaf[0]);
+                probe->rgb[1] = LittleFloat(leaf[1]);
+                probe->rgb[2] = LittleFloat(leaf[2]);
+
+                VectorCopy(dir, probe->dir);
+                probe->intensity = LittleFloat(leaf[6]);
+            }
+        }
+    }
+}
+
+static qboolean Lightgrid_DecodeOctree(lightgrid_decode_state_t *state, int depth, const vec3_t bmins, const vec3_t bmaxs)
+{
+    if (depth > LIGHTGRID_MAX_DEPTH)
+        return false;
+
+    if (state->node_index >= state->node_count)
+        return false;
+
+    const byte child_mask = state->nodes[state->node_index * NODE_STRIDE];
+    state->node_index++;
+
+    if (!child_mask)
+    {
+        if (state->leaf_index >= state->leaf_count)
+            return false;
+
+        Lightgrid_FillLeaf(state, bmins, bmaxs, state->leaves + LEAF_FLOATS * state->leaf_index);
+        state->leaf_index++;
+        return true;
+    }
+
+    vec3_t mid;
+    VectorAverage(bmins, bmaxs, mid);
+
+    for (int i = 0; i < 8; i++)
+    {
+        if (!(child_mask & (1 << i)))
+            continue;
+
+        vec3_t child_mins, child_maxs;
+
+        const qboolean x_pos = (i & 4) == 0;
+        const qboolean y_pos = (i & 2) == 0;
+        const qboolean z_pos = (i & 1) == 0;
+
+        child_mins[0] = x_pos ? mid[0] : bmins[0];
+        child_maxs[0] = x_pos ? bmaxs[0] : mid[0];
+
+        child_mins[1] = y_pos ? mid[1] : bmins[1];
+        child_maxs[1] = y_pos ? bmaxs[1] : mid[1];
+
+        child_mins[2] = z_pos ? mid[2] : bmins[2];
+        child_maxs[2] = z_pos ? bmaxs[2] : mid[2];
+
+        if (!Lightgrid_DecodeOctree(state, depth + 1, child_mins, child_maxs))
+            return false;
+    }
+
+    return true;
+}
+
+lightgrid_t *Lightgrid_Alloc(int nx, int ny, int nz, float cellsize, const vec3_t mins, const vec3_t maxs)
+{
+    if (nx <= 0 || ny <= 0 || nz <= 0)
+        return NULL;
+
+    const size_t total = (size_t)nx * ny * nz;
+    if (total > SIZE_MAX / sizeof(lightgrid_probe_t))
+        return NULL;
+
+    lightgrid_t *lg = (lightgrid_t *)Z_Malloc(sizeof(lightgrid_t));
+    if (!lg)
+        return NULL;
+
+    memset(lg, 0, sizeof(*lg));
+    lg->probes = (lightgrid_probe_t *)Z_Malloc(total * sizeof(lightgrid_probe_t));
+    if (!lg->probes)
+    {
+        Z_Free(lg);
+        return NULL;
+    }
+
+    lg->nx = nx;
+    lg->ny = ny;
+    lg->nz = nz;
+    lg->cellsize = cellsize;
+    VectorCopy(mins, lg->mins);
+    VectorCopy(maxs, lg->maxs);
+
+    return lg;
+}
+
+void Lightgrid_Free(lightgrid_t *lg)
+{
+    if (!lg)
+        return;
+
+    if (lg->probes)
+        Z_Free(lg->probes);
+
+    Z_Free(lg);
+}
+
+lightgrid_t *Lightgrid_LoadFromBSPX_Octree(const bspx_lump_t *l)
+{
+    if (!l || !l->data || l->size < sizeof(uint32_t) * 3 + sizeof(vec3_t) * 2 + sizeof(float))
+        return NULL;
+
+    const byte *data = (const byte *)l->data;
+    size_t remaining = l->size;
+
+    uint32_t magic = LittleLong(*(const uint32_t *)data);
+    data += sizeof(uint32_t);
+    remaining -= sizeof(uint32_t);
+
+    uint32_t version = LittleLong(*(const uint32_t *)data);
+    data += sizeof(uint32_t);
+    remaining -= sizeof(uint32_t);
+
+    vec3_t mins, maxs;
+    memcpy(mins, data, sizeof(vec3_t));
+    data += sizeof(vec3_t);
+    remaining -= sizeof(vec3_t);
+
+    memcpy(maxs, data, sizeof(vec3_t));
+    data += sizeof(vec3_t);
+    remaining -= sizeof(vec3_t);
+
+    for (int i = 0; i < 3; i++)
+    {
+        mins[i] = LittleFloat(mins[i]);
+        maxs[i] = LittleFloat(maxs[i]);
+    }
+
+    float cellsize = LittleFloat(*(const float *)data);
+    data += sizeof(float);
+    remaining -= sizeof(float);
+
+    if (remaining < sizeof(uint32_t) * 2)
+        return NULL;
+
+    const uint32_t node_count = LittleLong(*(const uint32_t *)data);
+    data += sizeof(uint32_t);
+    const uint32_t leaf_count = LittleLong(*(const uint32_t *)data);
+    data += sizeof(uint32_t);
+
+    remaining -= sizeof(uint32_t) * 2;
+
+    if (magic != LIGHTGRID_MAGIC || version != LIGHTGRID_VERSION)
+        return NULL;
+
+    if (!node_count || !leaf_count)
+        return NULL;
+
+    if (node_count > SIZE_MAX / NODE_STRIDE || leaf_count > SIZE_MAX / (sizeof(float) * LEAF_FLOATS))
+        return NULL;
+
+    size_t nodes_size = (size_t)node_count * NODE_STRIDE;
+    size_t leaves_size = (size_t)leaf_count * sizeof(float) * LEAF_FLOATS;
+
+    if (nodes_size > remaining)
+        return NULL;
+    if (leaves_size != remaining - nodes_size)
+        return NULL;
+
+    const byte *nodes = data;
+    const float *leaves = (const float *)(data + nodes_size);
+
+    vec3_t size;
+    VectorSubtract(maxs, mins, size);
+    if (cellsize <= 0.f)
+        return NULL;
+
+    int nx = (int)ceilf(size[0] / cellsize);
+    int ny = (int)ceilf(size[1] / cellsize);
+    int nz = (int)ceilf(size[2] / cellsize);
+
+    if (nx <= 0 || ny <= 0 || nz <= 0)
+        return NULL;
+
+    lightgrid_t *lg = Lightgrid_Alloc(nx, ny, nz, cellsize, mins, maxs);
+    if (!lg)
+        return NULL;
+
+    lightgrid_decode_state_t state = {
+        .nodes = nodes,
+        .node_count = node_count,
+        .node_index = 0,
+        .leaves = leaves,
+        .leaf_count = leaf_count,
+        .leaf_index = 0,
+        .grid = lg,
+        .cellsize = cellsize,
+    };
+
+    VectorCopy(mins, state.mins);
+    VectorCopy(maxs, state.maxs);
+
+    if (!Lightgrid_DecodeOctree(&state, 0, mins, maxs) || state.node_index != state.node_count || state.leaf_index != state.leaf_count)
+    {
+        Lightgrid_Free(lg);
+        return NULL;
+    }
+
+    return lg;
+}

--- a/common/lightgrid.h
+++ b/common/lightgrid.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "../Quake/quakedef.h"
+
+// BSPX lightgrid probe decoded from octree lightgrid data
+typedef struct lightgrid_probe_s {
+    float rgb[3];
+    float dir[3];
+    float intensity;
+} lightgrid_probe_t;
+
+typedef struct lightgrid_s {
+    int nx, ny, nz;
+    float cellsize;
+    vec3_t mins, maxs;
+
+    lightgrid_probe_t *probes; // size = nx*ny*nz
+} lightgrid_t;
+
+typedef struct bspx_lump_s {
+    const void *data;
+    size_t size;
+} bspx_lump_t;
+
+lightgrid_t *Lightgrid_Alloc(int nx, int ny, int nz, float cellsize, const vec3_t mins, const vec3_t maxs);
+lightgrid_t *Lightgrid_LoadFromBSPX_Octree(const bspx_lump_t *l);
+void Lightgrid_Free(lightgrid_t *lg);


### PR DESCRIPTION
## Summary
- add shared BSPX octree lightgrid decoder with allocation helpers
- hook BSPX lightgrid octree loading into the client state and renderer sampling
- update build scripts to compile the new common lightgrid module

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693309b9f8e8832e8428f9fcee57fa72)