### PR TITLE
Declare r_dlight_style in gl_rlight

### DIFF
--- a/Quake/gl_rlight.c
+++ b/Quake/gl_rlight.c
@@ -30,6 +30,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 extern cvar_t r_flatlightstyles; //johnfitz
 extern cvar_t r_lerplightstyles;
 extern cvar_t r_dynamic;
+extern cvar_t r_dlight_style;
 extern cvar_t r_dlight_entities;
 extern cvar_t r_lightgrid;
 extern cvar_t r_lightgrid_force;


### PR DESCRIPTION
## Summary
- declare the `r_dlight_style` cvar in `gl_rlight.c` so the file can reference it

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694485be4bec832e97b7963396ee6caf)