### PR TITLE
Fix SSAO shader forward declaration

### DIFF
--- a/Quake/shaders/ssao.frag
+++ b/Quake/shaders/ssao.frag
@@ -159,6 +159,8 @@ float DepthToNdcZ(float depth, float reversed, int mode)
         return ndc;
 }
 
+vec3 ReconstructViewPos(vec2 uv, float depth);
+
 // Centralized SSAO depth conversion. Returns positive view-space depth (+X forward).
 float ViewZFromDepth(vec2 uv, float depth01, bool reversedZ)
 {


### PR DESCRIPTION
### Motivation
- The SSAO fragment shader called `ReconstructViewPos` from `ViewZFromDepth` before the function was declared, which can trigger GLSL compile errors such as an undefined variable for `ReconstructViewPos` and prevent OpenGL initialization.
- Ensuring a forward declaration prevents compile-order issues across GLSL implementations and GPU drivers.

### Description
- Add a forward declaration `vec3 ReconstructViewPos(vec2 uv, float depth);` above `ViewZFromDepth` in `Quake/shaders/ssao.frag` to satisfy the GLSL compiler.
- The actual `ReconstructViewPos` implementation remains unchanged later in the file.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951bb16a6f0832ea582645b6b757b9e)