### PR TITLE
Include ktx2_write.c in Visual Studio project to resolve KTX2 linker error

### DIFF
--- a/Windows/VisualStudio/ironwail.vcxproj
+++ b/Windows/VisualStudio/ironwail.vcxproj
@@ -261,6 +261,7 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
     <ClCompile Include="..\..\Quake\gl_sky.c" />
     <ClCompile Include="..\..\Quake\gl_texmgr.c" />
     <ClCompile Include="..\..\Quake\gl_ktx2.c" />
+    <ClCompile Include="..\..\Quake\ktx2_write.c" />
     <ClCompile Include="..\..\Quake\gl_vidsdl.c" />
     <ClCompile Include="..\..\Quake\gl_warp.c" />
     <ClCompile Include="..\..\common\lightgrid.c" />

--- a/Windows/VisualStudio/ironwail.vcxproj.filters
+++ b/Windows/VisualStudio/ironwail.vcxproj.filters
@@ -96,6 +96,9 @@
     <ClCompile Include="..\..\Quake\gl_ktx2.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Quake\ktx2_write.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\Quake\gl_vidsdl.c">
       <Filter>Source Files</Filter>
     </ClCompile>


### PR DESCRIPTION
### Motivation
- The Visual Studio build reported an unresolved external symbol `KTX2_WriteRGBA8File` from `r_maptex_export.c` during linking. 
- The implementation of that function is in `Quake/ktx2_write.c`, which was not included in the project. 
- Including the source ensures the KTX2 writer is compiled into the executable so texture export works. 

### Description
- Added `..
..
Quake
tkx2_write.c` to `Windows/VisualStudio/ironwail.vcxproj` as a `<ClCompile>` entry so the file is compiled into the build. 
- Added the same file to `Windows/VisualStudio/ironwail.vcxproj.filters` under `Source Files` for IDE organization. 
- The change addresses the missing symbol by including the implementation file alongside the existing `gl_ktx2.c`. 

### Testing
- No automated tests were run after this change. 
- The project files were inspected to confirm the new `<ClCompile>` and filter entries are present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694991bf3038832e9cacb0dea6e5f166)