### PR TITLE
Fix SSAO half-res sampling alignment and add debug views

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -268,7 +268,7 @@ cvar_t	r_ssao_blur_radius = { "r_ssao_blur_radius", "2", CVAR_ARCHIVE };
 cvar_t	r_ssao_blur_sigma = { "r_ssao_blur_sigma", "2.0", CVAR_ARCHIVE };
 cvar_t	r_ssao_blur_bilateral = { "r_ssao_blur_bilateral", "1", CVAR_ARCHIVE };
 cvar_t	r_ssao_halfres = { "r_ssao_halfres", "1", CVAR_ARCHIVE };
-// r_ssao_debug modes: 0 off, 1 AO raw, 2 AO blurred, 3 noise, 4 view-space Z, 5 normals, 6 AO UVs.
+// r_ssao_debug modes: 0 off, 1 AO raw, 2 AO blurred, 3 noise, 4 view-space Z, 5 normals, 6 AO UVs, 7 view-space length, 8 radius px.
 cvar_t	r_ssao_debug = { "r_ssao_debug", "0", CVAR_ARCHIVE };
 cvar_t	r_ssao_debug_far = { "r_ssao_debug_far", "4096", CVAR_ARCHIVE };
 cvar_t	r_ssao_reversedz_mode = { "r_ssao_reversedz_mode", "0", CVAR_ARCHIVE };
@@ -693,8 +693,8 @@ void GL_CreateFrameBuffers (void)
 		int width = framebufs.ssao.width[i];
 		int height = framebufs.ssao.height[i];
 		const char *suffix = (i == 0) ? "full" : "half";
-		framebufs.ssao.ao_tex[i] = GL_CreateTexture2D (ssao_format, width, height, GL_LINEAR, va ("ssao %s", suffix));
-		framebufs.ssao.blur_tex[i] = GL_CreateTexture2D (ssao_format, width, height, GL_LINEAR, va ("ssao blur %s", suffix));
+		framebufs.ssao.ao_tex[i] = GL_CreateTexture2D (ssao_format, width, height, GL_NEAREST, va ("ssao %s", suffix));
+		framebufs.ssao.blur_tex[i] = GL_CreateTexture2D (ssao_format, width, height, GL_NEAREST, va ("ssao blur %s", suffix));
 		framebufs.ssao.ao_fbo[i] = GL_CreateSimpleFBO (GL_TEXTURE_2D, framebufs.ssao.ao_tex[i], 0, 0, va ("ssao fbo %s", suffix));
 		framebufs.ssao.blur_fbo[i] = GL_CreateSimpleFBO (GL_TEXTURE_2D, framebufs.ssao.blur_tex[i], 0, 0, va ("ssao blur fbo %s", suffix));
 	}
@@ -1028,7 +1028,7 @@ static GLuint GL_GenerateSSAOTexture (float view_min_x, float view_min_y, float 
 	int reversed_z_mode = (int)Q_rint (r_ssao_reversedz_mode.value);
 	reversed_z_mode = CLAMP (0, reversed_z_mode, 2);
 	int debug_mode_cvar = (int)Q_rint (r_ssao_debug.value);
-	int debug_mode_i = (debug_mode_cvar > 0) ? CLAMP (1, debug_mode_cvar, 6) : -1;
+	int debug_mode_i = (debug_mode_cvar > 0) ? CLAMP (1, debug_mode_cvar, 8) : -1;
 	float debug_mode = (float)debug_mode_i;
 	float debug_far = q_max (0.1f, r_ssao_debug_far.value);
 	float noise_enabled = (r_ssao_noise.value > 0.f) ? 1.f : 0.f;
@@ -1091,8 +1091,8 @@ static GLuint GL_GenerateSSAOTexture (float view_min_x, float view_min_y, float 
 		(float)width,
 		(float)height);
 	GL_Uniform4fFunc (5,
-		(float)vid.width / (float)SSAO_NOISE_SIZE,
-		(float)vid.height / (float)SSAO_NOISE_SIZE,
+		(float)width / (float)SSAO_NOISE_SIZE,
+		(float)height / (float)SSAO_NOISE_SIZE,
 		noise_enabled,
 		noise_seed);
 	GL_Uniform4fFunc (6, view_znear, view_zfar, reversed_z, depth_cutoff);

--- a/Quake/shaders/postprocess.frag
+++ b/Quake/shaders/postprocess.frag
@@ -237,7 +237,7 @@ float SampleSSAO(vec2 uv, DepthSamplingInfo info, float centerDepth, bool useDep
                         float weight = (x == 0 ? (1.0 - frac.x) : frac.x) * (y == 0 ? (1.0 - frac.y) : frac.y);
                         if (useDepth && info.valid)
                         {
-                                vec2 sampleScreenPx = (aoTexel + 0.5) * ssaoToScreen;
+                                vec2 sampleScreenPx = aoTexel * ssaoToScreen + vec2(0.5);
                                 float sampleDepth = SampleLinearDepth(sampleScreenPx, info);
                                 float depthDiff = abs(sampleDepth - centerDepth);
                                 float depthWeight = smoothstep(0.0, 1.0, depthThreshold / max(depthDiff, 1e-4));

--- a/Quake/shaders/ssao.frag
+++ b/Quake/shaders/ssao.frag
@@ -103,8 +103,14 @@ vec2 AoUvFromPixel(vec2 aoPixel)
 vec2 ScreenUvFromAoPixel(vec2 aoPixel)
 {
         vec2 scale = AoToScreenScale();
-        vec2 screenPixel = aoPixel * scale + 0.5 * scale;
+        vec2 screenPixel = aoPixel * scale + vec2(0.5);
         return ApplyYFlip(screenPixel * ScreenInvSize());
+}
+
+vec2 ScreenPixelFromAoPixel(vec2 aoPixel)
+{
+        vec2 scale = AoToScreenScale();
+        return aoPixel * scale + vec2(0.5);
 }
 
 // Ironwail uses reverse-Z with clip control: near depth ~1, far depth ~0 when reversed is enabled.
@@ -239,11 +245,10 @@ void main()
         vec2 noiseVec;
         if (noiseEnabled > 0.5 && u_noiseMode > 0)
         {
-                vec2 screenPixel = floor(ScreenUvFromAoPixel(aoPixel) * ScreenSize());
-                ivec2 noisePixel = ivec2(screenPixel);
+                ivec2 noisePixel = ivec2(aoPixel);
                 if (u_noiseMode == 2)
                 {
-                        vec2 noiseUV = (screenPixel + 0.5) / ScreenSize() * u_noiseParams.xy;
+                        vec2 noiseUV = (aoPixel + 0.5) * AoInvSize() * u_noiseParams.xy;
                         vec2 noiseSample = texture(NoiseTexture, noiseUV).rg * 2.0 - 1.0;
                         noiseVec = normalize(noiseSample);
                 }
@@ -276,6 +281,19 @@ void main()
                 outColor = vec4(v, v, v, 1.0);
                 return;
         }
+        if (debugMode == 7)
+        {
+                if (IsSkyDepth(depth, u_depthParams))
+                {
+                        outColor = vec4(1.0);
+                        return;
+                }
+                vec3 viewPos = ReconstructViewPos(depthUv, depth);
+                float dist = length(viewPos);
+                float v = clamp(dist / debugFar, 0.0, 1.0);
+                outColor = vec4(v, v, v, 1.0);
+                return;
+        }
         if (IsSkyDepth(depth, u_depthParams))
         {
                 outColor = vec4(1.0);
@@ -288,6 +306,19 @@ void main()
         {
                 vec3 debugNormal = normal * 0.5 + 0.5;
                 outColor = vec4(debugNormal, 1.0);
+                return;
+        }
+        if (debugMode == 8)
+        {
+                vec2 screenCenter = ScreenPixelFromAoPixel(aoPixel);
+                vec3 offsetPos = viewPos + vec3(0.0, u_params0.x, 0.0);
+                vec4 clip = u_proj * vec4(offsetPos, 1.0);
+                float w = max(clip.w, 1e-6);
+                vec2 ndc = clip.xy / w;
+                vec2 screenOffset = (ApplyYFlip(ndc * 0.5 + 0.5) * ScreenSize()) - screenCenter;
+                float radiusPx = length(screenOffset);
+                float v = clamp(radiusPx / debugFar, 0.0, 1.0);
+                outColor = vec4(v, v, v, 1.0);
                 return;
         }
 

--- a/Quake/shaders/ssao_blur.frag
+++ b/Quake/shaders/ssao_blur.frag
@@ -52,7 +52,7 @@ vec2 AoUvFromPixel(vec2 aoPixel)
 vec2 ScreenUvFromAoPixel(vec2 aoPixel)
 {
         vec2 scale = AoToScreenScale();
-        vec2 screenPixel = aoPixel * scale + 0.5 * scale;
+        vec2 screenPixel = aoPixel * scale + vec2(0.5);
         return ApplyYFlip(screenPixel * ScreenInvSize());
 }
 


### PR DESCRIPTION
### Motivation
- Remove visible screen-space vertical/horizontal stripe artifacts caused by misaligned half-resolution SSAO sampling, deterministic noise tiling, and sampling/filtering mismatch. 
- Provide targeted debug visualizations to quickly verify raw AO, the noise/rotation vector, view-space depth/position, reconstructed normals, and pixel-radius diagnostics. 
- Make AO sampling deterministic and predictable across full/half-res passes to avoid banding and tiling. 
- Keep the fix localized to SSAO-related code without unrelated refactors. 

### Description
- Fixed AO<->screen pixel-center mapping and upsample sampling by aligning AO pixel centers in `Quake/shaders/ssao.frag`, `Quake/shaders/ssao_blur.frag`, and `Quake/shaders/postprocess.frag` (use explicit `+ vec2(0.5)` and new `ScreenPixelFromAoPixel`).
- Retiled and reworked noise sampling so noise is indexed in AO texel space (use `aoPixel` / `AoInvSize()`), and updated uniform noise scale to be AO-size aware in `Quake/gl_rmain.c` (`GL_Uniform4fFunc` now passes `width/SSAO_NOISE_SIZE`/`height/SSAO_NOISE_SIZE`).
- Added new SSAO debug modes `7` (view-space length) and `8` (sample radius in pixels) and exposed them via the existing `r_ssao_debug` cvar documentation change.
- Switched SSAO render target creation to use `GL_NEAREST` filtering for `ao_tex` and `blur_tex` to avoid unintended linear filtering during raw AO sampling, and corrected postprocess upsample mapping in `Quake/shaders/postprocess.frag`.

### Testing
- No automated tests were executed for this change.
- Shader compile/runtime verification should be performed during regular runtime testing to validate debug modes and that stripe artifacts are resolved (not included in this patch run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951ae55ce3c832eb7bbb5aed57b2cbd)