### PR TITLE
Fix autoexposure blit framebuffer call

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -1091,7 +1091,7 @@ static qboolean GL_SampleAutoExposureLuminance (float *out_luminance)
 
 	GL_BindFramebufferFunc (GL_READ_FRAMEBUFFER, framebufs.composite.fbo);
 	GL_BindFramebufferFunc (GL_DRAW_FRAMEBUFFER, framebufs.autoexposure.fbo);
-	glBlitFramebuffer (0, 0, vid.width, vid.height, 0, 0, width, height, GL_COLOR_BUFFER_BIT, GL_LINEAR);
+	GL_BlitFramebufferFunc (0, 0, vid.width, vid.height, 0, 0, width, height, GL_COLOR_BUFFER_BIT, GL_LINEAR);
 
 	GL_BindFramebufferFunc (GL_READ_FRAMEBUFFER, framebufs.autoexposure.fbo);
 	glReadBuffer (GL_COLOR_ATTACHMENT0);


### PR DESCRIPTION
### Motivation
- The direct `glBlitFramebuffer` call in autoexposure sampling was undefined in some builds and caused compiler warnings treated as errors.
- The codebase uses loaded GL function pointers elsewhere, so the call should use the same `GL_BlitFramebufferFunc` wrapper for consistency. 
- Ensure the autoexposure path uses the dynamically loaded GL entry point to avoid platform-specific symbol issues.

### Description
- Updated `Quake/gl_rmain.c` inside `GL_SampleAutoExposureLuminance` to replace `glBlitFramebuffer` with `GL_BlitFramebufferFunc`.
- Only the blit call was changed and no other rendering logic or behavior was modified.
- One file (`Quake/gl_rmain.c`) was modified with a single-line replacement.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694983f98064832ebf2d3791c9fe7b8a)