### PR TITLE
Expose KTX2 header parse helper

### DIFF
--- a/Quake/gl_ktx2.c
+++ b/Quake/gl_ktx2.c
@@ -144,6 +144,11 @@ qboolean KTX2_IsValid(const uint8_t *data, size_t size)
     return KTX2_ParseHeader(&hdr, data, size);
 }
 
+qboolean KTX2_ParseHeaderPublic(ktx2_header_t *out, const uint8_t *data, size_t size)
+{
+    return KTX2_ParseHeader(out, data, size);
+}
+
 qboolean KTX2_TranscodeToRGBA(const uint8_t *filedata, size_t filesize, const ktx2_header_t *hdr, ktx2_decoded_image_t *out)
 {
     int i;

--- a/Quake/gl_ktx2.h
+++ b/Quake/gl_ktx2.h
@@ -45,6 +45,7 @@ typedef struct {
 } ktx2_header_t;
 
 qboolean KTX2_IsValid(const uint8_t *data, size_t size);
+qboolean KTX2_ParseHeaderPublic(ktx2_header_t *out, const uint8_t *data, size_t size);
 gltexture_t *R_LoadKTX2Texture(const char *name, const uint8_t *data, size_t size);
 void KTX2_LogInfo(const char *fmt, ...);
 void KTX2_LogError(const char *fmt, ...);


### PR DESCRIPTION
## Summary
- expose the KTX2 header parsing routine through a public helper
- declare the new helper so callers can validate KTX2 payloads before transcoding

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694184954cd4832e98e9cc2998f9a557)