### PR TITLE
Remove r_lavaalpha cvar and lock lava opacity at 1.0

### DIFF
--- a/Linux/sgml/Quakespasm.sgml
+++ b/Linux/sgml/Quakespasm.sgml
@@ -436,7 +436,7 @@ quakespasm (cl_alwaysrun 1, cl_forwardspeed 200, cl_backspeed 200)
 </itemize>
 <sect2>Visual improvements
 <itemize>
-<item> New cvars r_lavaalpha, r_slimealpha, r_telealpha for fine-tuning specific liquid opacities (from DirectQ/RMQEngine, non-archived, default to 0), and new worldspawn keys _wateralpha, _lavaalpha, _slimealpha, _telealpha, _skyfog (unique to Quakespasm, similar to the behaviour of the "fog" worldspawn key).
+<item> New cvars r_slimealpha, r_telealpha for fine-tuning specific liquid opacities (from DirectQ/RMQEngine, non-archived, default to 0), and new worldspawn keys _wateralpha, _slimealpha, _telealpha, _skyfog (unique to Quakespasm, similar to the behaviour of the "fog" worldspawn key).
 <item> GLSL gamma is now supported on older hardware without NPOT extension.
 </itemize>
 <sect2>Interface improvements

--- a/Misc/fix_externaltex.patch
+++ b/Misc/fix_externaltex.patch
@@ -90,7 +90,6 @@ index 6883161..4a8a745 100644
 +
  cvar_t	gl_zfix = {"gl_zfix", "0", CVAR_NONE}; // QuakeSpasm z-fighting fix
  
- cvar_t	r_lavaalpha = {"r_lavaalpha","0",CVAR_NONE};
 diff --git a/Quake/gl_rmisc.c b/Quake/gl_rmisc.c
 index 963d55e..e9b251b 100644
 --- a/Quake/gl_rmisc.c
@@ -104,7 +103,6 @@ index 963d55e..e9b251b 100644
  extern gltexture_t *playertextures[MAX_SCOREBOARD]; //johnfitz
  
 @@ -230,6 +231,7 @@ void R_Init (void)
- 	Cvar_SetCallback (&r_lavaalpha, R_SetLavaalpha_f);
  	Cvar_SetCallback (&r_telealpha, R_SetTelealpha_f);
  	Cvar_SetCallback (&r_slimealpha, R_SetSlimealpha_f);
 +	Cvar_RegisterVariable (&r_externaltexture_fix);//mk

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -342,7 +342,6 @@ extern cvar_t	r_softemu_dither_texture;
 
 cvar_t	gl_zfix = { "gl_zfix", "1", CVAR_ARCHIVE }; // QuakeSpasm z-fighting fix
 
-cvar_t	r_lavaalpha = { "r_lavaalpha","1",CVAR_NONE };
 cvar_t	r_telealpha = { "r_telealpha","0",CVAR_NONE };
 cvar_t	r_slimealpha = { "r_slimealpha","0",CVAR_NONE };
 

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -317,22 +317,6 @@ static void R_SetWateralpha_f (cvar_t *var)
 
 /*
 ====================
-R_SetLavaalpha_f -- ericw
-====================
-*/
-static void R_SetLavaalpha_f (cvar_t *var)
-{
-	float alpha = CLAMP(0.f, var->value, 1.f);
-	if (alpha != var->value)
-		Cvar_SetValueQuick (var, alpha);
-
-	if (cls.signon == SIGNONS && cl.worldmodel && !(cl.worldmodel->contentstransparent&SURF_DRAWLAVA) && alpha && alpha < 1)
-				Con_Warning("Map does not appear to be lava-vised\n");
-	map_lavaalpha = alpha;
-}
-
-/*
-====================
 R_SetTelealpha_f -- ericw
 ====================
 */
@@ -383,7 +367,7 @@ GL_WaterAlphaForTextureType
 float GL_WaterAlphaForTextureType (textype_t type)
 {
 	if (type == TEXTYPE_LAVA)
-		return map_lavaalpha > 0 ? map_lavaalpha : map_fallbackalpha;
+		return map_lavaalpha;
 	else if (type == TEXTYPE_TELE)
 		return map_telealpha > 0 ? map_telealpha : map_fallbackalpha;
 	else if (type == TEXTYPE_SLIME)
@@ -561,11 +545,9 @@ Cvar_RegisterVariable (&r_vignette);
 	//johnfitz
 
 	Cvar_RegisterVariable (&gl_zfix); // QuakeSpasm z-fighting fix
-	Cvar_RegisterVariable (&r_lavaalpha);
 	Cvar_RegisterVariable (&r_telealpha);
 	Cvar_RegisterVariable (&r_slimealpha);
 	Cvar_RegisterVariable (&r_scale);
-	Cvar_SetCallback (&r_lavaalpha, R_SetLavaalpha_f);
 	Cvar_SetCallback (&r_telealpha, R_SetTelealpha_f);
 	Cvar_SetCallback (&r_slimealpha, R_SetSlimealpha_f);
 
@@ -667,7 +649,7 @@ static void R_ParseWorldspawn (void)
 
 	map_fallbackalpha = r_wateralpha.value;
 	map_wateralpha = (cl.worldmodel->contentstransparent&SURF_DRAWWATER)?r_wateralpha.value:1;
-	map_lavaalpha = (cl.worldmodel->contentstransparent&SURF_DRAWLAVA)?r_lavaalpha.value:1;
+	map_lavaalpha = 1.0f;
 	map_telealpha = (cl.worldmodel->contentstransparent&SURF_DRAWTELE)?r_telealpha.value:1;
 	map_slimealpha = (cl.worldmodel->contentstransparent&SURF_DRAWSLIME)?r_slimealpha.value:1;
 
@@ -698,9 +680,6 @@ static void R_ParseWorldspawn (void)
 if (!strcmp("wateralpha", key))
 map_wateralpha = atof(value);
 
-if (!strcmp("lavaalpha", key))
-map_lavaalpha = atof(value);
-
 if (!strcmp("telealpha", key))
 map_telealpha = atof(value);
 
@@ -711,7 +690,7 @@ map_slimealpha = atof(value);
 
 map_fallbackalpha = CLAMP(0.f, map_fallbackalpha, 1.f);
 map_wateralpha = CLAMP(0.f, map_wateralpha, 1.f);
-map_lavaalpha = CLAMP(0.f, map_lavaalpha, 1.f);
+map_lavaalpha = 1.0f;
 map_telealpha = CLAMP(0.f, map_telealpha, 1.f);
 map_slimealpha = CLAMP(0.f, map_slimealpha, 1.f);
 
@@ -748,7 +727,7 @@ void R_NewMap (void)
 
         Sky_NewMap (); //johnfitz -- skybox in worldspawn
         Fog_NewMap (); //johnfitz -- global fog in worldspawn
-        R_ParseWorldspawn (); //ericw -- wateralpha, lavaalpha, telealpha, slimealpha in worldspawn
+        R_ParseWorldspawn (); //ericw -- wateralpha, telealpha, slimealpha in worldspawn
         R_ParseDlightEntities (); // persistent dlights from BSP entities
 
 	// Load pointfile if map has no vis data and either developer mode is on or the game was started from a map editing tool

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -98,7 +98,6 @@ extern	cvar_t	r_fullbright;
 extern	cvar_t	r_lightmap;
 extern	cvar_t	r_rgblighting_enable;
 extern	cvar_t	r_wateralpha;
-extern	cvar_t	r_lavaalpha;
 extern	cvar_t	r_telealpha;
 extern	cvar_t	r_slimealpha;
 extern	cvar_t	r_litwater;

--- a/Quakespasm.html
+++ b/Quakespasm.html
@@ -556,7 +556,7 @@ quakespasm (cl_alwaysrun 1, cl_forwardspeed 200, cl_backspeed 200)
 <H3>Visual improvements</H3>
 <P>
 <UL>
-<LI> New cvars r_lavaalpha, r_slimealpha, r_telealpha for fine-tuning specific liquid opacities (from DirectQ/RMQEngine, non-archived, default to 0), and new worldspawn keys _wateralpha, _lavaalpha, _slimealpha, _telealpha, _skyfog (unique to Quakespasm, similar to the behaviour of the "fog" worldspawn key).</LI>
+<LI> New cvars r_slimealpha, r_telealpha for fine-tuning specific liquid opacities (from DirectQ/RMQEngine, non-archived, default to 0), and new worldspawn keys _wateralpha, _slimealpha, _telealpha, _skyfog (unique to Quakespasm, similar to the behaviour of the "fog" worldspawn key).</LI>
 <LI> GLSL gamma is now supported on older hardware without NPOT extension.</LI>
 </UL>
 </P>

--- a/Quakespasm.txt
+++ b/Quakespasm.txt
@@ -763,11 +763,11 @@
 
   Visual improvements:
 
-  -  New cvars r_lavaalpha, r_slimealpha, r_telealpha for fine-tuning
-     specific liquid opacities (from DirectQ/RMQEngine, non-archived,
-     default to 0), and new worldspawn keys _wateralpha, _lavaalpha,
-     _slimealpha, _telealpha, _skyfog (unique to Quakespasm, similar to
-     the behaviour of the "fog" worldspawn key).
+  -  New cvars r_slimealpha, r_telealpha for fine-tuning specific liquid
+     opacities (from DirectQ/RMQEngine, non-archived, default to 0), and
+     new worldspawn keys _wateralpha, _slimealpha, _telealpha, _skyfog
+     (unique to Quakespasm, similar to the behaviour of the "fog"
+     worldspawn key).
 
   -  GLSL gamma is now supported on older hardware without NPOT
      extension.


### PR DESCRIPTION
### Motivation
- Simplify liquid rendering by removing per-map or per-cvar control of lava opacity and always render lava fully opaque.
- Eliminate the `r_lavaalpha` cvar and any worldspawn `_lavaalpha` handling to avoid inconsistent lava alpha behavior.

### Description
- Remove the `r_lavaalpha` declaration and registration, drop the `R_SetLavaalpha_f` callback, and stop registering the cvar in `Quake/gl_rmain.c` and `Quake/gl_rmisc.c`.
- Force `map_lavaalpha` to `1.0f` in `R_ParseWorldspawn` and replace the previous clamping/parsing logic, and make `GL_WaterAlphaForTextureType` return `map_lavaalpha` for lava.
- Remove the `r_lavaalpha` extern from `Quake/glquake.h` and strip worldspawn `_lavaalpha` parsing, and update comments referencing lavaalpha.
- Update documentation and references in `Quakespasm.txt`, `Quakespasm.html`, `Linux/sgml/Quakespasm.sgml`, and `Misc/fix_externaltex.patch` to remove `r_lavaalpha` / `_lavaalpha` mentions.

### Testing
- No automated tests were run for these changes.
- The repository changes were compiled and committed locally as part of the change (commit succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949ea3c864c832e948c01deb53e265b)