### PR TITLE
Handle model-aware light sampling

### DIFF
--- a/Quake/gl_lightgrid.c
+++ b/Quake/gl_lightgrid.c
@@ -411,7 +411,7 @@ lightgrid_raw_t *Lightgrid_GenerateRaw(const struct qmodel_s *model)
         }
 
         lightcache_t cache = {0};
-        R_LightPoint(pos, 0.f, &cache);
+        R_LightPoint((qmodel_t *)model, pos, 0.f, &cache);
 
         cell->rgb[0] = lightcolor[0] * (1.f/255.f);
         cell->rgb[1] = lightcolor[1] * (1.f/255.f);

--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -2690,7 +2690,7 @@ static void LightgridRAW_ComputeLightingAtPoint (qmodel_t *mod, const lightgrid_
 	lightcache_t cache = {0};
 
 	/* Seed with baked BSP lighting so we always capture existing lightmaps */
-	R_LightPoint (pos, 0.f, &cache);
+        R_LightPoint (mod, pos, 0.f, &cache);
 	cell->rgb[0] = lightcolor[0] * (1.f / 255.f);
 	cell->rgb[1] = lightcolor[1] * (1.f / 255.f);
 	cell->rgb[2] = lightcolor[2] * (1.f / 255.f);

--- a/Quake/gl_rlight.c
+++ b/Quake/gl_rlight.c
@@ -351,7 +351,7 @@ static inline int LightStyleValue (unsigned short style)
 	return d_lightstylevalue[0];
 }
 
-static void InterpolateLightmap (vec3_t color, msurface_t *surf, int ds, int dt, qboolean use_rgb)
+static void InterpolateLightmap (qmodel_t *model, vec3_t color, msurface_t *surf, int ds, int dt, qboolean use_rgb)
 {
 	const byte *lightmap;
 	const byte *samples;
@@ -367,23 +367,18 @@ static void InterpolateLightmap (vec3_t color, msurface_t *surf, int ds, int dt,
 
 	samples = surf->samples;
 
-	if (use_rgb)
+	if (use_rgb && model && model->lightdata && model->lightdata_rgb)
 	{
-		qmodel_t *model = cl.worldmodel;
+		const int bytes_per_sample = (model->flags & MOD_HDRLIGHTING) ? 4 : 3;
+		const ptrdiff_t offset = samples - model->lightdata;
 
-		if (model && model->lightdata && model->lightdata_rgb)
+		if (bytes_per_sample > 0 && offset >= 0 && (offset % bytes_per_sample) == 0)
 		{
-			const int bytes_per_sample = (model->flags & MOD_HDRLIGHTING) ? 4 : 3;
-			const ptrdiff_t offset = samples - model->lightdata;
+			const size_t sample_offset = (size_t)offset / (size_t)bytes_per_sample;
+			const size_t rgb_offset = sample_offset * 3;
 
-			if (bytes_per_sample > 0 && offset >= 0 && (offset % bytes_per_sample) == 0)
-			{
-				const size_t sample_offset = (size_t)offset / (size_t)bytes_per_sample;
-				const size_t rgb_offset = sample_offset * 3;
-
-				if (rgb_offset + 3 <= (size_t)model->lightdata_rgb_size)
-					samples = model->lightdata_rgb + rgb_offset;
-			}
+			if (rgb_offset + 3 <= (size_t)model->lightdata_rgb_size)
+				samples = model->lightdata_rgb + rgb_offset;
 		}
 	}
 
@@ -409,7 +404,7 @@ static void InterpolateLightmap (vec3_t color, msurface_t *surf, int ds, int dt,
 RecursiveLightPoint -- johnfitz -- replaced entire function for lit support via lordhavoc
 =============
 */
-int RecursiveLightPoint (lightcache_t *cache, mnode_t *node, vec3_t rayorg, vec3_t start, vec3_t end, float *maxdist)
+int RecursiveLightPoint (qmodel_t *model, lightcache_t *cache, mnode_t *node, vec3_t rayorg, vec3_t start, vec3_t end, float *maxdist)
 {
 	float		front, back, frac;
 	vec3_t		mid;
@@ -432,7 +427,7 @@ loc0:
 
 	// LordHavoc: optimized recursion
 	if ((back < 0) == (front < 0))
-//		return RecursiveLightPoint (cache, node->children[front < 0], rayorg, start, end, maxdist);
+//		return RecursiveLightPoint (model, cache, node->children[front < 0], rayorg, start, end, maxdist);
 	{
 		node = node->children[front < 0];
 		goto loc0;
@@ -444,7 +439,7 @@ loc0:
 	mid[2] = start[2] + (end[2] - start[2])*frac;
 
 // go down front side
-	if (RecursiveLightPoint (cache, node->children[front < 0], rayorg, start, mid, maxdist))
+	if (RecursiveLightPoint (model, cache, node->children[front < 0], rayorg, start, mid, maxdist))
 		return true;	// hit something
 	else
 	{
@@ -453,7 +448,7 @@ loc0:
 		msurface_t *surf;
 	// check for impact on this node
 
-		surf = cl.worldmodel->surfaces + node->firstsurface;
+		surf = model->surfaces + node->firstsurface;
 		for (i = 0;i < node->numsurfaces;i++, surf++)
 		{
 			float sfront, sback, dist;
@@ -504,7 +499,7 @@ loc0:
 
 			if (dist < *maxdist)
 			{
-				cache->surfidx = surf - cl.worldmodel->surfaces + 1;
+				cache->surfidx = surf - model->surfaces + 1;
 				cache->ds = ds;
 				cache->dt = dt;
 			}
@@ -517,7 +512,7 @@ loc0:
 		}
 
 	// go down back side
-		return RecursiveLightPoint (cache, node->children[front >= 0], rayorg, mid, end, maxdist);
+		return RecursiveLightPoint (model, cache, node->children[front >= 0], rayorg, mid, end, maxdist);
 	}
 }
 
@@ -526,7 +521,7 @@ loc0:
 R_LightPoint -- johnfitz -- replaced entire function for lit support via lordhavoc
 =============
 */
-int R_LightPoint (vec3_t p, float ofs, lightcache_t *cache)
+int R_LightPoint (qmodel_t *model, vec3_t p, float ofs, lightcache_t *cache)
 {
         vec3_t          start, end;
         float           maxdist = 8192.f; //johnfitz -- was 2048
@@ -560,10 +555,10 @@ int R_LightPoint (vec3_t p, float ofs, lightcache_t *cache)
                 return ((lightcolor[0] + lightcolor[1] + lightcolor[2]) * (1.0f / 3.0f));
         }
 
-        if (cl.worldmodel->has_lightdata_rgb && r_rgblighting_enable.value)
+        if (model && model->has_lightdata_rgb && r_rgblighting_enable.value)
                 use_rgblight = true;
 
-        if (!cl.worldmodel->lightdata)
+        if (!model || !model->lightdata)
         {
                 lightcolor[0] = lightcolor[1] = lightcolor[2] = 255;
                 return 255;
@@ -579,18 +574,18 @@ int R_LightPoint (vec3_t p, float ofs, lightcache_t *cache)
         lightcolor[0] = lightcolor[1] = lightcolor[2] = 0;
 
         if (cache->surfidx <= 0 // no cache or pitch black
-                || cache->surfidx > cl.worldmodel->numsurfaces
+                || (model && cache->surfidx > model->numsurfaces)
                 || fabsf (cache->pos[0] - p[0]) >= 1.f
                 || fabsf (cache->pos[1] - p[1]) >= 1.f
                 || fabsf (cache->pos[2] - p[2]) >= 1.f)
         {
                 cache->surfidx = 0;
                 VectorCopy (p, cache->pos);
-                RecursiveLightPoint (cache, cl.worldmodel->nodes, start, start, end, &maxdist);
+                RecursiveLightPoint (model, cache, model->nodes, start, start, end, &maxdist);
         }
 
         if (cache->surfidx > 0)
-                InterpolateLightmap (lightcolor, cl.worldmodel->surfaces + cache->surfidx - 1, cache->ds, cache->dt, use_rgblight);
+                InterpolateLightmap (model, lightcolor, model->surfaces + cache->surfidx - 1, cache->ds, cache->dt, use_rgblight);
 
         return ((lightcolor[0] + lightcolor[1] + lightcolor[2]) * (1.0f / 3.0f));
 }

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -517,7 +517,7 @@ void GLMesh_LoadVertexBuffer (qmodel_t *m, aliashdr_t *hdr);
 void GLMesh_LoadVertexBuffers (void);
 void GLMesh_DeleteVertexBuffers (void);
 
-int R_LightPoint (vec3_t p, float ofs, lightcache_t *cache);
+int R_LightPoint (qmodel_t *model, vec3_t p, float ofs, lightcache_t *cache);
 qboolean R_LightgridEnabled (void);
 void R_LightgridLighting (const vec3_t pos, vec3_t out_color);
 void R_LightgridLightingDir (const vec3_t pos, vec3_t out_color, vec3_t out_dir);

--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -356,8 +356,8 @@ void R_SetupAliasLighting (entity_t     *e)
                 // if the initial trace is completely black, try again from above
                 // this helps with models whose origin is slightly below ground level
                 // (e.g. some of the candles in the DOTM start map)
-                if (!R_LightPoint (e->origin, 0.f, &e->lightcache))
-                        R_LightPoint (e->origin, e->model->maxs[2] * 0.5f, &e->lightcache);
+                if (!R_LightPoint (e->model, e->origin, 0.f, &e->lightcache))
+                        R_LightPoint (e->model, e->origin, e->model->maxs[2] * 0.5f, &e->lightcache);
 
                 VectorCopy (lightcolor, ambientcolor);
 


### PR DESCRIPTION
## Summary
- update R_LightPoint to accept a model parameter and rely on it instead of the global world model
- adjust light sampling helpers and call sites to pass through the appropriate qmodel_t instance
- keep lightmap interpolation model-aware while maintaining cached lighting behavior

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939d483e180832e8b182e79ae0c164e)