### PR TITLE
Fix SSAO depth linearization and debug outputs

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -267,8 +267,8 @@ cvar_t	r_ssao_blur = { "r_ssao_blur", "1", CVAR_ARCHIVE };
 cvar_t	r_ssao_blur_radius = { "r_ssao_blur_radius", "2", CVAR_ARCHIVE };
 cvar_t	r_ssao_blur_sigma = { "r_ssao_blur_sigma", "2.0", CVAR_ARCHIVE };
 cvar_t	r_ssao_halfres = { "r_ssao_halfres", "1", CVAR_ARCHIVE };
-// r_ssao_debug modes: -1 off, 1 raw depth, 2 view-space Z, 3 view position length, 4 view normals, 5 AO,
-// 6 sample delta, 7 depth compare sign, 8 NDC depth.
+// r_ssao_debug modes: -1 off, 0 final AO, 1 raw depth, 2 view-space Z, 3 view position length,
+// 4 view normals, 5 AO only, 6 AO * albedo.
 cvar_t	r_ssao_debug = { "r_ssao_debug", "-1", CVAR_ARCHIVE };
 cvar_t	r_ssao_debug_far = { "r_ssao_debug_far", "4096", CVAR_ARCHIVE };
 cvar_t	r_ssao_reversedz_mode = { "r_ssao_reversedz_mode", "0", CVAR_ARCHIVE };
@@ -1008,7 +1008,7 @@ static GLuint GL_GenerateSSAOTexture (float view_min_x, float view_min_y, float 
 	int reversed_z_mode = (int)Q_rint (r_ssao_reversedz_mode.value);
 	reversed_z_mode = CLAMP (0, reversed_z_mode, 2);
 	int debug_mode_i = (int)Q_rint (r_ssao_debug.value);
-	debug_mode_i = CLAMP (-1, debug_mode_i, 8);
+	debug_mode_i = CLAMP (-1, debug_mode_i, 6);
 	float debug_mode = (float)debug_mode_i;
 	float debug_far = q_max (0.1f, r_ssao_debug_far.value);
 	static qboolean ssao_logged = false;
@@ -1060,7 +1060,7 @@ static GLuint GL_GenerateSSAOTexture (float view_min_x, float view_min_y, float 
 	glDrawArrays (GL_TRIANGLES, 0, 3);
 	GL_LogErrorIfDeveloper ("SSAO draw");
 
-	if (r_ssao_blur.value > 0.f && glprogs.ssao_blur && (debug_mode_i < 0 || debug_mode_i == 5))
+	if (r_ssao_blur.value > 0.f && glprogs.ssao_blur && (debug_mode_i < 0 || debug_mode_i == 0 || debug_mode_i == 5 || debug_mode_i == 6))
 	{
 		int blur_radius = (int)Q_rint (r_ssao_blur_radius.value);
 		blur_radius = CLAMP (1, blur_radius, 4);
@@ -1072,7 +1072,6 @@ static GLuint GL_GenerateSSAOTexture (float view_min_x, float view_min_y, float 
 		GL_Uniform4fFunc (1, view_znear, view_zfar, reversed_z, depth_cutoff);
 		GL_Uniform4fFunc (2, blur_sigma, (float)blur_radius, depth_threshold_scale, 0.f);
 		GL_Uniform4fFunc (3, view_min_x, view_min_y, view_max_x, view_max_y);
-		GL_UniformMatrix4fvFunc (4, 1, GL_FALSE, r_matinvproj);
 		GL_Uniform1iFunc (5, reversed_z_mode);
 
 		GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.ssao.blur_fbo[index]);
@@ -1668,7 +1667,6 @@ void GL_PostProcess (void)
 	float godrays_debug_source;
 	float ssao_intensity;
 	float ssao_debug_mode;
-	float ssao_debug_enabled;
 	float view_min_x;
 	float view_min_y;
 	float view_max_x;
@@ -1740,7 +1738,6 @@ void GL_PostProcess (void)
 	ssao_debug_mode = r_ssao_debug.value;
 	if (ssao_texture == 0)
 		ssao_debug_mode = -1.f;
-	ssao_debug_enabled = (ssao_debug_mode >= 0.f) ? 1.f : 0.f;
 	if (ssao_texture == 0 || r_ssao.value <= 0.f)
 		ssao_intensity = 0.f;
 
@@ -1825,7 +1822,7 @@ void GL_PostProcess (void)
 	GL_Uniform4fFunc (11, teleport_fade, teleport_blur, 0.f, 0.f);
 	GL_Uniform1fFunc (12, r_saturation.value);
 	GL_Uniform4fFunc (16, godrays_texture ? 1.f : 0.f, godrays_debug, godrays_debug_source, 0.f);
-	GL_Uniform4fFunc (17, ssao_intensity, ssao_debug_enabled, 0.f, 0.f);
+		GL_Uniform4fFunc (17, ssao_intensity, ssao_debug_mode, 0.f, 0.f);
 	{
 		float filmgrain_amount = 0.f;
 		qboolean filmgrain_enabled = (r_filmgrain.value > 0.f && r_filmgrain_affect_ui.value <= 0.f);

--- a/Quake/shaders/postprocess.frag
+++ b/Quake/shaders/postprocess.frag
@@ -140,7 +140,7 @@ layout(location=13) uniform vec4 FilmGrainParams0; // x: amount, y: size, z: spe
 layout(location=14) uniform vec4 FilmGrainParams1; // x: blend, y: color, z: debug, w: seed
 layout(location=15) uniform vec4 FilmGrainParams2; // x: frame, yzw: unused
 layout(location=16) uniform vec4 GodraysParams; // x: enabled, y: debug, z: debug source mode, w: unused
-layout(location=17) uniform vec4 SSAOParams; // x: intensity, yzw: unused
+layout(location=17) uniform vec4 SSAOParams; // x: intensity, y: debug mode, zw: unused
 
 const int MOTION_MAX_SAMPLES = 64;
 const float OPAQUE_ALPHA_THRESHOLD = 0.999;
@@ -452,11 +452,19 @@ void main()
                 }
 
                 float ssaoIntensity = SSAOParams.x;
-                float ssaoDebug = SSAOParams.y;
-                if (ssaoDebug > 0.5 && inView)
+                int ssaoDebugMode = int(floor(SSAOParams.y + 0.5));
+                if (ssaoDebugMode >= 0 && inView)
                 {
-                        float debugValue = texture(SSAOTexture, uv).r;
-                        color.rgb = vec3(debugValue);
+                        float ao = texture(SSAOTexture, uv).r;
+                        if (ssaoDebugMode == 6)
+                        {
+                                if (centerOpaque)
+                                        color.rgb *= ao;
+                        }
+                        else
+                        {
+                                color.rgb = vec3(ao);
+                        }
                 }
                 else if (ssaoIntensity > 0.0 && inView && centerOpaque)
                 {

--- a/Quake/shaders/ssao.frag
+++ b/Quake/shaders/ssao.frag
@@ -76,6 +76,20 @@ float DepthToNdcZ(float depth, float reversed, int mode)
         return ndc;
 }
 
+float LinearizeViewZ(float depth)
+{
+        float ndcDepth = DepthToNdcZ(depth, u_depthParams.z, u_reversedZMode);
+        float nearPlane = u_depthParams.x;
+        float farPlane = u_depthParams.y;
+        if (u_depthParams.z > 0.5)
+        {
+                float denom = nearPlane + ndcDepth * (farPlane - nearPlane);
+                return (nearPlane * farPlane) / max(denom, 1e-6);
+        }
+        float denom = farPlane + nearPlane - ndcDepth * (farPlane - nearPlane);
+        return (2.0 * nearPlane * farPlane) / max(denom, 1e-6);
+}
+
 vec3 ReconstructViewPos(vec2 uv, float depth)
 {
         float ndcDepth = DepthToNdcZ(depth, u_depthParams.z, u_reversedZMode);
@@ -85,18 +99,6 @@ vec3 ReconstructViewPos(vec2 uv, float depth)
         if (abs(w) < 1e-6)
                 return vec3(0.0);
         return view.xyz / w;
-}
-
-float GetViewZ(vec2 uv, float depth)
-{
-        vec3 view = ReconstructViewPos(uv, depth);
-        // SSAO FIX: Quake view space uses +X as forward depth, not -Z.
-        return view.x;
-}
-
-float LinearizeViewZ(vec2 uv, float depth)
-{
-        return GetViewZ(uv, depth);
 }
 
 vec3 ComputeNormalFromViewPos(vec3 viewPos)
@@ -111,13 +113,6 @@ vec3 ComputeNormalFromViewPos(vec3 viewPos)
         if (dot(normal, viewDir) < 0.0)
                 normal = -normal;
         return normal;
-}
-
-float NdcZToDisplay(float ndcDepth, float reversed)
-{
-        if (reversed > 0.5)
-                return clamp(ndcDepth, 0.0, 1.0);
-        return clamp(ndcDepth * 0.5 + 0.5, 0.0, 1.0);
 }
 
 bool IsSkyDepth(float depth, vec4 depthParams)
@@ -149,13 +144,6 @@ void main()
                 outColor = vec4(depth, depth, depth, 1.0);
                 return;
         }
-        if (debugMode == 8)
-        {
-                float ndcDepth = DepthToNdcZ(depth, u_depthParams.z, u_reversedZMode);
-                float v = NdcZToDisplay(ndcDepth, u_depthParams.z);
-                outColor = vec4(v, v, v, 1.0);
-                return;
-        }
         if (debugMode == 2)
         {
                 if (IsSkyDepth(depth, u_depthParams))
@@ -163,7 +151,7 @@ void main()
                         outColor = vec4(1.0);
                         return;
                 }
-                float viewZ = LinearizeViewZ(uv, depth);
+                float viewZ = LinearizeViewZ(depth);
                 float v = clamp(viewZ / debugFar, 0.0, 1.0);
                 outColor = vec4(v, v, v, 1.0);
                 return;
@@ -187,7 +175,6 @@ void main()
         }
 
         vec3 viewPos = ReconstructViewPos(uv, depth);
-        float centerViewDepth = viewPos.x;
         vec3 normal = ComputeNormalFromViewPos(viewPos);
         if (debugMode == 4)
         {
@@ -204,9 +191,6 @@ void main()
         float radius = u_params0.x;
         float bias = u_params0.y;
         float occlusion = 0.0;
-        float debugDeltaAccum = 0.0;
-        float debugSignAccum = 0.0;
-        int debugSamples = 0;
         int samples = clamp(u_samples, 1, SSAO_MAX_SAMPLES);
 
         for (int i = 0; i < SSAO_MAX_SAMPLES; ++i)
@@ -224,44 +208,19 @@ void main()
                 float sampleDepth = texture(DepthTexture, sampleUV).r;
                 if (IsSkyDepth(sampleDepth, u_depthParams))
                         continue;
-                vec3 sampleViewPos = ReconstructViewPos(sampleUV, sampleDepth);
-                // SSAO FIX: Depth comparisons should use view-space X (forward axis).
-                float sampleViewDepth = sampleViewPos.x;
+                float sampleViewDepth = LinearizeViewZ(sampleDepth);
                 float samplePosDepth = samplePos.x;
                 float dz = sampleViewDepth - samplePosDepth - bias;
-                if (debugMode == 6 || debugMode == 7)
-                {
-                        debugDeltaAccum += abs(sampleViewDepth - centerViewDepth);
-                        debugSignAccum += (sampleViewDepth >= centerViewDepth) ? 1.0 : -1.0;
-                        debugSamples += 1;
-                }
                 float rangeCheck = smoothstep(0.0, 1.0, radius / max(abs(dz), 1e-4));
                 if (dz < 0.0)
                         occlusion += rangeCheck;
-        }
-
-        if (debugMode == 6)
-        {
-                float denom = max(float(debugSamples), 1.0);
-                float avgDelta = debugDeltaAccum / denom;
-                float v = clamp(avgDelta / max(radius, 1e-4), 0.0, 1.0);
-                outColor = vec4(v, v, v, 1.0);
-                return;
-        }
-        if (debugMode == 7)
-        {
-                float denom = max(float(debugSamples), 1.0);
-                float avgSign = debugSignAccum / denom;
-                float v = avgSign > 0.0 ? 1.0 : 0.0;
-                outColor = vec4(v, v, v, 1.0);
-                return;
         }
 
         float ao = 1.0 - occlusion / float(samples);
         ao = clamp(ao, 0.0, 1.0);
         ao = pow(ao, u_params0.z);
         ao = max(ao, u_params0.w);
-        if (debugMode == 5)
+        if (debugMode == 5 || debugMode == 6)
         {
                 outColor = vec4(ao, ao, ao, 1.0);
                 return;

--- a/Quake/shaders/ssao_blur.frag
+++ b/Quake/shaders/ssao_blur.frag
@@ -5,7 +5,6 @@ layout(location=0) uniform vec4 u_params0; // xy: inv resolution, zw: direction
 layout(location=1) uniform vec4 u_depthParams; // x: near, y: far, z: reversed Z, w: sky depth cutoff
 layout(location=2) uniform vec4 u_params1; // x: sigma, y: radius, z: depth threshold scale, w: unused
 layout(location=3) uniform vec4 u_viewRect; // xy: view min, zw: view max
-layout(location=4) uniform mat4 u_invProj;
 layout(location=5) uniform int u_reversedZMode; // 0: default, 1: invert raw, 2: invert ndc
 
 layout(location=0) out vec4 outColor;
@@ -27,22 +26,18 @@ float DepthToNdcZ(float depth, float reversed, int mode)
         return ndc;
 }
 
-vec3 ReconstructViewPos(vec2 uv, float depth)
+float LinearizeViewZ(float depth)
 {
         float ndcDepth = DepthToNdcZ(depth, u_depthParams.z, u_reversedZMode);
-        vec4 clip = vec4(uv * 2.0 - 1.0, ndcDepth, 1.0);
-        vec4 view = u_invProj * clip;
-        float w = view.w;
-        if (abs(w) < 1e-6)
-                return vec3(0.0);
-        return view.xyz / w;
-}
-
-float GetViewZ(vec2 uv, float depth)
-{
-        vec3 view = ReconstructViewPos(uv, depth);
-        // SSAO FIX: Quake view space uses +X as forward depth, not -Z.
-        return view.x;
+        float nearPlane = u_depthParams.x;
+        float farPlane = u_depthParams.y;
+        if (u_depthParams.z > 0.5)
+        {
+                float denom = nearPlane + ndcDepth * (farPlane - nearPlane);
+                return (nearPlane * farPlane) / max(denom, 1e-6);
+        }
+        float denom = farPlane + nearPlane - ndcDepth * (farPlane - nearPlane);
+        return (2.0 * nearPlane * farPlane) / max(denom, 1e-6);
 }
 
 bool IsSkyDepth(float depth, vec4 depthParams)
@@ -77,7 +72,7 @@ void main()
                 return;
         }
 
-        float centerDepth = GetViewZ(uv, centerDepthRaw);
+        float centerDepth = LinearizeViewZ(centerDepthRaw);
         float sigma = max(u_params1.x, 0.01);
         int radius = int(u_params1.y + 0.5);
         float depthThreshold = max(u_params1.z, 0.0) * max(centerDepth, 1e-4);
@@ -95,7 +90,7 @@ void main()
                 float sampleDepthRaw = texture(DepthTexture, sampleUV).r;
                 if (IsSkyDepth(sampleDepthRaw, u_depthParams))
                         continue;
-                float sampleDepth = GetViewZ(sampleUV, sampleDepthRaw);
+                float sampleDepth = LinearizeViewZ(sampleDepthRaw);
                 float depthDiff = abs(sampleDepth - centerDepth);
                 float depthWeight = smoothstep(0.0, 1.0, depthThreshold / max(depthDiff, 1e-4));
                 float weight = Gaussian(float(i), sigma) * depthWeight;


### PR DESCRIPTION
### Motivation
- The SSAO pass was comparing non-linear depth samples directly with view-space positions which produced overexposed/whitened AO and banding artifacts.
- Depth interpretation was inconsistent across SSAO shader stages and blur, causing incorrect range checks and global AO effects.
- Debug views were insufficient to rapidly identify space mismatches between depth, view-Z, and reconstructed positions.
- Make a minimal targeted fix so SSAO comparisons use linear view-space depth/positions without rewriting the AO kernel.

### Description
- Added `LinearizeViewZ` in `Quake/shaders/ssao.frag` and `Quake/shaders/ssao_blur.frag` to convert depth texture samples into linear view-space depth using `u_depthParams` and `DepthToNdcZ`.
- Replaced direct use of raw depth samples in SSAO and blur with linear view-space depth for all depth comparisons and the occlusion `dz` test, and removed legacy debug sample/compare code paths.
- Updated debug mode handling: remapped `r_ssao_debug` modes, forwarded the debug mode through the `SSAOParams` uniform, and made the postprocess shader support AO-only and AO*albedo debug displays via `Quake/shaders/postprocess.frag`.
- Adjusted host-side shader setup in `Quake/gl_rmain.c` to clamp debug mode range, pass the debug mode value, and include blur for relevant debug views, and simplified unused uniform usage in the blur path.

### Testing
- No automated tests were executed for this change.
- Visual/functional validation is expected by enabling `r_ssao_debug` modes to confirm linear view-Z and local AO behavior (manual verification required).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69519afee698832e9a54c41fc6a77401)