### PR TITLE
Fix LIGHTGRID_OCTREE BSPX loading

### DIFF
--- a/Quake/gl_lightgrid.c
+++ b/Quake/gl_lightgrid.c
@@ -243,33 +243,54 @@ static size_t Lightgrid_BackendBytes(const lightgrid_t *lg)
     case LIGHTGRID_BACKEND_OCTREE:
         if (!lg->octree)
             return 0;
-        return lg->octree->node_count * sizeof(*lg->octree->nodes) +
-               lg->octree->leaf_count * sizeof(*lg->octree->leaves);
+        if (!lg->octree->nodes || !lg->octree->leaves)
+            return 0;
+
+        size_t bytes = lg->octree->node_count * sizeof(*lg->octree->nodes);
+        bytes += lg->octree->leaf_count * sizeof(*lg->octree->leaves);
+
+        for (size_t i = 0; i < lg->octree->leaf_count; i++)
+        {
+            const lightgrid_octree_leaf_t *leaf = &lg->octree->leaves[i];
+            size_t count = (size_t)leaf->size[0] * (size_t)leaf->size[1] * (size_t)leaf->size[2];
+            bytes += count * sizeof(*leaf->samples);
+        }
+
+        return bytes;
     default:
         return 0;
     }
 }
 
-static qboolean Lightgrid_ValidateLeaf(const lightgrid_octree_leaf_t *leaf, size_t leaf_index, qboolean verbose)
+static qboolean Lightgrid_ValidateLeaf(const lightgrid_octree_t *oct, const lightgrid_octree_leaf_t *leaf, size_t leaf_index, qboolean verbose)
 {
     if (!leaf)
         return false;
 
-    for (int i = 0; i < 3; i++)
-    {
-        if (!R_IsFinite(leaf->rgb[i]) || !R_IsFinite(leaf->dir[i]))
-        {
-            if (verbose)
-                Con_Printf("LIGHTGRID_OCTREE leaf %zu has non-finite payload\n", leaf_index);
-            return false;
-        }
-    }
-
-    if (!R_IsFinite(leaf->intensity) || leaf->intensity < 0.f)
+    if (leaf->size[0] <= 0 || leaf->size[1] <= 0 || leaf->size[2] <= 0)
     {
         if (verbose)
-            Con_Printf("LIGHTGRID_OCTREE leaf %zu has invalid intensity\n", leaf_index);
+            Con_Printf("LIGHTGRID_OCTREE leaf %zu has non-positive size (%d %d %d)\n", leaf_index, leaf->size[0], leaf->size[1], leaf->size[2]);
         return false;
+    }
+
+    if (!leaf->samples)
+        return false;
+
+    size_t count = (size_t)leaf->size[0] * (size_t)leaf->size[1] * (size_t)leaf->size[2];
+    for (size_t i = 0; i < count; i++)
+    {
+        const lightgrid_octree_sampleset_t *set = &leaf->samples[i];
+
+        if (set->occluded)
+            continue;
+
+        if (set->used_samples > 4 || set->used_samples > oct->header.num_styles)
+        {
+            if (verbose)
+                Con_Printf("LIGHTGRID_OCTREE leaf %zu sample %zu has invalid used_samples %u\n", leaf_index, i, set->used_samples);
+            return false;
+        }
     }
 
     return true;
@@ -287,19 +308,36 @@ qboolean Lightgrid_ValidateOctree(const lightgrid_octree_t *oct, qboolean verbos
         return false;
     }
 
-    if (oct->root_node >= oct->node_count)
+    if (oct->header.root_node >= oct->node_count)
     {
         if (verbose)
-            Con_Printf("LIGHTGRID_OCTREE root %u outside node count %zu\n", oct->root_node, oct->node_count);
+            Con_Printf("LIGHTGRID_OCTREE root %u outside node count %zu\n", oct->header.root_node, oct->node_count);
         return false;
     }
 
     for (int i = 0; i < 3; i++)
     {
-        if (!R_IsFinite(oct->mins[i]) || !R_IsFinite(oct->maxs[i]) || oct->mins[i] > oct->maxs[i])
+        if (!R_IsFinite(oct->header.grid_dist[i]) || oct->header.grid_dist[i] <= 0.f)
         {
             if (verbose)
-                Con_Printf("LIGHTGRID_OCTREE invalid bounds [%f %f] axis %d\n", oct->mins[i], oct->maxs[i], i);
+                Con_Printf("LIGHTGRID_OCTREE invalid grid dist %f axis %d\n", oct->header.grid_dist[i], i);
+            return false;
+        }
+
+        if (!R_IsFinite(oct->header.grid_mins[i]))
+        {
+            if (verbose)
+                Con_Printf("LIGHTGRID_OCTREE invalid grid mins %f axis %d\n", oct->header.grid_mins[i], i);
+            return false;
+        }
+    }
+
+    for (int i = 0; i < 3; i++)
+    {
+        if (oct->header.grid_size[i] <= 0)
+        {
+            if (verbose)
+                Con_Printf("LIGHTGRID_OCTREE invalid grid size axis %d: %d\n", i, oct->header.grid_size[i]);
             return false;
         }
     }
@@ -312,12 +350,12 @@ qboolean Lightgrid_ValidateOctree(const lightgrid_octree_t *oct, qboolean verbos
         for (int c = 0; c < 8; c++)
         {
             uint32_t child = oct->nodes[i].child[c];
-            if (child == LIGHTGRID_OCTREE_CHILD_EMPTY)
+            if (child & LIGHTGRID_OCTREE_FLAG_OCCLUDED)
                 continue;
 
-            if (child & LIGHTGRID_OCTREE_CHILD_LEAF)
+            if (child & LIGHTGRID_OCTREE_FLAG_LEAF)
             {
-                uint32_t leaf_index = child & ~LIGHTGRID_OCTREE_CHILD_LEAF;
+                uint32_t leaf_index = child & ~LIGHTGRID_OCTREE_FLAG_MASK;
                 if (leaf_index >= oct->leaf_count)
                 {
                     if (verbose)
@@ -336,7 +374,7 @@ qboolean Lightgrid_ValidateOctree(const lightgrid_octree_t *oct, qboolean verbos
 
     for (size_t i = 0; i < oct->leaf_count; i++)
     {
-        if (!Lightgrid_ValidateLeaf(&oct->leaves[i], i, verbose))
+        if (!Lightgrid_ValidateLeaf(oct, &oct->leaves[i], i, verbose))
             return false;
     }
 
@@ -361,7 +399,7 @@ static int Lightgrid_OctreeDepth(const lightgrid_octree_t *oct)
         goto done;
 
     size_t top = 0;
-    node_stack[top] = oct->root_node;
+    node_stack[top] = oct->header.root_node;
     depth_stack[top] = 1;
     top++;
 
@@ -376,7 +414,7 @@ static int Lightgrid_OctreeDepth(const lightgrid_octree_t *oct)
         for (int c = 0; c < 8; c++)
         {
             uint32_t child = node->child[c];
-            if (child == LIGHTGRID_OCTREE_CHILD_EMPTY || (child & LIGHTGRID_OCTREE_CHILD_LEAF))
+            if ((child & LIGHTGRID_OCTREE_FLAG_OCCLUDED) || (child & LIGHTGRID_OCTREE_FLAG_LEAF))
                 continue;
 
             if (child < oct->node_count && top < stack_size)
@@ -428,12 +466,13 @@ static void Lightgrid_DumpOctree(const lightgrid_octree_t *oct)
     }
 
     int depth = Lightgrid_OctreeDepth(oct);
-    Con_Printf("LIGHTGRID_OCTREE: %zu nodes, %zu leaves, depth %d, flags 0x%08x\n",
-        oct->node_count, oct->leaf_count, depth, oct->flags);
-    Con_Printf(" bounds: mins(%.1f %.1f %.1f) maxs(%.1f %.1f %.1f)\n",
-        oct->mins[0], oct->mins[1], oct->mins[2],
-        oct->maxs[0], oct->maxs[1], oct->maxs[2]);
-    Con_Printf(" payload: float32 rgb+dir+intensity\n");
+    Con_Printf("LIGHTGRID_OCTREE: %zu nodes, %zu leaves, depth %d\n",
+        oct->node_count, oct->leaf_count, depth);
+    Con_Printf(" grid: dist(%.1f %.1f %.1f) size(%d %d %d) mins(%.1f %.1f %.1f) styles %u\n",
+        oct->header.grid_dist[0], oct->header.grid_dist[1], oct->header.grid_dist[2],
+        oct->header.grid_size[0], oct->header.grid_size[1], oct->header.grid_size[2],
+        oct->header.grid_mins[0], oct->header.grid_mins[1], oct->header.grid_mins[2],
+        oct->header.num_styles);
 
     if (r_lightgrid_octree_debug.value > 0.f)
         Lightgrid_ValidateOctree(oct, true);
@@ -1090,82 +1129,114 @@ static qboolean Lightgrid_SampleRawProbe(const lightgrid_t *lg, const vec3_t pos
 static qboolean Lightgrid_SampleOctreeProbe(const lightgrid_t *lg, const vec3_t pos, lightgrid_probe_t *out_probe)
 {
     const lightgrid_octree_t *oct = lg ? lg->octree : NULL;
-    vec3_t node_mins, node_maxs, center;
-    size_t steps = 0;
-    uint32_t node_index;
-    const lightgrid_octree_node_t *node;
+    int test_point[3];
     const lightgrid_octree_leaf_t *leaf = NULL;
+    const lightgrid_octree_sampleset_t *set = NULL;
+    uint32_t node_index;
+    size_t steps = 0;
 
     if (!oct || !out_probe)
         return false;
 
     for (int i = 0; i < 3; i++)
     {
-        if (pos[i] < oct->mins[i] || pos[i] > oct->maxs[i])
-            return false; // Let caller fall back (RAW clamps instead)
+        float local = (pos[i] - oct->header.grid_mins[i]) / oct->header.grid_dist[i];
+        test_point[i] = Q_rint(local);
+        if (test_point[i] < 0 || test_point[i] >= oct->header.grid_size[i])
+            return false;
     }
 
-    VectorCopy(oct->mins, node_mins);
-    VectorCopy(oct->maxs, node_maxs);
+    node_index = oct->header.root_node;
 
-    VectorCopy(pos, center);
-
-    node_index = oct->root_node;
-
-    while (steps < oct->node_count)
+    while (steps < (oct->node_count + oct->leaf_count))
     {
-        node = &oct->nodes[node_index];
-
-        VectorLerp(node_mins, node_maxs, 0.5f, center);
-
-        int child = 0;
-        if (pos[0] >= center[0]) child |= 1;
-        if (pos[1] >= center[1]) child |= 2;
-        if (pos[2] >= center[2]) child |= 4;
-
-        uint32_t raw_child = node->child[child];
-
-        if (raw_child == LIGHTGRID_OCTREE_CHILD_EMPTY)
-            break;
-
-        if (raw_child & LIGHTGRID_OCTREE_CHILD_LEAF)
+        if (node_index & LIGHTGRID_OCTREE_FLAG_OCCLUDED)
         {
-            uint32_t leaf_index = raw_child & ~LIGHTGRID_OCTREE_CHILD_LEAF;
+            VectorSet(out_probe->rgb, 0.f, 0.f, 0.f);
+            VectorSet(out_probe->dir, 0.f, 0.f, 1.f);
+            out_probe->intensity = 0.f;
+            out_probe->ao = 0.f;
+            out_probe->emissive = 0.f;
+            out_probe->sh_valid = false;
+            out_probe->sh9 = NULL;
+            return true;
+        }
+
+        if (node_index & LIGHTGRID_OCTREE_FLAG_LEAF)
+        {
+            uint32_t leaf_index = node_index & ~LIGHTGRID_OCTREE_FLAG_MASK;
             if (leaf_index >= oct->leaf_count)
                 return false;
             leaf = &oct->leaves[leaf_index];
             break;
         }
 
-        if (raw_child >= oct->node_count)
+        if (node_index >= oct->node_count)
             return false;
 
-        /* descend into child node */
-        if (pos[0] >= center[0])
-            node_mins[0] = center[0];
-        else
-            node_maxs[0] = center[0];
-        if (pos[1] >= center[1])
-            node_mins[1] = center[1];
-        else
-            node_maxs[1] = center[1];
-        if (pos[2] >= center[2])
-            node_mins[2] = center[2];
-        else
-            node_maxs[2] = center[2];
+        const lightgrid_octree_node_t *node = &oct->nodes[node_index];
 
-        node_index = raw_child;
+        int signx = test_point[0] >= node->division_point[0];
+        int signy = test_point[1] >= node->division_point[1];
+        int signz = test_point[2] >= node->division_point[2];
+        int child = 4 * signx + 2 * signy + signz;
+
+        node_index = node->child[child];
         steps++;
     }
 
     if (!leaf)
         return false;
 
-    VectorCopy(leaf->rgb, out_probe->rgb);
-    VectorCopy(leaf->dir, out_probe->dir);
-    if (VectorNormalize(out_probe->dir) == 0.f)
+    int lx = test_point[0] - leaf->mins[0];
+    int ly = test_point[1] - leaf->mins[1];
+    int lz = test_point[2] - leaf->mins[2];
+
+    if (lx < 0 || ly < 0 || lz < 0 || lx >= leaf->size[0] || ly >= leaf->size[1] || lz >= leaf->size[2])
+        return false;
+
+    size_t idx = ((size_t)leaf->size[0] * (size_t)leaf->size[1] * (size_t)lz) + ((size_t)leaf->size[0] * (size_t)ly) + (size_t)lx;
+    set = &leaf->samples[idx];
+
+    if (set->occluded)
+    {
+        VectorSet(out_probe->rgb, 0.f, 0.f, 0.f);
         VectorSet(out_probe->dir, 0.f, 0.f, 1.f);
-    out_probe->intensity = leaf->intensity;
+        out_probe->intensity = 0.f;
+        out_probe->ao = 0.f;
+        out_probe->emissive = 0.f;
+        out_probe->sh_valid = false;
+        out_probe->sh9 = NULL;
+        return true;
+    }
+
+    const lightgrid_octree_sample_t *chosen = NULL;
+    for (uint8_t i = 0; i < set->used_samples; i++)
+    {
+        const lightgrid_octree_sample_t *candidate = &set->samples[i];
+        if (candidate->style == 0)
+        {
+            chosen = candidate;
+            break;
+        }
+        if (!chosen)
+            chosen = candidate;
+    }
+
+    if (chosen)
+    {
+        out_probe->rgb[0] = chosen->color[0] / 255.0f;
+        out_probe->rgb[1] = chosen->color[1] / 255.0f;
+        out_probe->rgb[2] = chosen->color[2] / 255.0f;
+        out_probe->intensity = q_max(q_max(out_probe->rgb[0], out_probe->rgb[1]), out_probe->rgb[2]);
+    }
+    else
+    {
+        VectorSet(out_probe->rgb, 0.f, 0.f, 0.f);
+        out_probe->intensity = 0.f;
+    }
+
+    VectorSet(out_probe->dir, 0.f, 0.f, 1.f);
     out_probe->ao = 0.f;
     out_probe->emissive = 0.f;
     out_probe->sh_valid = false;

--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -2844,137 +2844,199 @@ static void Mod_LoadLightgridRaw_f (cvar_t *var)
 
 static qboolean LightgridOctree_LoadBSPX (qmodel_t *mod, void *data, int size)
 {
-	const lightgrid_octree_header_t *hdr;
-	const lightgrid_octree_disk_node_t *disk_nodes;
-	lightgrid_octree_t *oct;
-	lightgrid_t *lg;
-	vec3_t mins, maxs;
-	uint32_t version, flags, nodes_offset, leaves_offset, leaf_stride;
-	uint32_t node_count, leaf_count, root_node;
-	size_t nodes_size, leaves_size;
-	const byte *payload;
+        const byte *cursor, *end;
+        lightgrid_octree_t *oct;
+        lightgrid_t *lg;
 
-	if (!mod || !data || size < (int)sizeof(lightgrid_octree_header_t))
-		return false;
+        if (!mod || !data || size <= 0)
+                return false;
 
-	payload = (const byte *)data;
-	hdr = (const lightgrid_octree_header_t *)payload;
+        cursor = (const byte *)data;
+        end = cursor + size;
 
-	if (LittleLong (hdr->magic) != LIGHTGRID_OCTREE_MAGIC)
-		return false;
+        if ((size_t)(end - cursor) < sizeof(float) * 6 + sizeof(uint8_t) + sizeof(uint32_t))
+                return false;
 
-	version = LittleLong (hdr->version);
-	if (version != LIGHTGRID_OCTREE_VERSION_1)
-		return false;
+        oct = (lightgrid_octree_t *)Hunk_AllocName (sizeof(*oct), "lgoctree");
+        if (!oct)
+                return false;
 
-	flags = LittleLong (hdr->flags);
-	if ((flags & LIGHTGRID_OCTREE_FLAG_FLOAT32) == 0)
-		return false;
+        memset (oct, 0, sizeof(*oct));
 
-	root_node = LittleLong (hdr->root_node);
-	node_count = LittleLong (hdr->node_count);
-	leaf_count = LittleLong (hdr->leaf_count);
-	nodes_offset = LittleLong (hdr->nodes_offset);
-	leaves_offset = LittleLong (hdr->leaves_offset);
-	leaf_stride = LittleLong (hdr->leaf_stride);
-
-	if (!node_count || !leaf_count)
-		return false;
-
-	if (root_node >= node_count)
-		return false;
-
-	if ((nodes_offset & 3u) || (leaves_offset & 3u) || (leaf_stride & 3u))
-		return false;
-
-	if (nodes_offset > leaves_offset)
-		return false;
-
-	if (leaf_stride < sizeof(lightgrid_octree_disk_leaf_t))
-		return false;
-
-	if ((size_t)node_count > SIZE_MAX / sizeof(lightgrid_octree_disk_node_t))
-		return false;
-	nodes_size = (size_t)node_count * sizeof(lightgrid_octree_disk_node_t);
-	if (nodes_offset + nodes_size > (size_t)size)
-		return false;
-
-	if ((size_t)leaf_count > SIZE_MAX / (size_t)leaf_stride)
-		return false;
-	leaves_size = (size_t)leaf_count * (size_t)leaf_stride;
-	if ((size_t)leaves_offset + leaves_size > (size_t)size)
-		return false;
-
-	mins[0] = LittleFloat (hdr->mins[0]);
-	mins[1] = LittleFloat (hdr->mins[1]);
-	mins[2] = LittleFloat (hdr->mins[2]);
-	maxs[0] = LittleFloat (hdr->maxs[0]);
-	maxs[1] = LittleFloat (hdr->maxs[1]);
-	maxs[2] = LittleFloat (hdr->maxs[2]);
-
-	for (int i = 0; i < 3; i++)
-	{
-		if (!isfinite (mins[i]) || !isfinite (maxs[i]) || mins[i] > maxs[i])
-			return false;
-	}
-
-	disk_nodes = (const lightgrid_octree_disk_node_t *)(payload + nodes_offset);
-	for (size_t i = 0; i < node_count; i++)
-	{
-		for (int c = 0; c < 8; c++)
-		{
-			uint32_t child = LittleLong (disk_nodes[i].child[c]);
-
-			if (child == LIGHTGRID_OCTREE_CHILD_EMPTY)
-				continue;
-			if (child & LIGHTGRID_OCTREE_CHILD_LEAF)
-			{
-				uint32_t leaf_idx = child & ~LIGHTGRID_OCTREE_CHILD_LEAF;
-				if (leaf_idx >= leaf_count)
-					return false;
-			}
-			else if (child >= node_count)
-			{
-				return false;
-			}
-		}
-	}
-
-	oct = (lightgrid_octree_t *)Hunk_AllocName (sizeof(*oct), "lgoctree");
-	if (!oct)
-		return false;
-
-	memset (oct, 0, sizeof(*oct));
-	VectorCopy (mins, oct->mins);
-	VectorCopy (maxs, oct->maxs);
-	oct->flags = flags;
-	oct->root_node = root_node;
-	oct->node_count = node_count;
-	oct->leaf_count = leaf_count;
-
-	oct->nodes = (lightgrid_octree_node_t *)Hunk_AllocName (node_count * sizeof(lightgrid_octree_node_t), "lgoctnodes");
-	oct->leaves = (lightgrid_octree_leaf_t *)Hunk_AllocName (leaf_count * sizeof(lightgrid_octree_leaf_t), "lgoctleaf");
-	if (!oct->nodes || !oct->leaves)
-		return false;
-
-	for (size_t i = 0; i < node_count; i++)
-	{
-		for (int c = 0; c < 8; c++)
-			oct->nodes[i].child[c] = LittleLong (disk_nodes[i].child[c]);
-	}
-
-        for (size_t i = 0; i < leaf_count; i++)
+        for (int i = 0; i < 3; i++)
         {
-                const lightgrid_octree_disk_leaf_t *src = (const lightgrid_octree_disk_leaf_t *)(payload + leaves_offset + i * leaf_stride);
-                lightgrid_octree_leaf_t *dst = &oct->leaves[i];
+                float temp;
+                memcpy(&temp, cursor, sizeof(temp));
+                oct->header.grid_dist[i] = LittleFloat (temp);
+                cursor += sizeof(float);
+        }
 
-		dst->rgb[0] = LittleFloat (src->rgb[0]);
-		dst->rgb[1] = LittleFloat (src->rgb[1]);
-		dst->rgb[2] = LittleFloat (src->rgb[2]);
-		dst->dir[0] = LittleFloat (src->dir[0]);
-		dst->dir[1] = LittleFloat (src->dir[1]);
-                dst->dir[2] = LittleFloat (src->dir[2]);
-                dst->intensity = LittleFloat (src->intensity);
+        for (int i = 0; i < 3; i++)
+        {
+                int32_t temp;
+                memcpy(&temp, cursor, sizeof(temp));
+                oct->header.grid_size[i] = LittleLong (temp);
+                cursor += sizeof(uint32_t);
+        }
+
+        for (int i = 0; i < 3; i++)
+        {
+                float temp;
+                memcpy(&temp, cursor, sizeof(temp));
+                oct->header.grid_mins[i] = LittleFloat (temp);
+                cursor += sizeof(float);
+        }
+
+        oct->header.num_styles = *cursor;
+        cursor += sizeof(uint8_t);
+
+        {
+                uint32_t temp;
+                memcpy(&temp, cursor, sizeof(temp));
+                oct->header.root_node = LittleLong (temp);
+        }
+        cursor += sizeof(uint32_t);
+
+        if (cursor > end)
+                return false;
+
+        if ((size_t)(end - cursor) < sizeof(uint32_t))
+                return false;
+
+        {
+                uint32_t temp;
+                memcpy(&temp, cursor, sizeof(temp));
+                oct->node_count = (size_t)LittleLong (temp);
+        }
+        cursor += sizeof(uint32_t);
+
+        if (!oct->node_count)
+                return false;
+
+        if (oct->node_count > SIZE_MAX / sizeof(lightgrid_octree_node_t))
+                return false;
+
+        {
+                size_t node_bytes = sizeof(int32_t) * 3 + sizeof(uint32_t) * 8;
+                if (oct->node_count > (size_t)(end - cursor) / node_bytes)
+                        return false;
+        }
+
+        oct->nodes = (lightgrid_octree_node_t *)Hunk_AllocName (oct->node_count * sizeof(lightgrid_octree_node_t), "lgoctnodes");
+        if (!oct->nodes)
+                return false;
+
+        for (size_t i = 0; i < oct->node_count; i++)
+        {
+                for (int axis = 0; axis < 3; axis++)
+                {
+                        int32_t temp;
+                        memcpy(&temp, cursor, sizeof(temp));
+                        oct->nodes[i].division_point[axis] = LittleLong (temp);
+                        cursor += sizeof(uint32_t);
+                }
+
+                for (int c = 0; c < 8; c++)
+                {
+                        uint32_t temp;
+                        memcpy(&temp, cursor, sizeof(temp));
+                        oct->nodes[i].child[c] = LittleLong (temp);
+                        cursor += sizeof(uint32_t);
+                }
+        }
+
+        if ((size_t)(end - cursor) < sizeof(uint32_t))
+                return false;
+
+        {
+                uint32_t temp;
+                memcpy(&temp, cursor, sizeof(temp));
+                oct->leaf_count = (size_t)LittleLong (temp);
+        }
+        cursor += sizeof(uint32_t);
+
+        if (!oct->leaf_count)
+                return false;
+
+        if (oct->leaf_count > SIZE_MAX / sizeof(lightgrid_octree_leaf_t))
+                return false;
+
+        {
+                size_t leaf_header_bytes = sizeof(uint32_t) * 6;
+                if (oct->leaf_count > (size_t)(end - cursor) / leaf_header_bytes)
+                        return false;
+        }
+
+        oct->leaves = (lightgrid_octree_leaf_t *)Hunk_AllocName (oct->leaf_count * sizeof(lightgrid_octree_leaf_t), "lgoctleaf");
+        if (!oct->leaves)
+                return false;
+
+        memset (oct->leaves, 0, oct->leaf_count * sizeof(lightgrid_octree_leaf_t));
+
+        for (size_t i = 0; i < oct->leaf_count; i++)
+        {
+                for (int axis = 0; axis < 3; axis++)
+                {
+                        int32_t temp;
+                        memcpy(&temp, cursor, sizeof(temp));
+                        oct->leaves[i].mins[axis] = LittleLong (temp);
+                        cursor += sizeof(uint32_t);
+                }
+                for (int axis = 0; axis < 3; axis++)
+                {
+                        int32_t temp;
+                        memcpy(&temp, cursor, sizeof(temp));
+                        oct->leaves[i].size[axis] = LittleLong (temp);
+                        cursor += sizeof(uint32_t);
+                }
+        }
+
+        for (size_t leaf_index = 0; leaf_index < oct->leaf_count; leaf_index++)
+        {
+                lightgrid_octree_leaf_t *leaf = &oct->leaves[leaf_index];
+                if (leaf->size[0] <= 0 || leaf->size[1] <= 0 || leaf->size[2] <= 0)
+                        return false;
+                size_t sample_count = (size_t)leaf->size[0] * (size_t)leaf->size[1] * (size_t)leaf->size[2];
+
+                if (!sample_count || sample_count > SIZE_MAX / sizeof(lightgrid_octree_sampleset_t))
+                        return false;
+
+                if ((size_t)(end - cursor) < sample_count)
+                        return false;
+
+                leaf->samples = (lightgrid_octree_sampleset_t *)Hunk_AllocName (sample_count * sizeof(lightgrid_octree_sampleset_t), "lgoctsamp");
+                if (!leaf->samples)
+                        return false;
+
+                memset (leaf->samples, 0, sample_count * sizeof(lightgrid_octree_sampleset_t));
+
+                for (size_t i = 0; i < sample_count; i++)
+                {
+                        lightgrid_octree_sampleset_t *set = &leaf->samples[i];
+                        uint8_t used = *cursor++;
+
+                        if (used == 0xFF)
+                        {
+                                set->occluded = true;
+                                continue;
+                        }
+
+                        set->used_samples = used;
+
+                        if (set->used_samples > 4)
+                                return false;
+
+                        if ((size_t)(end - cursor) < (size_t)set->used_samples * (sizeof(uint8_t) + 3))
+                                return false;
+
+                        for (int j = 0; j < set->used_samples; j++)
+                        {
+                                set->samples[j].style = *cursor++;
+                                set->samples[j].color[0] = *cursor++;
+                                set->samples[j].color[1] = *cursor++;
+                                set->samples[j].color[2] = *cursor++;
+                        }
+                }
         }
 
         if (!Lightgrid_ValidateOctree (oct, r_lightgrid_octree_debug.value > 0.f))
@@ -2986,18 +3048,24 @@ static qboolean LightgridOctree_LoadBSPX (qmodel_t *mod, void *data, int size)
         if (!lg)
                 return false;
 
-	memset (lg, 0, sizeof(*lg));
-	lg->backend = LIGHTGRID_BACKEND_OCTREE;
-	lg->octree = oct;
-	lg->source = LIGHTGRID_SRC_OCTREE;
-	VectorCopy (mins, lg->mins);
-	VectorCopy (maxs, lg->maxs);
+        memset (lg, 0, sizeof(*lg));
+        lg->backend = LIGHTGRID_BACKEND_OCTREE;
+        lg->octree = oct;
+        lg->source = LIGHTGRID_SRC_OCTREE;
 
-	Lightgrid_Set (lg);
+        VectorCopy (oct->header.grid_mins, lg->mins);
+        for (int i = 0; i < 3; i++)
+                lg->maxs[i] = oct->header.grid_mins[i] + oct->header.grid_dist[i] * (oct->header.grid_size[i] - 1);
 
-	Con_Printf ("Loaded LIGHTGRID_OCTREE (%zu nodes, %zu leaves)\n", oct->node_count, oct->leaf_count);
+        Lightgrid_Set (lg);
 
-	return true;
+        Con_Printf ("Loaded LIGHTGRID_OCTREE: dist(%.1f %.1f %.1f) size(%d %d %d) mins(%.1f %.1f %.1f) styles %u (%zu nodes, %zu leaves)\n",
+                oct->header.grid_dist[0], oct->header.grid_dist[1], oct->header.grid_dist[2],
+                oct->header.grid_size[0], oct->header.grid_size[1], oct->header.grid_size[2],
+                oct->header.grid_mins[0], oct->header.grid_mins[1], oct->header.grid_mins[2],
+                oct->header.num_styles, oct->node_count, oct->leaf_count);
+
+        return true;
 }
 typedef struct lightgrid_static_light_s
 {

--- a/common/lightgrid.h
+++ b/common/lightgrid.h
@@ -66,46 +66,42 @@ typedef enum lightgrid_backend_e {
 #define LIGHTGRID_OCTREE_CHILD_EMPTY 0xFFFFFFFFu
 #define LIGHTGRID_OCTREE_CHILD_LEAF  0x80000000u
 
+#define LIGHTGRID_OCTREE_FLAG_LEAF     (1u << 31)
+#define LIGHTGRID_OCTREE_FLAG_OCCLUDED (1u << 30)
+#define LIGHTGRID_OCTREE_FLAG_MASK     (LIGHTGRID_OCTREE_FLAG_LEAF | LIGHTGRID_OCTREE_FLAG_OCCLUDED)
+
 typedef struct lightgrid_octree_header_s {
-    uint32_t magic;
-    uint32_t version;
-    uint32_t flags;
-    uint32_t reserved0;
-    vec3_t mins;
-    vec3_t maxs;
+    vec3_t grid_dist;
+    int32_t grid_size[3];
+    vec3_t grid_mins;
+    uint8_t num_styles;
     uint32_t root_node;
-    uint32_t node_count;
-    uint32_t leaf_count;
-    uint32_t nodes_offset;
-    uint32_t leaves_offset;
-    uint32_t leaf_stride;
-    uint32_t reserved1[3];
 } lightgrid_octree_header_t;
 
-typedef struct lightgrid_octree_disk_node_s {
-    uint32_t child[8];
-} lightgrid_octree_disk_node_t;
-
-typedef struct lightgrid_octree_disk_leaf_s {
-    float rgb[3];
-    float dir[3];
-    float intensity;
-} lightgrid_octree_disk_leaf_t;
-
 typedef struct lightgrid_octree_node_s {
+    int32_t division_point[3];
     uint32_t child[8];
 } lightgrid_octree_node_t;
 
+typedef struct lightgrid_octree_sample_s {
+    uint8_t color[3];
+    uint8_t style;
+} lightgrid_octree_sample_t;
+
+typedef struct lightgrid_octree_sampleset_s {
+    lightgrid_octree_sample_t samples[4];
+    uint8_t used_samples;
+    qboolean occluded;
+} lightgrid_octree_sampleset_t;
+
 typedef struct lightgrid_octree_leaf_s {
-    vec3_t rgb;
-    vec3_t dir;
-    float intensity;
+    int32_t mins[3];
+    int32_t size[3];
+    lightgrid_octree_sampleset_t *samples; // array of size[0] * size[1] * size[2]
 } lightgrid_octree_leaf_t;
 
 typedef struct lightgrid_octree_s {
-    vec3_t mins, maxs;
-    uint32_t flags;
-    uint32_t root_node;
+    lightgrid_octree_header_t header;
     size_t node_count;
     size_t leaf_count;
     lightgrid_octree_node_t *nodes;


### PR DESCRIPTION
## Summary
- update LIGHTGRID_OCTREE data structures to match ericw-tools BSPX layout and sample format
- implement accurate BSPX parsing and validation for octree nodes, leaves, and light samples
- adjust octree sampling to follow ericw traversal, style selection, and occlusion handling

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942dbbbcfec832e8d068d4dabeb6595)