### PR TITLE
Normalize lightgrid helper and toggle behavior

### DIFF
--- a/Quake/gl_rlight.c
+++ b/Quake/gl_rlight.c
@@ -34,6 +34,16 @@ extern cvar_t r_rgblighting_enable;
 
 gpulightbuffer_t r_lightbuffer;
 float r_lightstyle_framefrac;
+static qboolean R_LightgridEnabledInternal (const lightgrid_t *lg)
+{
+        if (r_lightgrid.value <= 0.f)
+                return false;
+
+        if (lg && lg->probes && lg->cellsize > 0.f)
+                return true;
+
+        return r_lightgrid_force.value > 0.f;
+}
 
 /*
 ==================
@@ -262,14 +272,36 @@ vec3_t lightcolor; //johnfitz -- lit support via lordhavoc
 
 /*
 ==================
+R_LightgridEnabled
+==================
+*/
+qboolean R_LightgridEnabled (void)
+{
+        return R_LightgridEnabledInternal (Lightgrid_Get ());
+}
+
+/*
+==================
 R_LightgridLighting
 ==================
 */
-void R_LightgridLighting (const vec3_t pos, vec3_t out_color, vec3_t out_dir)
+void R_LightgridLighting (const vec3_t pos, vec3_t out_color)
+{
+        vec3_t dummy_dir;
+
+        R_LightgridLightingDir (pos, out_color, dummy_dir);
+}
+
+/*
+==================
+R_LightgridLightingDir
+==================
+*/
+void R_LightgridLightingDir (const vec3_t pos, vec3_t out_color, vec3_t out_dir)
 {
         const lightgrid_t *lg = Lightgrid_Get ();
 
-        if (!lg || (!r_lightgrid.value && !r_lightgrid_force.value))
+        if (!R_LightgridEnabledInternal (lg))
         {
                 VectorClear (out_color);
                 VectorSet (out_dir, 0.f, 0.f, 1.f);
@@ -277,9 +309,6 @@ void R_LightgridLighting (const vec3_t pos, vec3_t out_color, vec3_t out_dir)
         }
 
         Lightgrid_Sample (pos, out_color, out_dir);
-
-        // convert to 0-255 range expected by the renderer
-        VectorScale (out_color, 255.f, out_color);
 }
 
 /*
@@ -509,15 +538,16 @@ int R_LightPoint (vec3_t p, float ofs, lightcache_t *cache)
         VectorClear (cache->lightgrid_color);
         VectorClear (cache->lightgrid_dir);
 
-        lightgrid_active = (Lightgrid_Get () != NULL) && (r_lightgrid.value || r_lightgrid_force.value);
+        lightgrid_active = R_LightgridEnabled ();
 
         if (lightgrid_active)
         {
-                vec3_t lg_color, lg_dir;
+                vec3_t lg_color, lg_dir, lg_color255;
 
-                R_LightgridLighting (p, lg_color, lg_dir);
+                R_LightgridLightingDir (p, lg_color, lg_dir);
+                VectorScale (lg_color, 255.f, lg_color255);
 
-                VectorCopy (lg_color, lightcolor);
+                VectorCopy (lg_color255, lightcolor);
                 R_AddDynamicLights_Lightgrid (p, lightcolor);
 
                 cache->surfidx = 0;
@@ -570,7 +600,10 @@ const lightgrid_probe_t *R_GetLightgridSample (const vec3_t pos)
         const lightgrid_t *lg = Lightgrid_Get ();
         int x, y, z;
 
-        if (!r_lightgrid.value || !lg || !lg->probes || lg->cellsize <= 0.f)
+        if (!lg || !lg->probes || lg->cellsize <= 0.f)
+                return NULL;
+
+        if (!R_LightgridEnabledInternal (lg))
                 return NULL;
 
         x = (int)floorf((pos[0] - lg->mins[0]) / lg->cellsize);

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -1655,7 +1655,7 @@ void R_SetupView (void)
         r_framedata.lightmap_params[1] = r_tonemap.value > 0.f ? 1.f : 0.f;
         r_framedata.lightmap_params[2] = (r_lightingdir.value > 0.f && lightmap_dir_texture) ? 1.f : 0.f;
         r_framedata.lightmap_params[3] = r_lightstyle_framefrac;
-        r_framedata.lightgrid_params[0] = (Lightgrid_Get () != NULL && (r_lightgrid.value || r_lightgrid_force.value)) ? 1.f : 0.f;
+        r_framedata.lightgrid_params[0] = R_LightgridEnabled () ? 1.f : 0.f;
         r_framedata.lightgrid_params[1] = 0.f;
         r_framedata.lightgrid_params[2] = 0.f;
         r_framedata.lightgrid_params[3] = 0.f;

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -518,7 +518,9 @@ void GLMesh_LoadVertexBuffers (void);
 void GLMesh_DeleteVertexBuffers (void);
 
 int R_LightPoint (vec3_t p, float ofs, lightcache_t *cache);
-void R_LightgridLighting (const vec3_t pos, vec3_t out_color, vec3_t out_dir);
+qboolean R_LightgridEnabled (void);
+void R_LightgridLighting (const vec3_t pos, vec3_t out_color);
+void R_LightgridLightingDir (const vec3_t pos, vec3_t out_color, vec3_t out_dir);
 void R_AddDynamicLights_Lightgrid (const vec3_t pos, vec3_t lightcolor);
 
 #define WORLDSHADER_SOLID		0

--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -131,7 +131,7 @@ static void R_ApplyLightgridLighting (const entity_t *e, vec3_t ambientcolor, ve
         vec3_t          forward, right, up, shadevector;
         float           dir_dot;
 
-        if (!r_lightgrid.value || !e->lightcache.lightgrid_has_sample)
+        if (!R_LightgridEnabled () || !e->lightcache.lightgrid_has_sample)
                 return;
 
         VectorScale (e->lightcache.lightgrid_color, e->lightcache.lightgrid_intensity * 255.f, gridcolor);
@@ -329,17 +329,17 @@ void R_SetupAliasLighting (entity_t     *e)
         qboolean        used_lightgrid = false;
         qboolean        base_from_lightgrid = false;
 
-        if (Lightgrid_Get () && (r_lightgrid.value || r_lightgrid_force.value))
+        if (R_LightgridEnabled ())
         {
-                vec3_t lg_color, lg_dir;
+                vec3_t lg_color, lg_dir, lg_color255;
 
-                Lightgrid_Sample (e->origin, lg_color, lg_dir);
-                VectorScale (lg_color, 255.0f, lg_color);
+                R_LightgridLightingDir (e->origin, lg_color, lg_dir);
+                VectorScale (lg_color, 255.0f, lg_color255);
 
-                VectorCopy (lg_color, lightcolor);
+                VectorCopy (lg_color255, lightcolor);
                 R_AddDynamicLights_Lightgrid (e->origin, lightcolor);
 
-                VectorCopy (lg_color, ambientcolor);
+                VectorCopy (lg_color255, ambientcolor);
                 VectorSubtract (lightcolor, ambientcolor, dlightcolor);
 
                 VectorCopy (lg_dir, e->lightcache.lightgrid_dir);
@@ -361,16 +361,17 @@ void R_SetupAliasLighting (entity_t     *e)
 
                 VectorCopy (lightcolor, ambientcolor);
 
-                if ((r_lightgrid.value || r_lightgrid_force.value) && e->lightcache.lightgrid_has_sample)
+                if (R_LightgridEnabled () && e->lightcache.lightgrid_has_sample)
                 {
-                        vec3_t lg_color, lg_dir;
+                        vec3_t lg_color, lg_dir, lg_color255;
 
-                        R_LightgridLighting (e->origin, lg_color, lg_dir);
+                        R_LightgridLightingDir (e->origin, lg_color, lg_dir);
+                        VectorScale (lg_color, 255.0f, lg_color255);
 
                         for (i = 0; i < 3; i++)
-                                dyn_add[i] = fmaxf (lightcolor[i] - lg_color[i], 0.f);
+                                dyn_add[i] = fmaxf (lightcolor[i] - lg_color255[i], 0.f);
 
-                        VectorCopy (lg_color, ambientcolor);
+                        VectorCopy (lg_color255, ambientcolor);
                         VectorCopy (lg_dir, e->lightcache.lightgrid_dir);
                         VectorCopy (lg_color, e->lightcache.lightgrid_color);
                         e->lightcache.lightgrid_intensity = 1.f;


### PR DESCRIPTION
## Summary
- add normalized lightgrid helper functions and keep sampling consistent
- gate lightgrid usage with a central toggle tied to r_lightgrid
- update alias lighting to store normalized colors while still mixing dynamic lights

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69396aef4024832e98c1768f3225c63e)