### PR TITLE
Add BSPX RGB lightmap support

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -41,6 +41,7 @@ static void Mod_LoadMD5MeshModel (qmodel_t *mod, const char *buffer);
 static qmodel_t *Mod_LoadModel (qmodel_t *mod, qboolean crash);
 static qboolean Mod_ParseWorldspawnKey (qmodel_t *mod, const char *key, char *value, size_t valuesize);
 static qboolean BSPX_LightGridLoad (qmodel_t *mod, void *lump, int lumpsize);
+void Mod_LoadRGBLightingBSPX (qmodel_t *mod, void *buffer, int size);
 
 static void Mod_Print (void);
 
@@ -656,6 +657,30 @@ static void *Q1BSPX_FindLump(const char *lumpname, int *lumpsize)
                 }
         }
         return NULL;
+}
+
+void Mod_LoadRGBLightingBSPX (qmodel_t *mod, void *buffer, int size)
+{
+        int expected_size;
+        byte *memptr;
+
+        if (!mod || !mod->lightdatasize)
+                return;
+
+        expected_size = mod->lightdatasize * 3;
+
+        if (size != expected_size)
+                return;
+
+        memptr = (byte *)Hunk_AllocName(size, loadname);
+        memcpy(memptr, buffer, size);
+
+        mod->lightdata_rgb = memptr;
+        mod->lightdata_rgb_size = size;
+        mod->has_lightdata_rgb = true;
+
+        Con_Printf("BSPX: loaded RGBLIGHTING (%d bytes)\n", size);
+        Q1BSPX_MarkUsed("RGBLIGHTING");
 }
 
 static size_t Mod_FindEndOfStandardLumps(const lump_t *lumps, int numlumps, qboolean *misaligned)
@@ -1332,6 +1357,10 @@ static void Mod_LoadLighting (lump_t *l)
 	loadmodel->lightdatasamples = 0;
 	loadmodel->lightdirdata = NULL;
 	loadmodel->lightdirsamples = 0;
+	loadmodel->lightdata_rgb = NULL;
+	loadmodel->lightdata_rgb_size = 0;
+	loadmodel->has_lightdata_rgb = false;
+	loadmodel->lightdatasize = l->filelen;
 	loadmodel->flags &= ~MOD_HDRLIGHTING;
 	loadmodel->litfile = false;
 	// LordHavoc: check for a .lit file
@@ -3274,6 +3303,16 @@ static void Mod_LoadBrushModel (qmodel_t *mod, void *buffer)
 	Mod_LoadSurfedges (&header.lumps[LUMP_SURFEDGES]);
 	Mod_LoadTextures (&header.lumps[LUMP_TEXTURES]);
 	Mod_LoadLighting (&header.lumps[LUMP_LIGHTING]);
+	{
+		void *lump;
+		int lumpsize;
+
+		lump = Q1BSPX_FindLump("RGBLIGHTING", &lumpsize);
+		if (lump && lumpsize > 0)
+		{
+			Mod_LoadRGBLightingBSPX(mod, lump, lumpsize);
+		}
+	}
 	Mod_LoadPlanes (&header.lumps[LUMP_PLANES]);
 	Mod_LoadTexinfo (&header.lumps[LUMP_TEXINFO]);
 	Mod_LoadEntities (&header.lumps[LUMP_ENTITIES]);	//Spike: moved this earlier, so that we can parse worldspawn keys earlier.

--- a/Quake/gl_model.h
+++ b/Quake/gl_model.h
@@ -504,12 +504,16 @@ typedef struct qmodel_s
 	byte		*visdata;
 	byte		*lightdata;
 	byte		*lightdirdata;
+	byte		*lightdata_rgb;
 	int			lightdatasamples;
 	int			lightdirsamples;
+	int			lightdatasize;
+	int			lightdata_rgb_size;
 	char		*entities;
 
 	qboolean	litfile;
 	qboolean	viswarn; // for Mod_DecompressVis()
+	qboolean	has_lightdata_rgb;
 
 	int			bspversion;
 	int			bspx_entries_count;

--- a/Quake/gl_rlight.c
+++ b/Quake/gl_rlight.c
@@ -28,6 +28,7 @@ extern cvar_t r_flatlightstyles; //johnfitz
 extern cvar_t r_lerplightstyles;
 extern cvar_t r_dynamic;
 extern cvar_t r_lightgrid;
+extern cvar_t r_rgblighting_enable;
 
 gpulightbuffer_t r_lightbuffer;
 float r_lightstyle_framefrac;
@@ -265,14 +266,43 @@ static inline int LightStyleValue (unsigned short style)
 	return d_lightstylevalue[0];
 }
 
-static void InterpolateLightmap (vec3_t color, msurface_t *surf, int ds, int dt)
+static void InterpolateLightmap (vec3_t color, msurface_t *surf, int ds, int dt, qboolean use_rgb)
 {
-	byte *lightmap;
+	const byte *lightmap;
+	const byte *samples;
 	int maps, line3, dsfrac = ds & 15, dtfrac = dt & 15, r00 = 0, g00 = 0, b00 = 0, r01 = 0, g01 = 0, b01 = 0, r10 = 0, g10 = 0, b10 = 0, r11 = 0, g11 = 0, b11 = 0;
 	int scale;
 	line3 = ((surf->extents[0]>>4)+1)*3;
 
-	lightmap = surf->samples + ((dt>>4) * ((surf->extents[0]>>4)+1) + (ds>>4))*3; // LordHavoc: *3 for color
+	if (!surf->samples)
+	{
+		VectorClear(color);
+		return;
+	}
+
+	samples = surf->samples;
+
+	if (use_rgb)
+	{
+		qmodel_t *model = cl.worldmodel;
+
+		if (model && model->lightdata && model->lightdata_rgb)
+		{
+			const int bytes_per_sample = (model->flags & MOD_HDRLIGHTING) ? 4 : 3;
+			const ptrdiff_t offset = samples - model->lightdata;
+
+			if (bytes_per_sample > 0 && offset >= 0 && (offset % bytes_per_sample) == 0)
+			{
+				const size_t sample_offset = (size_t)offset / (size_t)bytes_per_sample;
+				const size_t rgb_offset = sample_offset * 3;
+
+				if (rgb_offset + 3 <= (size_t)model->lightdata_rgb_size)
+					samples = model->lightdata_rgb + rgb_offset;
+			}
+		}
+	}
+
+	lightmap = samples + ((dt>>4) * ((surf->extents[0]>>4)+1) + (ds>>4))*3; // LordHavoc: *3 for color
 
 	for (maps = 0;maps < MAXLIGHTMAPS && surf->styles[maps] != INVALID_LIGHTSTYLE;maps++)
 	{
@@ -416,6 +446,7 @@ int R_LightPoint (vec3_t p, float ofs, lightcache_t *cache)
 	vec3_t		start, end;
 	float		maxdist = 8192.f; //johnfitz -- was 2048
 	const lightgrid_probe_t *probe = NULL;
+	qboolean	use_rgblight = false;
 
 	cache->lightgrid_has_sample = false;
 	cache->lightgrid_intensity = 0.f;
@@ -424,6 +455,9 @@ int R_LightPoint (vec3_t p, float ofs, lightcache_t *cache)
 
 	if (r_lightgrid.value)
 		probe = R_GetLightgridSample (p);
+
+	if (cl.worldmodel->has_lightdata_rgb && r_rgblighting_enable.value)
+		use_rgblight = true;
 
 	if (!cl.worldmodel->lightdata)
 	{
@@ -463,7 +497,7 @@ int R_LightPoint (vec3_t p, float ofs, lightcache_t *cache)
 	}
 
 	if (cache->surfidx > 0)
-		InterpolateLightmap (lightcolor, cl.worldmodel->surfaces + cache->surfidx - 1, cache->ds, cache->dt);
+		InterpolateLightmap (lightcolor, cl.worldmodel->surfaces + cache->surfidx - 1, cache->ds, cache->dt, use_rgblight);
 
 	if (!probe && r_lightgrid.value)
 		probe = R_GetLightgridSample (p);

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -194,6 +194,7 @@ cvar_t	r_lightmap_linear = { "r_lightmap_linear", "1", CVAR_ARCHIVE };
 cvar_t	r_lightmap_mipmaps = { "r_lightmap_mipmaps", "1", CVAR_ARCHIVE };
 cvar_t	r_lightmap16f = { "r_lightmap16f", "0", CVAR_ARCHIVE };
 cvar_t	r_lightingdir = { "r_lightingdir", "0", CVAR_ARCHIVE };
+cvar_t	r_rgblighting_enable = { "r_rgblighting_enable", "1", CVAR_ARCHIVE };
 cvar_t	r_saturation = { "r_saturation", "1", CVAR_ARCHIVE };
 cvar_t	r_wateralpha = { "r_wateralpha","1",CVAR_ARCHIVE };
 cvar_t	r_litwater = { "r_litwater","1",CVAR_NONE };

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -367,6 +367,7 @@ Cvar_RegisterVariable (&r_lightmap_linear);
 Cvar_RegisterVariable (&r_lightmap_mipmaps);
 Cvar_RegisterVariable (&r_lightmap16f);
 Cvar_RegisterVariable (&r_lightingdir);
+Cvar_RegisterVariable (&r_rgblighting_enable);
 Cvar_RegisterVariable (&r_fullbright);
 Cvar_RegisterVariable (&r_drawentities);
 Cvar_RegisterVariable (&r_drawviewmodel);

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -96,6 +96,7 @@ extern	cvar_t	r_pos;
 extern	cvar_t	r_waterwarp;
 extern	cvar_t	r_fullbright;
 extern	cvar_t	r_lightmap;
+extern	cvar_t	r_rgblighting_enable;
 extern	cvar_t	r_wateralpha;
 extern	cvar_t	r_lavaalpha;
 extern	cvar_t	r_telealpha;


### PR DESCRIPTION
## Summary
- add model fields and loader hook to capture BSPX RGBLIGHTING lumps alongside standard lightmaps
- provide optional RGB light sampling in R_LightPoint controlled by a new r_rgblighting_enable cvar
- expose and register the RGB lighting toggle for rendering

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933781983dc832e90732a702f399919)