### PR TITLE
Declare r_dlight_entities in gl_rmisc

### DIFF
--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -54,6 +54,7 @@ extern cvar_t r_lightmap_linear;
 extern cvar_t r_lightmap_mipmaps;
 extern cvar_t r_lightmap16f;
 extern cvar_t r_lightingdir;
+extern cvar_t r_dlight_entities;
 //johnfitz
 extern cvar_t gl_zfix; // QuakeSpasm z-fighting fix
 extern cvar_t r_alphasort;


### PR DESCRIPTION
## Summary
- declare the r_dlight_entities cvar in gl_rmisc to match its definition
- allow the cvar to be registered without compiler errors

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694338d14bb8832e87a1d47483babafc)