### PR TITLE
Add lightgrid source to Visual Studio project

### DIFF
--- a/Windows/VisualStudio/ironwail.vcxproj
+++ b/Windows/VisualStudio/ironwail.vcxproj
@@ -262,6 +262,7 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
     <ClCompile Include="..\..\Quake\gl_ktx2.c" />
     <ClCompile Include="..\..\Quake\gl_vidsdl.c" />
     <ClCompile Include="..\..\Quake\gl_warp.c" />
+    <ClCompile Include="..\..\common\lightgrid.c" />
     <ClCompile Include="..\..\Quake\host.c" />
     <ClCompile Include="..\..\Quake\host_cmd.c" />
     <ClCompile Include="..\..\Quake\image.c" />

--- a/Windows/VisualStudio/ironwail.vcxproj.filters
+++ b/Windows/VisualStudio/ironwail.vcxproj.filters
@@ -99,6 +99,9 @@
     <ClCompile Include="..\..\Quake\gl_warp.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\common\lightgrid.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\Quake\host.c">
       <Filter>Source Files</Filter>
     </ClCompile>


### PR DESCRIPTION
## Summary
- include common/lightgrid.c in the Visual Studio project so it builds across all platforms/configurations
- add the source entry to the filters file for IDE organization

## Testing
- msbuild Windows/VisualStudio/ironwail.vcxproj /p:Configuration=Release /p:Platform=x64 *(fails: msbuild not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693319f7d7e4832ea609d8b184845806)