### PR TITLE
Guard against invalid texture pointers in godrays path

### DIFF
--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -445,6 +445,9 @@ qboolean R_TextureEmitsGodrays (texture_t *t)
 	if (!t)
 		return false;
 
+	if (!R_IsPointerSane (t))
+		return false;
+
 	if (r_godrays_emit_emissive.value > 0.f
 		&& (R_IsPointerSane (t->fullbright) || R_IsPointerSane (t->emissive)))
 		return true;
@@ -755,6 +758,9 @@ GL_Bind (GL_TEXTURE2, skybox->cubemap);
 			qboolean force_fullbright = false;
 
 			if (!t)
+				continue;
+
+			if (!R_IsPointerSane (t))
 				continue;
 
 			if (pass == BP_GODRAYS)


### PR DESCRIPTION
### Motivation
- Crash reports showed reads from address `0xFFFFFFFFFFFFFFFF` when evaluating `t->fullbright`/`t->emissive` in the godrays path, indicating corrupted or invalid `texture_t *` pointers. 
- The godrays emission checks were dereferencing texture pointers without verifying the texture structure itself was sane. 
- Preventing dereferences of corrupted pointers in the rendering loop should avoid these read-access crashes. 

### Description
- Added a sanity check `if (!R_IsPointerSane(t))` in `R_TextureEmitsGodrays` to avoid inspecting invalid `texture_t` structures. 
- Added the same pointer sanity guard inside the brush-model texture loop in `R_DrawBrushModels` to `continue` when `t` is not sane before using its fields. 
- Changes are limited to `Quake/r_world.c` and ensure `t->fullbright`/`t->emissive` are only accessed when the parent `texture_t` pointer appears valid. 

### Testing
- No automated tests were run for this change. 
- The change is a defensive runtime guard intended to prevent crashes rather than alter rendering behavior when pointers are valid.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949ef0a477c832ea73f14cd7bbeb901)