### PR TITLE
Guard bmodel entity model access

### DIFF
--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -621,12 +621,14 @@ static void R_DrawBrushModels_Real (entity_t **ents, int count, brushpass_t pass
                 break;
         }
 
-        for (i = 0, totalinst = 0; i < count; i++)
-        {
-                entity_t *ent = ents[i];
-                if (ent->model->texofs[texend] - ent->model->texofs[texbegin] > 0)
-                        R_InitBModelInstance (&bmodel_instances[totalinst++], ent);
-        }
+	for (i = 0, totalinst = 0; i < count; i++)
+	{
+		entity_t *ent = ents[i];
+		if (!ent || !ent->model)
+			continue;
+		if (ent->model->texofs[texend] - ent->model->texofs[texbegin] > 0)
+			R_InitBModelInstance (&bmodel_instances[totalinst++], ent);
+	}
 
         if (!totalinst)
                 return;
@@ -668,8 +670,12 @@ GL_Bind (GL_TEXTURE2, skybox->cubemap);
                 if (!numtex)
                         continue;
 
-                for (numinst = 1; i < count && ents[i]->model == model && numinst < MAX_BMODEL_INSTANCES; i++)
-                        numinst += (ents[i]->model->texofs[texend] - ents[i]->model->texofs[texbegin]) > 0;
+		for (numinst = 1; i < count && ents[i]->model == model && numinst < MAX_BMODEL_INSTANCES; i++)
+		{
+			if (!ents[i] || !ents[i]->model)
+				continue;
+			numinst += (ents[i]->model->texofs[texend] - ents[i]->model->texofs[texbegin]) > 0;
+		}
 
 		for (j = model->texofs[texbegin]; j < model->texofs[texend]; j++)
 		{
@@ -792,6 +798,8 @@ GL_Upload (GL_SHADER_STORAGE_BUFFER, bmodel_instances, sizeof(bmodel_instances[0
 	{
 		int numinst;
 		entity_t *e = ents[i++];
+		if (!e || !e->model)
+			continue;
 		qmodel_t *model = e->model;
 		qboolean isworld = (e == &cl_entities[0]);
 		int frame = isworld ? 0 : e->frame;


### PR DESCRIPTION
### Motivation

- A crash was observed when dereferencing `ent->model->texofs[...]` because `ent->model` was not a valid `qmodel_t *`, indicating pointer corruption or invalid assignments.
- The immediate goal is to avoid dereferencing potentially null/invalid model pointers in bmodel drawing paths to prevent access violations and make the code more robust for debugging.

### Description

- Added null checks for `ent` and `ent->model` in the initial bmodel instance collection loop in `r_world.c` to skip invalid entries before reading `texofs`.
- Added null checks for the entity `e` and `e->model` at the start of the batching loop and made the `numinst` aggregation loop skip `ents[i]` entries that are null or have null `model` pointers. 
- Added a similar guard in the water bmodel draw loop to avoid dereferencing `model` for entities without valid models.
- Changes are contained in `Quake/r_world.c` and are intended as defensive checks to avoid crashes while the root cause (pointer corruption / lifetime issues) is investigated.

### Testing

- No automated tests were executed for this change.
- Recommend running the project build and sanitizers such as AddressSanitizer and application verifier to validate the fix under real workloads.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949bb1b7390832ea01c9ff2724d4b07)