### PR TITLE
Improve lightgrid sampling and bounce lighting for probes

### DIFF
--- a/Quake/gl_lightgrid.c
+++ b/Quake/gl_lightgrid.c
@@ -23,6 +23,12 @@ cvar_t r_lightgrid            = { "r_lightgrid", "1", CVAR_ARCHIVE };
 cvar_t r_lightgrid_debug      = { "r_lightgrid_debug", "0", CVAR_NONE };
 cvar_t r_lightgrid_force      = { "r_lightgrid_force", "0", CVAR_ARCHIVE };
 cvar_t r_generate_lightgrid_test = { "r_generate_lightgrid_test", "0", CVAR_NONE };
+cvar_t r_lightgrid_weight_direct = { "r_lightgrid_weight_direct", "0.3", CVAR_ARCHIVE };
+cvar_t r_lightgrid_weight_lightmap = { "r_lightgrid_weight_lightmap", "1", CVAR_ARCHIVE };
+cvar_t r_lightgrid_surface_weight = { "r_lightgrid_surface_weight", "0", CVAR_ARCHIVE };
+cvar_t r_lightgrid_bounce_factor = { "r_lightgrid_bounce_factor", "0.5", CVAR_ARCHIVE };
+cvar_t r_lightgrid_bounce_rays = { "r_lightgrid_bounce_rays", "16", CVAR_ARCHIVE };
+cvar_t r_lightgrid_sh9 = { "r_lightgrid_sh9", "0", CVAR_ARCHIVE };
 
 static qboolean R_IsFinite (float v)
 {
@@ -50,6 +56,12 @@ void Lightgrid_Init(void)
     Cvar_RegisterVariable(&r_lightgrid_debug);
     Cvar_RegisterVariable(&r_lightgrid_force);
     Cvar_RegisterVariable(&r_generate_lightgrid_test);
+    Cvar_RegisterVariable(&r_lightgrid_weight_direct);
+    Cvar_RegisterVariable(&r_lightgrid_weight_lightmap);
+    Cvar_RegisterVariable(&r_lightgrid_surface_weight);
+    Cvar_RegisterVariable(&r_lightgrid_bounce_factor);
+    Cvar_RegisterVariable(&r_lightgrid_bounce_rays);
+    Cvar_RegisterVariable(&r_lightgrid_sh9);
     Lightgrid_Clear();
 }
 
@@ -342,6 +354,57 @@ static float Lightgrid_Random01(void)
     return (float)rand() / (float)RAND_MAX;
 }
 
+static void Lightgrid_RandomHemisphereDir(vec3_t out)
+{
+    const float u = Lightgrid_Random01();
+    const float v = Lightgrid_Random01();
+    const float phi = 2.f * (float)M_PI * u;
+    const float cos_theta = v;
+    const float sin_theta = sqrtf(q_max(0.f, 1.f - cos_theta * cos_theta));
+
+    out[0] = cosf(phi) * sin_theta;
+    out[1] = sinf(phi) * sin_theta;
+    out[2] = fabsf(cos_theta);
+}
+
+static qboolean Lightgrid_TraceLine(const qmodel_t *mod, const vec3_t start, const vec3_t end, vec3_t impact)
+{
+    trace_t trace;
+
+    if (!mod || !mod->hulls || !mod->hulls[0].planes)
+    {
+        if (impact)
+            VectorCopy(end, impact);
+        return true;
+    }
+
+    if (impact)
+        VectorCopy(end, impact);
+
+    memset(&trace, 0, sizeof(trace));
+
+    vec3_t mutable_start, mutable_end;
+    VectorCopy(start, mutable_start);
+    VectorCopy(end, mutable_end);
+
+    SV_RecursiveHullCheck(mod->hulls, 0, 0, 1, mutable_start, mutable_end, &trace);
+
+    if (impact)
+        VectorCopy(trace.endpos, impact);
+
+    vec3_t delta;
+    VectorSubtract(end, trace.endpos, delta);
+    return VectorLength(delta) < 1.f;
+}
+
+void SH9_EncodeDirectional(vec3_t dir, vec3_t rgb, sh9_color_t *out)
+{
+    // Stub for future SH9 encoding implementation.
+    (void)dir;
+    (void)rgb;
+    (void)out;
+}
+
 static void Lightgrid_FillRandomCell(lightcell_t *cell)
 {
     cell->rgb[0] = Lightgrid_Random01();
@@ -350,6 +413,8 @@ static void Lightgrid_FillRandomCell(lightcell_t *cell)
 
     VectorSet(cell->dir,0,0,1);
     cell->intensity = (cell->rgb[0] + cell->rgb[1] + cell->rgb[2]) / 3.f;
+    memset(&cell->sh, 0, sizeof(cell->sh));
+    cell->sh_valid = false;
 }
 
 /* =====================================================================
@@ -397,6 +462,7 @@ lightgrid_raw_t *Lightgrid_GenerateRaw(const struct qmodel_s *model)
     raw->ny = ny;
     raw->nz = nz;
     raw->cellSize = cellSize;
+    raw->has_sh9 = (r_lightgrid_sh9.value != 0.f);
     VectorCopy(mins, raw->origin);
 
     size_t count = (size_t)nx * ny * nz;
@@ -423,6 +489,10 @@ lightgrid_raw_t *Lightgrid_GenerateRaw(const struct qmodel_s *model)
         VectorAdd(pos, jitter, pos);
 
         static const vec3_t luminance_weights = {0.299f, 0.587f, 0.114f};
+        const qboolean sh_enabled = r_lightgrid_sh9.value != 0.f;
+
+        memset(&cell->sh, 0, sizeof(cell->sh));
+        cell->sh_valid = sh_enabled;
 
         if (r_generate_lightgrid_test.value > 0.f)
         {
@@ -431,18 +501,75 @@ lightgrid_raw_t *Lightgrid_GenerateRaw(const struct qmodel_s *model)
         }
 
         lightcache_t cache = {0};
+        vec3_t direct = {0, 0, 0};
+        vec3_t lightmap = {0, 0, 0};
+        vec3_t dirsum = {0,0,0};
+
         R_LightPoint((qmodel_t *)model, pos, 0.f, &cache);
 
-        cell->rgb[0] = lightcolor[0] * (1.f/255.f);
-        cell->rgb[1] = lightcolor[1] * (1.f/255.f);
-        cell->rgb[2] = lightcolor[2] * (1.f/255.f);
+        direct[0] = lightcolor[0] * (1.f/255.f);
+        direct[1] = lightcolor[1] * (1.f/255.f);
+        direct[2] = lightcolor[2] * (1.f/255.f);
 
-        float base = DotProduct(cell->rgb, luminance_weights);
+        R_SampleLightmapAtPoint(pos, lightmap);
 
-        vec3_t dirsum = {0,0,0};
+        if (r_lightgrid_surface_weight.value != 0.f && cache.surfidx > 0 && cache.surfidx <= model->numsurfaces)
+        {
+            const msurface_t *surf = &model->surfaces[cache.surfidx - 1];
+            vec3_t center;
+            for (int i = 0; i < 3; i++)
+                center[i] = 0.5f * (surf->mins[i] + surf->maxs[i]);
+
+            float dist = VectorDistance(pos, center);
+            float weight = 1.f / (1.f + dist);
+            VectorScale(lightmap, weight, lightmap);
+        }
+
+        VectorClear(cell->rgb);
+        VectorMA(cell->rgb, r_lightgrid_weight_direct.value, direct, cell->rgb);
+        VectorMA(cell->rgb, r_lightgrid_weight_lightmap.value, lightmap, cell->rgb);
+
         Lightgrid_AddDlights(pos, cell->rgb, dirsum);
 
+        /* Second bounce approximation */
+        const int bounce_rays = q_max(0, (int)r_lightgrid_bounce_rays.value);
+        if (bounce_rays > 0 && r_lightgrid_bounce_factor.value > 0.f)
+        {
+            vec3_t bounce_accum = {0, 0, 0};
+            const float bounce_scale = r_lightgrid_bounce_factor.value / (float)bounce_rays;
+            for (int i = 0; i < bounce_rays; i++)
+            {
+                vec3_t raydir;
+                Lightgrid_RandomHemisphereDir(raydir);
+
+                vec3_t end;
+                VectorMA(pos, 512.f, raydir, end);
+
+                vec3_t impact;
+                qboolean unobstructed = Lightgrid_TraceLine((qmodel_t *)model, pos, end, impact);
+                if (unobstructed)
+                    continue;
+
+                vec3_t hit_color;
+                if (R_SampleLightmapAtPoint(impact, hit_color))
+                {
+                    VectorMA(bounce_accum, bounce_scale, hit_color, bounce_accum);
+
+                    if (sh_enabled)
+                    {
+                        sh9_color_t coeff = {{{0}}};
+                        SH9_EncodeDirectional(raydir, hit_color, &coeff);
+                        for (int c = 0; c < 9; c++)
+                            VectorAdd(cell->sh.c[c], coeff.c[c], cell->sh.c[c]);
+                    }
+                }
+            }
+
+            VectorAdd(cell->rgb, bounce_accum, cell->rgb);
+        }
+
         vec3_t up = {0,0,1};
+        float base = DotProduct(cell->rgb, luminance_weights);
         VectorMA(dirsum, base, up, dirsum);
 
         float dirlen = VectorNormalize(dirsum);

--- a/Quake/gl_lightgrid.h
+++ b/Quake/gl_lightgrid.h
@@ -10,12 +10,19 @@
 #include "../common/lightgrid.h"
 
 struct qmodel_s;
+typedef struct sh9_color_s sh9_color_t;
 typedef struct lightgrid_raw_s lightgrid_raw_t;
 
 extern cvar_t r_lightgrid;
 extern cvar_t r_lightgrid_debug;
 extern cvar_t r_lightgrid_force;
 extern cvar_t r_generate_lightgrid_test;
+extern cvar_t r_lightgrid_weight_direct;
+extern cvar_t r_lightgrid_weight_lightmap;
+extern cvar_t r_lightgrid_surface_weight;
+extern cvar_t r_lightgrid_bounce_factor;
+extern cvar_t r_lightgrid_bounce_rays;
+extern cvar_t r_lightgrid_sh9;
 
 void Lightgrid_Init (void);
 void Lightgrid_Shutdown (void);
@@ -28,4 +35,5 @@ void Lightgrid_Sample (const vec3_t pos, vec3_t out_color, vec3_t out_dir);
 const lightgrid_t *Lightgrid_Get (void);
 void Lightgrid_SetSource (const char *name);
 const char *Lightgrid_GetSource (void);
+void SH9_EncodeDirectional(vec3_t dir, vec3_t rgb, sh9_color_t *out);
 

--- a/Quake/gl_model.h
+++ b/Quake/gl_model.h
@@ -428,11 +428,18 @@ typedef struct
 	int		size;
 } bspx_entry_t;
 
+typedef struct sh9_color_s
+{
+        vec3_t c[9];
+} sh9_color_t;
+
 typedef struct lightcell_s
 {
-	vec3_t rgb;
-	vec3_t dir;
-	float intensity;
+        vec3_t rgb;
+        vec3_t dir;
+        float intensity;
+        sh9_color_t sh;
+        qboolean sh_valid;
 } lightcell_t;
 
 typedef struct lightgrid_raw_s
@@ -441,6 +448,7 @@ typedef struct lightgrid_raw_s
         float cellSize;
         vec3_t origin;       // world-space min corner
         lightcell_t *cells;  // array of nx*ny*nz
+        qboolean has_sh9;
 } lightgrid_raw_t;
 
 typedef struct bspx_lump_out_s

--- a/Quake/gl_rlight.c
+++ b/Quake/gl_rlight.c
@@ -433,6 +433,34 @@ static void InterpolateLightmap (qmodel_t *model, vec3_t color, msurface_t *surf
         }
 }
 
+static void R_SurfaceFallbackColor(const qmodel_t *model, const msurface_t *surf, vec3_t out)
+{
+        const texture_t *tex = NULL;
+
+        if (model && surf && surf->texinfo && surf->texinfo->texnum >= 0 && surf->texinfo->texnum < model->numtextures)
+                tex = model->textures[surf->texinfo->texnum];
+
+        VectorSet(out, 127.f, 127.f, 127.f);
+
+        if (!tex)
+                return;
+
+        switch (tex->type)
+        {
+        case TEXTYPE_LAVA:
+                VectorSet(out, 255.f, 128.f, 32.f);
+                break;
+        case TEXTYPE_SLIME:
+                VectorSet(out, 64.f, 200.f, 96.f);
+                break;
+        case TEXTYPE_WATER:
+                VectorSet(out, 64.f, 96.f, 196.f);
+                break;
+        default:
+                break;
+        }
+}
+
 static void R_ClampSampleColor(vec3_t color)
 {
         for (int i = 0; i < 3; i++)
@@ -499,6 +527,80 @@ static void R_SamplePointInternal (qmodel_t *model, const vec3_t pos, float ofs,
                 InterpolateLightmap (model, out_color, model->surfaces + cache->surfidx - 1, cache->ds, cache->dt, use_rgblight);
                 R_ClampSampleColor (out_color);
         }
+}
+
+qboolean R_SampleLightmapAtPoint(const vec3_t pos, vec3_t out_rgb)
+{
+        qmodel_t *model = cl.worldmodel;
+        qboolean use_rgblight;
+        qboolean found = false;
+        float best_dist = FLT_MAX;
+
+        VectorClear(out_rgb);
+
+        if (!model || !model->lightdata)
+                return false;
+
+        use_rgblight = model->has_lightdata_rgb && r_rgblighting_enable.value;
+
+        mleaf_t *leaf = Mod_PointInLeaf(pos, model);
+        if (!leaf || leaf->contents == CONTENTS_SOLID)
+                return false;
+
+        for (int i = 0; i < leaf->nummarksurfaces; i++)
+        {
+                msurface_t *surf = &model->surfaces[leaf->firstmarksurface[i]];
+
+                if (!surf->texinfo || (surf->flags & SURF_DRAWTILED))
+                        continue;
+
+                const float pdist = DotProduct(pos, surf->plane->normal) - surf->plane->dist;
+                if (fabsf(pdist) > 8.f)
+                        continue;
+
+                int ds = (int)((double)DoublePrecisionDotProduct(pos, surf->texinfo->vecs[0]) + surf->texinfo->vecs[0][3]);
+                int dt = (int)((double)DoublePrecisionDotProduct(pos, surf->texinfo->vecs[1]) + surf->texinfo->vecs[1][3]);
+
+                if (ds < surf->texturemins[0] || dt < surf->texturemins[1])
+                        continue;
+
+                ds -= surf->texturemins[0];
+                dt -= surf->texturemins[1];
+
+                if (ds > surf->extents[0] || dt > surf->extents[1])
+                        continue;
+
+                vec3_t color;
+                if (surf->samples)
+                {
+                        InterpolateLightmap(model, color, surf, ds, dt, use_rgblight);
+                }
+                else
+                {
+                        R_SurfaceFallbackColor(model, surf, color);
+                }
+
+                if (!VectorLength(color))
+                        continue;
+
+                const float adist = fabsf(pdist);
+                if (adist < best_dist)
+                {
+                        VectorCopy(color, out_rgb);
+                        best_dist = adist;
+                        found = true;
+                }
+        }
+
+        if (found)
+        {
+                VectorScale(out_rgb, 1.f / 255.f, out_rgb);
+                return true;
+        }
+
+        R_SurfaceFallbackColor(model, NULL, out_rgb);
+        VectorScale(out_rgb, 1.f / 255.f, out_rgb);
+        return false;
 }
 
 /*

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -518,6 +518,7 @@ void GLMesh_LoadVertexBuffers (void);
 void GLMesh_DeleteVertexBuffers (void);
 
 int R_LightPoint (qmodel_t *model, vec3_t p, float ofs, lightcache_t *cache);
+qboolean R_SampleLightmapAtPoint(const vec3_t pos, vec3_t out_rgb);
 qboolean R_LightgridEnabled (void);
 void R_LightgridLighting (const vec3_t pos, vec3_t out_color);
 void R_LightgridLightingDir (const vec3_t pos, vec3_t out_color, vec3_t out_dir);


### PR DESCRIPTION
## Summary
- add lightmap sampling helper to retrieve BSP lightmap colors at arbitrary world positions
- blend direct, lightmap, dynamic, and optional surface-weighted lighting in the lightgrid generator with configurable weights
- introduce hemispherical bounce sampling with SH9 preparation and new configuration CVars for higher fidelity probes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a005d3658832eac0484e54b7f8e40)