### PR TITLE
Fix missing brace closing Mod_LoadFaces

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -3159,6 +3159,7 @@ static void Mod_LoadFaces (lump_t *l)
                 }
         }
 }
+}
 
 static void Mod_SetParent (mnode_t *node, mnode_t *parent)
 {


### PR DESCRIPTION
## Summary
- add a missing closing brace at the end of Mod_LoadFaces so subsequent functions compile correctly

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938ab64bb00832e8b991ab3e679f109)