### PR TITLE
Add BSPX lightgrid octree backend

### DIFF
--- a/Quake/gl_lightgrid.c
+++ b/Quake/gl_lightgrid.c
@@ -141,6 +141,9 @@ void Lightgrid_UploadToGPU(lightgrid_t *lg)
     if (!lg)
         return;
 
+    if (lg->backend != LIGHTGRID_BACKEND_RAW || !lg->probes)
+        return;
+
     count = (size_t)lg->nx * (size_t)lg->ny * (size_t)lg->nz;
     if (count == 0 || count > LIGHTGRID_MAX_CELLS)
         return;
@@ -710,24 +713,14 @@ static void Lightgrid_DefaultSample(vec3_t out_color, vec3_t out_dir)
     VectorSet(out_dir, 0,0,1);
 }
 
-static const lightcell_t *Lightgrid_At(const lightgrid_t *lg, int x, int y, int z)
+static qboolean Lightgrid_SampleRawProbe(const lightgrid_t *lg, const vec3_t pos, lightgrid_probe_t *out_probe)
 {
-    return &lg->probes[
-        (size_t)z * lg->ny * lg->nx +
-        (size_t)y * lg->nx +
-        x
-    ];
-}
+    float fx, fy, fz;
+    int x0, x1, y0, y1, z0, z1;
+    const lightcell_t *c000, *c100, *c010, *c110, *c001, *c101, *c011, *c111;
 
-void Lightgrid_Sample(const vec3_t pos, vec3_t out_color, vec3_t out_dir)
-{
-    const lightgrid_t *lg = Lightgrid_Get();
-
-    if (!lg || !lg->probes || lg->cellsize <= 0.f || !r_lightgrid.value)
-    {
-        Lightgrid_DefaultSample(out_color, out_dir);
-        return;
-    }
+    if (!lg || !lg->probes || !out_probe || lg->cellsize <= 0.f)
+        return false;
 
     vec3_t p;
     VectorCopy(pos, p);
@@ -735,88 +728,198 @@ void Lightgrid_Sample(const vec3_t pos, vec3_t out_color, vec3_t out_dir)
     for (int i = 0; i < 3; i++)
         p[i] = CLAMP(lg->mins[i], p[i], lg->maxs[i]);
 
-    float fx = (p[0] - lg->mins[0]) / lg->cellsize;
-    float fy = (p[1] - lg->mins[1]) / lg->cellsize;
-    float fz = (p[2] - lg->mins[2]) / lg->cellsize;
+    fx = (p[0] - lg->mins[0]) / lg->cellsize;
+    fy = (p[1] - lg->mins[1]) / lg->cellsize;
+    fz = (p[2] - lg->mins[2]) / lg->cellsize;
 
-    int x0 = CLAMP(0, (int)floorf(fx), lg->nx - 1);
-    int y0 = CLAMP(0, (int)floorf(fy), lg->ny - 1);
-    int z0 = CLAMP(0, (int)floorf(fz), lg->nz - 1);
+    x0 = CLAMP(0, (int)floorf(fx), lg->nx - 1);
+    y0 = CLAMP(0, (int)floorf(fy), lg->ny - 1);
+    z0 = CLAMP(0, (int)floorf(fz), lg->nz - 1);
 
-    int x1 = q_min(x0 + 1, lg->nx - 1);
-    int y1 = q_min(y0 + 1, lg->ny - 1);
-    int z1 = q_min(z0 + 1, lg->nz - 1);
+    x1 = q_min(x0 + 1, lg->nx - 1);
+    y1 = q_min(y0 + 1, lg->ny - 1);
+    z1 = q_min(z0 + 1, lg->nz - 1);
 
     fx -= floorf(fx);
     fy -= floorf(fy);
     fz -= floorf(fz);
 
-    const lightcell_t *c000 = Lightgrid_At(lg, x0, y0, z0);
-    const lightcell_t *c100 = Lightgrid_At(lg, x1, y0, z0);
-    const lightcell_t *c010 = Lightgrid_At(lg, x0, y1, z0);
-    const lightcell_t *c110 = Lightgrid_At(lg, x1, y1, z0);
-    const lightcell_t *c001 = Lightgrid_At(lg, x0, y0, z1);
-    const lightcell_t *c101 = Lightgrid_At(lg, x1, y0, z1);
-    const lightcell_t *c011 = Lightgrid_At(lg, x0, y1, z1);
-    const lightcell_t *c111 = Lightgrid_At(lg, x1, y1, z1);
+    c000 = &lg->probes[(z0 * lg->ny + y0) * lg->nx + x0];
+    c100 = &lg->probes[(z0 * lg->ny + y0) * lg->nx + x1];
+    c010 = &lg->probes[(z0 * lg->ny + y1) * lg->nx + x0];
+    c110 = &lg->probes[(z0 * lg->ny + y1) * lg->nx + x1];
+    c001 = &lg->probes[(z1 * lg->ny + y0) * lg->nx + x0];
+    c101 = &lg->probes[(z1 * lg->ny + y0) * lg->nx + x1];
+    c011 = &lg->probes[(z1 * lg->ny + y1) * lg->nx + x0];
+    c111 = &lg->probes[(z1 * lg->ny + y1) * lg->nx + x1];
 
-    vec3_t rgb000,rgb100,rgb010,rgb110,rgb001,rgb101,rgb011,rgb111;
-    vec3_t dir000,dir100,dir010,dir110,dir001,dir101,dir011,dir111;
-    vec3_t c00,c10,c01,c11,c0,c1,c;
-    vec3_t d00,d10,d01,d11,d0,d1,d;
+    for (int i = 0; i < 3; i++)
+    {
+        float c00, c10, c01, c11, c0, c1;
 
-    #define PREMUL(dst, p) \
-        VectorScale(p->rgb, p->intensity, dst)
+        c00 = Lerp(c000->rgb[i], c100->rgb[i], fx);
+        c10 = Lerp(c010->rgb[i], c110->rgb[i], fx);
+        c01 = Lerp(c001->rgb[i], c101->rgb[i], fx);
+        c11 = Lerp(c011->rgb[i], c111->rgb[i], fx);
 
-    PREMUL(rgb000, c000);
-    PREMUL(rgb100, c100);
-    PREMUL(rgb010, c010);
-    PREMUL(rgb110, c110);
-    PREMUL(rgb001, c001);
-    PREMUL(rgb101, c101);
-    PREMUL(rgb011, c011);
-    PREMUL(rgb111, c111);
+        c0 = Lerp(c00, c10, fy);
+        c1 = Lerp(c01, c11, fy);
 
-    #undef PREMUL
+        out_probe->rgb[i] = Lerp(c0, c1, fz);
+    }
 
-    #define PREMUL_DIR(dst,p) VectorScale(p->dir, p->intensity, dst)
+    out_probe->intensity = Lerp(
+        Lerp(Lerp(c000->intensity, c100->intensity, fx), Lerp(c010->intensity, c110->intensity, fx), fy),
+        Lerp(Lerp(c001->intensity, c101->intensity, fx), Lerp(c011->intensity, c111->intensity, fx), fy),
+        fz);
 
-    PREMUL_DIR(dir000, c000);
-    PREMUL_DIR(dir100, c100);
-    PREMUL_DIR(dir010, c010);
-    PREMUL_DIR(dir110, c110);
-    PREMUL_DIR(dir001, c001);
-    PREMUL_DIR(dir101, c101);
-    PREMUL_DIR(dir011, c011);
-    PREMUL_DIR(dir111, c111);
+    out_probe->emissive = Lerp(
+        Lerp(Lerp(c000->emissive, c100->emissive, fx), Lerp(c010->emissive, c110->emissive, fx), fy),
+        Lerp(Lerp(c001->emissive, c101->emissive, fx), Lerp(c011->emissive, c111->emissive, fx), fy),
+        fz);
 
-    #undef PREMUL_DIR
+    out_probe->ao = Lerp(
+        Lerp(Lerp(c000->ao, c100->ao, fx), Lerp(c010->ao, c110->ao, fx), fy),
+        Lerp(Lerp(c001->ao, c101->ao, fx), Lerp(c011->ao, c111->ao, fx), fy),
+        fz);
 
-    VectorLerp(rgb000, rgb100, fx, c00);
-    VectorLerp(rgb010, rgb110, fx, c10);
-    VectorLerp(rgb001, rgb101, fx, c01);
-    VectorLerp(rgb011, rgb111, fx, c11);
+    {
+        vec3_t d00, d10, d01, d11, d0, d1, dir;
 
-    VectorLerp(c00, c10, fy, c0);
-    VectorLerp(c01, c11, fy, c1);
+#define PREMUL_DIR(dst,p) VectorScale((p)->dir, (p)->intensity, (dst))
+        PREMUL_DIR(d00, c000);
+        PREMUL_DIR(d10, c010);
+        PREMUL_DIR(d01, c001);
+        PREMUL_DIR(d11, c011);
+#undef PREMUL_DIR
 
-    VectorLerp(c0, c1, fz, c);
+        VectorLerp(d00, d10, fx, d0);
+        VectorLerp(d01, d11, fx, d1);
 
-    VectorLerp(dir000, dir100, fx, d00);
-    VectorLerp(dir010, dir110, fx, d10);
-    VectorLerp(dir001, dir101, fx, d01);
-    VectorLerp(dir011, dir111, fx, d11);
+        VectorLerp(d0, d1, fz, dir);
+        if (VectorNormalize(dir) == 0.f)
+            VectorSet(dir, 0.f, 0.f, 1.f);
 
-    VectorLerp(d00, d10, fy, d0);
-    VectorLerp(d01, d11, fy, d1);
+        VectorCopy(dir, out_probe->dir);
+    }
 
-    VectorLerp(d0, d1, fz, d);
+    out_probe->sh_valid = false;
+    out_probe->sh9 = NULL;
 
-    if (VectorNormalize(d) == 0)
-        VectorSet(d,0,0,1);
+    return true;
+}
 
-    VectorCopy(c, out_color);
-    VectorCopy(d, out_dir);
+static qboolean Lightgrid_SampleOctreeProbe(const lightgrid_t *lg, const vec3_t pos, lightgrid_probe_t *out_probe)
+{
+    const lightgrid_octree_t *oct = lg ? lg->octree : NULL;
+    vec3_t node_mins, node_maxs, center;
+    size_t steps = 0;
+    uint32_t node_index;
+    const lightgrid_octree_node_t *node;
+    const lightgrid_octree_leaf_t *leaf = NULL;
+
+    if (!oct || !out_probe)
+        return false;
+
+    VectorCopy(oct->mins, node_mins);
+    VectorCopy(oct->maxs, node_maxs);
+
+    VectorCopy(pos, center);
+    for (int i = 0; i < 3; i++)
+        center[i] = CLAMP(node_mins[i], center[i], node_maxs[i]);
+
+    node_index = oct->root_node;
+
+    while (steps < oct->node_count)
+    {
+        node = &oct->nodes[node_index];
+
+        VectorLerp(node_mins, node_maxs, 0.5f, center);
+
+        int child = 0;
+        if (pos[0] >= center[0]) child |= 1;
+        if (pos[1] >= center[1]) child |= 2;
+        if (pos[2] >= center[2]) child |= 4;
+
+        uint32_t raw_child = node->child[child];
+
+        if (raw_child == LIGHTGRID_OCTREE_CHILD_EMPTY)
+            break;
+
+        if (raw_child & LIGHTGRID_OCTREE_CHILD_LEAF)
+        {
+            uint32_t leaf_index = raw_child & ~LIGHTGRID_OCTREE_CHILD_LEAF;
+            if (leaf_index >= oct->leaf_count)
+                return false;
+            leaf = &oct->leaves[leaf_index];
+            break;
+        }
+
+        if (raw_child >= oct->node_count)
+            return false;
+
+        /* descend into child node */
+        if (pos[0] >= center[0])
+            node_mins[0] = center[0];
+        else
+            node_maxs[0] = center[0];
+        if (pos[1] >= center[1])
+            node_mins[1] = center[1];
+        else
+            node_maxs[1] = center[1];
+        if (pos[2] >= center[2])
+            node_mins[2] = center[2];
+        else
+            node_maxs[2] = center[2];
+
+        node_index = raw_child;
+        steps++;
+    }
+
+    if (!leaf)
+        return false;
+
+    VectorCopy(leaf->rgb, out_probe->rgb);
+    VectorCopy(leaf->dir, out_probe->dir);
+    if (VectorNormalize(out_probe->dir) == 0.f)
+        VectorSet(out_probe->dir, 0.f, 0.f, 1.f);
+    out_probe->intensity = leaf->intensity;
+    out_probe->ao = 0.f;
+    out_probe->emissive = 0.f;
+    out_probe->sh_valid = false;
+    out_probe->sh9 = NULL;
+    return true;
+}
+
+qboolean Lightgrid_SampleProbe(const lightgrid_t *lg, const vec3_t pos, lightgrid_probe_t *out_probe)
+{
+    if (!lg || !out_probe || !r_lightgrid.value)
+        return false;
+
+    switch (lg->backend)
+    {
+    case LIGHTGRID_BACKEND_OCTREE:
+        return Lightgrid_SampleOctreeProbe(lg, pos, out_probe);
+    case LIGHTGRID_BACKEND_RAW:
+        return Lightgrid_SampleRawProbe(lg, pos, out_probe);
+    default:
+        return false;
+    }
+}
+
+void Lightgrid_Sample(const vec3_t pos, vec3_t out_color, vec3_t out_dir)
+{
+    const lightgrid_t *lg = Lightgrid_Get();
+    lightgrid_probe_t probe;
+
+    if (!Lightgrid_SampleProbe(lg, pos, &probe))
+    {
+        Lightgrid_DefaultSample(out_color, out_dir);
+        return;
+    }
+
+    VectorScale(probe.rgb, probe.intensity, out_color);
+    VectorCopy(probe.dir, out_dir);
 }
 
 /* =====================================================================

--- a/Quake/gl_lightgrid.h
+++ b/Quake/gl_lightgrid.h
@@ -36,6 +36,7 @@ lightgrid_t *Lightgrid_FromRaw (const lightgrid_raw_t *raw);
 lightgrid_raw_t *Lightgrid_GenerateRaw (const struct qmodel_s *model);
 void Lightgrid_BuildFallback (void);
 void Lightgrid_Sample (const vec3_t pos, vec3_t out_color, vec3_t out_dir);
+qboolean Lightgrid_SampleProbe (const lightgrid_t *lg, const vec3_t pos, lightgrid_probe_t *out_probe);
 const lightgrid_t *Lightgrid_Get (void);
 void Lightgrid_SetSource (const char *name);
 const char *Lightgrid_GetSource (void);

--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -47,6 +47,7 @@ static qboolean Mod_IsInlineSubmodel (const qmodel_t *mod);
 static qboolean Mod_IsExternalBrushModel (const qmodel_t *mod);
 static qboolean Mod_ShouldSkipBrushExtras (const qmodel_t *mod);
 static qboolean BSPX_LightGridLoad (qmodel_t *mod, void *lump, int lumpsize);
+static qboolean LightgridOctree_LoadBSPX (qmodel_t *mod, void *data, int size);
 static qboolean LightgridRAW_Load (qmodel_t *mod, void *data, int size, const char *source_path);
 static qboolean LightgridRAW_BuildBuffer (qmodel_t *mod, byte **out_buffer, size_t *out_size);
 static void Lightgrid_Info_f (void);
@@ -2765,6 +2766,161 @@ static qboolean LightgridRAW_Load (qmodel_t *mod, void *data, int size, const ch
         return true;
 }
 
+
+static qboolean LightgridOctree_LoadBSPX (qmodel_t *mod, void *data, int size)
+{
+	const lightgrid_octree_header_t *hdr;
+	const lightgrid_octree_disk_node_t *disk_nodes;
+	lightgrid_octree_t *oct;
+	lightgrid_t *lg;
+	vec3_t mins, maxs;
+	uint32_t version, flags, nodes_offset, leaves_offset, leaf_stride;
+	uint32_t node_count, leaf_count, root_node;
+	size_t nodes_size, leaves_size;
+	const byte *payload;
+
+	if (!mod || !data || size < (int)sizeof(lightgrid_octree_header_t))
+		return false;
+
+	payload = (const byte *)data;
+	hdr = (const lightgrid_octree_header_t *)payload;
+
+	if (LittleLong (hdr->magic) != LIGHTGRID_OCTREE_MAGIC)
+		return false;
+
+	version = LittleLong (hdr->version);
+	if (version != LIGHTGRID_OCTREE_VERSION_1)
+		return false;
+
+	flags = LittleLong (hdr->flags);
+	if ((flags & LIGHTGRID_OCTREE_FLAG_FLOAT32) == 0)
+		return false;
+
+	root_node = LittleLong (hdr->root_node);
+	node_count = LittleLong (hdr->node_count);
+	leaf_count = LittleLong (hdr->leaf_count);
+	nodes_offset = LittleLong (hdr->nodes_offset);
+	leaves_offset = LittleLong (hdr->leaves_offset);
+	leaf_stride = LittleLong (hdr->leaf_stride);
+
+	if (!node_count || !leaf_count)
+		return false;
+
+	if (root_node >= node_count)
+		return false;
+
+	if ((nodes_offset & 3u) || (leaves_offset & 3u) || (leaf_stride & 3u))
+		return false;
+
+	if (nodes_offset > leaves_offset)
+		return false;
+
+	if (leaf_stride < sizeof(lightgrid_octree_disk_leaf_t))
+		return false;
+
+	if ((size_t)node_count > SIZE_MAX / sizeof(lightgrid_octree_disk_node_t))
+		return false;
+	nodes_size = (size_t)node_count * sizeof(lightgrid_octree_disk_node_t);
+	if (nodes_offset + nodes_size > (size_t)size)
+		return false;
+
+	if ((size_t)leaf_count > SIZE_MAX / (size_t)leaf_stride)
+		return false;
+	leaves_size = (size_t)leaf_count * (size_t)leaf_stride;
+	if ((size_t)leaves_offset + leaves_size > (size_t)size)
+		return false;
+
+	mins[0] = LittleFloat (hdr->mins[0]);
+	mins[1] = LittleFloat (hdr->mins[1]);
+	mins[2] = LittleFloat (hdr->mins[2]);
+	maxs[0] = LittleFloat (hdr->maxs[0]);
+	maxs[1] = LittleFloat (hdr->maxs[1]);
+	maxs[2] = LittleFloat (hdr->maxs[2]);
+
+	for (int i = 0; i < 3; i++)
+	{
+		if (!isfinite (mins[i]) || !isfinite (maxs[i]) || mins[i] > maxs[i])
+			return false;
+	}
+
+	disk_nodes = (const lightgrid_octree_disk_node_t *)(payload + nodes_offset);
+	for (size_t i = 0; i < node_count; i++)
+	{
+		for (int c = 0; c < 8; c++)
+		{
+			uint32_t child = LittleLong (disk_nodes[i].child[c]);
+
+			if (child == LIGHTGRID_OCTREE_CHILD_EMPTY)
+				continue;
+			if (child & LIGHTGRID_OCTREE_CHILD_LEAF)
+			{
+				uint32_t leaf_idx = child & ~LIGHTGRID_OCTREE_CHILD_LEAF;
+				if (leaf_idx >= leaf_count)
+					return false;
+			}
+			else if (child >= node_count)
+			{
+				return false;
+			}
+		}
+	}
+
+	oct = (lightgrid_octree_t *)Hunk_AllocName (sizeof(*oct), "lgoctree");
+	if (!oct)
+		return false;
+
+	memset (oct, 0, sizeof(*oct));
+	VectorCopy (mins, oct->mins);
+	VectorCopy (maxs, oct->maxs);
+	oct->flags = flags;
+	oct->root_node = root_node;
+	oct->node_count = node_count;
+	oct->leaf_count = leaf_count;
+
+	oct->nodes = (lightgrid_octree_node_t *)Hunk_AllocName (node_count * sizeof(lightgrid_octree_node_t), "lgoctnodes");
+	oct->leaves = (lightgrid_octree_leaf_t *)Hunk_AllocName (leaf_count * sizeof(lightgrid_octree_leaf_t), "lgoctleaf");
+	if (!oct->nodes || !oct->leaves)
+		return false;
+
+	for (size_t i = 0; i < node_count; i++)
+	{
+		for (int c = 0; c < 8; c++)
+			oct->nodes[i].child[c] = LittleLong (disk_nodes[i].child[c]);
+	}
+
+	for (size_t i = 0; i < leaf_count; i++)
+	{
+		const lightgrid_octree_disk_leaf_t *src = (const lightgrid_octree_disk_leaf_t *)(payload + leaves_offset + i * leaf_stride);
+		lightgrid_octree_leaf_t *dst = &oct->leaves[i];
+
+		dst->rgb[0] = LittleFloat (src->rgb[0]);
+		dst->rgb[1] = LittleFloat (src->rgb[1]);
+		dst->rgb[2] = LittleFloat (src->rgb[2]);
+		dst->dir[0] = LittleFloat (src->dir[0]);
+		dst->dir[1] = LittleFloat (src->dir[1]);
+		dst->dir[2] = LittleFloat (src->dir[2]);
+		dst->intensity = LittleFloat (src->intensity);
+	}
+
+	mod->lightgrid_octree = oct;
+
+	lg = (lightgrid_t *)Hunk_AllocName (sizeof(*lg), "lightgrid");
+	if (!lg)
+		return false;
+
+	memset (lg, 0, sizeof(*lg));
+	lg->backend = LIGHTGRID_BACKEND_OCTREE;
+	lg->octree = oct;
+	lg->source = LIGHTGRID_SRC_OCTREE;
+	VectorCopy (mins, lg->mins);
+	VectorCopy (maxs, lg->maxs);
+
+	Lightgrid_Set (lg);
+
+	Con_Printf ("Loaded LIGHTGRID_OCTREE (%zu nodes, %zu leaves)\n", oct->node_count, oct->leaf_count);
+
+	return true;
+}
 typedef struct lightgrid_static_light_s
 {
         vec3_t origin;
@@ -3593,29 +3749,53 @@ static qboolean BSPX_LightGridLoad (qmodel_t *mod, void *lump, int lumpsize)
         return true;
 }
 
+
+
 static void Lightgrid_Info_f (void)
 {
-        const lightgrid_t *lg = Lightgrid_Get ();
+	const lightgrid_t *lg = Lightgrid_Get ();
 
-        if (!lg)
-        {
-                Con_Printf ("No lightgrid loaded\n");
-                return;
-        }
+	if (!lg)
+	{
+		Con_Printf ("No lightgrid loaded\n");
+		return;
+	}
 
-        {
-                size_t count = (size_t)lg->nx * (size_t)lg->ny * (size_t)lg->nz;
-                double mem_mb = (double)(count * sizeof(lightgrid_probe_t)) / (1024.0 * 1024.0);
+	switch (lg->backend)
+	{
+	case LIGHTGRID_BACKEND_OCTREE:
+	{
+		const lightgrid_octree_t *oct = lg->octree;
 
-                Con_Printf ("Lightgrid: %dx%dx%d cells, cell size %.1f\n", lg->nx, lg->ny, lg->nz, lg->cellsize);
-                Con_Printf ("Memory usage: %.2f MB\n", mem_mb);
-                Con_Printf ("Source: %s\n", Lightgrid_GetSource ());
-        }
+		if (!oct)
+		{
+			Con_Printf ("No lightgrid loaded\n");
+			return;
+		}
+
+		Con_Printf ("Lightgrid (octree): %zu nodes, %zu leaves\n", oct->node_count, oct->leaf_count);
+		Con_Printf ("Bounds: mins (%.1f %.1f %.1f) maxs (%.1f %.1f %.1f)\n",
+			oct->mins[0], oct->mins[1], oct->mins[2], oct->maxs[0], oct->maxs[1], oct->maxs[2]);
+		Con_Printf ("Source: %s\n", Lightgrid_GetSource ());
+		break;
+	}
+
+	case LIGHTGRID_BACKEND_RAW:
+	default:
+	{
+		size_t count = (size_t)lg->nx * (size_t)lg->ny * (size_t)lg->nz;
+		double mem_mb = (double)(count * sizeof(lightgrid_probe_t)) / (1024.0 * 1024.0);
+
+		Con_Printf ("Lightgrid: %dx%dx%d cells, cell size %.1f\n", lg->nx, lg->ny, lg->nz, lg->cellsize);
+		Con_Printf ("Memory usage: %.2f MB\n", mem_mb);
+		Con_Printf ("Source: %s\n", Lightgrid_GetSource ());
+		break;
+	}
+	}
 }
-
 static void Lightgrid_Dump_f (void)
 {
-        const lightgrid_t *lg = Lightgrid_Get ();
+const lightgrid_t *lg = Lightgrid_Get ();
         int argc = Cmd_Argc ();
 
         if (argc < 4)
@@ -3748,7 +3928,7 @@ static void Mod_LoadLightgrid (qmodel_t *mod)
 
                 if (lglump && lumpsize > 0)
                 {
-                        if (BSPX_LightGridLoad (mod, lglump, lumpsize))
+                        if (LightgridOctree_LoadBSPX (mod, lglump, lumpsize))
                         {
                                 Q1BSPX_MarkUsed ("LIGHTGRID_OCTREE");
                                 have_lightgrid = true;

--- a/Quake/gl_model.h
+++ b/Quake/gl_model.h
@@ -585,6 +585,7 @@ typedef struct qmodel_s
 	qboolean	viswarn; // for Mod_DecompressVis()
 	qboolean	has_lightdata_rgb;
 	lightgrid_raw_t *lightgrid_raw;
+	lightgrid_octree_t *lightgrid_octree;
 
 	int			bspversion;
 	int			bspx_entries_count;

--- a/Quake/gl_rlight.c
+++ b/Quake/gl_rlight.c
@@ -913,22 +913,14 @@ int R_LightPoint (qmodel_t *model, vec3_t p, float ofs, lightcache_t *cache)
 
 const lightgrid_probe_t *R_GetLightgridSample (const vec3_t pos)
 {
+        static lightgrid_probe_t probe;
         const lightgrid_t *lg = Lightgrid_Get ();
-        int x, y, z;
-
-        if (!lg || !lg->probes || lg->cellsize <= 0.f)
-                return NULL;
 
         if (!R_LightgridEnabledInternal (lg))
                 return NULL;
 
-        x = (int)floorf((pos[0] - lg->mins[0]) / lg->cellsize);
-        y = (int)floorf((pos[1] - lg->mins[1]) / lg->cellsize);
-        z = (int)floorf((pos[2] - lg->mins[2]) / lg->cellsize);
+        if (!Lightgrid_SampleProbe (lg, pos, &probe))
+                return NULL;
 
-        x = CLAMP(0, x, lg->nx - 1);
-        y = CLAMP(0, y, lg->ny - 1);
-        z = CLAMP(0, z, lg->nz - 1);
-
-        return &lg->probes[(z * lg->ny + y) * lg->nx + x];
+        return &probe;
 }

--- a/common/lightgrid.c
+++ b/common/lightgrid.c
@@ -75,6 +75,7 @@ lightgrid_t *Lightgrid_Alloc(int nx, int ny, int nz, float cellsize, const vec3_
         return NULL;
 
     memset(lg, 0, sizeof(*lg));
+    lg->backend = LIGHTGRID_BACKEND_RAW;
     lg->probes = (lightcell_t *)Hunk_AllocName(total * sizeof(lightcell_t), "lightgrid_probes");
     if (!lg->probes)
         return NULL;

--- a/common/lightgrid.h
+++ b/common/lightgrid.h
@@ -17,6 +17,101 @@ typedef struct lightcell_s {
 } lightcell_t;
 typedef lightcell_t lightgrid_probe_t;
 
+typedef enum lightgrid_backend_e {
+    LIGHTGRID_BACKEND_NONE = 0,
+    LIGHTGRID_BACKEND_RAW,
+    LIGHTGRID_BACKEND_OCTREE
+} lightgrid_backend_t;
+
+//
+// LIGHTGRID_OCTREE BSPX lump layout (little-endian, 4-byte aligned)
+//
+// Header (lightgrid_octree_header_t):
+//   magic   : 'LGOT' (LIGHTGRID_OCTREE_MAGIC)
+//   version : currently LIGHTGRID_OCTREE_VERSION_1
+//   flags   : bitfield (LIGHTGRID_OCTREE_FLAG_FLOAT32 required for v1)
+//   bounds  : axis-aligned mins/maxs in world space (float32)
+//   root    : index of the root node in the node array
+//   counts  : node_count + leaf_count
+//   offsets : byte offsets (from start of the lump) to the node array and
+//             leaf array. Both must be 4-byte aligned and monotonically
+//             increasing (nodes first, then leaves). leaf_stride specifies
+//             the on-disk size of each leaf payload.
+//
+// Nodes (lightgrid_octree_disk_node_t):
+//   8 uint32_t child slots. Each slot contains either:
+//     * LIGHTGRID_OCTREE_CHILD_EMPTY (0xFFFFFFFF) for a missing child
+//     * A node index (< node_count) with the high bit clear
+//     * A leaf reference with LIGHTGRID_OCTREE_CHILD_LEAF flag set and the
+//       low 31 bits holding the leaf index (< leaf_count)
+//
+// Leaves (lightgrid_octree_disk_leaf_t):
+//   Payload encoding is defined by the header flags; v1 requires
+//   LIGHTGRID_OCTREE_FLAG_FLOAT32 and stores:
+//     rgb[3]      : float32
+//     dir[3]      : float32 (unit or near-unit direction)
+//     intensity   : float32
+//   leaf_stride allows future packed/quantized payloads; for v1 it must be
+//   >= sizeof(lightgrid_octree_disk_leaf_t). Implementations must skip any
+//   trailing padding when advancing by leaf_stride bytes.
+//
+// All integer fields are little-endian; floats use IEEE-754 little-endian
+// encoding. The loader validates bounds, counts, indices, and alignment
+// before use.
+
+#define LIGHTGRID_OCTREE_MAGIC 0x544f474cU /* 'LGOT' */
+#define LIGHTGRID_OCTREE_VERSION_1 1u
+#define LIGHTGRID_OCTREE_FLAG_FLOAT32 (1u << 0) // Payload stored as float32
+
+#define LIGHTGRID_OCTREE_CHILD_EMPTY 0xFFFFFFFFu
+#define LIGHTGRID_OCTREE_CHILD_LEAF  0x80000000u
+
+typedef struct lightgrid_octree_header_s {
+    uint32_t magic;
+    uint32_t version;
+    uint32_t flags;
+    uint32_t reserved0;
+    vec3_t mins;
+    vec3_t maxs;
+    uint32_t root_node;
+    uint32_t node_count;
+    uint32_t leaf_count;
+    uint32_t nodes_offset;
+    uint32_t leaves_offset;
+    uint32_t leaf_stride;
+    uint32_t reserved1[3];
+} lightgrid_octree_header_t;
+
+typedef struct lightgrid_octree_disk_node_s {
+    uint32_t child[8];
+} lightgrid_octree_disk_node_t;
+
+typedef struct lightgrid_octree_disk_leaf_s {
+    float rgb[3];
+    float dir[3];
+    float intensity;
+} lightgrid_octree_disk_leaf_t;
+
+typedef struct lightgrid_octree_node_s {
+    uint32_t child[8];
+} lightgrid_octree_node_t;
+
+typedef struct lightgrid_octree_leaf_s {
+    vec3_t rgb;
+    vec3_t dir;
+    float intensity;
+} lightgrid_octree_leaf_t;
+
+typedef struct lightgrid_octree_s {
+    vec3_t mins, maxs;
+    uint32_t flags;
+    uint32_t root_node;
+    size_t node_count;
+    size_t leaf_count;
+    lightgrid_octree_node_t *nodes;
+    lightgrid_octree_leaf_t *leaves;
+} lightgrid_octree_t;
+
 #define LIGHTGRID_STANDARD_CELLSIZE 32.f
 #define LIGHTGRID_MAX_NX 128
 #define LIGHTGRID_MAX_NY 128
@@ -24,11 +119,17 @@ typedef lightcell_t lightgrid_probe_t;
 #define LIGHTGRID_MAX_CELLS (4 * 1024 * 1024)
 
 typedef struct lightgrid_s {
+    lightgrid_backend_t backend;
+
+    // RAW grid storage (unchanged semantics)
     int nx, ny, nz;
     float cellsize;
     vec3_t mins, maxs;
 
     lightcell_t *probes; // size = nx*ny*nz
+
+    // Optional octree backend
+    lightgrid_octree_t *octree;
 
     int source; // enum lightgrid_source_e
     GLuint tex_color3d;


### PR DESCRIPTION
## Summary
- document the LIGHTGRID_OCTREE BSPX format and add an octree backend alongside the existing raw grid
- load LIGHTGRID_OCTREE lumps into the new backend and expose unified sampling and GPU upload guards
- update lightgrid info/reporting and rendering code to seamlessly sample octree or raw data

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940722ab0f4832ebda9b8c7af6839e8)