### PR TITLE
Fix SSAO depth reconstruction, reverse‑Z handling and stabilize AO sampling

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -258,16 +258,16 @@ cvar_t	r_bloom_threshold = { "r_bloom_threshold", "1.0", CVAR_ARCHIVE };
 
 cvar_t	r_ssao = { "r_ssao", "0", CVAR_ARCHIVE };
 cvar_t	r_ssao_radius = { "r_ssao_radius", "24", CVAR_ARCHIVE };
-cvar_t	r_ssao_intensity = { "r_ssao_intensity", "0.8", CVAR_ARCHIVE };
+cvar_t	r_ssao_intensity = { "r_ssao_intensity", "0.5", CVAR_ARCHIVE };
 cvar_t	r_ssao_bias = { "r_ssao_bias", "0.02", CVAR_ARCHIVE };
-cvar_t	r_ssao_power = { "r_ssao_power", "1.2", CVAR_ARCHIVE };
+cvar_t	r_ssao_power = { "r_ssao_power", "1.5", CVAR_ARCHIVE };
 cvar_t	r_ssao_min = { "r_ssao_min", "0.55", CVAR_ARCHIVE };
 cvar_t	r_ssao_samples = { "r_ssao_samples", "12", CVAR_ARCHIVE };
 cvar_t	r_ssao_blur = { "r_ssao_blur", "1", CVAR_ARCHIVE };
 cvar_t	r_ssao_blur_radius = { "r_ssao_blur_radius", "2", CVAR_ARCHIVE };
 cvar_t	r_ssao_blur_sigma = { "r_ssao_blur_sigma", "2.0", CVAR_ARCHIVE };
 cvar_t	r_ssao_halfres = { "r_ssao_halfres", "1", CVAR_ARCHIVE };
-// r_ssao_debug modes: 0 off, 1 raw depth, 2 linear depth, 3 view-space Z, 4 AO, 5 normals-from-depth.
+// r_ssao_debug modes: 0 off, 1 raw depth, 2 linear view-space Z, 3 normals, 4 AO.
 cvar_t	r_ssao_debug = { "r_ssao_debug", "0", CVAR_ARCHIVE };
 cvar_t	r_ssao_debug_far = { "r_ssao_debug_far", "4096", CVAR_ARCHIVE };
 cvar_t	r_ssao_reversedz_mode = { "r_ssao_reversedz_mode", "0", CVAR_ARCHIVE };
@@ -528,6 +528,7 @@ static GLuint GL_CreateFBOAttachment (GLenum format, int samples, GLenum filter,
 {
 	GLenum target = samples > 1 ? GL_TEXTURE_2D_MULTISAMPLE : GL_TEXTURE_2D;
 	GLuint texnum;
+	qboolean is_depth_format = (format == GL_DEPTH24_STENCIL8 || format == GL_DEPTH32F_STENCIL8 || format == GL_DEPTH_COMPONENT24 || format == GL_DEPTH_COMPONENT32F);
 
 	glGenTextures (1, &texnum);
 	GL_BindNative (GL_TEXTURE0, target, texnum);
@@ -541,6 +542,8 @@ static GLuint GL_CreateFBOAttachment (GLenum format, int samples, GLenum filter,
 		GL_TexStorage2DFunc (target, 1, format, vid.width, vid.height);
 		glTexParameteri (target, GL_TEXTURE_MAG_FILTER, filter);
 		glTexParameteri (target, GL_TEXTURE_MIN_FILTER, filter);
+		if (is_depth_format)
+			glTexParameteri (target, GL_TEXTURE_COMPARE_MODE, GL_NONE);
 	}
 	glTexParameteri (target, GL_TEXTURE_MAX_LEVEL, 0);
 	GL_LogErrorIfDeveloper ("GL_CreateFBOAttachment");
@@ -880,9 +883,10 @@ static GLuint GL_GenerateBloomTexture (void)
 	return input_tex;
 }
 
-static void GL_LogSSAODepthInfo (GLuint depth_tex, int ssao_width, int ssao_height, float view_min_x, float view_min_y, float view_max_x, float view_max_y)
+static void GL_LogSSAODepthInfo (GLuint depth_tex, GLuint ao_tex, int ssao_width, int ssao_height, float view_min_x, float view_min_y, float view_max_x, float view_max_y)
 {
 	static GLuint last_depth_tex = 0;
+	static GLuint last_ao_tex = 0;
 	static int last_ssao_width = 0;
 	static int last_ssao_height = 0;
 	static int last_debug_mode = -1;
@@ -892,11 +896,12 @@ static void GL_LogSSAODepthInfo (GLuint depth_tex, int ssao_width, int ssao_heig
 	static float last_view_max_y = -1.f;
 
 	int debug_mode = (int)Q_rint (r_ssao_debug.value);
-	if (depth_tex == 0)
+	if (depth_tex == 0 || ao_tex == 0 || debug_mode <= 0)
 		return;
 
 	if (debug_mode == last_debug_mode &&
 		depth_tex == last_depth_tex &&
+		ao_tex == last_ao_tex &&
 		ssao_width == last_ssao_width &&
 		ssao_height == last_ssao_height &&
 		view_min_x == last_view_min_x &&
@@ -907,6 +912,7 @@ static void GL_LogSSAODepthInfo (GLuint depth_tex, int ssao_width, int ssao_heig
 
 	last_debug_mode = debug_mode;
 	last_depth_tex = depth_tex;
+	last_ao_tex = ao_tex;
 	last_ssao_width = ssao_width;
 	last_ssao_height = ssao_height;
 	last_view_min_x = view_min_x;
@@ -917,20 +923,33 @@ static void GL_LogSSAODepthInfo (GLuint depth_tex, int ssao_width, int ssao_heig
 	GLint internal_format = 0;
 	GLint tex_width = 0;
 	GLint tex_height = 0;
+	GLint compare_mode = 0;
+	GLint ao_internal_format = 0;
+	GLint ao_width = 0;
+	GLint ao_height = 0;
 	GLfloat depth_range[2] = { 0.f, 1.f };
 	GLint viewport[4] = { 0, 0, 0, 0 };
+	GLint draw_fbo = 0;
 	const char *target_name = "GL_TEXTURE_2D";
 
 	GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, depth_tex);
 	glGetTexLevelParameteriv (GL_TEXTURE_2D, 0, GL_TEXTURE_INTERNAL_FORMAT, &internal_format);
 	glGetTexLevelParameteriv (GL_TEXTURE_2D, 0, GL_TEXTURE_WIDTH, &tex_width);
 	glGetTexLevelParameteriv (GL_TEXTURE_2D, 0, GL_TEXTURE_HEIGHT, &tex_height);
+	glGetTexParameteriv (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE, &compare_mode);
+	GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, ao_tex);
+	glGetTexLevelParameteriv (GL_TEXTURE_2D, 0, GL_TEXTURE_INTERNAL_FORMAT, &ao_internal_format);
+	glGetTexLevelParameteriv (GL_TEXTURE_2D, 0, GL_TEXTURE_WIDTH, &ao_width);
+	glGetTexLevelParameteriv (GL_TEXTURE_2D, 0, GL_TEXTURE_HEIGHT, &ao_height);
 	glGetFloatv (GL_DEPTH_RANGE, depth_range);
 	glGetIntegerv (GL_VIEWPORT, viewport);
+	glGetIntegerv (GL_FRAMEBUFFER_BINDING, &draw_fbo);
 
-	Con_DPrintf ("SSAO depth input: tex=%u target=%s format=0x%X size=%dx%d viewport=%dx%d+%d+%d\n",
+	Con_DPrintf ("SSAO depth input: tex=%u target=%s format=0x%X size=%dx%d compare=0x%X viewport=%dx%d+%d+%d fbo=%d\n",
 		depth_tex, target_name, internal_format, tex_width, tex_height,
-		viewport[2], viewport[3], viewport[0], viewport[1]);
+		compare_mode, viewport[2], viewport[3], viewport[0], viewport[1], draw_fbo);
+	Con_DPrintf ("SSAO AO output: tex=%u format=0x%X size=%dx%d\n",
+		ao_tex, ao_internal_format, ao_width, ao_height);
 	Con_DPrintf ("SSAO depth range: [%0.4f, %0.4f] reversedZ=%d mode=%d znear=%0.4f zfar=%0.4f cutoff=%0.4f viewRect=[%0.3f,%0.3f]-[%0.3f,%0.3f] ssao=%dx%d debug=%d\n",
 		depth_range[0], depth_range[1],
 		gl_clipcontrol_able ? 1 : 0,
@@ -940,6 +959,23 @@ static void GL_LogSSAODepthInfo (GLuint depth_tex, int ssao_width, int ssao_heig
 		view_min_x, view_min_y, view_max_x, view_max_y,
 		ssao_width, ssao_height, debug_mode);
 	GL_LogErrorIfDeveloper ("GL_LogSSAODepthInfo");
+}
+
+static float R_SanitizeSSAOValue (float value, float fallback, float minval, float maxval)
+{
+#if defined(_MSC_VER)
+	if (_finite (value) == 0)
+		return fallback;
+#else
+	if (!isfinite (value))
+		return fallback;
+#endif
+
+	if (value < minval)
+		return minval;
+	if (value > maxval)
+		return maxval;
+	return value;
 }
 
 static GLuint GL_GenerateSSAOTexture (float view_min_x, float view_min_y, float view_max_x, float view_max_y)
@@ -953,9 +989,9 @@ static GLuint GL_GenerateSSAOTexture (float view_min_x, float view_min_y, float 
 
 	int samples = (int)Q_rint (r_ssao_samples.value);
 	samples = CLAMP (4, samples, SSAO_MAX_SAMPLES);
-	float radius = q_max (0.01f, r_ssao_radius.value);
-	float bias = q_max (0.f, r_ssao_bias.value);
-	float power = q_max (0.01f, r_ssao_power.value);
+	float radius = R_SanitizeSSAOValue (r_ssao_radius.value, 24.f, 0.01f, 8192.f);
+	float bias = R_SanitizeSSAOValue (r_ssao_bias.value, 0.02f, 0.f, 1.f) * radius;
+	float power = R_SanitizeSSAOValue (r_ssao_power.value, 1.f, 0.01f, 8.f);
 	float min_ao = CLAMP (0.f, r_ssao_min.value, 1.f);
 	qboolean use_halfres = (r_ssao_halfres.value > 0.f);
 	int index = use_halfres ? 1 : 0;
@@ -990,7 +1026,7 @@ static GLuint GL_GenerateSSAOTexture (float view_min_x, float view_min_y, float 
 		GL_ClearBufferfvFunc (GL_COLOR, 0, clear);
 	}
 
-	GL_LogSSAODepthInfo (framebufs.composite.depth_stencil_tex, width, height, view_min_x, view_min_y, view_max_x, view_max_y);
+	GL_LogSSAODepthInfo (framebufs.composite.depth_stencil_tex, framebufs.ssao.ao_tex[index], width, height, view_min_x, view_min_y, view_max_x, view_max_y);
 
 	GL_UseProgram (glprogs.ssao);
 	GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
@@ -1687,7 +1723,7 @@ void GL_PostProcess (void)
 	inv_scale = r_refdef.scale > 0 ? 1.f / (float)r_refdef.scale : 1.f;
 
 	ssao_texture = GL_GenerateSSAOTexture (view_min_x, view_min_y, view_max_x, view_max_y);
-	ssao_intensity = CLAMP (0.f, r_ssao_intensity.value, 2.f);
+	ssao_intensity = R_SanitizeSSAOValue (r_ssao_intensity.value, 0.f, 0.f, 1.f);
 	ssao_debug = q_max (0.f, r_ssao_debug.value);
 	if (ssao_texture == 0)
 		ssao_debug = 0.f;

--- a/Quake/shaders/ssao.frag
+++ b/Quake/shaders/ssao.frag
@@ -49,17 +49,23 @@ const vec3 SSAO_KERNEL[SSAO_MAX_SAMPLES] = vec3[](
         vec3(0.2397, -0.1794, 0.3984)
 );
 
+// Root cause: SSAO sampled depth in mixed clip/window space with reverse-Z ambiguity.
+// Fix: reconstruct view space from the same depth buffer using consistent NDC mapping.
 float DepthToNdcZ(float depth, float reversed, int mode)
 {
+        float raw = depth;
+        if (mode == 1)
+                raw = 1.0 - raw;
         if (reversed > 0.5)
         {
-                if (mode == 1)
-                        depth = 1.0 - depth;
                 if (mode == 2)
-                        return (1.0 - depth) * 2.0 - 1.0;
-                return depth;
+                        raw = 1.0 - raw;
+                return raw;
         }
-        return depth * 2.0 - 1.0;
+        float ndc = raw * 2.0 - 1.0;
+        if (mode == 2)
+                ndc = -ndc;
+        return ndc;
 }
 
 vec3 ReconstructViewPos(vec2 uv, float depth)
@@ -83,6 +89,8 @@ vec3 ComputeNormalFromViewPos(vec3 viewPos)
         vec3 normal = normalize(cross(dx, dy));
         if (length(normal) < 1e-4)
                 return vec3(0.0, 0.0, 1.0);
+        if (normal.z < 0.0)
+                normal = -normal;
         return normal;
 }
 
@@ -110,22 +118,15 @@ void main()
         float depth = texture(DepthTexture, uv).r;
         if (debugMode == 1)
         {
-                outColor = vec4(depth, depth, depth, 1.0);
+                float debugDepth = depth;
+                if (u_reversedZMode == 1)
+                        debugDepth = 1.0 - debugDepth;
+                if (u_depthParams.z > 0.5)
+                        debugDepth = 1.0 - debugDepth;
+                outColor = vec4(debugDepth, debugDepth, debugDepth, 1.0);
                 return;
         }
         if (debugMode == 2)
-        {
-                if (IsSkyDepth(depth, u_depthParams))
-                {
-                        outColor = vec4(1.0);
-                        return;
-                }
-                float viewZ = GetViewZ(uv, depth);
-                float v = clamp(viewZ / debugFar, 0.0, 1.0);
-                outColor = vec4(v, v, v, 1.0);
-                return;
-        }
-        if (debugMode == 3)
         {
                 if (IsSkyDepth(depth, u_depthParams))
                 {
@@ -145,7 +146,7 @@ void main()
 
         vec3 viewPos = ReconstructViewPos(uv, depth);
         vec3 normal = ComputeNormalFromViewPos(viewPos);
-        if (debugMode == 5)
+        if (debugMode == 3)
         {
                 vec3 debugNormal = normal * 0.5 + 0.5;
                 outColor = vec4(debugNormal, 1.0);
@@ -180,12 +181,14 @@ void main()
                 vec3 sampleViewPos = ReconstructViewPos(sampleUV, sampleDepth);
                 float sampleViewDepth = -sampleViewPos.z;
                 float samplePosDepth = -samplePos.z;
-                float rangeCheck = smoothstep(0.0, 1.0, radius / max(abs(samplePosDepth - sampleViewDepth), 1e-4));
-                if (sampleViewDepth + bias < samplePosDepth)
+                float dz = sampleViewDepth - samplePosDepth - bias;
+                float rangeCheck = smoothstep(0.0, 1.0, radius / max(abs(dz), 1e-4));
+                if (dz < 0.0)
                         occlusion += rangeCheck;
         }
 
         float ao = 1.0 - occlusion / float(samples);
+        ao = clamp(ao, 0.0, 1.0);
         ao = pow(ao, u_params0.z);
         ao = max(ao, u_params0.w);
         outColor = vec4(ao, ao, ao, 1.0);

--- a/Quake/shaders/ssao_blur.frag
+++ b/Quake/shaders/ssao_blur.frag
@@ -12,15 +12,19 @@ layout(location=0) out vec4 outColor;
 
 float DepthToNdcZ(float depth, float reversed, int mode)
 {
+        float raw = depth;
+        if (mode == 1)
+                raw = 1.0 - raw;
         if (reversed > 0.5)
         {
-                if (mode == 1)
-                        depth = 1.0 - depth;
                 if (mode == 2)
-                        return (1.0 - depth) * 2.0 - 1.0;
-                return depth;
+                        raw = 1.0 - raw;
+                return raw;
         }
-        return depth * 2.0 - 1.0;
+        float ndc = raw * 2.0 - 1.0;
+        if (mode == 2)
+                ndc = -ndc;
+        return ndc;
 }
 
 vec3 ReconstructViewPos(vec2 uv, float depth)


### PR DESCRIPTION
### Motivation

- Resolve SSAO showing full-white debug or large black blocks at high intensity by fixing mixed depth conventions and unstable sampling.
- Ensure SSAO reads the same depth attachment used for the main scene and that depth textures are sampled as plain `sampler2D` (no compare mode).
- Make depth→view‑space reconstruction robust to Reverse‑Z and engine projection peculiarities so AO comparisons happen in consistent units.
- Harden parameter handling and provide debug logging to diagnose future depth/half‑res/format issues.

### Description

- GL backend: set `GL_TEXTURE_COMPARE_MODE = GL_NONE` for depth FBO attachments, extended `GL_LogSSAODepthInfo` to print bound depth/AO texture IDs, formats, sizes, compare mode and FBO, and updated call sites to pass the AO texture.
- Parameter sanitization: added `R_SanitizeSSAOValue` and clamped/validated SSAO inputs, scaled `bias` by `radius`, and adjusted defaults (`r_ssao_intensity` -> 0.5, `r_ssao_power` -> 1.5).
- SSAO shader changes: replaced ambiguous depth→NDC mapping with a consistent `DepthToNdcZ` that respects Reverse‑Z and `u_reversedZMode`, reconstruct view‑space position using `u_invProj`, compute normals from viewPos derivatives with handedness fix, and switch occlusion test to view‑space distance with bias/range check and final clamping (`ao = clamp(ao,0,1)`).
- Blur shader: mirrored the depth→NDC fix so depth‑aware blur remains consistent with SSAO reconstruction.

### Testing

- No automated tests were executed for these changes.
- (Manual/interactive verification recommended: enable `r_ssao_debug` to inspect depth, view‑Z, normals and AO debug modes and check logs produced by `GL_LogSSAODepthInfo`.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e846eb278832e9b8ba27f91b9fc33)