### PR TITLE
Fix lightgrid probe typedef

### DIFF
--- a/Quake/render.h
+++ b/Quake/render.h
@@ -32,7 +32,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 //=============================================================================
 
-typedef struct lightgrid_probe_s lightgrid_probe_t;
+typedef struct lightcell_s lightcell_t;
+typedef lightcell_t lightgrid_probe_t;
 typedef struct lightgrid_s lightgrid_t;
 
 typedef struct lightcache_s {


### PR DESCRIPTION
## Summary
- align the lightgrid probe typedef with the shared lightcell type to avoid redefinition conflicts

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b31693d50832eb2b78795f29138e4)