### PR TITLE
Fix godray texture scan for submodel surfaces

### DIFF
--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -463,6 +463,9 @@ static qboolean R_GodraysNameMatch (const char *name)
 static qboolean R_ModelTextureHasGodrayFlag (const qmodel_t *model, int texnum)
 {
 	int i;
+	int start;
+	int count;
+	static int last_bad_range_frame = -1;
 
 	if (!model || texnum < 0)
 		return false;
@@ -470,9 +473,22 @@ static qboolean R_ModelTextureHasGodrayFlag (const qmodel_t *model, int texnum)
 	if (model->numsurfaces <= 0 || !model->surfaces)
 		return false;
 
-	for (i = 0; i < model->numsurfaces; ++i)
+	start = model->firstmodelsurface;
+	count = model->nummodelsurfaces;
+	if (start < 0 || count <= 0 || start >= model->numsurfaces || start + count > model->numsurfaces)
 	{
-		msurface_t *surface = &model->surfaces[i];
+		if (r_framecount != last_bad_range_frame)
+		{
+			last_bad_range_frame = r_framecount;
+			Con_DWarning ("R_ModelTextureHasGodrayFlag: invalid surface range on %s (first=%d count=%d total=%d)\n",
+				model->name, start, count, model->numsurfaces);
+		}
+		return false;
+	}
+
+	for (i = 0; i < count; ++i)
+	{
+		msurface_t *surface = &model->surfaces[start + i];
 		if (surface->texinfo && surface->texinfo->texnum == texnum && (surface->texinfo->flags & TEX_GODRAY_EMIT))
 			return true;
 	}


### PR DESCRIPTION
### Motivation
- The godray emission check iterated over `model->numsurfaces`, which can mismatch for submodels and cause `texinfo` lookups to reference surfaces that don't belong to the examined submodel.
- This can lead to reading the wrong `texinfo` and incorrect godray behavior or crashes when surface indices are out of range.
- Add a proper per-model surface-range scan and a one-per-frame warning to detect invalid surface ranges early.

### Description
- Change `R_ModelTextureHasGodrayFlag` to iterate only over the submodel surface range using `model->firstmodelsurface` and `model->nummodelsurfaces`.
- Validate the computed `start`/`count` range and emit a `Con_DWarning` once per frame when the range is invalid using a `last_bad_range_frame` sentinel.
- Use `model->surfaces[start + i]` for the loop body to avoid reading surfaces outside the submodel.
- Add local variables `start`, `count`, and `last_bad_range_frame` to support the new logic.

### Testing
- No automated tests were run on this change.
- A single-file compile or runtime smoke test was not executed as part of this PR.
- The change was committed to the repository and the modified file is `Quake/r_world.c`.
- Manual runtime verification is recommended to ensure no further index issues appear when rendering brush model instances.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ab2fb1820832e863cc26143f4c68e)