### PR TITLE
DoF autofocus: use server-side traces to include alias and moving BSP models

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -310,6 +310,7 @@ static float R_GetDynamicDoFFocus (float fallback)
 	vec3_t end;
 	float range;
 	float target;
+	qboolean traced = false;
 
 	if (r_dof_autofocus.value <= 0.f)
 	{
@@ -329,13 +330,30 @@ static float R_GetDynamicDoFFocus (float fallback)
 
 	VectorMA (r_origin, range, vpn, end);
 
-	memset (&trace, 0, sizeof (trace));
-	trace.fraction = 1.f;
-	VectorCopy (end, trace.endpos);
+	if (sv.active)
+	{
+		extern edict_t* sv_player;
+		qcvm_t* oldvm = qcvm;
 
-	SV_RecursiveHullCheck (cl.worldmodel->hulls, 0, 0.f, 1.f, r_origin, end, &trace);
+		PR_SwitchQCVM (NULL);
+		PR_SwitchQCVM (&sv.qcvm);
 
-	if (trace.allsolid || trace.fraction <= 0.f)
+		trace = SV_Move (r_origin, vec3_origin, vec3_origin, end, MOVE_NORMAL, sv_player);
+		traced = true;
+
+		PR_SwitchQCVM (oldvm);
+	}
+
+	if (!traced)
+	{
+		memset (&trace, 0, sizeof (trace));
+		trace.fraction = 1.f;
+		VectorCopy (end, trace.endpos);
+
+		SV_RecursiveHullCheck (cl.worldmodel->hulls, 0, 0.f, 1.f, r_origin, end, &trace);
+	}
+
+	if (trace.allsolid || trace.startsolid || trace.fraction <= 0.f)
 		target = fallback;
 	else
 		target = q_max (trace.fraction * range, 0.f);


### PR DESCRIPTION
### Motivation
- Autofocus (`r_dof_autofocus`) should consider dynamic entities (alias models, non-static BSP/brush models) when determining focus distance.
- World-only hull traces miss server entities and moving models, producing incorrect focus for scenes with dynamic geometry.
- Fall back to the previous world hull trace when server data is unavailable.
- Treat traces that start inside geometry as a fallback to the configured focus distance.

### Description
- Modified `R_GetDynamicDoFFocus` in `Quake/gl_rmain.c` to attempt an entity-aware trace when the server is active:
  - If `sv.active` is true, switch QCVM to the server VM with `PR_SwitchQCVM`, call `SV_Move(r_origin, vec3_origin, vec3_origin, end, MOVE_NORMAL, sv_player)`, then restore the old QCVM.
  - Use a `traced` flag to decide whether the server trace was performed and otherwise fall back to calling `SV_RecursiveHullCheck` against the world hulls.
- Changed focus decision to treat `trace.startsolid` as a failing trace (use fallback focus) in addition to `trace.allsolid` and `trace.fraction <= 0.f`.
- Small bookkeeping additions: `qboolean traced` local flag and preservation/restoration of `qcvm` around the server trace.

### Testing
- No automated tests were executed for this change.
- The change is limited to `Quake/gl_rmain.c` and updates the autofocus tracing path; integration/engine tests or a build verification would be recommended after merge.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945a4e5b478832eadcec9c6d53fc83d)