### PR TITLE
Apply lightgrid modulation to world lightmaps

### DIFF
--- a/Quake/gl_model.h
+++ b/Quake/gl_model.h
@@ -134,6 +134,7 @@ typedef struct
 typedef struct glvert_s {
 	vec3_t		pos;
 	vec3_t		normal;
+	vec3_t		lightgrid;
 	float		st[4];
 	float		lmofs;
 	unsigned	styles;

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -1651,10 +1651,14 @@ void R_SetupView (void)
         r_framedata.eye[1] = r_refdef.vieworg[1];
         r_framedata.eye[2] = r_refdef.vieworg[2];
         r_framedata.eye[3] = cl.time;
-	r_framedata.lightmap_params[0] = r_lightmap_linear.value > 0.f ? 1.f : 0.f;
-	r_framedata.lightmap_params[1] = r_tonemap.value > 0.f ? 1.f : 0.f;
-	r_framedata.lightmap_params[2] = (r_lightingdir.value > 0.f && lightmap_dir_texture) ? 1.f : 0.f;
-	r_framedata.lightmap_params[3] = r_lightstyle_framefrac;
+        r_framedata.lightmap_params[0] = r_lightmap_linear.value > 0.f ? 1.f : 0.f;
+        r_framedata.lightmap_params[1] = r_tonemap.value > 0.f ? 1.f : 0.f;
+        r_framedata.lightmap_params[2] = (r_lightingdir.value > 0.f && lightmap_dir_texture) ? 1.f : 0.f;
+        r_framedata.lightmap_params[3] = r_lightstyle_framefrac;
+        r_framedata.lightgrid_params[0] = (Lightgrid_Get () != NULL && (r_lightgrid.value || r_lightgrid_force.value)) ? 1.f : 0.f;
+        r_framedata.lightgrid_params[1] = 0.f;
+        r_framedata.lightgrid_params[2] = 0.f;
+        r_framedata.lightgrid_params[3] = 0.f;
 
 	double prev_delta = cl.time - r_prev_frame_time;
 	qboolean prev_valid = r_prev_frame_valid && prev_delta > 0.0;

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -431,6 +431,7 @@ typedef struct gpuframedata_s {
         vec4_t          prev_eye;       // xyz: prev_eyepos, w: delta_time
         vec4_t          zparams;        // x: zlogscale, y: zlogbias, zw: padding
         float           lightmap_params[4];
+        vec4_t          lightgrid_params; // x: enabled, yzw: unused
         unsigned int    numlights;
         unsigned int    prev_frame_valid;
         unsigned int    _padding1;

--- a/Quake/r_brush.c
+++ b/Quake/r_brush.c
@@ -25,6 +25,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include <limits.h>
 
 #include "quakedef.h"
+#include "gl_lightgrid.h"
 
 extern cvar_t gl_fullbrights, gl_overbright; //johnfitz
 extern cvar_t r_lightmap_mipmaps;
@@ -836,11 +837,11 @@ void GL_BuildBModelVertexBuffer (void)
 
 				lindex = m->surfedges[fa->firstedge + k];
 				if (lindex > 0)
-				{
-					r_pedge = &m->edges[lindex];
-					vertindex = r_pedge->v[0];
-					vec = m->vertexes[vertindex].position;
-				}
+                                {
+                                        r_pedge = &m->edges[lindex];
+                                        vertindex = r_pedge->v[0];
+                                        vec = m->vertexes[vertindex].position;
+                                }
 				else
 				{
 					r_pedge = &m->edges[-lindex];
@@ -848,13 +849,20 @@ void GL_BuildBModelVertexBuffer (void)
 					vec = m->vertexes[vertindex].position;
 				}
 
-				VectorCopy (vec, vert->pos);
-				VectorCopy (surfnormal, vert->normal);
-				if ((fa->texinfo->flags & TEX_VERTEXNORMALS) && (m->vertexes[vertindex].normal[0] || m->vertexes[vertindex].normal[1] || m->vertexes[vertindex].normal[2]))
-					VectorCopy (m->vertexes[vertindex].normal, vert->normal);
+                                VectorCopy (vec, vert->pos);
+                                VectorCopy (surfnormal, vert->normal);
+                                if ((fa->texinfo->flags & TEX_VERTEXNORMALS) && (m->vertexes[vertindex].normal[0] || m->vertexes[vertindex].normal[1] || m->vertexes[vertindex].normal[2]))
+                                        VectorCopy (m->vertexes[vertindex].normal, vert->normal);
 
-				s = DotProduct (vec, fa->texinfo->vecs[0]) + fa->texinfo->vecs[0][3] * useofs;
-				s *= texscalex;
+                                {
+                                        vec3_t lg_color, lg_dir;
+
+                                        Lightgrid_Sample (vec, lg_color, lg_dir);
+                                        VectorCopy (lg_color, vert->lightgrid);
+                                }
+
+                                s = DotProduct (vec, fa->texinfo->vecs[0]) + fa->texinfo->vecs[0][3] * useofs;
+                                s *= texscalex;
 
 				t = DotProduct (vec, fa->texinfo->vecs[1]) + fa->texinfo->vecs[1][3] * useofs;
 				t *= texscaley;

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -290,10 +290,11 @@ static void R_FlushBModelCalls (void)
 	GL_BindBuffer (GL_ARRAY_BUFFER, gl_bmodel_vbo);
 	GL_BindBuffer (GL_DRAW_INDIRECT_BUFFER, cmdbuf);
 	GL_VertexAttribPointerFunc (0, 3, GL_FLOAT, GL_FALSE, sizeof (glvert_t), (void *) offsetof (glvert_t, pos));
-	GL_VertexAttribPointerFunc (1, 4, GL_FLOAT, GL_FALSE, sizeof (glvert_t), (void *) offsetof (glvert_t, st));
-	GL_VertexAttribPointerFunc (2, 1, GL_FLOAT, GL_FALSE, sizeof (glvert_t), (void *) offsetof (glvert_t, lmofs));
-	GL_VertexAttribIPointerFunc (3, 4, GL_UNSIGNED_BYTE, sizeof (glvert_t), (void *) offsetof (glvert_t, styles));
+        GL_VertexAttribPointerFunc (1, 4, GL_FLOAT, GL_FALSE, sizeof (glvert_t), (void *) offsetof (glvert_t, st));
+        GL_VertexAttribPointerFunc (2, 1, GL_FLOAT, GL_FALSE, sizeof (glvert_t), (void *) offsetof (glvert_t, lmofs));
+        GL_VertexAttribIPointerFunc (3, 4, GL_UNSIGNED_BYTE, sizeof (glvert_t), (void *) offsetof (glvert_t, styles));
         GL_VertexAttribPointerFunc (4, 3, GL_FLOAT, GL_FALSE, sizeof (glvert_t), (void *) offsetof (glvert_t, normal));
+        GL_VertexAttribPointerFunc (5, 3, GL_FLOAT, GL_FALSE, sizeof (glvert_t), (void *) offsetof (glvert_t, lightgrid));
 
 	if (gl_bindless_able)
 	{
@@ -515,7 +516,7 @@ static void R_DrawBrushModels_Real (entity_t **ents, int count, brushpass_t pass
         if (!totalinst)
                 return;
 
-        state = GLS_CULL_BACK | GLS_ATTRIBS(5);
+        state = GLS_CULL_BACK | GLS_ATTRIBS(6);
         if (!translucent)
                 state |= GLS_BLEND_OPAQUE;
         else
@@ -612,7 +613,7 @@ void R_DrawBrushModels_Water (entity_t **ents, int count, qboolean translucent)
 	GL_BeginGroup (translucent ? "Water (translucent)" : "Water (opaque)");
 
 	// setup state
-	state = GLS_CULL_BACK | GLS_ATTRIBS(5);
+        state = GLS_CULL_BACK | GLS_ATTRIBS(6);
 	if (translucent)
 		state |= GLS_BLEND_ALPHA_OIT | GLS_NO_ZWRITE;
 	else

--- a/Quake/shaders/frame_uniforms.glsl
+++ b/Quake/shaders/frame_uniforms.glsl
@@ -20,6 +20,7 @@ layout(std140, binding=0) uniform FrameDataUBO
         float   ZLogScale;
         float   ZLogBias;
         vec4    LightmapParams;
+        vec4    LightgridParams;
         uint    NumLights;
         uint    PrevFrameValid;
         uint    _Pad1;

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -128,6 +128,7 @@ layout(location=8) flat in float in_lmofs;
 layout(location=11) noperspective in vec4 in_curr_clip;
 layout(location=12) noperspective in vec4 in_prev_clip;
 layout(location=13) in vec3 in_normal;
+layout(location=14) in vec3 in_lightgrid;
 
 // ALU-only 16x16 Bayer matrix
 float bayer01(ivec2 coord)
@@ -334,6 +335,9 @@ void main()
                         );
                 }
         }
+
+        vec3 lightgrid = mix(vec3(1.0), in_lightgrid, LightgridParams.x);
+        static_light *= lightgrid;
 
         if (LightmapParams.z > 0.5)
         {

--- a/Quake/shaders/world.vert
+++ b/Quake/shaders/world.vert
@@ -117,6 +117,7 @@ layout(location=1) in vec4 in_uv;
 layout(location=2) in float in_lmofs;
 layout(location=3) in ivec4 in_styles;
 layout(location=4) in vec3 in_normal;
+layout(location=5) in vec3 in_lightgrid;
 
 
 layout(location=0) flat out uint out_flags;
@@ -139,6 +140,7 @@ layout(location=8) flat out float out_lmofs;
 layout(location=11) noperspective out vec4 out_curr_clip;
 layout(location=12) noperspective out vec4 out_prev_clip;
 layout(location=13) out vec3 out_normal;
+layout(location=14) out vec3 out_lightgrid;
 
 void main()
 {
@@ -161,11 +163,12 @@ void main()
 		prev_clip.z += ZBIAS;
 	}
 	gl_Position = curr_clip;
-	out_curr_clip = curr_clip;
-	out_prev_clip = prev_clip;
-	out_pos = world_pos;
+        out_curr_clip = curr_clip;
+        out_prev_clip = prev_clip;
+        out_pos = world_pos;
         out_normal = normalize(world_normal);
-	out_uv = in_uv.xy;
+        out_lightgrid = in_lightgrid;
+        out_uv = in_uv.xy;
 	out_lmuv = in_uv.zw;
 	out_depth = gl_Position.w;
 	out_coord = (gl_Position.xy / gl_Position.w * 0.5 + 0.5) * vec2(LIGHT_TILES_X, LIGHT_TILES_Y);


### PR DESCRIPTION
## Summary
- add per-vertex lightgrid sampling to brush vertex data and feed it to world shaders
- modulate world lightmap lighting by lightgrid values while keeping lightstyles and dynamic lights intact
- expose lightgrid enable flag through frame uniform data for shader control

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693952b6f00c832ebdd00e6d3f5cd067)