### PR TITLE
Fix R_ClearEfrags comment terminator

### DIFF
--- a/Quake/gl_refrag.c
+++ b/Quake/gl_refrag.c
@@ -156,6 +156,7 @@ void R_CheckEfrags (void)
 ===========
 R_ClearEfrags
 ===========
+*/
 void R_ClearEfrags (void)
 {
 	if (!R_EfragsPointerIsCanonical (cl_efrags))


### PR DESCRIPTION
## Summary
- close the comment banner for R_ClearEfrags in gl_refrag.c so the function compiles

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69433eeacbe8832e964d3c3c0fcf09d9)