### PR TITLE
Add CVAR-controlled filmgrain postprocess effect

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -241,6 +241,16 @@ cvar_t	r_screendarken = { "r_screendarken", "0", CVAR_ARCHIVE };
 cvar_t	r_screendarken_depth = { "r_screendarken_depth", "0.4", CVAR_ARCHIVE };
 cvar_t	r_teleportfx = { "r_teleportfx", "1", CVAR_ARCHIVE };
 cvar_t	r_teleportfx_time = { "r_teleportfx_time", "0.35", CVAR_ARCHIVE };
+cvar_t	r_filmgrain = { "r_filmgrain", "0", CVAR_ARCHIVE };
+cvar_t	r_filmgrain_amount = { "r_filmgrain_amount", "0.08", CVAR_ARCHIVE };
+cvar_t	r_filmgrain_size = { "r_filmgrain_size", "1.0", CVAR_ARCHIVE };
+cvar_t	r_filmgrain_speed = { "r_filmgrain_speed", "1.0", CVAR_ARCHIVE };
+cvar_t	r_filmgrain_color = { "r_filmgrain_color", "0", CVAR_ARCHIVE };
+cvar_t	r_filmgrain_luma_weight = { "r_filmgrain_luma_weight", "0.6", CVAR_ARCHIVE };
+cvar_t	r_filmgrain_blend = { "r_filmgrain_blend", "0.6", CVAR_ARCHIVE };
+cvar_t	r_filmgrain_seed = { "r_filmgrain_seed", "0", CVAR_ARCHIVE };
+cvar_t	r_filmgrain_affect_ui = { "r_filmgrain_affect_ui", "0", CVAR_ARCHIVE };
+cvar_t	r_filmgrain_debug = { "r_filmgrain_debug", "0", CVAR_ARCHIVE };
 
 cvar_t	r_overbrightbits = { "r_overbrightbits", "1", CVAR_ARCHIVE };
 
@@ -759,6 +769,23 @@ static void GL_PostProcessFallback (void)
 	free (pixels);
 }
 
+static void GL_SetFilmgrainUniforms (float amount, qboolean allow_debug)
+{
+	float amount_clamped = CLAMP (0.f, amount, 1.f);
+	float size = CLAMP (0.5f, r_filmgrain_size.value, 4.f);
+	float speed = q_max (0.f, r_filmgrain_speed.value);
+	float luma_weight = CLAMP (0.f, r_filmgrain_luma_weight.value, 1.f);
+	float blend = CLAMP (0.f, r_filmgrain_blend.value, 1.f);
+	float color = r_filmgrain_color.value > 0.f ? 1.f : 0.f;
+	float debug = (allow_debug && r_filmgrain_debug.value > 0.f) ? 1.f : 0.f;
+	float seed = r_filmgrain_seed.value;
+	float frame = (r_filmgrain_seed.value != 0.f) ? (float)r_framecount : (float)cl.time;
+
+	GL_Uniform4fFunc (13, amount_clamped, size, speed, luma_weight);
+	GL_Uniform4fFunc (14, blend, color, debug, seed);
+	GL_Uniform4fFunc (15, frame, 0.f, 0.f, 0.f);
+}
+
 
 void GL_PostProcess (void)
 	{
@@ -894,6 +921,13 @@ void GL_PostProcess (void)
 	screen_darken_depth);
 	GL_Uniform4fFunc (11, teleport_fade, teleport_blur, 0.f, 0.f);
 	GL_Uniform1fFunc (12, r_saturation.value);
+	{
+		float filmgrain_amount = 0.f;
+		qboolean filmgrain_enabled = (r_filmgrain.value > 0.f && r_filmgrain_affect_ui.value <= 0.f);
+		if (filmgrain_enabled)
+			filmgrain_amount = r_filmgrain_amount.value;
+		GL_SetFilmgrainUniforms (filmgrain_amount, filmgrain_enabled);
+	}
 
 	dof_enabled = R_DoFEnabled ();
 
@@ -1544,7 +1578,33 @@ qboolean GL_NeedsPostprocess (void)
 		return true;
 	if (r_tonemap.value > 0.f || r_bloom.value > 0.f || saturation != 1.f || GL_ShouldApplyMotionBlur ())
 		return true;
+	if (r_filmgrain.value > 0.f && r_filmgrain_affect_ui.value <= 0.f)
+		return true;
 	return false;
+}
+
+void GL_ApplyFilmgrainUI (void)
+{
+	if (r_filmgrain.value <= 0.f || r_filmgrain_affect_ui.value <= 0.f)
+		return;
+	if (!glprogs.filmgrain || framebufs.composite.color_tex == 0)
+		return;
+
+	GL_BeginGroup ("Filmgrain UI");
+
+	GL_BindFramebufferFunc (GL_FRAMEBUFFER, 0);
+	glViewport (glx, gly, glwidth, glheight);
+	glReadBuffer (GL_BACK);
+	GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, framebufs.composite.color_tex);
+	glCopyTexSubImage2D (GL_TEXTURE_2D, 0, 0, 0, glx, gly, glwidth, glheight);
+
+	GL_UseProgram (glprogs.filmgrain);
+	GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
+	GL_SetFilmgrainUniforms (r_filmgrain_amount.value, true);
+
+	glDrawArrays (GL_TRIANGLES, 0, 3);
+
+	GL_EndGroup ();
 }
 
 /*

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -92,6 +92,16 @@ extern cvar_t r_screendarken;
 extern cvar_t r_screendarken_depth;
 extern cvar_t r_teleportfx;
 extern cvar_t r_teleportfx_time;
+extern cvar_t r_filmgrain;
+extern cvar_t r_filmgrain_amount;
+extern cvar_t r_filmgrain_size;
+extern cvar_t r_filmgrain_speed;
+extern cvar_t r_filmgrain_color;
+extern cvar_t r_filmgrain_luma_weight;
+extern cvar_t r_filmgrain_blend;
+extern cvar_t r_filmgrain_seed;
+extern cvar_t r_filmgrain_affect_ui;
+extern cvar_t r_filmgrain_debug;
 
 #if defined(USE_SIMD)
 extern cvar_t r_simd;
@@ -426,6 +436,16 @@ Cvar_RegisterVariable (&r_vignette);
 	Cvar_RegisterVariable (&r_screendarken_depth);
 	Cvar_RegisterVariable (&r_teleportfx);
 	Cvar_RegisterVariable (&r_teleportfx_time);
+	Cvar_RegisterVariable (&r_filmgrain);
+	Cvar_RegisterVariable (&r_filmgrain_amount);
+	Cvar_RegisterVariable (&r_filmgrain_size);
+	Cvar_RegisterVariable (&r_filmgrain_speed);
+	Cvar_RegisterVariable (&r_filmgrain_color);
+	Cvar_RegisterVariable (&r_filmgrain_luma_weight);
+	Cvar_RegisterVariable (&r_filmgrain_blend);
+	Cvar_RegisterVariable (&r_filmgrain_seed);
+	Cvar_RegisterVariable (&r_filmgrain_affect_ui);
+	Cvar_RegisterVariable (&r_filmgrain_debug);
         Cvar_RegisterVariable (&r_overbrightbits);
         Cvar_SetCallback (&r_overbrightbits, R_OverbrightBits_f);
 

--- a/Quake/gl_screen.c
+++ b/Quake/gl_screen.c
@@ -2171,9 +2171,9 @@ void SCR_UpdateScreen (void)
 	}
 
 	Draw_Flush ();
+	GL_ApplyFilmgrainUI ();
 
 	GL_EndGroup ();
 
 	GL_EndRendering ();
 }
-

--- a/Quake/gl_shaders.c
+++ b/Quake/gl_shaders.c
@@ -507,12 +507,13 @@ void GL_CreateShaders (void)
 {
 	int palettize, dither, mode, alphatest, warp, oit, md5;
 
-    glprogs.gui = GL_CreateProgram (GLSL_PATH("gui.vert"), GLSL_PATH("gui.frag"), "gui");
-    glprogs.viewblend = GL_CreateProgram (GLSL_PATH("viewblend.vert"), GLSL_PATH("viewblend.frag"), "viewblend");
+	glprogs.gui = GL_CreateProgram (GLSL_PATH("gui.vert"), GLSL_PATH("gui.frag"), "gui");
+	glprogs.viewblend = GL_CreateProgram (GLSL_PATH("viewblend.vert"), GLSL_PATH("viewblend.frag"), "viewblend");
 	for (warp = 0; warp < 2; warp++)
             glprogs.warpscale[warp] = GL_CreateProgram (GLSL_PATH("warpscale.vert"), GLSL_PATH("warpscale.frag"), "view warp/scale|WARP %d", warp);
 	for (palettize = 0; palettize < 3; palettize++)
             glprogs.postprocess[palettize] = GL_CreateProgram (GLSL_PATH("postprocess.vert"), GLSL_PATH("postprocess.frag"), "postprocess|PALETTIZE %d", palettize);
+	glprogs.filmgrain = GL_CreateProgram (GLSL_PATH("postprocess.vert"), GLSL_PATH("filmgrain.frag"), "filmgrain");
 
 	glprogs.bloom_extract = GL_CreateProgram (GLSL_PATH("postprocess.vert"), GLSL_PATH("bloom_extract.frag"), "bloom extract");
     glprogs.bloom_blur = GL_CreateProgram (GLSL_PATH("postprocess.vert"), GLSL_PATH("bloom_blur.frag"), "bloom blur");

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -546,6 +546,7 @@ typedef struct glprogs_s {
 	GLuint		viewblend;
 	GLuint		warpscale[2];		// [warp]
 	GLuint		postprocess[3];		// [palettize:off/dithered/direct]
+	GLuint		filmgrain;
 	GLuint		bloom_extract;
 	GLuint		bloom_blur;
 	GLuint		oit_resolve[2];		// [msaa]
@@ -578,6 +579,7 @@ void GL_UseProgram (GLuint program);
 void GL_ClearCachedProgram (void);
 void GL_CreateShaders (void);
 void GL_DeleteShaders (void);
+void GL_ApplyFilmgrainUI (void);
 
 typedef struct glframebufs_s {
 	GLint			max_color_tex_samples;

--- a/Quake/shaders/filmgrain.frag
+++ b/Quake/shaders/filmgrain.frag
@@ -1,0 +1,72 @@
+layout(binding=0) uniform sampler2D ScreenTexture;
+
+layout(location=13) uniform vec4 FilmGrainParams0; // x: amount, y: size, z: speed, w: luma weight
+layout(location=14) uniform vec4 FilmGrainParams1; // x: blend, y: color, z: debug, w: seed
+layout(location=15) uniform vec4 FilmGrainParams2; // x: frame, yzw: unused
+
+float tri(float x)
+{
+	float orig = x * 2.0 - 1.0;
+	uint signbit = floatBitsToUint(orig) & 0x80000000u;
+	x = sqrt(abs(orig)) - 1.;
+	x = uintBitsToFloat(floatBitsToUint(x) ^ signbit);
+	return x;
+}
+
+float InterleavedGradientNoise(vec2 p)
+{
+	return fract(52.9829189 * fract(dot(p, vec2(0.06711056, 0.00583715))));
+}
+
+vec3 FilmGrainNoise(vec2 coord, float time, float seed, float colored)
+{
+	vec2 base = coord + vec2(seed, seed * 0.37);
+	float n0 = tri(InterleavedGradientNoise(base + vec2(time * 11.1, time * 7.3)));
+	float n1 = tri(InterleavedGradientNoise(base + vec2(17.7 + time * 5.2, 3.1 + time * 9.2)));
+	float n2 = tri(InterleavedGradientNoise(base + vec2(8.3 + time * 6.7, 12.9 + time * 4.1)));
+	vec3 colorNoise = (vec3(n0, n1, n2) + n0) * 0.5;
+	return mix(vec3(n0), colorNoise, colored);
+}
+
+layout(location=0) out vec4 out_fragcolor;
+
+void main()
+{
+	ivec2 pixel = ivec2(gl_FragCoord.xy);
+	vec4 color = texelFetch(ScreenTexture, pixel, 0);
+
+	float grainAmount = clamp(FilmGrainParams0.x, 0.0, 1.0);
+	float grainDebug = FilmGrainParams1.z;
+	if (grainAmount > 0.0 || grainDebug > 0.5)
+	{
+		float grainSize = max(FilmGrainParams0.y, 0.01);
+		float grainSpeed = max(FilmGrainParams0.z, 0.0);
+		float lumaWeight = clamp(FilmGrainParams0.w, 0.0, 1.0);
+		float blend = clamp(FilmGrainParams1.x, 0.0, 1.0);
+		float colored = clamp(FilmGrainParams1.y, 0.0, 1.0);
+		float seed = FilmGrainParams1.w;
+		float frame = FilmGrainParams2.x;
+		float time = frame * grainSpeed;
+		vec2 grainCoord = (gl_FragCoord.xy + vec2(0.25, 0.75)) / grainSize;
+		vec3 grain = FilmGrainNoise(grainCoord, time, seed, colored);
+
+		float luma = dot(color.rgb, vec3(0.299, 0.587, 0.114));
+		float shadow = clamp(1.0 - luma, 0.0, 1.0);
+		float lumaFactor = mix(1.0, shadow, lumaWeight);
+		float response = mix(1.0, smoothstep(0.0, 1.0, shadow), 0.5);
+		float amount = grainAmount * lumaFactor * response;
+
+		if (grainDebug > 0.5)
+		{
+			color.rgb = vec3(0.5) + grain * 0.5;
+		}
+		else
+		{
+			vec3 add = color.rgb + grain * amount;
+			vec3 soft = color.rgb + (color.rgb - color.rgb * color.rgb) * grain * amount;
+			color.rgb = clamp(mix(add, soft, blend), vec3(0.0), vec3(1.0));
+		}
+	}
+
+	out_fragcolor = vec4(color.rgb, 1.0);
+}

--- a/Quake/shaders/postprocess.frag
+++ b/Quake/shaders/postprocess.frag
@@ -57,6 +57,21 @@ float tri(float x)
 	return x;
 }
 
+float InterleavedGradientNoise(vec2 p)
+{
+	return fract(52.9829189 * fract(dot(p, vec2(0.06711056, 0.00583715))));
+}
+
+vec3 FilmGrainNoise(vec2 coord, float time, float seed, float colored)
+{
+	vec2 base = coord + vec2(seed, seed * 0.37);
+	float n0 = tri(InterleavedGradientNoise(base + vec2(time * 11.1, time * 7.3)));
+	float n1 = tri(InterleavedGradientNoise(base + vec2(17.7 + time * 5.2, 3.1 + time * 9.2)));
+	float n2 = tri(InterleavedGradientNoise(base + vec2(8.3 + time * 6.7, 12.9 + time * 4.1)));
+	vec3 colorNoise = (vec3(n0, n1, n2) + n0) * 0.5;
+	return mix(vec3(n0), colorNoise, colored);
+}
+
 vec3 UchimuraTonemap(vec3 x)
 {
         const float P = 1.0;
@@ -117,6 +132,9 @@ layout(location=9) uniform vec4 PostFXParams1; // xyz: vignette color, w: blend 
 layout(location=10) uniform vec4 PostFXParams2; // x: vignette noise amount, y: chromatic aberration (pixels), z: screen-space darken strength, w: screen-space darken depth range
 layout(location=11) uniform vec4 TeleportParams; // x: teleport fade, y: blur radius (pixels)
 layout(location=12) uniform float u_saturation;
+layout(location=13) uniform vec4 FilmGrainParams0; // x: amount, y: size, z: speed, w: luma weight
+layout(location=14) uniform vec4 FilmGrainParams1; // x: blend, y: color, z: debug, w: seed
+layout(location=15) uniform vec4 FilmGrainParams2; // x: frame, yzw: unused
 
 const int MOTION_MAX_SAMPLES = 64;
 const float OPAQUE_ALPHA_THRESHOLD = 0.999;
@@ -469,4 +487,37 @@ void main()
         mapped = clamp(mapped, 0.0, 1.0);
         out_fragcolor = vec4(pow(mapped, vec3(gamma)), 1.0);
 #endif // PALETTIZE
+
+	float grainAmount = clamp(FilmGrainParams0.x, 0.0, 1.0);
+	float grainDebug = FilmGrainParams1.z;
+	if (grainAmount > 0.0 || grainDebug > 0.5)
+	{
+		float grainSize = max(FilmGrainParams0.y, 0.01);
+		float grainSpeed = max(FilmGrainParams0.z, 0.0);
+		float lumaWeight = clamp(FilmGrainParams0.w, 0.0, 1.0);
+		float blend = clamp(FilmGrainParams1.x, 0.0, 1.0);
+		float colored = clamp(FilmGrainParams1.y, 0.0, 1.0);
+		float seed = FilmGrainParams1.w;
+		float frame = FilmGrainParams2.x;
+		float time = frame * grainSpeed;
+		vec2 grainCoord = (gl_FragCoord.xy + vec2(0.25, 0.75)) / grainSize;
+		vec3 grain = FilmGrainNoise(grainCoord, time, seed, colored);
+
+		float luma = dot(out_fragcolor.rgb, vec3(0.299, 0.587, 0.114));
+		float shadow = clamp(1.0 - luma, 0.0, 1.0);
+		float lumaFactor = mix(1.0, shadow, lumaWeight);
+		float response = mix(1.0, smoothstep(0.0, 1.0, shadow), 0.5);
+		float amount = grainAmount * lumaFactor * response;
+
+		if (grainDebug > 0.5)
+		{
+			out_fragcolor.rgb = vec3(0.5) + grain * 0.5;
+		}
+		else
+		{
+			vec3 add = out_fragcolor.rgb + grain * amount;
+			vec3 soft = out_fragcolor.rgb + (out_fragcolor.rgb - out_fragcolor.rgb * out_fragcolor.rgb) * grain * amount;
+			out_fragcolor.rgb = clamp(mix(add, soft, blend), vec3(0.0), vec3(1.0));
+		}
+	}
 }


### PR DESCRIPTION
### Motivation
- Provide a subtle, high-quality filmgrain postprocess to give scenes an analog look while remaining controllable at runtime via CVARs. 
- Allow filmgrain to be applied either to the 3D scene only or to the final UI/HUD as an optional last-step pass. 
- Keep the implementation minimal-invasive and cheap (single pass, no extra textures unless engine already has one). 

### Description
- Added runtime CVARs in `gl_rmain.c` (`r_filmgrain`, `r_filmgrain_amount`, `r_filmgrain_size`, `r_filmgrain_speed`, `r_filmgrain_color`, `r_filmgrain_luma_weight`, `r_filmgrain_blend`, `r_filmgrain_seed`, `r_filmgrain_affect_ui`, `r_filmgrain_debug`) and registered them in `gl_rmisc.c`. 
- Added a new `filmgrain.frag` shader and integrated grain logic into `postprocess.frag` (uniforms `FilmGrainParams0/1/2`) using an interleaved-gradient-noise style generator, temporal phase via frame/time, luma-weighting, and two blend modes (add and a soft/modulate-like mix). 
- Wired up a new GL program handle `glprogs.filmgrain` in `gl_shaders.c`, added `GL_SetFilmgrainUniforms` and uniform uploads in `GL_PostProcess`, and exposed `GL_ApplyFilmgrainUI` (declared in `glquake.h`) which is invoked from `SCR_UpdateScreen` when `r_filmgrain_affect_ui` is enabled. 
- Design choices: one-pass shader (no extra textures), symmetric grain range, optional colored/mono grain, `r_filmgrain_debug` to visualize pattern for repetition checks, and fallback to scene postprocess path when applicable. 

### Testing
- No automated tests were executed for this change. 
- Changes were added and committed to the repository but no compile or runtime verification was performed in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69486f66c4e4832e982c116877c36640)