### PR TITLE
Apply overbright only to static model lighting

### DIFF
--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -439,8 +439,6 @@ void R_SetupAliasLighting (entity_t     *e)
 		VectorClear (dlightcolor);
 	}
 
-	const float overbright = gl_overbright_models.value ? 2.0f : 1.0f;
-
 	{
 		vec3_t pre_total;
 		vec3_t post_total;
@@ -448,7 +446,7 @@ void R_SetupAliasLighting (entity_t     *e)
 		for (i = 0; i < 3; i++)
 		{
 			float L = pre_total[i] * (1.0f / 256.0f);
-			L = fminf(L * overbright, 1.0f);
+			L = fminf(L, 1.0f);
 			L = powf(L, 1.0f / 2.2f);
 			post_total[i] = L;
 		}

--- a/Quake/shaders/alias.vert
+++ b/Quake/shaders/alias.vert
@@ -126,7 +126,7 @@ void main()
         float rim = pow(max(1.0 - dot(world_normal, view_dir), 0.0), 3.0) * 0.3;
         vec3 ambient = max(inst.LightColor.rgb - inst.DLightColor.rgb, vec3(0.0));
         vec3 litAmbient = ambient * (mix(0.35, 1.0, lighting) * Overbright);
-        vec3 litDlight = inst.DLightColor.rgb * (lighting * Overbright);
+        vec3 litDlight = inst.DLightColor.rgb * lighting;
         vec3 base_color = litAmbient + litDlight;
         bool is_viewmodel = (inst.Flags & ALIAS_FLAG_VIEWMODEL) != 0;
         vec3 final_color = is_viewmodel ? base_color + vec3(rim) : base_color;


### PR DESCRIPTION
### Motivation
- Make `r_overbrightbits` affect only the static lighting term used for models (lightgrid / lightpoint / vertex lighting), not the albedo or additive/dynamic lighting such as dlights, emissive or FX.
- Prevent dynamic/additive lights from being boosted by overbright so moving entities match the world lighting and FX remain unchanged.
- Restore the intended semantics: final color = albedo * (static_light * overbright_scale).

### Description
- Removed CPU-side multiplication of the pre-tone-mapped total by overbright in `R_SetupAliasLighting` (`Quake/r_alias.c`) so dynamic lighting is no longer upscaled on the CPU/ToneMap path.
- Updated the alias vertex shader (`Quake/shaders/alias.vert`) so `Overbright` is applied only to the ambient/static term (`litAmbient`) while the dynamic light contribution (`inst.DLightColor`) is left unscaled (`litDlight = inst.DLightColor.rgb * lighting`).
- Preserved the existing mechanism for computing/propagating the overbright scale (`r_framedata.dither[2]` / `ibuf.global.overbright`) so shaders still receive the configured `Overbright` value.

### Testing
- No automated tests were run for this change.
- Changes were compiled/committed locally as source edits; no further CI/test results are available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69457c43e6c4832eb2bc0943b0ada75e)