### PR TITLE
Initialize lightgrid lifecycle

### DIFF
--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -23,6 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // r_misc.c
 
 #include "quakedef.h"
+#include "gl_lightgrid.h"
 
 //johnfitz -- new cvars
 extern cvar_t r_clearcolor;
@@ -349,14 +350,16 @@ R_Init
 */
 void R_Init (void)
 {
-	cmd_function_t *cmd;
+        cmd_function_t *cmd;
 
-	Cmd_AddCommand ("timerefresh", R_TimeRefresh_f);
-	Cmd_AddCommand ("pointfile", R_ReadPointFile_f);
-	cmd = Cmd_AddCommand ("r_showbboxes_filter", R_ShowbboxesFilter_f);
-	if (cmd)
-		cmd->completion = R_ShowbboxesFilter_Completion_f;
-	Cmd_AddCommand ("r_showbboxes_filter_clear", R_ShowbboxesFilterClear_f);
+        Cmd_AddCommand ("timerefresh", R_TimeRefresh_f);
+        Cmd_AddCommand ("pointfile", R_ReadPointFile_f);
+        cmd = Cmd_AddCommand ("r_showbboxes_filter", R_ShowbboxesFilter_f);
+        if (cmd)
+                cmd->completion = R_ShowbboxesFilter_Completion_f;
+        Cmd_AddCommand ("r_showbboxes_filter_clear", R_ShowbboxesFilterClear_f);
+
+        Lightgrid_Init ();
 
 Cvar_RegisterVariable (&r_norefresh);
 Cvar_RegisterVariable (&r_lightmap);

--- a/Quake/gl_vidsdl.c
+++ b/Quake/gl_vidsdl.c
@@ -26,6 +26,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "cfgfile.h"
 #include "bgmusic.h"
 #include "resource.h"
+#include "gl_lightgrid.h"
 #if defined(SDL_FRAMEWORK) || defined(NO_SDL_CONFIG)
 #include <SDL2/SDL.h>
 #else
@@ -1391,6 +1392,7 @@ void	VID_Shutdown (void)
 {
 	if (vid_initialized)
 	{
+		Lightgrid_Shutdown ();
 		R_ShutdownShadow ();
 		VID_FreeMouseCursors();
 		SDL_GL_DeleteContext(gl_context);


### PR DESCRIPTION
## Summary
- register lightgrid console variables during renderer initialization and clear existing data
- clean up lightgrid state during video shutdown

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693325229ce0832e8e2a13c0399a7f54)