### PR TITLE
Filter SSAO and bloom for sky/liquid surfaces (material mask)

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -859,6 +859,15 @@ static GLuint GL_GenerateBloomTexture (void)
 		return fallback;
 
 	float threshold = q_max (0.f, r_bloom_threshold.value);
+	qboolean msaa = framebufs.scene.samples > 1;
+	GLuint velocity_texture = 0;
+	if (framebufs.scene.velocity_tex)
+	{
+		velocity_texture = msaa ? framebufs.resolved_scene.velocity_tex : framebufs.scene.velocity_tex;
+		if (framesetup.scene_fbo != framebufs.scene.fbo)
+			velocity_texture = 0;
+	}
+	float mask_enabled = velocity_texture ? 1.f : 0.f;
 
 	GL_BeginGroup ("Bloom extract");
 	GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.bloom.extract_fbo);
@@ -866,7 +875,8 @@ static GLuint GL_GenerateBloomTexture (void)
 	GL_UseProgram (glprogs.bloom_extract);
 	GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
 	GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, framebufs.composite.color_tex);
-	GL_Uniform4fFunc (0, threshold, 0.f, 0.f, 0.f);
+	GL_BindNative (GL_TEXTURE1, GL_TEXTURE_2D, velocity_texture);
+	GL_Uniform4fFunc (0, threshold, mask_enabled, 0.f, 0.f);
 	GL_Uniform4fFunc (1, (float)vid.width, (float)vid.height,
 		(float)vid.width / (float)width,
 		(float)vid.height / (float)height);

--- a/Quake/shaders/bloom_extract.frag
+++ b/Quake/shaders/bloom_extract.frag
@@ -1,6 +1,7 @@
 layout(binding=0) uniform sampler2D SceneTexture;
+layout(binding=1) uniform sampler2D MaskTexture;
 
-layout(location=0) uniform vec4 ThresholdParams; // x: threshold
+layout(location=0) uniform vec4 ThresholdParams; // x: threshold, y: mask enabled
 layout(location=1) uniform vec4 DownsampleParams; // xy: source size, zw: scale from target to source
 
 layout(location=0) out vec4 outColor;
@@ -8,21 +9,28 @@ layout(location=0) out vec4 outColor;
 void main()
 {
         float threshold = ThresholdParams.x;
+        float maskEnabled = ThresholdParams.y;
         vec2 sourceSize = DownsampleParams.xy;
         vec2 scale = DownsampleParams.zw;
         vec2 base = (gl_FragCoord.xy + 0.5) * scale - 0.5;
         vec2 maxCoord = max(sourceSize - vec2(1.0), vec2(0.0));
         ivec2 baseCoord = ivec2(floor(base));
         vec3 accum = vec3(0.0);
+        float weight = 0.0;
         for (int j = 0; j < 2; ++j)
         {
                 for (int i = 0; i < 2; ++i)
                 {
                         vec2 sampleCoord = clamp(vec2(baseCoord) + vec2(float(i), float(j)), vec2(0.0), maxCoord);
-                        accum += texelFetch(SceneTexture, ivec2(sampleCoord), 0).rgb;
+                        vec4 sampleColor = texelFetch(SceneTexture, ivec2(sampleCoord), 0);
+                        float mask = 1.0;
+                        if (maskEnabled > 0.5)
+                                mask = step(0.5, texelFetch(MaskTexture, ivec2(sampleCoord), 0).w);
+                        accum += sampleColor.rgb * mask;
+                        weight += mask;
                 }
         }
-        vec3 color = accum * 0.25;
+        vec3 color = (weight > 0.0) ? (accum / weight) : vec3(0.0);
         float brightness = dot(color, vec3(0.2126, 0.7152, 0.0722));
         float diff = max(brightness - threshold, 0.0);
         float factor = brightness > 0.0 ? diff / brightness : 0.0;

--- a/Quake/shaders/postprocess.frag
+++ b/Quake/shaders/postprocess.frag
@@ -329,12 +329,14 @@ void main()
         bool hasVelocityTexture = MotionParams1.z > 0.5;
         vec2 velocity = vec2(0.0);
         float viewModelMask = 0.0;
+        float materialMask = 0.0;
         if (hasVelocityTexture && inView)
         {
                 vec2 velocityUV = clamp((uv - viewMin) * invScale, vec2(0.0), viewSize * invScale);
                 vec4 velocitySample = texture(VelocityTexture, velocityUV);
                 velocity = velocitySample.xy;
                 viewModelMask = velocitySample.z;
+                materialMask = velocitySample.w;
         }
 
         if (MotionParams0.x > 0.5 && inView && hasVelocityTexture && viewModelMask < 0.5 && centerOpaque)
@@ -510,73 +512,82 @@ void main()
                 float ssaoIntensity = SSAOParams.x;
                 int ssaoDebugMode = int(floor(SSAOParams.y + 0.5));
                 bool ssaoInView = inView;
+                bool ssaoAllowed = materialMask < 0.5;
                 if ((ssaoDebugMode > 0 || ssaoIntensity > 0.0) && ssaoInView)
                 {
-                        float ssaoCenterDepth = 0.0;
-                        bool ssaoUseDepth = depthInfo.valid;
-                        if (ssaoUseDepth)
-                                ssaoCenterDepth = SampleLinearDepth(gl_FragCoord.xy, depthInfo);
-                        bool useDepthUpscale = ssaoUseDepth && (ssaoDebugMode <= 0 || ssaoDebugMode == 7);
-                        float ao = SampleSSAO(uv, depthInfo, ssaoCenterDepth, useDepthUpscale);
-                        if (ssaoDebugMode == 9)
+                        if (!ssaoAllowed)
                         {
-                                float mask = centerOpaque ? (1.0 - ao) : 0.0;
-                                color.rgb = vec3(mask);
+                                if (ssaoDebugMode > 0)
+                                        color.rgb = (ssaoDebugMode == 9) ? vec3(0.0) : vec3(1.0);
                         }
-                        else if (ssaoDebugMode == 8)
+                        else
                         {
-                                vec2 ssaoSize = vec2(textureSize(SSAOTexture, 0));
-                                vec2 colorSize = vec2(textureSize(GammaTexture, 0));
-                                vec2 ssaoCoord = uv * ssaoSize;
-                                ivec2 ssaoPixel = ivec2(clamp(floor(ssaoCoord), vec2(0.0), ssaoSize - vec2(1.0)));
-                                float rawAo = texelFetch(SSAOTexture, ssaoPixel, 0).r;
-                                float sigma = max(SSAOBlurParams.x, 0.01);
-                                int radius = int(SSAOBlurParams.y + 0.5);
-                                float depthThreshold = SSAOBlurParams.z * max(ssaoCenterDepth, 1e-4);
-                                vec2 ssaoToScreen = colorSize / max(ssaoSize, vec2(1.0));
-                                float accum = 0.0;
-                                float total = 0.0;
-                                float depthWeightSum = 0.0;
-                                float sampleCount = 0.0;
-
-                                for (int y = -4; y <= 4; ++y)
+                                float ssaoCenterDepth = 0.0;
+                                bool ssaoUseDepth = depthInfo.valid;
+                                if (ssaoUseDepth)
+                                        ssaoCenterDepth = SampleLinearDepth(gl_FragCoord.xy, depthInfo);
+                                bool useDepthUpscale = ssaoUseDepth && (ssaoDebugMode <= 0 || ssaoDebugMode == 7);
+                                float ao = SampleSSAO(uv, depthInfo, ssaoCenterDepth, useDepthUpscale);
+                                if (ssaoDebugMode == 9)
                                 {
-                                        if (abs(y) > radius)
-                                                continue;
-                                        for (int x = -4; x <= 4; ++x)
-                                        {
-                                                if (abs(x) > radius)
-                                                        continue;
-                                                vec2 offset = vec2(float(x), float(y));
-                                                vec2 sampleTexel = clamp(vec2(ssaoPixel) + offset, vec2(0.0), ssaoSize - vec2(1.0));
-                                                ivec2 samplePixel = ivec2(sampleTexel);
-                                                float sampleAo = texelFetch(SSAOTexture, samplePixel, 0).r;
-                                                float depthWeight = 1.0;
-                                                if (ssaoUseDepth)
-                                                {
-                                                        vec2 sampleScreenPx = sampleTexel * ssaoToScreen + vec2(0.5);
-                                                        float sampleDepth = SampleLinearDepth(sampleScreenPx, depthInfo);
-                                                        float depthDiff = abs(sampleDepth - ssaoCenterDepth);
-                                                        depthWeight = smoothstep(0.0, 1.0, depthThreshold / max(depthDiff, 1e-4));
-                                                }
-                                                float weight = Gaussian2(dot(offset, offset), sigma) * depthWeight;
-                                                accum += sampleAo * weight;
-                                                total += weight;
-                                                depthWeightSum += depthWeight;
-                                                sampleCount += 1.0;
-                                        }
+                                        float mask = centerOpaque ? (1.0 - ao) : 0.0;
+                                        color.rgb = vec3(mask);
                                 }
-                                float blurred = (total > 0.0) ? (accum / total) : rawAo;
-                                float avgDepthWeight = (sampleCount > 0.0) ? (depthWeightSum / sampleCount) : 1.0;
-                                color.rgb = vec3(rawAo, blurred, avgDepthWeight);
-                        }
-                        else if (ssaoDebugMode > 0)
-                        {
-                                color.rgb = vec3(ao);
-                        }
-                        else if (centerOpaque)
-                        {
-                                color.rgb *= mix(1.0, ao, ssaoIntensity);
+                                else if (ssaoDebugMode == 8)
+                                {
+                                        vec2 ssaoSize = vec2(textureSize(SSAOTexture, 0));
+                                        vec2 colorSize = vec2(textureSize(GammaTexture, 0));
+                                        vec2 ssaoCoord = uv * ssaoSize;
+                                        ivec2 ssaoPixel = ivec2(clamp(floor(ssaoCoord), vec2(0.0), ssaoSize - vec2(1.0)));
+                                        float rawAo = texelFetch(SSAOTexture, ssaoPixel, 0).r;
+                                        float sigma = max(SSAOBlurParams.x, 0.01);
+                                        int radius = int(SSAOBlurParams.y + 0.5);
+                                        float depthThreshold = SSAOBlurParams.z * max(ssaoCenterDepth, 1e-4);
+                                        vec2 ssaoToScreen = colorSize / max(ssaoSize, vec2(1.0));
+                                        float accum = 0.0;
+                                        float total = 0.0;
+                                        float depthWeightSum = 0.0;
+                                        float sampleCount = 0.0;
+
+                                        for (int y = -4; y <= 4; ++y)
+                                        {
+                                                if (abs(y) > radius)
+                                                        continue;
+                                                for (int x = -4; x <= 4; ++x)
+                                                {
+                                                        if (abs(x) > radius)
+                                                                continue;
+                                                        vec2 offset = vec2(float(x), float(y));
+                                                        vec2 sampleTexel = clamp(vec2(ssaoPixel) + offset, vec2(0.0), ssaoSize - vec2(1.0));
+                                                        ivec2 samplePixel = ivec2(sampleTexel);
+                                                        float sampleAo = texelFetch(SSAOTexture, samplePixel, 0).r;
+                                                        float depthWeight = 1.0;
+                                                        if (ssaoUseDepth)
+                                                        {
+                                                                vec2 sampleScreenPx = sampleTexel * ssaoToScreen + vec2(0.5);
+                                                                float sampleDepth = SampleLinearDepth(sampleScreenPx, depthInfo);
+                                                                float depthDiff = abs(sampleDepth - ssaoCenterDepth);
+                                                                depthWeight = smoothstep(0.0, 1.0, depthThreshold / max(depthDiff, 1e-4));
+                                                        }
+                                                        float weight = Gaussian2(dot(offset, offset), sigma) * depthWeight;
+                                                        accum += sampleAo * weight;
+                                                        total += weight;
+                                                        depthWeightSum += depthWeight;
+                                                        sampleCount += 1.0;
+                                                }
+                                        }
+                                        float blurred = (total > 0.0) ? (accum / total) : rawAo;
+                                        float avgDepthWeight = (sampleCount > 0.0) ? (depthWeightSum / sampleCount) : 1.0;
+                                        color.rgb = vec3(rawAo, blurred, avgDepthWeight);
+                                }
+                                else if (ssaoDebugMode > 0)
+                                {
+                                        color.rgb = vec3(ao);
+                                }
+                                else if (centerOpaque)
+                                {
+                                        color.rgb *= mix(1.0, ao, ssaoIntensity);
+                                }
                         }
                 }
 

--- a/Quake/shaders/sky_boxside.frag
+++ b/Quake/shaders/sky_boxside.frag
@@ -60,7 +60,7 @@ layout(location=1) out vec4 out_velocity;
 void main()
 {
 	out_fragcolor = texture(Tex, in_uv);
-        out_velocity = vec4(0.0);
+        out_velocity = vec4(0.0, 0.0, 0.0, 1.0);
 	out_fragcolor.rgb = mix(out_fragcolor.rgb, Fog.rgb, Fog.w);
 #if DITHER
 	out_fragcolor.rgb = sqrt(out_fragcolor.rgb);

--- a/Quake/shaders/sky_cubemap.frag
+++ b/Quake/shaders/sky_cubemap.frag
@@ -78,9 +78,10 @@ void main()
 	layer2.rgb *= layer2.a;
 	vec4 combined = layer1 + layer2;
 	out_fragcolor = vec4(base.rgb * (1.0 - combined.a) + combined.rgb, 1);
+	out_velocity = vec4(0.0, 0.0, 0.0, 1.0);
 #else
 	out_fragcolor = texture(Skybox, in_dir);
-        out_velocity = vec4(0.0);
+        out_velocity = vec4(0.0, 0.0, 0.0, 1.0);
 #endif
 	out_fragcolor.rgb = mix(out_fragcolor.rgb, SkyFog.rgb, SkyFog.a);
 #if DITHER

--- a/Quake/shaders/sky_layers.frag
+++ b/Quake/shaders/sky_layers.frag
@@ -82,6 +82,6 @@ void main()
 	result.rgb = mix(result.rgb, layer.rgb, layer.a);
 	result.rgb = mix(result.rgb, SkyFog.rgb, SkyFog.a);
 	out_fragcolor = result;
-        out_velocity = vec4(0.0);
+        out_velocity = vec4(0.0, 0.0, 0.0, 1.0);
 	out_fragcolor.rgb += SUPPRESS_BANDING() * ScreenDither;
 }

--- a/Quake/shaders/water.frag
+++ b/Quake/shaders/water.frag
@@ -162,7 +162,7 @@ void main()
         vec2 velocityOut = vec2(0.0);
         if (result.a >= 0.999)
                 velocityOut = velocity * result.a;
-        out_velocity = vec4(velocityOut, 0.0, 0.0);
+        out_velocity = vec4(velocityOut, 0.0, 1.0);
 #endif
 #if DITHER
 	if (Fog.w > 0.)


### PR DESCRIPTION
### Motivation
- Prevent SSAO from applying to sky, transparent/translucent surfaces and liquid surfaces to avoid incorrect ambient occlusion on those materials.
- Restrict bloom extraction to sky/liquid (lava, water, slime, teleport) surfaces similar to how godrays are masked.
- Provide a cheap material mask exported from geometry rendering so post-processing can decide per-pixel whether to run SSAO or include pixels in bloom.
- Fall back safely when velocity/mask data is not available (e.g. MSAA or unused attachments).

### Description
- Added a material mask channel in the scene velocity buffer (stored in the velocity texture's .w) and plumbed that mask through shaders emitted by sky and liquid renderers.
- Updated sky and liquid shaders (`shaders/sky_*`, `shaders/water.frag`, `shaders/sky_layers.frag`, etc.) to write the new mask value into the velocity output.
- Modified the postprocess shader (`shaders/postprocess.frag`) to sample the velocity/material mask and skip or alter SSAO application when the mask indicates sky/liquid pixels.
- Extended bloom extraction to accept an optional mask (`shaders/bloom_extract.frag`) and updated framebuffer setup and uniform/texture binding in `gl_rmain.c` so bloom extraction can limit contribution to masked surfaces with a safe fallback when velocity data is absent.

### Testing
- No automated tests were executed for this change.
- A commit with the changes was created successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951c878a630832e97190e5938c01e90)