### PR TITLE
Add r_maptex_export.c to Visual Studio project to resolve linker errors

### DIFF
--- a/Windows/VisualStudio/ironwail.vcxproj
+++ b/Windows/VisualStudio/ironwail.vcxproj
@@ -307,6 +307,7 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
     </ClCompile>
     <ClCompile Include="..\..\Quake\r_alias.c" />
     <ClCompile Include="..\..\Quake\r_brush.c" />
+    <ClCompile Include="..\..\Quake\r_maptex_export.c" />
     <ClCompile Include="..\..\Quake\r_part.c" />
     <ClCompile Include="..\..\Quake\r_sprite.c" />
     <ClCompile Include="..\..\Quake\r_world.c" />


### PR DESCRIPTION
### Motivation
- The build produced unresolved external symbols `R_MapTex_ExportInit` and `R_MapTex_ExportFromBsp`, indicating the map texture export implementation was not being compiled into the Windows project.
- The Visual Studio project did not include the `r_maptex_export.c` translation unit, so its definitions were missing at link time.

### Description
- Added a project compile entry for `..\..\Quake\r_maptex_export.c` to `Windows/VisualStudio/ironwail.vcxproj` so the map texture export code is built for Windows.
- The change is a single-line insertion: `<ClCompile Include="..\..\Quake\r_maptex_export.c" />` into the existing `ItemGroup` of source files.
- No other source code was modified; only the Visual Studio project file was updated.

### Testing
- No automated tests or CI jobs were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694990a7b45c832eae771151028d224e)