### PR TITLE
Fix SSAO depth bias compare and add AO mask debug view

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -268,7 +268,7 @@ cvar_t	r_ssao_blur_radius = { "r_ssao_blur_radius", "2", CVAR_ARCHIVE };
 cvar_t	r_ssao_blur_sigma = { "r_ssao_blur_sigma", "2.0", CVAR_ARCHIVE };
 cvar_t	r_ssao_blur_bilateral = { "r_ssao_blur_bilateral", "1", CVAR_ARCHIVE };
 cvar_t	r_ssao_halfres = { "r_ssao_halfres", "1", CVAR_ARCHIVE };
-// r_ssao_debug modes: 0 off, 1 depth raw, 2 view-space Z, 3 view-space position, 4 normals, 5 noise, 6 sample hit ratio, 7 AO raw, 8 blur debug.
+// r_ssao_debug modes: 0 off, 1 depth raw, 2 view-space Z, 3 view-space position, 4 normals, 5 noise, 6 sample hit ratio, 7 AO raw, 8 blur debug, 9 AO mask.
 cvar_t	r_ssao_debug = { "r_ssao_debug", "0", CVAR_ARCHIVE };
 cvar_t	r_ssao_debug_far = { "r_ssao_debug_far", "4096", CVAR_ARCHIVE };
 cvar_t	r_ssao_reversedz_mode = { "r_ssao_reversedz_mode", "0", CVAR_ARCHIVE };
@@ -1030,7 +1030,7 @@ static GLuint GL_GenerateSSAOTexture (float view_min_x, float view_min_y, float 
 	int reversed_z_mode = (int)Q_rint (r_ssao_reversedz_mode.value);
 	reversed_z_mode = CLAMP (0, reversed_z_mode, 2);
 	int debug_mode_cvar = (int)Q_rint (r_ssao_debug.value);
-	int debug_mode_i = (debug_mode_cvar > 0) ? CLAMP (1, debug_mode_cvar, 8) : -1;
+	int debug_mode_i = (debug_mode_cvar > 0) ? CLAMP (1, debug_mode_cvar, 9) : -1;
 	qboolean debug_show_ao_raw = (debug_mode_i == 7);
 	qboolean debug_show_blur_debug = (debug_mode_i == 8);
 	int debug_mode_ssao = -1;
@@ -1810,7 +1810,7 @@ void GL_PostProcess (void)
 	ssao_intensity = R_SanitizeSSAOValue (r_ssao_intensity.value, 0.f, 0.f, 1.f);
 	{
 		int debug_cvar = (int)Q_rint (r_ssao_debug.value);
-		int debug_mode_i = (debug_cvar > 0) ? CLAMP (1, debug_cvar, 8) : -1;
+		int debug_mode_i = (debug_cvar > 0) ? CLAMP (1, debug_cvar, 9) : -1;
 		ssao_debug_mode = (debug_mode_i > 0) ? (float)debug_mode_i : -1.f;
 	}
 	if (ssao_texture == 0)

--- a/Quake/shaders/postprocess.frag
+++ b/Quake/shaders/postprocess.frag
@@ -518,7 +518,12 @@ void main()
                                 ssaoCenterDepth = SampleLinearDepth(gl_FragCoord.xy, depthInfo);
                         bool useDepthUpscale = ssaoUseDepth && (ssaoDebugMode <= 0 || ssaoDebugMode == 7);
                         float ao = SampleSSAO(uv, depthInfo, ssaoCenterDepth, useDepthUpscale);
-                        if (ssaoDebugMode == 8)
+                        if (ssaoDebugMode == 9)
+                        {
+                                float mask = centerOpaque ? (1.0 - ao) : 0.0;
+                                color.rgb = vec3(mask);
+                        }
+                        else if (ssaoDebugMode == 8)
                         {
                                 vec2 ssaoSize = vec2(textureSize(SSAOTexture, 0));
                                 vec2 colorSize = vec2(textureSize(GammaTexture, 0));

--- a/Quake/shaders/ssao.frag
+++ b/Quake/shaders/ssao.frag
@@ -411,9 +411,9 @@ void main()
                         continue;
                 validSamples += 1.0;
                 float samplePosDepth = samplePos.x;
-                float dz = sampleViewDepth - samplePosDepth - bias;
-                float rangeCheck = smoothstep(0.0, 1.0, radius / max(abs(dz), 1e-4));
-                if (dz < 0.0)
+                float depthDelta = samplePosDepth - sampleViewDepth;
+                float rangeCheck = smoothstep(0.0, 1.0, radius / max(abs(depthDelta), 1e-4));
+                if (depthDelta > bias)
                         occlusion += rangeCheck;
         }
 

--- a/docs/ssao.md
+++ b/docs/ssao.md
@@ -29,6 +29,7 @@
 - `6`: sample hit ratio (valid samples / total)
 - `7`: AO raw (pre-blur)
 - `8`: blur debug (raw vs blur + depth weight)
+- `9`: AO mask (occlusion where applied)
 
 ## Noise controls
 - `r_ssao_noise` toggles per-pixel rotation.


### PR DESCRIPTION
### Motivation
- Recent SSAO changes caused over-occlusion and a global darkening because the depth/bias comparison used the wrong sign and direction.
- The render produced visible artifacts and unpredictable AO application that required a deterministic debug view to diagnose where AO is applied.
- The change aims to restore contact-based occlusion behavior (edges/corners) and provide a clear diagnostic mode for AO masking.

### Description
- Corrected the occlusion comparison in `Quake/shaders/ssao.frag` to compute `depthDelta = samplePos.x - sampleViewDepth` and use `if (depthDelta > bias)` with the existing `rangeCheck` to avoid inverted/over-occlusion. 
- Extended the `r_ssao_debug` handling in `Quake/gl_rmain.c` to accept mode `9` and propagate it to the postprocess stage. 
- Added handling for debug mode `9` in `Quake/shaders/postprocess.frag` to output an AO mask (`1.0 - ao` when the center is opaque) for visual verification. 
- Updated `docs/ssao.md` to document the new debug mode `9` and included the change in the SSAO debugging notes. 

### Testing
- No automated tests were run for this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951c2932320832e804541003a0ae1b1)