### PR TITLE
Add KTX2 lightgrid support and GPU upload

### DIFF
--- a/Quake/gl_lightgrid.c
+++ b/Quake/gl_lightgrid.c
@@ -82,22 +82,103 @@ void Lightgrid_Shutdown(void)
 
 void Lightgrid_Clear(void)
 {
+    GLuint tex[4];
+    int tex_count = 0;
+
     if (current_lightgrid)
     {
-#if USE_KTX2_LIGHTGRID
-        if (current_lightgrid->tex_color3d || current_lightgrid->tex_dir3d)
-        {
-            GLuint tex[2] = { current_lightgrid->tex_color3d, current_lightgrid->tex_dir3d };
-            glDeleteTextures(2, tex);
-            current_lightgrid->tex_color3d = 0;
-            current_lightgrid->tex_dir3d = 0;
-        }
-#endif
+        if (current_lightgrid->tex_color3d)
+            tex[tex_count++] = current_lightgrid->tex_color3d;
+        if (current_lightgrid->tex_dir3d)
+            tex[tex_count++] = current_lightgrid->tex_dir3d;
+        if (current_lightgrid->tex_intensity)
+            tex[tex_count++] = current_lightgrid->tex_intensity;
+        if (current_lightgrid->tex_ao)
+            tex[tex_count++] = current_lightgrid->tex_ao;
+
+        if (tex_count)
+            glDeleteTextures(tex_count, tex);
+
+        current_lightgrid->tex_color3d = 0;
+        current_lightgrid->tex_dir3d = 0;
+        current_lightgrid->tex_intensity = 0;
+        current_lightgrid->tex_ao = 0;
 
         Lightgrid_Free(current_lightgrid);
     }
+
     current_lightgrid = NULL;
+    cl.lightgrid = NULL;
     q_strlcpy(lightgrid_source, "NONE", sizeof(lightgrid_source));
+}
+
+static void Lightgrid_UploadTexture3D(GLuint *tex, GLenum internal_format, GLenum format, const float *payload, int nx, int ny, int nz)
+{
+    if (!*tex)
+        glGenTextures(1, tex);
+
+    glBindTexture(GL_TEXTURE_3D, *tex);
+    glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
+    GL_TexImage3DFunc(GL_TEXTURE_3D, 0, internal_format, nx, ny, nz, 0, format, GL_FLOAT, payload);
+}
+
+void Lightgrid_UploadToGPU(lightgrid_t *lg)
+{
+    float *color_payload = NULL;
+    float *dir_payload = NULL;
+    float *intensity_payload = NULL;
+    float *ao_payload = NULL;
+    size_t count;
+
+    if (!lg)
+        return;
+
+    count = (size_t)lg->nx * (size_t)lg->ny * (size_t)lg->nz;
+    if (count == 0 || count > LIGHTGRID_MAX_CELLS)
+        return;
+
+    color_payload = (float *)malloc(count * 3 * sizeof(float));
+    dir_payload = (float *)malloc(count * 3 * sizeof(float));
+    intensity_payload = (float *)malloc(count * sizeof(float));
+    ao_payload = (float *)malloc(count * sizeof(float));
+
+    if (!color_payload || !dir_payload || !intensity_payload || !ao_payload)
+        goto done;
+
+    for (size_t i = 0; i < count; ++i)
+    {
+        const lightcell_t *cell = &lg->probes[i];
+
+        color_payload[i * 3 + 0] = cell->rgb[0];
+        color_payload[i * 3 + 1] = cell->rgb[1];
+        color_payload[i * 3 + 2] = cell->rgb[2];
+
+        dir_payload[i * 3 + 0] = cell->dir[0];
+        dir_payload[i * 3 + 1] = cell->dir[1];
+        dir_payload[i * 3 + 2] = cell->dir[2];
+
+        intensity_payload[i] = cell->intensity;
+        ao_payload[i] = cell->ao;
+    }
+
+    Lightgrid_UploadTexture3D(&lg->tex_color3d, GL_RGB16F, GL_RGB, color_payload, lg->nx, lg->ny, lg->nz);
+    Lightgrid_UploadTexture3D(&lg->tex_dir3d, GL_RGB16F, GL_RGB, dir_payload, lg->nx, lg->ny, lg->nz);
+    Lightgrid_UploadTexture3D(&lg->tex_intensity, GL_R16F, GL_RED, intensity_payload, lg->nx, lg->ny, lg->nz);
+    Lightgrid_UploadTexture3D(&lg->tex_ao, GL_R16F, GL_RED, ao_payload, lg->nx, lg->ny, lg->nz);
+
+done:
+    if (color_payload)
+        free(color_payload);
+    if (dir_payload)
+        free(dir_payload);
+    if (intensity_payload)
+        free(intensity_payload);
+    if (ao_payload)
+        free(ao_payload);
 }
 
 /* =====================================================================
@@ -430,20 +511,6 @@ static qboolean Lightgrid_LoadKTXPayload(const char *path, int nx, int ny, int n
     return true;
 }
 
-static void Lightgrid_Upload3D(GLuint *tex, const float *payload, int nx, int ny, int nz)
-{
-    if (!*tex)
-        glGenTextures(1, tex);
-
-    glBindTexture(GL_TEXTURE_3D, *tex);
-    glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
-    GL_TexImage3DFunc(GL_TEXTURE_3D, 0, GL_RGBA32F, nx, ny, nz, 0, GL_RGBA, GL_FLOAT, payload);
-}
-
 qboolean Lightgrid_LoadFromKTX2(const char *mapname)
 {
     lightgrid_meta_t meta;
@@ -496,13 +563,9 @@ qboolean Lightgrid_LoadFromKTX2(const char *mapname)
             VectorSet(p->dir, 0, 0, 1);
     }
 
-    Lightgrid_Upload3D(&lg->tex_color3d, color_payload, meta.nx, meta.ny, meta.nz);
-    Lightgrid_Upload3D(&lg->tex_dir3d, dir_payload, meta.nx, meta.ny, meta.nz);
-
-    current_lightgrid = lg;
-    cl.lightgrid = lg;
     lg->source = LIGHTGRID_SRC_KTX2;
-    q_strlcpy(lightgrid_source, "KTX2", sizeof(lightgrid_source));
+
+    Lightgrid_Set(lg);
 
     free(color_payload);
     free(dir_payload);
@@ -1029,8 +1092,7 @@ void Lightgrid_BuildFallback(void)
         return;
     }
 
-    current_lightgrid = lg;
-    cl.lightgrid      = lg;
+    Lightgrid_Set(lg);
 
 #if USE_KTX2_LIGHTGRID
     if (r_lightgrid_ktx_enable.value && r_lightgrid_ktx_export.value)
@@ -1079,6 +1141,38 @@ static void Lightgrid_AddDlights(const vec3_t pos, vec3_t color, vec3_t dirsum)
 /* =====================================================================
    Public API
    ===================================================================== */
+
+void Lightgrid_Set(lightgrid_t *lg)
+{
+    Lightgrid_Clear();
+
+    if (!lg)
+        return;
+
+    Lightgrid_UploadToGPU(lg);
+
+    current_lightgrid = lg;
+    cl.lightgrid = lg;
+
+    switch (lg->source)
+    {
+    case LIGHTGRID_SRC_KTX2:
+        q_strlcpy(lightgrid_source, "KTX2", sizeof(lightgrid_source));
+        break;
+    case LIGHTGRID_SRC_V2:
+        q_strlcpy(lightgrid_source, "V2", sizeof(lightgrid_source));
+        break;
+    case LIGHTGRID_SRC_OCTREE:
+        q_strlcpy(lightgrid_source, "OCTREE", sizeof(lightgrid_source));
+        break;
+    case LIGHTGRID_SRC_RAW:
+        q_strlcpy(lightgrid_source, "RAW", sizeof(lightgrid_source));
+        break;
+    default:
+        q_strlcpy(lightgrid_source, "UNKNOWN", sizeof(lightgrid_source));
+        break;
+    }
+}
 
 const lightgrid_t *Lightgrid_Get(void)
 {

--- a/Quake/gl_lightgrid.h
+++ b/Quake/gl_lightgrid.h
@@ -30,6 +30,8 @@ extern cvar_t r_lightgrid_ktx_prefer;
 void Lightgrid_Init (void);
 void Lightgrid_Shutdown (void);
 void Lightgrid_Clear (void);
+void Lightgrid_Set (lightgrid_t *lg);
+void Lightgrid_UploadToGPU (lightgrid_t *lg);
 lightgrid_t *Lightgrid_FromRaw (const lightgrid_raw_t *raw);
 lightgrid_raw_t *Lightgrid_GenerateRaw (const struct qmodel_s *model);
 void Lightgrid_BuildFallback (void);

--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -3534,9 +3534,9 @@ static qboolean BSPX_LightGridLoad (qmodel_t *mod, void *lump, int lumpsize)
 	if (!lg)
 		return false;
 
-	cl.lightgrid = lg;
+        Lightgrid_Set (lg);
 
-	return true;
+        return true;
 }
 
 static void Lightgrid_Info_f (void)

--- a/common/lightgrid.c
+++ b/common/lightgrid.c
@@ -3,6 +3,9 @@
 
 #define LIGHTGRID_MAGIC 0x4c475244u /* 'LGRD' */
 #define LIGHTGRID_VERSION_V2 2u
+#define KTX2_HEADER_SIZE 100
+
+static const uint8_t KTX2_MAGIC[12] = {0xAB, 'K', 'T', 'X', ' ', '2', '0', 0xBB, 0x0D, 0x0A, 0x1A, 0x0A};
 
 typedef struct lightgrid_v2_header_s
 {
@@ -170,7 +173,293 @@ lightgrid_t *Lightgrid_LoadV2(const char *path)
         cell->ao = has_ao ? LittleFloat(p[7]) : 0.f;
     }
 
-    lg->source = LIGHTGRID_SRC_RAW;
+    lg->source = LIGHTGRID_SRC_V2;
+
+    free(buffer);
+    return lg;
+}
+
+typedef struct lightgrid_ktx2_level_s
+{
+    uint64_t offset;
+    uint64_t length;
+} lightgrid_ktx2_level_t;
+
+typedef struct lightgrid_ktx2_header_s
+{
+    uint32_t vkformat;
+    uint32_t width, height, depth;
+    uint32_t level_count;
+    uint64_t kvd_offset, kvd_length;
+    lightgrid_ktx2_level_t levels[16];
+} lightgrid_ktx2_header_t;
+
+enum
+{
+    VK_FORMAT_R16G16B16_SFLOAT = 96,
+    VK_FORMAT_R16G16B16A16_SFLOAT = 97,
+    VK_FORMAT_R32G32B32_SFLOAT = 106,
+    VK_FORMAT_R32G32B32A32_SFLOAT = 109
+};
+
+static uint32_t Lightgrid_KTX2ReadU32(const uint8_t *p)
+{
+    return ((uint32_t)p[0]) | ((uint32_t)p[1] << 8) | ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24);
+}
+
+static uint64_t Lightgrid_KTX2ReadU64(const uint8_t *p)
+{
+    return ((uint64_t)p[0]) | ((uint64_t)p[1] << 8) | ((uint64_t)p[2] << 16) |
+           ((uint64_t)p[3] << 24) | ((uint64_t)p[4] << 32) | ((uint64_t)p[5] << 40) |
+           ((uint64_t)p[6] << 48) | ((uint64_t)p[7] << 56);
+}
+
+static qboolean Lightgrid_KTX2ParseHeader(const uint8_t *data, size_t size, lightgrid_ktx2_header_t *out)
+{
+    const size_t level_index_size = sizeof(uint64_t) * 3;
+    size_t level_table_size;
+
+    if (!data || size < KTX2_HEADER_SIZE)
+        return false;
+
+    if (memcmp(data, KTX2_MAGIC, sizeof(KTX2_MAGIC)) != 0)
+        return false;
+
+    memset(out, 0, sizeof(*out));
+
+    out->vkformat = Lightgrid_KTX2ReadU32(data + 12);
+    out->width = Lightgrid_KTX2ReadU32(data + 12 + 4 * 2);
+    out->height = Lightgrid_KTX2ReadU32(data + 12 + 4 * 3);
+    out->depth = Lightgrid_KTX2ReadU32(data + 12 + 4 * 4);
+    out->level_count = Lightgrid_KTX2ReadU32(data + 12 + 4 * 7);
+
+    out->kvd_offset = Lightgrid_KTX2ReadU64(data + 12 + 4 * 8 + 8 * 2);
+    out->kvd_length = Lightgrid_KTX2ReadU64(data + 12 + 4 * 8 + 8 * 3);
+
+    if (out->level_count == 0 || out->level_count > (int)(sizeof(out->levels) / sizeof(out->levels[0])))
+        return false;
+
+    level_table_size = out->level_count * level_index_size;
+    if (KTX2_HEADER_SIZE + level_table_size > size)
+        return false;
+
+    for (uint32_t i = 0; i < out->level_count; i++)
+    {
+        const uint8_t *entry = data + KTX2_HEADER_SIZE + i * level_index_size;
+        uint64_t offset = Lightgrid_KTX2ReadU64(entry + 0);
+        uint64_t length = Lightgrid_KTX2ReadU64(entry + 8);
+
+        if (offset > size || length > size - offset)
+            return false;
+
+        out->levels[i].offset = offset;
+        out->levels[i].length = length;
+    }
+
+    if (out->kvd_length && (out->kvd_offset > size || out->kvd_length > size - out->kvd_offset))
+        return false;
+
+    return true;
+}
+
+static qboolean Lightgrid_KTX2ReadMetadata(const uint8_t *data, const lightgrid_ktx2_header_t *hdr, float *out_cellsize, vec3_t origin)
+{
+    qboolean have_cellsize = false;
+    qboolean have_origin = false;
+    size_t offset = 0;
+
+    if (!hdr->kvd_length)
+        return false;
+
+    while (offset + 4 <= hdr->kvd_length)
+    {
+        uint32_t kv_size = Lightgrid_KTX2ReadU32(data + offset);
+        size_t padded = (kv_size + 3u) & ~3u;
+        const uint8_t *kv = data + offset + 4;
+
+        if (kv_size == 0 || offset + 4 + padded > hdr->kvd_length)
+            break;
+
+        const char *key = (const char *)kv;
+        size_t key_len = strlen(key);
+        if (key_len + 1 > kv_size)
+            break;
+
+        const uint8_t *value = kv + key_len + 1;
+        size_t value_len = kv_size - (key_len + 1);
+
+        if (!have_cellsize && !q_strcasecmp(key, "LGRID_CELLSIZE") && value_len >= sizeof(float))
+        {
+            float v;
+            memcpy(&v, value, sizeof(float));
+            *out_cellsize = LittleFloat(v);
+            have_cellsize = true;
+        }
+        else if (!have_origin && !q_strcasecmp(key, "LGRID_ORIGIN") && value_len >= sizeof(vec3_t))
+        {
+            float v[3];
+            memcpy(v, value, sizeof(vec3_t));
+            origin[0] = LittleFloat(v[0]);
+            origin[1] = LittleFloat(v[1]);
+            origin[2] = LittleFloat(v[2]);
+            have_origin = true;
+        }
+
+        offset += 4 + padded;
+    }
+
+    return have_cellsize && have_origin;
+}
+
+lightgrid_t *Lightgrid_LoadKTX2(const char *path)
+{
+    byte *buffer;
+    lightgrid_ktx2_header_t hdr;
+    int nx, ny, nz;
+    vec3_t origin, mins, maxs;
+    float cellsize = 0.f;
+    size_t component_count;
+    size_t component_size;
+    const uint8_t *payload;
+    size_t payload_len;
+    size_t probe_count;
+    lightgrid_t *lg;
+
+    if (!path)
+        return NULL;
+
+    buffer = COM_LoadMallocFile(path, NULL);
+    if (!buffer)
+        return NULL;
+
+    if (!Lightgrid_KTX2ParseHeader(buffer, (size_t)com_filesize, &hdr))
+    {
+        free(buffer);
+        return NULL;
+    }
+
+    if (hdr.depth == 0 || hdr.level_count == 0)
+    {
+        free(buffer);
+        return NULL;
+    }
+
+    switch (hdr.vkformat)
+    {
+    case VK_FORMAT_R16G16B16_SFLOAT:
+        component_count = 3;
+        component_size = sizeof(uint16_t);
+        break;
+    case VK_FORMAT_R32G32B32_SFLOAT:
+        component_count = 3;
+        component_size = sizeof(float);
+        break;
+    case VK_FORMAT_R16G16B16A16_SFLOAT:
+        component_count = 4;
+        component_size = sizeof(uint16_t);
+        break;
+    case VK_FORMAT_R32G32B32A32_SFLOAT:
+        component_count = 4;
+        component_size = sizeof(float);
+        break;
+    default:
+        free(buffer);
+        return NULL;
+    }
+
+    nx = (int)hdr.width;
+    ny = (int)hdr.height;
+    nz = (int)hdr.depth;
+    if (nx <= 0 || ny <= 0 || nz <= 0)
+    {
+        free(buffer);
+        return NULL;
+    }
+
+    if (!Lightgrid_KTX2ReadMetadata(buffer + hdr.kvd_offset, &hdr, &cellsize, origin))
+    {
+        free(buffer);
+        return NULL;
+    }
+
+    if (cellsize <= 0.f)
+    {
+        free(buffer);
+        return NULL;
+    }
+
+    probe_count = (size_t)nx * (size_t)ny * (size_t)nz;
+    if (probe_count == 0 || probe_count > LIGHTGRID_MAX_CELLS)
+    {
+        free(buffer);
+        return NULL;
+    }
+
+    payload = buffer + hdr.levels[0].offset;
+    payload_len = (size_t)hdr.levels[0].length;
+
+    if ((size_t)component_size > SIZE_MAX / component_count ||
+        component_count * component_size > SIZE_MAX / probe_count)
+    {
+        free(buffer);
+        return NULL;
+    }
+
+    if (payload_len < probe_count * component_count * component_size)
+    {
+        free(buffer);
+        return NULL;
+    }
+
+    VectorCopy(origin, mins);
+    maxs[0] = origin[0] + cellsize * nx;
+    maxs[1] = origin[1] + cellsize * ny;
+    maxs[2] = origin[2] + cellsize * nz;
+
+    lg = Lightgrid_Alloc(nx, ny, nz, cellsize, mins, maxs);
+    if (!lg)
+    {
+        free(buffer);
+        return NULL;
+    }
+
+    for (size_t i = 0; i < probe_count; i++)
+    {
+        const uint8_t *texel = payload + i * component_count * component_size;
+        lightcell_t *cell = &lg->probes[i];
+        float rgb[3];
+        float alpha = 0.f;
+
+        if (component_size == sizeof(uint16_t))
+        {
+            rgb[0] = LightgridRAW_HalfToFloat(((const uint16_t *)texel)[0]);
+            rgb[1] = LightgridRAW_HalfToFloat(((const uint16_t *)texel)[1]);
+            rgb[2] = LightgridRAW_HalfToFloat(((const uint16_t *)texel)[2]);
+            if (component_count == 4)
+                alpha = LightgridRAW_HalfToFloat(((const uint16_t *)texel)[3]);
+        }
+        else
+        {
+            rgb[0] = LittleFloat(((const float *)texel)[0]);
+            rgb[1] = LittleFloat(((const float *)texel)[1]);
+            rgb[2] = LittleFloat(((const float *)texel)[2]);
+            if (component_count == 4)
+                alpha = LittleFloat(((const float *)texel)[3]);
+        }
+
+        VectorCopy(rgb, cell->rgb);
+        cell->dir[0] = 0.f;
+        cell->dir[1] = 0.f;
+        cell->dir[2] = 1.f;
+        cell->ao = 0.f;
+
+        if (component_count == 3)
+            cell->intensity = sqrtf(rgb[0] * rgb[0] + rgb[1] * rgb[1] + rgb[2] * rgb[2]);
+        else
+            cell->intensity = alpha;
+    }
+
+    lg->source = LIGHTGRID_SRC_KTX2;
 
     free(buffer);
     return lg;
@@ -178,5 +467,22 @@ lightgrid_t *Lightgrid_LoadV2(const char *path)
 
 lightgrid_t *Lightgrid_LoadExternal(const char *path)
 {
-    return Lightgrid_LoadV2(path);
+    if (!path)
+        return NULL;
+
+    typedef lightgrid_t *(*lightgrid_loader_fn)(const char *path);
+    static lightgrid_loader_fn loaders[] = {
+        Lightgrid_LoadV2,
+        Lightgrid_LoadKTX2,
+        NULL
+    };
+
+    for (int i = 0; loaders[i]; ++i)
+    {
+        lightgrid_t *lg = loaders[i](path);
+        if (lg)
+            return lg;
+    }
+
+    return NULL;
 }

--- a/common/lightgrid.h
+++ b/common/lightgrid.h
@@ -33,6 +33,7 @@ typedef struct lightgrid_s {
 
 typedef enum lightgrid_source_e {
     LIGHTGRID_SRC_NONE = 0,
+    LIGHTGRID_SRC_V2,
     LIGHTGRID_SRC_OCTREE,
     LIGHTGRID_SRC_RAW,
     LIGHTGRID_SRC_KTX2
@@ -40,5 +41,6 @@ typedef enum lightgrid_source_e {
 
 lightgrid_t *Lightgrid_Alloc(int nx, int ny, int nz, float cellsize, const vec3_t mins, const vec3_t maxs);
 lightgrid_t *Lightgrid_LoadV2(const char *path);
+lightgrid_t *Lightgrid_LoadKTX2(const char *path);
 lightgrid_t *Lightgrid_LoadExternal(const char *path);
 void Lightgrid_Free(lightgrid_t *lg);


### PR DESCRIPTION
## Summary
- add support for loading 3D lightgrids from KTX2 files with required metadata validation
- introduce a loader registry for external lightgrid files and integrate unified GPU uploading and state management
- provide public lightgrid setters/getters and ensure GPU textures are created and cleaned consistently

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b2ae6edd8832eb210d0d12e14ac5d)