### PR TITLE
Fix SSAO depth reconstruction consistency

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -1140,6 +1140,7 @@ static GLuint GL_GenerateSSAOTexture (float view_min_x, float view_min_y, float 
 		GL_Uniform4fFunc (5, view_min_x, view_min_y, view_max_x, view_max_y);
 		GL_Uniform1iFunc (6, reversed_z_mode);
 		GL_Uniform1iFunc (7, 0);
+		GL_UniformMatrix4fvFunc (8, 1, GL_FALSE, r_matinvproj);
 
 		GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.ssao.blur_fbo[index]);
 		GL_LogErrorIfDeveloper ("SSAO blur bind FBO");

--- a/Quake/shaders/ssao.frag
+++ b/Quake/shaders/ssao.frag
@@ -160,18 +160,11 @@ float DepthToNdcZ(float depth, float reversed, int mode)
 }
 
 // Centralized SSAO depth conversion. Returns positive view-space depth (+X forward).
-float ViewZFromDepth(float depth01, mat4 proj, bool reversedZ)
+float ViewZFromDepth(vec2 uv, float depth01, bool reversedZ)
 {
-        float ndcDepth = DepthToNdcZ(depth01, reversedZ ? 1.0 : 0.0, u_reversedZMode);
-        float nearPlane = u_depthParams.x;
-        float farPlane = u_depthParams.y;
-        if (reversedZ)
-        {
-                float denom = nearPlane + ndcDepth * (farPlane - nearPlane);
-                return (nearPlane * farPlane) / max(denom, 1e-6);
-        }
-        float denom = farPlane + nearPlane - ndcDepth * (farPlane - nearPlane);
-        return (2.0 * nearPlane * farPlane) / max(denom, 1e-6);
+        // SSAO FIX: Use inverse projection for depth reconstruction to avoid reversed-Z/clip-control mismatches.
+        vec3 viewPos = ReconstructViewPos(uv, depth01);
+        return viewPos.x;
 }
 
 float DepthRawFromPixel(ivec2 pixel)
@@ -191,7 +184,7 @@ vec3 ReconstructViewPos(vec2 uv, float depth)
         vec4 view = u_invProj * clip;
         float w = view.w;
         if (abs(w) < 1e-6)
-                return vec3(0.0);
+                return vec3(1e30);
         return view.xyz / w;
 }
 
@@ -263,6 +256,16 @@ float RandIGN(ivec2 pixel, float seed)
         return fract(52.9829189 * f);
 }
 
+bool IsInvalidFloat(float v)
+{
+        return !(v > -1e20 && v < 1e20);
+}
+
+bool IsInvalidVec3(vec3 v)
+{
+        return IsInvalidFloat(v.x) || IsInvalidFloat(v.y) || IsInvalidFloat(v.z);
+}
+
 void main()
 {
         vec2 aoPixel = AoPixelCoord();
@@ -322,7 +325,12 @@ void main()
                         outColor = vec4(1.0);
                         return;
                 }
-                float viewZ = ViewZFromDepth(depth, u_proj, u_depthParams.z > 0.5);
+                float viewZ = ViewZFromDepth(screenUv, depth, u_depthParams.z > 0.5);
+                if (IsInvalidFloat(viewZ))
+                {
+                        outColor = vec4(1.0, 0.0, 1.0, 1.0);
+                        return;
+                }
                 float v = clamp(viewZ / debugFar, 0.0, 1.0);
                 outColor = vec4(v, v, v, 1.0);
                 return;
@@ -335,6 +343,11 @@ void main()
                         return;
                 }
                 vec3 viewPos = ReconstructViewPos(screenUv, depth);
+                if (IsInvalidVec3(viewPos))
+                {
+                        outColor = vec4(1.0, 0.0, 1.0, 1.0);
+                        return;
+                }
                 float viewZ = max(viewPos.x, 0.0);
                 float v = clamp(viewZ / debugFar, 0.0, 1.0);
                 outColor = vec4(v, v, v, 1.0);
@@ -356,7 +369,17 @@ void main()
         }
 
         vec3 viewPos = ReconstructViewPos(screenUv, depth);
+        if (IsInvalidVec3(viewPos))
+        {
+                outColor = (debugMode >= 0) ? vec4(1.0, 0.0, 1.0, 1.0) : vec4(1.0);
+                return;
+        }
         vec3 normal = (u_normalSource != 0) ? ComputeNormalFromViewPos(viewPos) : ReconstructNormalFromDepth(screenUv);
+        if (IsInvalidVec3(normal))
+        {
+                outColor = (debugMode >= 0) ? vec4(1.0, 0.0, 1.0, 1.0) : vec4(1.0);
+                return;
+        }
         if (debugMode == 4)
         {
                 vec3 debugNormal = normal * 0.5 + 0.5;
@@ -389,7 +412,9 @@ void main()
                 float sampleDepth = DepthRawFromUv(sampleUV);
                 if (IsSkyDepth(sampleDepth, u_depthParams))
                         continue;
-                float sampleViewDepth = ViewZFromDepth(sampleDepth, u_proj, u_depthParams.z > 0.5);
+                float sampleViewDepth = ViewZFromDepth(sampleUV, sampleDepth, u_depthParams.z > 0.5);
+                if (IsInvalidFloat(sampleViewDepth))
+                        continue;
                 float samplePosDepth = samplePos.x;
                 float dz = sampleViewDepth - samplePosDepth - bias;
                 float rangeCheck = smoothstep(0.0, 1.0, radius / max(abs(dz), 1e-4));

--- a/Quake/shaders/ssao_blur.frag
+++ b/Quake/shaders/ssao_blur.frag
@@ -9,6 +9,7 @@ layout(location=4) uniform vec4 u_params1; // x: sigma, y: radius, z: depth thre
 layout(location=5) uniform vec4 u_viewRect; // xy: view min, zw: view max
 layout(location=6) uniform int u_reversedZMode; // 0: default, 1: invert raw, 2: invert ndc
 layout(location=7) uniform int u_yFlip; // 0: none, 1: flip Y
+layout(location=8) uniform mat4 u_invProj;
 
 layout(location=0) out vec4 outColor;
 
@@ -54,6 +55,11 @@ vec2 UnflipUv(vec2 uv)
 vec2 AoUvFromPixel(vec2 aoPixel)
 {
         return ApplyYFlip((aoPixel + 0.5) * AoInvSize());
+}
+
+vec2 ScreenUvFromPixel(ivec2 pixel)
+{
+        return ApplyYFlip((vec2(pixel) + 0.5) * ScreenInvSize());
 }
 
 ivec2 ClampScreenPixel(vec2 pixel)
@@ -108,18 +114,16 @@ float DepthToNdcZ(float depth, float reversed, int mode)
 }
 
 // Centralized SSAO depth conversion. Returns positive view-space depth (+X forward).
-float ViewZFromDepth(float depth01, mat4 proj, bool reversedZ)
+float ViewZFromDepth(vec2 uv, float depth01, bool reversedZ)
 {
+        // SSAO FIX: Use inverse projection to keep blur depth comparisons consistent with SSAO reconstruction.
         float ndcDepth = DepthToNdcZ(depth01, reversedZ ? 1.0 : 0.0, u_reversedZMode);
-        float nearPlane = u_depthParams.x;
-        float farPlane = u_depthParams.y;
-        if (reversedZ)
-        {
-                float denom = nearPlane + ndcDepth * (farPlane - nearPlane);
-                return (nearPlane * farPlane) / max(denom, 1e-6);
-        }
-        float denom = farPlane + nearPlane - ndcDepth * (farPlane - nearPlane);
-        return (2.0 * nearPlane * farPlane) / max(denom, 1e-6);
+        vec4 clip = vec4(uv * 2.0 - 1.0, ndcDepth, 1.0);
+        vec4 view = u_invProj * clip;
+        float w = view.w;
+        if (abs(w) < 1e-6)
+                return 1e30;
+        return view.x / w;
 }
 
 float DepthRawFromPixel(ivec2 pixel)
@@ -130,6 +134,11 @@ float DepthRawFromPixel(ivec2 pixel)
 float DepthRawFromUv(vec2 uv)
 {
         return DepthRawFromPixel(ScreenPixelFromUv(uv));
+}
+
+bool IsInvalidFloat(float v)
+{
+        return !(v > -1e20 && v < 1e20);
 }
 
 bool IsSkyDepth(float depth, vec4 depthParams)
@@ -159,6 +168,7 @@ void main()
         }
 
         ivec2 screenPixel = ScreenPixelFromAoPixelNearest(aoPixel);
+        vec2 screenUv = ScreenUvFromPixel(screenPixel);
         float centerDepthRaw = DepthRawFromPixel(screenPixel);
         if (IsSkyDepth(centerDepthRaw, u_depthParams))
         {
@@ -166,7 +176,12 @@ void main()
                 return;
         }
 
-        float centerDepth = ViewZFromDepth(centerDepthRaw, mat4(1.0), u_depthParams.z > 0.5);
+        float centerDepth = ViewZFromDepth(screenUv, centerDepthRaw, u_depthParams.z > 0.5);
+        if (IsInvalidFloat(centerDepth))
+        {
+                outColor = vec4(1.0);
+                return;
+        }
         float sigma = max(u_params1.x, 0.01);
         int radius = int(u_params1.y + 0.5);
         float depthThreshold = max(u_params1.z, 0.0) * max(centerDepth, 1e-4);
@@ -186,7 +201,9 @@ void main()
                 float sampleDepthRaw = DepthRawFromUv(sampleDepthUv);
                 if (IsSkyDepth(sampleDepthRaw, u_depthParams))
                         continue;
-                float sampleDepth = ViewZFromDepth(sampleDepthRaw, mat4(1.0), u_depthParams.z > 0.5);
+                float sampleDepth = ViewZFromDepth(sampleDepthUv, sampleDepthRaw, u_depthParams.z > 0.5);
+                if (IsInvalidFloat(sampleDepth))
+                        continue;
                 float depthDiff = abs(sampleDepth - centerDepth);
                 float depthWeight = useBilateral ? smoothstep(0.0, 1.0, depthThreshold / max(depthDiff, 1e-4)) : 1.0;
                 float weight = Gaussian(float(i), sigma) * depthWeight;


### PR DESCRIPTION
### Motivation
- Reversed-Z/clip-control and AO half-res / UV mismatches were producing crosshatch/banding/noise artifacts, so depth reconstruction and blur comparisons must be consistent and robust.
- The goal is to ensure SSAO and its blur use the same inverse-projection reconstruction and to guard against NaNs/Inf that produce fullscreen noise.

### Description
- Replaced the direct analytic depth→viewZ math with reconstruction via `ReconstructViewPos(uv, depth)` and return `viewPos.x` from `ViewZFromDepth` in both AO and blur shaders.
- Added sentinel returns from `ReconstructViewPos` for invalid `w`, plus `IsInvalidFloat`/`IsInvalidVec3` helpers and early magenta debug/skip paths to avoid propagating NaNs.
- Made the blur pass compute consistent screen UVs with a new `ScreenUvFromPixel` helper, added `u_invProj` uniform to the blur shader, and upload the matrix from `GL_GenerateSSAOTexture` via `GL_UniformMatrix4fvFunc(8, ...)`.
- Added checks to skip invalid sample depths in AO and blur, and tightened depth sampling to use the AO→screen mappings (texel snapping) to prevent half-res drift/banding.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951b930547c832e8958da0a0da64bee)