### PR TITLE
Use existing lightgrid when saving RAW data

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -2808,9 +2808,15 @@ static qboolean LightgridRAW_BuildBuffer (qmodel_t *mod, byte **out_buffer, size
         if (!mod || !out_buffer || !out_size)
                 return false;
 
-        raw = mod->lightgrid_raw;
-        if (!raw)
-                raw = LightgridRAW_Generate (mod, LIGHTGRID_STANDARD_CELLSIZE, LIGHTGRID_STANDARD_CELLSIZE, LIGHTGRID_STANDARD_CELLSIZE);
+	raw = mod->lightgrid_raw;
+	if (!raw && cl.lightgrid)
+	{
+		raw = LightgridRAW_FromGrid (cl.lightgrid, LIGHTGRID_STANDARD_CELLSIZE);
+		if (raw)
+			mod->lightgrid_raw = raw;
+	}
+	if (!raw)
+		raw = LightgridRAW_Generate (mod, LIGHTGRID_STANDARD_CELLSIZE, LIGHTGRID_STANDARD_CELLSIZE, LIGHTGRID_STANDARD_CELLSIZE);
 
         if (!raw)
                 return false;


### PR DESCRIPTION
## Summary
- reuse the currently loaded lightgrid when no raw grid is cached
- fall back to generating a new raw grid only if no loaded grid exists

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938c1c209d4832e93de6ea7b38f6688)