### PR TITLE
Add test cvar for random lightgrid generation

### DIFF
--- a/Quake/gl_lightgrid.c
+++ b/Quake/gl_lightgrid.c
@@ -14,11 +14,13 @@ static char lightgrid_source[16] = "NONE";
 
 cvar_t  r_lightgrid = { "r_lightgrid", "1", CVAR_ARCHIVE };
 cvar_t  r_lightgrid_debug = { "r_lightgrid_debug", "0", CVAR_NONE };
+cvar_t  r_generate_lightgrid_test = { "r_generate_lightgrid_test", "0", CVAR_NONE };
 
 void Lightgrid_Init (void)
 {
     Cvar_RegisterVariable (&r_lightgrid);
     Cvar_RegisterVariable (&r_lightgrid_debug);
+    Cvar_RegisterVariable (&r_generate_lightgrid_test);
     Lightgrid_Clear ();
 }
 
@@ -311,6 +313,23 @@ static void Lightgrid_AddDlights (const vec3_t pos, vec3_t color, vec3_t dirsum)
     }
 }
 
+static float Lightgrid_Random01 (void)
+{
+    return rand () * (1.f / (float)RAND_MAX);
+}
+
+static void Lightgrid_FillRandomCell (lightcell_t *cell)
+{
+    cell->rgb[0] = Lightgrid_Random01 ();
+    cell->rgb[1] = Lightgrid_Random01 ();
+    cell->rgb[2] = Lightgrid_Random01 ();
+
+    cell->dir[0] = cell->dir[1] = 0.f;
+    cell->dir[2] = 1.f;
+
+    cell->intensity = (cell->rgb[0] + cell->rgb[1] + cell->rgb[2]) * (1.f / 3.f);
+}
+
 lightgrid_raw_t *Lightgrid_GenerateRaw (const qmodel_t *model)
 {
     vec3_t mins, maxs, size;
@@ -363,6 +382,12 @@ lightgrid_raw_t *Lightgrid_GenerateRaw (const qmodel_t *model)
                 pos[0] = mins[0] + (x + 0.5f) * cellsize;
                 pos[1] = mins[1] + (y + 0.5f) * cellsize;
                 pos[2] = mins[2] + (z + 0.5f) * cellsize;
+
+                if (r_generate_lightgrid_test.value > 0.f)
+                {
+                    Lightgrid_FillRandomCell (cell);
+                    continue;
+                }
 
                 R_LightPoint (pos, 0.f, &cache);
                 cell->rgb[0] = lightcolor[0] * (1.f / 255.f);

--- a/Quake/gl_lightgrid.h
+++ b/Quake/gl_lightgrid.h
@@ -14,6 +14,7 @@ typedef struct lightgrid_raw_s lightgrid_raw_t;
 
 extern cvar_t r_lightgrid;
 extern cvar_t r_lightgrid_debug;
+extern cvar_t r_generate_lightgrid_test;
 
 void Lightgrid_Init (void);
 void Lightgrid_Shutdown (void);

--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -2686,6 +2686,22 @@ static void LightgridRAW_ComputeLightingAtPoint (qmodel_t *mod, const lightgrid_
         }
 }
 
+static float LightgridRAW_Random01 (void)
+{
+        return rand () * (1.f / (float)RAND_MAX);
+}
+
+static void LightgridRAW_FillTestCell (lightcell_t *cell)
+{
+        cell->rgb[0] = LightgridRAW_Random01 ();
+        cell->rgb[1] = LightgridRAW_Random01 ();
+        cell->rgb[2] = LightgridRAW_Random01 ();
+
+        cell->dir[0] = cell->dir[1] = 0.f;
+        cell->dir[2] = 1.f;
+        cell->intensity = (cell->rgb[0] + cell->rgb[1] + cell->rgb[2]) * (1.f / 3.f);
+}
+
 lightgrid_raw_t *LightgridRAW_Generate(qmodel_t *mod, float cellX, float cellY, float cellZ)
 {
         vec3_t mins, maxs;
@@ -2750,6 +2766,12 @@ lightgrid_raw_t *LightgridRAW_Generate(qmodel_t *mod, float cellX, float cellY, 
                                 pos[0] = mins[0] + (x + 0.5f) * cellsize;
                                 pos[1] = mins[1] + (y + 0.5f) * cellsize;
                                 pos[2] = mins[2] + (z + 0.5f) * cellsize;
+
+                                if (r_generate_lightgrid_test.value > 0.f)
+                                {
+                                        LightgridRAW_FillTestCell (cell);
+                                        continue;
+                                }
 
                                 LightgridRAW_ComputeLightingAtPoint (mod, lights, num_lights, pos, cell);
                         }

--- a/Quake/gl_rlight.c
+++ b/Quake/gl_rlight.c
@@ -23,6 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "quakedef.h"
 #include "../common/lightgrid.h"
+#include "gl_lightgrid.h"
 
 extern cvar_t r_flatlightstyles; //johnfitz
 extern cvar_t r_lerplightstyles;
@@ -520,7 +521,7 @@ int R_LightPoint (vec3_t p, float ofs, lightcache_t *cache)
 
 const lightgrid_probe_t *R_GetLightgridSample (const vec3_t pos)
 {
-        lightgrid_t *lg = cl.lightgrid;
+        const lightgrid_t *lg = Lightgrid_Get ();
         int x, y, z;
 
         if (!r_lightgrid.value || !lg || !lg->probes || lg->cellsize <= 0.f)


### PR DESCRIPTION
## Summary
- add `r_generate_lightgrid_test` to fill generated lightgrid cells with random colors for testing and export
- apply the test data path to both fallback lightgrid generation and RAW lightgrid builds
- have the renderer sample the active lightgrid via `Lightgrid_Get`

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938cf2dc5b0832e8c8abfc9ef2d16c2)