### PR TITLE
Fix const qualifier warning and avoid occluded lightgrid samples for items

### DIFF
--- a/Quake/gl_rlight.c
+++ b/Quake/gl_rlight.c
@@ -1201,17 +1201,31 @@ qboolean R_EntityStaticLight (entity_t *e, vec3_t out_color255, entity_lightinfo
 
         if (r_model_lightgrid.value > 0.f && R_LightgridEnabled ())
         {
-                const lightgrid_probe_t *probe = R_GetLightgridSample (e->origin);
-                if (probe)
+                vec3_t sample_pos;
+                VectorCopy (e->origin, sample_pos);
+
+                for (int attempt = 0; attempt < 2; attempt++)
                 {
+                        const lightgrid_probe_t *probe = R_GetLightgridSample (sample_pos);
+                        if (!probe)
+                                break;
+
                         VectorCopy (probe->rgb, lightgrid_color);
                         lightgrid_ao = CLAMP (0.f, probe->ao, 1.f);
                         lightgrid_valid = probe->intensity > 0.f || lightgrid_ao > 0.f;
-                        if (lightgrid_valid)
-                        {
-                                VectorScale (lightgrid_color, lightgrid_ao * 255.f, out_color255);
-                                used_lightgrid = true;
-                        }
+                        if (lightgrid_valid || attempt == 1 || !e->model)
+                                break;
+
+                        float ofs = e->model->maxs[2] * 0.5f;
+                        if (ofs <= 0.f)
+                                break;
+                        sample_pos[2] += ofs;
+                }
+
+                if (lightgrid_valid)
+                {
+                        VectorScale (lightgrid_color, lightgrid_ao * 255.f, out_color255);
+                        used_lightgrid = true;
                 }
         }
 

--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -150,7 +150,7 @@ static void R_ApplyLightgridLighting (const entity_t *e, vec3_t ambientcolor, ve
         }
 }
 
-static const char *R_ModelTypeName (const qmodel_t *model)
+static const char *R_ModelTypeName (qmodel_t *model)
 {
         if (!model)
                 return "none";


### PR DESCRIPTION
### Motivation
- Silence MSVC `C4090` const-qualifier warnings caused by a helper calling `Mod_Extradata` with a `const qmodel_t *` parameter.
- Prevent health/ammo item boxes from rendering black when floor-level lightgrid samples return fully-occluded probes.
- Allow the model-type helper to call `Mod_Extradata` without casts that trigger qualifier mismatches.

### Description
- Change the signature of `R_ModelTypeName` from `static const char *R_ModelTypeName (const qmodel_t *model)` to `static const char *R_ModelTypeName (qmodel_t *model)` to remove the `const` mismatch.
- Modify `R_EntityStaticLight` to retry `R_GetLightgridSample` at a raised `z` position derived from `e->model->maxs[2]` when the first probe appears fully occluded.
- Only accept and apply a lightgrid probe when it is considered valid (or after the second attempt), and otherwise fall back to `R_LightPointNoGrid`/minlight logic.

### Testing
- No automated tests were run for this change.
- No automated build or CI was executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948502c3e7c832e971dbf79cc7a41b4)