### PR TITLE
Guard console redraws during asset loading to avoid re-entrant rendering

### DIFF
--- a/Quake/console.c
+++ b/Quake/console.c
@@ -1278,7 +1278,7 @@ void Con_Printf (const char *fmt, ...)
 	Con_Print (msg);
 
 // update the screen if the console is displayed
-	if (cls.signon != SIGNONS && !scr_disabled_for_loading )
+	if (cls.signon != SIGNONS && !scr_disabled_for_loading && !Host_IsAssetLoading ())
 	{
 	// protect against infinite loop if something in SCR_UpdateScreen calls
 	// Con_Printd
@@ -2424,4 +2424,3 @@ void LOG_Close (void)
 	close (log_fd);
 	log_fd = -1;
 }
-

--- a/Quake/host.c
+++ b/Quake/host.c
@@ -149,6 +149,16 @@ void Host_EndAssetLoading (void)
 
 /*
 ================
+Host_IsAssetLoading
+================
+*/
+qboolean Host_IsAssetLoading (void)
+{
+	return host_assetloading_depth > 0;
+}
+
+/*
+================
 Max_Edicts_f -- johnfitz
 ================
 */
@@ -1576,4 +1586,3 @@ void Host_Shutdown(void)
         LOG_Close ();
         LOC_Shutdown ();
 }
-

--- a/Quake/quakedef.h
+++ b/Quake/quakedef.h
@@ -417,6 +417,7 @@ void Host_ClientCommands (const char *fmt, ...) FUNC_PRINTF(1,2);
 void Host_ShutdownServer (qboolean crash);
 void Host_BeginAssetLoading (void);
 void Host_EndAssetLoading (void);
+qboolean Host_IsAssetLoading (void);
 void Host_WriteConfiguration (void);
 void Host_Resetdemos (void);
 
@@ -456,4 +457,3 @@ void Host_InvokeOnMainThread (void (*func) (void *param), void *param);
 #endif /* RC_INVOKED */
 
 #endif	/* QUAKEDEFS_H */
-


### PR DESCRIPTION
### Motivation

- A crash was observed where `Con_Printf` triggered `SCR_UpdateScreen()` while a brush model was still being loaded, causing re-entrant rendering to read partially-initialized model data and producing an access violation.
- The root cause is rendering re-entrancy during critical initialization (model/light loading) when `Con_Printf` emits status lines that force a screen update. This change prevents console-triggered redraws during those critical asset-loading phases.

### Description

- Add a public check `Host_IsAssetLoading` in `quakedef.h` to expose the asset-loading state.
- Implement `Host_IsAssetLoading()` in `host.c` to return true when `host_assetloading_depth > 0`.
- Modify `Con_Printf` in `console.c` to skip calling `SCR_UpdateScreen()` while `Host_IsAssetLoading()` is true, avoiding re-entrant rendering during model load.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949b6f22968832e8e73880d1ef3617b)