### PR TITLE
Limit dlight flicker to explosion/fire/lava

### DIFF
--- a/Quake/cl_main.c
+++ b/Quake/cl_main.c
@@ -427,7 +427,10 @@ static void CL_UpdateDlightArray (dlight_t *dl, int count, float frametime)
 		if (dl->baseradius < 0)
 			dl->baseradius = 0;
 
-		dl->radius = dl->baseradius * (1.0f + 0.1f * (float) sin (cl.time * 9.0 + dl->flicker_seed));
+		if (CL_DlightShouldFlicker (dl))
+			dl->radius = dl->baseradius * (1.0f + 0.1f * (float) sin (cl.time * 9.0 + dl->flicker_seed));
+		else
+			dl->radius = dl->baseradius;
 		if (dl->radius < 0)
 			dl->radius = 0;
 	}
@@ -571,9 +574,16 @@ static void CL_SetDlightColorForEntity (dlight_t *dl, const entity_t *ent)
                 return;
         }
 
+        if (name && (q_strcasestr (name, "fire") || q_strcasestr (name, "flame") || q_strcasestr (name, "torch")))
+        {
+                dl->type = DLIGHT_TORCH;
+                return;
+        }
+
         if (name && q_strcasestr (name, "lava"))
         {
                 dl->color[0] = 1.00f; dl->color[1] = 0.15f; dl->color[2] = 0.05f;
+                dl->type = DLIGHT_LAVA;
                 return;
         }
 
@@ -1180,4 +1190,3 @@ void CL_Init (void)
 
 	Cmd_AddCommand_ServerCommand ("v_water", V_Water_f);
 }
-

--- a/Quake/client.h
+++ b/Quake/client.h
@@ -80,6 +80,7 @@ typedef enum
 	DLIGHT_EXPLOSION,
 	DLIGHT_TORCH,
 	DLIGHT_TELEPORT,
+	DLIGHT_LAVA,
 	DLIGHT_MAX_TYPES
 } dlighttype_t;
 typedef struct
@@ -345,6 +346,11 @@ extern	int				cl_numvisedicts;
 static inline qboolean CL_DlightIsActive (const dlight_t *dl)
 {
 	return dl && dl->die >= cl.time && dl->spawn <= cl.time && dl->baseradius > 0;
+}
+
+static inline qboolean CL_DlightShouldFlicker (const dlight_t *dl)
+{
+	return dl && (dl->type == DLIGHT_EXPLOSION || dl->type == DLIGHT_TORCH || dl->type == DLIGHT_LAVA);
 }
 
 extern	entity_t		*cl_entities; //johnfitz -- was a static array, now on hunk

--- a/Quake/gl_rlight.c
+++ b/Quake/gl_rlight.c
@@ -289,6 +289,7 @@ const vec3_t *R_GetDynamicLightTemperature (int type)
 		{ 1.30f, 1.00f, 0.50f }, // explosion
 		{ 1.30f, 1.10f, 0.80f }, // torch
 		{ 1.00f, 0.60f, 1.50f }, // teleport
+		{ 1.20f, 0.40f, 0.20f }, // lava
 	};
 
 	if (type < 0 || type >= DLIGHT_MAX_TYPES)
@@ -345,7 +346,10 @@ static void R_PushDlightArray (dlight_t *lights, int count)
 		if (!CL_DlightIsActive (l))
 			continue;
 
-		radius = l->baseradius * (1.f + 0.1f * (float) sin (cl.time * 9.0 + l->flicker_seed));
+		if (CL_DlightShouldFlicker (l))
+			radius = l->baseradius * (1.f + 0.1f * (float) sin (cl.time * 9.0 + l->flicker_seed));
+		else
+			radius = l->baseradius;
 		radius = q_max (radius, 0.f);
 		l->radius = radius;
 
@@ -364,14 +368,17 @@ static void R_PushDlightArray (dlight_t *lights, int count)
 		out = &r_lightbuffer.lights[r_framedata.numlights++];
 		const vec3_t *temp = R_GetDynamicLightTemperature (l->type);
 		float radiusFactor = q_min (1.f, q_max (radius / 350.f, 0.2f));
-		float flicker = 1.f + (float)sin (cl.time * 15.0 + l->key) * 0.1f;
 		vec3_t finalcolor;
 		finalcolor[0] = l->color[0] * (*temp)[0] * radiusFactor;
 		finalcolor[1] = l->color[1] * (*temp)[1] * radiusFactor;
 		finalcolor[2] = l->color[2] * (*temp)[2] * radiusFactor;
-		finalcolor[0] *= flicker;
-		finalcolor[1] *= flicker;
-		finalcolor[2] *= flicker;
+		if (CL_DlightShouldFlicker (l))
+		{
+			float flicker = 1.f + (float)sin (cl.time * 15.0 + l->key) * 0.1f;
+			finalcolor[0] *= flicker;
+			finalcolor[1] *= flicker;
+			finalcolor[2] *= flicker;
+		}
 		if (l->type == DLIGHT_TORCH)
 		{
 			float colorshift = (float)sin (cl.time * 11.0 + l->key) * 0.1f;


### PR DESCRIPTION
### Motivation
- Reduce visual flicker noise by only applying radius/color flicker to lights that should visually flicker (explosions, torches/fire, and lava).
- Provide a distinct lava dlight type so lava can receive its own tint and flicker behavior.
- Centralize the flicker policy so other code paths can consistently query which dlights should flicker.

### Description
- Added `DLIGHT_LAVA` to `dlighttype_t` and added a helper `CL_DlightShouldFlicker` in `client.h` to identify flickering dlight types.
- Updated `CL_UpdateDlightArray` and `R_PushDlightArray` to use `CL_DlightShouldFlicker` so radius and color flicker are only applied for explosion/torch/lava lights.
- Added a lava temperature entry in `R_GetDynamicLightTemperature` and set entity dlight types in `CL_SetDlightColorForEntity` so flame-like names map to `DLIGHT_TORCH` and lava to `DLIGHT_LAVA`.

### Testing
- No automated tests were run on this change.
- The changes were committed locally (`git commit`) after applying the edits to `Quake/client.h`, `Quake/cl_main.c`, and `Quake/gl_rlight.c`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695247645514832e83b2c40e191a9890)