### PR TITLE
Add additive dynamic light pass

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -199,6 +199,8 @@ cvar_t	r_saturation = { "r_saturation", "1", CVAR_ARCHIVE };
 cvar_t	r_wateralpha = { "r_wateralpha","1",CVAR_ARCHIVE };
 cvar_t	r_litwater = { "r_litwater","1",CVAR_NONE };
 cvar_t	r_dynamic = { "r_dynamic","1",CVAR_ARCHIVE };
+cvar_t  r_dlight_style = { "r_dlight_style", "0", CVAR_ARCHIVE };
+cvar_t  r_dlight_debug = { "r_dlight_debug", "0", CVAR_NONE };
 cvar_t	r_dlight_entities = { "r_dlight_entities", "1", CVAR_ARCHIVE };
 cvar_t	r_novis = { "r_novis","0",CVAR_ARCHIVE };
 #if defined(USE_SIMD)
@@ -1660,6 +1662,10 @@ void R_SetupView (void)
         r_framedata.lightgrid_params[1] = (r_lightgrid_debug.value >= 2.f) ? 1.f : 0.f;
         r_framedata.lightgrid_params[2] = 0.f;
         r_framedata.lightgrid_params[3] = 0.f;
+        r_framedata.dlight_params[0] = r_dlight_style.value > 0.f ? 1.f : 0.f;
+        r_framedata.dlight_params[1] = r_dlight_debug.value > 0.f ? 1.f : 0.f;
+        r_framedata.dlight_params[2] = 0.f;
+        r_framedata.dlight_params[3] = 0.f;
 
 	double prev_delta = cl.time - r_prev_frame_time;
 	qboolean prev_valid = r_prev_frame_valid && prev_delta > 0.0;
@@ -1824,8 +1830,8 @@ R_DrawWater
 */
 static void R_DrawWater (qboolean translucent)
 {
-	entity_t** entlist = cl_sorted_visedicts;
-	int* ofs = cl_modtype_ofs + 2 * mod_brush;
+        entity_t** entlist = cl_sorted_visedicts;
+        int* ofs = cl_modtype_ofs + 2 * mod_brush;
 
 	if (translucent)
 	{
@@ -2797,7 +2803,49 @@ static void R_EndTranslucency (void)
 		GL_EndGroup ();
 	}
 
-	GL_EndGroup (); // translucent objects
+        GL_EndGroup (); // translucent objects
+}
+
+// Quake3-style dynamic light pass rationale: render only additive dlight
+// contributions (albedo * dlight) in a separate pass to preserve contrast of
+// the baked lighting while avoiding gamma artifacts from modulating the base
+// color. Static lighting remains untouched in the base pass.
+static void R_DrawDLightPass (void)
+{
+        int count = 0;
+        entity_t **ents;
+
+        if (r_dlight_style.value <= 0.f)
+                return;
+
+        if (r_framedata.numlights == 0 || r_dynamic.value <= 0.f || !r_drawworld_cheatsafe)
+                return;
+
+        ents = R_GetVisEntities (mod_brush, false, &count);
+        if (count <= 0)
+                return;
+
+        GL_BeginGroup ("Dynamic lights (additive)");
+
+        r_framedata.dlight_params[2] = 1.f;
+        {
+                GLuint buf;
+                GLbyte *ofs;
+                GL_Upload (GL_UNIFORM_BUFFER, &r_framedata, sizeof (r_framedata), &buf, &ofs);
+                GL_BindBufferRange (GL_UNIFORM_BUFFER, 0, buf, (GLintptr)ofs, sizeof (r_framedata));
+        }
+
+        R_DrawBrushModels_DLights (ents, count);
+
+        r_framedata.dlight_params[2] = 0.f;
+        {
+                GLuint buf;
+                GLbyte *ofs;
+                GL_Upload (GL_UNIFORM_BUFFER, &r_framedata, sizeof (r_framedata), &buf, &ofs);
+                GL_BindBufferRange (GL_UNIFORM_BUFFER, 0, buf, (GLintptr)ofs, sizeof (r_framedata));
+        }
+
+        GL_EndGroup ();
 }
 
 /*
@@ -2815,13 +2863,15 @@ void R_RenderScene (void)
 	// are available to all draw calls, even when light clustering is skipped.
 	R_UploadFrameData ();
 	
-	R_DrawViewModel (); //johnfitz -- moved here from R_RenderView
-	
-	S_ExtraUpdate (); // don't let sound get messed up if going slow
-	
-	R_DrawEntitiesOnList (false); //johnfitz -- false means this is the pass for nonalpha entities
-	
-	R_DrawParticles (false);
+        R_DrawViewModel (); //johnfitz -- moved here from R_RenderView
+
+        S_ExtraUpdate (); // don't let sound get messed up if going slow
+
+        R_DrawEntitiesOnList (false); //johnfitz -- false means this is the pass for nonalpha entities
+
+        R_DrawDLightPass ();
+
+        R_DrawParticles (false);
 	
 	Sky_DrawSky (); //johnfitz
 	

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -373,15 +373,17 @@ Cvar_RegisterVariable (&r_rgblighting_enable);
 Cvar_RegisterVariable (&r_fullbright);
 Cvar_RegisterVariable (&r_drawentities);
 Cvar_RegisterVariable (&r_drawviewmodel);
-	Cvar_RegisterVariable (&r_wateralpha);
-	Cvar_SetCallback (&r_wateralpha, R_SetWateralpha_f);
-	Cvar_RegisterVariable (&r_litwater);
-	Cvar_RegisterVariable (&r_dynamic);
-	Cvar_RegisterVariable (&r_dlight_entities);
-	Cvar_RegisterVariable (&r_novis);
+        Cvar_RegisterVariable (&r_wateralpha);
+        Cvar_SetCallback (&r_wateralpha, R_SetWateralpha_f);
+        Cvar_RegisterVariable (&r_litwater);
+        Cvar_RegisterVariable (&r_dynamic);
+        Cvar_RegisterVariable (&r_dlight_style);
+        Cvar_RegisterVariable (&r_dlight_debug);
+        Cvar_RegisterVariable (&r_dlight_entities);
+        Cvar_RegisterVariable (&r_novis);
 #if defined(USE_SIMD)
-	Cvar_RegisterVariable (&r_simd);
-	Cvar_SetCallback (&r_simd, R_SIMD_f);
+        Cvar_RegisterVariable (&r_simd);
+        Cvar_SetCallback (&r_simd, R_SIMD_f);
 	R_SIMD_f(&r_simd);
 #endif
 	Cvar_RegisterVariable (&r_speeds);

--- a/Quake/gl_shaders.c
+++ b/Quake/gl_shaders.c
@@ -519,10 +519,13 @@ void GL_CreateShaders (void)
         for (mode = 0; mode < 2; mode++)
                 glprogs.oit_resolve[mode] = GL_CreateProgram (GLSL_PATH("oit_resolve.vert"), GLSL_PATH("oit_resolve.frag"), "oit resolve|MSAA %d", mode);
 
-	for (oit = 0; oit < 2; oit++)
-		for (dither = 0; dither < 3; dither++)
-			for (mode = 0; mode < 3; mode++)
+        for (oit = 0; oit < 2; oit++)
+                for (dither = 0; dither < 3; dither++)
+                        for (mode = 0; mode < 3; mode++)
                                 glprogs.world[oit][dither][mode] = GL_CreateProgram (GLSL_PATH("world.vert"), GLSL_PATH("world.frag"), "world|OIT %d; DITHER %d; MODE %d", oit, dither, mode);
+
+        for (alphatest = 0; alphatest < 2; alphatest++)
+                glprogs.world_dlight[alphatest] = GL_CreateProgram (GLSL_PATH("world_dlight.vert"), GLSL_PATH("world_dlight.frag"), "world dlight|ALPHATEST %d", alphatest);
 
 	for (dither = 0; dither < 2; dither++)
 	{

--- a/Quake/gl_vidsdl.c
+++ b/Quake/gl_vidsdl.c
@@ -1110,28 +1110,31 @@ static void GL_SetStateEx (unsigned mask, unsigned force)
 
 	if (diff & GLS_MASK_BLEND)
 	{
-		switch (mask & GLS_MASK_BLEND)
-		{
-			default:
-			case GLS_BLEND_OPAQUE:
-				glBlendFunc(GL_ONE, GL_ZERO);
-				break;
-			case GLS_BLEND_ALPHA_OIT:
-				if (R_GetEffectiveAlphaMode () == ALPHAMODE_OIT)
-				{
-					GL_BlendFunciFunc(0, GL_ONE, GL_ONE); // accum
-					GL_BlendFunciFunc(1, GL_ZERO, GL_ONE_MINUS_SRC_COLOR); // revealage
-					break;
-				}
-				// fallthrough!
-			case GLS_BLEND_ALPHA:
-				glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-				break;
-			case GLS_BLEND_MULTIPLY:
-				glBlendFunc(GL_ZERO, GL_SRC_COLOR);
-				break;
-		}
-	}
+                switch (mask & GLS_MASK_BLEND)
+                {
+                        default:
+                        case GLS_BLEND_OPAQUE:
+                                glBlendFunc(GL_ONE, GL_ZERO);
+                                break;
+                        case GLS_BLEND_ALPHA_OIT:
+                                if (R_GetEffectiveAlphaMode () == ALPHAMODE_OIT)
+                                {
+                                        GL_BlendFunciFunc(0, GL_ONE, GL_ONE); // accum
+                                        GL_BlendFunciFunc(1, GL_ZERO, GL_ONE_MINUS_SRC_COLOR); // revealage
+                                        break;
+                                }
+                                // fallthrough!
+                        case GLS_BLEND_ALPHA:
+                                glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+                                break;
+                        case GLS_BLEND_MULTIPLY:
+                                glBlendFunc(GL_ZERO, GL_SRC_COLOR);
+                                break;
+                        case GLS_BLEND_ADD:
+                                glBlendFunc(GL_ONE, GL_ONE);
+                                break;
+                }
+        }
 
 	if (diff & GLS_MASK_CULL)
 	{

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -270,29 +270,30 @@ void GL_EndGroup (void);
 #define GLS_INSTANCED_ATTRIBS(n)	((n) << GLS_INSTANCED_ATTRIBS_SHIFT)
 
 typedef enum {
-	GLS_NO_ZTEST				= 1 << 0,
-	GLS_NO_ZWRITE				= 1 << 1,
+        GLS_NO_ZTEST                            = 1 << 0,
+        GLS_NO_ZWRITE                           = 1 << 1,
 
-	GLS_BLEND_OPAQUE			= 0 << 2,
-	GLS_BLEND_ALPHA				= 1 << 2,
-	GLS_BLEND_ALPHA_OIT			= 2 << 2,
-	GLS_BLEND_MULTIPLY			= 3 << 2,
-	GLS_MASK_BLEND				= 3 << 2,
+        GLS_BLEND_OPAQUE                        = 0 << 2,
+        GLS_BLEND_ALPHA                         = 1 << 2,
+        GLS_BLEND_ALPHA_OIT                     = 2 << 2,
+        GLS_BLEND_MULTIPLY                      = 3 << 2,
+        GLS_BLEND_ADD                           = 4 << 2,
+        GLS_MASK_BLEND                          = 7 << 2,
 
-	GLS_CULL_BACK				= 0 << 4,
-	GLS_CULL_NONE				= 1 << 4,
-	GLS_CULL_FRONT				= 2 << 4,
-	GLS_MASK_CULL				= 3 << 4,
+        GLS_CULL_BACK                           = 0 << 5,
+        GLS_CULL_NONE                           = 1 << 5,
+        GLS_CULL_FRONT                          = 2 << 5,
+        GLS_MASK_CULL                           = 3 << 5,
 
-	GLS_ATTRIBS_BITS			= 3,
-	GLS_ATTRIBS_SHIFT			= 6,
-	GLS_ATTRIBS_MAXCOUNT		= (1 << GLS_ATTRIBS_BITS) - 1,
-	GLS_MASK_ATTRIBS			= GLS_ATTRIBS_MAXCOUNT << GLS_ATTRIBS_SHIFT,
+        GLS_ATTRIBS_BITS                        = 3,
+        GLS_ATTRIBS_SHIFT                       = 7,
+        GLS_ATTRIBS_MAXCOUNT            = (1 << GLS_ATTRIBS_BITS) - 1,
+        GLS_MASK_ATTRIBS                        = GLS_ATTRIBS_MAXCOUNT << GLS_ATTRIBS_SHIFT,
 
-	GLS_INSTANCED_ATTRIBS_SHIFT	= GLS_ATTRIBS_SHIFT + GLS_ATTRIBS_BITS,
-	GLS_MASK_INSTANCED_ATTRIBS	= GLS_ATTRIBS_MAXCOUNT << GLS_INSTANCED_ATTRIBS_SHIFT,
+        GLS_INSTANCED_ATTRIBS_SHIFT     = GLS_ATTRIBS_SHIFT + GLS_ATTRIBS_BITS,
+        GLS_MASK_INSTANCED_ATTRIBS      = GLS_ATTRIBS_MAXCOUNT << GLS_INSTANCED_ATTRIBS_SHIFT,
 
-	GLS_DEFAULT_STATE			= GLS_BLEND_OPAQUE | GLS_CULL_BACK | GLS_ATTRIBS (1),
+        GLS_DEFAULT_STATE                       = GLS_BLEND_OPAQUE | GLS_CULL_BACK | GLS_ATTRIBS (1),
 } glstatebits_t;
 
 extern unsigned glstate;
@@ -432,6 +433,7 @@ typedef struct gpuframedata_s {
         vec4_t          zparams;        // x: zlogscale, y: zlogbias, zw: padding
         float           lightmap_params[4];
         vec4_t          lightgrid_params; // x: enabled, yzw: unused
+        vec4_t          dlight_params;  // x: style, y: debug view, z: pass selector, w: padding
         unsigned int    numlights;
         unsigned int    prev_frame_valid;
         unsigned int    _padding1;
@@ -467,6 +469,7 @@ void R_ResizeShadowMapIfNeeded (void);
 
 void R_DrawBrushModels (entity_t **ents, int count);
 void R_DrawBrushModels_Water (entity_t **ents, int count, qboolean translucent);
+void R_DrawBrushModels_DLights (entity_t **ents, int count);
 void R_DrawBrushModels_SkyLayers (entity_t **ents, int count);
 void R_DrawBrushModels_SkyCubemap (entity_t **ents, int count);
 void R_DrawBrushModels_SkyStencil (entity_t **ents, int count);
@@ -544,6 +547,7 @@ typedef struct glprogs_s {
 
 	/* 3d */
 	GLuint		world[2][3][3];		// [OIT][standard/dithered/banded][solid/alpha test/water]
+	GLuint		world_dlight[2];		// [alpha test]
 	GLuint		water[2][2];		// [OIT][dither]
 	GLuint		skystencil;
 	GLuint		skylayers[2];		// [dither]

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -443,6 +443,8 @@ typedef enum {
         BP_SKYCUBEMAP,
         BP_SKYSTENCIL,
         BP_SHOWTRIS,
+        BP_DLIGHT_SOLID,
+        BP_DLIGHT_ALPHA,
 } brushpass_t;
 
 /*
@@ -504,6 +506,16 @@ static void R_DrawBrushModels_Real (entity_t **ents, int count, brushpass_t pass
                 texend = TEXTYPE_COUNT;
                 program = glprogs.world[0][0][0];
                 break;
+        case BP_DLIGHT_SOLID:
+                texbegin = 0;
+                texend = TEXTYPE_CUTOUT;
+                program = glprogs.world_dlight[0];
+                break;
+        case BP_DLIGHT_ALPHA:
+                texbegin = TEXTYPE_CUTOUT;
+                texend = TEXTYPE_CUTOUT + 1;
+                program = glprogs.world_dlight[1];
+                break;
         }
 
         for (i = 0, totalinst = 0; i < count; i++)
@@ -517,7 +529,9 @@ static void R_DrawBrushModels_Real (entity_t **ents, int count, brushpass_t pass
                 return;
 
         state = GLS_CULL_BACK | GLS_ATTRIBS(6);
-        if (!translucent)
+        if (pass == BP_DLIGHT_SOLID || pass == BP_DLIGHT_ALPHA)
+                state |= GLS_BLEND_ADD | GLS_NO_ZWRITE;
+        else if (!translucent)
                 state |= GLS_BLEND_OPAQUE;
         else
                 state |= GLS_BLEND_ALPHA_OIT | GLS_NO_ZWRITE;
@@ -760,8 +774,17 @@ void R_DrawBrushModels (entity_t **ents, int count)
 			if (mask & (1 << BP_ALPHATEST))
 				R_DrawBrushModels_Real (ents + i, j - i, BP_ALPHATEST, true);
 			i = j;
-		}
-	}
+        }
+}
+
+void R_DrawBrushModels_DLights (entity_t **ents, int count)
+{
+        if (!count)
+                return;
+
+        R_DrawBrushModels_Real (ents, count, BP_DLIGHT_SOLID, false);
+        R_DrawBrushModels_Real (ents, count, BP_DLIGHT_ALPHA, false);
+}
 }
 
 

--- a/Quake/shaders/frame_uniforms.glsl
+++ b/Quake/shaders/frame_uniforms.glsl
@@ -21,6 +21,7 @@ layout(std140, binding=0) uniform FrameDataUBO
         float   ZLogBias;
         vec4    LightmapParams;
         vec4    LightgridParams;
+        vec4    DLightParams;
         uint    NumLights;
         uint    PrevFrameValid;
         uint    _Pad1;

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -287,12 +287,15 @@ void main()
 
 	// Gamma correction
 	bool linear_lightmaps = LightmapParams.x > 0.5;
-	if (!linear_lightmaps)
-	{
-		result.rgb = pow(result.rgb, vec3(2.2));
-		fullbright = pow(fullbright, vec3(2.2));
-		emissive = pow(emissive, vec3(2.2));
-	}
+        if (!linear_lightmaps)
+        {
+                result.rgb = pow(result.rgb, vec3(2.2));
+                fullbright = pow(fullbright, vec3(2.2));
+                emissive = pow(emissive, vec3(2.2));
+        }
+
+        bool additive_dlights = DLightParams.x > 0.5;
+        bool dlight_debug = DLightParams.y > 0.5;
 
 	// Lightmap sampling
 	vec2 lmuv = in_lmuv;
@@ -339,6 +342,13 @@ void main()
 
     static_light *= lightgrid;
 
+    if (dlight_debug)
+    {
+        static_light = vec3(0.0);
+        fullbright = vec3(0.0);
+        emissive = vec3(0.0);
+    }
+
 	// Directional lightmap
 	if (LightmapParams.z > 0.5)
 	{
@@ -376,11 +386,11 @@ void main()
 	const float SPECULAR_POWER = 16.0;
 	const float SPECULAR_SCALE = 0.4;
 
-	// Dynamic lights (clustered lighting)
-	if (NumLights > 0u)
-	{
-		ivec3 cluster_coord = ivec3(
-			int(floor(in_coord.x)),
+        // Dynamic lights (clustered lighting)
+        if (!additive_dlights && NumLights > 0u)
+        {
+                ivec3 cluster_coord = ivec3(
+                        int(floor(in_coord.x)),
 			int(floor(in_coord.y)),
 			int(floor(log2(in_depth) * ZLogScale + ZLogBias))
 		);
@@ -448,7 +458,7 @@ void main()
 	}
 
 	// Sun light
-	vec3 sun_light = ComputeSunLight(in_pos, surface_normal);
+        vec3 sun_light = dlight_debug ? vec3(0.0) : ComputeSunLight(in_pos, surface_normal);
 	total_light += max(min(sun_light, 1.0 - total_light), 0.0);
 
 	// Apply lighting

--- a/Quake/shaders/world_dlight.frag
+++ b/Quake/shaders/world_dlight.frag
@@ -1,0 +1,150 @@
+layout(binding=0) uniform sampler2D Tex;
+layout(binding=2) uniform sampler2D LMTex; // unused, kept for binding slot consistency
+layout(binding=3) uniform sampler2D LMTexDir; // unused
+
+#include "frame_uniforms.glsl"
+
+#ifndef ALPHATEST
+#define ALPHATEST 0
+#endif
+
+vec3 ApplyFog(vec3 clr, vec3 p)
+{
+        float fog = exp2(-abs(Fog.w) * dot(p, p));
+        fog = clamp(fog, 0.0, 1.0);
+        return mix(Fog.rgb, clr, fog);
+}
+
+#define LIGHT_TILES_X 32
+#define LIGHT_TILES_Y 16
+#define LIGHT_TILES_Z 32
+#define MAX_LIGHTS    64
+
+struct Light
+{
+        vec3    origin;
+        float   radius;
+        vec3    color;
+        float   minlight;
+};
+
+layout(std430, binding=0) restrict readonly buffer LightBuffer
+{
+        vec2    LightStyles[64];
+        Light   Lights[];
+};
+
+layout(rg32ui, binding=0) uniform readonly uimage3D LightClusters;
+
+layout(location=0) flat in uint in_flags;
+layout(location=1) flat in float in_alpha;
+layout(location=2) in vec3 in_pos;
+layout(location=3) in vec2 in_uv;
+layout(location=4) in float in_depth;
+layout(location=5) noperspective in vec2 in_coord;
+layout(location=6) in vec3 in_normal;
+#if BINDLESS
+        layout(location=7) flat in uvec4 in_samplers0;
+        layout(location=8) flat in uvec2 in_samplers1;
+#endif
+
+layout(location=0) out vec4 out_fragcolor;
+layout(location=1) out vec4 out_velocity;
+
+float whitenoise01(vec2 p)
+{
+        vec3 p3 = fract(vec3(p.xyx) * 0.1031);
+        p3 += dot(p3, p3.yzx + 33.33);
+        return fract((p3.x + p3.y) * p3.z);
+}
+
+void main()
+{
+        (void)in_flags;
+        vec2 uv = in_uv;
+#if BINDLESS
+        (void)in_samplers1;
+        sampler2D baseSampler = sampler2D(in_samplers0.xy);
+        vec4 texel = texture(baseSampler, uv);
+#else
+        vec4 texel = texture(Tex, uv);
+#endif
+
+#if ALPHATEST
+        if (texel.a < 0.666)
+                discard;
+#endif
+
+        float alpha = texel.a * in_alpha;
+        vec3 albedo = texel.rgb;
+        bool linear_lightmaps = LightmapParams.x > 0.5;
+        if (!linear_lightmaps)
+                albedo = pow(albedo, vec3(2.2));
+
+        vec3 surface_normal = normalize(in_normal);
+        if (!gl_FrontFacing)
+                surface_normal = -surface_normal;
+
+        vec3 dynamic_light = vec3(0.0);
+        if (NumLights > 0u)
+        {
+                ivec3 cluster_coord = ivec3(
+                        int(floor(in_coord.x)),
+                        int(floor(in_coord.y)),
+                        int(floor(log2(in_depth) * ZLogScale + ZLogBias))
+                );
+
+                uvec2 clusterdata = imageLoad(LightClusters, cluster_coord).xy;
+
+                if ((clusterdata.x | clusterdata.y) != 0u)
+                {
+                        float dynamic_light_noise = 1.0 - whitenoise01(in_pos.xy) * 0.15;
+                        vec4 plane = vec4(surface_normal, dot(in_pos, surface_normal));
+
+                        for (uint i = 0u, ofs = 0u; i < 2u; i++, ofs += 32u)
+                        {
+                                uint mask = clusterdata[i];
+                                while (mask != 0u)
+                                {
+                                        int j = findLSB(mask);
+                                        mask ^= 1u << j;
+                                        Light l = Lights[ofs + uint(j)];
+
+                                        float rad = l.radius;
+                                        float dist = dot(l.origin, plane.xyz) - plane.w;
+                                        rad -= abs(dist);
+                                        float minlight = l.minlight;
+
+                                        if (rad <= 0.0 || rad < minlight)
+                                                continue;
+
+                                        vec3 local_pos = l.origin - plane.xyz * dist;
+                                        minlight = rad - minlight;
+                                        vec3 light_vec = local_pos - in_pos;
+                                        float surface_dist = length(light_vec);
+                                        float attenuation = clamp((minlight - surface_dist) / 16.0, 0.0, 1.0);
+                                        float normalized_dist = surface_dist / rad;
+                                        float falloff = pow(1.0 - clamp(normalized_dist, 0.0, 1.0), 1.5);
+                                        if (surface_dist > 0.0)
+                                        {
+                                                vec3 light_dir = light_vec / surface_dist;
+                                                float ndotl = max(dot(surface_normal, light_dir), 0.0);
+                                                vec3 light_contrib = attenuation * falloff * l.color * dynamic_light_noise * ndotl;
+                                                dynamic_light += light_contrib;
+                                        }
+                                }
+                        }
+                }
+        }
+
+        vec3 contrib = clamp(dynamic_light * Overbright, 0.0, Overbright);
+        vec3 color = albedo * contrib;
+
+        if (!linear_lightmaps)
+                color = pow(color, vec3(1.0 / 2.2));
+
+        color = ApplyFog(color, in_pos - EyePos);
+
+        out_fragcolor = vec4(color, 0.0);
+        out_velocity = vec4(0.0);
+}

--- a/Quake/shaders/world_dlight.vert
+++ b/Quake/shaders/world_dlight.vert
@@ -1,0 +1,156 @@
+#if defined(GL_ARB_shader_draw_parameters)
+        #extension GL_ARB_shader_draw_parameters : require
+        #define DRAW_ID                 gl_DrawIDARB
+#else
+        layout(location=0) uniform int DrawID;
+        #define DRAW_ID                 DrawID
+#endif
+
+#include "frame_uniforms.glsl"
+
+#ifndef MODE
+#define MODE 0
+#endif
+
+#define LIGHT_TILES_X 32
+#define LIGHT_TILES_Y 16
+#define LIGHT_TILES_Z 32
+#define MAX_LIGHTS    64
+
+struct Light
+{
+        vec3    origin;
+        float   radius;
+        vec3    color;
+        float   minlight;
+};
+
+layout(std430, binding=0) restrict readonly buffer LightBuffer
+{
+        vec2    LightStyles[64];
+        Light   Lights[];
+};
+
+struct Call
+{
+        uint    flags;
+        float   wateralpha;
+#if BINDLESS
+        uvec2   txhandle;
+        uvec2   fbhandle;
+        uvec2   emhandle;
+#else
+        int             baseinstance;
+        int             padding;
+#endif // BINDLESS
+};
+const uint
+        CF_USE_POLYGON_OFFSET = 1u,
+        CF_USE_FULLBRIGHT = 2u,
+        CF_NOLIGHTMAP = 4u,
+        CF_USE_EMISSIVE = 8u,
+        CF_ALPHA_TEST = 16u
+;
+
+layout(std430, binding=1) restrict readonly buffer CallBuffer
+{
+        Call call_data[];
+};
+
+#if BINDLESS
+        #define GET_INSTANCE_ID(call) (gl_BaseInstanceARB + gl_InstanceID)
+#else
+        #define GET_INSTANCE_ID(call) (call.baseinstance + gl_InstanceID)
+#endif
+struct Instance
+{
+        vec4    mat[3];
+        vec4    prev_mat[3];
+        float   alpha;
+        float   pad0;
+        float   pad1;
+        float   pad2;
+};
+
+layout(std430, binding=2) restrict readonly buffer InstanceBuffer
+{
+        Instance instance_data[];
+};
+
+vec3 TransformPosition(vec3 p, vec4 mat[3])
+{
+        mat4x3 world = transpose(mat3x4(mat[0], mat[1], mat[2]));
+        return (world * vec4(p, 1.0)).xyz;
+}
+
+vec3 Transform(vec3 p, Instance instance)
+{
+        return TransformPosition(p, instance.mat);
+}
+
+vec3 TransformDirection(vec3 n, Instance instance)
+{
+        mat4x3 world = transpose(mat3x4(instance.mat[0], instance.mat[1], instance.mat[2]));
+        return (world * vec4(n, 0.0)).xyz;
+}
+
+layout(location=0) in vec3 in_pos;
+layout(location=1) in vec4 in_uv;
+layout(location=2) in float in_lmofs;
+layout(location=3) in ivec4 in_styles;
+layout(location=4) in vec3 in_normal;
+layout(location=5) in vec3 in_lightgrid;
+
+layout(location=0) flat out uint out_flags;
+layout(location=1) flat out float out_alpha;
+layout(location=2) out vec3 out_pos;
+layout(location=3) out vec2 out_uv;
+layout(location=4) out float out_depth;
+layout(location=5) noperspective out vec2 out_coord;
+layout(location=6) out vec3 out_normal;
+#if BINDLESS
+        layout(location=7) flat out uvec4 out_samplers0;
+        layout(location=8) flat out uvec2 out_samplers1;
+#endif
+
+void main()
+{
+        Call call = call_data[DRAW_ID];
+        int instance_id = GET_INSTANCE_ID(call);
+        Instance instance = instance_data[instance_id];
+        vec3 world_pos = Transform(in_pos, instance);
+        vec3 world_normal = TransformDirection(in_normal, instance);
+        vec4 curr_clip = ViewProj * vec4(world_pos, 1.0);
+#if REVERSED_Z
+        const float ZBIAS = -1./1024;
+#else
+        const float ZBIAS =  1./1024;
+#endif
+        if ((call.flags & CF_USE_POLYGON_OFFSET) != 0u)
+        {
+                curr_clip.z += ZBIAS;
+        }
+        gl_Position = curr_clip;
+        out_pos = world_pos;
+        out_normal = normalize(world_normal);
+        out_uv = in_uv.xy;
+        out_depth = gl_Position.w;
+        out_coord = (gl_Position.xy / gl_Position.w * 0.5 + 0.5) * vec2(LIGHT_TILES_X, LIGHT_TILES_Y);
+        out_flags = call.flags;
+#if MODE == 2
+        out_alpha = instance.alpha < 0.0 ? call.wateralpha : instance.alpha;
+#else
+        out_alpha = instance.alpha < 0.0 ? 1.0 : instance.alpha;
+#endif
+#if BINDLESS
+        out_samplers0.xy = call.txhandle;
+        if ((call.flags & CF_USE_FULLBRIGHT) != 0u)
+                out_samplers0.zw = call.fbhandle;
+        else
+                out_samplers0.zw = uvec2(0u);
+        if ((call.flags & CF_USE_EMISSIVE) != 0u)
+                out_samplers1.xy = call.emhandle;
+        else
+                out_samplers1.xy = uvec2(0u);
+#endif
+}


### PR DESCRIPTION
## Summary
- add cvars and frame uniform updates to control Quake3-style dynamic light rendering
- implement additive dynamic light pass and shaders for world/brush models with new GL state
- adjust blend handling and shader registration to support the new pass

## Testing
- `ninja -C Linux -j2` *(fails: build.ninja missing)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69443fbf4ec0832e9e942d600b984b39)