### PR TITLE
Integrate lightgrid lighting into rendering

### DIFF
--- a/Quake/gl_lightgrid.c
+++ b/Quake/gl_lightgrid.c
@@ -19,6 +19,7 @@ static char lightgrid_source[16] = "NONE";
 
 cvar_t r_lightgrid            = { "r_lightgrid", "1", CVAR_ARCHIVE };
 cvar_t r_lightgrid_debug      = { "r_lightgrid_debug", "0", CVAR_NONE };
+cvar_t r_lightgrid_force      = { "r_lightgrid_force", "0", CVAR_ARCHIVE };
 cvar_t r_generate_lightgrid_test = { "r_generate_lightgrid_test", "0", CVAR_NONE };
 
 /* =====================================================================
@@ -36,6 +37,7 @@ void Lightgrid_Init(void)
 {
     Cvar_RegisterVariable(&r_lightgrid);
     Cvar_RegisterVariable(&r_lightgrid_debug);
+    Cvar_RegisterVariable(&r_lightgrid_force);
     Cvar_RegisterVariable(&r_generate_lightgrid_test);
     Lightgrid_Clear();
 }

--- a/Quake/gl_lightgrid.h
+++ b/Quake/gl_lightgrid.h
@@ -14,6 +14,7 @@ typedef struct lightgrid_raw_s lightgrid_raw_t;
 
 extern cvar_t r_lightgrid;
 extern cvar_t r_lightgrid_debug;
+extern cvar_t r_lightgrid_force;
 extern cvar_t r_generate_lightgrid_test;
 
 void Lightgrid_Init (void);

--- a/Quake/gl_rlight.c
+++ b/Quake/gl_rlight.c
@@ -29,6 +29,7 @@ extern cvar_t r_flatlightstyles; //johnfitz
 extern cvar_t r_lerplightstyles;
 extern cvar_t r_dynamic;
 extern cvar_t r_lightgrid;
+extern cvar_t r_lightgrid_force;
 extern cvar_t r_rgblighting_enable;
 
 gpulightbuffer_t r_lightbuffer;
@@ -259,6 +260,60 @@ LIGHT SAMPLING
 
 vec3_t lightcolor; //johnfitz -- lit support via lordhavoc
 
+/*
+==================
+R_LightgridLighting
+==================
+*/
+void R_LightgridLighting (const vec3_t pos, vec3_t out_color, vec3_t out_dir)
+{
+        const lightgrid_t *lg = Lightgrid_Get ();
+
+        if (!lg || (!r_lightgrid.value && !r_lightgrid_force.value))
+        {
+                VectorClear (out_color);
+                VectorSet (out_dir, 0.f, 0.f, 1.f);
+                return;
+        }
+
+        Lightgrid_Sample (pos, out_color, out_dir);
+
+        // convert to 0-255 range expected by the renderer
+        VectorScale (out_color, 255.f, out_color);
+}
+
+/*
+==================
+R_AddDynamicLights_Lightgrid
+==================
+*/
+void R_AddDynamicLights_Lightgrid (const vec3_t pos, vec3_t lightcolor)
+{
+        int i;
+
+        if (!r_dynamic.value)
+                return;
+
+        for (i = 0; i < MAX_DLIGHTS; i++)
+        {
+                const dlight_t *l = &cl_dlights[i];
+                vec3_t dist;
+                float add;
+
+                if (l->die < cl.time || l->spawn > cl.time || !l->baseradius)
+                        continue;
+
+                VectorSubtract (pos, l->origin, dist);
+                add = l->radius - VectorLength (dist);
+
+                if (add <= l->minlight)
+                        continue;
+
+                add -= l->minlight;
+                VectorMA (lightcolor, add, l->color, lightcolor);
+        }
+}
+
 static inline int LightStyleValue (unsigned short style)
 {
 	if (style < 256)
@@ -444,79 +499,70 @@ R_LightPoint -- johnfitz -- replaced entire function for lit support via lordhav
 */
 int R_LightPoint (vec3_t p, float ofs, lightcache_t *cache)
 {
-	vec3_t		start, end;
-	float		maxdist = 8192.f; //johnfitz -- was 2048
-	const lightgrid_probe_t *probe = NULL;
-	qboolean	use_rgblight = false;
+        vec3_t          start, end;
+        float           maxdist = 8192.f; //johnfitz -- was 2048
+        qboolean        use_rgblight = false;
+        qboolean        lightgrid_active;
 
-	cache->lightgrid_has_sample = false;
-	cache->lightgrid_intensity = 0.f;
-	VectorClear (cache->lightgrid_color);
-	VectorClear (cache->lightgrid_dir);
+        cache->lightgrid_has_sample = false;
+        cache->lightgrid_intensity = 0.f;
+        VectorClear (cache->lightgrid_color);
+        VectorClear (cache->lightgrid_dir);
 
-	if (r_lightgrid.value)
-		probe = R_GetLightgridSample (p);
+        lightgrid_active = (Lightgrid_Get () != NULL) && (r_lightgrid.value || r_lightgrid_force.value);
 
-	if (cl.worldmodel->has_lightdata_rgb && r_rgblighting_enable.value)
-		use_rgblight = true;
+        if (lightgrid_active)
+        {
+                vec3_t lg_color, lg_dir;
 
-	if (!cl.worldmodel->lightdata)
-	{
-		if (probe)
-		{
-			VectorCopy (probe->dir, cache->lightgrid_dir);
-			VectorCopy (probe->rgb, cache->lightgrid_color);
-			cache->lightgrid_intensity = probe->intensity;
-			cache->lightgrid_has_sample = true;
+                R_LightgridLighting (p, lg_color, lg_dir);
 
-			VectorScale (cache->lightgrid_color, cache->lightgrid_intensity * 255.f, lightcolor);
-			return ((lightcolor[0] + lightcolor[1] + lightcolor[2]) * (1.0f / 3.0f));
-		}
+                VectorCopy (lg_color, lightcolor);
+                R_AddDynamicLights_Lightgrid (p, lightcolor);
 
-		lightcolor[0] = lightcolor[1] = lightcolor[2] = 255;
-		return 255;
-	}
+                cache->surfidx = 0;
+                VectorCopy (p, cache->pos);
+                cache->lightgrid_has_sample = true;
+                cache->lightgrid_intensity = 1.f;
+                VectorCopy (lg_color, cache->lightgrid_color);
+                VectorCopy (lg_dir, cache->lightgrid_dir);
 
-	start[0] = p[0];
-	start[1] = p[1];
-	start[2] = p[2] + ofs;
-	end[0] = start[0];
-	end[1] = start[1];
-	end[2] = start[2] - maxdist;
+                return ((lightcolor[0] + lightcolor[1] + lightcolor[2]) * (1.0f / 3.0f));
+        }
 
-	lightcolor[0] = lightcolor[1] = lightcolor[2] = 0;
+        if (cl.worldmodel->has_lightdata_rgb && r_rgblighting_enable.value)
+                use_rgblight = true;
 
-	if (cache->surfidx <= 0 // no cache or pitch black
-		|| cache->surfidx > cl.worldmodel->numsurfaces
-		|| fabsf (cache->pos[0] - p[0]) >= 1.f
-		|| fabsf (cache->pos[1] - p[1]) >= 1.f
-		|| fabsf (cache->pos[2] - p[2]) >= 1.f)
-	{
-		cache->surfidx = 0;
-		VectorCopy (p, cache->pos);
-		RecursiveLightPoint (cache, cl.worldmodel->nodes, start, start, end, &maxdist);
-	}
+        if (!cl.worldmodel->lightdata)
+        {
+                lightcolor[0] = lightcolor[1] = lightcolor[2] = 255;
+                return 255;
+        }
 
-	if (cache->surfidx > 0)
-		InterpolateLightmap (lightcolor, cl.worldmodel->surfaces + cache->surfidx - 1, cache->ds, cache->dt, use_rgblight);
+        start[0] = p[0];
+        start[1] = p[1];
+        start[2] = p[2] + ofs;
+        end[0] = start[0];
+        end[1] = start[1];
+        end[2] = start[2] - maxdist;
 
-	if (!probe && r_lightgrid.value)
-		probe = R_GetLightgridSample (p);
+        lightcolor[0] = lightcolor[1] = lightcolor[2] = 0;
 
-	if (probe)
-	{
-		vec3_t gridcolor;
+        if (cache->surfidx <= 0 // no cache or pitch black
+                || cache->surfidx > cl.worldmodel->numsurfaces
+                || fabsf (cache->pos[0] - p[0]) >= 1.f
+                || fabsf (cache->pos[1] - p[1]) >= 1.f
+                || fabsf (cache->pos[2] - p[2]) >= 1.f)
+        {
+                cache->surfidx = 0;
+                VectorCopy (p, cache->pos);
+                RecursiveLightPoint (cache, cl.worldmodel->nodes, start, start, end, &maxdist);
+        }
 
-		VectorCopy (probe->dir, cache->lightgrid_dir);
-		VectorCopy (probe->rgb, cache->lightgrid_color);
-		cache->lightgrid_intensity = probe->intensity;
-		cache->lightgrid_has_sample = true;
+        if (cache->surfidx > 0)
+                InterpolateLightmap (lightcolor, cl.worldmodel->surfaces + cache->surfidx - 1, cache->ds, cache->dt, use_rgblight);
 
-		VectorScale (cache->lightgrid_color, cache->lightgrid_intensity * 255.f, gridcolor);
-		VectorAdd (lightcolor, gridcolor, lightcolor);
-	}
-
-	return ((lightcolor[0] + lightcolor[1] + lightcolor[2]) * (1.0f / 3.0f));
+        return ((lightcolor[0] + lightcolor[1] + lightcolor[2]) * (1.0f / 3.0f));
 }
 
 const lightgrid_probe_t *R_GetLightgridSample (const vec3_t pos)

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -517,6 +517,8 @@ void GLMesh_LoadVertexBuffers (void);
 void GLMesh_DeleteVertexBuffers (void);
 
 int R_LightPoint (vec3_t p, float ofs, lightcache_t *cache);
+void R_LightgridLighting (const vec3_t pos, vec3_t out_color, vec3_t out_dir);
+void R_AddDynamicLights_Lightgrid (const vec3_t pos, vec3_t lightcolor);
 
 #define WORLDSHADER_SOLID		0
 #define WORLDSHADER_ALPHATEST	1

--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -29,6 +29,7 @@ extern cvar_t gl_overbright_models, gl_fullbrights, r_lerpmodels, r_lerpmove, r_
 extern cvar_t scr_fov, cl_gun_fovscale, cl_gun_x, cl_gun_y, cl_gun_z;
 extern cvar_t r_oit;
 extern cvar_t r_lightgrid;
+extern cvar_t r_lightgrid_force;
 extern cvar_t r_lightgrid_debug;
 
 //up to 16 color translated skins
@@ -319,37 +320,67 @@ R_SetupAliasLighting -- johnfitz -- broken out from R_DrawAliasModel and rewritt
 */
 void R_SetupAliasLighting (entity_t     *e)
 {
-	vec3_t		dist;
-	float		add;
-	unsigned int	i;
-	vec3_t		dlightcolor = {0.f, 0.f, 0.f};
-	vec3_t		ambientcolor;
+        vec3_t          dist;
+        float           add;
+        unsigned int    i;
+        vec3_t          dlightcolor = {0.f, 0.f, 0.f};
+        vec3_t          ambientcolor;
+        vec3_t          dyn_add;
+        qboolean        used_lightgrid = false;
 
-	// if the initial trace is completely black, try again from above
-	// this helps with models whose origin is slightly below ground level
-	// (e.g. some of the candles in the DOTM start map)
-	if (!R_LightPoint (e->origin, 0.f, &e->lightcache))
-		R_LightPoint (e->origin, e->model->maxs[2] * 0.5f, &e->lightcache);
+        // if the initial trace is completely black, try again from above
+        // this helps with models whose origin is slightly below ground level
+        // (e.g. some of the candles in the DOTM start map)
+        if (!R_LightPoint (e->origin, 0.f, &e->lightcache))
+                R_LightPoint (e->origin, e->model->maxs[2] * 0.5f, &e->lightcache);
 
-	VectorCopy (lightcolor, ambientcolor);
+        VectorCopy (lightcolor, ambientcolor);
+        VectorClear (dyn_add);
 
-	R_ApplyLightgridLighting (e, ambientcolor, dlightcolor);
+        if ((r_lightgrid.value || r_lightgrid_force.value) && e->lightcache.lightgrid_has_sample)
+        {
+                vec3_t lg_color, lg_dir;
 
-	//add dlights
-	for (i=0; i<r_framedata.numlights; i++)
-	{
-		gpulight_t *l = &r_lightbuffer.lights[i];
-		VectorSubtract (e->origin, l->pos, dist);
-		add = DotProduct (dist, dist);
-		if (l->radius * l->radius > add)
-		{
-			const float intensity = l->radius - sqrtf (add);
-			VectorMA (lightcolor, intensity, l->color, lightcolor);
-			VectorMA (dlightcolor, intensity, l->color, dlightcolor);
-		}
-	}
+                R_LightgridLighting (e->origin, lg_color, lg_dir);
 
-	// viewmodel lighting is typically darker because world lights aren't placed for a free camera
+                for (i = 0; i < 3; i++)
+                        dyn_add[i] = fmaxf (lightcolor[i] - lg_color[i], 0.f);
+
+                VectorCopy (lg_color, ambientcolor);
+                VectorCopy (lg_dir, e->lightcache.lightgrid_dir);
+                VectorCopy (lg_color, e->lightcache.lightgrid_color);
+                e->lightcache.lightgrid_intensity = 1.f;
+
+                used_lightgrid = true;
+        }
+
+        R_ApplyLightgridLighting (e, ambientcolor, dlightcolor);
+
+        if (used_lightgrid)
+        {
+                for (i = 0; i < 3; i++)
+                {
+                        dlightcolor[i] += dyn_add[i];
+                }
+        }
+        else
+        {
+                //add dlights
+                for (i=0; i<r_framedata.numlights; i++)
+                {
+                        gpulight_t *l = &r_lightbuffer.lights[i];
+                        VectorSubtract (e->origin, l->pos, dist);
+                        add = DotProduct (dist, dist);
+                        if (l->radius * l->radius > add)
+                        {
+                                const float intensity = l->radius - sqrtf (add);
+                                VectorMA (lightcolor, intensity, l->color, lightcolor);
+                                VectorMA (dlightcolor, intensity, l->color, dlightcolor);
+                        }
+                }
+        }
+
+        // viewmodel lighting is typically darker because world lights aren't placed for a free camera
 	if (e == &cl.viewent)
 	{
 		for (i = 0; i < 3; i++)


### PR DESCRIPTION
## Summary
- add r_lightgrid_force cvar and expose lightgrid sampling helpers for renderer use
- route R_LightPoint to lightgrid lighting with dynamic light falloff when grids are available
- feed alias model lighting from interpolated lightgrid data without double-counting dynamic lights

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938d7725058832ead0edc2cde85ec9b)