### PR TITLE
Fix GLSL 'sample' keyword conflict in godrays mask shader

### DIFF
--- a/Quake/shaders/godrays_mask.frag
+++ b/Quake/shaders/godrays_mask.frag
@@ -26,9 +26,9 @@ vec4 SampleMaskAt(vec2 targetCoord)
                 for (int i = 0; i < 2; ++i)
                 {
                         ivec2 sampleCoord = baseCoord + ivec2(i, j);
-                        vec4 sample = FetchSource(sampleCoord, maxCoord);
-                        accum_rgb += sample.rgb * sample.a;
-                        accum_a += sample.a;
+                        vec4 sourceSample = FetchSource(sampleCoord, maxCoord);
+                        accum_rgb += sourceSample.rgb * sourceSample.a;
+                        accum_a += sourceSample.a;
                 }
         }
         float avg_a = accum_a * 0.25;


### PR DESCRIPTION
### Motivation

- The `godrays_mask.frag` fragment shader failed to compile on some drivers due to use of the identifier `sample`, which conflicts with GLSL keywords or built-ins.
- This caused runtime OpenGL shader compilation errors and prevented godrays postprocessing from initializing.

### Description

- Renamed the local variable `sample` to `sourceSample` in `Quake/shaders/godrays_mask.frag` to avoid the GLSL keyword conflict.
- Updated the subsequent uses in the sample accumulation loop to reference `sourceSample` instead of `sample`.
- This is a purely local renaming with no change to the shader math or output.

### Testing

- No automated tests were executed for this shader-only change.
- The change is minimal and intended to resolve shader compilation errors reported by OpenGL drivers.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b084963c8832e9bbc97ab651b64b6)