### PR TITLE
Adjust octree sample loading to match EricW Python behavior

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -2582,20 +2582,44 @@ static qboolean LightgridOctree_LoadBSPX (qmodel_t *mod, void *data, int size)
 				continue;
 			}
 
-			set->used_samples = used;
-
-			if (set->used_samples > 4)
+			if ((size_t)(end - cursor) < (size_t)used * (sizeof(uint8_t) + 3))
 				return false;
 
-			if ((size_t)(end - cursor) < (size_t)set->used_samples * (sizeof(uint8_t) + 3))
-				return false;
+			if (used == 0)
+				continue;
 
-			for (int j = 0; j < set->used_samples; j++)
+			lightgrid_octree_sample_t chosen = { {0, 0, 0}, 0 };
+			qboolean chosen_set = false;
+			for (uint32_t j = 0; j < used; j++)
 			{
-				set->samples[j].style = *cursor++;
-				set->samples[j].color[0] = *cursor++;
-				set->samples[j].color[1] = *cursor++;
-				set->samples[j].color[2] = *cursor++;
+				uint8_t style = *cursor++;
+				uint8_t color[3];
+				color[0] = *cursor++;
+				color[1] = *cursor++;
+				color[2] = *cursor++;
+
+				if (!chosen_set)
+				{
+					chosen.style = style;
+					chosen.color[0] = color[0];
+					chosen.color[1] = color[1];
+					chosen.color[2] = color[2];
+					chosen_set = true;
+				}
+
+				if (style == 0)
+				{
+					chosen.style = style;
+					chosen.color[0] = color[0];
+					chosen.color[1] = color[1];
+					chosen.color[2] = color[2];
+				}
+			}
+
+			if (chosen_set)
+			{
+				set->samples[0] = chosen;
+				set->used_samples = 1;
 			}
 		}
 	}


### PR DESCRIPTION
### Motivation
- Make the C `LIGHTGRID_OCTREE` loader behave like the Python `lightgrid_ericw_octree_to_raw_core_ericw.py` parser by scanning all styles per sample and choosing a preferred style when present.
- Avoid rejecting octree payloads simply for having more styles than a small fixed cap and instead preserve occlusion semantics.

### Description
- Modified the parsing loop in `LightgridOctree_LoadBSPX` (in `Quake/gl_model.c`) to read the `used` count and iterate all style/color entries rather than writing them directly into the samples array.
- The loader now selects the preferred style `0` if present, otherwise the first style, and writes that single chosen sample into `set->samples[0]` with `set->used_samples = 1`.
- Removed the previous immediate failure on `used_samples > 4` and tightened the buffer-length check to validate there is room for `used` entries before consuming them.
- Preserved existing occlusion handling (`0xFF` used value) and early-skip for `used == 0` cases.

### Testing
- No automated tests were executed against this change.
- A commit containing the code changes was created and staged in the working tree.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947074831a4832ea9b6a33474142429)