### PR TITLE
Fix const usage in hull tracing

### DIFF
--- a/Quake/world.c
+++ b/Quake/world.c
@@ -556,8 +556,8 @@ SV_HullPointContents
 int SV_HullPointContents (hull_t *hull, int num, vec3_t p)
 {
 	float		d;
-	mclipnode_t	*node; //johnfitz -- was dclipnode_t
-	mplane_t	*plane;
+	const mclipnode_t	*node; //johnfitz -- was dclipnode_t
+	const mplane_t	*plane;
 
 	while (num >= 0)
 	{
@@ -638,10 +638,10 @@ SV_RecursiveHullCheck
 
 ==================
 */
-qboolean SV_RecursiveHullCheck (hull_t *hull, int num, float p1f, float p2f, vec3_t p1, vec3_t p2, trace_t *trace)
+qboolean SV_RecursiveHullCheck (const hull_t *hull, int num, float p1f, float p2f, vec3_t p1, vec3_t p2, trace_t *trace)
 {
-	mclipnode_t	*node; //johnfitz -- was dclipnode_t
-	mplane_t	*plane;
+	const mclipnode_t	*node; //johnfitz -- was dclipnode_t
+	const mplane_t	*plane;
 	float		t1, t2;
 	float		frac;
 	int			i;

--- a/Quake/world.h
+++ b/Quake/world.h
@@ -81,7 +81,7 @@ trace_t SV_Move (vec3_t start, vec3_t mins, vec3_t maxs, vec3_t end, int type, e
 
 // passedict is explicitly excluded from clipping checks (normally NULL)
 
-qboolean SV_RecursiveHullCheck (hull_t *hull, int num, float p1f, float p2f, vec3_t p1, vec3_t p2, trace_t *trace);
+qboolean SV_RecursiveHullCheck (const hull_t *hull, int num, float p1f, float p2f, vec3_t p1, vec3_t p2, trace_t *trace);
 
 #endif	/* _QUAKE_WORLD_H */
 


### PR DESCRIPTION
## Summary
- update SV_RecursiveHullCheck to accept const hull pointers and propagate const locals
- adjust function declaration to match definition and callers to avoid const qualifier warnings

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939b10c3ac0832e8d9b9b407fe14c01)