### PR TITLE
Fix weapon whip max macro

### DIFF
--- a/Quake/view.c
+++ b/Quake/view.c
@@ -767,7 +767,7 @@ static void V_AddWeaponWhip (entity_t *view)
 	float dt;
 	float velz;
 
-	scale = max(0.f, v_weaponwhip.value);
+    scale = q_max(0.f, v_weaponwhip.value);
 	if (scale == 0.f)
 	{
 		was_onground = cl.onground;


### PR DESCRIPTION
## Summary
- use q_max for weapon whip scale calculation to avoid undefined max macro on Windows builds

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934de2dfbe0832e974f84ba2b7cd54b)