### PR TITLE
Implement dynamic dlight pool with deterministic prioritization and GPU budget

### DIFF
--- a/Quake/cl_main.c
+++ b/Quake/cl_main.c
@@ -24,6 +24,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "quakedef.h"
 #include "bgmusic.h"
 #include "../common/lightgrid.h"
+#include "r_dlight_pool.h"
 
 // we need to declare some mouse variables here, because the menu system
 // references them even when on a unix system.
@@ -61,9 +62,6 @@ client_state_t	cl;
 entity_t		cl_static_entities[MAX_STATIC_ENTITIES];
 lightstyle_t	cl_lightstyle[MAX_LIGHTSTYLES];
 int					cl_max_lightstyles = MAX_LIGHTSTYLES;
-dlight_t		cl_dlights[MAX_DLIGHTS];
-dlight_t		cl_entity_dlights[MAX_ENTITY_DLIGHTS];
-int				cl_num_entity_dlights;
 
 entity_t		*cl_entities; //johnfitz -- was a static array, now on hunk
 int				cl_max_edicts; //johnfitz -- only changes when new map loads
@@ -111,9 +109,7 @@ void CL_ClearState (void)
 	SZ_Clear (&cls.message);
 
 // clear other arrays
-	memset (cl_dlights, 0, sizeof(cl_dlights));
-	memset (cl_entity_dlights, 0, sizeof(cl_entity_dlights));
-	cl_num_entity_dlights = 0;
+	DLightPool_Clear ();
 	memset (cl_lightstyle, 0, sizeof(cl_lightstyle));
 	cl_max_lightstyles = MAX_LIGHTSTYLES;
 	memset (cl_temp_entities, 0, sizeof(cl_temp_entities));
@@ -171,6 +167,7 @@ void CL_Disconnect (void)
 	CL_ClearSignons ();
 
 	V_ResetEffects ();
+	DLightPool_Clear ();
 }
 
 void CL_Disconnect_f (void)
@@ -361,52 +358,16 @@ CL_AllocDlight
 */
 dlight_t *CL_AllocDlight (int key)
 {
-	int		i;
-	dlight_t	*dl;
+	dlight_t *dl = DLightPool_AllocTransientByKey (key, cl.time);
 
-// first look for an exact key match
-	if (key)
-	{
-		dl = cl_dlights;
-                for (i=0 ; i<MAX_DLIGHTS ; i++, dl++)
-                {
-                        if (dl->key == key)
-                        {
-                                memset (dl, 0, sizeof(*dl));
-                                dl->key = key;
-                                dl->color[0] = dl->color[1] = dl->color[2] = 1; //johnfitz -- lit support via lordhavoc
-                                dl->type = DLIGHT_DEFAULT;
-                                dl->spawn = cl.time - 0.001;
-                                dl->flicker_seed = (float) rand ();
-                                return dl;
-                        }
-                }
-        }
-
-// then look for anything else
-	dl = cl_dlights;
-	for (i=0 ; i<MAX_DLIGHTS ; i++, dl++)
-	{
-                if (dl->die < cl.time || dl->spawn > cl.time)
-                {
-                        memset (dl, 0, sizeof(*dl));
-                        dl->key = key;
-                        dl->color[0] = dl->color[1] = dl->color[2] = 1; //johnfitz -- lit support via lordhavoc
-                        dl->type = DLIGHT_DEFAULT;
-                        dl->spawn = cl.time - 0.001;
-                        dl->flicker_seed = (float) rand ();
-                        return dl;
-                }
-        }
-
-        dl = &cl_dlights[0];
-        memset (dl, 0, sizeof(*dl));
-        dl->key = key;
-        dl->color[0] = dl->color[1] = dl->color[2] = 1; //johnfitz -- lit support via lordhavoc
-        dl->type = DLIGHT_DEFAULT;
-        dl->spawn = cl.time - 0.001;
-        dl->flicker_seed = (float) rand ();
-        return dl;
+	dl->key = key;
+	dl->color[0] = dl->color[1] = dl->color[2] = 1; //johnfitz -- lit support via lordhavoc
+	dl->type = DLIGHT_DEFAULT;
+	dl->spawn = cl.time - 0.001;
+	dl->flicker_seed = (float) rand ();
+	dl->active = true;
+	dl->kind = DL_TRANSIENT;
+	return dl;
 }
 
 
@@ -416,26 +377,6 @@ CL_DecayLights
 
 ===============
 */
-static void CL_UpdateDlightArray (dlight_t *dl, int count, float frametime)
-{
-	for (int i = 0; i < count; i++, dl++)
-	{
-		if (dl->die < cl.time || dl->spawn > cl.time || !dl->baseradius)
-			continue;
-
-		dl->baseradius -= frametime*dl->decay;
-		if (dl->baseradius < 0)
-			dl->baseradius = 0;
-
-		if (CL_DlightShouldFlicker (dl))
-			dl->radius = dl->baseradius * (1.0f + 0.1f * (float) sin (cl.time * 9.0 + dl->flicker_seed));
-		else
-			dl->radius = dl->baseradius;
-		if (dl->radius < 0)
-			dl->radius = 0;
-	}
-}
-
 /*
 ===============
 CL_DecayLights
@@ -446,9 +387,7 @@ void CL_DecayLights (void)
 	float time;
 
 	time = cl.time - cl.oldtime;
-
-	CL_UpdateDlightArray (cl_dlights, MAX_DLIGHTS, time);
-	CL_UpdateDlightArray (cl_entity_dlights, cl_num_entity_dlights, time);
+	DLightPool_Decay (time, cl.time);
 }
 
 
@@ -853,7 +792,6 @@ int CL_ReadFromServer (void)
 	int			num_beams = 0; //johnfitz
 	int			num_dlights = 0; //johnfitz
 	beam_t		*b; //johnfitz
-	dlight_t	*l; //johnfitz
 	int			i; //johnfitz
 
 	CL_AdvanceTime ();
@@ -899,15 +837,14 @@ int CL_ReadFromServer (void)
 	dev_stats.beams = num_beams;
 	dev_peakstats.beams = q_max(num_beams, dev_peakstats.beams);
 
-        //dlights
-        for (i=0, l=cl_dlights ; i<MAX_DLIGHTS ; i++, l++)
-                if (l->die >= cl.time && l->spawn <= cl.time && l->baseradius)
-                        num_dlights++;
-        for (i=0, l=cl_entity_dlights ; i<cl_num_entity_dlights ; i++, l++)
-                if (l->die >= cl.time && l->spawn <= cl.time && l->baseradius)
-                        num_dlights++;
+	//dlights
+	{
+		dlight_pool_stats_t stats;
+		DLightPool_GetStats (&stats);
+		num_dlights = stats.active;
+	}
 	if (num_dlights > 32 && dev_peakstats.dlights <= 32)
-		Con_DWarning ("%i dlights exceeded standard limit of 32 (max = %d).\n", num_dlights, MAX_DLIGHTS);
+		Con_DWarning ("%i dlights exceeded standard limit of 32 (max = %d).\n", num_dlights, DLIGHT_GPU_MAX);
 	dev_stats.dlights = num_dlights;
 	dev_peakstats.dlights = q_max(num_dlights, dev_peakstats.dlights);
 
@@ -1138,6 +1075,7 @@ void CL_Init (void)
 
 	CL_InitInput ();
 	CL_InitTEnts ();
+	DLightPool_Init ();
 
 	Cvar_RegisterVariable (&cl_name);
 	Cvar_RegisterVariable (&cl_color);

--- a/Quake/client.h
+++ b/Quake/client.h
@@ -69,8 +69,6 @@ extern cshift_t		cshift_empty;
 
 #define	SIGNONS		4			// signon messages to receive before connected
 
-#define	MAX_DLIGHTS		64 //johnfitz -- was 32
-#define	MAX_ENTITY_DLIGHTS		64 // persistent dlights spawned from BSP entities
 typedef enum
 {
 	DLIGHT_DEFAULT = 0,
@@ -83,7 +81,12 @@ typedef enum
 	DLIGHT_LAVA,
 	DLIGHT_MAX_TYPES
 } dlighttype_t;
-typedef struct
+typedef enum
+{
+	DL_TRANSIENT = 0,
+	DL_PERSISTENT
+} dlight_kind_t;
+typedef struct dlight_s
 {
 	vec3_t	origin;
 	float	radius;
@@ -97,6 +100,13 @@ typedef struct
 	float	flicker_seed;
 	dlighttype_t type;
 	int		style;			// optional light style/flicker index (entity dlights)
+	int		id;
+	dlight_kind_t kind;
+	qboolean active;
+	float	spawn_time;
+	float	last_score;
+	int		flags;
+	int		last_frame_touched;
 } dlight_t;
 
 #define	MAX_BEAMS	32 //johnfitz -- was 24
@@ -335,9 +345,6 @@ extern	client_state_t	cl;
 extern	entity_t		cl_static_entities[MAX_STATIC_ENTITIES];
 extern	int			cl_max_lightstyles;
 extern	lightstyle_t	cl_lightstyle[MAX_LIGHTSTYLES];
-extern	dlight_t		cl_dlights[MAX_DLIGHTS];
-extern	dlight_t		cl_entity_dlights[MAX_ENTITY_DLIGHTS];
-extern	int			cl_num_entity_dlights;
 extern	entity_t		cl_temp_entities[MAX_TEMP_ENTITIES];
 extern	beam_t			cl_beams[MAX_BEAMS];
 extern	entity_t		*cl_visedicts[MAX_VISEDICTS];
@@ -345,7 +352,7 @@ extern	int				cl_numvisedicts;
 
 static inline qboolean CL_DlightIsActive (const dlight_t *dl)
 {
-	return dl && dl->die >= cl.time && dl->spawn <= cl.time && dl->baseradius > 0;
+	return dl && dl->active && dl->die >= cl.time && dl->spawn <= cl.time && dl->baseradius > 0;
 }
 
 static inline qboolean CL_DlightShouldFlicker (const dlight_t *dl)

--- a/Quake/gl_rlight.c
+++ b/Quake/gl_rlight.c
@@ -24,6 +24,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "quakedef.h"
 #include "../common/lightgrid.h"
 #include "gl_lightgrid.h"
+#include "r_dlight_pool.h"
 #include <float.h>
 #include <math.h>
 
@@ -76,14 +77,10 @@ static qboolean R_ParseDlightOrigin (const char *value, vec3_t origin)
 	return value && sscanf (value, "%f %f %f", &origin[0], &origin[1], &origin[2]) == 3;
 }
 
-static void R_AddEntityDlight (const vec3_t origin, float radius, const vec3_t color, int style)
+static void R_AddEntityDlight (const vec3_t origin, float radius, const vec3_t color, int style, int key)
 {
-	if (cl_num_entity_dlights >= MAX_ENTITY_DLIGHTS)
-		return;
+	dlight_t *dl = DLightPool_GetOrCreatePersistent (key, cl.time);
 
-	dlight_t *dl = &cl_entity_dlights[cl_num_entity_dlights++];
-
-	memset (dl, 0, sizeof(*dl));
 	VectorCopy (origin, dl->origin);
 	VectorCopy (color, dl->color);
 	dl->baseradius = radius;
@@ -92,10 +89,12 @@ static void R_AddEntityDlight (const vec3_t origin, float radius, const vec3_t c
 	dl->die = FLT_MAX;
 	dl->decay = 0.f;
 	dl->minlight = 0.f;
-	dl->key = -(1000 + cl_num_entity_dlights);
+	dl->key = key;
 	dl->type = DLIGHT_DEFAULT;
 	dl->style = style;
 	dl->flicker_seed = (float) rand ();
+	dl->kind = DL_PERSISTENT;
+	dl->active = true;
 }
 
 // Parse BSP entity lump for persistent dynamic lights.
@@ -110,9 +109,9 @@ static void R_AddEntityDlight (const vec3_t origin, float radius, const vec3_t c
 void R_ParseDlightEntities (void)
 {
 	const char *data;
+	int entity_dlight_count = 0;
 
-	memset (cl_entity_dlights, 0, sizeof (cl_entity_dlights));
-	cl_num_entity_dlights = 0;
+	DLightPool_ClearPersistent ();
 
 	if (!cl.worldmodel || !cl.worldmodel->entities)
 		return;
@@ -172,24 +171,31 @@ void R_ParseDlightEntities (void)
 
 		if ((classname_is_dlight || (classname_is_light && marked_dynamic)) && radius > 0.f && parsed_origin)
 		{
-			R_AddEntityDlight (origin, radius, color, style);
-			if (cl_num_entity_dlights >= MAX_ENTITY_DLIGHTS)
-				break;
+			const int key = -(1000 + ++entity_dlight_count);
+			R_AddEntityDlight (origin, radius, color, style, key);
 		}
 
 		data = COM_Parse (data);
 	}
 
-	if (cl_num_entity_dlights || developer.value)
+	if (entity_dlight_count || developer.value)
 	{
-		const int debugcount = q_min (cl_num_entity_dlights, 5);
-		Con_DPrintf ("Spawned %d entity dlights (showing %d):\n", cl_num_entity_dlights, debugcount);
-		for (int i = 0; i < debugcount; i++)
+		int active_count = 0;
+		const dlight_t *const *active = DLightPool_GetActiveList (&active_count);
+		int shown = 0;
+
+		Con_DPrintf ("Spawned %d entity dlights (showing %d):\n",
+				entity_dlight_count, q_min (entity_dlight_count, 5));
+
+		for (int i = 0; i < active_count && shown < 5; i++)
 		{
-			const dlight_t *dl = &cl_entity_dlights[i];
-			Con_DPrintf ("  #%d origin %.1f %.1f %.1f radius %.1f color %.2f %.2f %.2f style %d\n", i,
+			const dlight_t *dl = active[i];
+			if (dl->kind != DL_PERSISTENT)
+				continue;
+			Con_DPrintf ("  #%d origin %.1f %.1f %.1f radius %.1f color %.2f %.2f %.2f style %d\n", shown,
 					dl->origin[0], dl->origin[1], dl->origin[2], dl->baseradius,
 					dl->color[0], dl->color[1], dl->color[2], dl->style);
+			shown++;
 		}
 	}
 	return;
@@ -326,13 +332,13 @@ void GLLight_DeleteResources (void)
 	gl_lightclustertexture = 0;
 }
 
-static void R_PushDlightArray (dlight_t *lights, int count)
+static void R_PushDlightArray (dlight_t *const *lights, int count)
 {
 	int	j;
 
 	for (int i = 0; i < count; i++)
 	{
-		dlight_t *l = &lights[i];
+		dlight_t *l = lights[i];
 		gpulight_t *out;
 		qboolean cull = false;
 		float radius;
@@ -407,6 +413,7 @@ void R_PushDlights (void)
 	GLuint		buf;
 	GLbyte		*ofs;
 	gpu_cluster_inputs_t cluster_inputs;
+	dlight_t *submit[DLIGHT_GPU_MAX];
 
 	r_framedata.numlights = 0;
 
@@ -416,9 +423,17 @@ void R_PushDlights (void)
         // was disabled by the user.
         if (r_dynamic.value > 0.f || r_dlight_style.value > 0.f)
         {
-                R_PushDlightArray (cl_dlights, MAX_DLIGHTS);
-                if (r_dlight_entities.value > 0.f && cl_num_entity_dlights > 0)
-			R_PushDlightArray (cl_entity_dlights, cl_num_entity_dlights);
+		const int budget = q_min (DLightPool_GetBudget (), DLIGHT_GPU_MAX);
+		DLightPool_NewFrame (cl.time, r_framecount);
+		const int num_submit = DLightPool_CollectForRender (cl.time, r_refdef.vieworg, r_viewleaf, submit, budget);
+		if (num_submit > 0)
+			R_PushDlightArray (submit, num_submit);
+		DLightPool_DebugPrintIfEnabled ();
+	}
+	else
+	{
+		DLightPool_NewFrame (cl.time, r_framecount);
+		DLightPool_DebugPrintIfEnabled ();
 	}
 
 	GL_BeginGroup ("Light clustering");
@@ -492,13 +507,16 @@ void R_LightgridLighting (const vec3_t pos, vec3_t out_color, float *out_ao)
 R_AddDynamicLights_Lightgrid
 ==================
 */
-static void R_AddDynamicLights_LightgridArray (const dlight_t *lights, int count, const vec3_t pos, vec3_t lightcolor)
+static void R_AddDynamicLights_LightgridArray (const dlight_t *const *lights, int count, const vec3_t pos, vec3_t lightcolor)
 {
 	for (int i = 0; i < count; i++)
 	{
-		const dlight_t *l = &lights[i];
+		const dlight_t *l = lights[i];
 		vec3_t dist;
 		float add;
+
+		if (l->kind == DL_PERSISTENT && r_dlight_entities.value <= 0.f)
+			continue;
 
 		if (!CL_DlightIsActive (l))
 			continue;
@@ -519,9 +537,10 @@ void R_AddDynamicLights_Lightgrid (const vec3_t pos, vec3_t lightcolor)
 	if (!r_dynamic.value)
 		return;
 
-	R_AddDynamicLights_LightgridArray (cl_dlights, MAX_DLIGHTS, pos, lightcolor);
-	if (r_dlight_entities.value > 0.f && cl_num_entity_dlights > 0)
-		R_AddDynamicLights_LightgridArray (cl_entity_dlights, cl_num_entity_dlights, pos, lightcolor);
+	int count = 0;
+	const dlight_t *const *active = DLightPool_GetActiveList (&count);
+	if (active && count > 0)
+		R_AddDynamicLights_LightgridArray (active, count, pos, lightcolor);
 }
 
 

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -25,6 +25,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "quakedef.h"
 #include "gl_lightgrid.h"
 #include "r_maptex_export.h"
+#include "r_dlight_pool.h"
 
 //johnfitz -- new cvars
 extern cvar_t r_clearcolor;
@@ -486,6 +487,7 @@ Cvar_RegisterVariable (&r_drawviewmodel);
         Cvar_RegisterVariable (&r_dlight_style);
         Cvar_RegisterVariable (&r_dlight_debug);
         Cvar_RegisterVariable (&r_dlight_entities);
+	DLightPool_RegisterCvars ();
         Cvar_RegisterVariable (&r_novis);
 #if defined(USE_SIMD)
         Cvar_RegisterVariable (&r_simd);

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -414,9 +414,11 @@ typedef struct gpulight_s {
 	float	minlight;
 } gpulight_t;
 
+#define DLIGHT_GPU_MAX 64
+
 typedef struct gpulightbuffer_s {
 	float		lightstyles[MAX_LIGHTSTYLES * 2];
-	gpulight_t	lights[MAX_DLIGHTS];
+	gpulight_t	lights[DLIGHT_GPU_MAX];
 } gpulightbuffer_t;
 
 typedef struct gpuframedata_s {

--- a/Quake/r_dlight_pool.c
+++ b/Quake/r_dlight_pool.c
@@ -1,0 +1,500 @@
+#include "quakedef.h"
+#include "r_dlight_pool.h"
+#include <float.h>
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+
+extern cvar_t r_dlight_debug;
+extern cvar_t r_dlight_entities;
+
+typedef struct dlight_pool_s
+{
+	dlight_t *items;
+	int capacity;
+	int next_id;
+	int framecount;
+	double time;
+	vec3_t last_vieworg;
+	qboolean has_vieworg;
+	dlight_t **scratch;
+	int scratch_capacity;
+	dlight_pool_stats_t stats;
+} dlight_pool_t;
+
+static dlight_pool_t dlight_pool;
+static dlight_t dlight_fallback;
+
+cvar_t r_dlight_budget = { "r_dlight_budget", "64", CVAR_ARCHIVE };
+cvar_t r_dlight_pool_max = { "r_dlight_pool_max", "512", CVAR_ARCHIVE };
+
+int DLightPool_GetBudget (void)
+{
+	return CLAMP (0, (int)r_dlight_budget.value, 1024);
+}
+
+static int DLightPool_GetPoolMax (void)
+{
+	return CLAMP (0, (int)r_dlight_pool_max.value, 8192);
+}
+
+static void DLightPool_ClampCvar (cvar_t *var, int minval, int maxval)
+{
+	const int value = (int)var->value;
+	const int clamped = CLAMP (minval, value, maxval);
+	if (clamped != value)
+		Cvar_SetValueQuick (var, (float)clamped);
+}
+
+static void DLightPool_Budget_Changed (cvar_t *var)
+{
+	DLightPool_ClampCvar (var, 0, 1024);
+}
+
+static void DLightPool_PoolMax_Changed (cvar_t *var)
+{
+	DLightPool_ClampCvar (var, 0, 8192);
+}
+
+void DLightPool_RegisterCvars (void)
+{
+	Cvar_RegisterVariable (&r_dlight_budget);
+	Cvar_RegisterVariable (&r_dlight_pool_max);
+	Cvar_SetCallback (&r_dlight_budget, DLightPool_Budget_Changed);
+	Cvar_SetCallback (&r_dlight_pool_max, DLightPool_PoolMax_Changed);
+}
+
+static void DLightPool_ResetStats (void)
+{
+	memset (&dlight_pool.stats, 0, sizeof (dlight_pool.stats));
+}
+
+void DLightPool_Init (void)
+{
+	memset (&dlight_pool, 0, sizeof (dlight_pool));
+	memset (&dlight_fallback, 0, sizeof (dlight_fallback));
+	dlight_pool.next_id = 1;
+}
+
+void DLightPool_Shutdown (void)
+{
+	free (dlight_pool.items);
+	free (dlight_pool.scratch);
+	DLightPool_Init ();
+}
+
+void DLightPool_Clear (void)
+{
+	if (dlight_pool.items && dlight_pool.capacity > 0)
+		memset (dlight_pool.items, 0, sizeof (dlight_pool.items[0]) * dlight_pool.capacity);
+	dlight_pool.next_id = 1;
+	DLightPool_ResetStats ();
+}
+
+void DLightPool_ClearPersistent (void)
+{
+	for (int i = 0; i < dlight_pool.capacity; i++)
+	{
+		dlight_t *dl = &dlight_pool.items[i];
+		if (dl->active && dl->kind == DL_PERSISTENT)
+			dl->active = false;
+	}
+}
+
+static void DLightPool_EnsureScratch (int needed)
+{
+	if (needed <= dlight_pool.scratch_capacity)
+		return;
+
+	dlight_pool.scratch = (dlight_t **)realloc (dlight_pool.scratch, sizeof (dlight_pool.scratch[0]) * needed);
+	dlight_pool.scratch_capacity = needed;
+}
+
+static void DLightPool_EnsureCapacity (int desired)
+{
+	const int pool_max = DLightPool_GetPoolMax ();
+	if (desired > pool_max)
+		desired = pool_max;
+	if (desired <= dlight_pool.capacity)
+		return;
+
+	int new_capacity = dlight_pool.capacity ? dlight_pool.capacity * 2 : 64;
+	if (new_capacity < desired)
+		new_capacity = desired;
+	if (new_capacity > pool_max)
+		new_capacity = pool_max;
+	if (new_capacity <= dlight_pool.capacity)
+		return;
+
+	dlight_pool.items = (dlight_t *)realloc (dlight_pool.items, sizeof (dlight_pool.items[0]) * new_capacity);
+	memset (dlight_pool.items + dlight_pool.capacity, 0, sizeof (dlight_pool.items[0]) * (new_capacity - dlight_pool.capacity));
+	dlight_pool.capacity = new_capacity;
+}
+
+static void DLightPool_ResetLight (dlight_t *dl, dlight_kind_t kind, double time)
+{
+	memset (dl, 0, sizeof (*dl));
+	dl->id = dlight_pool.next_id++;
+	dl->kind = kind;
+	dl->active = true;
+	dl->spawn_time = (float)time;
+	dl->spawn = (float)time;
+	dl->die = (kind == DL_PERSISTENT) ? FLT_MAX : (float)time;
+	dl->last_frame_touched = dlight_pool.framecount;
+}
+
+static float DLightPool_ScoreLight (dlight_t *dl, double time, const vec3_t vieworg)
+{
+	vec3_t delta;
+	float dist;
+	float influence;
+	float lum;
+	float bias = 1.f;
+	float radius = dl->radius > 0.f ? dl->radius : dl->baseradius;
+
+	VectorSubtract (vieworg, dl->origin, delta);
+	dist = VectorLength (delta);
+	influence = radius / q_max (dist, 1.f);
+	lum = q_max (dl->color[0], q_max (dl->color[1], dl->color[2]));
+
+	if (dl->kind == DL_TRANSIENT)
+	{
+		float age = (float)(time - dl->spawn_time);
+		float boost = 1.f - age * 0.5f;
+		boost = CLAMP (0.5f, boost, 1.f);
+		bias *= boost;
+	}
+	else
+	{
+		bias *= 1.05f;
+	}
+
+	return influence * lum * bias;
+}
+
+static int DLightPool_CompareScore (const void *a, const void *b)
+{
+	const dlight_t *dl_a = *(const dlight_t *const *)a;
+	const dlight_t *dl_b = *(const dlight_t *const *)b;
+
+	if (dl_a->last_score > dl_b->last_score)
+		return -1;
+	if (dl_a->last_score < dl_b->last_score)
+		return 1;
+	if (dl_a->spawn_time > dl_b->spawn_time)
+		return -1;
+	if (dl_a->spawn_time < dl_b->spawn_time)
+		return 1;
+	if (dl_a->id < dl_b->id)
+		return -1;
+	if (dl_a->id > dl_b->id)
+		return 1;
+	return 0;
+}
+
+static dlight_t *DLightPool_EvictWorstTransient (double time)
+{
+	int best_index = -1;
+	float best_score = FLT_MAX;
+
+	for (int i = 0; i < dlight_pool.capacity; i++)
+	{
+		dlight_t *dl = &dlight_pool.items[i];
+		if (!dl->active || dl->kind != DL_TRANSIENT)
+			continue;
+
+		if (dl->die < time)
+			continue;
+
+		float score = 0.f;
+		if (dlight_pool.has_vieworg)
+			score = DLightPool_ScoreLight (dl, dlight_pool.time, dlight_pool.last_vieworg);
+
+		if (score < best_score)
+		{
+			best_score = score;
+			best_index = i;
+		}
+		else if (score == best_score && best_index >= 0)
+		{
+			const dlight_t *best = &dlight_pool.items[best_index];
+			if (dl->spawn_time < best->spawn_time || (dl->spawn_time == best->spawn_time && dl->id > best->id))
+				best_index = i;
+		}
+	}
+
+	if (best_index < 0)
+		return NULL;
+
+	dlight_pool.stats.evicted++;
+	return &dlight_pool.items[best_index];
+}
+
+static dlight_t *DLightPool_AcquireSlot (double time)
+{
+	for (int i = 0; i < dlight_pool.capacity; i++)
+	{
+		dlight_t *dl = &dlight_pool.items[i];
+		if (!dl->active)
+			return dl;
+		if (dl->kind == DL_TRANSIENT && (dl->die < time || dl->spawn > time))
+			return dl;
+	}
+
+	DLightPool_EnsureCapacity (dlight_pool.capacity + 1);
+	if (dlight_pool.capacity > 0)
+	{
+		for (int i = 0; i < dlight_pool.capacity; i++)
+		{
+			dlight_t *dl = &dlight_pool.items[i];
+			if (!dl->active)
+				return dl;
+		}
+	}
+
+	dlight_t *evicted = DLightPool_EvictWorstTransient (time);
+	if (evicted)
+		return evicted;
+
+	dlight_pool.stats.evicted++;
+	return &dlight_fallback;
+}
+
+dlight_t *DLightPool_AllocTransient (double time)
+{
+	dlight_t *dl = DLightPool_AcquireSlot (time);
+	DLightPool_ResetLight (dl, DL_TRANSIENT, time);
+	return dl;
+}
+
+dlight_t *DLightPool_AllocTransientByKey (int key, double time)
+{
+	if (key)
+	{
+		for (int i = 0; i < dlight_pool.capacity; i++)
+		{
+			dlight_t *dl = &dlight_pool.items[i];
+			if (dl->active && dl->kind == DL_TRANSIENT && dl->key == key)
+			{
+				DLightPool_ResetLight (dl, DL_TRANSIENT, time);
+				dl->key = key;
+				return dl;
+			}
+		}
+	}
+
+	dlight_t *dl = DLightPool_AcquireSlot (time);
+	DLightPool_ResetLight (dl, DL_TRANSIENT, time);
+	dl->key = key;
+	return dl;
+}
+
+dlight_t *DLightPool_GetOrCreatePersistent (int key, double time)
+{
+	for (int i = 0; i < dlight_pool.capacity; i++)
+	{
+		dlight_t *dl = &dlight_pool.items[i];
+		if (dl->active && dl->kind == DL_PERSISTENT && dl->key == key)
+		{
+			dl->last_frame_touched = dlight_pool.framecount;
+			return dl;
+		}
+	}
+
+	dlight_t *dl = DLightPool_AcquireSlot (time);
+	DLightPool_ResetLight (dl, DL_PERSISTENT, time);
+	dl->key = key;
+	return dl;
+}
+
+void DLightPool_KillByKey (int key)
+{
+	for (int i = 0; i < dlight_pool.capacity; i++)
+	{
+		dlight_t *dl = &dlight_pool.items[i];
+		if (dl->active && dl->key == key)
+		{
+			dl->active = false;
+			break;
+		}
+	}
+}
+
+void DLightPool_NewFrame (double time, int framecount)
+{
+	dlight_pool.time = time;
+	dlight_pool.framecount = framecount;
+	dlight_pool.has_vieworg = false;
+	DLightPool_ResetStats ();
+
+	for (int i = 0; i < dlight_pool.capacity; i++)
+	{
+		dlight_t *dl = &dlight_pool.items[i];
+		if (!dl->active)
+			continue;
+		if (dl->kind == DL_TRANSIENT && dl->die < time)
+		{
+			dl->active = false;
+			dlight_pool.stats.expired++;
+		}
+	}
+}
+
+void DLightPool_Decay (float frametime, double time)
+{
+	for (int i = 0; i < dlight_pool.capacity; i++)
+	{
+		dlight_t *dl = &dlight_pool.items[i];
+		if (!dl->active)
+			continue;
+		if (dl->die < time || dl->spawn > time || !dl->baseradius)
+			continue;
+
+		dl->baseradius -= frametime * dl->decay;
+		if (dl->baseradius < 0.f)
+			dl->baseradius = 0.f;
+
+		if (CL_DlightShouldFlicker (dl))
+			dl->radius = dl->baseradius * (1.0f + 0.1f * (float) sin (time * 9.0 + dl->flicker_seed));
+		else
+			dl->radius = dl->baseradius;
+		if (dl->radius < 0.f)
+			dl->radius = 0.f;
+	}
+}
+
+static void DLightPool_UpdateStats (void)
+{
+	dlight_pool.stats.active = 0;
+	dlight_pool.stats.persistent = 0;
+	dlight_pool.stats.transient = 0;
+
+	for (int i = 0; i < dlight_pool.capacity; i++)
+	{
+		const dlight_t *dl = &dlight_pool.items[i];
+		if (!CL_DlightIsActive (dl))
+			continue;
+		dlight_pool.stats.active++;
+		if (dl->kind == DL_PERSISTENT)
+			dlight_pool.stats.persistent++;
+		else
+			dlight_pool.stats.transient++;
+	}
+}
+
+const dlight_t *const *DLightPool_GetActiveList (int *count)
+{
+	if (count)
+		*count = 0;
+
+	if (!dlight_pool.items || dlight_pool.capacity <= 0)
+		return NULL;
+
+	DLightPool_EnsureScratch (dlight_pool.capacity);
+
+	int found = 0;
+	for (int i = 0; i < dlight_pool.capacity; i++)
+	{
+		dlight_t *dl = &dlight_pool.items[i];
+		if (!CL_DlightIsActive (dl))
+			continue;
+		dlight_pool.scratch[found++] = dl;
+	}
+
+	if (count)
+		*count = found;
+	return (const dlight_t *const *)dlight_pool.scratch;
+}
+
+int DLightPool_CollectForRender (double time, const vec3_t vieworg, const mleaf_t *viewleaf,
+		dlight_t **out, int out_max)
+{
+	(void)viewleaf;
+
+	dlight_pool.time = time;
+	VectorCopy (vieworg, dlight_pool.last_vieworg);
+	dlight_pool.has_vieworg = true;
+
+	if (!out || out_max <= 0)
+	{
+		dlight_pool.stats.submitted = 0;
+		return 0;
+	}
+
+	if (!dlight_pool.items || dlight_pool.capacity <= 0)
+	{
+		dlight_pool.stats.submitted = 0;
+		return 0;
+	}
+
+	DLightPool_EnsureScratch (dlight_pool.capacity);
+
+	int found = 0;
+	for (int i = 0; i < dlight_pool.capacity; i++)
+	{
+		dlight_t *dl = &dlight_pool.items[i];
+		if (!dl->active)
+			continue;
+
+		if (dl->kind == DL_PERSISTENT && r_dlight_entities.value <= 0.f)
+			continue;
+
+		if (dl->kind == DL_TRANSIENT && dl->die < time)
+		{
+			dl->active = false;
+			dlight_pool.stats.expired++;
+			continue;
+		}
+
+		if (dl->spawn > time)
+		{
+			dl->die = 0.f;
+			continue;
+		}
+
+		if (!dl->baseradius)
+			continue;
+
+		if (dl->color[0] <= 0.f && dl->color[1] <= 0.f && dl->color[2] <= 0.f)
+			continue;
+
+		dl->last_score = DLightPool_ScoreLight (dl, time, vieworg);
+		dlight_pool.scratch[found++] = dl;
+	}
+
+	if (found > 1)
+		qsort (dlight_pool.scratch, found, sizeof (dlight_pool.scratch[0]), DLightPool_CompareScore);
+
+	const int submit_count = q_min (found, out_max);
+	for (int i = 0; i < submit_count; i++)
+		out[i] = dlight_pool.scratch[i];
+
+	dlight_pool.stats.submitted = submit_count;
+	DLightPool_UpdateStats ();
+
+	return submit_count;
+}
+
+void DLightPool_GetStats (dlight_pool_stats_t *out)
+{
+	if (!out)
+		return;
+	DLightPool_UpdateStats ();
+	*out = dlight_pool.stats;
+}
+
+void DLightPool_DebugPrintIfEnabled (void)
+{
+	if (r_dlight_debug.value <= 0.f)
+		return;
+
+	DLightPool_UpdateStats ();
+
+	Con_DPrintf ("pool active=%d persistent=%d transient=%d submitted=%d expired=%d evicted=%d\n",
+			dlight_pool.stats.active,
+			dlight_pool.stats.persistent,
+			dlight_pool.stats.transient,
+			dlight_pool.stats.submitted,
+			dlight_pool.stats.expired,
+			dlight_pool.stats.evicted);
+}

--- a/Quake/r_dlight_pool.h
+++ b/Quake/r_dlight_pool.h
@@ -1,0 +1,35 @@
+#ifndef R_DLIGHT_POOL_H
+#define R_DLIGHT_POOL_H
+
+typedef struct dlight_pool_stats_s
+{
+	int active;
+	int persistent;
+	int transient;
+	int submitted;
+	int expired;
+	int evicted;
+} dlight_pool_stats_t;
+
+extern cvar_t r_dlight_budget;
+extern cvar_t r_dlight_pool_max;
+
+void DLightPool_RegisterCvars (void);
+void DLightPool_Init (void);
+void DLightPool_Shutdown (void);
+void DLightPool_Clear (void);
+void DLightPool_ClearPersistent (void);
+void DLightPool_NewFrame (double time, int framecount);
+void DLightPool_Decay (float frametime, double time);
+int DLightPool_GetBudget (void);
+dlight_t *DLightPool_AllocTransient (double time);
+dlight_t *DLightPool_AllocTransientByKey (int key, double time);
+dlight_t *DLightPool_GetOrCreatePersistent (int key, double time);
+void DLightPool_KillByKey (int key);
+int DLightPool_CollectForRender (double time, const vec3_t vieworg, const mleaf_t *viewleaf,
+		dlight_t **out, int out_max);
+const dlight_t *const *DLightPool_GetActiveList (int *count);
+void DLightPool_GetStats (dlight_pool_stats_t *out);
+void DLightPool_DebugPrintIfEnabled (void);
+
+#endif // R_DLIGHT_POOL_H


### PR DESCRIPTION
### Motivation

- Remove the static `MAX_DLIGHTS` / `MAX_ENTITY_DLIGHTS` arrays and allow storing more candidate lights than the GPU upload limit. 
- Provide a deterministic, stable selection/prioritization so persistent BSP/entity lights do not flicker under overload. 
- Cap GPU submissions with a configurable budget to avoid spikes while keeping visual behavior identical in common cases. 
- Expose debug info and safety caps for tuning and diagnostics.

### Description

- Add a new dlight pool module `r_dlight_pool.h` / `r_dlight_pool.c` implementing dynamic storage, stable light IDs/handles, transient vs persistent kinds, scoring, deterministic tie-breakers (spawn time then id), eviction policy, and debug stats; key APIs include `DLightPool_AllocTransient*`, `DLightPool_GetOrCreatePersistent`, `DLightPool_CollectForRender`, and `DLightPool_DebugPrintIfEnabled`.
- Introduce cvars `r_dlight_budget` (default `64`) and `r_dlight_pool_max` (default `512`) and register/clamp them via `DLightPool_RegisterCvars` so the GPU submission count and pool safety cap are configurable.
- Integrate the pool into client + renderer paths by replacing usages of the static arrays: replace `cl_dlights`/`cl_entity_dlights` allocation/decay/collection with pool calls in `Quake/cl_main.c` and `Quake/gl_rlight.c`, wire `R_PushDlights` to call `DLightPool_CollectForRender` and submit the top N lights to existing GPU packing code, and expose the active list to lightgrid sampling routines.
- Keep shader/GPU layout unchanged while introducing `DLIGHT_GPU_MAX` (64) and bounding submissions to `q_min(DLightPool_GetBudget(), DLIGHT_GPU_MAX)` so runtime behavior matches prior limits unless the cvar is changed.
- Preserve compatibility for existing code paths that allocate dlights by key (`CL_AllocDlight` now uses the pool allocation helpers) and provide `DLightPool_KillByKey` / persistent-clear semantics used when parsing BSP entity dlights.
- Add debug stats printed when `r_dlight_debug` is enabled: `pool active=X persistent=Y transient=Z submitted=N expired=E evicted=V`.
- Files added/modified (high-level): added `Quake/r_dlight_pool.h` and `Quake/r_dlight_pool.c`; updated `Quake/client.h`, `Quake/cl_main.c`, `Quake/gl_rlight.c`, `Quake/gl_rmisc.c`, and `Quake/glquake.h` to integrate the pool and the new cvars.

### Testing

- No automated tests were executed for this change.
- The change includes runtime debug output gated by `r_dlight_debug` and cvar clamping callbacks to help exercise the new code under CI or local runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69524bf6eeb0832eb4d291585b3f3dd6)