### PR TITLE
Add bindless extension requirement for world dlight shader

### DIFF
--- a/Quake/shaders/world_dlight.frag
+++ b/Quake/shaders/world_dlight.frag
@@ -1,4 +1,8 @@
+#if BINDLESS
+#extension GL_ARB_bindless_texture : require
+#else
 layout(binding=0) uniform sampler2D Tex;
+#endif
 layout(binding=2) uniform sampler2D LMTex; // unused, kept for binding slot consistency
 layout(binding=3) uniform sampler2D LMTexDir; // unused
 


### PR DESCRIPTION
## Summary
- enable the bindless texture extension in the world_dlight fragment shader when needed
- keep the existing bound texture uniform path for non-bindless builds

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694451e4936c832e94607c705e647335)