### PR TITLE
Guard Mod_SetParent against null nodes

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -3143,13 +3143,16 @@ static void Mod_LoadFaces (lump_t *l)
 
 static void Mod_SetParent (mnode_t *node, mnode_t *parent)
 {
-        node->parent = parent;
+		if (!node)
+			return;
 
-        if (node->contents < 0)
-                return;
+		node->parent = parent;
 
-        Mod_SetParent (node->children[0], node);
-        Mod_SetParent (node->children[1], node);
+		if (node->contents < 0)
+			return;
+
+		Mod_SetParent (node->children[0], node);
+		Mod_SetParent (node->children[1], node);
 }
 
 static void Mod_LoadNodes_S (lump_t *l)


### PR DESCRIPTION
## Summary
- add a null check in Mod_SetParent to avoid dereferencing null nodes before recursion

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938a6a1337c832e8150c053120cd2b0)