### PR TITLE
Prepare lightgrid infrastructure for future V3

### DIFF
--- a/Quake/gl_model.h
+++ b/Quake/gl_model.h
@@ -465,12 +465,6 @@ typedef struct lightgrid_raw_header_s
         vec3_t origin;       // world-space min corner
 } lightgrid_raw_header_t;
 
-typedef struct sh9_color_s
-{
-        vec3_t c[9];
-} sh9_color_t;
-
-
 typedef struct lightgrid_raw_s
 {
         int nx, ny, nz;

--- a/common/lightgrid.c
+++ b/common/lightgrid.c
@@ -58,7 +58,7 @@ void Lightgrid_Free(lightgrid_t *lg)
         return;
 }
 
-static qboolean Lightgrid_ReadV2Header(const lightgrid_v2_header_t *hdr, int *nx, int *ny, int *nz, float *cellsize, vec3_t origin)
+static qboolean Lightgrid_ReadV2Header(const lightgrid_v2_header_t *hdr, int *nx, int *ny, int *nz, float *cellsize, vec3_t origin, uint32_t *components)
 {
     if (LittleLong(hdr->magic) != LIGHTGRID_MAGIC)
         return false;
@@ -70,6 +70,7 @@ static qboolean Lightgrid_ReadV2Header(const lightgrid_v2_header_t *hdr, int *nx
     *ny = LittleLong(hdr->ny);
     *nz = LittleLong(hdr->nz);
     *cellsize = LittleFloat(hdr->cellsize);
+    *components = LittleLong(hdr->components);
 
     origin[0] = LittleFloat(hdr->origin[0]);
     origin[1] = LittleFloat(hdr->origin[1]);
@@ -99,7 +100,9 @@ lightgrid_t *Lightgrid_LoadV2(const char *path)
     float cellsize;
     vec3_t origin;
 
-    if (!Lightgrid_ReadV2Header(hdr, &nx, &ny, &nz, &cellsize, origin))
+    uint32_t components = 0;
+
+    if (!Lightgrid_ReadV2Header(hdr, &nx, &ny, &nz, &cellsize, origin, &components))
     {
         free(buffer);
         return NULL;
@@ -140,7 +143,30 @@ lightgrid_t *Lightgrid_LoadV2(const char *path)
         return NULL;
     }
 
-    const qboolean has_ao = (floats_per_probe == 8);
+    const uint32_t required_components = LIGHTGRID_COMPONENT_RGB | LIGHTGRID_COMPONENT_DIR | LIGHTGRID_COMPONENT_INTENSITY;
+    const uint32_t known_components = required_components | LIGHTGRID_COMPONENT_AO;
+    const uint32_t unknown_components = components & ~(known_components | LIGHTGRID_COMPONENT_SH9_FLAG);
+
+    if (components && (components & required_components) != required_components)
+    {
+        free(buffer);
+        return NULL;
+    }
+
+    if (unknown_components)
+        Con_DPrintf("Lightgrid V2: ignoring unknown component flags 0x%x\n", unknown_components);
+
+    const qboolean has_ao = components ? ((components & LIGHTGRID_COMPONENT_AO) != 0) : (floats_per_probe == 8);
+
+    if (components)
+    {
+        const size_t expected_floats = 7 + (has_ao ? 1 : 0);
+        if (expected_floats != floats_per_probe)
+        {
+            free(buffer);
+            return NULL;
+        }
+    }
     const float *probe_data = (const float *)(buffer + header_size);
 
     lightgrid_t *lg = Lightgrid_Alloc(nx, ny, nz, cellsize, mins, maxs);
@@ -266,6 +292,7 @@ static qboolean Lightgrid_KTX2ReadMetadata(const uint8_t *data, const lightgrid_
 {
     qboolean have_cellsize = false;
     qboolean have_origin = false;
+    qboolean have_sh9 = false;
     size_t offset = 0;
 
     if (!hdr->kvd_length)
@@ -304,9 +331,16 @@ static qboolean Lightgrid_KTX2ReadMetadata(const uint8_t *data, const lightgrid_
             origin[2] = LittleFloat(v[2]);
             have_origin = true;
         }
+        else if (!have_sh9 && !q_strcasecmp(key, "LGRID_SH9"))
+        {
+            have_sh9 = true;
+        }
 
         offset += 4 + padded;
     }
+
+    if (have_sh9)
+        Con_DPrintf("Lightgrid KTX2: detected LGRID_SH9 metadata (ignored for now)\n");
 
     return have_cellsize && have_origin;
 }
@@ -465,6 +499,13 @@ lightgrid_t *Lightgrid_LoadKTX2(const char *path)
     return lg;
 }
 
+// Placeholder for future Lightgrid V3 loader.
+lightgrid_t *Lightgrid_LoadV3(const char *path)
+{
+    (void)path;
+    return NULL;
+}
+
 lightgrid_t *Lightgrid_LoadExternal(const char *path)
 {
     if (!path)
@@ -474,6 +515,7 @@ lightgrid_t *Lightgrid_LoadExternal(const char *path)
     static lightgrid_loader_fn loaders[] = {
         Lightgrid_LoadV2,
         Lightgrid_LoadKTX2,
+        Lightgrid_LoadV3,
         NULL
     };
 

--- a/common/lightgrid.h
+++ b/common/lightgrid.h
@@ -2,12 +2,16 @@
 
 #include "quakedef.h"
 
+typedef struct sh9_color_s {
+    vec3_t c[9];
+} sh9_color_t;
+
 typedef struct lightcell_s {
     vec3_t rgb;
     vec3_t dir;
     float intensity;
     float ao;
-    // placeholder for future SH9
+    sh9_color_t *sh9; // NULL unless Lightgrid V3 allocates it
 } lightcell_t;
 typedef lightcell_t lightgrid_probe_t;
 
@@ -31,6 +35,14 @@ typedef struct lightgrid_s {
     GLuint tex_ao;
 } lightgrid_t;
 
+typedef enum lightgrid_component_e {
+    LIGHTGRID_COMPONENT_RGB = (1u << 0),
+    LIGHTGRID_COMPONENT_DIR = (1u << 1),
+    LIGHTGRID_COMPONENT_INTENSITY = (1u << 2),
+    LIGHTGRID_COMPONENT_AO = (1u << 3),
+    LIGHTGRID_COMPONENT_SH9_FLAG = (1u << 8) // Future V3 SH9 data
+} lightgrid_component_t;
+
 typedef enum lightgrid_source_e {
     LIGHTGRID_SRC_NONE = 0,
     LIGHTGRID_SRC_V2,
@@ -42,5 +54,6 @@ typedef enum lightgrid_source_e {
 lightgrid_t *Lightgrid_Alloc(int nx, int ny, int nz, float cellsize, const vec3_t mins, const vec3_t maxs);
 lightgrid_t *Lightgrid_LoadV2(const char *path);
 lightgrid_t *Lightgrid_LoadKTX2(const char *path);
+lightgrid_t *Lightgrid_LoadV3(const char *path);
 lightgrid_t *Lightgrid_LoadExternal(const char *path);
 void Lightgrid_Free(lightgrid_t *lg);


### PR DESCRIPTION
## Summary
- add shared SH9 color struct and lightcell pointer for future Lightgrid V3 data
- update loaders to document component flags, ignore unknown bits, and register a stub V3 loader
- detect and log optional LGRID_SH9 metadata blocks in KTX2 files without using the data yet

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b2d73c35c832e93295097d07cb571)