### PR TITLE
Add emissive lightgrid support fields

### DIFF
--- a/Quake/gl_model.h
+++ b/Quake/gl_model.h
@@ -95,6 +95,7 @@ typedef struct texture_s
 	textype_t			type;
 	struct gltexture_s	*gltexture; //johnfitz -- pointer to gltexture
 	struct gltexture_s	*fullbright; //johnfitz -- fullbright mask texture
+	struct gltexture_s	*emissive; // emissive map texture
 	int					anim_total;				// total tenths in sequence ( 0 = no)
 	int					anim_min, anim_max;		// time for this frame min <=time< max
 	struct texture_s	*anim_next;		// in the animation sequence

--- a/common/lightgrid.c
+++ b/common/lightgrid.c
@@ -18,6 +18,47 @@ typedef struct lightgrid_v2_header_s
     vec3_t origin;
 } lightgrid_v2_header_t;
 
+static float LightgridRAW_HalfToFloat(unsigned short h)
+{
+    unsigned int sign = (unsigned int)(h & 0x8000) << 16;
+    unsigned int exp = (h >> 10) & 0x1f;
+    unsigned int mant = h & 0x3ff;
+    unsigned int f;
+
+    if (exp == 0)
+    {
+        if (mant == 0)
+        {
+            f = sign;
+        }
+        else
+        {
+            exp = 1;
+            while ((mant & 0x400) == 0)
+            {
+                mant <<= 1;
+                exp--;
+            }
+            mant &= ~0x400;
+            exp += (127 - 15);
+            mant <<= 13;
+            f = sign | (exp << 23) | mant;
+        }
+    }
+    else if (exp == 31)
+    {
+        f = sign | 0x7f800000 | (mant << 13);
+    }
+    else
+    {
+        exp = exp + (127 - 15);
+        mant = mant << 13;
+        f = sign | (exp << 23) | mant;
+    }
+
+    return *((float *)&f);
+}
+
 lightgrid_t *Lightgrid_Alloc(int nx, int ny, int nz, float cellsize, const vec3_t mins, const vec3_t maxs)
 {
     if (nx <= 0 || ny <= 0 || nz <= 0)

--- a/common/lightgrid.h
+++ b/common/lightgrid.h
@@ -11,6 +11,8 @@ typedef struct lightcell_s {
     vec3_t dir;
     float intensity;
     float ao;
+    float emissive;
+    qboolean sh_valid;
     sh9_color_t *sh9; // NULL unless Lightgrid V3 allocates it
 } lightcell_t;
 typedef lightcell_t lightgrid_probe_t;


### PR DESCRIPTION
## Summary
- add half-float conversion helper for lightgrid loading
- extend lightgrid probes with emissive and SH validity flags
- add emissive texture slot to texture metadata

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b3be721e0832ea3c1171e4e9bcece)