### PR TITLE
Fix lightstyle definitions for lightgrid build

### DIFF
--- a/Quake/cl_main.c
+++ b/Quake/cl_main.c
@@ -60,6 +60,7 @@ client_state_t	cl;
 // FIXME: put these on hunk?
 entity_t		cl_static_entities[MAX_STATIC_ENTITIES];
 lightstyle_t	cl_lightstyle[MAX_LIGHTSTYLES];
+int					cl_max_lightstyles = MAX_LIGHTSTYLES;
 dlight_t		cl_dlights[MAX_DLIGHTS];
 
 entity_t		*cl_entities; //johnfitz -- was a static array, now on hunk
@@ -110,6 +111,7 @@ void CL_ClearState (void)
 // clear other arrays
 	memset (cl_dlights, 0, sizeof(cl_dlights));
 	memset (cl_lightstyle, 0, sizeof(cl_lightstyle));
+	cl_max_lightstyles = MAX_LIGHTSTYLES;
 	memset (cl_temp_entities, 0, sizeof(cl_temp_entities));
 	memset (cl_beams, 0, sizeof(cl_beams));
 

--- a/Quake/client.h
+++ b/Quake/client.h
@@ -33,6 +33,8 @@ typedef struct
 	char	map[MAX_STYLESTRING];
 	char	average; //johnfitz
 	char	peak; //johnfitz
+	vec3_t	colours; // FTE extended lightstyles
+	int		colourkey;
 } lightstyle_t;
 
 typedef struct
@@ -329,6 +331,7 @@ extern	client_state_t	cl;
 
 // FIXME, allocate dynamically
 extern	entity_t		cl_static_entities[MAX_STATIC_ENTITIES];
+extern	int			cl_max_lightstyles;
 extern	lightstyle_t	cl_lightstyle[MAX_LIGHTSTYLES];
 extern	dlight_t		cl_dlights[MAX_DLIGHTS];
 extern	entity_t		cl_temp_entities[MAX_TEMP_ENTITIES];


### PR DESCRIPTION
## Summary
- add colour data and colour key fields to lightstyle definitions
- introduce cl_max_lightstyles tracking and reset logic for lightstyle arrays

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934d348ea54832ebb51c970cfac154a)