### PR TITLE
Simplify lightgrid to ambient-only sampling

### DIFF
--- a/Quake/gl_lightgrid.c
+++ b/Quake/gl_lightgrid.c
@@ -1002,17 +1002,10 @@ lightgrid_t *Lightgrid_FromRaw(const lightgrid_raw_t *raw)
     for (size_t i = 0; i < count; i++)
     {
         const lightcell_t *cell = &raw->cells[i];
-        vec3_t dir;
 
         VectorCopy(cell->rgb, lg->probes[i].rgb);
-
-        VectorCopy(cell->dir, dir);
-        if (VectorNormalize(dir) == 0)
-            VectorSet(dir, 0,0,1);
-
-        VectorCopy(dir, lg->probes[i].dir);
-        lg->probes[i].intensity = cell->intensity;
         lg->probes[i].ao = cell->ao;
+        lg->probes[i].emissive = cell->emissive;
     }
 
     lg->source = LIGHTGRID_SRC_RAW;
@@ -1024,10 +1017,11 @@ lightgrid_t *Lightgrid_FromRaw(const lightgrid_raw_t *raw)
    Sampling
    ===================================================================== */
 
-static void Lightgrid_DefaultSample(vec3_t out_color, vec3_t out_dir)
+static void Lightgrid_DefaultSample(vec3_t out_color, float *out_ao)
 {
     VectorSet(out_color, 1,1,1);
-    VectorSet(out_dir, 0,0,1);
+    if (out_ao)
+        *out_ao = 1.f;
 }
 
 static qboolean Lightgrid_SampleRawProbe(const lightgrid_t *lg, const vec3_t pos, lightgrid_probe_t *out_probe)
@@ -1085,11 +1079,6 @@ static qboolean Lightgrid_SampleRawProbe(const lightgrid_t *lg, const vec3_t pos
         out_probe->rgb[i] = Lerp(c0, c1, fz);
     }
 
-    out_probe->intensity = Lerp(
-        Lerp(Lerp(c000->intensity, c100->intensity, fx), Lerp(c010->intensity, c110->intensity, fx), fy),
-        Lerp(Lerp(c001->intensity, c101->intensity, fx), Lerp(c011->intensity, c111->intensity, fx), fy),
-        fz);
-
     out_probe->emissive = Lerp(
         Lerp(Lerp(c000->emissive, c100->emissive, fx), Lerp(c010->emissive, c110->emissive, fx), fy),
         Lerp(Lerp(c001->emissive, c101->emissive, fx), Lerp(c011->emissive, c111->emissive, fx), fy),
@@ -1099,26 +1088,6 @@ static qboolean Lightgrid_SampleRawProbe(const lightgrid_t *lg, const vec3_t pos
         Lerp(Lerp(c000->ao, c100->ao, fx), Lerp(c010->ao, c110->ao, fx), fy),
         Lerp(Lerp(c001->ao, c101->ao, fx), Lerp(c011->ao, c111->ao, fx), fy),
         fz);
-
-    {
-        vec3_t d00, d10, d01, d11, d0, d1, dir;
-
-#define PREMUL_DIR(dst,p) VectorScale((p)->dir, (p)->intensity, (dst))
-        PREMUL_DIR(d00, c000);
-        PREMUL_DIR(d10, c010);
-        PREMUL_DIR(d01, c001);
-        PREMUL_DIR(d11, c011);
-#undef PREMUL_DIR
-
-        VectorLerp(d00, d10, fx, d0);
-        VectorLerp(d01, d11, fx, d1);
-
-        VectorLerp(d0, d1, fz, dir);
-        if (VectorNormalize(dir) == 0.f)
-            VectorSet(dir, 0.f, 0.f, 1.f);
-
-        VectorCopy(dir, out_probe->dir);
-    }
 
     out_probe->sh_valid = false;
     out_probe->sh9 = NULL;
@@ -1153,8 +1122,6 @@ static qboolean Lightgrid_SampleOctreeProbe(const lightgrid_t *lg, const vec3_t 
         if (node_index & LIGHTGRID_OCTREE_FLAG_OCCLUDED)
         {
             VectorSet(out_probe->rgb, 0.f, 0.f, 0.f);
-            VectorSet(out_probe->dir, 0.f, 0.f, 1.f);
-            out_probe->intensity = 0.f;
             out_probe->ao = 0.f;
             out_probe->emissive = 0.f;
             out_probe->sh_valid = false;
@@ -1201,8 +1168,6 @@ static qboolean Lightgrid_SampleOctreeProbe(const lightgrid_t *lg, const vec3_t 
     if (set->occluded)
     {
         VectorSet(out_probe->rgb, 0.f, 0.f, 0.f);
-        VectorSet(out_probe->dir, 0.f, 0.f, 1.f);
-        out_probe->intensity = 0.f;
         out_probe->ao = 0.f;
         out_probe->emissive = 0.f;
         out_probe->sh_valid = false;
@@ -1228,16 +1193,13 @@ static qboolean Lightgrid_SampleOctreeProbe(const lightgrid_t *lg, const vec3_t 
         out_probe->rgb[0] = chosen->color[0] / 255.0f;
         out_probe->rgb[1] = chosen->color[1] / 255.0f;
         out_probe->rgb[2] = chosen->color[2] / 255.0f;
-        out_probe->intensity = q_max(q_max(out_probe->rgb[0], out_probe->rgb[1]), out_probe->rgb[2]);
     }
     else
     {
         VectorSet(out_probe->rgb, 0.f, 0.f, 0.f);
-        out_probe->intensity = 0.f;
     }
 
-    VectorSet(out_probe->dir, 0.f, 0.f, 1.f);
-    out_probe->ao = 0.f;
+    out_probe->ao = 1.f;
     out_probe->emissive = 0.f;
     out_probe->sh_valid = false;
     out_probe->sh9 = NULL;
@@ -1260,19 +1222,20 @@ qboolean Lightgrid_SampleProbe(const lightgrid_t *lg, const vec3_t pos, lightgri
     }
 }
 
-void Lightgrid_Sample(const vec3_t pos, vec3_t out_color, vec3_t out_dir)
+void Lightgrid_Sample(const vec3_t pos, vec3_t out_color, float *out_ao)
 {
     const lightgrid_t *lg = Lightgrid_Get();
     lightgrid_probe_t probe;
 
     if (!Lightgrid_SampleProbe(lg, pos, &probe))
     {
-        Lightgrid_DefaultSample(out_color, out_dir);
+        Lightgrid_DefaultSample(out_color, out_ao);
         return;
     }
 
-    VectorScale(probe.rgb, probe.intensity, out_color);
-    VectorCopy(probe.dir, out_dir);
+    VectorCopy(probe.rgb, out_color);
+    if (out_ao)
+        *out_ao = probe.ao;
 }
 
 /* =====================================================================

--- a/Quake/gl_lightgrid.h
+++ b/Quake/gl_lightgrid.h
@@ -38,7 +38,7 @@ lightgrid_t *Lightgrid_FromRaw (const lightgrid_raw_t *raw);
 lightgrid_raw_t *Lightgrid_GenerateRaw (const struct qmodel_s *model);
 void Lightgrid_BuildFallback (void);
 qboolean Lightgrid_ValidateOctree (const lightgrid_octree_t *oct, qboolean verbose);
-void Lightgrid_Sample (const vec3_t pos, vec3_t out_color, vec3_t out_dir);
+void Lightgrid_Sample (const vec3_t pos, vec3_t out_color, float *out_ao);
 qboolean Lightgrid_SampleProbe (const lightgrid_t *lg, const vec3_t pos, lightgrid_probe_t *out_probe);
 const lightgrid_t *Lightgrid_Get (void);
 void Lightgrid_SetSource (const char *name);

--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -2412,33 +2412,15 @@ static qboolean Lightgrid_SampleProbeAtPos (const lightgrid_t *lg, const vec3_t 
                 out_probe->rgb[i] = Lerp (c0, c1, fz);
         }
 
-        out_probe->intensity = Lerp (
-                Lerp (Lerp (c000->intensity, c100->intensity, fx), Lerp (c010->intensity, c110->intensity, fx), fy),
-                Lerp (Lerp (c001->intensity, c101->intensity, fx), Lerp (c011->intensity, c111->intensity, fx), fy),
+        out_probe->ao = Lerp (
+                Lerp (Lerp (c000->ao, c100->ao, fx), Lerp (c010->ao, c110->ao, fx), fy),
+                Lerp (Lerp (c001->ao, c101->ao, fx), Lerp (c011->ao, c111->ao, fx), fy),
                 fz);
 
         out_probe->emissive = Lerp (
                 Lerp (Lerp (c000->emissive, c100->emissive, fx), Lerp (c010->emissive, c110->emissive, fx), fy),
                 Lerp (Lerp (c001->emissive, c101->emissive, fx), Lerp (c011->emissive, c111->emissive, fx), fy),
                 fz);
-
-        {
-                vec3_t d00, d10, d01, d11, d0, d1, dir;
-
-                VectorLerp (c000->dir, c100->dir, fx, d00);
-                VectorLerp (c010->dir, c110->dir, fx, d10);
-                VectorLerp (c001->dir, c101->dir, fx, d01);
-                VectorLerp (c011->dir, c111->dir, fx, d11);
-
-                VectorLerp (d00, d10, fy, d0);
-                VectorLerp (d01, d11, fy, d1);
-
-                VectorLerp (d0, d1, fz, dir);
-                if (VectorNormalize (dir) == 0.f)
-                        VectorSet (dir, 0.f, 0.f, 1.f);
-
-                VectorCopy (dir, out_probe->dir);
-        }
 
         return true;
 }
@@ -2495,17 +2477,13 @@ static lightgrid_raw_t *LightgridRAW_FromGrid (const lightgrid_t *src, float tar
                                 if (!Lightgrid_SampleProbeAtPos (src, pos, &probe))
                                 {
                                         VectorClear (cell->rgb);
-                                        VectorSet (cell->dir, 0.f, 0.f, 1.f);
-                                        cell->intensity = 0.f;
                                         cell->ao = 1.f;
                                         cell->emissive = 0.f;
                                         continue;
                                 }
 
                                 VectorCopy (probe.rgb, cell->rgb);
-                                VectorCopy (probe.dir, cell->dir);
-                                cell->intensity = probe.intensity;
-                                cell->ao = 1.f;
+                                cell->ao = probe.ao;
                                 cell->emissive = probe.emissive;
                         }
                 }
@@ -2699,13 +2677,17 @@ static qboolean LightgridRAW_Load (qmodel_t *mod, void *data, int size, const ch
 
                 if (version == LIGHTGRID_RAW_VERSION_1 || (components & LIGHTGRID_RAW_COMPONENT_DIR))
                 {
-                        READ_COMPONENT_FLOAT (cell->dir[0]);
-                        READ_COMPONENT_FLOAT (cell->dir[1]);
-                        READ_COMPONENT_FLOAT (cell->dir[2]);
+                        float discard;
+                        READ_COMPONENT_FLOAT (discard);
+                        READ_COMPONENT_FLOAT (discard);
+                        READ_COMPONENT_FLOAT (discard);
                 }
 
                 if (version == LIGHTGRID_RAW_VERSION_1 || (components & LIGHTGRID_RAW_COMPONENT_INTENSITY))
-                        READ_COMPONENT_FLOAT (cell->intensity);
+                {
+                        float discard;
+                        READ_COMPONENT_FLOAT (discard);
+                }
 
                 if (components & LIGHTGRID_RAW_COMPONENT_AO)
                         READ_COMPONENT_FLOAT (cell->ao);

--- a/Quake/gl_rlight.c
+++ b/Quake/gl_rlight.c
@@ -298,30 +298,23 @@ qboolean R_LightgridEnabled (void)
 R_LightgridLighting
 ==================
 */
-void R_LightgridLighting (const vec3_t pos, vec3_t out_color)
-{
-        vec3_t dummy_dir;
-
-        R_LightgridLightingDir (pos, out_color, dummy_dir);
-}
-
-/*
-==================
-R_LightgridLightingDir
-==================
-*/
-void R_LightgridLightingDir (const vec3_t pos, vec3_t out_color, vec3_t out_dir)
+void R_LightgridLighting (const vec3_t pos, vec3_t out_color, float *out_ao)
 {
         const lightgrid_t *lg = Lightgrid_Get ();
+        float ao = 1.f;
 
         if (!R_LightgridEnabledInternal (lg))
         {
                 VectorClear (out_color);
-                VectorSet (out_dir, 0.f, 0.f, 1.f);
+                if (out_ao)
+                        *out_ao = 1.f;
                 return;
         }
 
-        Lightgrid_Sample (pos, out_color, out_dir);
+        Lightgrid_Sample (pos, out_color, &ao);
+        VectorScale (out_color, ao, out_color);
+        if (out_ao)
+                *out_ao = ao;
 }
 
 /*
@@ -803,17 +796,17 @@ int R_LightPoint (qmodel_t *model, vec3_t p, float ofs, lightcache_t *cache)
         qboolean        lightgrid_active;
 
         cache->lightgrid_has_sample = false;
-        cache->lightgrid_intensity = 0.f;
+        cache->lightgrid_ao = 0.f;
         VectorClear (cache->lightgrid_color);
-        VectorClear (cache->lightgrid_dir);
 
         lightgrid_active = R_LightgridEnabled ();
 
         if (lightgrid_active)
         {
-                vec3_t lg_color, lg_dir, lg_color255;
+                vec3_t lg_color, lg_color255;
+                float lg_ao = 1.f;
 
-                R_LightgridLightingDir (p, lg_color, lg_dir);
+                R_LightgridLighting (p, lg_color, &lg_ao);
                 VectorScale (lg_color, 255.f, lg_color255);
 
                 VectorCopy (lg_color255, lightcolor);
@@ -822,9 +815,8 @@ int R_LightPoint (qmodel_t *model, vec3_t p, float ofs, lightcache_t *cache)
                 cache->surfidx = 0;
                 VectorCopy (p, cache->pos);
                 cache->lightgrid_has_sample = true;
-                cache->lightgrid_intensity = 1.f;
+                cache->lightgrid_ao = lg_ao;
                 VectorCopy (lg_color, cache->lightgrid_color);
-                VectorCopy (lg_dir, cache->lightgrid_dir);
 
                 return ((lightcolor[0] + lightcolor[1] + lightcolor[2]) * (1.0f / 3.0f));
         }

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -521,8 +521,7 @@ int R_LightPoint (qmodel_t *model, vec3_t p, float ofs, lightcache_t *cache);
 qboolean R_SampleLightmapAtPoint(const vec3_t pos, vec3_t out_rgb);
 qboolean R_SampleLightmapAndDeluxemapAtPoint(const vec3_t pos, vec3_t out_rgb, vec3_t out_dir);
 qboolean R_LightgridEnabled (void);
-void R_LightgridLighting (const vec3_t pos, vec3_t out_color);
-void R_LightgridLightingDir (const vec3_t pos, vec3_t out_color, vec3_t out_dir);
+void R_LightgridLighting (const vec3_t pos, vec3_t out_color, float *out_ao);
 void R_AddDynamicLights_Lightgrid (const vec3_t pos, vec3_t lightcolor);
 
 #define WORLDSHADER_SOLID		0

--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -96,7 +96,7 @@ COMPILE_TIME_ASSERT (alias_global_size_matches_std430, sizeof (ibuf.global) % 16
 static qboolean r_lightgrid_debug_sample_reported = false;
 static const qmodel_t *r_lightgrid_debug_last_world = NULL;
 
-static void R_DebugLightgridSample (const entity_t *e, const vec3_t ambient_add, const vec3_t dlight_add, float dir_dot)
+static void R_DebugLightgridSample (const entity_t *e, const vec3_t ambient_add)
 {
         if (!r_lightgrid_debug.value)
         {
@@ -115,62 +115,38 @@ static void R_DebugLightgridSample (const entity_t *e, const vec3_t ambient_add,
 
         r_lightgrid_debug_sample_reported = true;
 
-        Con_Printf ("r_lightgrid_debug: %s probe rgb=(%.2f %.2f %.2f) intensity=%.2f dir=(%.2f %.2f %.2f) dir_dot=%.2f ambient_add=(%.1f %.1f %.1f) dlight_add=(%.1f %.1f %.1f)\n",
+        Con_Printf ("r_lightgrid_debug: %s probe rgb=(%.2f %.2f %.2f) ao=%.2f ambient_add=(%.1f %.1f %.1f)\n",
                 e->model ? e->model->name : "<no model>",
                 e->lightcache.lightgrid_color[0], e->lightcache.lightgrid_color[1], e->lightcache.lightgrid_color[2],
-                e->lightcache.lightgrid_intensity,
-                e->lightcache.lightgrid_dir[0], e->lightcache.lightgrid_dir[1], e->lightcache.lightgrid_dir[2],
-                dir_dot,
-                ambient_add[0], ambient_add[1], ambient_add[2],
-                dlight_add[0], dlight_add[1], dlight_add[2]);
+                e->lightcache.lightgrid_ao,
+                ambient_add[0], ambient_add[1], ambient_add[2]);
 }
 
 static void R_ApplyLightgridLighting (const entity_t *e, vec3_t ambientcolor, vec3_t dlightcolor)
 {
         vec3_t          gridcolor;
-        vec3_t          forward, right, up, shadevector;
-        float           dir_dot;
 
         if (!R_LightgridEnabled () || !e->lightcache.lightgrid_has_sample)
                 return;
 
-        VectorScale (e->lightcache.lightgrid_color, e->lightcache.lightgrid_intensity * 255.f, gridcolor);
+        VectorScale (e->lightcache.lightgrid_color, e->lightcache.lightgrid_ao * 255.f, gridcolor);
         if (gridcolor[0] == 0.f && gridcolor[1] == 0.f && gridcolor[2] == 0.f)
                 return;
 
-        vec3_t angles;
-        VectorCopy (e->angles, angles);
-        AngleVectors (angles, forward, right, up);
-        VectorAdd (forward, up, shadevector);
-        if (VectorNormalize (shadevector) == 0.f)
-        {
-                shadevector[0] = 0.f;
-                shadevector[1] = 0.f;
-                shadevector[2] = 1.f;
-        }
-
-        dir_dot = CLAMP (0.f, DotProduct (e->lightcache.lightgrid_dir, shadevector), 1.f);
-
         {
                 vec3_t ambient_add;
-                vec3_t dlight_add;
                 for (int i = 0; i < 3; i++)
                 {
-                        float directional = gridcolor[i] * dir_dot;
-                        float ambient = gridcolor[i] - directional;
-
                         ambientcolor[i] -= gridcolor[i];
                         if (ambientcolor[i] < 0.f)
                                 ambientcolor[i] = 0.f;
 
-                        ambientcolor[i] += ambient;
-                        dlightcolor[i] += directional;
+                        ambientcolor[i] += gridcolor[i];
 
-                        ambient_add[i] = ambient;
-                        dlight_add[i] = directional;
+                        ambient_add[i] = gridcolor[i];
                 }
 
-                R_DebugLightgridSample (e, ambient_add, dlight_add, dir_dot);
+                R_DebugLightgridSample (e, ambient_add);
         }
 }
 
@@ -328,12 +304,13 @@ void R_SetupAliasLighting (entity_t     *e)
         vec3_t          dyn_add = {0.f, 0.f, 0.f};
         qboolean        used_lightgrid = false;
         qboolean        base_from_lightgrid = false;
+        float           lg_ao = 1.f;
 
         if (R_LightgridEnabled ())
         {
-                vec3_t lg_color, lg_dir, lg_color255;
+                vec3_t lg_color, lg_color255;
 
-                R_LightgridLightingDir (e->origin, lg_color, lg_dir);
+                R_LightgridLighting (e->origin, lg_color, &lg_ao);
                 VectorScale (lg_color, 255.0f, lg_color255);
 
                 VectorCopy (lg_color255, lightcolor);
@@ -342,9 +319,8 @@ void R_SetupAliasLighting (entity_t     *e)
                 VectorCopy (lg_color255, ambientcolor);
                 VectorSubtract (lightcolor, ambientcolor, dlightcolor);
 
-                VectorCopy (lg_dir, e->lightcache.lightgrid_dir);
                 VectorCopy (lg_color, e->lightcache.lightgrid_color);
-                e->lightcache.lightgrid_intensity = 1.f;
+                e->lightcache.lightgrid_ao = lg_ao;
                 e->lightcache.lightgrid_has_sample = true;
 
                 used_lightgrid = true;
@@ -363,18 +339,17 @@ void R_SetupAliasLighting (entity_t     *e)
 
                 if (R_LightgridEnabled () && e->lightcache.lightgrid_has_sample)
                 {
-                        vec3_t lg_color, lg_dir, lg_color255;
+                        vec3_t lg_color, lg_color255;
 
-                        R_LightgridLightingDir (e->origin, lg_color, lg_dir);
+                        R_LightgridLighting (e->origin, lg_color, &lg_ao);
                         VectorScale (lg_color, 255.0f, lg_color255);
 
                         for (i = 0; i < 3; i++)
                                 dyn_add[i] = fmaxf (lightcolor[i] - lg_color255[i], 0.f);
 
                         VectorCopy (lg_color255, ambientcolor);
-                        VectorCopy (lg_dir, e->lightcache.lightgrid_dir);
                         VectorCopy (lg_color, e->lightcache.lightgrid_color);
-                        e->lightcache.lightgrid_intensity = 1.f;
+                        e->lightcache.lightgrid_ao = lg_ao;
 
                         used_lightgrid = true;
                 }
@@ -762,9 +737,8 @@ static void R_DrawAliasModel_Real (entity_t *e, qboolean showtris)
                 VectorCopy (lightcolor, e->lightcache.ambientcolor);
                 VectorClear (e->lightcache.dlightcolor);
                 e->lightcache.lightgrid_has_sample = false;
-                e->lightcache.lightgrid_intensity = 0.f;
+                e->lightcache.lightgrid_ao = 0.f;
                 VectorClear (e->lightcache.lightgrid_color);
-                VectorClear (e->lightcache.lightgrid_dir);
         }
 
 	if (showtris)

--- a/Quake/r_brush.c
+++ b/Quake/r_brush.c
@@ -855,10 +855,11 @@ void GL_BuildBModelVertexBuffer (void)
                                         VectorCopy (m->vertexes[vertindex].normal, vert->normal);
 
                                 {
-                                        vec3_t lg_color, lg_dir;
+                                        vec3_t lg_color;
+                                        float lg_ao = 1.f;
 
-                                        Lightgrid_Sample (vec, lg_color, lg_dir);
-                                        VectorCopy (lg_color, vert->lightgrid);
+                                        Lightgrid_Sample (vec, lg_color, &lg_ao);
+                                        VectorScale (lg_color, lg_ao, vert->lightgrid);
                                 }
 
                                 s = DotProduct (vec, fa->texinfo->vecs[0]) + fa->texinfo->vecs[0][3] * useofs;

--- a/Quake/render.h
+++ b/Quake/render.h
@@ -43,9 +43,8 @@ typedef struct lightcache_s {
 	short				dt;
 	vec3_t				ambientcolor;
 	vec3_t				dlightcolor;
-	vec3_t				lightgrid_dir;
 	vec3_t				lightgrid_color;
-	float				lightgrid_intensity;
+	float				lightgrid_ao;
 	qboolean		lightgrid_has_sample;
 } lightcache_t;
 

--- a/common/lightgrid.h
+++ b/common/lightgrid.h
@@ -8,8 +8,6 @@ typedef struct sh9_color_s {
 
 typedef struct lightcell_s {
     vec3_t rgb;
-    vec3_t dir;
-    float intensity;
     float ao;
     float emissive;
     qboolean sh_valid;


### PR DESCRIPTION
## Summary
- treat both raw and octree lightgrids as ambient-only by relying on RGB and AO data
- remove directional and intensity handling from sampling and rendering paths
- adjust lightgrid debug and cache plumbing to reflect ambient-only semantics

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943164c0e8c832e9ea1cf5cc05f3e76)