### PR TITLE
Guard godrays texture lookups against invalid indices

### DIFF
--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -56,6 +56,28 @@ typedef struct gpumark_frame_s {
 
 byte *SV_FatPVS (vec3_t org, qmodel_t *worldmodel);
 
+static texture_t *R_GetUsedTexture (const qmodel_t *model, int used_index, int *out_texnum)
+{
+	int used_count;
+	int texnum;
+
+	if (!model || !model->usedtextures || !model->textures)
+		return NULL;
+
+	used_count = model->texofs[TEXTYPE_COUNT];
+	if (used_index < 0 || used_index >= used_count)
+		return NULL;
+
+	texnum = model->usedtextures[used_index];
+	if (texnum < 0 || texnum >= model->numtextures)
+		return NULL;
+
+	if (out_texnum)
+		*out_texnum = texnum;
+
+	return model->textures[texnum];
+}
+
 /*
 ===============
 R_MarkVisSurfaces
@@ -651,9 +673,13 @@ GL_Bind (GL_TEXTURE2, skybox->cubemap);
 
 		for (j = model->texofs[texbegin]; j < model->texofs[texend]; j++)
 		{
-			texture_t *t = model->textures[model->usedtextures[j]];
+			int texnum = -1;
+			texture_t *t = R_GetUsedTexture (model, j, &texnum);
 			unsigned extra_flags = 0u;
 			qboolean force_fullbright = false;
+
+			if (!t)
+				continue;
 
 			if (pass == BP_GODRAYS)
 			{
@@ -662,7 +688,6 @@ GL_Bind (GL_TEXTURE2, skybox->cubemap);
 
 				if (r_godrays_emit_lighttex.value > 0.f && t)
 				{
-					int texnum = model->usedtextures[j];
 					if (R_ModelTextureHasGodrayFlag (model, texnum))
 						lighttex = true;
 					else if ((t->type != TEXTYPE_SKY) && r_godrays_lighttex_name_match.value > 0.f && R_GodraysNameMatch (t->name))
@@ -779,7 +804,11 @@ GL_Upload (GL_SHADER_STORAGE_BUFFER, bmodel_instances, sizeof(bmodel_instances[0
 
 		for (j = model->texofs[TEXTYPE_FIRSTLIQUID]; j < model->texofs[TEXTYPE_LASTLIQUID+1]; j++)
 		{
-			texture_t *t = model->textures[model->usedtextures[j]];
+			texture_t *t = R_GetUsedTexture (model, j, NULL);
+
+			if (!t)
+				continue;
+
 			float alpha = GL_WaterAlphaForEntityTextureType (e, t->type);
 			if ((alpha < 1.f) != translucent)
 				continue;


### PR DESCRIPTION
### Motivation

- Prevent a crash caused by dereferencing an invalid texture pointer when processing godrays and water for brush models.
- The crash was caused by `model->textures[model->usedtextures[j]]` when `usedtextures` or its indices were out-of-bounds or corrupted.

### Description

- Add a safe helper `R_GetUsedTexture` that validates `model`, `usedtextures`, and the `used_index` and returns `NULL` for invalid lookups.
- Replace direct lookups `model->textures[model->usedtextures[j]]` with `R_GetUsedTexture` in the godrays and water paths in `Quake/r_world.c`.
- Early-`continue` when `R_GetUsedTexture` returns `NULL`, and use the helper's `out_texnum` to check godray flags with `R_ModelTextureHasGodrayFlag`.
- This avoids dereferencing invalid pointers and skips draw calls that would otherwise crash.

### Testing

- No automated tests were run.
- The change is limited to `Quake/r_world.c` and is defensive-only, returning early on invalid data to avoid crashes.
- A full build or runtime validation is recommended to confirm the fix in various maps and models.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694997c4a280832e95bb5951de534996)