### PR TITLE
Improve lightgrid debug visuals and limits

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -2299,7 +2299,7 @@ static lightgrid_raw_t *LightgridRAW_FromGrid (const lightgrid_t *src, float tar
 
         nx = q_max (1, q_min (32, (int)ceilf (size[0] / target_cellsize)));
         ny = q_max (1, q_min (32, (int)ceilf (size[1] / target_cellsize)));
-        nz = q_max (1, q_min (32, (int)ceilf (size[2] / target_cellsize)));
+        nz = q_max (1, q_min (64, (int)ceilf (size[2] / target_cellsize)));
 
         raw = (lightgrid_raw_t *)Hunk_AllocName (sizeof(*raw), "lightgrid_raw_resampled");
         if (!raw)
@@ -2308,6 +2308,8 @@ static lightgrid_raw_t *LightgridRAW_FromGrid (const lightgrid_t *src, float tar
         memset (raw, 0, sizeof(*raw));
 
         const size_t count = (size_t)nx * (size_t)ny * (size_t)nz;
+        if (count == 0 || count > SIZE_MAX / sizeof(lightcell_t))
+                return NULL;
         raw->cells = (lightcell_t *)Hunk_AllocName (count * sizeof(lightcell_t), "lightgrid_cells_resampled");
         if (!raw->cells)
                 return NULL;
@@ -2712,6 +2714,11 @@ lightgrid_raw_t *LightgridRAW_Generate(qmodel_t *mod, float cellX, float cellY, 
         nz = q_max (1, nz);
 
         count = (size_t)nx * (size_t)ny * (size_t)nz;
+        if (count == 0 || count > SIZE_MAX / sizeof(lightcell_t))
+        {
+                Con_Warning ("lightgrid too large to generate (%dx%dx%d)\n", nx, ny, nz);
+                return NULL;
+        }
 
         raw = (lightgrid_raw_t *)Hunk_AllocName (sizeof(*raw), "lightgrid_raw");
         if (!raw)

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -2604,13 +2604,19 @@ static void R_ShowLightgridDebug (void)
                         for (int x = 0; x < lg->nx; x++)
                         {
                                 vec3_t center;
+                                uint32_t color;
+                                const lightgrid_probe_t *probe = &lg->probes[(z * lg->ny + y) * lg->nx + x];
 
-				VectorSet (center,
-					lg->mins[0] + (x + 0.5f) * lg->cellsize,
-					lg->mins[1] + (y + 0.5f) * lg->cellsize,
-					lg->mins[2] + (z + 0.5f) * lg->cellsize);
+                                VectorSet (center,
+                                        lg->mins[0] + (x + 0.5f) * lg->cellsize,
+                                        lg->mins[1] + (y + 0.5f) * lg->cellsize,
+                                        lg->mins[2] + (z + 0.5f) * lg->cellsize);
 
-                                R_EmitDiamond (center, radius, 0xffffffff);
+                                color = (probe->intensity > 0.f)
+                                        ? R_PackDebugColor (probe->rgb)
+                                        : 0xffffffff;
+
+                                R_EmitDiamond (center, radius, color);
                         }
                 }
         }


### PR DESCRIPTION
## Summary
- color lightgrid debug probes using their RGB values when present and white otherwise
- increase resampled lightgrid vertical resolution limit to 64 while guarding allocations
- warn and skip generation when the requested lightgrid would exceed allocation limits

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938b9b77aa8832ebfc5be2831aa241b)