### PR TITLE
Guard DoF autofocus against empty world hull data

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -369,6 +369,7 @@ static float R_GetDynamicDoFFocus (float fallback)
 	float range;
 	float target;
 	qboolean traced = false;
+	const hull_t *world_hull;
 
 	if (r_dof_autofocus.value <= 0.f)
 	{
@@ -376,7 +377,14 @@ static float R_GetDynamicDoFFocus (float fallback)
 		return fallback;
 	}
 
-	if (cls.state != ca_connected || !cl.worldmodel || !cl.worldmodel->hulls)
+	if (cls.state != ca_connected || !cl.worldmodel)
+	{
+		r_dof_autofocus_initialized = false;
+		return fallback;
+	}
+
+	world_hull = &cl.worldmodel->hulls[0];
+	if (!world_hull->clipnodes || !world_hull->planes)
 	{
 		r_dof_autofocus_initialized = false;
 		return fallback;
@@ -408,7 +416,7 @@ static float R_GetDynamicDoFFocus (float fallback)
 		trace.fraction = 1.f;
 		VectorCopy (end, trace.endpos);
 
-		SV_RecursiveHullCheck (cl.worldmodel->hulls, 0, 0.f, 1.f, r_origin, end, &trace);
+		SV_RecursiveHullCheck (world_hull, 0, 0.f, 1.f, r_origin, end, &trace);
 	}
 
 	if (trace.allsolid || trace.startsolid || trace.fraction <= 0.f)


### PR DESCRIPTION
### Motivation

- Fix an access violation when `SV_RecursiveHullCheck` dereferences `node->planenum` while the world's hull data is uninitialized (e.g. `clipnodes`/`planes` are NULL). 
- `R_GetDynamicDoFFocus` previously checked only `cl.worldmodel->hulls` existence and then called the recursive hull trace with index `0`, which can hit a NULL `clipnodes`/`planes` inside the hull. 
- Root cause is an empty/unloaded world model (or uninitialized `hull_t`) being used for a trace without validating its internal pointers. 
- Intention is to validate the hull internals before invoking the recursive hull trace to avoid dereferencing NULL pointers.

### Description

- Introduce a local `const hull_t *world_hull` and obtain it as `&cl.worldmodel->hulls[0]` after confirming `cl.worldmodel` is present. 
- Add checks for `world_hull->clipnodes` and `world_hull->planes` and return the fallback when they are not populated. 
- Replace the direct call `SV_RecursiveHullCheck(cl.worldmodel->hulls, ...)` with `SV_RecursiveHullCheck(world_hull, ...)` to use the validated hull pointer. 
- Preserve existing autofocus initialization/reset behavior on early returns.

### Testing

- No automated tests were run for this change. 
- Change applied and committed locally without running test suites. 
- Affected code paths are guarded to avoid NULL dereferences at runtime. 
- Manual runtime verification was not performed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949ae45cb5c832ea69ef04f6c36e240)