### PR TITLE
Add hybrid linear color pipeline, lightmap colorspace controls, and final sRGB transform

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -215,7 +215,7 @@ cvar_t	r_speeds = { "r_speeds","0",CVAR_NONE };
 cvar_t	r_pos = { "r_pos","0",CVAR_NONE };
 cvar_t	r_fullbright = { "r_fullbright","0",CVAR_NONE };
 cvar_t	r_lightmap = { "r_lightmap","0",CVAR_NONE };
-cvar_t	r_lightmap_linear = { "r_lightmap_linear", "1", CVAR_ARCHIVE };
+cvar_t	r_lightmap_linear = { "r_lightmap_linear", "0", CVAR_ARCHIVE };
 cvar_t	r_lightmap_mipmaps = { "r_lightmap_mipmaps", "1", CVAR_ARCHIVE };
 cvar_t	r_lightmap16f = { "r_lightmap16f", "0", CVAR_ARCHIVE };
 cvar_t	r_lightingdir = { "r_lightingdir", "0", CVAR_ARCHIVE };
@@ -228,6 +228,11 @@ cvar_t	r_gamma = { "r_gamma", "2.2", CVAR_ARCHIVE };
 cvar_t	r_debug_colorspace = { "r_debug_colorspace", "0", CVAR_ARCHIVE };
 cvar_t	r_post_contrast = { "r_post_contrast", "1.0", CVAR_ARCHIVE };
 cvar_t	r_post_saturation = { "r_post_saturation", "1.05", CVAR_ARCHIVE };
+cvar_t	r_color_midtone = { "r_color_midtone", "1.0", CVAR_ARCHIVE };
+cvar_t	r_color_contrast = { "r_color_contrast", "1.0", CVAR_ARCHIVE };
+cvar_t	r_color_saturation = { "r_color_saturation", "1.05", CVAR_ARCHIVE };
+cvar_t	r_lightmap_colorspace = { "r_lightmap_colorspace", "srgb", CVAR_ARCHIVE };
+cvar_t	r_lightmap_colorspace_debug = { "r_lightmap_colorspace_debug", "0", CVAR_ARCHIVE };
 cvar_t	r_wateralpha = { "r_wateralpha","1",CVAR_ARCHIVE };
 cvar_t	r_litwater = { "r_litwater","1",CVAR_NONE };
 cvar_t	r_dynamic = { "r_dynamic","1",CVAR_ARCHIVE };
@@ -1601,10 +1606,14 @@ static void GL_PostProcessFallback (void)
 		GL_SetFramebufferSRGB (srgb_output);
 	}
 
-	float sat = CLAMP (0.9f, r_post_saturation.value, 1.2f);
-	float post_contrast = CLAMP (0.8f, r_post_contrast.value, 1.2f);
+	float sat = CLAMP (0.9f, r_color_saturation.value, 1.2f);
+	float post_contrast = CLAMP (0.8f, r_color_contrast.value, 1.2f);
 	qboolean manual_gamma = GL_UseManualGamma ();
 	float gamma = manual_gamma ? (1.0f / q_max (0.1f, r_gamma.value)) : 1.0f;
+	float midtone = q_max (0.1f, r_color_midtone.value);
+	qboolean output_srgb = (r_srgb_framebuffer.value <= 0.f);
+	if (vid_framebuffer_srgb_capable && r_srgb_framebuffer.value > 0.f)
+		output_srgb = false;
 	for (size_t i = 0; i < numpixels; ++i)
 	{
 		float color[3] = {
@@ -1612,10 +1621,11 @@ static void GL_PostProcessFallback (void)
 			pixels[i * 4 + 1] * (1.f / 255.f),
 			pixels[i * 4 + 2] * (1.f / 255.f)
 		};
-		float l = color[0] * 0.299f + color[1] * 0.587f + color[2] * 0.114f;
-		color[0] = l + (color[0] - l) * sat;
-		color[1] = l + (color[1] - l) * sat;
-		color[2] = l + (color[2] - l) * sat;
+		if (midtone != 1.f)
+		{
+			for (int c = 0; c < 3; ++c)
+				color[c] = powf (color[c], 1.0f / midtone);
+		}
 		if (post_contrast != 1.f)
 		{
 			for (int c = 0; c < 3; ++c)
@@ -1624,11 +1634,28 @@ static void GL_PostProcessFallback (void)
 				color[c] = CLAMP (0.f, color[c] + t * ((post_contrast - 1.f) * 2.f), 1.f);
 			}
 		}
+		if (sat != 1.f)
+		{
+			float l = color[0] * 0.299f + color[1] * 0.587f + color[2] * 0.114f;
+			color[0] = l + (color[0] - l) * sat;
+			color[1] = l + (color[1] - l) * sat;
+			color[2] = l + (color[2] - l) * sat;
+		}
 		if (manual_gamma)
 		{
 			color[0] = powf (color[0], gamma);
 			color[1] = powf (color[1], gamma);
 			color[2] = powf (color[2], gamma);
+		}
+		if (output_srgb)
+		{
+			for (int c = 0; c < 3; ++c)
+			{
+				if (color[c] <= 0.0031308f)
+					color[c] = color[c] * 12.92f;
+				else
+					color[c] = 1.055f * powf (color[c], 1.0f / 2.4f) - 0.055f;
+			}
 		}
 		pixels[i * 4 + 0] = (byte)CLAMP (0, (int)Q_rint (color[0] * 255.f), 255);
 		pixels[i * 4 + 1] = (byte)CLAMP (0, (int)Q_rint (color[1] * 255.f), 255);
@@ -1831,7 +1858,7 @@ void GL_PostProcess (void)
 	float view_max_x;
 	float view_max_y;
 	float inv_scale;
-        r_post_saturation.value = CLAMP (0.9f, r_post_saturation.value, 1.2f);
+        r_color_saturation.value = CLAMP (0.9f, r_color_saturation.value, 1.2f);
 	if (!GL_NeedsPostprocess ())
 		return;
 
@@ -1973,12 +2000,17 @@ void GL_PostProcess (void)
 	{
 		qboolean manual_gamma = GL_UseManualGamma ();
 		float gamma = manual_gamma ? (1.0f / q_max (0.1f, r_gamma.value)) : 1.0f;
-		float post_contrast = CLAMP (0.8f, r_post_contrast.value, 1.2f);
+		float post_contrast = CLAMP (0.8f, r_color_contrast.value, 1.2f);
 		GL_Uniform4fFunc (0, gamma, post_contrast, 1.f / r_refdef.scale, dither);
 	}
 	{
 		qboolean manual_gamma = GL_UseManualGamma ();
-		GL_Uniform2fFunc (19, CLAMP (0.f, r_debug_colorspace.value, 4.f), manual_gamma ? 1.f : 0.f);
+		int debug_mode = (int)Q_rint (CLAMP (0.f, r_debug_colorspace.value, 4.f));
+		qboolean linear_debug = (debug_mode == 2);
+		qboolean output_srgb = (r_srgb_framebuffer.value <= 0.f) || !vid_framebuffer_srgb_capable;
+		if (linear_debug)
+			output_srgb = false;
+		GL_Uniform4fFunc (19, (float)debug_mode, manual_gamma ? 1.f : 0.f, output_srgb ? 1.f : 0.f, 0.f);
 	}
 	GL_Uniform3fFunc (5, bloom_intensity, exposure, tonemap_mode);
 	GL_Uniform4fFunc (6, motion_enabled ? 1.f : 0.f, motion_effective_shutter, motion_min_velocity, motion_depth_threshold);
@@ -1999,7 +2031,8 @@ void GL_PostProcess (void)
 	screen_darken_depth,
 	0.f);
 	GL_Uniform4fFunc (11, teleport_fade, teleport_blur, 0.f, 0.f);
-	GL_Uniform1fFunc (12, CLAMP (0.9f, r_post_saturation.value, 1.2f));
+	GL_Uniform1fFunc (12, CLAMP (0.9f, r_color_saturation.value, 1.2f));
+	GL_Uniform1fFunc (20, q_max (0.1f, r_color_midtone.value));
 	GL_Uniform4fFunc (16, godrays_texture ? 1.f : 0.f, godrays_debug, godrays_debug_source, 0.f);
 	{
 		float upscale_nearest = (r_ssao_upscale_nearest.value > 0.f) ? 1.f : 0.f;
@@ -2656,13 +2689,15 @@ GL_NeedsPostprocess
 */
 qboolean GL_NeedsPostprocess (void)
 {
-        float saturation = CLAMP (0.9f, r_post_saturation.value, 1.2f);
-	r_post_saturation.value = saturation;
+        float saturation = CLAMP (0.9f, r_color_saturation.value, 1.2f);
+	r_color_saturation.value = saturation;
 	if (softemu || R_GetEffectiveAlphaMode () == ALPHAMODE_OIT || R_DoFEnabled ())
 		return true;
 	if (r_manual_gamma.value > 0.f || r_debug_colorspace.value > 0.f)
 		return true;
-	if (r_tonemap.value > 0.f || r_bloom.value > 0.f || r_post_contrast.value != 1.f || saturation != 1.f || GL_ShouldApplyMotionBlur ())
+	if (r_tonemap.value > 0.f || r_bloom.value > 0.f || r_color_contrast.value != 1.f || saturation != 1.f || r_color_midtone.value != 1.f || GL_ShouldApplyMotionBlur ())
+		return true;
+	if (r_srgb_framebuffer.value <= 0.f)
 		return true;
 	if (r_filmgrain.value > 0.f && r_filmgrain_affect_ui.value <= 0.f)
 		return true;
@@ -2672,6 +2707,21 @@ qboolean GL_NeedsPostprocess (void)
 		return true;
 	return false;
 }
+
+/*
+====================================================================================================
+COLOR-SPACE POLICY (HYBRID LINEAR)
+
+1) Lighting/compositing happens in linear HDR (RGBA16F targets).
+2) Albedo/diffuse textures are uploaded as sRGB. Non-color data (normals/depth/noise/LUTs/masks)
+   stays linear/UNORM.
+3) Lightmaps are controlled by r_lightmap_colorspace (srgb|linear). "srgb" assumes gamma-encoded
+   bakes and decodes on sampling; "linear" bypasses conversion.
+4) UI/HUD/2D is mixed AFTER tone mapping in LDR space (postprocess output).
+5) Exactly one output transform: postprocess applies the Quake curve + optional legacy gamma, then
+   performs linear->sRGB conversion if the backbuffer is not sRGB-capable.
+====================================================================================================
+*/
 
 void GL_ApplyFilmgrainUI (void)
 {
@@ -2826,7 +2876,7 @@ void R_SetupView (void)
         r_framedata.eye[1] = r_refdef.vieworg[1];
         r_framedata.eye[2] = r_refdef.vieworg[2];
         r_framedata.eye[3] = cl.time;
-        r_framedata.lightmap_params[0] = r_lightmap_linear.value > 0.f ? 1.f : 0.f;
+        r_framedata.lightmap_params[0] = r_lightmap_colorspace_debug.value > 0.f ? 1.f : 0.f;
         r_framedata.lightmap_params[1] = r_tonemap.value > 0.f ? 1.f : 0.f;
         r_framedata.lightmap_params[2] = (r_lightingdir.value > 0.f && lightmap_dir_texture) ? 1.f : 0.f;
         r_framedata.lightmap_params[3] = r_lightstyle_framefrac;

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -92,8 +92,15 @@ extern cvar_t r_gamma;
 extern cvar_t r_debug_colorspace;
 extern cvar_t r_post_contrast;
 extern cvar_t r_post_saturation;
+extern cvar_t r_color_midtone;
+extern cvar_t r_color_contrast;
+extern cvar_t r_color_saturation;
+extern cvar_t r_lightmap_colorspace;
+extern cvar_t r_lightmap_colorspace_debug;
 extern cvar_t r_bloom;
 extern void TexMgr_SRGBTextures_f (cvar_t *var);
+extern void TexMgr_LightmapColorspace_f (cvar_t *var);
+extern void TexMgr_LightmapLinearCompat_f (cvar_t *var);
 extern cvar_t r_bloom_threshold;
 extern cvar_t r_ssao;
 extern cvar_t r_ssao_radius;
@@ -185,6 +192,25 @@ extern cvar_t r_simd;
 qboolean use_simd;
 
 extern gltexture_t *playertextures[MAX_SCOREBOARD]; //johnfitz
+
+static qboolean r_color_syncing = false;
+
+static void R_ColorCurveSync_f (cvar_t *var)
+{
+	if (r_color_syncing)
+		return;
+
+	r_color_syncing = true;
+	if (var == &r_post_contrast)
+		Cvar_SetValueQuick (&r_color_contrast, r_post_contrast.value);
+	else if (var == &r_color_contrast)
+		Cvar_SetValueQuick (&r_post_contrast, r_color_contrast.value);
+	else if (var == &r_post_saturation)
+		Cvar_SetValueQuick (&r_color_saturation, r_post_saturation.value);
+	else if (var == &r_color_saturation)
+		Cvar_SetValueQuick (&r_post_saturation, r_color_saturation.value);
+	r_color_syncing = false;
+}
 
 extern char r_showbboxes_filter_strings[MAXCMDLINE];
 extern qboolean r_showbboxes_filter_byindex;
@@ -439,6 +465,10 @@ void R_Init (void)
 Cvar_RegisterVariable (&r_norefresh);
 Cvar_RegisterVariable (&r_lightmap);
 Cvar_RegisterVariable (&r_lightmap_linear);
+Cvar_SetCallback (&r_lightmap_linear, TexMgr_LightmapLinearCompat_f);
+Cvar_RegisterVariable (&r_lightmap_colorspace);
+Cvar_SetCallback (&r_lightmap_colorspace, TexMgr_LightmapColorspace_f);
+Cvar_RegisterVariable (&r_lightmap_colorspace_debug);
 Cvar_RegisterVariable (&r_lightmap_mipmaps);
 Cvar_RegisterVariable (&r_lightmap16f);
 Cvar_RegisterVariable (&r_lightingdir);
@@ -497,6 +527,13 @@ Cvar_RegisterVariable (&r_gamma);
 Cvar_RegisterVariable (&r_debug_colorspace);
 Cvar_RegisterVariable (&r_post_contrast);
 Cvar_RegisterVariable (&r_post_saturation);
+Cvar_RegisterVariable (&r_color_midtone);
+Cvar_RegisterVariable (&r_color_contrast);
+Cvar_RegisterVariable (&r_color_saturation);
+Cvar_SetCallback (&r_post_contrast, R_ColorCurveSync_f);
+Cvar_SetCallback (&r_post_saturation, R_ColorCurveSync_f);
+Cvar_SetCallback (&r_color_contrast, R_ColorCurveSync_f);
+Cvar_SetCallback (&r_color_saturation, R_ColorCurveSync_f);
 Cvar_RegisterVariable (&r_bloom);
 Cvar_RegisterVariable (&r_bloom_threshold);
 Cvar_RegisterVariable (&r_ssao);

--- a/Quake/gl_texmgr.c
+++ b/Quake/gl_texmgr.c
@@ -35,10 +35,11 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 extern cvar_t r_lightmap_mipmaps;
 extern cvar_t r_lightmap16f;
 extern cvar_t r_lightmap_linear;
+extern cvar_t r_lightmap_colorspace;
 extern cvar_t r_srgb_textures;
 extern cvar_t r_manual_gamma;
 extern cvar_t r_gamma;
-extern cvar_t r_post_contrast;
+extern cvar_t r_color_contrast;
 
 typedef struct {
 	GLenum		id;
@@ -834,6 +835,18 @@ static const char *TexMgr_InternalFormatName (GLenum format)
 	}
 }
 
+static float TexMgr_SRGBToLinear (float c)
+{
+	if (c <= 0.04045f)
+		return c / 12.92f;
+	return powf ((c + 0.055f) / 1.055f, 2.4f);
+}
+
+static qboolean TexMgr_LightmapUsesSRGB (void)
+{
+	return !q_strcasecmp (r_lightmap_colorspace.string, "srgb");
+}
+
 static void TexMgr_LinearizeWadPixels (gltexture_t *glt, unsigned *data)
 {
 	size_t pixel_count;
@@ -865,6 +878,41 @@ static void TexMgr_LinearizeWadPixels (gltexture_t *glt, unsigned *data)
 void TexMgr_SRGBTextures_f (cvar_t *var)
 {
 	(void)var;
+	TexMgr_ReloadImages ();
+}
+
+static qboolean texmgr_lightmap_colorspace_syncing = false;
+
+void TexMgr_LightmapColorspace_f (cvar_t *var)
+{
+	if (texmgr_lightmap_colorspace_syncing)
+		return;
+
+	if (q_strcasecmp (var->string, "srgb") && q_strcasecmp (var->string, "linear"))
+	{
+		Con_Warning ("r_lightmap_colorspace must be \"srgb\" or \"linear\".\n");
+		texmgr_lightmap_colorspace_syncing = true;
+		Cvar_SetQuick (var, "srgb");
+		texmgr_lightmap_colorspace_syncing = false;
+		return;
+	}
+
+	texmgr_lightmap_colorspace_syncing = true;
+	Cvar_SetValueQuick (&r_lightmap_linear, !q_strcasecmp (var->string, "linear") ? 1.f : 0.f);
+	texmgr_lightmap_colorspace_syncing = false;
+
+	TexMgr_ReloadImages ();
+}
+
+void TexMgr_LightmapLinearCompat_f (cvar_t *var)
+{
+	if (texmgr_lightmap_colorspace_syncing)
+		return;
+
+	texmgr_lightmap_colorspace_syncing = true;
+	Cvar_SetQuick (&r_lightmap_colorspace, (var->value > 0.f) ? "linear" : "srgb");
+	texmgr_lightmap_colorspace_syncing = false;
+
 	TexMgr_ReloadImages ();
 }
 
@@ -2325,6 +2373,9 @@ static void TexMgr_LoadLightmap (gltexture_t *glt, byte *data)
 {
 	qboolean use_mipmaps = (r_lightmap_mipmaps.value > 0.f) && (glt->flags & TEXPREF_MIPMAP);
 	qboolean use_half = (r_lightmap16f.value > 0.f) && (!strstr(glt->name, "lightmap_dir"));
+	qboolean use_srgb = TexMgr_LightmapUsesSRGB ();
+	if (use_srgb)
+		glt->flags |= TEXPREF_SRGB;
 
 	// upload it
 	glt->compression = 1;
@@ -2337,28 +2388,33 @@ static void TexMgr_LoadLightmap (gltexture_t *glt, byte *data)
 	        if (!float_data)
 	                Sys_Error ("TexMgr_LoadLightmap: out of memory on %" SDL_PRIu64 " bytes", (uint64_t)(pixels * sizeof (*float_data)));
 	        for (size_t idx = 0; idx < pixels; idx++)
-	                float_data[idx] = data[idx] * (1.0f / 255.0f);
+	        {
+	                float value = data[idx] * (1.0f / 255.0f);
+	                if (use_srgb)
+	                        value = TexMgr_SRGBToLinear (value);
+	                float_data[idx] = value;
+	        }
 	        GL_TexImage (glt, 0, GL_RGBA16F, glt->width, glt->height, GL_RGBA, GL_FLOAT, float_data);
 	        free (float_data);
 	}
 	else
 	{
-		glt->internal_format = GL_RGBA8;
+		glt->internal_format = use_srgb ? GL_SRGB8_ALPHA8 : GL_RGBA8;
 	        GLsizeiptr upload_size = (GLsizeiptr) glt->width * glt->height * 4;
 	        if (TexMgr_EnsureLightmapUploadBuffer (upload_size))
 	        {
-	                glTexImage2D (glt->target, 0, GL_RGBA8, glt->width, glt->height, 0, gl_lightmap_format, GL_UNSIGNED_BYTE, NULL);
+	                glTexImage2D (glt->target, 0, glt->internal_format, glt->width, glt->height, 0, gl_lightmap_format, GL_UNSIGNED_BYTE, NULL);
 	                memcpy (lightmap_upload_ptr, data, upload_size);
 	                glTexSubImage2D (glt->target, 0, 0, 0, glt->width, glt->height, gl_lightmap_format, GL_UNSIGNED_BYTE, (const GLvoid *) 0);
 	                GL_BindBuffer (GL_PIXEL_UNPACK_BUFFER, 0);
 	        }
 	        else
-	                GL_TexImage (glt, 0, GL_RGBA8, glt->width, glt->height, gl_lightmap_format, GL_UNSIGNED_BYTE, data);
+	                GL_TexImage (glt, 0, glt->internal_format, glt->width, glt->height, gl_lightmap_format, GL_UNSIGNED_BYTE, data);
 	}
 
 #ifdef GL_EXT_texture_sRGB_decode
         glTexParameteri (glt->target, GL_TEXTURE_SRGB_DECODE_EXT,
-                        r_lightmap_linear.value > 0.f ? GL_DECODE_EXT : GL_SKIP_DECODE_EXT);
+                        use_srgb ? GL_DECODE_EXT : GL_SKIP_DECODE_EXT);
 #endif
 
 	TexMgr_LogTextureUpload (glt);
@@ -2989,7 +3045,7 @@ Returns index of palette buffer to use:
 	/* can we use the original palette? */
 	{
 		float gamma = (r_manual_gamma.value > 0.f) ? (1.0f / q_max (0.1f, r_gamma.value)) : 1.0f;
-		float contrast = r_post_contrast.value;
+		float contrast = r_color_contrast.value;
 		if (gamma == 1.f && contrast == 1.f &&
 		blend[3] == 0.f)
 			return 0;
@@ -3012,7 +3068,7 @@ Returns index of palette buffer to use:
 	GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 1, gl_palette_buffer[1], 0, 256 * sizeof (GLuint));
 	{
 		float gamma = (r_manual_gamma.value > 0.f) ? (1.0f / q_max (0.1f, r_gamma.value)) : 1.0f;
-		float contrast = CLAMP (0.1f, r_post_contrast.value, 2.0f);
+		float contrast = CLAMP (0.1f, r_color_contrast.value, 2.0f);
 		GL_Uniform2fFunc (0, gamma, contrast);
 		GL_Uniform1fFunc (2, r_manual_gamma.value > 0.f ? 1.f : 0.f);
 	}

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -433,7 +433,7 @@ typedef struct gpuframedata_s {
         float           lightmap_params[4];
         vec4_t          lightgrid_params; // x: enabled, yzw: unused
         vec4_t          dlight_params;  // x: style, y: debug view, z: pass selector, w: padding
-        vec4_t          colorspace_params; // x: debug mode, yzw: unused
+        vec4_t          colorspace_params; // x: debug mode, y: manual gamma, z: output sRGB, w: unused
         unsigned int    numlights;
         unsigned int    prev_frame_valid;
         unsigned int    _padding1;

--- a/Quake/shaders/postprocess.frag
+++ b/Quake/shaders/postprocess.frag
@@ -142,7 +142,8 @@ layout(location=15) uniform vec4 FilmGrainParams2; // x: frame, yzw: unused
 layout(location=16) uniform vec4 GodraysParams; // x: enabled, y: debug, z: debug source mode, w: unused
 layout(location=17) uniform vec4 SSAOParams; // x: intensity, y: debug mode, z: upscale nearest, w: unused
 layout(location=18) uniform vec4 SSAOBlurParams; // x: blur sigma, y: blur radius, z: depth threshold scale, w: unused
-layout(location=19) uniform vec2 ColorSpaceParams; // x: debug mode, y: manual gamma enabled
+layout(location=19) uniform vec4 ColorSpaceParams; // x: debug mode, y: manual gamma enabled, z: output sRGB conversion, w: reserved
+layout(location=20) uniform float u_midtone;
 
 const int MOTION_MAX_SAMPLES = 64;
 const float OPAQUE_ALPHA_THRESHOLD = 0.999;
@@ -283,6 +284,14 @@ vec3 ApplySaturation(vec3 color, float saturation)
         return mix(vec3(luma), color, saturation);
 }
 
+vec3 LinearToSRGB(vec3 color)
+{
+        vec3 cutoff = step(vec3(0.0031308), color);
+        vec3 lower = color * 12.92;
+        vec3 higher = 1.055 * pow(color, vec3(1.0 / 2.4)) - 0.055;
+        return mix(lower, higher, cutoff);
+}
+
 void AccumulateMotionSample(inout vec3 accum, inout float weight, vec2 sampleUV, vec2 sampleCoordPx, vec2 viewMin, vec2 viewMax, DepthSamplingInfo info, bool useDepth, float centerDepth, float depthThresholdRatio)
 {
         if (!all(greaterThanEqual(sampleUV, viewMin)) || !all(lessThanEqual(sampleUV, viewMax)))
@@ -311,6 +320,7 @@ void main()
         float dither = Params.w;
         int debugMode = int(floor(ColorSpaceParams.x + 0.5));
         float manualGamma = ColorSpaceParams.y;
+        float outputSrgb = ColorSpaceParams.z;
         ivec2 pixel = ivec2(gl_FragCoord.xy);
         vec4 color = texelFetch(GammaTexture, pixel, 0);
         bool centerOpaque = color.a >= OPAQUE_ALPHA_THRESHOLD;
@@ -658,10 +668,15 @@ void main()
                 out_fragcolor = vec4(maxHdr > 1.0 ? vec3(1.0, 0.0, 0.0) : vec3(0.0), 1.0);
                 return;
         }
+        float midtone = max(u_midtone, 0.1);
+        if (abs(midtone - 1.0) > 1e-4)
+                mapped = pow(mapped, vec3(1.0 / midtone));
         mapped = ApplyPostContrast(mapped, postContrast);
         mapped = ApplySaturation(mapped, u_saturation);
         if (manualGamma > 0.5)
                 mapped = pow(mapped, vec3(gamma));
+        if (outputSrgb > 0.5)
+                mapped = LinearToSRGB(mapped);
         out_fragcolor = vec4(mapped, 1.0);
 #endif // PALETTIZE
 

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -356,6 +356,15 @@ void main()
 		static_light *= ndl;
 	}
 
+	if (LightmapParams.x > 0.5)
+	{
+		OUT_COLOR = vec4(clamp(static_light, 0.0, 1.0), 1.0);
+#if !OIT
+		out_velocity = vec4(0.0);
+#endif
+		return;
+	}
+
 	// Surface normal computation
 	vec3 surface_normal = in_normal;
 	float surface_normal_len = length(surface_normal);


### PR DESCRIPTION
### Motivation
- Move lighting/compositing to a single linear HDR path while restoring a Quake-like final “punch” via a controllable postprocess curve. 
- Ensure albedo textures are treated as sRGB and non-color data remains linear, and give explicit control over how baked lightmaps are interpreted. 
- Provide exactly one place for final output transforms to prevent double gamma-correction and ambiguous legacy behavior. 
- Make changes minimally invasive by extending existing FBO/pass/texture management and reusing current postprocess shaders.

### Description
- Added new color control CVARs and hooks: `r_color_midtone`, `r_color_contrast`, `r_color_saturation`, `r_lightmap_colorspace` and `r_lightmap_colorspace_debug`, plus compatibility sync callbacks with legacy `r_post_*` and `r_lightmap_linear` (files changed: `Quake/gl_rmain.c`, `Quake/gl_rmisc.c`).
- Implemented a hybrid linear postprocess flow: midtone→contrast→saturation applied in the post pass and a single optional linear→sRGB conversion executed in the final postprocess shader if the backbuffer is not sRGB-capable (files changed: `Quake/shaders/postprocess.frag`, `Quake/gl_rmain.c`).
- Lightmap colorspace handling in the texture manager: `TexMgr_LightmapColorspace_f` and `TexMgr_LightmapLinearCompat_f`, `TexMgr_SRGBToLinear`, and conditional upload/decoding so lightmaps can be uploaded as `GL_SRGB8_ALPHA8` or converted to linear float when needed (file changed: `Quake/gl_texmgr.c`).
- Small shader and uniform plumbing: pass midtone and output-sRGB flags into postprocess, add a lightmap debug output path in `world.frag` for quick visualization, and update palette postprocess to use the new contrast CVAR (files changed: `Quake/shaders/world.frag`, `Quake/shaders/postprocess.frag`, `Quake/glquake.h`).

### Testing
- No automated tests were executed as part of this change. 
- Changes were compiled and committed locally (no test harness run). 
- Runtime validation (manual visual checks / QA) is expected to verify: single final sRGB transform, lightmap srgb|linear toggle behavior, and familiar Quake midtone/contrast look. 
- Recommend running the project test suite and a visual testpattern (gamma/gray ramps + lightmap debug) before merging to confirm no double-gamma regressions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952414a06bc832eb07655ae136d0253)