### PR TITLE
Adjust lightgrid generation limits

### DIFF
--- a/Quake/gl_lightgrid.c
+++ b/Quake/gl_lightgrid.c
@@ -421,6 +421,13 @@ static void Lightgrid_FillRandomCell(lightcell_t *cell)
    RAW Lightgrid generator (fallback)
    ===================================================================== */
 
+static void Lightgrid_ComputeDims(const vec3_t size, float cellSize, int *nx, int *ny, int *nz)
+{
+    *nx = q_max(1, q_min(LIGHTGRID_MAX_NX, (int)ceilf(size[0] / cellSize)));
+    *ny = q_max(1, q_min(LIGHTGRID_MAX_NY, (int)ceilf(size[1] / cellSize)));
+    *nz = q_max(1, q_min(LIGHTGRID_MAX_NZ, (int)ceilf(size[2] / cellSize)));
+}
+
 lightgrid_raw_t *Lightgrid_GenerateRaw(const struct qmodel_s *model)
 {
     if (!model)
@@ -448,11 +455,16 @@ lightgrid_raw_t *Lightgrid_GenerateRaw(const struct qmodel_s *model)
     VectorCopy(model->maxs, maxs);
     VectorSubtract(maxs, mins, size);
 
-    const float cellSize = LIGHTGRID_STANDARD_CELLSIZE;
+    float cellSize = LIGHTGRID_STANDARD_CELLSIZE;
 
-    int nx = q_max(1, q_min(LIGHTGRID_MAX_NX, (int)ceilf(size[0] / cellSize)));
-    int ny = q_max(1, q_min(LIGHTGRID_MAX_NY, (int)ceilf(size[1] / cellSize)));
-    int nz = q_max(1, q_min(LIGHTGRID_MAX_NZ, (int)ceilf(size[2] / cellSize)));
+    int nx, ny, nz;
+    Lightgrid_ComputeDims(size, cellSize, &nx, &ny, &nz);
+
+    while ((size_t)nx * ny * nz > LIGHTGRID_MAX_CELLS)
+    {
+        cellSize *= 2.f;
+        Lightgrid_ComputeDims(size, cellSize, &nx, &ny, &nz);
+    }
 
         lightgrid_raw_t *raw =
         (lightgrid_raw_t*)Hunk_AllocName(sizeof(*raw), "lightgrid_raw");

--- a/common/lightgrid.h
+++ b/common/lightgrid.h
@@ -9,10 +9,11 @@ typedef struct lightgrid_probe_s {
     float intensity;
 } lightgrid_probe_t;
 
-#define LIGHTGRID_STANDARD_CELLSIZE 64.f
-#define LIGHTGRID_MAX_NX 32
-#define LIGHTGRID_MAX_NY 32
-#define LIGHTGRID_MAX_NZ 64
+#define LIGHTGRID_STANDARD_CELLSIZE 32.f
+#define LIGHTGRID_MAX_NX 64
+#define LIGHTGRID_MAX_NY 64
+#define LIGHTGRID_MAX_NZ 128
+#define LIGHTGRID_MAX_CELLS (512 * 1024)
 
 typedef struct lightgrid_s {
     int nx, ny, nz;


### PR DESCRIPTION
## Summary
- reduce the default lightgrid cell size while expanding maximum grid dimensions
- cap the total number of lightgrid cells and increase cell size during generation until within the limit

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a1f4c3280832ea1d2cc979ea54c0e)