### PR TITLE
Fix miniz stdio configuration and add ZIP helper prototypes

### DIFF
--- a/Quake/common.c
+++ b/Quake/common.c
@@ -46,6 +46,8 @@ static qboolean		com_modified;	// set true if using non-id files
 qboolean		fitzmode;
 
 static void COM_Path_f (void);
+static qboolean		COM_ExtractZipEntry (pack_t *pack, int file_index, void **out_data, size_t *out_size);
+static int QDECL COM_Pk3Compare (const void *a, const void *b);
 
 // if a packfile directory differs from this, it is assumed to be hacked
 #define PAK0_COUNT		339	/* id1/pak0.pak - v1.0x */

--- a/Quake/miniz.h
+++ b/Quake/miniz.h
@@ -134,7 +134,8 @@
    If all macros here are defined the only functionality remaining will be CRC-32 and adler-32. */
 
 /* Define MINIZ_NO_STDIO to disable all usage and any functions which rely on stdio for file I/O. */
-#define MINIZ_NO_STDIO
+/* Disabled: ironwail needs stdio-backed ZIP helpers such as mz_zip_reader_init_file(). */
+/* #define MINIZ_NO_STDIO */
 
 /* If MINIZ_NO_TIME is specified then the ZIP archive functions will not be able to get the current time, or */
 /* get/set file times, and the C run-time funcs that get/set times won't be called. */


### PR DESCRIPTION
## Summary
- re-enable stdio-dependent functions in miniz by disabling the MINIZ_NO_STDIO define
- add forward declarations for ZIP extraction helpers used in common.c

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694199d296a8832e8969ab7a56527ef2)