### PR TITLE
Fix dlight cvars and R_DrawBrushModels braces

### DIFF
--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -54,6 +54,8 @@ extern cvar_t r_lightmap_linear;
 extern cvar_t r_lightmap_mipmaps;
 extern cvar_t r_lightmap16f;
 extern cvar_t r_lightingdir;
+extern cvar_t r_dlight_style;
+extern cvar_t r_dlight_debug;
 extern cvar_t r_dlight_entities;
 //johnfitz
 extern cvar_t gl_zfix; // QuakeSpasm z-fighting fix

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -774,7 +774,8 @@ void R_DrawBrushModels (entity_t **ents, int count)
 			if (mask & (1 << BP_ALPHATEST))
 				R_DrawBrushModels_Real (ents + i, j - i, BP_ALPHATEST, true);
 			i = j;
-        }
+		}
+	}
 }
 
 void R_DrawBrushModels_DLights (entity_t **ents, int count)
@@ -784,7 +785,6 @@ void R_DrawBrushModels_DLights (entity_t **ents, int count)
 
         R_DrawBrushModels_Real (ents, count, BP_DLIGHT_SOLID, false);
         R_DrawBrushModels_Real (ents, count, BP_DLIGHT_ALPHA, false);
-}
 }
 
 


### PR DESCRIPTION
## Summary
- declare missing dynamic light cvars before registration
- fix R_DrawBrushModels brace structure to resolve syntax error

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694451091b98832e9f65250f72770494)