### PR TITLE
Add linear interpolation helper

### DIFF
--- a/Quake/mathlib.c
+++ b/Quake/mathlib.c
@@ -429,6 +429,11 @@ float GetClampedLogFraction (float val, float minval, float maxval)
 	return CLAMP (0.f, val, 1.f);
 }
 
+float Lerp (float minval, float maxval, float t)
+{
+	return minval + (maxval - minval) * t;
+}
+
 float LogLerp (float minval, float maxval, float t)
 {
 	return minval * exp (t * log (maxval / minval));

--- a/Quake/mathlib.h
+++ b/Quake/mathlib.h
@@ -107,6 +107,7 @@ float Log2f (float val);
 float Exp2f (float val);
 float GetLogFraction (float val, float minval, float maxval);
 float GetClampedLogFraction (float val, float minval, float maxval);
+float Lerp (float minval, float maxval, float t);
 float LogLerp (float minval, float maxval, float t);
 
 float EaseInOut (float t);


### PR DESCRIPTION
## Summary
- add a shared float Lerp helper to mathlib and expose it in the header
- resolve implicit Lerp usage in gl_model by providing a central implementation

## Testing
- not run (not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938b55a6b34832ebfd5456666bb3b66)