### PR TITLE
Fix lightgrid build warnings

### DIFF
--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -127,7 +127,9 @@ static void R_ApplyLightgridLighting (const entity_t *e, vec3_t ambientcolor, ve
         if (gridcolor[0] == 0.f && gridcolor[1] == 0.f && gridcolor[2] == 0.f)
                 return;
 
-        AngleVectors (e->angles, forward, right, up);
+        vec3_t angles;
+        VectorCopy (e->angles, angles);
+        AngleVectors (angles, forward, right, up);
         VectorAdd (forward, up, shadevector);
         if (VectorNormalize (shadevector) == 0.f)
         {

--- a/common/lightgrid.c
+++ b/common/lightgrid.c
@@ -1,3 +1,4 @@
+#include "../Quake/quakedef.h"
 #include "lightgrid.h"
 
 #define LIGHTGRID_MAGIC 0x4c475244u /* 'LGRD' */


### PR DESCRIPTION
## Summary
- include the precompiled header in lightgrid implementation to satisfy Windows build requirements
- avoid const qualifier mismatch when calling AngleVectors in alias rendering code

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69331e82fbb8832eb4d4152f2fdfaf98)