### PR TITLE
Ensure miniz archive APIs stay enabled

### DIFF
--- a/Quake/miniz.h
+++ b/Quake/miniz.h
@@ -178,6 +178,11 @@
 #define MINIZ_NO_ARCHIVE_WRITING_APIS
 #endif
 
+/* ironwail relies on the archive reader helpers (e.g. mz_zip_reader_get_num_files)
+   for loading ZIP-based content, so ensure the archive APIs stay enabled even if
+   a build system tries to disable them globally. */
+#undef MINIZ_NO_ARCHIVE_APIS
+
 #if defined(__TINYC__) && (defined(__linux) || defined(__linux__))
 /* TODO: Work around "error: include file 'sys\utime.h' when compiling with tcc on Linux */
 #define MINIZ_NO_TIME


### PR DESCRIPTION
## Summary
- ensure miniz archive reader APIs remain enabled to provide mz_zip_reader_get_num_files
- guard against build configurations that disable archive support

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69419edc9700832ea8aa40ca3ab0dde7)