### PR TITLE
Fix lightgrid debug visualization

### DIFF
--- a/Quake/gl_lightgrid.c
+++ b/Quake/gl_lightgrid.c
@@ -331,6 +331,9 @@ void Lightgrid_BuildFallback (void)
 
 const lightgrid_t *Lightgrid_Get (void)
 {
-    return current_lightgrid;
+    if (current_lightgrid)
+        return current_lightgrid;
+
+    return cl.lightgrid;
 }
 

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -2540,6 +2540,8 @@ static void R_ShowPointFile (void)
 	GL_EndGroup ();
 }
 
+static int r_lightgrid_debug_warn_frame = -1;
+
 static void R_ShowLightgridDebug (void)
 {
 	const lightgrid_t *lg;
@@ -2551,7 +2553,23 @@ static void R_ShowLightgridDebug (void)
 
 	lg = Lightgrid_Get ();
 	if (!lg || !lg->probes || lg->cellsize <= 0.f)
+	{
+		if (r_lightgrid_debug_warn_frame != r_framecount)
+		{
+			const char *reason = "unknown";
+
+			if (!lg)
+				reason = "no lightgrid is loaded";
+			else if (!lg->probes)
+				reason = "lightgrid has no probes";
+			else if (lg->cellsize <= 0.f)
+				reason = "lightgrid cell size is invalid";
+
+			Con_Printf ("r_lightgrid_debug: %s\n", reason);
+			r_lightgrid_debug_warn_frame = r_framecount;
+		}
 		return;
+	}
 
 	GL_BeginGroup ("Lightgrid debug");
 


### PR DESCRIPTION
## Summary
- ensure lightgrid debug renders by using the loaded client lightgrid
- log a debug message when lightgrid data is missing or invalid while debugging

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69335ac7cf40832ea41ce3b271981349)