### PR TITLE
Fix map texture export build errors (q_isalnum declaration + BSP/WAD detection)

### DIFF
--- a/Quake/r_maptex_export.c
+++ b/Quake/r_maptex_export.c
@@ -3,6 +3,7 @@
 #include "r_maptex_export.h"
 #include "gl_texmgr.h"
 #include "bspfile.h"
+#include "q_ctype.h"
 
 /*
 ===============================================================================
@@ -492,29 +493,35 @@ void R_MapTex_ExportFromBsp(qmodel_t *mod, const byte *bsp_base, const lump_t *t
                         continue;
                 }
 
-                if (!use_bsp)
                 {
-                        const byte *wad_buffer = NULL;
-                        size_t wad_size = 0;
-
-                        if (!MapTex_FindMiptexInWads(wads, wad_count, mt.name, &wad_buffer, &wad_size))
+                        const byte *level_data = NULL;
+                        size_t level_size = 0;
+                        qboolean use_bsp = MapTex_GetMiptexLevel(&mt, source_base, source_size, 0,
+                                                                &level_data, &level_size);
+                        if (!use_bsp)
                         {
-                                if (r_maptex_export_verbose.value)
-                                        Con_Warning("MapTex: wad texture %s missing\n", mt.name);
-                                failed++;
-                                continue;
-                        }
+                                const byte *wad_buffer = NULL;
+                                size_t wad_size = 0;
 
-                        if (!MapTex_ReadMiptexFromBuffer(wad_buffer, wad_size, &mt))
-                        {
-                                if (r_maptex_export_verbose.value)
-                                        Con_Warning("MapTex: invalid wad miptex %s\n", mt.name);
-                                failed++;
-                                continue;
-                        }
+                                if (!MapTex_FindMiptexInWads(wads, wad_count, mt.name, &wad_buffer, &wad_size))
+                                {
+                                        if (r_maptex_export_verbose.value)
+                                                Con_Warning("MapTex: wad texture %s missing\n", mt.name);
+                                        failed++;
+                                        continue;
+                                }
 
-                        source_base = wad_buffer;
-                        source_size = wad_size;
+                                if (!MapTex_ReadMiptexFromBuffer(wad_buffer, wad_size, &mt))
+                                {
+                                        if (r_maptex_export_verbose.value)
+                                                Con_Warning("MapTex: invalid wad miptex %s\n", mt.name);
+                                        failed++;
+                                        continue;
+                                }
+
+                                source_base = wad_buffer;
+                                source_size = wad_size;
+                        }
                 }
 
                 MapTex_SanitizeName(mt.name, sanitized, sizeof(sanitized));


### PR DESCRIPTION
### Motivation
- Resolve compiler errors and warnings triggered when building the map texture exporter caused by an undeclared `q_isalnum` and an undefined `use_bsp` control flow.
- Ensure the exporter correctly selects BSP embedded miptex data when available and falls back to WAD entries only when BSP data is missing.

### Description
- Added `#include "q_ctype.h"` so `q_isalnum` (and related helpers) are declared for `MapTex_SanitizeName`.
- Replaced the undefined `use_bsp` usage with a local boolean computed via `MapTex_GetMiptexLevel` to detect whether level 0 mip data is present in the BSP.
- When BSP level 0 is missing the code now attempts to find and read the miptex from WADs via `MapTex_FindMiptexInWads` and `MapTex_ReadMiptexFromBuffer` before exporting.
- Small refactor of the BSP vs WAD fallback block to avoid using an undeclared identifier and keep `source_base`/`source_size` correct.

### Testing
- No automated tests were run on this change.
- Local compilation was not reported in the automated rollout logs, only the original build errors and the applied source fixes were recorded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949911f4f70832e9878089886a08917)