### PR TITLE
Fix lightgrid includes for precompiled headers

### DIFF
--- a/common/lightgrid.c
+++ b/common/lightgrid.c
@@ -1,4 +1,4 @@
-#include "../Quake/quakedef.h"
+#include "quakedef.h"
 #include "lightgrid.h"
 
 #define LIGHTGRID_MAGIC 0x4c475244u /* 'LGRD' */

--- a/common/lightgrid.h
+++ b/common/lightgrid.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../Quake/quakedef.h"
+#include "quakedef.h"
 
 // BSPX lightgrid probe decoded from octree lightgrid data
 typedef struct lightgrid_probe_s {


### PR DESCRIPTION
## Summary
- include the shared quakedef.h header directly in lightgrid sources to satisfy precompiled header expectations

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69331f3871b4832eaad0192ac225d604)