### PR TITLE
Fix SSAO view-space reconstruction and expand debug modes

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -267,7 +267,7 @@ cvar_t	r_ssao_blur = { "r_ssao_blur", "1", CVAR_ARCHIVE };
 cvar_t	r_ssao_blur_radius = { "r_ssao_blur_radius", "2", CVAR_ARCHIVE };
 cvar_t	r_ssao_blur_sigma = { "r_ssao_blur_sigma", "2.0", CVAR_ARCHIVE };
 cvar_t	r_ssao_halfres = { "r_ssao_halfres", "1", CVAR_ARCHIVE };
-// r_ssao_debug modes: -1 off, 0 raw depth, 1 linear view-space Z, 2 view-space Z (abs), 3 normals, 4 AO raw, 5 AO blurred.
+// r_ssao_debug modes: -1 off, 1 raw depth, 2 view-space Z, 3 view position length, 4 view normals, 5 AO, 6 sample delta, 7 depth compare sign.
 cvar_t	r_ssao_debug = { "r_ssao_debug", "-1", CVAR_ARCHIVE };
 cvar_t	r_ssao_debug_far = { "r_ssao_debug_far", "4096", CVAR_ARCHIVE };
 cvar_t	r_ssao_reversedz_mode = { "r_ssao_reversedz_mode", "0", CVAR_ARCHIVE };
@@ -1007,7 +1007,7 @@ static GLuint GL_GenerateSSAOTexture (float view_min_x, float view_min_y, float 
 	int reversed_z_mode = (int)Q_rint (r_ssao_reversedz_mode.value);
 	reversed_z_mode = CLAMP (0, reversed_z_mode, 2);
 	int debug_mode_i = (int)Q_rint (r_ssao_debug.value);
-	debug_mode_i = CLAMP (-1, debug_mode_i, 5);
+	debug_mode_i = CLAMP (-1, debug_mode_i, 7);
 	float debug_mode = (float)debug_mode_i;
 	float debug_far = q_max (0.1f, r_ssao_debug_far.value);
 	static qboolean ssao_logged = false;

--- a/Quake/shaders/ssao.frag
+++ b/Quake/shaders/ssao.frag
@@ -79,7 +79,10 @@ vec3 ReconstructViewPos(vec2 uv, float depth)
         float ndcDepth = DepthToNdcZ(depth, u_depthParams.z, u_reversedZMode);
         vec4 clip = vec4(uv * 2.0 - 1.0, ndcDepth, 1.0);
         vec4 view = u_invProj * clip;
-        return view.xyz / max(view.w, 1e-6);
+        float w = view.w;
+        if (abs(w) < 1e-6)
+                return vec3(0.0);
+        return view.xyz / w;
 }
 
 float GetViewZ(vec2 uv, float depth)
@@ -127,12 +130,12 @@ void main()
         }
 
         float depth = DepthRaw(uv);
-        if (debugMode == 0)
+        if (debugMode == 1)
         {
                 outColor = vec4(depth, depth, depth, 1.0);
                 return;
         }
-        if (debugMode == 1)
+        if (debugMode == 2)
         {
                 if (IsSkyDepth(depth, u_depthParams))
                 {
@@ -144,15 +147,15 @@ void main()
                 outColor = vec4(v, v, v, 1.0);
                 return;
         }
-        if (debugMode == 2)
+        if (debugMode == 3)
         {
                 if (IsSkyDepth(depth, u_depthParams))
                 {
                         outColor = vec4(1.0);
                         return;
                 }
-                float viewZ = GetViewZ(uv, depth);
-                float v = clamp(abs(viewZ) / debugFar, 0.0, 1.0);
+                vec3 viewPos = ReconstructViewPos(uv, depth);
+                float v = clamp(length(viewPos) / debugFar, 0.0, 1.0);
                 outColor = vec4(v, v, v, 1.0);
                 return;
         }
@@ -163,8 +166,9 @@ void main()
         }
 
         vec3 viewPos = ReconstructViewPos(uv, depth);
+        float centerViewDepth = viewPos.x;
         vec3 normal = ComputeNormalFromViewPos(viewPos);
-        if (debugMode == 3)
+        if (debugMode == 4)
         {
                 vec3 debugNormal = normal * 0.5 + 0.5;
                 outColor = vec4(debugNormal, 1.0);
@@ -179,6 +183,9 @@ void main()
         float radius = u_params0.x;
         float bias = u_params0.y;
         float occlusion = 0.0;
+        float debugDeltaAccum = 0.0;
+        float debugSignAccum = 0.0;
+        int debugSamples = 0;
         int samples = clamp(u_samples, 1, SSAO_MAX_SAMPLES);
 
         for (int i = 0; i < SSAO_MAX_SAMPLES; ++i)
@@ -201,14 +208,42 @@ void main()
                 float sampleViewDepth = sampleViewPos.x;
                 float samplePosDepth = samplePos.x;
                 float dz = sampleViewDepth - samplePosDepth - bias;
+                if (debugMode == 6 || debugMode == 7)
+                {
+                        debugDeltaAccum += abs(sampleViewDepth - centerViewDepth);
+                        debugSignAccum += (sampleViewDepth >= centerViewDepth) ? 1.0 : -1.0;
+                        debugSamples += 1;
+                }
                 float rangeCheck = smoothstep(0.0, 1.0, radius / max(abs(dz), 1e-4));
                 if (dz < 0.0)
                         occlusion += rangeCheck;
+        }
+
+        if (debugMode == 6)
+        {
+                float denom = max(float(debugSamples), 1.0);
+                float avgDelta = debugDeltaAccum / denom;
+                float v = clamp(avgDelta / max(radius, 1e-4), 0.0, 1.0);
+                outColor = vec4(v, v, v, 1.0);
+                return;
+        }
+        if (debugMode == 7)
+        {
+                float denom = max(float(debugSamples), 1.0);
+                float avgSign = debugSignAccum / denom;
+                float v = avgSign > 0.0 ? 1.0 : 0.0;
+                outColor = vec4(v, v, v, 1.0);
+                return;
         }
 
         float ao = 1.0 - occlusion / float(samples);
         ao = clamp(ao, 0.0, 1.0);
         ao = pow(ao, u_params0.z);
         ao = max(ao, u_params0.w);
+        if (debugMode == 5)
+        {
+                outColor = vec4(ao, ao, ao, 1.0);
+                return;
+        }
         outColor = vec4(ao, ao, ao, 1.0);
 }

--- a/Quake/shaders/ssao_blur.frag
+++ b/Quake/shaders/ssao_blur.frag
@@ -32,7 +32,10 @@ vec3 ReconstructViewPos(vec2 uv, float depth)
         float ndcDepth = DepthToNdcZ(depth, u_depthParams.z, u_reversedZMode);
         vec4 clip = vec4(uv * 2.0 - 1.0, ndcDepth, 1.0);
         vec4 view = u_invProj * clip;
-        return view.xyz / max(view.w, 1e-6);
+        float w = view.w;
+        if (abs(w) < 1e-6)
+                return vec3(0.0);
+        return view.xyz / w;
 }
 
 float GetViewZ(vec2 uv, float depth)


### PR DESCRIPTION
### Motivation
- Fix incorrect SSAO caused by mixed depth/space interpretation and Reverse‑Z ambiguities that produced flat/overbright AO or edge-only artifacts.
- Provide robust, single-source view-space reconstruction and prevent NaNs/Infs when `w` is near zero during `invProj` reconstruction.
- Make SSAO debugging deterministic and expressive by exposing per-pixel diagnostics (raw depth, viewZ, viewPos length, normals, AO, sample delta, compare sign).
- Ensure the shader uses consistent view-space axes (Quake uses +X forward) for depth comparisons.

### Description
- Updated `r_ssao_debug` mapping and clamp range in `Quake/gl_rmain.c` so debug modes cover `1..7` and the engine passes the new modes to the shader via uniforms.
- Hardened `ReconstructViewPos` in `Quake/shaders/ssao.frag` and `Quake/shaders/ssao_blur.frag` to return a safe `vec3(0.0)` when `view.w` is nearly zero, avoiding divisions that produce NaNs/Infs.
- Implemented and remapped SSAO debug modes inside `Quake/shaders/ssao.frag` to provide: raw depth (`1`), reconstructed viewZ (`2`), view position length (`3`), view normal (`4`), AO (`5`), sample delta (`6`), and depth compare sign (`7`), with sample-accumulation logic added for modes `6`/`7`.
- Kept Reverse‑Z handling via existing `DepthToNdcZ` and consistent use of reconstructed view positions/depths (center/sample) for all comparisons, and added `centerViewDepth` bookkeeping used during sample loops.

### Testing
- No automated tests were executed as part of this change; QA is expected to be performed with the provided in-engine debug modes (manual validation steps described in the commit message).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951951de9bc832e999ef652871d3a30)