### PR TITLE
Fix SSAO view-space depth axis, normal orientation, and add depth binding/logging

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -924,6 +924,7 @@ static void GL_LogSSAODepthInfo (GLuint depth_tex, GLuint ao_tex, int ssao_width
 	GLint tex_width = 0;
 	GLint tex_height = 0;
 	GLint compare_mode = 0;
+	GLint bound_depth_tex = 0;
 	GLint ao_internal_format = 0;
 	GLint ao_width = 0;
 	GLint ao_height = 0;
@@ -933,6 +934,7 @@ static void GL_LogSSAODepthInfo (GLuint depth_tex, GLuint ao_tex, int ssao_width
 	const char *target_name = "GL_TEXTURE_2D";
 
 	GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, depth_tex);
+	glGetIntegerv (GL_TEXTURE_BINDING_2D, &bound_depth_tex);
 	glGetTexLevelParameteriv (GL_TEXTURE_2D, 0, GL_TEXTURE_INTERNAL_FORMAT, &internal_format);
 	glGetTexLevelParameteriv (GL_TEXTURE_2D, 0, GL_TEXTURE_WIDTH, &tex_width);
 	glGetTexLevelParameteriv (GL_TEXTURE_2D, 0, GL_TEXTURE_HEIGHT, &tex_height);
@@ -945,8 +947,8 @@ static void GL_LogSSAODepthInfo (GLuint depth_tex, GLuint ao_tex, int ssao_width
 	glGetIntegerv (GL_VIEWPORT, viewport);
 	glGetIntegerv (GL_FRAMEBUFFER_BINDING, &draw_fbo);
 
-	Con_DPrintf ("SSAO depth input: tex=%u target=%s format=0x%X size=%dx%d compare=0x%X viewport=%dx%d+%d+%d fbo=%d\n",
-		depth_tex, target_name, internal_format, tex_width, tex_height,
+	Con_DPrintf ("SSAO depth input: tex=%u bound=%d target=%s format=0x%X size=%dx%d compare=0x%X viewport=%dx%d+%d+%d fbo=%d\n",
+		depth_tex, bound_depth_tex, target_name, internal_format, tex_width, tex_height,
 		compare_mode, viewport[2], viewport[3], viewport[0], viewport[1], draw_fbo);
 	Con_DPrintf ("SSAO AO output: tex=%u format=0x%X size=%dx%d\n",
 		ao_tex, ao_internal_format, ao_width, ao_height);
@@ -1007,6 +1009,14 @@ static GLuint GL_GenerateSSAOTexture (float view_min_x, float view_min_y, float 
 	int debug_mode_i = (int)Q_rint (r_ssao_debug.value);
 	float debug_mode = q_max (0.f, (float)debug_mode_i);
 	float debug_far = q_max (0.1f, r_ssao_debug_far.value);
+	static qboolean ssao_logged = false;
+	if (!ssao_logged)
+	{
+		// SSAO FIX: Log depth configuration once to validate reversed-Z/clip control wiring.
+		Con_DPrintf ("SSAO config: reversedZ=%d clipcontrol=%d znear=%0.4f zfar=%0.4f\n",
+			(int)reversed_z, gl_clipcontrol_able ? 1 : 0, view_znear, view_zfar);
+		ssao_logged = true;
+	}
 
 	GL_BeginGroup ("SSAO");
 	GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.ssao.ao_fbo[index]);

--- a/Quake/shaders/ssao.frag
+++ b/Quake/shaders/ssao.frag
@@ -79,7 +79,8 @@ vec3 ReconstructViewPos(vec2 uv, float depth)
 float GetViewZ(vec2 uv, float depth)
 {
         vec3 view = ReconstructViewPos(uv, depth);
-        return -view.z;
+        // SSAO FIX: Quake view space uses +X as forward depth, not -Z.
+        return view.x;
 }
 
 vec3 ComputeNormalFromViewPos(vec3 viewPos)
@@ -89,7 +90,9 @@ vec3 ComputeNormalFromViewPos(vec3 viewPos)
         vec3 normal = normalize(cross(dx, dy));
         if (length(normal) < 1e-4)
                 return vec3(0.0, 0.0, 1.0);
-        if (normal.z < 0.0)
+        // SSAO FIX: Orient reconstructed normals toward the camera for stable TBN.
+        vec3 viewDir = normalize(-viewPos);
+        if (dot(normal, viewDir) < 0.0)
                 normal = -normal;
         return normal;
 }
@@ -179,8 +182,9 @@ void main()
                 if (IsSkyDepth(sampleDepth, u_depthParams))
                         continue;
                 vec3 sampleViewPos = ReconstructViewPos(sampleUV, sampleDepth);
-                float sampleViewDepth = -sampleViewPos.z;
-                float samplePosDepth = -samplePos.z;
+                // SSAO FIX: Depth comparisons should use view-space X (forward axis).
+                float sampleViewDepth = sampleViewPos.x;
+                float samplePosDepth = samplePos.x;
                 float dz = sampleViewDepth - samplePosDepth - bias;
                 float rangeCheck = smoothstep(0.0, 1.0, radius / max(abs(dz), 1e-4));
                 if (dz < 0.0)

--- a/Quake/shaders/ssao_blur.frag
+++ b/Quake/shaders/ssao_blur.frag
@@ -38,7 +38,8 @@ vec3 ReconstructViewPos(vec2 uv, float depth)
 float GetViewZ(vec2 uv, float depth)
 {
         vec3 view = ReconstructViewPos(uv, depth);
-        return -view.z;
+        // SSAO FIX: Quake view space uses +X as forward depth, not -Z.
+        return view.x;
 }
 
 bool IsSkyDepth(float depth, vec4 depthParams)


### PR DESCRIPTION
### Motivation
- The SSAO debug output showed all-white/black and noisy patterns consistent with incorrect depth-to-view reconstruction and wrong forward axis assumptions. 
- The engine uses clip-control/reversed-Z and Quake's view-space forward axis is +X, so SSAO must compare against the view-space X component, not -Z. 
- Reconstructed normals were sometimes flipped, breaking TBN and producing dither/noise in AO sampling. 
- Small, targeted fixes and runtime instrumentation are needed so debug modes can validate depth/texture wiring without large refactors. 

### Description
- Change `GetViewZ()` in `Quake/shaders/ssao.frag` and `Quake/shaders/ssao_blur.frag` to use `view.x` (Quake forward axis) and add an inline comment marked `SSAO FIX:` to explain the change. 
- Flip reconstructed normals toward the camera in `ssao.frag` (added `viewDir` dot check and `SSAO FIX:` comment) so TBN/noise orientation is stable. 
- Use view-space X for SSAO sample depth comparisons in `ssao.frag` (`sampleViewDepth = sampleViewPos.x` and `samplePosDepth = samplePos.x`) with `SSAO FIX:` comment. 
- Add instrumentation in `Quake/gl_rmain.c` to log the bound depth texture id in `GL_LogSSAODepthInfo` and emit a one-time `SSAO config:` line (reversed-Z/clipcontrol/znear/zfar) to help validate depth/clip-control wiring. 

### Testing
- No automated tests were run on the modified code. 
- Changes were limited to shader and SSAO wiring/logging to minimize risk and make it simple to validate with `r_ssao_debug` modes at runtime. 
- Runtime verification steps are expected to be: enable `r_ssao_debug` (1..4) and inspect the on-screen depth/normal/AO outputs and the console SSAO config/log lines. 
- If automated CI is available, a shader compile check and a render smoke test are recommended (not executed here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69518d2c8fe4832eb850a1567e7e6c52)