### PR TITLE
Guard against invalid brush model pointers during draw passes

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -175,6 +175,19 @@ void Mod_Init (void)
 
 /*
 ===============
+Mod_IsKnownModel
+===============
+*/
+qboolean Mod_IsKnownModel (const qmodel_t *mod)
+{
+	if (!mod)
+		return false;
+
+	return (mod >= mod_known && mod < mod_known + mod_numknown);
+}
+
+/*
+===============
 Mod_Extradata
 
 Caches the data if needed

--- a/Quake/gl_model.h
+++ b/Quake/gl_model.h
@@ -570,6 +570,7 @@ void	Mod_ResetAll (void); // for gamedir changes (Host_Game_f)
 qmodel_t *Mod_ForName (const char *name, qboolean crash);
 void	*Mod_Extradata (qmodel_t *mod);	// handles caching
 void	Mod_TouchModel (const char *name);
+qboolean Mod_IsKnownModel (const qmodel_t *mod);
 
 #define VIS_ALIGN			16						// vis buffer size alignment (in bytes)
 #define VIS_ALIGN_MASK		(VIS_ALIGN - 1)			// alignment - 1, to simplify alignment code

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -624,7 +624,7 @@ static void R_DrawBrushModels_Real (entity_t **ents, int count, brushpass_t pass
 	for (i = 0, totalinst = 0; i < count; i++)
 	{
 		entity_t *ent = ents[i];
-		if (!ent || !ent->model)
+		if (!ent || !Mod_IsKnownModel (ent->model))
 			continue;
 		if (ent->model->texofs[texend] - ent->model->texofs[texbegin] > 0)
 			R_InitBModelInstance (&bmodel_instances[totalinst++], ent);
@@ -656,24 +656,28 @@ GL_Bind (GL_TEXTURE2, skybox->cubemap);
         GL_Upload (GL_SHADER_STORAGE_BUFFER, bmodel_instances, sizeof(bmodel_instances[0]) * totalinst, &buf, &ofs);
         GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 2, buf, (GLintptr)ofs, sizeof(bmodel_instances[0]) * totalinst);
 
-        for (i = 0, baseinst = 0; i < count; /**/)
-        {
-                int numinst;
-                entity_t *e = ents[i++];
-                qmodel_t *model = e->model;
-                qboolean isworld = (e == &cl_entities[0]);
-                qboolean isstatic = PTR_IN_RANGE (e, cl_static_entities, cl_static_entities + MAX_STATIC_ENTITIES);
-                qboolean zfix = !isworld && !isstatic;
-                int frame = isworld ? 0 : e->frame;
-                int numtex = model->texofs[texend] - model->texofs[texbegin];
+	for (i = 0, baseinst = 0; i < count; /**/)
+	{
+		int numinst;
+		entity_t *e = ents[i++];
+		qmodel_t *model;
+
+		if (!e || !Mod_IsKnownModel (e->model))
+			continue;
+		model = e->model;
+		qboolean isworld = (e == &cl_entities[0]);
+		qboolean isstatic = PTR_IN_RANGE (e, cl_static_entities, cl_static_entities + MAX_STATIC_ENTITIES);
+		qboolean zfix = !isworld && !isstatic;
+		int frame = isworld ? 0 : e->frame;
+		int numtex = model->texofs[texend] - model->texofs[texbegin];
 
                 if (!numtex)
                         continue;
 
-		for (numinst = 1; i < count && ents[i]->model == model && numinst < MAX_BMODEL_INSTANCES; i++)
+		for (numinst = 1; i < count && numinst < MAX_BMODEL_INSTANCES; i++)
 		{
-			if (!ents[i] || !ents[i]->model)
-				continue;
+			if (!ents[i] || ents[i]->model != model)
+				break;
 			numinst += (ents[i]->model->texofs[texend] - ents[i]->model->texofs[texbegin]) > 0;
 		}
 
@@ -733,6 +737,10 @@ R_EntHasWater
 static qboolean R_EntHasWater (entity_t *ent, qboolean translucent)
 {
 	int i;
+
+	if (!ent || !Mod_IsKnownModel (ent->model))
+		return false;
+
 	for (i = TEXTYPE_FIRSTLIQUID; i < TEXTYPE_LASTLIQUID+1; i++)
 	{
 		int numtex = ent->model->texofs[i+1] - ent->model->texofs[i];


### PR DESCRIPTION
### Motivation
- A crash occurred when `ent->model` contained a corrupt/invalid pointer and the renderer accessed `ent->model->texofs[...]`. 
- The pointer values looked like overwritten ASCII/integer patterns, indicating memory corruption (buffer overflow/memcpy/use-after-free) elsewhere. 
- The goal is to avoid dereferencing invalid `qmodel_t` pointers during bmodel rendering and related checks to prevent access violations. 

### Description
- Added `qboolean Mod_IsKnownModel(const qmodel_t *mod);` to `gl_model.h` and implemented it in `gl_model.c` to validate that a `qmodel_t *` lies within the `mod_known` array range. 
- Replaced raw `ent->model` null checks with `Mod_IsKnownModel()` in `r_world.c` to skip entities that reference invalid/unknown models before reading `texofs`. 
- Hardened the bmodel instance grouping loop to stop grouping when the next entity's `model` does not match, avoiding accidental derefs of invalid entries. 
- Added a guard in `R_EntHasWater` to return false when `ent` or its `model` is not a known model. 

### Testing
- No automated tests were executed for this change. 
- A local commit was created with the changes; no build or runtime tests were run as part of this rollout. 
- Manual or CI build and runtime testing is recommended to verify the fix under corrupted-entity scenarios. 
- Please run the rendering and map-loading regression tests to confirm there are no false negatives introduced by the added guards.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949c6855fb8832ebed2889d7d92cacb)