### PR TITLE
Decouple texture pipeline from LMP palettes; add PNG/KTX2 palette loading and RGBA decoding

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -1175,7 +1175,6 @@ static void Mod_LoadTextures (lump_t *l)
 //johnfitz -- more variables
 	char		texturename[64];
 	int			nummiptex;
-	src_offset_t		offset;
 	int			mark, fwidth, fheight;
 	char		filename[MAX_OSPATH], mapname[MAX_OSPATH];
 	byte		*data;
@@ -1307,28 +1306,27 @@ static void Mod_LoadTextures (lump_t *l)
                                 }
                                 else //use the texture from the bsp file
                                 {
+                                        qboolean has_fullbright = Mod_CheckFullbrights ((byte *)(tx + 1), pixels);
+                                        qboolean is_cutout = (tx->type == TEXTYPE_CUTOUT);
+                                        texmgr_palmode_t palmode = TEXMGR_PALMODE_STANDARD;
+                                        byte *rgba = (byte *) Hunk_AllocNameNoFill (pixels * 4, "tex_rgba");
+
+                                        if (has_fullbright)
+                                                palmode = is_cutout ? TEXMGR_PALMODE_NOBRIGHT : TEXMGR_PALMODE_ALPHABRIGHT;
+
+                                        TexMgr_DecodeIndexedToRGBA ((byte *)(tx + 1), pixels, is_cutout ? 255 : -1, palmode, rgba);
+
                                         q_snprintf (texturename, sizeof(texturename), "%s:%s", loadmodel->name, tx->name);
-                                        offset = (src_offset_t)(mt+1) - (src_offset_t)mod_base;
-                                        if (Mod_CheckFullbrights ((byte *)(tx+1), pixels))
+                                        tx->gltexture = TexMgr_LoadImage (loadmodel, texturename, tx->width, tx->height,
+                                                SRC_RGBA, rgba, "", (src_offset_t)rgba, TEXPREF_MIPMAP | TEXPREF_BINDLESS | (is_cutout ? TEXPREF_ALPHA : 0));
+
+                                        if (has_fullbright && is_cutout)
                                         {
-                                                if (tx->type != TEXTYPE_CUTOUT)
-                                                {
-                                                        tx->gltexture = TexMgr_LoadImage (loadmodel, texturename, tx->width, tx->height,
-                                                                SRC_INDEXED, (byte *)(tx+1), loadmodel->name, offset, TEXPREF_MIPMAP | TEXPREF_ALPHABRIGHT | TEXPREF_BINDLESS);
-                                                }
-                                                else
-                                                {
-                                                        tx->gltexture = TexMgr_LoadImage (loadmodel, texturename, tx->width, tx->height,
-                                                                SRC_INDEXED, (byte *)(tx+1), loadmodel->name, offset, TEXPREF_MIPMAP | TEXPREF_NOBRIGHT | TEXPREF_BINDLESS);
-                                                        q_snprintf (texturename, sizeof(texturename), "%s:%s_glow", loadmodel->name, tx->name);
-                                                        tx->fullbright = TexMgr_LoadImage (loadmodel, texturename, tx->width, tx->height,
-                                                                SRC_INDEXED, (byte *)(tx+1), loadmodel->name, offset, TEXPREF_MIPMAP | TEXPREF_FULLBRIGHT | TEXPREF_BINDLESS);
-                                                }
-                                        }
-                                        else
-                                        {
-                                                tx->gltexture = TexMgr_LoadImage (loadmodel, texturename, tx->width, tx->height,
-                                                        SRC_INDEXED, (byte *)(tx+1), loadmodel->name, offset, TEXPREF_MIPMAP | TEXPREF_BINDLESS);
+                                                byte *fb_rgba = (byte *) Hunk_AllocNameNoFill (pixels * 4, "tex_fbright");
+                                                TexMgr_BuildFullbrightRGBA ((byte *)(tx + 1), pixels, 255, fb_rgba);
+                                                q_snprintf (texturename, sizeof(texturename), "%s:%s_glow", loadmodel->name, tx->name);
+                                                tx->fullbright = TexMgr_LoadImage (loadmodel, texturename, tx->width, tx->height,
+                                                        SRC_RGBA, fb_rgba, "", (src_offset_t)fb_rgba, TEXPREF_MIPMAP | TEXPREF_BINDLESS);
                                         }
                                 }
                                 tx->emissive = Mod_LoadEmissiveMap (loadmodel, filename, TEXPREF_MIPMAP | TEXPREF_BINDLESS);
@@ -1369,28 +1367,27 @@ static void Mod_LoadTextures (lump_t *l)
                                 }
                                 else //use the texture from the bsp file
                                 {
+                                        qboolean has_fullbright = Mod_CheckFullbrights ((byte *)(tx + 1), pixels);
+                                        qboolean is_cutout = (tx->type == TEXTYPE_CUTOUT);
+                                        texmgr_palmode_t palmode = TEXMGR_PALMODE_STANDARD;
+                                        byte *rgba = (byte *) Hunk_AllocNameNoFill (pixels * 4, "tex_rgba");
+
+                                        if (has_fullbright)
+                                                palmode = is_cutout ? TEXMGR_PALMODE_NOBRIGHT : TEXMGR_PALMODE_ALPHABRIGHT;
+
+                                        TexMgr_DecodeIndexedToRGBA ((byte *)(tx + 1), pixels, is_cutout ? 255 : -1, palmode, rgba);
+
                                         q_snprintf (texturename, sizeof(texturename), "%s:%s", loadmodel->name, tx->name);
-                                        offset = (src_offset_t)(mt+1) - (src_offset_t)mod_base;
-                                        if (Mod_CheckFullbrights ((byte *)(tx+1), pixels))
+                                        tx->gltexture = TexMgr_LoadImage (loadmodel, texturename, tx->width, tx->height,
+                                                SRC_RGBA, rgba, "", (src_offset_t)rgba, TEXPREF_MIPMAP | extraflags | (is_cutout ? TEXPREF_ALPHA : 0));
+
+                                        if (has_fullbright && is_cutout)
                                         {
-                                                if (tx->type != TEXTYPE_CUTOUT)
-                                                {
-                                                        tx->gltexture = TexMgr_LoadImage (loadmodel, texturename, tx->width, tx->height,
-                                                                SRC_INDEXED, (byte *)(tx+1), loadmodel->name, offset, TEXPREF_MIPMAP | TEXPREF_ALPHABRIGHT | extraflags);
-                                                }
-                                                else
-                                                {
-                                                        tx->gltexture = TexMgr_LoadImage (loadmodel, texturename, tx->width, tx->height,
-                                                                SRC_INDEXED, (byte *)(tx+1), loadmodel->name, offset, TEXPREF_MIPMAP | TEXPREF_NOBRIGHT | extraflags);
-                                                        q_snprintf (texturename, sizeof(texturename), "%s:%s_glow", loadmodel->name, tx->name);
-                                                        tx->fullbright = TexMgr_LoadImage (loadmodel, texturename, tx->width, tx->height,
-                                                                SRC_INDEXED, (byte *)(tx+1), loadmodel->name, offset, TEXPREF_MIPMAP | TEXPREF_FULLBRIGHT | extraflags);
-                                                }
-                                        }
-                                        else
-                                        {
-                                                tx->gltexture = TexMgr_LoadImage (loadmodel, texturename, tx->width, tx->height,
-                                                        SRC_INDEXED, (byte *)(tx+1), loadmodel->name, offset, TEXPREF_MIPMAP | extraflags);
+                                                byte *fb_rgba = (byte *) Hunk_AllocNameNoFill (pixels * 4, "tex_fbright");
+                                                TexMgr_BuildFullbrightRGBA ((byte *)(tx + 1), pixels, 255, fb_rgba);
+                                                q_snprintf (texturename, sizeof(texturename), "%s:%s_glow", loadmodel->name, tx->name);
+                                                tx->fullbright = TexMgr_LoadImage (loadmodel, texturename, tx->width, tx->height,
+                                                        SRC_RGBA, fb_rgba, "", (src_offset_t)fb_rgba, TEXPREF_MIPMAP | extraflags);
                                         }
                                 }
                                 tx->emissive = Mod_LoadEmissiveMap (loadmodel, filename, TEXPREF_MIPMAP | extraflags);

--- a/Quake/gl_sky.c
+++ b/Quake/gl_sky.c
@@ -71,6 +71,7 @@ void Sky_LoadTexture (qmodel_t *mod, texture_t *mt)
 	char		texturename[64];
 	unsigned	x, y, p, r, g, b, count, halfwidth, *rgba;
 	byte		*src, *front_data, *back_data;
+	byte		*back_rgba, *front_rgba;
 
 	if (mt->width != 256 || mt->height != 128)
 	{
@@ -82,6 +83,8 @@ void Sky_LoadTexture (qmodel_t *mod, texture_t *mt)
 	halfwidth = mt->width / 2;
 	back_data = (byte *) Hunk_AllocName (halfwidth*mt->height*2, "skytex");
 	front_data = back_data + halfwidth*mt->height;
+	back_rgba = (byte *) Hunk_AllocNameNoFill (halfwidth * mt->height * 4, "skytex");
+	front_rgba = (byte *) Hunk_AllocNameNoFill (halfwidth * mt->height * 4, "skytex");
 	src = (byte *)(mt + 1);
 
 // extract back layer and upload
@@ -89,7 +92,8 @@ void Sky_LoadTexture (qmodel_t *mod, texture_t *mt)
 		memcpy (back_data + y*halfwidth, src + halfwidth + y*mt->width, halfwidth);
 
 	q_snprintf(texturename, sizeof(texturename), "%s:%s_back", mod->name, mt->name);
-	mt->gltexture = TexMgr_LoadImage (mod, texturename, halfwidth, mt->height, SRC_INDEXED, back_data, "", (src_offset_t)back_data, TEXPREF_BINDLESS);
+	TexMgr_DecodeIndexedToRGBA (back_data, halfwidth * mt->height, -1, TEXMGR_PALMODE_STANDARD, back_rgba);
+	mt->gltexture = TexMgr_LoadImage (mod, texturename, halfwidth, mt->height, SRC_RGBA, back_rgba, "", (src_offset_t)back_rgba, TEXPREF_BINDLESS);
 
 // extract front layer and upload
 	r = g = b = count = 0;
@@ -98,9 +102,7 @@ void Sky_LoadTexture (qmodel_t *mod, texture_t *mt)
 		for (x=0 ; x<halfwidth ; x++)
 		{
 			p = src[x];
-			if (p == 0)
-				p = 255;
-			else
+			if (p != 0)
 			{
 				rgba = &d_8to24table[p];
 				r += ((byte *)rgba)[0];
@@ -114,7 +116,8 @@ void Sky_LoadTexture (qmodel_t *mod, texture_t *mt)
 
 	front_data = back_data + halfwidth*mt->height;
 	q_snprintf(texturename, sizeof(texturename), "%s:%s_front", mod->name, mt->name);
-	mt->fullbright = TexMgr_LoadImage (mod, texturename, halfwidth, mt->height, SRC_INDEXED, front_data, "", (src_offset_t)front_data, TEXPREF_ALPHA|TEXPREF_BINDLESS);
+	TexMgr_DecodeIndexedToRGBA (front_data, halfwidth * mt->height, 0, TEXMGR_PALMODE_STANDARD, front_rgba);
+	mt->fullbright = TexMgr_LoadImage (mod, texturename, halfwidth, mt->height, SRC_RGBA, front_rgba, "", (src_offset_t)front_rgba, TEXPREF_ALPHA|TEXPREF_BINDLESS);
 
 // calculate r_fastsky color based on average of all opaque foreground colors
 	skyflatcolor[0] = (float)r/(count*255);
@@ -133,7 +136,7 @@ void Sky_LoadTextureQ64 (qmodel_t *mod, texture_t *mt)
 {
 	char		texturename[64];
 	unsigned	i, p, r, g, b, count, halfheight, *rgba;
-	byte		*front, *back, *front_rgba;
+	byte		*front, *back, *front_rgba, *back_rgba;
 
 	if (mt->width != 32 || mt->height != 64)
 	{
@@ -147,10 +150,12 @@ void Sky_LoadTextureQ64 (qmodel_t *mod, texture_t *mt)
 	front = (byte *)(mt+1);
 	back = (byte *)(mt+1) + mt->width*halfheight;
 	front_rgba = (byte *) Hunk_AllocName (4*mt->width*halfheight, "q64_skytex");
+	back_rgba = (byte *) Hunk_AllocNameNoFill (4*mt->width*halfheight, "q64_skytex");
 
 	// Normal indexed texture for the back layer
 	q_snprintf(texturename, sizeof(texturename), "%s:%s_back", mod->name, mt->name);
-	mt->gltexture = TexMgr_LoadImage (mod, texturename, mt->width, halfheight, SRC_INDEXED, back, "", (src_offset_t)back, TEXPREF_BINDLESS);
+	TexMgr_DecodeIndexedToRGBA (back, mt->width * halfheight, -1, TEXMGR_PALMODE_STANDARD, back_rgba);
+	mt->gltexture = TexMgr_LoadImage (mod, texturename, mt->width, halfheight, SRC_RGBA, back_rgba, "", (src_offset_t)back_rgba, TEXPREF_BINDLESS);
 
 	// front layer, convert to RGBA and upload
 	p = r = g = b = count = 0;

--- a/Quake/gl_texmgr.c
+++ b/Quake/gl_texmgr.c
@@ -25,6 +25,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "quakedef.h"
 #include "glquake.h"
 #include "bc7enc.h"
+#include "gl_ktx2.h"
 
 #ifndef GL_COMPRESSED_RED_GREEN_RGTC2
 #define GL_COMPRESSED_RED_GREEN_RGTC2 0x8DBD
@@ -53,6 +54,7 @@ cvar_t			r_softemu_mdl_warp = {"r_softemu_mdl_warp", "-1", CVAR_ARCHIVE};
 cvar_t			r_softemu_dither_screen = {"r_softemu_dither_screen", "1.0", CVAR_ARCHIVE};
 cvar_t			r_softemu_dither_texture = {"r_softemu_dither_texture", "1.0", CVAR_ARCHIVE};
 cvar_t			r_bc7_compress = {"r_bc7_compress", "0", CVAR_ARCHIVE};
+static cvar_t		gl_legacy_palettes = {"gl_legacy_palettes", "0", CVAR_ARCHIVE};
 
 static cvar_t	gl_max_size = {"gl_max_size", "0", CVAR_NONE};
 static cvar_t	gl_picmip = {"gl_picmip", "0", CVAR_NONE};
@@ -771,6 +773,153 @@ static void TexMgr_LinearizeWadPixels (gltexture_t *glt, unsigned *data)
 	}
 }
 
+static byte *TexMgr_LoadFileWithSize (const char *path, size_t *size_out)
+{
+	FILE *f;
+	byte *buffer;
+	long length;
+
+	COM_FOpenFile (path, &f, NULL);
+	if (!f)
+		return NULL;
+
+	if (fseek (f, 0, SEEK_END) != 0)
+	{
+		fclose (f);
+		return NULL;
+	}
+
+	length = ftell (f);
+	if (length <= 0)
+	{
+		fclose (f);
+		return NULL;
+	}
+
+	if (fseek (f, 0, SEEK_SET) != 0)
+	{
+		fclose (f);
+		return NULL;
+	}
+
+	buffer = (byte *) malloc ((size_t) length);
+	if (!buffer)
+	{
+		fclose (f);
+		return NULL;
+	}
+
+	if (fread (buffer, 1, (size_t) length, f) != (size_t) length)
+	{
+		fclose (f);
+		free (buffer);
+		return NULL;
+	}
+
+	fclose (f);
+	*size_out = (size_t) length;
+	return buffer;
+}
+
+static qboolean TexMgr_LoadPaletteKTX2 (byte *pal)
+{
+	ktx2_header_t hdr;
+	ktx2_decoded_image_t decoded;
+	byte *raw;
+	size_t size;
+	qboolean ok = false;
+
+	raw = TexMgr_LoadFileWithSize ("gfx/palette.ktx2", &size);
+	if (!raw)
+		return false;
+
+	memset (&decoded, 0, sizeof (decoded));
+	if (!KTX2_ParseHeaderPublic (&hdr, raw, size))
+		goto cleanup;
+
+	if (!KTX2_TranscodeToRGBA (raw, size, &hdr, &decoded))
+		goto cleanup;
+
+	if (hdr.width * hdr.height < 256u)
+	{
+		Con_Warning ("palette.ktx2 too small (%ux%u)\n", (unsigned) hdr.width, (unsigned) hdr.height);
+		goto cleanup;
+	}
+
+	if (!decoded.mip_data[0] || decoded.mip_size[0] < 256u * 4u)
+		goto cleanup;
+
+	for (unsigned i = 0; i < 256; ++i)
+	{
+		const byte *src = decoded.mip_data[0] + i * 4;
+		pal[i * 3 + 0] = src[0];
+		pal[i * 3 + 1] = src[1];
+		pal[i * 3 + 2] = src[2];
+	}
+
+	ok = true;
+
+cleanup:
+	KTX2_FreeDecodedImage (&decoded);
+	free (raw);
+	return ok;
+}
+
+static qboolean TexMgr_LoadPaletteImage (byte *pal)
+{
+	int width, height;
+	enum srcformat fmt;
+	byte *data = Image_LoadImage ("gfx/palette", &width, &height, &fmt);
+
+	if (!data)
+		return false;
+	if (fmt != SRC_RGBA)
+	{
+		Con_Warning ("gfx/palette loaded with unexpected format %d\n", fmt);
+		return false;
+	}
+	if (width * height < 256)
+	{
+		Con_Warning ("gfx/palette image too small (%dx%d)\n", width, height);
+		return false;
+	}
+
+	for (int i = 0; i < 256; ++i)
+	{
+		pal[i * 3 + 0] = data[i * 4 + 0];
+		pal[i * 3 + 1] = data[i * 4 + 1];
+		pal[i * 3 + 2] = data[i * 4 + 2];
+	}
+
+	return true;
+}
+
+static qboolean TexMgr_LoadColormap (byte **colormap)
+{
+	FILE *f;
+
+	COM_FOpenFile ("gfx/colormap.lmp", &f, NULL);
+	if (!f)
+		return false;
+
+	*colormap = (byte *) Hunk_AllocNoFill (256 * 64);
+	if (fread (*colormap, 256 * 64, 1, f) != 1)
+		Sys_Error ("TexMgr_LoadPalette: colormap read error");
+	fclose (f);
+	return true;
+}
+
+static void TexMgr_SetDefaultFullbright (const byte *pal)
+{
+	memset (is_fullbright, 0, sizeof (is_fullbright));
+	for (int i = 224; i < 255; ++i)
+	{
+		const byte *src = pal + i * 3;
+		if (src[0] || src[1] || src[2])
+			SetBit (is_fullbright, i);
+	}
+}
+
 /*
 =================
 TexMgr_LoadPalette -- johnfitz -- was VID_SetPalette, moved here, renamed, rewritten
@@ -780,47 +929,65 @@ void TexMgr_LoadPalette (void)
 {
 	byte *pal, *src, *colormap;
 	int i, j, mark, numfb;
+	qboolean pal_loaded = false;
 	FILE *f;
-
-	COM_FOpenFile ("gfx/palette.lmp", &f, NULL);
-	if (!f)
-		Sys_Error ("Couldn't load gfx/palette.lmp");
 
 	mark = Hunk_LowMark ();
 	pal = (byte *) Hunk_AllocNoFill (768);
-	if (fread (pal, 768, 1, f) != 1)
-		Sys_Error ("Failed reading gfx/palette.lmp");
-	fclose(f);
+	colormap = NULL;
 
-	COM_FOpenFile ("gfx/colormap.lmp", &f, NULL);
-	if (!f)
-		Sys_Error ("Couldn't load gfx/colormap.lmp");
-	colormap = (byte *) Hunk_AllocNoFill (256 * 64);
-	if (fread (colormap, 256 * 64, 1, f) != 1)
-		Sys_Error ("TexMgr_LoadPalette: colormap read error");
-	fclose(f);
+	if (!gl_legacy_palettes.value)
+	{
+		pal_loaded = TexMgr_LoadPaletteKTX2 (pal);
+		if (!pal_loaded)
+			pal_loaded = TexMgr_LoadPaletteImage (pal);
+	}
+
+	if (!pal_loaded)
+	{
+		COM_FOpenFile ("gfx/palette.lmp", &f, NULL);
+		if (!f)
+			Sys_Error ("Couldn't load gfx/palette.lmp");
+
+		if (fread (pal, 768, 1, f) != 1)
+			Sys_Error ("Failed reading gfx/palette.lmp");
+		fclose (f);
+		pal_loaded = true;
+	}
+
+	if (!TexMgr_LoadColormap (&colormap))
+	{
+		if (gl_legacy_palettes.value)
+			Sys_Error ("Couldn't load gfx/colormap.lmp");
+		Con_Warning ("Couldn't load gfx/colormap.lmp, using default fullbright range\n");
+		TexMgr_SetDefaultFullbright (pal);
+		colormap = NULL;
+	}
 
 	//find fullbright colors
-	memset (is_fullbright, 0, sizeof (is_fullbright));
-	numfb = 0;
-	src = pal;
-	for (i = 0; i < 256; i++, src += 3)
+	if (colormap)
 	{
-		if (!src[0] && !src[1] && !src[2])
-			continue; // black can't be fullbright
-
-		for (j = 1; j < 64; j++)
-			if (colormap[i + j * 256] != colormap[i])
-				break;
-
-		if (j == 64) 
+		memset (is_fullbright, 0, sizeof (is_fullbright));
+		numfb = 0;
+		src = pal;
+		for (i = 0; i < 256; i++, src += 3)
 		{
-			SetBit (is_fullbright, i);
-			numfb++;
+			if (!src[0] && !src[1] && !src[2])
+				continue; // black can't be fullbright
+
+			for (j = 1; j < 64; j++)
+				if (colormap[i + j * 256] != colormap[i])
+					break;
+
+			if (j == 64) 
+			{
+				SetBit (is_fullbright, i);
+				numfb++;
+			}
 		}
+		if (developer.value)
+			Con_SafePrintf ("Colormap has %d fullbright colors\n", numfb);
 	}
-	if (developer.value)
-		Con_SafePrintf ("Colormap has %d fullbright colors\n", numfb);
 
 	//fill color tables
 	src = pal;
@@ -857,6 +1024,60 @@ void TexMgr_LoadPalette (void)
 	((byte *) &d_8to24table_conchars[0]) [3] = 0;
 
 	Hunk_FreeToLowMark (mark);
+}
+
+void TexMgr_DecodeIndexedToRGBA (const byte *indexed, int pixel_count, int transparent_index, texmgr_palmode_t mode, byte *rgba)
+{
+	for (int i = 0; i < pixel_count; ++i)
+	{
+		int idx = indexed[i];
+		byte *dst = rgba + i * 4;
+		const byte *src = (const byte *) &d_8to24table_opaque[idx];
+		qboolean transparent = (transparent_index >= 0 && idx == transparent_index);
+		qboolean is_fb = GetBit (is_fullbright, idx);
+
+		if (transparent)
+		{
+			dst[0] = dst[1] = dst[2] = 0;
+			dst[3] = 0;
+			continue;
+		}
+
+		dst[0] = src[0];
+		dst[1] = src[1];
+		dst[2] = src[2];
+		dst[3] = 255;
+
+		if (mode == TEXMGR_PALMODE_ALPHABRIGHT)
+			dst[3] = is_fb ? 0 : 255;
+		else if (mode == TEXMGR_PALMODE_NOBRIGHT && is_fb)
+		{
+			dst[0] = dst[1] = dst[2] = 0;
+		}
+	}
+}
+
+void TexMgr_BuildFullbrightRGBA (const byte *indexed, int pixel_count, int transparent_index, byte *rgba)
+{
+	for (int i = 0; i < pixel_count; ++i)
+	{
+		int idx = indexed[i];
+		byte *dst = rgba + i * 4;
+		const byte *src = (const byte *) &d_8to24table_opaque[idx];
+		qboolean transparent = (transparent_index >= 0 && idx == transparent_index);
+		qboolean is_fb = GetBit (is_fullbright, idx);
+
+		if (transparent || !is_fb)
+		{
+			dst[0] = dst[1] = dst[2] = dst[3] = 0;
+			continue;
+		}
+
+		dst[0] = src[0];
+		dst[1] = src[1];
+		dst[2] = src[2];
+		dst[3] = 255;
+	}
 }
 
 /*
@@ -903,6 +1124,7 @@ void TexMgr_Init (void)
 	TexMgr_ApplySettings ();
 
 	// palette
+	Cvar_RegisterVariable (&gl_legacy_palettes);
 	TexMgr_LoadPalette ();
 
 Cvar_RegisterVariable (&gl_max_size);

--- a/Quake/gl_texmgr.h
+++ b/Quake/gl_texmgr.h
@@ -97,6 +97,16 @@ extern unsigned int d_8to24table_fbright[256];
 extern unsigned int d_8to24table_nobright[256];
 extern unsigned int d_8to24table_conchars[256];
 
+typedef enum
+{
+	TEXMGR_PALMODE_STANDARD = 0,
+	TEXMGR_PALMODE_ALPHABRIGHT,
+	TEXMGR_PALMODE_NOBRIGHT
+} texmgr_palmode_t;
+
+void TexMgr_DecodeIndexedToRGBA (const byte *indexed, int pixel_count, int transparent_index, texmgr_palmode_t mode, byte *rgba);
+void TexMgr_BuildFullbrightRGBA (const byte *indexed, int pixel_count, int transparent_index, byte *rgba);
+
 extern GLint gl_max_texture_size;
 
 typedef enum
@@ -177,4 +187,3 @@ void GL_DeleteNativeTexture (GLuint texnum);
 void GL_ClearBindings (void);
 
 #endif	/* _GL_TEXMAN_H */
-

--- a/Quake/gl_vidsdl.c
+++ b/Quake/gl_vidsdl.c
@@ -1734,7 +1734,10 @@ void	VID_Init (void)
 	vid_initialized = true;
 
 	vid.colormap = host_colormap;
-	vid.fullbright = 256 - LittleLong (*((int *)vid.colormap + 2048));
+	if (vid.colormap)
+		vid.fullbright = 256 - LittleLong (*((int *)vid.colormap + 2048));
+	else
+		vid.fullbright = 224;
 
 	VID_SetMode (width, height, refreshrate, fullscreen);
 	VID_ApplyVSync ();

--- a/Quake/host.c
+++ b/Quake/host.c
@@ -1478,7 +1478,7 @@ void Host_Init (void)
 	{
 		host_colormap = (byte *)COM_LoadHunkFile ("gfx/colormap.lmp", NULL);
 		if (!host_colormap)
-			Sys_Error ("Couldn't load gfx/colormap.lmp");
+			Con_Warning ("Couldn't load gfx/colormap.lmp\n");
 
 		V_Init ();
 		Chase_Init ();


### PR DESCRIPTION
### Motivation

- Move the texture pipeline away from mandatory LMP palette/colormap files and allow modern palette asset formats to drive the palette LUT used by GL shaders and uploads.
- Decode indexed WAD/BSP/sky textures into linear RGBA at import so runtime colormap lookups and palette-only uploads are optional.
- Preserve fullbright metadata while allowing the colormap to be optional, and provide a compatibility path for legacy LMP/colormap usage.
- Provide a runtime toggle to re-enable legacy palette behaviour for compatibility with older content.

### Description

- Add `texmgr_palmode_t` plus new helpers `TexMgr_DecodeIndexedToRGBA` and `TexMgr_BuildFullbrightRGBA` (declared in `gl_texmgr.h` and implemented in `gl_texmgr.c`) to convert indexed images to RGBA using the palette tables.
- Implement palette loading from `gfx/palette.ktx2` (KTX2) and `gfx/palette.png` (PNG) with a fallback to `gfx/palette.lmp`, and add tolerant colormap handling with a default fullbright range when `gfx/colormap.lmp` is missing.
- Introduce `gl_legacy_palettes` cvar and register it in `TexMgr_Init` to allow gating of the legacy LMP/colormap path.
- Convert BSP and sky loaders to decode indexed data to RGBA at import and emit explicit fullbright RGBA textures for cutout/sky fullbright masks, and change startup to warn (not fatal) when `gfx/colormap.lmp` is missing while providing a sensible default in that case.

### Testing

- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d32db5c28832eb8c38deeb46e51c5)