### PR TITLE
Fix alias lighting to use world lightmaps

### DIFF
--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -329,11 +329,13 @@ void R_SetupAliasLighting (entity_t     *e)
 
         if (!base_from_lightgrid)
         {
+                qmodel_t *lightmodel = cl.worldmodel ? cl.worldmodel : e->model;
+
                 // if the initial trace is completely black, try again from above
                 // this helps with models whose origin is slightly below ground level
                 // (e.g. some of the candles in the DOTM start map)
-                if (!R_LightPoint (e->model, e->origin, 0.f, &e->lightcache))
-                        R_LightPoint (e->model, e->origin, e->model->maxs[2] * 0.5f, &e->lightcache);
+                if (!R_LightPoint (lightmodel, e->origin, 0.f, &e->lightcache))
+                        R_LightPoint (lightmodel, e->origin, e->model->maxs[2] * 0.5f, &e->lightcache);
 
                 VectorCopy (lightcolor, ambientcolor);
 


### PR DESCRIPTION
## Summary
- sample lighting for alias models from the world model instead of the alias itself when lightgrids are unavailable
- ensures player viewmodels and other alias entities pick up colors from static lightmaps

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69445487d58c832e9df71be3ba2cc914)