### PR TITLE
Guard against invalid gltexture pointers

### DIFF
--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -106,6 +106,32 @@ static texture_t *R_GetUsedTexture (const qmodel_t *model, int used_index, int *
 	return tex;
 }
 
+static qboolean R_IsPointerSane (const void *ptr)
+{
+	return ptr && ptr != (const void *)-1 && (uintptr_t)ptr >= 4096;
+}
+
+static gltexture_t *R_SanitizeGLTexture (gltexture_t *tex, const char *texname, const char *label)
+{
+	static int last_bad_glt_frame = -1;
+
+	if (!tex)
+		return NULL;
+
+	if (!R_IsPointerSane (tex))
+	{
+		if (r_framecount != last_bad_glt_frame)
+		{
+			last_bad_glt_frame = r_framecount;
+			Con_DWarning ("R_SanitizeGLTexture: invalid %s texture on %s (ptr=%p)\n",
+				label, texname ? texname : "<unknown>", (void *)tex);
+		}
+		return NULL;
+	}
+
+	return tex;
+}
+
 /*
 ===============
 R_MarkVisSurfaces
@@ -419,7 +445,8 @@ qboolean R_TextureEmitsGodrays (texture_t *t)
 	if (!t)
 		return false;
 
-	if (r_godrays_emit_emissive.value > 0.f && (t->fullbright || t->emissive))
+	if (r_godrays_emit_emissive.value > 0.f
+		&& (R_IsPointerSane (t->fullbright) || R_IsPointerSane (t->emissive)))
 		return true;
 
 	if (r_godrays_emit_lighttex.value > 0.f && r_godrays_lighttex_name_match.value > 0.f && R_GodraysNameMatch (t->name))
@@ -465,9 +492,9 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
 
 	if (t)
 	{
-		tx = t->gltexture;
-		fb = t->fullbright;
-		em = t->emissive;
+		tx = R_SanitizeGLTexture (t->gltexture, t->name, "base");
+		fb = R_SanitizeGLTexture (t->fullbright, t->name, "fullbright");
+		em = R_SanitizeGLTexture (t->emissive, t->name, "emissive");
 		if (r_lightmap_cheatsafe)
 			tx = fb = em = NULL;
 		if (!gl_fullbrights.value && t->type != TEXTYPE_SKY && !force_fullbright)
@@ -732,7 +759,8 @@ GL_Bind (GL_TEXTURE2, skybox->cubemap);
 
 			if (pass == BP_GODRAYS)
 			{
-				qboolean emissive = (r_godrays_emit_emissive.value > 0.f && t && (t->fullbright || t->emissive));
+				qboolean emissive = (r_godrays_emit_emissive.value > 0.f
+					&& (R_IsPointerSane (t->fullbright) || R_IsPointerSane (t->emissive)));
 				qboolean lighttex = false;
 
 				if (r_godrays_emit_lighttex.value > 0.f && t)


### PR DESCRIPTION
### Motivation
- Prevent crashes caused by corrupted or sentinel texture pointers (e.g. `(texture_t*)-1` or very small addresses) being dereferenced during world rendering. 
- Reduce likelihood of use-after-free / corrupted `fullbright` / `emissive` / `gltexture` causing undefined behavior in draw/godray code. 
- Provide informative, rate-limited warnings when invalid GL texture pointers are observed to aid debugging. 

### Description
- Added `R_IsPointerSane` helper to validate pointer sanity checks (non-null, not `-1`, and address >= `4096`).
- Added `R_SanitizeGLTexture` which wraps `R_IsPointerSane` and logs a per-frame warning when a `gltexture_t` pointer is invalid.
- Replaced direct uses of `t->gltexture`, `t->fullbright`, and `t->emissive` with sanitized versions in `R_AddBModelCall` and related code paths. 
- Updated `R_TextureEmitsGodrays` and the godrays detection in bmodel iteration to use the pointer-sanity check instead of trusting raw fields. 

### Testing
- No automated tests were run on this change.
- The code compiles locally as part of a normal edit/commit workflow (no test harness executed).
- Runtime behavior: invalid texture pointers are now skipped and will produce a rate-limited `Con_DWarning` instead of being dereferenced (manual validation expected).
- Further testing recommended: exercise model loading, dynamic texture unloads, and multithreaded model updates to confirm crash is prevented and warnings are actionable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949ecfb2070832e8b1162fa9de78e3d)