### PR TITLE
Lightgrid: color debug diamonds from probes and add `r_lightgrid_intensity` cvar

### DIFF
--- a/Quake/gl_lightgrid.c
+++ b/Quake/gl_lightgrid.c
@@ -26,6 +26,7 @@ cvar_t r_lightgrid_backend    = { "r_lightgrid_backend", "NONE", CVAR_ROM };
 cvar_t r_lightgrid_debug      = { "r_lightgrid_debug", "0", CVAR_NONE };
 cvar_t r_lightgrid_octree_debug = { "r_lightgrid_octree_debug", "0", CVAR_NONE };
 cvar_t r_lightgrid_style      = { "r_lightgrid_style", "0", CVAR_ARCHIVE };
+cvar_t r_lightgrid_intensity  = { "r_lightgrid_intensity", "1", CVAR_ARCHIVE };
 cvar_t r_lightgrid_force      = { "r_lightgrid_force", "0", CVAR_ARCHIVE };
 cvar_t r_lightgrid_apply_world = { "r_lightgrid_apply_world", "0", CVAR_ARCHIVE };
 cvar_t r_generate_lightgrid_test = { "r_generate_lightgrid_test", "0", CVAR_NONE };
@@ -77,6 +78,7 @@ void Lightgrid_Init(void)
     Cvar_RegisterVariable(&r_lightgrid_debug);
     Cvar_RegisterVariable(&r_lightgrid_octree_debug);
     Cvar_RegisterVariable(&r_lightgrid_style);
+    Cvar_RegisterVariable(&r_lightgrid_intensity);
     Cvar_RegisterVariable(&r_lightgrid_force);
     Cvar_RegisterVariable(&r_lightgrid_apply_world);
     Cvar_RegisterVariable(&r_generate_lightgrid_test);
@@ -1373,6 +1375,7 @@ void Lightgrid_Sample(const vec3_t pos, vec3_t out_color, float *out_ao)
 {
     const lightgrid_t *lg = Lightgrid_Get();
     lightgrid_probe_t probe;
+    const float intensity_scale = q_max(0.f, r_lightgrid_intensity.value);
 
     if (!Lightgrid_SampleProbe(lg, pos, &probe))
     {
@@ -1380,7 +1383,7 @@ void Lightgrid_Sample(const vec3_t pos, vec3_t out_color, float *out_ao)
         return;
     }
 
-    VectorCopy(probe.rgb, out_color);
+    VectorScale(probe.rgb, intensity_scale, out_color);
     if (out_ao)
         *out_ao = CLAMP(0.f, probe.ao, 1.f);
 }

--- a/Quake/gl_lightgrid.h
+++ b/Quake/gl_lightgrid.h
@@ -18,6 +18,7 @@ extern cvar_t r_lightgrid_backend;
 extern cvar_t r_lightgrid_debug;
 extern cvar_t r_lightgrid_octree_debug;
 extern cvar_t r_lightgrid_style;
+extern cvar_t r_lightgrid_intensity;
 extern cvar_t r_lightgrid_force;
 extern cvar_t r_lightgrid_apply_world;
 extern cvar_t r_generate_lightgrid_test;
@@ -51,4 +52,3 @@ void SH9_EncodeDirectional(vec3_t dir, vec3_t rgb, sh9_color_t *out);
 qboolean Lightgrid_LoadFromKTX2(const char *mapname);
 qboolean Lightgrid_ExportToKTX2(const lightgrid_t *grid, const char *mapname);
 #endif
-

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -2630,23 +2630,23 @@ static void R_ShowLightgridDebug (void)
         {
                 for (int y = 0; y < lg->ny; y++)
                 {
-                        for (int x = 0; x < lg->nx; x++)
-                        {
-                                vec3_t center;
-                                uint32_t color;
-                                const lightgrid_probe_t *probe = &lg->probes[(z * lg->ny + y) * lg->nx + x];
+                                for (int x = 0; x < lg->nx; x++)
+                                {
+                                        vec3_t center;
+                                        vec3_t debug_color;
+                                        uint32_t color;
+                                        const lightgrid_probe_t *probe = &lg->probes[(z * lg->ny + y) * lg->nx + x];
 
-                                VectorSet (center,
-                                        lg->mins[0] + (x + 0.5f) * lg->cellsize,
-                                        lg->mins[1] + (y + 0.5f) * lg->cellsize,
-                                        lg->mins[2] + (z + 0.5f) * lg->cellsize);
+                                        VectorSet (center,
+                                                lg->mins[0] + (x + 0.5f) * lg->cellsize,
+                                                lg->mins[1] + (y + 0.5f) * lg->cellsize,
+                                                lg->mins[2] + (z + 0.5f) * lg->cellsize);
 
-                                color = (probe->intensity > 0.f)
-                                        ? R_PackDebugColor (probe->rgb)
-                                        : 0xffffffff;
+                                        VectorScale (probe->rgb, q_max (0.f, r_lightgrid_intensity.value), debug_color);
+                                        color = R_PackDebugColor (debug_color);
 
-                                R_EmitDiamond (center, radius, color);
-                        }
+                                        R_EmitDiamond (center, radius, color);
+                                }
                 }
         }
 


### PR DESCRIPTION
### Motivation
- Debug lightgrid diamonds were rendering all white in debug mode instead of showing each probe's RGB, making it hard to inspect probe colors.
- Add a user-exposed intensity control so the contribution of light probes can be scaled at runtime (`r_lightgrid_intensity`).

### Description
- Added new cvar `r_lightgrid_intensity` (`Quake/gl_lightgrid.h`, `Quake/gl_lightgrid.c`) and registered it in `Lightgrid_Init`.
- Apply the intensity multiplier when sampling probes in `Lightgrid_Sample` by scaling `probe.rgb` before returning (`VectorScale` with `r_lightgrid_intensity`).
- Fixed debug visualization in `R_ShowLightgridDebug` (`Quake/gl_rmain.c`) to pack and emit the probe RGB (scaled by `r_lightgrid_intensity`) for the debug diamonds instead of defaulting to white.
- Modified files: `Quake/gl_lightgrid.h`, `Quake/gl_lightgrid.c`, `Quake/gl_rmain.c`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945d4a09bd0832e80e9160b1ed8a1f9)