### PR TITLE
Prevent reentrant rendering during model load and harden texture access

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -452,9 +452,11 @@ static qmodel_t *Mod_LoadModel (qmodel_t *mod, qboolean crash)
 //
 // load the file
 //
+	Host_BeginAssetLoading ();
 	buf = COM_LoadMallocFile (mod->name, &mod->path_id);
 	if (!buf)
 	{
+		Host_EndAssetLoading ();
 		if (crash)
 			Host_Error ("Mod_LoadModel: %s not found", mod->name); //johnfitz -- was "Mod_NumForName"
 		return NULL;
@@ -495,6 +497,7 @@ static qmodel_t *Mod_LoadModel (qmodel_t *mod, qboolean crash)
 	}
 
 	free (buf);
+	Host_EndAssetLoading ();
 
 	return mod;
 }

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -60,11 +60,22 @@ static texture_t *R_GetUsedTexture (const qmodel_t *model, int used_index, int *
 {
 	int used_count;
 	int texnum;
+	static int last_warn_frame = -1;
 
 	if (!model || !model->usedtextures || !model->textures)
 		return NULL;
 
 	used_count = model->texofs[TEXTYPE_COUNT];
+	if (model->numtextures <= 0 || used_count < 0 || used_count > model->numtextures)
+	{
+		if (r_framecount != last_warn_frame)
+		{
+			last_warn_frame = r_framecount;
+			Con_DWarning ("R_GetUsedTexture: invalid texture table on %s (used=%d numtextures=%d)\n",
+				model->name, used_count, model->numtextures);
+		}
+		return NULL;
+	}
 	if (used_index < 0 || used_index >= used_count)
 		return NULL;
 
@@ -74,6 +85,9 @@ static texture_t *R_GetUsedTexture (const qmodel_t *model, int used_index, int *
 
 	if (out_texnum)
 		*out_texnum = texnum;
+
+	if (!model->textures[texnum])
+		return NULL;
 
 	return model->textures[texnum];
 }
@@ -671,8 +685,19 @@ GL_Bind (GL_TEXTURE2, skybox->cubemap);
 		int frame = isworld ? 0 : e->frame;
 		int numtex = model->texofs[texend] - model->texofs[texbegin];
 
-                if (!numtex)
-                        continue;
+		if (model->texofs[TEXTYPE_COUNT] < 0
+			|| model->texofs[TEXTYPE_COUNT] > model->numtextures
+			|| model->texofs[texbegin] < 0
+			|| model->texofs[texend] < model->texofs[texbegin]
+			|| model->texofs[texend] > model->texofs[TEXTYPE_COUNT])
+		{
+			Con_DWarning ("R_DrawBrushModels: invalid texofs for %s (%d..%d of %d)\n",
+				model->name, model->texofs[texbegin], model->texofs[texend], model->texofs[TEXTYPE_COUNT]);
+			continue;
+		}
+
+		if (!numtex)
+			continue;
 
 		for (numinst = 1; i < count && numinst < MAX_BMODEL_INSTANCES; i++)
 		{


### PR DESCRIPTION
### Motivation
- Fix crashes caused by reentrant rendering during model/map load where `Con_Printf` -> `SCR_UpdateScreen` can invoke `R_DrawBrushModels_Real` while model data is incomplete. 
- Avoid dereferencing invalid `texture_t` pointers or out-of-range indices originating from partially-initialized `qmodel_t` structures. 
- Provide earlier diagnostics for inconsistent model texture state to help detect loader/race conditions. 
- Reduce likelihood of using console prints that force screen updates during critical load paths.

### Description
- Wrap `Mod_LoadModel` file loading with the asset-loading guard calls `Host_BeginAssetLoading()` and `Host_EndAssetLoading()` to suppress console-driven screen updates during model load (file `Quake/gl_model.c`).
- Add defensive validation in `R_GetUsedTexture` to check `mod->numtextures` and `used_count` bounds and return `NULL` for invalid states, with a per-frame developer warning (file `Quake/r_world.c`).
- Add `NULL` checks for `model->textures[texnum]` before returning and add comprehensive `texofs` bounds validation in `R_DrawBrushModels_Real` to skip models with inconsistent texture ranges and emit `Con_DWarning` diagnostics (file `Quake/r_world.c`).
- Minor cleanup of an unused local variable and preservation of existing behavior when asset loading fails by ensuring `Host_EndAssetLoading()` is called on error paths (file `Quake/gl_model.c`).

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949e26b771c832e9427d3f7bb4a5374)