### PR TITLE
Use deluxemap directions in lightgrid generation

### DIFF
--- a/Quake/gl_lightgrid.c
+++ b/Quake/gl_lightgrid.c
@@ -998,7 +998,9 @@ lightgrid_raw_t *Lightgrid_GenerateRaw(const struct qmodel_s *model)
         mleaf_t *leaf;
         vec3_t pos;
         vec3_t color;
+        vec3_t dir;
         qboolean valid;
+        qboolean dir_valid;
     } lightmap_cache = {0};
 
     const float weight_direct    = r_lightgrid_weight_direct.value;
@@ -1039,6 +1041,8 @@ lightgrid_raw_t *Lightgrid_GenerateRaw(const struct qmodel_s *model)
 
                 vec3_t direct = {0, 0, 0};
                 vec3_t lightmap = {0, 0, 0};
+                vec3_t lightmap_dir = {0, 0, 0};
+                qboolean lightmap_dir_valid = false;
                 vec3_t dirsum = {0,0,0};
 
                 vec3_t pos_copy;
@@ -1065,19 +1069,24 @@ lightgrid_raw_t *Lightgrid_GenerateRaw(const struct qmodel_s *model)
                     if (DotProduct(delta, delta) < 0.0625f)
                     {
                         VectorCopy(lightmap_cache.color, lightmap);
+                        VectorCopy(lightmap_cache.dir, lightmap_dir);
+                        lightmap_dir_valid = lightmap_cache.dir_valid;
                         lightmap_found = true;
                     }
                 }
 
                 if (!lightmap_found)
                 {
-                    lightmap_found = R_SampleLightmapAtPoint(pos, lightmap);
+                    lightmap_found = R_SampleLightmapAndDeluxemapAtPoint(pos, lightmap, lightmap_dir);
+                    lightmap_dir_valid = VectorLength(lightmap_dir) > 0.f;
                     if (lightmap_found)
                     {
                         VectorCopy(lightmap, lightmap_cache.color);
                         VectorCopy(pos, lightmap_cache.pos);
                         lightmap_cache.leaf = leaf;
                         lightmap_cache.valid = true;
+                        VectorCopy(lightmap_dir, lightmap_cache.dir);
+                        lightmap_cache.dir_valid = lightmap_dir_valid;
                     }
                 }
 
@@ -1125,6 +1134,38 @@ lightgrid_raw_t *Lightgrid_GenerateRaw(const struct qmodel_s *model)
                 if (weight_lightmap > 0.f)
                     VectorMA(cell->rgb, weight_lightmap, lightmap, cell->rgb);
 
+                if (weight_lightmap > 0.f && lightmap_dir_valid)
+                {
+                    const float lm_luma = DotProduct(lightmap, luminance_weights) * weight_lightmap;
+                    if (lm_luma > 0.f)
+                        VectorMA(dirsum, lm_luma, lightmap_dir, dirsum);
+                }
+
+                if (weight_direct > 0.f)
+                {
+                    vec3_t direct_dir;
+                    qboolean direct_dir_valid = false;
+
+                    if (lightmap_dir_valid)
+                    {
+                        VectorCopy(lightmap_dir, direct_dir);
+                        direct_dir_valid = true;
+                    }
+                    else
+                    {
+                        vec3_t unused_color;
+                        if (R_SampleLightmapAndDeluxemapAtPoint(pos, unused_color, direct_dir))
+                            direct_dir_valid = VectorLength(direct_dir) > 0.f;
+                    }
+
+                    if (direct_dir_valid)
+                    {
+                        const float dir_luma = DotProduct(direct, luminance_weights) * weight_direct;
+                        if (dir_luma > 0.f)
+                            VectorMA(dirsum, dir_luma, direct_dir, dirsum);
+                    }
+                }
+
                 Lightgrid_AddDlights(pos, cell->rgb, dirsum);
 
                 /* Second bounce approximation */
@@ -1148,9 +1189,13 @@ lightgrid_raw_t *Lightgrid_GenerateRaw(const struct qmodel_s *model)
                                 continue;
 
                             vec3_t hit_color;
-                            if (R_SampleLightmapAtPoint(impact, hit_color))
+                            vec3_t hit_dir;
+                            if (R_SampleLightmapAndDeluxemapAtPoint(impact, hit_color, hit_dir))
                             {
                                 VectorMA(bounce_accum, bounce_scale, hit_color, bounce_accum);
+                                const float hit_luma = DotProduct(hit_color, luminance_weights) * bounce_scale;
+                                if (hit_luma > 0.f && VectorLength(hit_dir) > 0.f)
+                                    VectorMA(dirsum, hit_luma, hit_dir, dirsum);
                                 residual -= bounce_scale;
                             }
                         }

--- a/Quake/gl_rlight.c
+++ b/Quake/gl_rlight.c
@@ -358,17 +358,67 @@ void R_AddDynamicLights_Lightgrid (const vec3_t pos, vec3_t lightcolor)
 
 static inline int LightStyleValue (unsigned short style)
 {
-	if (style < 256)
-		return d_lightstylevalue[style];
+if (style < 256)
+return d_lightstylevalue[style];
 
-	return d_lightstylevalue[0];
+return d_lightstylevalue[0];
+}
+
+static qboolean SampleDeluxemapDir(const qmodel_t *model, const msurface_t *surf, int ds, int dt, vec3_t out_dir)
+{
+const byte *samples;
+int smax, tmax;
+int dsfrac = ds & 15, dtfrac = dt & 15;
+float fsfrac = dsfrac * (1.f / 16.f);
+float ftfrac = dtfrac * (1.f / 16.f);
+const float to_signed = 2.f * (1.f / 255.f);
+
+if (!model || !model->lightdirdata || !surf || !surf->luxsamples)
+{
+VectorClear(out_dir);
+return false;
+}
+
+samples = surf->luxsamples;
+smax = (surf->extents[0] >> 4) + 1;
+tmax = (surf->extents[1] >> 4) + 1;
+
+const int s0 = ds >> 4;
+const int t0 = dt >> 4;
+const int stride = smax * 3;
+
+const byte *row0 = samples + t0 * stride;
+const byte *row1 = (t0 + 1 < tmax) ? row0 + stride : row0;
+const byte *col00 = row0 + s0 * 3;
+const byte *col10 = (s0 + 1 < smax) ? col00 + 3 : col00;
+const byte *col01 = row1 + s0 * 3;
+const byte *col11 = (s0 + 1 < smax) ? col01 + 3 : col01;
+
+vec3_t lux00 = {col00[0] * to_signed - 1.f, col00[1] * to_signed - 1.f, col00[2] * to_signed - 1.f};
+vec3_t lux10 = {col10[0] * to_signed - 1.f, col10[1] * to_signed - 1.f, col10[2] * to_signed - 1.f};
+vec3_t lux01 = {col01[0] * to_signed - 1.f, col01[1] * to_signed - 1.f, col01[2] * to_signed - 1.f};
+vec3_t lux11 = {col11[0] * to_signed - 1.f, col11[1] * to_signed - 1.f, col11[2] * to_signed - 1.f};
+
+vec3_t top, bottom;
+VectorLerp(lux00, fsfrac, lux10, top);
+VectorLerp(lux01, fsfrac, lux11, bottom);
+VectorLerp(top, ftfrac, bottom, out_dir);
+
+const float len = VectorNormalize(out_dir);
+if (len < 1e-6f || !R_IsFinite(len))
+{
+VectorClear(out_dir);
+return false;
+}
+
+return true;
 }
 
 static void InterpolateLightmap (qmodel_t *model, vec3_t color, msurface_t *surf, int ds, int dt, qboolean use_rgb)
 {
-        const byte *samples;
-        int smax, tmax;
-        int dsfrac = ds & 15, dtfrac = dt & 15;
+const byte *samples;
+int smax, tmax;
+int dsfrac = ds & 15, dtfrac = dt & 15;
         float fsfrac = dsfrac * (1.f / 16.f);
         float ftfrac = dtfrac * (1.f / 16.f);
         int bytes_per_pixel;
@@ -526,32 +576,35 @@ static void R_SamplePointInternal (qmodel_t *model, const vec3_t pos, float ofs,
         {
                 InterpolateLightmap (model, out_color, model->surfaces + cache->surfidx - 1, cache->ds, cache->dt, use_rgblight);
                 R_ClampSampleColor (out_color);
-        }
+}
 }
 
-qboolean R_SampleLightmapAtPoint(const vec3_t pos, vec3_t out_rgb)
+static qboolean R_SampleLightmapAtPointInternal(const vec3_t pos, vec3_t out_rgb, vec3_t out_dir, qboolean want_dir)
 {
-        qmodel_t *model = cl.worldmodel;
-        qboolean use_rgblight;
-        qboolean found = false;
-        float best_dist = FLT_MAX;
+qmodel_t *model = cl.worldmodel;
+qboolean use_rgblight;
+qboolean found = false;
+qboolean dir_valid = false;
+float best_dist = FLT_MAX;
 
-        VectorClear(out_rgb);
+VectorClear(out_rgb);
+if (out_dir)
+VectorClear(out_dir);
 
-        if (!model || !model->lightdata)
-                return false;
+if (!model || !model->lightdata)
+return false;
 
         use_rgblight = model->has_lightdata_rgb && r_rgblighting_enable.value;
 
         vec3_t pos_copy;
         VectorCopy(pos, pos_copy);
         mleaf_t *leaf = Mod_PointInLeaf(pos_copy, model);
-        if (!leaf || leaf->contents == CONTENTS_SOLID)
-                return false;
+if (!leaf || leaf->contents == CONTENTS_SOLID)
+return false;
 
-        for (int i = 0; i < leaf->nummarksurfaces; i++)
-        {
-                msurface_t *surf = &model->surfaces[leaf->firstmarksurface[i]];
+for (int i = 0; i < leaf->nummarksurfaces; i++)
+{
+msurface_t *surf = &model->surfaces[leaf->firstmarksurface[i]];
 
                 if (!surf->texinfo || (surf->flags & SURF_DRAWTILED))
                         continue;
@@ -569,40 +622,57 @@ qboolean R_SampleLightmapAtPoint(const vec3_t pos, vec3_t out_rgb)
                 ds -= surf->texturemins[0];
                 dt -= surf->texturemins[1];
 
-                if (ds > surf->extents[0] || dt > surf->extents[1])
-                        continue;
+if (ds > surf->extents[0] || dt > surf->extents[1])
+continue;
 
-                vec3_t color;
-                if (surf->samples)
-                {
-                        InterpolateLightmap(model, color, surf, ds, dt, use_rgblight);
-                }
-                else
-                {
-                        R_SurfaceFallbackColor(model, surf, color);
-                }
+vec3_t color;
+if (surf->samples)
+{
+InterpolateLightmap(model, color, surf, ds, dt, use_rgblight);
+}
+else
+{
+R_SurfaceFallbackColor(model, surf, color);
+}
 
-                if (!VectorLength(color))
-                        continue;
+if (!VectorLength(color))
+continue;
 
-                const float adist = fabsf(pdist);
-                if (adist < best_dist)
-                {
-                        VectorCopy(color, out_rgb);
-                        best_dist = adist;
-                        found = true;
-                }
-        }
+const float adist = fabsf(pdist);
+if (adist < best_dist)
+{
+VectorCopy(color, out_rgb);
+best_dist = adist;
+found = true;
 
-        if (found)
-        {
-                VectorScale(out_rgb, 1.f / 255.f, out_rgb);
-                return true;
-        }
+if (want_dir && out_dir && surf->luxsamples)
+dir_valid = SampleDeluxemapDir(model, surf, ds, dt, out_dir);
+}
+}
 
-        R_SurfaceFallbackColor(model, NULL, out_rgb);
-        VectorScale(out_rgb, 1.f / 255.f, out_rgb);
-        return false;
+if (found)
+{
+VectorScale(out_rgb, 1.f / 255.f, out_rgb);
+if (want_dir && out_dir && !dir_valid)
+VectorClear(out_dir);
+return true;
+}
+
+R_SurfaceFallbackColor(model, NULL, out_rgb);
+VectorScale(out_rgb, 1.f / 255.f, out_rgb);
+if (want_dir && out_dir)
+VectorClear(out_dir);
+return false;
+}
+
+qboolean R_SampleLightmapAtPoint(const vec3_t pos, vec3_t out_rgb)
+{
+return R_SampleLightmapAtPointInternal(pos, out_rgb, NULL, false);
+}
+
+qboolean R_SampleLightmapAndDeluxemapAtPoint(const vec3_t pos, vec3_t out_rgb, vec3_t out_dir)
+{
+return R_SampleLightmapAtPointInternal(pos, out_rgb, out_dir, true);
 }
 
 /*

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -519,6 +519,7 @@ void GLMesh_DeleteVertexBuffers (void);
 
 int R_LightPoint (qmodel_t *model, vec3_t p, float ofs, lightcache_t *cache);
 qboolean R_SampleLightmapAtPoint(const vec3_t pos, vec3_t out_rgb);
+qboolean R_SampleLightmapAndDeluxemapAtPoint(const vec3_t pos, vec3_t out_rgb, vec3_t out_dir);
 qboolean R_LightgridEnabled (void);
 void R_LightgridLighting (const vec3_t pos, vec3_t out_color);
 void R_LightgridLightingDir (const vec3_t pos, vec3_t out_color, vec3_t out_dir);


### PR DESCRIPTION
## Summary
- add deluxemap sampling helpers to retrieve baked directional vectors from .lux data
- accumulate lux-weighted directions throughout raw lightgrid generation, including cached, direct, and bounce samples
- preserve existing behavior when deluxemap data is missing while keeping lightgrid direction normalization stable

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f575658b4832e9d253238c86e77e2)