### PR TITLE
Fix TraceLine call with mutable origin

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -2451,7 +2451,10 @@ static void LightgridRAW_ComputeLightingAtPoint (qmodel_t *mod, const lightgrid_
                 if (dist > l->radius)
                         continue;
 
-                TraceLine (l->origin, pos_copy, impact);
+                vec3_t light_origin;
+
+                VectorCopy (l->origin, light_origin);
+                TraceLine (light_origin, pos_copy, impact);
                 VectorSubtract (pos, impact, delta);
                 if (VectorLength (delta) > 1.f)
                         continue;


### PR DESCRIPTION
## Summary
- avoid passing const light origins to TraceLine by copying to a mutable vector first

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938a55d79d4832e8ff5789e4a511595)