### PR TITLE
Guard against invalid texture pointers in R_GetUsedTexture

### DIFF
--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -61,6 +61,8 @@ static texture_t *R_GetUsedTexture (const qmodel_t *model, int used_index, int *
 	int used_count;
 	int texnum;
 	static int last_warn_frame = -1;
+	static int last_bad_ptr_frame = -1;
+	texture_t *tex;
 
 	if (!model || !model->usedtextures || !model->textures)
 		return NULL;
@@ -86,10 +88,22 @@ static texture_t *R_GetUsedTexture (const qmodel_t *model, int used_index, int *
 	if (out_texnum)
 		*out_texnum = texnum;
 
-	if (!model->textures[texnum])
+	tex = model->textures[texnum];
+	if (!tex)
 		return NULL;
 
-	return model->textures[texnum];
+	if (tex == (texture_t *)-1 || (uintptr_t)tex < 4096)
+	{
+		if (r_framecount != last_bad_ptr_frame)
+		{
+			last_bad_ptr_frame = r_framecount;
+			Con_DWarning ("R_GetUsedTexture: invalid texture pointer on %s (used_index=%d texnum=%d ptr=%p)\n",
+				model->name, used_index, texnum, (void *)tex);
+		}
+		return NULL;
+	}
+
+	return tex;
 }
 
 /*


### PR DESCRIPTION
### Motivation
- Prevent dereference of corrupted/sentinel texture pointers returned from model arrays which caused access violations when reading fields like `t->fullbright`.
- Add a short-term defensive check in `R_GetUsedTexture` to avoid crashes while investigating root causes in model loading or memory management.

### Description
- Added a local `texture_t *tex` and a per-frame throttle `last_bad_ptr_frame` in `Quake/r_world.c` inside `R_GetUsedTexture` to validate the pointer before returning it.
- Check for `NULL`, sentinel `(texture_t *)-1`, and low-address values (`(uintptr_t)tex < 4096`) and call `Con_DWarning` once per frame when invalid pointers are observed.
- Return `NULL` instead of the invalid pointer to avoid later dereferences of `model->textures[texnum]`.
- Kept existing consistency checks and preserved the `out_texnum` reporting behavior.

### Testing
- No automated tests were executed for this change.
- Build/test automation: none run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949e4d770c0832ea15103c5834293d4)