### PR TITLE
Fix zip reader helpers for Windows build

### DIFF
--- a/Quake/common.c
+++ b/Quake/common.c
@@ -47,7 +47,7 @@ qboolean		fitzmode;
 
 static void COM_Path_f (void);
 static qboolean		COM_ExtractZipEntry (pack_t *pack, int file_index, void **out_data, size_t *out_size);
-static int QDECL COM_Pk3Compare (const void *a, const void *b);
+static int COM_Pk3Compare (const void *a, const void *b);
 
 // if a packfile directory differs from this, it is assumed to be hacked
 #define PAK0_COUNT		339	/* id1/pak0.pak - v1.0x */
@@ -1949,7 +1949,7 @@ static int COM_FindFile (const char *filename, int *handle, FILE **file,
 					if (handle)
 					{
 						*handle = Sys_FileOpenTmp (extracted, extracted_size);
-						mz_free (extracted);
+MZ_FREE (extracted);
 						if (*handle == -1)
 						{
 							com_filesize = -1;
@@ -1961,7 +1961,7 @@ static int COM_FindFile (const char *filename, int *handle, FILE **file,
 					else if (file)
 					{ /* open a new temporary file on the zip entry */
 						*file = Sys_fopen_tmp (extracted, extracted_size);
-						mz_free (extracted);
+MZ_FREE (extracted);
 						if (!*file)
 						{
 							com_filesize = -1;
@@ -2509,7 +2509,7 @@ static void COM_AddEnginePak (void)
 	com_modified = modified;
 }
 
-static int QDECL COM_Pk3Compare (const void *a, const void *b)
+static int COM_Pk3Compare (const void *a, const void *b)
 {
         const char *left = *(const char *const *) a;
         const char *right = *(const char *const *) b;

--- a/Quake/miniz.c
+++ b/Quake/miniz.c
@@ -1,4 +1,5 @@
 #include "miniz.h"
+#include <stdio.h>
 
 /**************************************************************************
  *
@@ -1487,9 +1488,85 @@ static mz_bool mz_zip_reader_end_internal(mz_zip_archive *pZip, mz_bool set_last
     return status;
 }
 
+static size_t mz_zip_file_read(void *pOpaque, mz_uint64 file_ofs, void *pBuf, size_t n)
+{
+    FILE *pFile = (FILE *)pOpaque;
+
+    if (!pFile)
+        return 0;
+
+#if defined(_WIN32)
+    if (_fseeki64(pFile, file_ofs, SEEK_SET))
+        return 0;
+#else
+    if (fseeko(pFile, (off_t)file_ofs, SEEK_SET))
+        return 0;
+#endif
+
+    return fread(pBuf, 1, n, pFile);
+}
+
+static mz_bool mz_zip_file_needs_keepalive(void *pOpaque)
+{
+    (void)pOpaque;
+    return MZ_FALSE;
+}
+
 mz_bool mz_zip_reader_end(mz_zip_archive *pZip)
 {
-    return mz_zip_reader_end_internal(pZip, MZ_TRUE);
+    mz_bool status = mz_zip_reader_end_internal(pZip, MZ_TRUE);
+
+    if (pZip && pZip->m_pRead == mz_zip_file_read && pZip->m_pIO_opaque)
+    {
+        fclose((FILE *)pZip->m_pIO_opaque);
+        pZip->m_pIO_opaque = NULL;
+    }
+
+    return status;
+}
+mz_bool mz_zip_reader_init_file(mz_zip_archive *pZip, const char *pFilename, mz_uint flags)
+{
+    FILE *pFile;
+    mz_uint64 file_size;
+
+    if ((!pZip) || (!pFilename))
+        return MZ_FALSE;
+
+    pFile = fopen(pFilename, "rb");
+    if (!pFile)
+        return mz_zip_set_error(pZip, MZ_ZIP_FILE_OPEN_FAILED);
+
+#if defined(_WIN32)
+    if (_fseeki64(pFile, 0, SEEK_END))
+    {
+        fclose(pFile);
+        return mz_zip_set_error(pZip, MZ_ZIP_FILE_OPEN_FAILED);
+    }
+    file_size = _ftelli64(pFile);
+    if (_fseeki64(pFile, 0, SEEK_SET))
+    {
+        fclose(pFile);
+        return mz_zip_set_error(pZip, MZ_ZIP_FILE_OPEN_FAILED);
+    }
+#else
+    if (fseeko(pFile, 0, SEEK_END))
+    {
+        fclose(pFile);
+        return mz_zip_set_error(pZip, MZ_ZIP_FILE_OPEN_FAILED);
+    }
+    file_size = (mz_uint64)ftello(pFile);
+    if (fseeko(pFile, 0, SEEK_SET))
+    {
+        fclose(pFile);
+        return mz_zip_set_error(pZip, MZ_ZIP_FILE_OPEN_FAILED);
+    }
+#endif
+
+    pZip->m_pIO_opaque = pFile;
+    pZip->m_pRead = mz_zip_file_read;
+    pZip->m_pNeeds_keepalive = mz_zip_file_needs_keepalive;
+
+    return mz_zip_reader_init(pZip, file_size, flags);
 }
 mz_bool mz_zip_reader_init(mz_zip_archive *pZip, mz_uint64 size, mz_uint flags)
 {

--- a/Quake/miniz.h
+++ b/Quake/miniz.h
@@ -649,6 +649,8 @@ typedef struct
 /* Inits a ZIP archive reader. */
 /* These functions read and validate the archive's central directory. */
 MINIZ_EXPORT mz_bool mz_zip_reader_init(mz_zip_archive *pZip, mz_uint64 size, mz_uint flags);
+/* Convenience helper to initialize a reader against a stdio-backed file. */
+MINIZ_EXPORT mz_bool mz_zip_reader_init_file(mz_zip_archive *pZip, const char *pFilename, mz_uint flags);
 
 /* Ends archive reading, freeing all allocations, and closing the input archive file if mz_zip_reader_init_file() was used. */
 MINIZ_EXPORT mz_bool mz_zip_reader_end(mz_zip_archive *pZip);


### PR DESCRIPTION
## Summary
- add stdio-based mz_zip_reader_init_file implementation and close file handles on shutdown
- replace unused mz_free calls with MZ_FREE and remove undefined QDECL qualifier

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69419c1804dc832eab4d8c5ed8966811)