### PR TITLE
Fix Windows build warnings in lighting code

### DIFF
--- a/Quake/gl_lightgrid.c
+++ b/Quake/gl_lightgrid.c
@@ -515,14 +515,16 @@ lightgrid_raw_t *Lightgrid_GenerateRaw(const struct qmodel_s *model)
 
         if (r_lightgrid_surface_weight.value != 0.f && cache.surfidx > 0 && cache.surfidx <= model->numsurfaces)
         {
-            const msurface_t *surf = &model->surfaces[cache.surfidx - 1];
-            vec3_t center;
-            for (int i = 0; i < 3; i++)
-                center[i] = 0.5f * (surf->mins[i] + surf->maxs[i]);
+                const msurface_t *surf = &model->surfaces[cache.surfidx - 1];
+                vec3_t center;
+                for (int i = 0; i < 3; i++)
+                        center[i] = 0.5f * (surf->mins[i] + surf->maxs[i]);
 
-            float dist = VectorDistance(pos, center);
-            float weight = 1.f / (1.f + dist);
-            VectorScale(lightmap, weight, lightmap);
+                vec3_t delta;
+                VectorSubtract(pos, center, delta);
+                float dist = VectorLength(delta);
+                float weight = 1.f / (1.f + dist);
+                VectorScale(lightmap, weight, lightmap);
         }
 
         VectorClear(cell->rgb);

--- a/Quake/gl_rlight.c
+++ b/Quake/gl_rlight.c
@@ -543,7 +543,9 @@ qboolean R_SampleLightmapAtPoint(const vec3_t pos, vec3_t out_rgb)
 
         use_rgblight = model->has_lightdata_rgb && r_rgblighting_enable.value;
 
-        mleaf_t *leaf = Mod_PointInLeaf(pos, model);
+        vec3_t pos_copy;
+        VectorCopy(pos, pos_copy);
+        mleaf_t *leaf = Mod_PointInLeaf(pos_copy, model);
         if (!leaf || leaf->contents == CONTENTS_SOLID)
                 return false;
 


### PR DESCRIPTION
## Summary
- avoid const qualifier warning by copying sample position before Mod_PointInLeaf
- replace undefined VectorDistance call with explicit vector subtraction and length

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a02ff53a0832ebb87313e984cbe44)