### PR TITLE
Add persistent BSP dynamic lights

### DIFF
--- a/Quake/cl_main.c
+++ b/Quake/cl_main.c
@@ -62,6 +62,8 @@ entity_t		cl_static_entities[MAX_STATIC_ENTITIES];
 lightstyle_t	cl_lightstyle[MAX_LIGHTSTYLES];
 int					cl_max_lightstyles = MAX_LIGHTSTYLES;
 dlight_t		cl_dlights[MAX_DLIGHTS];
+dlight_t		cl_entity_dlights[MAX_ENTITY_DLIGHTS];
+int				cl_num_entity_dlights;
 
 entity_t		*cl_entities; //johnfitz -- was a static array, now on hunk
 int				cl_max_edicts; //johnfitz -- only changes when new map loads
@@ -110,6 +112,8 @@ void CL_ClearState (void)
 
 // clear other arrays
 	memset (cl_dlights, 0, sizeof(cl_dlights));
+	memset (cl_entity_dlights, 0, sizeof(cl_entity_dlights));
+	cl_num_entity_dlights = 0;
 	memset (cl_lightstyle, 0, sizeof(cl_lightstyle));
 	cl_max_lightstyles = MAX_LIGHTSTYLES;
 	memset (cl_temp_entities, 0, sizeof(cl_temp_entities));
@@ -412,28 +416,42 @@ CL_DecayLights
 
 ===============
 */
+static void CL_UpdateDlightArray (dlight_t *dl, int count, float frametime)
+{
+	for (int i = 0; i < count; i++, dl++)
+	{
+		if (dl->die < cl.time || dl->spawn > cl.time || !dl->baseradius)
+			continue;
+
+		dl->baseradius -= frametime*dl->decay;
+		if (dl->baseradius < 0)
+			dl->baseradius = 0;
+
+		dl->radius = dl->baseradius * (1.0f + 0.1f * (float) sin (cl.time * 9.0 + dl->flicker_seed));
+		if (dl->radius < 0)
+			dl->radius = 0;
+	}
+}
+
+/*
+===============
+CL_DecayLights
+===============
+*/
 void CL_DecayLights (void)
 {
-	int			i;
-	dlight_t	*dl;
-	float		time;
+	float time;
 
 	time = cl.time - cl.oldtime;
 
-        dl = cl_dlights;
-        for (i=0 ; i<MAX_DLIGHTS ; i++, dl++)
-        {
-                if (dl->die < cl.time || dl->spawn > cl.time || !dl->baseradius)
-                        continue;
+	CL_UpdateDlightArray (cl_dlights, MAX_DLIGHTS, time);
+	CL_UpdateDlightArray (cl_entity_dlights, cl_num_entity_dlights, time);
+}
 
-                dl->baseradius -= time*dl->decay;
-                if (dl->baseradius < 0)
-                        dl->baseradius = 0;
 
-                dl->radius = dl->baseradius * (1.0f + 0.1f * (float) sin (cl.time * 9.0 + dl->flicker_seed));
-                if (dl->radius < 0)
-                        dl->radius = 0;
-        }
+/*
+===============
+CL_LerpPoint}
 }
 
 
@@ -873,6 +891,9 @@ int CL_ReadFromServer (void)
 
         //dlights
         for (i=0, l=cl_dlights ; i<MAX_DLIGHTS ; i++, l++)
+                if (l->die >= cl.time && l->spawn <= cl.time && l->baseradius)
+                        num_dlights++;
+        for (i=0, l=cl_entity_dlights ; i<cl_num_entity_dlights ; i++, l++)
                 if (l->die >= cl.time && l->spawn <= cl.time && l->baseradius)
                         num_dlights++;
 	if (num_dlights > 32 && dev_peakstats.dlights <= 32)

--- a/Quake/client.h
+++ b/Quake/client.h
@@ -70,6 +70,7 @@ extern cshift_t		cshift_empty;
 #define	SIGNONS		4			// signon messages to receive before connected
 
 #define	MAX_DLIGHTS		64 //johnfitz -- was 32
+#define	MAX_ENTITY_DLIGHTS		64 // persistent dlights spawned from BSP entities
 typedef enum
 {
 	DLIGHT_DEFAULT = 0,
@@ -94,8 +95,13 @@ typedef struct
 	vec3_t	color;				//johnfitz -- lit support via lordhavoc
 	float	flicker_seed;
 	dlighttype_t type;
+	int		style;			// optional light style/flicker index (entity dlights)
 } dlight_t;
 
+static inline qboolean CL_DlightIsActive (const dlight_t *dl)
+{
+	return dl && dl->die >= cl.time && dl->spawn <= cl.time && dl->baseradius > 0;
+}
 
 #define	MAX_BEAMS	32 //johnfitz -- was 24
 typedef struct
@@ -334,6 +340,8 @@ extern	entity_t		cl_static_entities[MAX_STATIC_ENTITIES];
 extern	int			cl_max_lightstyles;
 extern	lightstyle_t	cl_lightstyle[MAX_LIGHTSTYLES];
 extern	dlight_t		cl_dlights[MAX_DLIGHTS];
+extern	dlight_t		cl_entity_dlights[MAX_ENTITY_DLIGHTS];
+extern	int			cl_num_entity_dlights;
 extern	entity_t		cl_temp_entities[MAX_TEMP_ENTITIES];
 extern	beam_t			cl_beams[MAX_BEAMS];
 extern	entity_t		*cl_visedicts[MAX_VISEDICTS];

--- a/Quake/gl_lightgrid.c
+++ b/Quake/gl_lightgrid.c
@@ -15,6 +15,7 @@
 #include <math.h>
 
 extern vec3_t lightcolor;
+extern cvar_t r_dlight_entities;
 
 static lightgrid_t *current_lightgrid = NULL;
 static char lightgrid_source[16] = "NONE";
@@ -1867,13 +1868,13 @@ void Lightgrid_BuildFallback(void)
    Dlight integration
    ===================================================================== */
 
-static void Lightgrid_AddDlights(const vec3_t pos, vec3_t color, vec3_t dirsum)
+static void Lightgrid_AddDlightArray(const dlight_t *lights, int count, const vec3_t pos, vec3_t color, vec3_t dirsum)
 {
-    for (int i = 0; i < MAX_DLIGHTS; i++)
+    for (int i = 0; i < count; i++)
     {
-        const dlight_t *l = &cl_dlights[i];
+        const dlight_t *l = &lights[i];
 
-        if (l->die <= cl.time || (!l->radius && !l->minlight))
+        if (!CL_DlightIsActive (l) || (!l->radius && !l->minlight))
             continue;
 
         vec3_t delta;
@@ -1894,6 +1895,14 @@ static void Lightgrid_AddDlights(const vec3_t pos, vec3_t color, vec3_t dirsum)
             VectorMA(dirsum, add, delta, dirsum);
     }
 }
+
+static void Lightgrid_AddDlights(const vec3_t pos, vec3_t color, vec3_t dirsum)
+{
+    Lightgrid_AddDlightArray(cl_dlights, MAX_DLIGHTS, pos, color, dirsum);
+    if (r_dlight_entities.value > 0.f && cl_num_entity_dlights > 0)
+        Lightgrid_AddDlightArray(cl_entity_dlights, cl_num_entity_dlights, pos, color, dirsum);
+}
+
 
 /* =====================================================================
    Public API

--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -36,6 +36,7 @@ static qmodel_t*	loadmodel;
 static char	loadname[32];	// for hunk tags
 
 extern vec3_t lightcolor;
+extern cvar_t r_dlight_entities;
 
 static void Mod_LoadSpriteModel (qmodel_t *mod, void *buffer);
 static void Mod_LoadBrushModel (qmodel_t *mod, void *buffer);
@@ -3487,13 +3488,13 @@ static qboolean LightgridRAW_TraceLine (const qmodel_t *mod, const vec3_t start,
 }
 
 
-static void LightgridRAW_AddDynamicLights (const qmodel_t *mod, const vec3_t pos, vec3_t rgb, vec3_t dirsum)
+static void LightgridRAW_AddDynamicLights_Array (const qmodel_t *mod, const vec3_t pos, vec3_t rgb, vec3_t dirsum, const dlight_t *lights, int count)
 {
-        for (int i = 0; i < MAX_DLIGHTS; i++)
+        for (int i = 0; i < count; i++)
         {
-                const dlight_t *l = &cl_dlights[i];
+                const dlight_t *l = &lights[i];
 
-                if (l->die <= cl.time || (!l->radius && !l->minlight))
+                if (!CL_DlightIsActive (l))
                         continue;
 
                 vec3_t delta;
@@ -3523,6 +3524,14 @@ static void LightgridRAW_AddDynamicLights (const qmodel_t *mod, const vec3_t pos
                         VectorMA (dirsum, add, delta, dirsum);
         }
 }
+
+static void LightgridRAW_AddDynamicLights (const qmodel_t *mod, const vec3_t pos, vec3_t rgb, vec3_t dirsum)
+{
+        LightgridRAW_AddDynamicLights_Array (mod, pos, rgb, dirsum, cl_dlights, MAX_DLIGHTS);
+        if (r_dlight_entities.value > 0.f && cl_num_entity_dlights > 0)
+                LightgridRAW_AddDynamicLights_Array (mod, pos, rgb, dirsum, cl_entity_dlights, cl_num_entity_dlights);
+}
+
 
 static qboolean LightgridRAW_TextureIsEmissive (const texture_t *tx)
 {

--- a/Quake/gl_rlight.c
+++ b/Quake/gl_rlight.c
@@ -30,6 +30,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 extern cvar_t r_flatlightstyles; //johnfitz
 extern cvar_t r_lerplightstyles;
 extern cvar_t r_dynamic;
+extern cvar_t r_dlight_entities;
 extern cvar_t r_lightgrid;
 extern cvar_t r_lightgrid_force;
 extern cvar_t r_rgblighting_enable;
@@ -44,6 +45,149 @@ static qboolean R_IsFinite (float v)
 #else
         return isfinite(v);
 #endif
+}
+
+
+static void R_ParseDlightColor (const char *value, vec3_t color)
+{
+	float r = 1.f, g = 1.f, b = 1.f;
+	if (value && sscanf (value, "%f %f %f", &r, &g, &b) == 3)
+	{
+		// Accept either 0-1 or 0-255 ranges; normalize to 0-1 for storage.
+		if (r > 2.f || g > 2.f || b > 2.f)
+		{
+			r *= 1.f / 255.f;
+			g *= 1.f / 255.f;
+			b *= 1.f / 255.f;
+		}
+	}
+	color[0] = r;
+	color[1] = g;
+	color[2] = b;
+}
+
+static qboolean R_ParseDlightOrigin (const char *value, vec3_t origin)
+{
+	return value && sscanf (value, "%f %f %f", &origin[0], &origin[1], &origin[2]) == 3;
+}
+
+static void R_AddEntityDlight (const vec3_t origin, float radius, const vec3_t color, int style)
+{
+	if (cl_num_entity_dlights >= MAX_ENTITY_DLIGHTS)
+		return;
+
+	dlight_t *dl = &cl_entity_dlights[cl_num_entity_dlights++];
+
+	memset (dl, 0, sizeof(*dl));
+	VectorCopy (origin, dl->origin);
+	VectorCopy (color, dl->color);
+	dl->baseradius = radius;
+	dl->radius = radius;
+	dl->spawn = cl.time - 0.001f;
+	dl->die = FLT_MAX;
+	dl->decay = 0.f;
+	dl->minlight = 0.f;
+	dl->key = -(1000 + cl_num_entity_dlights);
+	dl->type = DLIGHT_DEFAULT;
+	dl->style = style;
+	dl->flicker_seed = (float) rand ();
+}
+
+// Parse BSP entity lump for persistent dynamic lights.
+// Supported forms:
+//   classname "dlight" (always persistent)
+//   classname "light" with either "dynamic" "1" or "dlight" "1"
+// Keys:
+//   "origin" (vector, required)
+//   "radius" or fallback "light" (radius/intensity)
+//   "_color" or "color" (RGB, accepts floats 0-1 or bytes 0-255, stored as 0-1)
+//   optional "style" / "flicker" / "pulse" (stored for future use)
+void R_ParseDlightEntities (void)
+{
+	const char *data;
+
+	memset (cl_entity_dlights, 0, sizeof (cl_entity_dlights));
+	cl_num_entity_dlights = 0;
+
+	if (!cl.worldmodel || !cl.worldmodel->entities)
+		return;
+
+	if (r_dlight_entities.value <= 0.f)
+		return;
+
+	data = cl.worldmodel->entities;
+	data = COM_Parse (data);
+	while (data && com_token[0])
+	{
+		vec3_t origin = {0.f, 0.f, 0.f};
+		vec3_t color = {1.f, 1.f, 1.f};
+		float radius = 0.f;
+		int style = 0;
+		qboolean classname_is_dlight = false;
+		qboolean classname_is_light = false;
+		qboolean marked_dynamic = false;
+		qboolean parsed_origin = false;
+
+		if (com_token[0] != '{')
+			break;
+
+		while (1)
+		{
+			char key[64], value[1024];
+			data = COM_Parse (data);
+			if (!data || !com_token[0])
+				return;
+			if (com_token[0] == '}')
+				break;
+			q_strlcpy (key, com_token, sizeof (key));
+			if (key[0] == '_')
+				memmove (key, key + 1, strlen (key));
+			data = COM_ParseEx (data, CPE_ALLOWTRUNC);
+			if (!data)
+				return;
+			q_strlcpy (value, com_token, sizeof (value));
+			if (!strcmp (key, "classname"))
+			{
+				classname_is_dlight = !strcmp (value, "dlight");
+				classname_is_light = !strcmp (value, "light");
+			}
+			else if (!strcmp (key, "origin"))
+				parsed_origin = R_ParseDlightOrigin (value, origin);
+			else if (!strcmp (key, "_color") || !strcmp (key, "color"))
+				R_ParseDlightColor (value, color);
+			else if (!strcmp (key, "radius"))
+				radius = atof (value);
+			else if (!strcmp (key, "light") && radius <= 0.f)
+				radius = atof (value);
+			else if (!strcmp (key, "dynamic") || !strcmp (key, "dlight"))
+				marked_dynamic = atoi (value) != 0;
+			else if (!strcmp (key, "style") || !strcmp (key, "flicker") || !strcmp (key, "pulse"))
+				style = atoi (value);
+		}
+
+		if ((classname_is_dlight || (classname_is_light && marked_dynamic)) && radius > 0.f && parsed_origin)
+		{
+			R_AddEntityDlight (origin, radius, color, style);
+			if (cl_num_entity_dlights >= MAX_ENTITY_DLIGHTS)
+				break;
+		}
+
+		data = COM_Parse (data);
+	}
+
+	if (cl_num_entity_dlights || developer.value)
+	{
+		const int debugcount = q_min (cl_num_entity_dlights, 5);
+		Con_DPrintf ("Spawned %d entity dlights (showing %d):\n", cl_num_entity_dlights, debugcount);
+		for (int i = 0; i < debugcount; i++)
+		{
+			const dlight_t *dl = &cl_entity_dlights[i];
+			Con_DPrintf ("  #%d origin %.1f %.1f %.1f radius %.1f color %.2f %.2f %.2f style %d\n", i,
+					dl->origin[0], dl->origin[1], dl->origin[2], dl->baseradius,
+					dl->color[0], dl->color[1], dl->color[2], dl->style);
+		}
+	}
+	return;
 }
 
 int RecursiveLightPoint (qmodel_t *model, lightcache_t *cache, mnode_t *node, vec3_t rayorg, vec3_t start, vec3_t end, float *maxdist);
@@ -176,81 +320,90 @@ void GLLight_DeleteResources (void)
 	gl_lightclustertexture = 0;
 }
 
+static void R_PushDlightArray (dlight_t *lights, int count)
+{
+	int	j;
+
+	for (int i = 0; i < count; i++)
+	{
+		dlight_t *l = &lights[i];
+		gpulight_t *out;
+		qboolean cull = false;
+		float radius;
+
+		if (l->spawn > cl.time)
+		{
+			l->die = 0.f;
+			continue;
+		}
+
+		if (!CL_DlightIsActive (l))
+			continue;
+
+		radius = l->baseradius * (1.f + 0.1f * (float) sin (cl.time * 9.0 + l->flicker_seed));
+		radius = q_max (radius, 0.f);
+		l->radius = radius;
+
+		for (j = 0; j < 4; j++)
+		{
+			mplane_t *p = &frustum[j];
+			if (DotProduct (p->normal, l->origin) - p->dist + radius < 0.f)
+			{
+				cull = true;
+				break;
+			}
+		}
+		if (cull)
+			continue;
+
+		out = &r_lightbuffer.lights[r_framedata.numlights++];
+		const vec3_t *temp = R_GetDynamicLightTemperature (l->type);
+		float radiusFactor = q_min (1.f, q_max (radius / 350.f, 0.2f));
+		float flicker = 1.f + (float)sin (cl.time * 15.0 + l->key) * 0.1f;
+		vec3_t finalcolor;
+		finalcolor[0] = l->color[0] * (*temp)[0] * radiusFactor;
+		finalcolor[1] = l->color[1] * (*temp)[1] * radiusFactor;
+		finalcolor[2] = l->color[2] * (*temp)[2] * radiusFactor;
+		finalcolor[0] *= flicker;
+		finalcolor[1] *= flicker;
+		finalcolor[2] *= flicker;
+		if (l->type == DLIGHT_TORCH)
+		{
+			float colorshift = (float)sin (cl.time * 11.0 + l->key) * 0.1f;
+			finalcolor[0] *= 1.0f + colorshift;
+			finalcolor[1] *= 1.0f - colorshift;
+		}
+		out->pos[0]   = l->origin[0];
+		out->pos[1]   = l->origin[1];
+		out->pos[2]   = l->origin[2];
+		out->radius   = radius;
+		out->color[0] = finalcolor[0];
+		out->color[1] = finalcolor[1];
+		out->color[2] = finalcolor[2];
+		out->minlight = l->minlight;
+	}
+}
+
 /*
-=============
+===============
 R_PushDlights
-=============
+===============
 */
 void R_PushDlights (void)
 {
-	int				i, j;
-	GLuint			buf;
-	GLbyte			*ofs;
+	int					i;
+	GLuint		buf;
+	GLbyte		*ofs;
 	gpu_cluster_inputs_t cluster_inputs;
 
 	r_framedata.numlights = 0;
 
 	if (r_dynamic.value)
 	{
-		dlight_t *l;
-		for (i = 0, l = cl_dlights; i < MAX_DLIGHTS; i++, l++)
-		{
-			gpulight_t *out;
-                        qboolean cull = false;
-                        float radius;
-
-                        if (l->spawn > cl.time)
-                        {
-                                l->die = 0.f;
-                                continue;
-                        }
-
-                        if (l->die < cl.time || !l->baseradius)
-                                continue;
-
-                        radius = l->baseradius * (1.f + 0.1f * (float) sin (cl.time * 9.0 + l->flicker_seed));
-                        radius = q_max (radius, 0.f);
-                        l->radius = radius;
-
-                        for (j = 0; j < 4; j++)
-                        {
-                                mplane_t *p = &frustum[j];
-                                if (DotProduct (p->normal, l->origin) - p->dist + radius < 0.f)
-                                {
-                                        cull = true;
-                                        break;
-                                }
-                        }
-                        if (cull)
-                                continue;
-
-                        out = &r_lightbuffer.lights[r_framedata.numlights++];
-                        const vec3_t *temp = R_GetDynamicLightTemperature (l->type);
-                        float radiusFactor = q_min (1.f, q_max (radius / 350.f, 0.2f));
-                        float flicker = 1.f + (float)sin (cl.time * 15.0 + l->key) * 0.1f;
-                        vec3_t finalcolor;
-                        finalcolor[0] = l->color[0] * (*temp)[0] * radiusFactor;
-                        finalcolor[1] = l->color[1] * (*temp)[1] * radiusFactor;
-                        finalcolor[2] = l->color[2] * (*temp)[2] * radiusFactor;
-                        finalcolor[0] *= flicker;
-                        finalcolor[1] *= flicker;
-                        finalcolor[2] *= flicker;
-                        if (l->type == DLIGHT_TORCH)
-                        {
-                                float colorshift = (float)sin (cl.time * 11.0 + l->key) * 0.1f;
-                                finalcolor[0] *= 1.0f + colorshift;
-                                finalcolor[1] *= 1.0f - colorshift;
-                        }
-                        out->pos[0]   = l->origin[0];
-                        out->pos[1]   = l->origin[1];
-                        out->pos[2]   = l->origin[2];
-                        out->radius   = radius;
-                        out->color[0] = finalcolor[0];
-                        out->color[1] = finalcolor[1];
-                        out->color[2] = finalcolor[2];
-                        out->minlight = l->minlight;
-                }
-        }
+		R_PushDlightArray (cl_dlights, MAX_DLIGHTS);
+		if (r_dlight_entities.value > 0.f && cl_num_entity_dlights > 0)
+			R_PushDlightArray (cl_entity_dlights, cl_num_entity_dlights);
+	}
 
 	GL_BeginGroup ("Light clustering");
 
@@ -271,6 +424,7 @@ void R_PushDlights (void)
 
 	GL_EndGroup ();
 }
+
 
 
 /*
@@ -322,32 +476,38 @@ void R_LightgridLighting (const vec3_t pos, vec3_t out_color, float *out_ao)
 R_AddDynamicLights_Lightgrid
 ==================
 */
+static void R_AddDynamicLights_LightgridArray (const dlight_t *lights, int count, const vec3_t pos, vec3_t lightcolor)
+{
+	for (int i = 0; i < count; i++)
+	{
+		const dlight_t *l = &lights[i];
+		vec3_t dist;
+		float add;
+
+		if (!CL_DlightIsActive (l))
+			continue;
+
+		VectorSubtract (pos, l->origin, dist);
+		add = l->radius - VectorLength (dist);
+
+		if (add <= l->minlight)
+			continue;
+
+		add -= l->minlight;
+		VectorMA (lightcolor, add, l->color, lightcolor);
+	}
+}
+
 void R_AddDynamicLights_Lightgrid (const vec3_t pos, vec3_t lightcolor)
 {
-        int i;
+	if (!r_dynamic.value)
+		return;
 
-        if (!r_dynamic.value)
-                return;
-
-        for (i = 0; i < MAX_DLIGHTS; i++)
-        {
-                const dlight_t *l = &cl_dlights[i];
-                vec3_t dist;
-                float add;
-
-                if (l->die < cl.time || l->spawn > cl.time || !l->baseradius)
-                        continue;
-
-                VectorSubtract (pos, l->origin, dist);
-                add = l->radius - VectorLength (dist);
-
-                if (add <= l->minlight)
-                        continue;
-
-                add -= l->minlight;
-                VectorMA (lightcolor, add, l->color, lightcolor);
-        }
+	R_AddDynamicLights_LightgridArray (cl_dlights, MAX_DLIGHTS, pos, lightcolor);
+	if (r_dlight_entities.value > 0.f && cl_num_entity_dlights > 0)
+		R_AddDynamicLights_LightgridArray (cl_entity_dlights, cl_num_entity_dlights, pos, lightcolor);
 }
+
 
 static inline int LightStyleValue (unsigned short style)
 {

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -199,6 +199,7 @@ cvar_t	r_saturation = { "r_saturation", "1", CVAR_ARCHIVE };
 cvar_t	r_wateralpha = { "r_wateralpha","1",CVAR_ARCHIVE };
 cvar_t	r_litwater = { "r_litwater","1",CVAR_NONE };
 cvar_t	r_dynamic = { "r_dynamic","1",CVAR_ARCHIVE };
+cvar_t	r_dlight_entities = { "r_dlight_entities", "1", CVAR_ARCHIVE };
 cvar_t	r_novis = { "r_novis","0",CVAR_ARCHIVE };
 #if defined(USE_SIMD)
 cvar_t	r_simd = { "r_simd","1",CVAR_ARCHIVE };

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -376,6 +376,7 @@ Cvar_RegisterVariable (&r_drawviewmodel);
 	Cvar_SetCallback (&r_wateralpha, R_SetWateralpha_f);
 	Cvar_RegisterVariable (&r_litwater);
 	Cvar_RegisterVariable (&r_dynamic);
+	Cvar_RegisterVariable (&r_dlight_entities);
 	Cvar_RegisterVariable (&r_novis);
 #if defined(USE_SIMD)
 	Cvar_RegisterVariable (&r_simd);
@@ -646,6 +647,7 @@ void R_NewMap (void)
         Sky_NewMap (); //johnfitz -- skybox in worldspawn
         Fog_NewMap (); //johnfitz -- global fog in worldspawn
         R_ParseWorldspawn (); //ericw -- wateralpha, lavaalpha, telealpha, slimealpha in worldspawn
+        R_ParseDlightEntities (); // persistent dlights from BSP entities
 
 	// Load pointfile if map has no vis data and either developer mode is on or the game was started from a map editing tool
 	if (developer.value || map_checks.value)

--- a/Quake/render.h
+++ b/Quake/render.h
@@ -137,6 +137,7 @@ void R_AddEfrags (entity_t *ent);
 void R_AddStaticModels (const byte *vis);
 
 void R_NewMap (void);
+void R_ParseDlightEntities (void);
 
 
 void R_ParseParticleEffect (void);


### PR DESCRIPTION
## Summary
- parse BSP entity lumps for dynamic light entities and cache them as persistent dlights
- expose a cvar to toggle entity-driven dlights and integrate them into rendering/lightgrid paths
- ensure persistent dlights decay, reset, and debug-print consistently alongside transient dlights

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69432b177474832e8197325a25225e8f)