### PR TITLE
Fix LIGHTGRID_OCTREE BSPX handling

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -2196,13 +2196,17 @@ static void Mod_LoadFaces (lump_t *l)
                                 Q1BSPX_MarkUsed("LMSTYLE");
                 }
 
-				{
-					void* lglump = Q1BSPX_FindLump ("LIGHTGRID_OCTREE", &lumpsize);
+                {
+                        void* lglump = Q1BSPX_FindLump ("LIGHTGRID_OCTREE", &lumpsize);
 
-					if (lglump && lumpsize > 0)
-						Q1BSPX_MarkUsed ("LIGHTGRID_OCTREE");
-						BSPX_LightGridLoad (loadmodel, lglump, lumpsize);
-				}
+                        if (lglump && lumpsize > 0)
+                        {
+                                if (BSPX_LightGridLoad (loadmodel, lglump, lumpsize))
+                                        Q1BSPX_MarkUsed ("LIGHTGRID_OCTREE");
+                                else
+                                        Q1BSPX_MarkUnsupported ("LIGHTGRID_OCTREE");
+                        }
+                }
 
         }
 


### PR DESCRIPTION
## Summary
- guard LIGHTGRID_OCTREE BSPX loading so the lump is only processed when present and non-empty
- record unsupported status when LIGHTGRID_OCTREE parsing fails to match other BSPX lump tracking

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69339b080300832eb713ce24c3a4c2d8)