### PR TITLE
Fix dynamic light style pass when r_dynamic is disabled

### DIFF
--- a/Quake/gl_rlight.c
+++ b/Quake/gl_rlight.c
@@ -398,10 +398,14 @@ void R_PushDlights (void)
 
 	r_framedata.numlights = 0;
 
-	if (r_dynamic.value)
-	{
-		R_PushDlightArray (cl_dlights, MAX_DLIGHTS);
-		if (r_dlight_entities.value > 0.f && cl_num_entity_dlights > 0)
+        // Collect dynamic lights both when the legacy r_dynamic toggle is
+        // enabled and when the Quake3-style additive path is requested via
+        // r_dlight_style. The latter needs the light list even if r_dynamic
+        // was disabled by the user.
+        if (r_dynamic.value > 0.f || r_dlight_style.value > 0.f)
+        {
+                R_PushDlightArray (cl_dlights, MAX_DLIGHTS);
+                if (r_dlight_entities.value > 0.f && cl_num_entity_dlights > 0)
 			R_PushDlightArray (cl_entity_dlights, cl_num_entity_dlights);
 	}
 

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -2818,7 +2818,7 @@ static void R_DrawDLightPass (void)
         if (r_dlight_style.value <= 0.f)
                 return;
 
-        if (r_framedata.numlights == 0 || r_dynamic.value <= 0.f || !r_drawworld_cheatsafe)
+        if (r_framedata.numlights == 0 || !r_drawworld_cheatsafe)
                 return;
 
         ents = R_GetVisEntities (mod_brush, false, &count);


### PR DESCRIPTION
## Summary
- ensure dynamic lights are gathered when r_dlight_style is enabled even if r_dynamic is off
- allow the additive dynamic light pass to run whenever r_dlight_style is active and lights exist

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944644f4e94832ea59934e4942497a1)