### PR TITLE
Add VectorAverage helper for lightgrid decoding

### DIFF
--- a/Quake/mathlib.c
+++ b/Quake/mathlib.c
@@ -275,22 +275,29 @@ int VectorCompare (const vec3_t v1, const vec3_t v2)
 
 void VectorMA (const vec3_t veca, float scale, const vec3_t vecb, vec3_t vecc)
 {
-	vecc[0] = veca[0] + scale*vecb[0];
-	vecc[1] = veca[1] + scale*vecb[1];
-	vecc[2] = veca[2] + scale*vecb[2];
+        vecc[0] = veca[0] + scale*vecb[0];
+        vecc[1] = veca[1] + scale*vecb[1];
+        vecc[2] = veca[2] + scale*vecb[2];
 }
 
 void VectorLerp (const vec3_t veca, const vec3_t vecb, float frac, vec3_t dst)
 {
-	dst[0] = LERP (veca[0], vecb[0], frac);
-	dst[1] = LERP (veca[1], vecb[1], frac);
-	dst[2] = LERP (veca[2], vecb[2], frac);
+        dst[0] = LERP (veca[0], vecb[0], frac);
+        dst[1] = LERP (veca[1], vecb[1], frac);
+        dst[2] = LERP (veca[2], vecb[2], frac);
+}
+
+void VectorAverage (const vec3_t veca, const vec3_t vecb, vec3_t dst)
+{
+        dst[0] = 0.5f * (veca[0] + vecb[0]);
+        dst[1] = 0.5f * (veca[1] + vecb[1]);
+        dst[2] = 0.5f * (veca[2] + vecb[2]);
 }
 
 
 vec_t _DotProduct (const vec3_t v1, const vec3_t v2)
 {
-	return v1[0]*v2[0] + v1[1]*v2[1] + v1[2]*v2[2];
+return v1[0]*v2[0] + v1[1]*v2[1] + v1[2]*v2[2];
 }
 
 void _VectorSubtract (const vec3_t veca, const vec3_t vecb, vec3_t out)

--- a/Quake/mathlib.h
+++ b/Quake/mathlib.h
@@ -82,6 +82,7 @@ void VectorAngles (const vec3_t forward, vec3_t angles); //johnfitz
 
 void VectorMA (const vec3_t veca, float scale, const vec3_t vecb, vec3_t vecc);
 void VectorLerp (const vec3_t veca, const vec3_t vecb, float frac, vec3_t dst);
+void VectorAverage (const vec3_t veca, const vec3_t vecb, vec3_t dst);
 
 vec_t _DotProduct (const vec3_t v1, const vec3_t v2);
 void _VectorSubtract (const vec3_t veca, const vec3_t vecb, vec3_t out);


### PR DESCRIPTION
## Summary
- add a VectorAverage helper to mathlib and expose it in the header
- allow lightgrid code to use the shared helper instead of an undefined symbol

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693321076990832e96a80873018fca3c)