### PR TITLE
Fix const qualifier warning in R_ModelTypeName

### DIFF
--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -150,7 +150,7 @@ static void R_ApplyLightgridLighting (const entity_t *e, vec3_t ambientcolor, ve
         }
 }
 
-static const char *R_ModelTypeName (const qmodel_t *model)
+static const char *R_ModelTypeName (qmodel_t *model)
 {
         if (!model)
                 return "none";


### PR DESCRIPTION
### Motivation
- Silence a compiler warning (C4090) where a `const qmodel_t *` was passed to `Mod_Extradata`, which expects a non-const model pointer.
- Ensure the model-type helper can call `Mod_Extradata` without requiring casts that trigger qualifier mismatches.

### Description
- Changed the signature of `R_ModelTypeName` from `static const char *R_ModelTypeName (const qmodel_t *model)` to `static const char *R_ModelTypeName (qmodel_t *model)`.
- This removes the `const` qualifier mismatch when calling `Mod_Extradata` inside the function.

### Testing
- No automated tests were run on this change.
- Compiler/build was not executed as part of this PR run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948502c3e7c832e971dbf79cc7a41b4)