### PR TITLE
Add LIGHTGRID_RAW support and generation fallback

### DIFF
--- a/Quake/gl_lightgrid.c
+++ b/Quake/gl_lightgrid.c
@@ -4,6 +4,7 @@ Copyright (C) 2024 Ironwail developers
 
 #include "quakedef.h"
 #include "gl_lightgrid.h"
+#include "gl_model.h"
 #include "glquake.h"
 
 extern vec3_t lightcolor;
@@ -222,6 +223,52 @@ static float Lightgrid_CellsizeForBounds (const vec3_t mins, const vec3_t maxs)
     return cellsize;
 }
 
+lightgrid_t *Lightgrid_FromRaw (const lightgrid_raw_t *raw)
+{
+    lightgrid_t *lg;
+    vec3_t mins, maxs;
+    size_t count;
+
+    if (!raw || !raw->cells || raw->cellSize <= 0.f)
+        return NULL;
+
+    if (raw->nx <= 0 || raw->ny <= 0 || raw->nz <= 0)
+        return NULL;
+
+    count = (size_t)raw->nx * (size_t)raw->ny * (size_t)raw->nz;
+    if (!count || count > (SIZE_MAX / sizeof(lightgrid_probe_t)))
+        return NULL;
+
+    VectorCopy (raw->origin, mins);
+    VectorCopy (raw->origin, maxs);
+    maxs[0] += raw->cellSize * raw->nx;
+    maxs[1] += raw->cellSize * raw->ny;
+    maxs[2] += raw->cellSize * raw->nz;
+
+    lg = Lightgrid_Alloc (raw->nx, raw->ny, raw->nz, raw->cellSize, mins, maxs);
+    if (!lg)
+        return NULL;
+
+    for (size_t i = 0; i < count; i++)
+    {
+        const lightcell_t *cell = &raw->cells[i];
+        vec3_t dir;
+
+        VectorCopy (cell->rgb, lg->probes[i].rgb);
+        VectorCopy (cell->dir, dir);
+        if (VectorNormalize (dir) == 0.f)
+        {
+            dir[0] = dir[1] = 0.f;
+            dir[2] = 1.f;
+        }
+
+        VectorCopy (dir, lg->probes[i].dir);
+        lg->probes[i].intensity = cell->intensity;
+    }
+
+    return lg;
+}
+
 static void Lightgrid_AddDlights (const vec3_t pos, vec3_t color, vec3_t dirsum)
 {
     int i;
@@ -251,20 +298,18 @@ static void Lightgrid_AddDlights (const vec3_t pos, vec3_t color, vec3_t dirsum)
     }
 }
 
-void Lightgrid_BuildFallback (void)
+lightgrid_raw_t *Lightgrid_GenerateRaw (const qmodel_t *model)
 {
     vec3_t mins, maxs, size;
     float cellsize;
     int nx, ny, nz;
     int x, y, z;
 
-    if (!cl.worldmodel)
-        return;
+    if (!model)
+        return NULL;
 
-    Con_Printf ("Lightgrid fallback: building interpolated grid...\n");
-
-    VectorCopy (cl.worldmodel->mins, mins);
-    VectorCopy (cl.worldmodel->maxs, maxs);
+    VectorCopy (model->mins, mins);
+    VectorCopy (model->maxs, maxs);
     VectorSubtract (maxs, mins, size);
 
     cellsize = Lightgrid_CellsizeForBounds (mins, maxs);
@@ -273,14 +318,22 @@ void Lightgrid_BuildFallback (void)
     ny = q_max (1, q_min (32, (int)ceilf (size[1] / cellsize)));
     nz = q_max (1, q_min (32, (int)ceilf (size[2] / cellsize)));
 
-    Lightgrid_Clear ();
+    lightgrid_raw_t *raw = (lightgrid_raw_t *)Hunk_AllocName (sizeof(*raw), "lightgrid_raw");
+    if (!raw)
+        return NULL;
 
-    current_lightgrid = Lightgrid_Alloc (nx, ny, nz, cellsize, mins, maxs);
-    if (!current_lightgrid)
-    {
-        Con_Printf ("Lightgrid fallback: failed to allocate grid\n");
-        return;
-    }
+    memset (raw, 0, sizeof(*raw));
+
+    const size_t count = (size_t)nx * (size_t)ny * (size_t)nz;
+    raw->cells = (lightcell_t *)Hunk_AllocName (count * sizeof(lightcell_t), "lightgrid_cells");
+    if (!raw->cells)
+        return NULL;
+
+    raw->nx = nx;
+    raw->ny = ny;
+    raw->nz = nz;
+    raw->cellSize = cellsize;
+    VectorCopy (mins, raw->origin);
 
     for (z = 0; z < nz; z++)
     {
@@ -289,7 +342,7 @@ void Lightgrid_BuildFallback (void)
             for (x = 0; x < nx; x++)
             {
                 vec3_t pos;
-                lightgrid_probe_t *cell = Lightgrid_At (x, y, z);
+                lightcell_t *cell = &raw->cells[(z * ny + y) * nx + x];
                 vec3_t dirsum = {0.f, 0.f, 0.f};
                 float baseintensity;
                 lightcache_t cache = {0};
@@ -326,7 +379,40 @@ void Lightgrid_BuildFallback (void)
         }
     }
 
-    Con_Printf ("Lightgrid fallback: done (%dx%dx%d)\n", nx, ny, nz);
+    return raw;
+}
+
+void Lightgrid_BuildFallback (void)
+{
+    lightgrid_t *lg;
+    lightgrid_raw_t *raw;
+
+    if (!cl.worldmodel)
+        return;
+
+    Con_Printf ("Lightgrid fallback: building interpolated grid...\n");
+
+    raw = Lightgrid_GenerateRaw (cl.worldmodel);
+    if (!raw)
+    {
+        Con_Printf ("Lightgrid fallback: failed to allocate grid\n");
+        return;
+    }
+
+    cl.worldmodel->lightgrid_raw = raw;
+
+    Lightgrid_Clear ();
+    lg = Lightgrid_FromRaw (raw);
+    if (!lg)
+    {
+        Con_Printf ("Lightgrid fallback: failed to upload grid\n");
+        return;
+    }
+
+    current_lightgrid = lg;
+    cl.lightgrid = lg;
+
+    Con_Printf ("Lightgrid fallback: done (%dx%dx%d)\n", raw->nx, raw->ny, raw->nz);
 }
 
 const lightgrid_t *Lightgrid_Get (void)

--- a/Quake/gl_lightgrid.h
+++ b/Quake/gl_lightgrid.h
@@ -9,6 +9,9 @@
 #include "quakedef.h"
 #include "../common/lightgrid.h"
 
+struct qmodel_s;
+typedef struct lightgrid_raw_s lightgrid_raw_t;
+
 extern cvar_t r_lightgrid;
 extern cvar_t r_lightgrid_debug;
 
@@ -16,6 +19,8 @@ void Lightgrid_Init (void);
 void Lightgrid_Shutdown (void);
 void Lightgrid_Clear (void);
 qboolean Lightgrid_LoadFromBSPX (void *bspx_data, int bspx_len);
+lightgrid_t *Lightgrid_FromRaw (const lightgrid_raw_t *raw);
+lightgrid_raw_t *Lightgrid_GenerateRaw (const struct qmodel_s *model);
 void Lightgrid_BuildFallback (void);
 void Lightgrid_Sample (const vec3_t pos, vec3_t out_color, vec3_t out_dir);
 const lightgrid_t *Lightgrid_Get (void);

--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -26,6 +26,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "quakedef.h"
 #include "gl_ktx2.h"
+#include "gl_lightgrid.h"
 #include "../common/lightgrid.h"
 
 #define INVALID_LIGHTSTYLE_OLD 255
@@ -41,6 +42,7 @@ static void Mod_LoadMD5MeshModel (qmodel_t *mod, const char *buffer);
 static qmodel_t *Mod_LoadModel (qmodel_t *mod, qboolean crash);
 static qboolean Mod_ParseWorldspawnKey (qmodel_t *mod, const char *key, char *value, size_t valuesize);
 static qboolean BSPX_LightGridLoad (qmodel_t *mod, void *lump, int lumpsize);
+static qboolean LightgridRAW_Load (qmodel_t *mod, void *data, int size);
 void Mod_LoadRGBLightingBSPX (qmodel_t *mod, void *buffer, int size);
 void Mod_LoadFaceNormalsBSPX (qmodel_t *mod, void *buffer, int size);
 
@@ -2185,6 +2187,91 @@ void Mod_CalcSurfaceBounds (msurface_t *s)
 	}
 }
 
+
+static qboolean LightgridRAW_Load (qmodel_t *mod, void *data, int size)
+{
+	const size_t header_size = sizeof(int) * 3 + sizeof(float) + sizeof(vec3_t);
+	const size_t cell_size = sizeof(vec3_t) * 2 + sizeof(float);
+	lightgrid_raw_t *raw;
+	lightgrid_t *lg;
+	int nx, ny, nz;
+	float cellsize;
+	vec3_t origin;
+	size_t count, expected;
+	const float *cells_in;
+
+	if (!data || size < (int)header_size)
+		return false;
+
+	nx = LittleLong (((int *)data)[0]);
+	ny = LittleLong (((int *)data)[1]);
+	nz = LittleLong (((int *)data)[2]);
+
+	if (nx <= 0 || ny <= 0 || nz <= 0)
+		return false;
+
+	count = (size_t)nx * (size_t)ny * (size_t)nz;
+	if (!count || count > (SIZE_MAX / sizeof(lightcell_t)))
+		return false;
+
+	expected = header_size + cell_size * count;
+	if ((size_t)size < expected)
+		return false;
+
+	memcpy (&cellsize, (byte *)data + sizeof(int) * 3, sizeof(float));
+	cellsize = LittleFloat (cellsize);
+	if (cellsize <= 0.f)
+		return false;
+	memcpy (origin, (byte *)data + sizeof(int) * 3 + sizeof(float), sizeof(vec3_t));
+	origin[0] = LittleFloat (origin[0]);
+	origin[1] = LittleFloat (origin[1]);
+	origin[2] = LittleFloat (origin[2]);
+
+	raw = (lightgrid_raw_t *)Hunk_AllocName (sizeof(*raw), "lightgrid_raw");
+	if (!raw)
+		return false;
+
+	memset (raw, 0, sizeof(*raw));
+	raw->cells = (lightcell_t *)Hunk_AllocName (count * sizeof(lightcell_t), "lightgrid_cells");
+	if (!raw->cells)
+		return false;
+
+	raw->nx = nx;
+	raw->ny = ny;
+	raw->nz = nz;
+	raw->cellSize = cellsize;
+	VectorCopy (origin, raw->origin);
+
+	cells_in = (const float *)((byte *)data + header_size);
+	for (size_t i = 0; i < count; i++)
+	{
+		lightcell_t *cell = &raw->cells[i];
+
+		cell->rgb[0] = LittleFloat (cells_in[0]);
+		cell->rgb[1] = LittleFloat (cells_in[1]);
+		cell->rgb[2] = LittleFloat (cells_in[2]);
+		cell->dir[0] = LittleFloat (cells_in[3]);
+		cell->dir[1] = LittleFloat (cells_in[4]);
+		cell->dir[2] = LittleFloat (cells_in[5]);
+		cell->intensity = LittleFloat (cells_in[6]);
+
+		cells_in += 7;
+	}
+
+	mod->lightgrid_raw = raw;
+
+	Lightgrid_Clear ();
+	lg = Lightgrid_FromRaw (raw);
+	if (!lg)
+		return false;
+
+	cl.lightgrid = lg;
+
+	Con_Printf ("Loaded LIGHTGRID_RAW (%dx%dx%d)\n", nx, ny, nz);
+
+	return true;
+}
+
 static qboolean BSPX_LightGridLoad (qmodel_t *mod, void *lump, int lumpsize)
 {
 	lightgrid_t *lg;
@@ -2287,35 +2374,77 @@ static void Mod_LoadFaces (lump_t *l)
                                 }
                         }
                 }
-                lmstyle16 = Q1BSPX_FindLump("LMSTYLE16", &lumpsize);
-                stylesperface = lumpsize/(sizeof(*lmstyle16)*count);
-                if (lumpsize != sizeof(*lmstyle16)*stylesperface*count)
-                        lmstyle16 = NULL;
-                else
-                        Q1BSPX_MarkUsed("LMSTYLE16");
-                if (!lmstyle16)
-                {
-                        lmstyle8 = Q1BSPX_FindLump("LMSTYLE", &lumpsize);
-                        stylesperface = lumpsize/(sizeof(*lmstyle8)*count);
-                        if (lumpsize != sizeof(*lmstyle8)*stylesperface*count)
-                                lmstyle8 = NULL;
-                        else
-                                Q1BSPX_MarkUsed("LMSTYLE");
-                }
+                		lmstyle16 = Q1BSPX_FindLump("LMSTYLE16", &lumpsize);
+		stylesperface = lumpsize/(sizeof(*lmstyle16)*count);
+		if (lumpsize != sizeof(*lmstyle16)*stylesperface*count)
+			lmstyle16 = NULL;
+		else
+			Q1BSPX_MarkUsed("LMSTYLE16");
+		if (!lmstyle16)
+		{
+			lmstyle8 = Q1BSPX_FindLump("LMSTYLE", &lumpsize);
+			stylesperface = lumpsize/(sizeof(*lmstyle8)*count);
+			if (lumpsize != sizeof(*lmstyle8)*stylesperface*count)
+				lmstyle8 = NULL;
+			else
+				Q1BSPX_MarkUsed("LMSTYLE");
+		}
 
-                {
-                        void* lglump = Q1BSPX_FindLump ("LIGHTGRID_OCTREE", &lumpsize);
+		{
+			qboolean have_lightgrid = false;
+			lightgrid_t *lg;
+			void* lglump = Q1BSPX_FindLump ("LIGHTGRID_RAW", &lumpsize);
 
-                        if (lglump && lumpsize > 0)
-                        {
-                                if (BSPX_LightGridLoad (loadmodel, lglump, lumpsize))
-                                        Q1BSPX_MarkUsed ("LIGHTGRID_OCTREE");
-                                else
-                                        Q1BSPX_MarkUnsupported ("LIGHTGRID_OCTREE");
-                        }
-                }
+			if (lglump && lumpsize > 0)
+			{
+				if (LightgridRAW_Load (loadmodel, lglump, lumpsize))
+				{
+					Q1BSPX_MarkUsed ("LIGHTGRID_RAW");
+					have_lightgrid = true;
+				}
+				else
+				{
+					Q1BSPX_MarkUnsupported ("LIGHTGRID_RAW");
+				}
+			}
 
-        }
+			if (!have_lightgrid)
+			{
+				lglump = Q1BSPX_FindLump ("LIGHTGRID_OCTREE", &lumpsize);
+
+				if (lglump && lumpsize > 0)
+				{
+					if (BSPX_LightGridLoad (loadmodel, lglump, lumpsize))
+					{
+						Q1BSPX_MarkUsed ("LIGHTGRID_OCTREE");
+						have_lightgrid = true;
+					}
+					else
+					{
+						Q1BSPX_MarkUnsupported ("LIGHTGRID_OCTREE");
+					}
+				}
+			}
+
+			if (!have_lightgrid)
+			{
+				lightgrid_raw_t *generated = Lightgrid_GenerateRaw (loadmodel);
+
+				if (generated)
+				{
+					loadmodel->lightgrid_raw = generated;
+
+					Lightgrid_Clear ();
+					lg = Lightgrid_FromRaw (generated);
+					if (lg)
+					{
+						cl.lightgrid = lg;
+						have_lightgrid = true;
+					}
+				}
+			}
+
+		}
 
 
         loadmodel->surfaces = out;

--- a/Quake/gl_model.h
+++ b/Quake/gl_model.h
@@ -427,6 +427,21 @@ typedef struct
 	int		size;
 } bspx_entry_t;
 
+typedef struct lightcell_s
+{
+	vec3_t rgb;
+	vec3_t dir;
+	float intensity;
+} lightcell_t;
+
+typedef struct lightgrid_raw_s
+{
+	int nx, ny, nz;
+	float cellSize;
+	vec3_t origin;       // world-space min corner
+	lightcell_t *cells;  // array of nx*ny*nz
+} lightgrid_raw_t;
+
 typedef struct bspx_header_s
 {
         int                     numlumps;
@@ -523,6 +538,7 @@ typedef struct qmodel_s
 	qboolean	litfile;
 	qboolean	viswarn; // for Mod_DecompressVis()
 	qboolean	has_lightdata_rgb;
+	lightgrid_raw_t *lightgrid_raw;
 
 	int			bspversion;
 	int			bspx_entries_count;


### PR DESCRIPTION
## Summary
- add raw lightgrid and cell structures to models
- load BSPX LIGHTGRID_RAW lumps with priority over octree and generate a fallback grid when absent
- provide helpers to generate raw lightgrid data and convert it for renderer use

## Testing
- not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693757faa9d4832eb362d2c2458b78d5)