### PR TITLE
Refactor lightgrid loading to RAW v2 only

### DIFF
--- a/Quake/gl_lightgrid.c
+++ b/Quake/gl_lightgrid.c
@@ -197,170 +197,6 @@ static float LightgridRAW_HalfToFloat(unsigned short h)
 }
 
 /* =====================================================================
-   BSPX Loader
-   ===================================================================== */
-
-qboolean Lightgrid_LoadFromBSPX(void *bspx_data, int bspx_len)
-{
-    if (!bspx_data || bspx_len <= 0)
-        return false;
-
-    Lightgrid_Clear();
-
-    const byte *payload = (const byte *)bspx_data;
-    size_t payload_size = (size_t)bspx_len;
-    size_t header_size = sizeof(int) * 3 + sizeof(float) + sizeof(vec3_t);
-    unsigned int version = LIGHTGRID_RAW_VERSION_1;
-    unsigned int components = LIGHTGRID_RAW_COMPONENTS_BASE;
-    unsigned int encoding = LIGHTGRID_RAW_ENCODING_FLOAT32;
-    int nx = 0, ny = 0, nz = 0;
-    float cellSize = 0.f;
-    vec3_t origin = {0.f, 0.f, 0.f};
-
-    if (payload_size >= sizeof(lightgrid_raw_header_t))
-    {
-        const lightgrid_raw_header_t *hdr = (const lightgrid_raw_header_t *)payload;
-        if (LittleLong(hdr->magic) == LIGHTGRID_RAW_MAGIC)
-        {
-            version = LittleLong(hdr->version);
-            if (version != LIGHTGRID_RAW_VERSION_2)
-                return false;
-
-            components = LittleLong(hdr->components);
-            encoding = LittleLong(hdr->encoding);
-            nx = LittleLong(hdr->nx);
-            ny = LittleLong(hdr->ny);
-            nz = LittleLong(hdr->nz);
-            cellSize = LittleFloat(hdr->cellSize);
-            VectorCopy(hdr->origin, origin);
-            origin[0] = LittleFloat(origin[0]);
-            origin[1] = LittleFloat(origin[1]);
-            origin[2] = LittleFloat(origin[2]);
-            header_size = sizeof(*hdr);
-        }
-    }
-
-    if (version == LIGHTGRID_RAW_VERSION_1)
-    {
-        if (payload_size < header_size)
-            return false;
-
-        nx = LittleLong(((int *)payload)[0]);
-        ny = LittleLong(((int *)payload)[1]);
-        nz = LittleLong(((int *)payload)[2]);
-
-        cellSize = LG_FLittle(payload + sizeof(int) * 3);
-        memcpy(origin, payload + sizeof(int) * 3 + sizeof(float), sizeof(vec3_t));
-        origin[0] = LittleFloat(origin[0]);
-        origin[1] = LittleFloat(origin[1]);
-        origin[2] = LittleFloat(origin[2]);
-    }
-
-    if (nx <= 0 || ny <= 0 || nz <= 0)
-        return false;
-
-    if (cellSize <= 0.f)
-        return false;
-
-    if (version == LIGHTGRID_RAW_VERSION_2 &&
-        (components & LIGHTGRID_RAW_COMPONENTS_BASE) != LIGHTGRID_RAW_COMPONENTS_BASE)
-        return false;
-
-    size_t count = (size_t)nx * (size_t)ny * (size_t)nz;
-    if (!count || count > LIGHTGRID_MAX_CELLS || count > SIZE_MAX / sizeof(lightcell_t))
-        return false;
-
-    if (payload_size < header_size)
-        return false;
-    payload_size -= header_size;
-
-    const size_t cell_stride = (version == LIGHTGRID_RAW_VERSION_1)
-        ? sizeof(vec3_t) * 2 + sizeof(float)
-        : LightgridRAW_CellSizeBytes(components, encoding);
-    if (!cell_stride || payload_size < cell_stride * count)
-        return false;
-
-    lightgrid_raw_t *raw = (lightgrid_raw_t *)Z_Malloc(sizeof(*raw));
-    if (!raw)
-        return false;
-    memset(raw, 0, sizeof(*raw));
-
-    raw->cells = (lightcell_t *)Z_Malloc(count * sizeof(lightcell_t));
-    if (!raw->cells)
-    {
-        Z_Free(raw);
-        return false;
-    }
-
-    raw->nx = nx;
-    raw->ny = ny;
-    raw->nz = nz;
-    raw->cellSize = cellSize;
-    VectorCopy(origin, raw->origin);
-
-    const byte *cell_bytes = payload + header_size;
-    for (size_t i = 0; i < count; i++)
-    {
-        lightcell_t *cell = &raw->cells[i];
-        const byte *component_ptr = cell_bytes;
-
-        cell->ao = 1.f;
-        cell->emissive = 0.f;
-        cell->sh_valid = false;
-
-#define READ_COMPONENT_FLOAT(out)                     \
-        do {                                          \
-            if (encoding == LIGHTGRID_RAW_ENCODING_FLOAT16) \
-            {                                         \
-                unsigned short half;                  \
-                memcpy(&half, component_ptr, sizeof(half)); \
-                half = LittleShort(half);             \
-                out = LightgridRAW_HalfToFloat(half); \
-                component_ptr += sizeof(unsigned short); \
-            }                                         \
-            else                                      \
-            {                                         \
-                memcpy(&out, component_ptr, sizeof(float)); \
-                out = LittleFloat(out);               \
-                component_ptr += sizeof(float);       \
-            }                                         \
-        } while (0)
-
-        READ_COMPONENT_FLOAT(cell->rgb[0]);
-        READ_COMPONENT_FLOAT(cell->rgb[1]);
-        READ_COMPONENT_FLOAT(cell->rgb[2]);
-        READ_COMPONENT_FLOAT(cell->dir[0]);
-        READ_COMPONENT_FLOAT(cell->dir[1]);
-        READ_COMPONENT_FLOAT(cell->dir[2]);
-        READ_COMPONENT_FLOAT(cell->intensity);
-
-        if (components & LIGHTGRID_RAW_COMPONENT_AO)
-            READ_COMPONENT_FLOAT(cell->ao);
-
-        if (components & LIGHTGRID_RAW_COMPONENT_EMISSIVE)
-            READ_COMPONENT_FLOAT(cell->emissive);
-
-        cell_bytes += cell_stride;
-#undef READ_COMPONENT_FLOAT
-    }
-
-    lightgrid_t *lg = Lightgrid_FromRaw(raw);
-
-    Z_Free(raw->cells);
-    Z_Free(raw);
-
-    if (!lg)
-        return false;
-
-    current_lightgrid = lg;
-    cl.lightgrid      = lg;
-    lg->source        = LIGHTGRID_SRC_OCTREE;
-    q_strlcpy(lightgrid_source, "OCTREE", sizeof(lightgrid_source));
-
-    return true;
-}
-
-/* =====================================================================
    KTX2 loader/export helpers
    ===================================================================== */
 
@@ -651,7 +487,7 @@ qboolean Lightgrid_LoadFromKTX2(const char *mapname)
     {
         const float *c = &color_payload[i * 4];
         const float *d = &dir_payload[i * 4];
-        lightgrid_probe_t *p = &lg->probes[i];
+        lightcell_t *p = &lg->probes[i];
 
         VectorCopy(c, p->rgb);
         p->intensity = c[3];
@@ -707,7 +543,7 @@ qboolean Lightgrid_ExportToKTX2(const lightgrid_t *grid, const char *mapname)
 
     for (size_t i = 0; i < count; i++)
     {
-        const lightgrid_probe_t *p = &grid->probes[i];
+        const lightcell_t *p = &grid->probes[i];
         float *c = &color_payload[i * 4];
         float *d = &dir_payload[i * 4];
 
@@ -789,7 +625,7 @@ lightgrid_t *Lightgrid_FromRaw(const lightgrid_raw_t *raw)
 
         VectorCopy(dir, lg->probes[i].dir);
         lg->probes[i].intensity = cell->intensity;
-        lg->probes[i].emissive = cell->emissive;
+        lg->probes[i].ao = cell->ao;
     }
 
     lg->source = LIGHTGRID_SRC_RAW;
@@ -807,7 +643,7 @@ static void Lightgrid_DefaultSample(vec3_t out_color, vec3_t out_dir)
     VectorSet(out_dir, 0,0,1);
 }
 
-static const lightgrid_probe_t *Lightgrid_At(const lightgrid_t *lg, int x, int y, int z)
+static const lightcell_t *Lightgrid_At(const lightgrid_t *lg, int x, int y, int z)
 {
     return &lg->probes[
         (size_t)z * lg->ny * lg->nx +
@@ -848,14 +684,14 @@ void Lightgrid_Sample(const vec3_t pos, vec3_t out_color, vec3_t out_dir)
     fy -= floorf(fy);
     fz -= floorf(fz);
 
-    const lightgrid_probe_t *c000 = Lightgrid_At(lg, x0, y0, z0);
-    const lightgrid_probe_t *c100 = Lightgrid_At(lg, x1, y0, z0);
-    const lightgrid_probe_t *c010 = Lightgrid_At(lg, x0, y1, z0);
-    const lightgrid_probe_t *c110 = Lightgrid_At(lg, x1, y1, z0);
-    const lightgrid_probe_t *c001 = Lightgrid_At(lg, x0, y0, z1);
-    const lightgrid_probe_t *c101 = Lightgrid_At(lg, x1, y0, z1);
-    const lightgrid_probe_t *c011 = Lightgrid_At(lg, x0, y1, z1);
-    const lightgrid_probe_t *c111 = Lightgrid_At(lg, x1, y1, z1);
+    const lightcell_t *c000 = Lightgrid_At(lg, x0, y0, z0);
+    const lightcell_t *c100 = Lightgrid_At(lg, x1, y0, z0);
+    const lightcell_t *c010 = Lightgrid_At(lg, x0, y1, z0);
+    const lightcell_t *c110 = Lightgrid_At(lg, x1, y1, z0);
+    const lightcell_t *c001 = Lightgrid_At(lg, x0, y0, z1);
+    const lightcell_t *c101 = Lightgrid_At(lg, x1, y0, z1);
+    const lightcell_t *c011 = Lightgrid_At(lg, x0, y1, z1);
+    const lightcell_t *c111 = Lightgrid_At(lg, x1, y1, z1);
 
     vec3_t rgb000,rgb100,rgb010,rgb110,rgb001,rgb101,rgb011,rgb111;
     vec3_t dir000,dir100,dir010,dir110,dir001,dir101,dir011,dir111;
@@ -985,9 +821,6 @@ static void Lightgrid_FillRandomCell(lightcell_t *cell)
     VectorSet(cell->dir,0,0,1);
     cell->intensity = (cell->rgb[0] + cell->rgb[1] + cell->rgb[2]) / 3.f;
     cell->ao = 1.f;
-    cell->emissive = 0.f;
-    memset(&cell->sh, 0, sizeof(cell->sh));
-    cell->sh_valid = false;
 }
 
 /* =====================================================================
@@ -1047,7 +880,6 @@ lightgrid_raw_t *Lightgrid_GenerateRaw(const struct qmodel_s *model)
     raw->ny = ny;
     raw->nz = nz;
     raw->cellSize = cellSize;
-    raw->has_sh9 = (r_lightgrid_sh9.value != 0.f);
     VectorCopy(mins, raw->origin);
 
     size_t count = (size_t)nx * ny * nz;
@@ -1074,10 +906,9 @@ lightgrid_raw_t *Lightgrid_GenerateRaw(const struct qmodel_s *model)
         VectorAdd(pos, jitter, pos);
 
         static const vec3_t luminance_weights = {0.299f, 0.587f, 0.114f};
-        const qboolean sh_enabled = r_lightgrid_sh9.value != 0.f;
 
-        memset(&cell->sh, 0, sizeof(cell->sh));
-        cell->sh_valid = sh_enabled;
+        cell->ao = 0.f;
+
 
         if (r_generate_lightgrid_test.value > 0.f)
         {
@@ -1141,14 +972,6 @@ lightgrid_raw_t *Lightgrid_GenerateRaw(const struct qmodel_s *model)
                 if (R_SampleLightmapAtPoint(impact, hit_color))
                 {
                     VectorMA(bounce_accum, bounce_scale, hit_color, bounce_accum);
-
-                    if (sh_enabled)
-                    {
-                        sh9_color_t coeff = {{{0}}};
-                        SH9_EncodeDirectional(raydir, hit_color, &coeff);
-                        for (int c = 0; c < 9; c++)
-                            VectorAdd(cell->sh.c[c], coeff.c[c], cell->sh.c[c]);
-                    }
                 }
             }
 

--- a/Quake/gl_lightgrid.h
+++ b/Quake/gl_lightgrid.h
@@ -30,7 +30,6 @@ extern cvar_t r_lightgrid_ktx_prefer;
 void Lightgrid_Init (void);
 void Lightgrid_Shutdown (void);
 void Lightgrid_Clear (void);
-qboolean Lightgrid_LoadFromBSPX (void *bspx_data, int bspx_len);
 lightgrid_t *Lightgrid_FromRaw (const lightgrid_raw_t *raw);
 lightgrid_raw_t *Lightgrid_GenerateRaw (const struct qmodel_s *model);
 void Lightgrid_BuildFallback (void);

--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -3508,33 +3508,29 @@ static void Lightgrid_Save_f (void)
 
 static qboolean BSPX_LightGridLoad (qmodel_t *mod, void *lump, int lumpsize)
 {
-        lightgrid_t *lg;
-        bspx_lump_t l;
+	lightgrid_t *lg;
+	char path[MAX_QPATH];
 
-        (void)mod;
+	(void)lump;
+	(void)lumpsize;
 
-        Lightgrid_Free(cl.lightgrid);
-        cl.lightgrid = NULL;
+	Lightgrid_Free(cl.lightgrid);
+	cl.lightgrid = NULL;
 
 #if USE_KTX2_LIGHTGRID
-        if (r_lightgrid_ktx_enable.value)
-        {
-                char base[MAX_QPATH];
-                COM_StripExtension(mod->name, base, sizeof(base));
-                if (Lightgrid_LoadFromKTX2(COM_SkipPath(base)))
-                        return true;
-        }
+	if (r_lightgrid_ktx_enable.value)
+	{
+		char base[MAX_QPATH];
+		COM_StripExtension(mod->name, base, sizeof(base));
+		if (Lightgrid_LoadFromKTX2(COM_SkipPath(base)))
+			return true;
+	}
 #endif
 
-        if (!lump || lumpsize <= 0)
-                return false;
+	COM_StripExtension(mod->name, path, sizeof(path));
+	COM_DefaultExtension(path, ".lgrd");
 
-        l.data = lump;
-        l.size = (size_t)lumpsize;
-
-    lg = Lightgrid_LoadFromBSPX_FTE(&l);
-    if (!lg)
-        lg = Lightgrid_LoadFromBSPX_Octree(&l);
+	lg = Lightgrid_LoadExternal(path);
 	if (!lg)
 		return false;
 

--- a/Quake/gl_model.h
+++ b/Quake/gl_model.h
@@ -25,6 +25,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "modelgen.h"
 #include "spritegn.h"
+#include "../common/lightgrid.h"
 
 /*
 
@@ -94,7 +95,6 @@ typedef struct texture_s
 	textype_t			type;
 	struct gltexture_s	*gltexture; //johnfitz -- pointer to gltexture
 	struct gltexture_s	*fullbright; //johnfitz -- fullbright mask texture
-	struct gltexture_s	*emissive;   // emissive texture map (Quake 3 style glow)
 	int					anim_total;				// total tenths in sequence ( 0 = no)
 	int					anim_min, anim_max;		// time for this frame min <=time< max
 	struct texture_s	*anim_next;		// in the animation sequence
@@ -347,7 +347,6 @@ typedef struct {
 	} poseverttype;	//spike
 	struct gltexture_s	*gltextures[MAX_SKINS][4]; //johnfitz
 	struct gltexture_s	*fbtextures[MAX_SKINS][4]; //johnfitz
-	struct gltexture_s	*emissivetextures[MAX_SKINS][4];
 	int					texels[MAX_SKINS];	// only for player skins
 	maliasframedesc_t	frames[1];	// variable sized
 } aliashdr_t;
@@ -471,16 +470,6 @@ typedef struct sh9_color_s
         vec3_t c[9];
 } sh9_color_t;
 
-typedef struct lightcell_s
-{
-        vec3_t rgb;
-        vec3_t dir;
-        float intensity;
-        float ao;
-        float emissive;
-        sh9_color_t sh;
-        qboolean sh_valid;
-} lightcell_t;
 
 typedef struct lightgrid_raw_s
 {
@@ -488,7 +477,6 @@ typedef struct lightgrid_raw_s
         float cellSize;
         vec3_t origin;       // world-space min corner
         lightcell_t *cells;  // array of nx*ny*nz
-        qboolean has_sh9;
 } lightgrid_raw_t;
 
 typedef struct bspx_lump_out_s

--- a/common/lightgrid.c
+++ b/common/lightgrid.c
@@ -2,131 +2,18 @@
 #include "lightgrid.h"
 
 #define LIGHTGRID_MAGIC 0x4c475244u /* 'LGRD' */
-#define LIGHTGRID_VERSION 1u
-#define LIGHTGRID_MAX_DEPTH 32
+#define LIGHTGRID_VERSION_V2 2u
 
-#define NODE_STRIDE 4
-#define LEAF_FLOATS 7
-
-typedef struct lightgrid_decode_state_s {
-    const byte *nodes;
-    size_t node_count;
-    size_t node_index;
-
-    const float *leaves;
-    size_t leaf_count;
-    size_t leaf_index;
-
-    lightgrid_t *grid;
+typedef struct lightgrid_v2_header_s
+{
+    uint32_t magic;
+    uint32_t version;
+    uint32_t components;
+    uint32_t reserved[5];
+    int32_t nx, ny, nz;
     float cellsize;
-    vec3_t mins;
-    vec3_t maxs;
-} lightgrid_decode_state_t;
-
-static void Lightgrid_FillLeaf(lightgrid_decode_state_t *state, const vec3_t bmins, const vec3_t bmaxs, const float *leaf)
-{
-    vec3_t dir;
-    int x0, y0, z0, x1, y1, z1;
-    const lightgrid_t *grid = state->grid;
-
-    dir[0] = LittleFloat(leaf[3]);
-    dir[1] = LittleFloat(leaf[4]);
-    dir[2] = LittleFloat(leaf[5]);
-
-    x0 = (int)ceilf(((bmins[0] - state->mins[0]) / state->cellsize) - 0.5f);
-    y0 = (int)ceilf(((bmins[1] - state->mins[1]) / state->cellsize) - 0.5f);
-    z0 = (int)ceilf(((bmins[2] - state->mins[2]) / state->cellsize) - 0.5f);
-
-    x1 = (int)floorf(((bmaxs[0] - state->mins[0]) / state->cellsize) - 0.5f);
-    y1 = (int)floorf(((bmaxs[1] - state->mins[1]) / state->cellsize) - 0.5f);
-    z1 = (int)floorf(((bmaxs[2] - state->mins[2]) / state->cellsize) - 0.5f);
-
-    x0 = CLAMP(0, x0, grid->nx - 1);
-    y0 = CLAMP(0, y0, grid->ny - 1);
-    z0 = CLAMP(0, z0, grid->nz - 1);
-
-    x1 = CLAMP(0, x1, grid->nx - 1);
-    y1 = CLAMP(0, y1, grid->ny - 1);
-    z1 = CLAMP(0, z1, grid->nz - 1);
-
-    if (x1 < x0 || y1 < y0 || z1 < z0)
-        return;
-
-    if (VectorNormalize(dir) == 0.f)
-    {
-        dir[0] = dir[1] = 0.f;
-        dir[2] = 1.f;
-    }
-
-    for (int z = z0; z <= z1; z++)
-    {
-        for (int y = y0; y <= y1; y++)
-        {
-            for (int x = x0; x <= x1; x++)
-            {
-                lightgrid_probe_t *probe = &grid->probes[(z * grid->ny + y) * grid->nx + x];
-
-                probe->rgb[0] = LittleFloat(leaf[0]);
-                probe->rgb[1] = LittleFloat(leaf[1]);
-                probe->rgb[2] = LittleFloat(leaf[2]);
-
-                VectorCopy(dir, probe->dir);
-                probe->intensity = LittleFloat(leaf[6]);
-            }
-        }
-    }
-}
-
-static qboolean Lightgrid_DecodeOctree(lightgrid_decode_state_t *state, int depth, const vec3_t bmins, const vec3_t bmaxs)
-{
-    if (depth > LIGHTGRID_MAX_DEPTH)
-        return false;
-
-    if (state->node_index >= state->node_count)
-        return false;
-
-    const byte child_mask = state->nodes[state->node_index * NODE_STRIDE];
-    state->node_index++;
-
-    if (!child_mask)
-    {
-        if (state->leaf_index >= state->leaf_count)
-            return false;
-
-        Lightgrid_FillLeaf(state, bmins, bmaxs, state->leaves + LEAF_FLOATS * state->leaf_index);
-        state->leaf_index++;
-        return true;
-    }
-
-    vec3_t mid;
-    VectorAverage(bmins, bmaxs, mid);
-
-    for (int i = 0; i < 8; i++)
-    {
-        if (!(child_mask & (1 << i)))
-            continue;
-
-        vec3_t child_mins, child_maxs;
-
-        const qboolean x_pos = (i & 4) == 0;
-        const qboolean y_pos = (i & 2) == 0;
-        const qboolean z_pos = (i & 1) == 0;
-
-        child_mins[0] = x_pos ? mid[0] : bmins[0];
-        child_maxs[0] = x_pos ? bmaxs[0] : mid[0];
-
-        child_mins[1] = y_pos ? mid[1] : bmins[1];
-        child_maxs[1] = y_pos ? bmaxs[1] : mid[1];
-
-        child_mins[2] = z_pos ? mid[2] : bmins[2];
-        child_maxs[2] = z_pos ? bmaxs[2] : mid[2];
-
-        if (!Lightgrid_DecodeOctree(state, depth + 1, child_mins, child_maxs))
-            return false;
-    }
-
-    return true;
-}
+    vec3_t origin;
+} lightgrid_v2_header_t;
 
 lightgrid_t *Lightgrid_Alloc(int nx, int ny, int nz, float cellsize, const vec3_t mins, const vec3_t maxs)
 {
@@ -134,7 +21,7 @@ lightgrid_t *Lightgrid_Alloc(int nx, int ny, int nz, float cellsize, const vec3_
         return NULL;
 
     const size_t total = (size_t)nx * ny * nz;
-    if (total > SIZE_MAX / sizeof(lightgrid_probe_t))
+    if (total > SIZE_MAX / sizeof(lightcell_t))
         return NULL;
 
     lightgrid_t *lg = (lightgrid_t *)Hunk_AllocName(sizeof(lightgrid_t), "lightgrid");
@@ -142,7 +29,7 @@ lightgrid_t *Lightgrid_Alloc(int nx, int ny, int nz, float cellsize, const vec3_
         return NULL;
 
     memset(lg, 0, sizeof(*lg));
-    lg->probes = (lightgrid_probe_t *)Hunk_AllocName(total * sizeof(lightgrid_probe_t), "lightgrid_probes");
+    lg->probes = (lightcell_t *)Hunk_AllocName(total * sizeof(lightcell_t), "lightgrid_probes");
     if (!lg->probes)
         return NULL;
 
@@ -156,6 +43,8 @@ lightgrid_t *Lightgrid_Alloc(int nx, int ny, int nz, float cellsize, const vec3_
     lg->source = LIGHTGRID_SRC_NONE;
     lg->tex_color3d = 0;
     lg->tex_dir3d = 0;
+    lg->tex_intensity = 0;
+    lg->tex_ao = 0;
 
     return lg;
 }
@@ -166,573 +55,128 @@ void Lightgrid_Free(lightgrid_t *lg)
         return;
 }
 
-lightgrid_t *Lightgrid_LoadFromBSPX_Octree(const bspx_lump_t *l)
+static qboolean Lightgrid_ReadV2Header(const lightgrid_v2_header_t *hdr, int *nx, int *ny, int *nz, float *cellsize, vec3_t origin)
 {
-    if (!l || !l->data || l->size < sizeof(uint32_t) * 3 + sizeof(vec3_t) * 2 + sizeof(float))
+    if (LittleLong(hdr->magic) != LIGHTGRID_MAGIC)
+        return false;
+
+    if (LittleLong(hdr->version) != LIGHTGRID_VERSION_V2)
+        return false;
+
+    *nx = LittleLong(hdr->nx);
+    *ny = LittleLong(hdr->ny);
+    *nz = LittleLong(hdr->nz);
+    *cellsize = LittleFloat(hdr->cellsize);
+
+    origin[0] = LittleFloat(hdr->origin[0]);
+    origin[1] = LittleFloat(hdr->origin[1]);
+    origin[2] = LittleFloat(hdr->origin[2]);
+
+    return true;
+}
+
+lightgrid_t *Lightgrid_LoadV2(const char *path)
+{
+    if (!path)
         return NULL;
 
-    const byte *data = (const byte *)l->data;
-    size_t remaining = l->size;
+    byte *buffer = COM_LoadMallocFile(path, NULL);
+    if (!buffer)
+        return NULL;
 
-    uint32_t magic = LittleLong(*(const uint32_t *)data);
-    data += sizeof(uint32_t);
-    remaining -= sizeof(uint32_t);
-
-    uint32_t version = LittleLong(*(const uint32_t *)data);
-    data += sizeof(uint32_t);
-    remaining -= sizeof(uint32_t);
-
-    vec3_t mins, maxs;
-    memcpy(mins, data, sizeof(vec3_t));
-    data += sizeof(vec3_t);
-    remaining -= sizeof(vec3_t);
-
-    memcpy(maxs, data, sizeof(vec3_t));
-    data += sizeof(vec3_t);
-    remaining -= sizeof(vec3_t);
-
-    for (int i = 0; i < 3; i++)
+    const size_t buffer_size = (size_t)com_filesize;
+    if (buffer_size < sizeof(lightgrid_v2_header_t))
     {
-        mins[i] = LittleFloat(mins[i]);
-        maxs[i] = LittleFloat(maxs[i]);
+        free(buffer);
+        return NULL;
     }
 
-    float cellsize = LittleFloat(*(const float *)data);
-    data += sizeof(float);
-    remaining -= sizeof(float);
+    const lightgrid_v2_header_t *hdr = (const lightgrid_v2_header_t *)buffer;
+    int nx, ny, nz;
+    float cellsize;
+    vec3_t origin;
 
-    if (remaining < sizeof(uint32_t) * 2)
+    if (!Lightgrid_ReadV2Header(hdr, &nx, &ny, &nz, &cellsize, origin))
+    {
+        free(buffer);
         return NULL;
+    }
 
-    const uint32_t node_count = LittleLong(*(const uint32_t *)data);
-    data += sizeof(uint32_t);
-    const uint32_t leaf_count = LittleLong(*(const uint32_t *)data);
-    data += sizeof(uint32_t);
-
-    remaining -= sizeof(uint32_t) * 2;
-
-    if (magic != LIGHTGRID_MAGIC || version != LIGHTGRID_VERSION)
-        return NULL;
-
-    if (!node_count || !leaf_count)
-        return NULL;
-
-    if (node_count > SIZE_MAX / NODE_STRIDE || leaf_count > SIZE_MAX / (sizeof(float) * LEAF_FLOATS))
-        return NULL;
-
-    size_t nodes_size = (size_t)node_count * NODE_STRIDE;
-    size_t leaves_size = (size_t)leaf_count * sizeof(float) * LEAF_FLOATS;
-
-    if (nodes_size > remaining)
-        return NULL;
-    if (leaves_size != remaining - nodes_size)
-        return NULL;
-
-    const byte *nodes = data;
-    const float *leaves = (const float *)(data + nodes_size);
-
-    vec3_t size;
-    VectorSubtract(maxs, mins, size);
     if (cellsize <= 0.f)
+    {
+        free(buffer);
         return NULL;
+    }
 
-    int nx = (int)ceilf(size[0] / cellsize);
-    int ny = (int)ceilf(size[1] / cellsize);
-    int nz = (int)ceilf(size[2] / cellsize);
+    vec3_t mins, maxs;
+    VectorCopy(origin, mins);
+    maxs[0] = origin[0] + cellsize * nx;
+    maxs[1] = origin[1] + cellsize * ny;
+    maxs[2] = origin[2] + cellsize * nz;
 
     if (nx <= 0 || ny <= 0 || nz <= 0)
+    {
+        free(buffer);
         return NULL;
+    }
+
+    const size_t probe_count = (size_t)nx * ny * nz;
+    const size_t header_size = sizeof(lightgrid_v2_header_t);
+    const size_t payload_bytes = buffer_size - header_size;
+
+    if (probe_count == 0 || payload_bytes == 0)
+    {
+        free(buffer);
+        return NULL;
+    }
+
+    const size_t floats_per_probe = payload_bytes / (sizeof(float) * probe_count);
+    if (payload_bytes % (sizeof(float) * probe_count) != 0 || (floats_per_probe != 7 && floats_per_probe != 8))
+    {
+        free(buffer);
+        return NULL;
+    }
+
+    const qboolean has_ao = (floats_per_probe == 8);
+    const float *probe_data = (const float *)(buffer + header_size);
 
     lightgrid_t *lg = Lightgrid_Alloc(nx, ny, nz, cellsize, mins, maxs);
     if (!lg)
-        return NULL;
-
-    lightgrid_decode_state_t state = {
-        .nodes = nodes,
-        .node_count = node_count,
-        .node_index = 0,
-        .leaves = leaves,
-        .leaf_count = leaf_count,
-        .leaf_index = 0,
-        .grid = lg,
-        .cellsize = cellsize,
-    };
-
-    VectorCopy(mins, state.mins);
-    VectorCopy(maxs, state.maxs);
-
-    if (!Lightgrid_DecodeOctree(&state, 0, mins, maxs) || state.node_index != state.node_count || state.leaf_index != state.leaf_count)
     {
-        Lightgrid_Free(lg);
+        free(buffer);
         return NULL;
     }
 
+    for (size_t i = 0; i < probe_count; i++)
+    {
+        const float *p = probe_data + floats_per_probe * i;
+        lightcell_t *cell = &lg->probes[i];
+
+        cell->rgb[0] = CLAMP(0.f, LittleFloat(p[0]), 1.f);
+        cell->rgb[1] = CLAMP(0.f, LittleFloat(p[1]), 1.f);
+        cell->rgb[2] = CLAMP(0.f, LittleFloat(p[2]), 1.f);
+
+        cell->dir[0] = LittleFloat(p[3]);
+        cell->dir[1] = LittleFloat(p[4]);
+        cell->dir[2] = LittleFloat(p[5]);
+        if (VectorNormalize(cell->dir) == 0.f)
+        {
+            cell->dir[0] = 0.f;
+            cell->dir[1] = 0.f;
+            cell->dir[2] = 1.f;
+        }
+
+        cell->intensity = LittleFloat(p[6]);
+        cell->ao = has_ao ? LittleFloat(p[7]) : 0.f;
+    }
+
+    lg->source = LIGHTGRID_SRC_RAW;
+
+    free(buffer);
     return lg;
 }
 
-typedef struct bspxlg_node_s {
-    int mid[3];
-    int child[8];
-} bspxlg_node_t;
-
-typedef struct bspxlg_sample_s {
-    byte style;
-    byte rgb[3];
-} bspxlg_sample_t;
-
-typedef struct bspxlg_leaf_s {
-    int mins[3];
-    int size[3];
-    unsigned char numstyles;
-    bspxlg_sample_t *rgbvalues;
-} bspxlg_leaf_t;
-
-typedef struct bspxlg_grid_s {
-    vec3_t gridscale;
-    vec3_t mins;
-    int count[3];
-    bspxlg_sample_t *samples;
-    bspxlg_node_t *nodes;
-    bspxlg_leaf_t *leafs;
-    unsigned int numnodes;
-    unsigned int numleafs;
-    unsigned int rootnode;
-} bspxlg_grid_t;
-
-typedef struct bspxlg_ctx_s {
-    const byte *data;
-    size_t ofs;
-    size_t size;
-    qboolean error;
-} bspxlg_ctx_t;
-
-#define BSPXLG_NODE_LEAF 0x80000000u
-
-static qboolean BSPXLG_CheckAdvance(bspxlg_ctx_t *ctx, size_t amount)
+lightgrid_t *Lightgrid_LoadExternal(const char *path)
 {
-    if (ctx->error)
-        return false;
-
-    if (amount > ctx->size - ctx->ofs)
-    {
-        ctx->error = true;
-        return false;
-    }
-
-    ctx->ofs += amount;
-    return true;
-}
-
-static qboolean BSPXLG_MulSize(size_t a, size_t b, size_t *out)
-{
-    if (a && b > SIZE_MAX / a)
-        return false;
-
-    *out = a * b;
-    return true;
-}
-
-static byte BSPXLG_ReadByte(bspxlg_ctx_t *ctx)
-{
-    if (ctx->error || ctx->ofs >= ctx->size)
-    {
-        ctx->error = true;
-        return 0;
-    }
-
-    return ctx->data[ctx->ofs++];
-}
-
-static int BSPXLG_ReadInt(bspxlg_ctx_t *ctx)
-{
-    int r = 0;
-    r |= (int)BSPXLG_ReadByte(ctx) << 0;
-    r |= (int)BSPXLG_ReadByte(ctx) << 8;
-    r |= (int)BSPXLG_ReadByte(ctx) << 16;
-    r |= (int)BSPXLG_ReadByte(ctx) << 24;
-    return r;
-}
-
-static float BSPXLG_ReadFloat(bspxlg_ctx_t *ctx)
-{
-    union { float f; int i; } u;
-    u.i = BSPXLG_ReadInt(ctx);
-    return u.f;
-}
-
-static void BSPXLG_FreeGrid(bspxlg_grid_t *grid)
-{
-    if (!grid)
-        return;
-
-    free(grid->samples);
-    free(grid->leafs);
-    free(grid->nodes);
-
-    free(grid);
-}
-
-static bspxlg_grid_t *BSPXLG_Load(const bspx_lump_t *l)
-{
-    bspxlg_ctx_t ctx = { .data = (const byte *)l->data, .ofs = 0u, .size = l->size, .error = false };
-    bspxlg_grid_t *grid = NULL;
-    bspxlg_sample_t *samples = NULL;
-    size_t nodestart;
-
-    vec3_t step;
-    vec3_t gridscale;
-    unsigned int numstyles, numnodes, numleafs, rootnode;
-    size_t leafsamps = 0;
-
-    if (!l || !l->data || l->size <= 0)
-        return NULL;
-
-    for (int j = 0; j < 3; j++)
-        step[j] = BSPXLG_ReadFloat(&ctx);
-    for (int j = 0; j < 3; j++)
-        gridscale[j] = step[j] ? 1.0f / step[j] : 0.0f;
-
-    vec3_t mins;
-    int size[3];
-    for (int j = 0; j < 3; j++)
-        size[j] = BSPXLG_ReadInt(&ctx);
-    for (int j = 0; j < 3; j++)
-        mins[j] = BSPXLG_ReadFloat(&ctx);
-
-    numstyles = BSPXLG_ReadByte(&ctx);
-    (void)numstyles;
-    rootnode = (unsigned int)BSPXLG_ReadInt(&ctx);
-    numnodes = (unsigned int)BSPXLG_ReadInt(&ctx);
-    nodestart = ctx.ofs;
-
-    {
-        size_t node_block_bytes;
-        if (!BSPXLG_MulSize((size_t)(3 + 8) * sizeof(int), numnodes, &node_block_bytes) || !BSPXLG_CheckAdvance(&ctx, node_block_bytes))
-            ctx.error = true;
-    }
-    numleafs = (unsigned int)BSPXLG_ReadInt(&ctx);
-
-    for (unsigned int i = 0; i < numleafs; i++)
-    {
-        size_t lsz[3];
-        size_t total;
-        size_t ms = 1;
-        for (int j = 0; j < 3; j++)
-            BSPXLG_ReadInt(&ctx);
-        for (int j = 0; j < 3; j++)
-            lsz[j] = (unsigned int)BSPXLG_ReadInt(&ctx);
-
-        {
-            size_t tmp;
-            if (!BSPXLG_MulSize(lsz[0], lsz[1], &tmp) || !BSPXLG_MulSize(tmp, lsz[2], &tmp))
-            {
-                ctx.error = true;
-                break;
-            }
-            total = tmp;
-        }
-
-        for (size_t j = 0; j < total; j++)
-        {
-            byte s = BSPXLG_ReadByte(&ctx);
-            if (s == 255)
-                continue;
-            if (ms < s)
-                ms = s;
-            if (!BSPXLG_CheckAdvance(&ctx, (size_t)s * 4u))
-                break;
-        }
-
-        if (ctx.error)
-            break;
-
-        if (total > 0 && ms > SIZE_MAX / total)
-        {
-            ctx.error = true;
-            break;
-        }
-
-        leafsamps += total * ms;
-    }
-
-    if (ctx.error)
-        goto fail;
-
-    {
-        size_t node_bytes, leaf_bytes, sample_bytes;
-        if (!BSPXLG_MulSize(sizeof(*grid->nodes), numnodes, &node_bytes) ||
-            !BSPXLG_MulSize(sizeof(*grid->leafs), numleafs, &leaf_bytes) || !BSPXLG_MulSize(sizeof(*samples), leafsamps, &sample_bytes))
-            goto fail;
-
-        grid = (bspxlg_grid_t *)calloc(1, sizeof(*grid));
-        if (!grid)
-            goto fail;
-
-        grid->nodes = (bspxlg_node_t *)calloc(numnodes, sizeof(*grid->nodes));
-        grid->leafs = (bspxlg_leaf_t *)calloc(numleafs, sizeof(*grid->leafs));
-        samples = (bspxlg_sample_t *)calloc(leafsamps, sizeof(*samples));
-    }
-
-    if (!grid->nodes || !grid->leafs || !samples)
-    {
-        BSPXLG_FreeGrid(grid);
-        if (samples)
-            free(samples);
-        return NULL;
-    }
-
-    VectorCopy(mins, grid->mins);
-    for (int j = 0; j < 3; j++)
-        grid->gridscale[j] = gridscale[j];
-    grid->count[0] = size[0];
-    grid->count[1] = size[1];
-    grid->count[2] = size[2];
-    grid->numnodes = numnodes;
-    grid->numleafs = numleafs;
-    grid->rootnode = rootnode;
-    grid->samples = samples;
-
-    ctx.ofs = nodestart;
-    for (unsigned int i = 0; i < numnodes; i++)
-    {
-        for (int j = 0; j < 3; j++)
-            grid->nodes[i].mid[j] = BSPXLG_ReadInt(&ctx);
-        for (int j = 0; j < 8; j++)
-            grid->nodes[i].child[j] = BSPXLG_ReadInt(&ctx);
-    }
-
-    BSPXLG_ReadInt(&ctx);
-
-    for (unsigned int i = 0; i < numleafs; i++)
-    {
-        size_t total;
-        size_t ms = 1;
-
-        for (int j = 0; j < 3; j++)
-            grid->leafs[i].mins[j] = BSPXLG_ReadInt(&ctx);
-        for (int j = 0; j < 3; j++)
-            grid->leafs[i].size[j] = BSPXLG_ReadInt(&ctx);
-
-        {
-            size_t tmp;
-            if (!BSPXLG_MulSize((size_t)grid->leafs[i].size[0], (size_t)grid->leafs[i].size[1], &tmp) ||
-                !BSPXLG_MulSize(tmp, (size_t)grid->leafs[i].size[2], &total))
-            {
-                ctx.error = true;
-                break;
-            }
-        }
-        grid->leafs[i].rgbvalues = samples;
-
-        {
-            size_t leafdataofs = ctx.ofs;
-            for (size_t j = 0; j < total; j++)
-            {
-                byte s = BSPXLG_ReadByte(&ctx);
-                if (s == 0xff)
-                    continue;
-                if (ms < s)
-                    ms = s;
-                if (!BSPXLG_CheckAdvance(&ctx, (size_t)s * 4u))
-                    break;
-            }
-            grid->leafs[i].numstyles = (unsigned char)ms;
-            ctx.ofs = leafdataofs;
-        }
-
-        if (ctx.error)
-            break;
-
-        for (size_t remaining = total; remaining-- > 0; )
-        {
-            byte s = BSPXLG_ReadByte(&ctx);
-            if (s == 0xff)
-            {
-                memset(samples, 0xff, sizeof(*samples));
-                samples += ms;
-                continue;
-            }
-
-            for (unsigned int k = 0; k < s; k++)
-            {
-                if (k >= ms)
-                {
-                    BSPXLG_ReadInt(&ctx);
-                }
-                else
-                {
-                    samples[k].style = BSPXLG_ReadByte(&ctx);
-                    samples[k].rgb[0] = BSPXLG_ReadByte(&ctx);
-                    samples[k].rgb[1] = BSPXLG_ReadByte(&ctx);
-                    samples[k].rgb[2] = BSPXLG_ReadByte(&ctx);
-                }
-            }
-            for (size_t k = s; k < ms; k++)
-            {
-                samples[k].style = k ? (byte)~0u : 0;
-                samples[k].rgb[0] = samples[k].rgb[1] = samples[k].rgb[2] = 0;
-            }
-
-            samples += ms;
-        }
-    }
-
-    if (ctx.error || ctx.ofs != ctx.size)
-    {
-        BSPXLG_FreeGrid(grid);
-        return NULL;
-    }
-
-    return grid;
-
-fail:
-    if (grid)
-    {
-        grid->samples = samples;
-        BSPXLG_FreeGrid(grid);
-    }
-    else if (samples)
-    {
-        free(samples);
-    }
-
-    return NULL;
-}
-
-static float BSPXLG_SingleValue(const bspxlg_grid_t *grid, int x, int y, int z, float w, vec3_t res_diffuse)
-{
-    const bspxlg_node_t *n;
-    const bspxlg_sample_t *samp;
-    unsigned int node = grid->rootnode;
-    int i;
-    float lev;
-
-    while (!(node & BSPXLG_NODE_LEAF))
-    {
-        if (node >= grid->numnodes)
-            return 0;
-
-        n = &grid->nodes[node];
-        node = (unsigned int)n->child[((x >= n->mid[0]) << 2) | ((y >= n->mid[1]) << 1) | ((z >= n->mid[2]) << 0)];
-    }
-
-    const bspxlg_leaf_t *leaf = &grid->leafs[node & ~BSPXLG_NODE_LEAF];
-    x -= leaf->mins[0];
-    y -= leaf->mins[1];
-    z -= leaf->mins[2];
-
-    if (x >= leaf->size[0] || y >= leaf->size[1] || z >= leaf->size[2])
-        return 0;
-
-    i = x + leaf->size[0] * (y + leaf->size[1] * z);
-    samp = leaf->rgbvalues + i * leaf->numstyles;
-
-    for (i = 0; i < leaf->numstyles; i++)
-    {
-        if (samp[i].style == 255)
-            break;
-
-        if (samp[i].style < cl_max_lightstyles)
-        {
-            lev = d_lightstylevalue[samp[i].style] * w;
-            res_diffuse[0] += samp[i].rgb[0] * lev * cl_lightstyle[samp[i].style].colours[0];
-            res_diffuse[1] += samp[i].rgb[1] * lev * cl_lightstyle[samp[i].style].colours[1];
-            res_diffuse[2] += samp[i].rgb[2] * lev * cl_lightstyle[samp[i].style].colours[2];
-        }
-    }
-
-    if (i == 0)
-        w = 0;
-
-    return w;
-}
-
-static void BSPXLG_Sample(const bspxlg_grid_t *grid, const vec3_t point, vec3_t res_diffuse, vec3_t res_dir)
-{
-    int tile[3];
-    float frac[3];
-    float s = 0.f;
-
-    VectorSet(res_diffuse, 0, 0, 0);
-    VectorSet(res_dir, 1, 0, 1);
-    VectorNormalize(res_dir);
-
-    for (int i = 0; i < 3; i++)
-    {
-        tile[i] = (int)floorf((point[i] - grid->mins[i]) * grid->gridscale[i]);
-        frac[i] = (point[i] - grid->mins[i]) * grid->gridscale[i] - tile[i];
-    }
-
-    for (int i = 0; i < 8; i++)
-    {
-        float w = ((i & 1) ? frac[0] : 1 - frac[0]) * ((i & 2) ? frac[1] : 1 - frac[1]) * ((i & 4) ? frac[2] : 1 - frac[2]);
-        s += BSPXLG_SingleValue(grid, tile[0] + !!(i & 1), tile[1] + !!(i & 2), tile[2] + !!(i & 4), w, res_diffuse);
-    }
-
-    if (s)
-        VectorScale(res_diffuse, 1.0f / (s * 255.0f), res_diffuse);
-}
-
-lightgrid_t *Lightgrid_LoadFromBSPX_FTE(const bspx_lump_t *l)
-{
-    bspxlg_grid_t *grid = BSPXLG_Load(l);
-    if (!grid)
-        return NULL;
-
-    if (grid->count[0] <= 0 || grid->count[1] <= 0 || grid->count[2] <= 0)
-    {
-        BSPXLG_FreeGrid(grid);
-        return NULL;
-    }
-
-    lightgrid_t *lg = Lightgrid_Alloc(grid->count[0], grid->count[1], grid->count[2],
-                                      grid->gridscale[0] ? 1.0f / grid->gridscale[0] : 0.0f,
-                                      grid->mins, grid->mins); /* maxs will be filled below */
-
-    if (!lg)
-    {
-        BSPXLG_FreeGrid(grid);
-        return NULL;
-    }
-
-    vec3_t size;
-    for (int i = 0; i < 3; i++)
-        size[i] = grid->count[i] * (lg->cellsize > 0.f ? lg->cellsize : 0.f);
-    VectorAdd(lg->mins, size, lg->maxs);
-
-    for (int z = 0; z < lg->nz; z++)
-    {
-        for (int y = 0; y < lg->ny; y++)
-        {
-            for (int x = 0; x < lg->nx; x++)
-            {
-                vec3_t p;
-                vec3_t diffuse, dir;
-                lightgrid_probe_t *probe = &lg->probes[(z * lg->ny + y) * lg->nx + x];
-
-                p[0] = lg->mins[0] + (x + 0.5f) * lg->cellsize;
-                p[1] = lg->mins[1] + (y + 0.5f) * lg->cellsize;
-                p[2] = lg->mins[2] + (z + 0.5f) * lg->cellsize;
-
-                BSPXLG_Sample(grid, p, diffuse, dir);
-
-                float intensity = VectorLength(diffuse);
-                if (intensity > 0.f)
-                {
-                    VectorScale(diffuse, 1.0f / intensity, probe->rgb);
-                    probe->intensity = intensity;
-                }
-                else
-                {
-                    probe->rgb[0] = probe->rgb[1] = probe->rgb[2] = 1.f;
-                    probe->intensity = 0.f;
-                }
-
-                VectorCopy(dir, probe->dir);
-            }
-        }
-    }
-
-    BSPXLG_FreeGrid(grid);
-    return lg;
+    return Lightgrid_LoadV2(path);
 }

--- a/common/lightgrid.h
+++ b/common/lightgrid.h
@@ -2,13 +2,14 @@
 
 #include "quakedef.h"
 
-// BSPX lightgrid probe decoded from octree lightgrid data
-typedef struct lightgrid_probe_s {
-    float rgb[3];
-    float dir[3];
+typedef struct lightcell_s {
+    vec3_t rgb;
+    vec3_t dir;
     float intensity;
-    float emissive;
-} lightgrid_probe_t;
+    float ao;
+    // placeholder for future SH9
+} lightcell_t;
+typedef lightcell_t lightgrid_probe_t;
 
 #define LIGHTGRID_STANDARD_CELLSIZE 32.f
 #define LIGHTGRID_MAX_NX 64
@@ -21,11 +22,13 @@ typedef struct lightgrid_s {
     float cellsize;
     vec3_t mins, maxs;
 
-    lightgrid_probe_t *probes; // size = nx*ny*nz
+    lightcell_t *probes; // size = nx*ny*nz
 
     int source; // enum lightgrid_source_e
-    unsigned int tex_color3d;
-    unsigned int tex_dir3d;
+    GLuint tex_color3d;
+    GLuint tex_dir3d;
+    GLuint tex_intensity;
+    GLuint tex_ao;
 } lightgrid_t;
 
 typedef enum lightgrid_source_e {
@@ -35,12 +38,7 @@ typedef enum lightgrid_source_e {
     LIGHTGRID_SRC_KTX2
 } lightgrid_source_t;
 
-typedef struct bspx_lump_s {
-    const void *data;
-    size_t size;
-} bspx_lump_t;
-
 lightgrid_t *Lightgrid_Alloc(int nx, int ny, int nz, float cellsize, const vec3_t mins, const vec3_t maxs);
-lightgrid_t *Lightgrid_LoadFromBSPX_Octree(const bspx_lump_t *l);
-lightgrid_t *Lightgrid_LoadFromBSPX_FTE(const bspx_lump_t *l);
+lightgrid_t *Lightgrid_LoadV2(const char *path);
+lightgrid_t *Lightgrid_LoadExternal(const char *path);
 void Lightgrid_Free(lightgrid_t *lg);


### PR DESCRIPTION
## Summary
- remove legacy BSPX and octree lightgrid loaders in favor of the RAW v2 format
- add a unified RAW v2 loader and external entry point
- align renderer lightgrid data structures with the simplified cell layout

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b2546160c832e87fca37aa2b6d993)