### PR TITLE
Fix alias emissive textures build errors

### DIFF
--- a/Quake/common.c
+++ b/Quake/common.c
@@ -1242,7 +1242,6 @@ if path doesn't have a .EXT, append extension
 (extension should include the leading ".")
 ==================
 */
-#if 0 /* can be dangerous */
 void COM_DefaultExtension (char *path, const char *extension, size_t len)
 {
 	char	*src;
@@ -1259,7 +1258,6 @@ void COM_DefaultExtension (char *path, const char *extension, size_t len)
 
 	q_strlcat(path, extension, len);
 }
-#endif
 
 /*
 ==================

--- a/Quake/common.h
+++ b/Quake/common.h
@@ -327,9 +327,7 @@ const char *COM_SkipSpace (const char *str);
 void COM_StripExtension (const char *in, char *out, size_t outsize);
 void COM_FileBase (const char *in, char *out, size_t outsize);
 void COM_AddExtension (char *path, const char *extension, size_t len);
-#if 0 /* COM_DefaultExtension can be dangerous */
 void COM_DefaultExtension (char *path, const char *extension, size_t len);
-#endif
 const char *COM_FileGetExtension (const char *in); /* doesn't return NULL */
 qboolean COM_HasExtension (const char *path, const char *extension);
 void COM_ExtractExtension (const char *in, char *out, size_t outsize);

--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -3528,7 +3528,7 @@ static qboolean BSPX_LightGridLoad (qmodel_t *mod, void *lump, int lumpsize)
 #endif
 
 	COM_StripExtension(mod->name, path, sizeof(path));
-	COM_DefaultExtension(path, ".lgrd");
+COM_DefaultExtension(path, ".lgrd", sizeof(path));
 
 	lg = Lightgrid_LoadExternal(path);
 	if (!lg)

--- a/Quake/gl_model.h
+++ b/Quake/gl_model.h
@@ -348,6 +348,7 @@ typedef struct {
 	} poseverttype;	//spike
 	struct gltexture_s	*gltextures[MAX_SKINS][4]; //johnfitz
 	struct gltexture_s	*fbtextures[MAX_SKINS][4]; //johnfitz
+	struct gltexture_s		*emissivetextures[MAX_SKINS][4];
 	int					texels[MAX_SKINS];	// only for player skins
 	maliasframedesc_t	frames[1];	// variable sized
 } aliashdr_t;


### PR DESCRIPTION
## Summary
- expose COM_DefaultExtension so lightgrid loading compiles
- add emissive texture slots to alias headers to match usage
- update lightgrid extension call to pass the buffer length

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b3f2d2d28832ea7123756c4783453)