### PR TITLE
Fix lightgrid cell struct to include direction and intensity

### DIFF
--- a/common/lightgrid.h
+++ b/common/lightgrid.h
@@ -8,6 +8,8 @@ typedef struct sh9_color_s {
 
 typedef struct lightcell_s {
     vec3_t rgb;
+    vec3_t dir;
+    float intensity;
     float ao;
     float emissive;
     qboolean sh_valid;


### PR DESCRIPTION
## Summary
- add direction and intensity fields to lightgrid cells to match loader usage

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943183ac2cc832eaa5add07679d6e43)