### PR TITLE
Include gl_ktx2.h in gl_model.c to declare R_LoadKTX2Texture

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -26,6 +26,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "quakedef.h"
 #include "gl_lightgrid.h"
+#include "gl_ktx2.h"
 #include "../common/lightgrid.h"
 
 #define INVALID_LIGHTSTYLE_OLD 255


### PR DESCRIPTION
### Motivation
- MSVC produced C2220/C4013/C4047 errors because `R_LoadKTX2Texture` was used in `Quake/gl_model.c` without a visible prototype.
- The undefined prototype leads to incorrect implicit function assumptions and type mismatches when assigning its return value to `gltexture_t *`.
- Adding the proper header makes the symbol visible to the compiler and prevents these warnings from being treated as errors.

### Description
- Added `#include "gl_ktx2.h"` to `Quake/gl_model.c` so the `R_LoadKTX2Texture` prototype is available.
- The change is a single-line include insertion near the other GL-related includes in `gl_model.c`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946f70c880c832e84b3eb288d756f77)