### PR TITLE
Add minimal Q3-style shader material parser and runtime hooks

### DIFF
--- a/Quake/Makefile
+++ b/Quake/Makefile
@@ -266,6 +266,8 @@ OBJS = strlcat.o \
 	common.o \
 	../common/lightgrid.o \
 	q3shader.o \
+	mat_shader.o \
+	mat_shader_parse.o \
         steam.o \
 	json.o \
 	miniz.o \

--- a/Quake/Makefile.w32
+++ b/Quake/Makefile.w32
@@ -270,6 +270,8 @@ OBJS = strlcat.o \
         cmd.o \
         common.o \
         q3shader.o \
+	mat_shader.o \
+	mat_shader_parse.o \
         steam.o \
 	json.o \
 	miniz.o \

--- a/Quake/Makefile.w64
+++ b/Quake/Makefile.w64
@@ -263,6 +263,8 @@ OBJS = strlcat.o \
         cmd.o \
         common.o \
         q3shader.o \
+	mat_shader.o \
+	mat_shader_parse.o \
         steam.o \
 	json.o \
 	miniz.o \

--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -27,6 +27,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "quakedef.h"
 #include "gl_lightgrid.h"
 #include "gl_ktx2.h"
+#include "mat_shader.h"
 #include "r_maptex_export.h"
 #include "../common/lightgrid.h"
 
@@ -345,6 +346,8 @@ void Mod_ClearAll (void)
 			TexMgr_FreeTexturesForOwner (mod); //johnfitz
 		}
 	}
+
+	Mat_Shader_Shutdown ();
 }
 
 void Mod_ResetAll (void)
@@ -1252,6 +1255,9 @@ static void Mod_LoadTextures (lump_t *l)
 
 			tx->fullbright = NULL; //johnfitz
 			tx->emissive = NULL;
+			tx->shader = NULL;
+			tx->shader_map = NULL;
+			tx->shader_flags = 0u;
 		tx->shift = 0;	// Q64 only
 		tx->type = Mod_TextureTypeFromName (tx->name);
 
@@ -1271,6 +1277,12 @@ static void Mod_LoadTextures (lump_t *l)
                 ktx2tex = NULL;
                 if (!isDedicated) //no texture uploading for dedicated server
                 {
+                        if (!q_strncasecmp (loadmodel->name, "maps/", 5))
+                                COM_StripExtension (loadmodel->name + 5, mapname, sizeof (mapname));
+                        else
+                                mapname[0] = '\0';
+                        Mat_Shader_ApplyToTexture (tx, mapname[0] ? mapname : NULL);
+
                         if (tx->type == TEXTYPE_SKY)
                         {
                                 if (loadmodel->bspversion == BSPVERSION_QUAKE64)
@@ -1282,16 +1294,27 @@ static void Mod_LoadTextures (lump_t *l)
                         {
                                 //external textures -- first look in "textures/mapname/" then look in "textures/"
                                 mark = Hunk_LowMark();
-                                COM_StripExtension (loadmodel->name + 5, mapname, sizeof(mapname));
-                                q_snprintf (filename, sizeof(filename), "textures/%s/#%s", mapname, tx->name+1); //this also replaces the '*' with a '#'
-                                ktx2tex = Mod_LoadKTX2Texture (filename);
-                                data = ktx2tex ? NULL : Image_LoadImage (filename, &fwidth, &fheight, &fmt);
-                                if (!ktx2tex && !data)
+                                if (tx->shader_map && tx->shader_map[0])
                                 {
-                                        q_snprintf (filename, sizeof(filename), "textures/#%s", tx->name+1);
+                                        COM_StripExtension (tx->shader_map, filename, sizeof (filename));
                                         ktx2tex = Mod_LoadKTX2Texture (filename);
-                                        if (!ktx2tex)
-                                                data = Image_LoadImage (filename, &fwidth, &fheight, &fmt);
+                                        data = ktx2tex ? NULL : Image_LoadImage (filename, &fwidth, &fheight, &fmt);
+                                }
+                                else
+                                {
+                                        if (mapname[0])
+                                                q_snprintf (filename, sizeof(filename), "textures/%s/#%s", mapname, tx->name+1); //this also replaces the '*' with a '#'
+                                        else
+                                                q_snprintf (filename, sizeof(filename), "textures/#%s", tx->name+1);
+                                        ktx2tex = Mod_LoadKTX2Texture (filename);
+                                        data = ktx2tex ? NULL : Image_LoadImage (filename, &fwidth, &fheight, &fmt);
+                                        if (!ktx2tex && !data && mapname[0])
+                                        {
+                                                q_snprintf (filename, sizeof(filename), "textures/#%s", tx->name+1);
+                                                ktx2tex = Mod_LoadKTX2Texture (filename);
+                                                if (!ktx2tex)
+                                                        data = Image_LoadImage (filename, &fwidth, &fheight, &fmt);
+                                        }
                                 }
 
                                 //now load whatever we found
@@ -1343,16 +1366,27 @@ static void Mod_LoadTextures (lump_t *l)
 
                                 //external textures -- first look in "textures/mapname/" then look in "textures/"
                                 mark = Hunk_LowMark ();
-                                COM_StripExtension (loadmodel->name + 5, mapname, sizeof(mapname));
-                                q_snprintf (filename, sizeof(filename), "textures/%s/%s", mapname, tx->name);
-                                ktx2tex = Mod_LoadKTX2Texture (filename);
-                                data = ktx2tex ? NULL : Image_LoadImage (filename, &fwidth, &fheight, &fmt);
-                                if (!ktx2tex && !data)
+                                if (tx->shader_map && tx->shader_map[0])
                                 {
-                                        q_snprintf (filename, sizeof(filename), "textures/%s", tx->name);
+                                        COM_StripExtension (tx->shader_map, filename, sizeof (filename));
                                         ktx2tex = Mod_LoadKTX2Texture (filename);
-                                        if (!ktx2tex)
-                                                data = Image_LoadImage (filename, &fwidth, &fheight, &fmt);
+                                        data = ktx2tex ? NULL : Image_LoadImage (filename, &fwidth, &fheight, &fmt);
+                                }
+                                else
+                                {
+                                        if (mapname[0])
+                                                q_snprintf (filename, sizeof(filename), "textures/%s/%s", mapname, tx->name);
+                                        else
+                                                q_snprintf (filename, sizeof(filename), "textures/%s", tx->name);
+                                        ktx2tex = Mod_LoadKTX2Texture (filename);
+                                        data = ktx2tex ? NULL : Image_LoadImage (filename, &fwidth, &fheight, &fmt);
+                                        if (!ktx2tex && !data && mapname[0])
+                                        {
+                                                q_snprintf (filename, sizeof(filename), "textures/%s", tx->name);
+                                                ktx2tex = Mod_LoadKTX2Texture (filename);
+                                                if (!ktx2tex)
+                                                        data = Image_LoadImage (filename, &fwidth, &fheight, &fmt);
+                                        }
                                 }
 
                                 //now load whatever we found

--- a/Quake/gl_model.h
+++ b/Quake/gl_model.h
@@ -85,6 +85,8 @@ typedef enum {
 	TEXTYPE_NUMLIQUIDS = TEXTYPE_LASTLIQUID + 1 - TEXTYPE_FIRSTLIQUID,
 } textype_t;
 
+struct shader_material_s;
+
 #define TEXTYPE_ISLIQUID(x) ((unsigned)((x) - TEXTYPE_FIRSTLIQUID) < (unsigned)TEXTYPE_NUMLIQUIDS)
 
 typedef struct texture_s
@@ -96,6 +98,9 @@ typedef struct texture_s
 	struct gltexture_s	*gltexture; //johnfitz -- pointer to gltexture
 	struct gltexture_s	*fullbright; //johnfitz -- fullbright mask texture
 	struct gltexture_s	*emissive; // emissive map texture
+	const struct shader_material_s *shader;
+	const char			*shader_map;
+	unsigned int		shader_flags;
 	int					anim_total;				// total tenths in sequence ( 0 = no)
 	int					anim_min, anim_max;		// time for this frame min <=time< max
 	struct texture_s	*anim_next;		// in the animation sequence

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -23,6 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "quakedef.h"
 #include "gl_lightgrid.h"
+#include "mat_shader.h"
 #include <float.h>
 #include <math.h>
 
@@ -3021,6 +3022,10 @@ void R_SetupView (void)
         r_framedata.colorspace_params[1] = 0.f;
         r_framedata.colorspace_params[2] = 0.f;
         r_framedata.colorspace_params[3] = 0.f;
+        r_framedata.shader_params[0] = r_shader_debug.value;
+        r_framedata.shader_params[1] = 0.f;
+        r_framedata.shader_params[2] = 0.f;
+        r_framedata.shader_params[3] = 0.f;
 
 	double prev_delta = cl.time - r_prev_frame_time;
 	qboolean prev_valid = r_prev_frame_valid && prev_delta > 0.0;

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -24,6 +24,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "quakedef.h"
 #include "gl_lightgrid.h"
+#include "mat_shader.h"
 #include "r_maptex_export.h"
 #include "r_dlight_pool.h"
 
@@ -476,6 +477,7 @@ void R_Init (void)
         Cmd_AddCommand ("r_showbboxes_filter_clear", R_ShowbboxesFilterClear_f);
 
         Lightgrid_Init ();
+        Mat_Shader_Init ();
         R_MapTex_ExportInit ();
 
 Cvar_RegisterVariable (&r_norefresh);

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -436,6 +436,7 @@ typedef struct gpuframedata_s {
         vec4_t          lightgrid_params; // x: enabled, yzw: unused
         vec4_t          dlight_params;  // x: style, y: debug view, z: pass selector, w: padding
         vec4_t          colorspace_params; // x: debug mode, y: manual gamma, z: output sRGB, w: unused
+        vec4_t          shader_params;  // x: shader debug, yzw: unused
         unsigned int    numlights;
         unsigned int    prev_frame_valid;
         unsigned int    _padding1;

--- a/Quake/mat_shader.c
+++ b/Quake/mat_shader.c
@@ -1,0 +1,675 @@
+/*
+Copyright (C) 2024
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+*/
+
+#include "quakedef.h"
+#include "mat_shader.h"
+#include "mat_shader_parse.h"
+#include "miniz.h"
+
+#define MAT_SHADER_HASH_SIZE 256
+#define MAT_SHADER_LIST_LIMIT 64
+
+typedef struct mat_shader_entry_s
+{
+	shader_material_t	*material;
+	unsigned int		hash;
+	struct mat_shader_entry_s *next;
+} mat_shader_entry_t;
+
+typedef struct mat_shader_warn_s
+{
+	char *token;
+} mat_shader_warn_t;
+
+static mat_shader_entry_t *mat_shader_hash[MAT_SHADER_HASH_SIZE];
+static shader_material_t **mat_shader_list;
+static mat_shader_warn_t *mat_shader_warned;
+static qboolean mat_shader_loaded;
+
+cvar_t r_shaders = { "r_shaders", "1", CVAR_ARCHIVE };
+cvar_t r_shader_debug = { "r_shader_debug", "0", CVAR_ARCHIVE };
+static cvar_t r_reloadshaders = { "r_reloadshaders", "0", CVAR_NONE };
+
+char *Mat_Shader_DupString (const char *value)
+{
+	size_t len;
+	char *out;
+
+	if (!value)
+		return NULL;
+
+	len = strlen (value) + 1;
+	out = (char *) Z_Malloc (len);
+	memcpy (out, value, len);
+	return out;
+}
+
+static void Mat_Shader_FreeMaterial (shader_material_t *material)
+{
+	size_t i;
+
+	if (!material)
+		return;
+
+	for (i = 0; i < VEC_SIZE (material->stages); ++i)
+	{
+		mat_shader_stage_t *stage = &material->stages[i];
+		if (stage->map_path)
+			Z_Free (stage->map_path);
+	}
+	VEC_FREE (material->stages);
+
+	if (material->editor_image)
+		Z_Free (material->editor_image);
+	if (material->name)
+		Z_Free (material->name);
+	if (material->source_file)
+		Z_Free (material->source_file);
+
+	Z_Free (material);
+}
+
+static void Mat_Shader_Reset (void)
+{
+	size_t i;
+
+	for (i = 0; i < VEC_SIZE (mat_shader_list); ++i)
+		Mat_Shader_FreeMaterial (mat_shader_list[i]);
+
+	VEC_FREE (mat_shader_list);
+
+	for (i = 0; i < countof (mat_shader_hash); ++i)
+	{
+		mat_shader_entry_t *entry = mat_shader_hash[i];
+		while (entry)
+		{
+			mat_shader_entry_t *next = entry->next;
+			Z_Free (entry);
+			entry = next;
+		}
+		mat_shader_hash[i] = NULL;
+	}
+
+	for (i = 0; i < VEC_SIZE (mat_shader_warned); ++i)
+	{
+		if (mat_shader_warned[i].token)
+			Z_Free (mat_shader_warned[i].token);
+	}
+	VEC_FREE (mat_shader_warned);
+}
+
+static unsigned int Mat_Shader_Hash (const char *name)
+{
+	return COM_HashString (name) % MAT_SHADER_HASH_SIZE;
+}
+
+static qboolean Mat_Shader_TokenWarned (const char *token)
+{
+	size_t i;
+
+	for (i = 0; i < VEC_SIZE (mat_shader_warned); ++i)
+	{
+		if (!q_strcasecmp (mat_shader_warned[i].token, token))
+			return true;
+	}
+
+	return false;
+}
+
+static void Mat_Shader_AddWarned (const char *token)
+{
+	mat_shader_warn_t warn;
+
+	memset (&warn, 0, sizeof (warn));
+	warn.token = Mat_Shader_DupString (token);
+	VEC_PUSH (mat_shader_warned, warn);
+}
+
+static void Mat_Shader_WarnOnce (const char *token, const char *context)
+{
+	if (Mat_Shader_TokenWarned (token))
+		return;
+
+	Mat_Shader_AddWarned (token);
+	Con_Warning ("MatShader: unknown token '%s' in %s\n", token, context ? context : "shader");
+}
+
+static void Mat_Shader_Register (shader_material_t *material)
+{
+	mat_shader_entry_t *entry;
+	unsigned int bucket;
+
+	entry = (mat_shader_entry_t *) Z_Malloc (sizeof (*entry));
+	entry->material = material;
+	entry->hash = Mat_Shader_Hash (material->name);
+	bucket = entry->hash;
+	entry->next = mat_shader_hash[bucket];
+	mat_shader_hash[bucket] = entry;
+
+	VEC_PUSH (mat_shader_list, material);
+}
+
+static void Mat_Shader_Unregister (const shader_material_t *material)
+{
+	unsigned int bucket;
+	mat_shader_entry_t **entry;
+	size_t i;
+
+	if (!material)
+		return;
+
+	bucket = Mat_Shader_Hash (material->name);
+	entry = &mat_shader_hash[bucket];
+	while (*entry)
+	{
+		if ((*entry)->material == material)
+		{
+			mat_shader_entry_t *next = (*entry)->next;
+			Z_Free (*entry);
+			*entry = next;
+			break;
+		}
+		entry = &(*entry)->next;
+	}
+
+	for (i = 0; i < VEC_SIZE (mat_shader_list); ++i)
+	{
+		if (mat_shader_list[i] == material)
+		{
+			mat_shader_list[i] = VEC_LAST (mat_shader_list);
+			VEC_POP (mat_shader_list);
+			break;
+		}
+	}
+}
+
+static const shader_material_t *Mat_Shader_FindInternal (const char *name)
+{
+	unsigned int bucket;
+	mat_shader_entry_t *entry;
+
+	if (!name || !name[0])
+		return NULL;
+
+	bucket = Mat_Shader_Hash (name);
+	for (entry = mat_shader_hash[bucket]; entry; entry = entry->next)
+	{
+		if (!q_strcasecmp (entry->material->name, name))
+			return entry->material;
+	}
+
+	return NULL;
+}
+
+static qboolean Mat_Shader_ReadFile (const char *path, const byte *data, size_t size, const char *label)
+{
+	char *buffer;
+	int parsed;
+
+	if (!data || size == 0)
+		return false;
+
+	buffer = (char *) Z_Malloc (size + 1);
+	memcpy (buffer, data, size);
+	buffer[size] = '\0';
+	parsed = Mat_Shader_ParseFile (path, buffer, label);
+	Z_Free (buffer);
+
+	return parsed > 0;
+}
+
+static qboolean Mat_Shader_LoadFromDirectory (const searchpath_t *search)
+{
+	char script_dir[MAX_OSPATH];
+	findfile_t *find;
+	qboolean loaded_any = false;
+
+	if ((size_t) q_snprintf (script_dir, sizeof (script_dir), "%s/scripts", search->filename) >= sizeof (script_dir))
+		return false;
+
+	for (find = Sys_FindFirst (script_dir, "shader"); find; find = Sys_FindNext (find))
+	{
+		char fullpath[MAX_OSPATH];
+		char relpath[MAX_QPATH];
+		byte *buffer;
+		int handle;
+		int size;
+
+		if (find->attribs & FA_DIRECTORY)
+			continue;
+
+		q_snprintf (relpath, sizeof (relpath), "scripts/%s", find->name);
+		q_snprintf (fullpath, sizeof (fullpath), "%s/%s", script_dir, find->name);
+
+		size = (int) Sys_FileOpenRead (fullpath, &handle);
+		if (size <= 0)
+		{
+			if (handle >= 0)
+				Sys_FileClose (handle);
+			continue;
+		}
+
+		buffer = (byte *) malloc (size + 1);
+		if (!buffer)
+		{
+			Sys_FileClose (handle);
+			continue;
+		}
+
+		if (Sys_FileRead (handle, buffer, size) != size)
+		{
+			free (buffer);
+			Sys_FileClose (handle);
+			continue;
+		}
+
+		Sys_FileClose (handle);
+		buffer[size] = '\0';
+
+		if (Mat_Shader_ReadFile (relpath, buffer, (size_t) size, relpath))
+			loaded_any = true;
+
+		free (buffer);
+	}
+
+	return loaded_any;
+}
+
+static qboolean Mat_Shader_LoadFromPack (const searchpath_t *search)
+{
+	int i;
+	qboolean loaded_any = false;
+	pack_t *pak = search->pack;
+
+	for (i = 0; i < pak->numfiles; ++i)
+	{
+		const char *name = pak->files[i].name;
+		size_t size = pak->files[i].filelen;
+		byte *buffer = NULL;
+
+		if (q_strncasecmp (name, "scripts/", 8))
+			continue;
+		if (q_strcasecmp (COM_FileGetExtension (name), "shader"))
+			continue;
+
+		if (pak->is_pk3)
+		{
+			size_t extracted_size = 0;
+			void *extracted = mz_zip_reader_extract_to_heap ((mz_zip_archive *) pak->zip, pak->files[i].filepos, &extracted_size, 0);
+			if (!extracted || extracted_size == 0)
+				continue;
+			buffer = (byte *) extracted;
+			size = extracted_size;
+		}
+		else
+		{
+			buffer = (byte *) malloc (size + 1);
+			if (!buffer)
+				continue;
+			Sys_FileSeek (pak->handle, pak->files[i].filepos);
+			if (Sys_FileRead (pak->handle, buffer, (int) size) != (int) size)
+			{
+				free (buffer);
+				continue;
+			}
+		}
+
+		if (buffer)
+		{
+			buffer[size] = '\0';
+			if (Mat_Shader_ReadFile (name, buffer, size, name))
+				loaded_any = true;
+
+			if (pak->is_pk3)
+				MZ_FREE (buffer);
+			else
+				free (buffer);
+		}
+	}
+
+	return loaded_any;
+}
+
+static void Mat_Shader_LoadAll (void)
+{
+	searchpath_t *search;
+	searchpath_t **paths = NULL;
+	size_t count = 0;
+	size_t i;
+
+	if (mat_shader_loaded && r_reloadshaders.value <= 0.f)
+		return;
+
+	Mat_Shader_Reset ();
+	mat_shader_loaded = true;
+
+	if (r_shaders.value <= 0.f)
+		return;
+
+	for (search = com_searchpaths; search; search = search->next)
+	{
+		VEC_PUSH (paths, search);
+	}
+
+	count = VEC_SIZE (paths);
+	for (i = count; i > 0; --i)
+	{
+		search = paths[i - 1];
+		if (*search->filename)
+			Mat_Shader_LoadFromDirectory (search);
+		else if (search->pack)
+			Mat_Shader_LoadFromPack (search);
+	}
+
+	VEC_FREE (paths);
+}
+
+static void Mat_Shader_Reload_f (cvar_t *var)
+{
+	if (var->value <= 0.f)
+		return;
+	Con_Printf ("Reloading material shaders\n");
+	r_reloadshaders.value = 0.f;
+	Mat_Shader_LoadAll ();
+}
+
+static void Mat_Shader_List_f (void)
+{
+	size_t count = Mat_Shader_Count ();
+	size_t limit = MAT_SHADER_LIST_LIMIT;
+	size_t i;
+
+	if (Cmd_Argc () > 1)
+		limit = (size_t) q_max (0, Q_atoi (Cmd_Argv (1)));
+
+	Con_Printf ("Loaded shaders: %zu\n", count);
+	for (i = 0; i < count && i < limit; ++i)
+	{
+		const shader_material_t *material = Mat_Shader_GetByIndex (i);
+		Con_Printf ("%s\n", material->name);
+	}
+}
+
+static void Mat_Shader_Print_f (void)
+{
+	const shader_material_t *material;
+
+	if (Cmd_Argc () < 2)
+	{
+		Con_Printf ("Usage: shaderprint <name>\n");
+		return;
+	}
+
+	material = Mat_Shader_Find (Cmd_Argv (1));
+	if (!material)
+	{
+		Con_Printf ("No shader named '%s'\n", Cmd_Argv (1));
+		return;
+	}
+
+	Mat_Shader_Print (material);
+}
+
+void Mat_Shader_Init (void)
+{
+	Cvar_RegisterVariable (&r_shaders);
+	Cvar_RegisterVariable (&r_shader_debug);
+	Cvar_RegisterVariable (&r_reloadshaders);
+	Cvar_SetCallback (&r_reloadshaders, Mat_Shader_Reload_f);
+
+	Cmd_AddCommand ("shaderlist", Mat_Shader_List_f);
+	Cmd_AddCommand ("shaderprint", Mat_Shader_Print_f);
+}
+
+void Mat_Shader_Shutdown (void)
+{
+	Mat_Shader_Reset ();
+	mat_shader_loaded = false;
+}
+
+void Mat_Shader_Reload (void)
+{
+	Mat_Shader_LoadAll ();
+}
+
+size_t Mat_Shader_Count (void)
+{
+	Mat_Shader_LoadAll ();
+	return VEC_SIZE (mat_shader_list);
+}
+
+const shader_material_t *Mat_Shader_GetByIndex (size_t index)
+{
+	Mat_Shader_LoadAll ();
+	if (index >= VEC_SIZE (mat_shader_list))
+		return NULL;
+	return mat_shader_list[index];
+}
+
+void Mat_Shader_Canonicalize (const char *name, char *out, size_t out_size)
+{
+	size_t i;
+
+	if (!out || out_size == 0)
+		return;
+
+	q_strlcpy (out, name ? name : "", out_size);
+	for (i = 0; out[i]; ++i)
+	{
+		if (out[i] == '\\')
+			out[i] = '/';
+	}
+	COM_StripExtension (out, out, out_size);
+	q_strlwr (out);
+}
+
+const shader_material_t *Mat_Shader_Find (const char *name)
+{
+	char canonical[MAX_QPATH];
+
+	if (!name || !name[0])
+		return NULL;
+
+	Mat_Shader_LoadAll ();
+	Mat_Shader_Canonicalize (name, canonical, sizeof (canonical));
+	return Mat_Shader_FindInternal (canonical);
+}
+
+const shader_material_t *Mat_Shader_FindForTextureName (const char *texname, const char *mapname)
+{
+	char candidate[MAX_QPATH];
+	const shader_material_t *material;
+
+	if (!texname || !texname[0])
+		return NULL;
+
+	if (mapname && mapname[0])
+	{
+		q_snprintf (candidate, sizeof (candidate), "textures/%s/%s", mapname, texname);
+		material = Mat_Shader_Find (candidate);
+		if (material)
+			return material;
+	}
+
+	q_snprintf (candidate, sizeof (candidate), "textures/%s", texname);
+	material = Mat_Shader_Find (candidate);
+	if (material)
+		return material;
+
+	return Mat_Shader_Find (texname);
+}
+
+const char *Mat_Shader_GetStage0Map (const shader_material_t *material, const char *texname)
+{
+	if (!material || !material->stage0.map_path || !material->stage0.map_path[0])
+		return NULL;
+
+	if (texname && texname[0])
+	{
+		char canonical_tex[MAX_QPATH];
+		Mat_Shader_Canonicalize (texname, canonical_tex, sizeof (canonical_tex));
+		if (q_strcasecmp (material->name, canonical_tex))
+			return NULL;
+	}
+
+	return material->stage0.map_path;
+}
+
+unsigned int Mat_Shader_GetTextureFlags (const shader_material_t *material)
+{
+	unsigned int flags = 0u;
+
+	if (!material)
+		return flags;
+
+	if (material->render_flags & MAT_RENDER_NODRAW)
+		flags |= MAT_SHADERFLAG_NODRAW;
+	if (material->render_flags & MAT_RENDER_SKY)
+		flags |= MAT_SHADERFLAG_SKY;
+	if (material->render_flags & MAT_RENDER_TRANS)
+		flags |= MAT_SHADERFLAG_TRANS;
+	if (material->render_flags & MAT_RENDER_ALPHASHADOW)
+		flags |= MAT_SHADERFLAG_ALPHASHADOW;
+	if (material->render_flags & MAT_RENDER_FOG)
+		flags |= MAT_SHADERFLAG_FOG;
+	if (material->surfaceparms & MAT_SURFPARM_SOLID)
+		flags |= MAT_SHADERFLAG_SOLID;
+	if (material->surfaceparms & MAT_SURFPARM_NONSOLID)
+		flags |= MAT_SHADERFLAG_NONSOLID;
+	if (material->surfaceparms & MAT_SURFPARM_PLAYERCLIP)
+		flags |= MAT_SHADERFLAG_PLAYERCLIP;
+	if (material->surfaceparms & MAT_SURFPARM_MONSTERCLIP)
+		flags |= MAT_SHADERFLAG_MONSTERCLIP;
+	if (material->surfaceparms & MAT_SURFPARM_STONE)
+		flags |= MAT_SHADERFLAG_STONE;
+	if (material->emissive_enable)
+		flags |= MAT_SHADERFLAG_EMISSIVE;
+	if (material->bloom_enable)
+		flags |= MAT_SHADERFLAG_BLOOM;
+	if (material->godray_enable)
+		flags |= MAT_SHADERFLAG_GODRAY;
+
+	return flags;
+}
+
+void Mat_Shader_ApplyToTexture (texture_t *tex, const char *mapname)
+{
+	unsigned int flags;
+	const shader_material_t *material = NULL;
+	char candidate[MAX_QPATH];
+
+	if (!tex)
+		return;
+	if (r_shaders.value <= 0.f)
+		return;
+
+	if (mapname && mapname[0])
+	{
+		q_snprintf (candidate, sizeof (candidate), "textures/%s/%s", mapname, tex->name);
+		material = Mat_Shader_Find (candidate);
+		if (material)
+			tex->shader_map = Mat_Shader_GetStage0Map (material, candidate);
+	}
+
+	if (!material)
+	{
+		q_snprintf (candidate, sizeof (candidate), "textures/%s", tex->name);
+		material = Mat_Shader_Find (candidate);
+		if (material)
+			tex->shader_map = Mat_Shader_GetStage0Map (material, candidate);
+	}
+
+	if (!material)
+	{
+		material = Mat_Shader_Find (tex->name);
+		if (material)
+			tex->shader_map = Mat_Shader_GetStage0Map (material, tex->name);
+	}
+
+	if (!material)
+		return;
+
+	flags = Mat_Shader_GetTextureFlags (material);
+
+	tex->shader = material;
+	tex->shader_flags = flags;
+
+	if ((material->render_flags & MAT_RENDER_SKY) && tex->type != TEXTYPE_SKY)
+		tex->type = TEXTYPE_SKY;
+	if ((material->render_flags & MAT_RENDER_TRANS) && r_shader_debug.value >= 1.f)
+		Con_DPrintf ("MatShader: surfaceparm trans on %s (TODO: blend path)\n", tex->name);
+
+	if (r_shader_debug.value >= 1.f)
+	{
+		if (tex->shader_map)
+			Con_Printf ("MatShader: %s overrides %s\n", tex->name, tex->shader_map);
+	}
+}
+
+void Mat_Shader_Print (const shader_material_t *material)
+{
+	if (!material)
+		return;
+
+	Con_Printf ("Shader: %s\n", material->name);
+	if (material->source_file && material->source_file[0])
+		Con_Printf ("  source: %s\n", material->source_file);
+	if (material->editor_image)
+		Con_Printf ("  editor image: %s\n", material->editor_image);
+	Con_Printf ("  surfaceparms: 0x%08x\n", material->surfaceparms);
+	Con_Printf ("  render flags: 0x%08x\n", material->render_flags);
+	Con_Printf ("  content flags: 0x%08x\n", material->content_flags);
+	Con_Printf ("  emissive: %s (scale %.2f)\n", material->emissive_enable ? "on" : "off", material->emissive_scale);
+	Con_Printf ("  bloom: %s (scale %.2f)\n", material->bloom_enable ? "on" : "off", material->bloom_scale);
+	Con_Printf ("  godray: %s (scale %.2f)\n", material->godray_enable ? "on" : "off", material->godray_scale);
+	if (material->stage0.map_path)
+		Con_Printf ("  stage0 map: %s\n", material->stage0.map_path);
+}
+
+void Mat_Shader_Insert (shader_material_t *material)
+{
+	shader_material_t *owned;
+	const shader_material_t *existing;
+
+	if (!material || !material->name || !material->name[0])
+		return;
+
+	existing = Mat_Shader_FindInternal (material->name);
+	if (existing)
+	{
+		Mat_Shader_Unregister (existing);
+		Mat_Shader_FreeMaterial ((shader_material_t *) existing);
+	}
+
+	owned = (shader_material_t *) Z_Malloc (sizeof (*owned));
+	memcpy (owned, material, sizeof (*owned));
+	Mat_Shader_Register (owned);
+}
+
+void Mat_Shader_Remove (const shader_material_t *material)
+{
+	Mat_Shader_Unregister (material);
+	Mat_Shader_FreeMaterial ((shader_material_t *) material);
+}
+
+void Mat_Shader_ReportUnknownToken (const char *token, const char *context)
+{
+	Mat_Shader_WarnOnce (token, context);
+}

--- a/Quake/mat_shader.h
+++ b/Quake/mat_shader.h
@@ -1,0 +1,131 @@
+/*
+Copyright (C) 2024
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+*/
+
+#ifndef MAT_SHADER_H
+#define MAT_SHADER_H
+
+#include "quakedef.h"
+
+typedef enum
+{
+	MAT_SURFPARM_SOLID		= (1u << 0),
+	MAT_SURFPARM_NONSOLID		= (1u << 1),
+	MAT_SURFPARM_PLAYERCLIP		= (1u << 2),
+	MAT_SURFPARM_MONSTERCLIP	= (1u << 3),
+	MAT_SURFPARM_TRANS		= (1u << 4),
+	MAT_SURFPARM_ALPHASHADOW	= (1u << 5),
+	MAT_SURFPARM_SKY		= (1u << 6),
+	MAT_SURFPARM_FOG		= (1u << 7),
+	MAT_SURFPARM_NODRAW		= (1u << 8),
+	MAT_SURFPARM_STONE		= (1u << 9)
+} mat_surfaceparm_t;
+
+typedef enum
+{
+	MAT_RENDER_TRANS		= (1u << 0),
+	MAT_RENDER_ALPHASHADOW		= (1u << 1),
+	MAT_RENDER_SKY			= (1u << 2),
+	MAT_RENDER_FOG			= (1u << 3),
+	MAT_RENDER_NODRAW		= (1u << 4)
+} mat_render_flags_t;
+
+typedef enum
+{
+	MAT_CONTENT_SOLID		= (1u << 0),
+	MAT_CONTENT_NONSOLID		= (1u << 1),
+	MAT_CONTENT_PLAYERCLIP		= (1u << 2),
+	MAT_CONTENT_MONSTERCLIP		= (1u << 3)
+} mat_content_flags_t;
+
+typedef enum
+{
+	MAT_RGBGEN_DEFAULT = 0,
+	MAT_RGBGEN_IDENTITY
+} mat_rgbgen_t;
+
+typedef enum
+{
+	MAT_SHADERFLAG_NODRAW		= (1u << 0),
+	MAT_SHADERFLAG_SKY		= (1u << 1),
+	MAT_SHADERFLAG_TRANS		= (1u << 2),
+	MAT_SHADERFLAG_ALPHASHADOW	= (1u << 3),
+	MAT_SHADERFLAG_FOG		= (1u << 4),
+	MAT_SHADERFLAG_SOLID		= (1u << 5),
+	MAT_SHADERFLAG_NONSOLID		= (1u << 6),
+	MAT_SHADERFLAG_PLAYERCLIP	= (1u << 7),
+	MAT_SHADERFLAG_MONSTERCLIP	= (1u << 8),
+	MAT_SHADERFLAG_STONE		= (1u << 9),
+	MAT_SHADERFLAG_EMISSIVE		= (1u << 10),
+	MAT_SHADERFLAG_BLOOM		= (1u << 11),
+	MAT_SHADERFLAG_GODRAY		= (1u << 12)
+} mat_shader_flags_t;
+
+typedef struct mat_shader_stage_s
+{
+	char		*map_path;
+	mat_rgbgen_t	rgbgen;
+} mat_shader_stage_t;
+
+typedef struct shader_material_s
+{
+	char			*name;
+	char			*editor_image;
+	char			*source_file;
+	unsigned int		surfaceparms;
+	unsigned int		content_flags;
+	unsigned int		render_flags;
+	qboolean		emissive_enable;
+	qboolean		bloom_enable;
+	qboolean		godray_enable;
+	float			emissive_scale;
+	float			bloom_scale;
+	float			godray_scale;
+	mat_shader_stage_t	stage0;
+	mat_shader_stage_t	*stages;
+} shader_material_t;
+
+// Developer note:
+// Supported directives: qer_editorimage, surfaceparm, emissive, bloom, godray, emissive_scale,
+// bloom_scale, godray_scale, and a single stage block with map + rgbGen identity.
+// To add new surfaceparms, extend mat_surfaceparm_table in mat_shader_parse.c and map to flags.
+
+typedef struct texture_s texture_t;
+
+extern cvar_t r_shaders;
+extern cvar_t r_shader_debug;
+
+void Mat_Shader_Init (void);
+void Mat_Shader_Shutdown (void);
+void Mat_Shader_Reload (void);
+size_t Mat_Shader_Count (void);
+const shader_material_t *Mat_Shader_GetByIndex (size_t index);
+void Mat_Shader_Canonicalize (const char *name, char *out, size_t out_size);
+const shader_material_t *Mat_Shader_Find (const char *name);
+const shader_material_t *Mat_Shader_FindForTextureName (const char *texname, const char *mapname);
+const char *Mat_Shader_GetStage0Map (const shader_material_t *material, const char *texname);
+unsigned int Mat_Shader_GetTextureFlags (const shader_material_t *material);
+void Mat_Shader_ApplyToTexture (texture_t *tex, const char *mapname);
+void Mat_Shader_Print (const shader_material_t *material);
+char *Mat_Shader_DupString (const char *value);
+void Mat_Shader_Insert (shader_material_t *material);
+void Mat_Shader_Remove (const shader_material_t *material);
+void Mat_Shader_ReportUnknownToken (const char *token, const char *context);
+
+#endif // MAT_SHADER_H

--- a/Quake/mat_shader_parse.c
+++ b/Quake/mat_shader_parse.c
@@ -1,0 +1,270 @@
+/*
+Copyright (C) 2024
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+*/
+
+#include "quakedef.h"
+#include "mat_shader.h"
+#include "mat_shader_parse.h"
+
+typedef struct
+{
+	const char *name;
+	unsigned int surfaceparm;
+	unsigned int render_flags;
+	unsigned int content_flags;
+} surfaceparm_map_t;
+
+static const surfaceparm_map_t mat_surfaceparm_table[] =
+{
+	{ "solid", MAT_SURFPARM_SOLID, 0u, MAT_CONTENT_SOLID },
+	{ "nonsolid", MAT_SURFPARM_NONSOLID, 0u, MAT_CONTENT_NONSOLID },
+	{ "playerclip", MAT_SURFPARM_PLAYERCLIP, 0u, MAT_CONTENT_PLAYERCLIP },
+	{ "monsterclip", MAT_SURFPARM_MONSTERCLIP, 0u, MAT_CONTENT_MONSTERCLIP },
+	{ "trans", MAT_SURFPARM_TRANS, MAT_RENDER_TRANS, 0u },
+	{ "alphashadow", MAT_SURFPARM_ALPHASHADOW, MAT_RENDER_ALPHASHADOW, 0u },
+	{ "sky", MAT_SURFPARM_SKY, MAT_RENDER_SKY, 0u },
+	{ "fog", MAT_SURFPARM_FOG, MAT_RENDER_FOG, 0u },
+	{ "nodraw", MAT_SURFPARM_NODRAW, MAT_RENDER_NODRAW, 0u },
+	{ "stone", MAT_SURFPARM_STONE, 0u, 0u }
+};
+
+static qboolean Mat_Shader_ParseBool (const char *token, qboolean default_value)
+{
+	if (!token || !token[0])
+		return default_value;
+	if (!q_strcasecmp (token, "true") || !q_strcasecmp (token, "yes") || !q_strcasecmp (token, "on"))
+		return true;
+	if (!q_strcasecmp (token, "false") || !q_strcasecmp (token, "no") || !q_strcasecmp (token, "off"))
+		return false;
+	return Q_atof (token) != 0.f;
+}
+
+static void Mat_Shader_ApplySurfaceParm (shader_material_t *material, const char *token)
+{
+	for (size_t i = 0; i < countof (mat_surfaceparm_table); ++i)
+	{
+		if (!q_strcasecmp (token, mat_surfaceparm_table[i].name))
+		{
+			material->surfaceparms |= mat_surfaceparm_table[i].surfaceparm;
+			material->render_flags |= mat_surfaceparm_table[i].render_flags;
+			material->content_flags |= mat_surfaceparm_table[i].content_flags;
+			return;
+		}
+	}
+
+	Mat_Shader_ReportUnknownToken (token, material->name);
+}
+
+static const char *Mat_Shader_SkipBlock (const char *data)
+{
+	int depth = 1;
+	while ((data = COM_Parse (data)) != NULL)
+	{
+		if (!com_token[0])
+			continue;
+		if (!strcmp (com_token, "{"))
+			depth++;
+		else if (!strcmp (com_token, "}"))
+		{
+			depth--;
+			if (depth <= 0)
+				break;
+		}
+	}
+	return data;
+}
+
+static const char *Mat_Shader_ParseStage (const char *data, shader_material_t *material, size_t stage_index)
+{
+	mat_shader_stage_t stage;
+
+	memset (&stage, 0, sizeof (stage));
+	stage.rgbgen = MAT_RGBGEN_DEFAULT;
+
+	while ((data = COM_Parse (data)) != NULL)
+	{
+		if (!com_token[0])
+			continue;
+		if (!strcmp (com_token, "}"))
+			break;
+		if (!q_strcasecmp (com_token, "map"))
+		{
+			data = COM_Parse (data);
+			if (!data)
+				break;
+			if (com_token[0])
+				stage.map_path = Mat_Shader_DupString (com_token);
+			continue;
+		}
+		if (!q_strcasecmp (com_token, "rgbGen"))
+		{
+			data = COM_Parse (data);
+			if (!data)
+				break;
+			if (!q_strcasecmp (com_token, "identity"))
+				stage.rgbgen = MAT_RGBGEN_IDENTITY;
+			continue;
+		}
+	}
+
+	if (!material->stages)
+		material->stages = NULL;
+	VEC_PUSH (material->stages, stage);
+
+	if (stage_index == 0)
+		material->stage0 = stage;
+
+	return data;
+}
+
+static const char *Mat_Shader_ParseMaterial (const char *data, const char *name, const char *source_file)
+{
+	shader_material_t material;
+	const shader_material_t *existing;
+	int stage_index = 0;
+	char canonical[MAX_QPATH];
+
+	memset (&material, 0, sizeof (material));
+	Mat_Shader_Canonicalize (name, canonical, sizeof (canonical));
+	material.name = Mat_Shader_DupString (canonical);
+	material.source_file = Mat_Shader_DupString (source_file ? source_file : "");
+	material.emissive_scale = 1.f;
+	material.bloom_scale = 1.f;
+	material.godray_scale = 1.f;
+
+	while ((data = COM_Parse (data)) != NULL)
+	{
+		if (!com_token[0])
+			continue;
+		if (!strcmp (com_token, "}"))
+			break;
+		if (!strcmp (com_token, "{"))
+		{
+			data = Mat_Shader_ParseStage (data, &material, (size_t)stage_index++);
+			continue;
+		}
+		if (!q_strcasecmp (com_token, "qer_editorimage"))
+		{
+			data = COM_Parse (data);
+			if (!data)
+				break;
+			material.editor_image = Mat_Shader_DupString (com_token);
+			continue;
+		}
+		if (!q_strcasecmp (com_token, "surfaceparm"))
+		{
+			data = COM_Parse (data);
+			if (!data)
+				break;
+			Mat_Shader_ApplySurfaceParm (&material, com_token);
+			continue;
+		}
+		if (!q_strcasecmp (com_token, "emissive"))
+		{
+			data = COM_Parse (data);
+			if (!data)
+				break;
+			material.emissive_enable = Mat_Shader_ParseBool (com_token, false);
+			continue;
+		}
+		if (!q_strcasecmp (com_token, "bloom"))
+		{
+			data = COM_Parse (data);
+			if (!data)
+				break;
+			material.bloom_enable = Mat_Shader_ParseBool (com_token, false);
+			continue;
+		}
+		if (!q_strcasecmp (com_token, "godray"))
+		{
+			data = COM_Parse (data);
+			if (!data)
+				break;
+			material.godray_enable = Mat_Shader_ParseBool (com_token, false);
+			continue;
+		}
+		if (!q_strcasecmp (com_token, "emissive_scale"))
+		{
+			data = COM_Parse (data);
+			if (!data)
+				break;
+			material.emissive_scale = Q_atof (com_token);
+			continue;
+		}
+		if (!q_strcasecmp (com_token, "bloom_scale"))
+		{
+			data = COM_Parse (data);
+			if (!data)
+				break;
+			material.bloom_scale = Q_atof (com_token);
+			continue;
+		}
+		if (!q_strcasecmp (com_token, "godray_scale"))
+		{
+			data = COM_Parse (data);
+			if (!data)
+				break;
+			material.godray_scale = Q_atof (com_token);
+			continue;
+		}
+		Mat_Shader_ReportUnknownToken (com_token, material.name);
+	}
+
+	existing = Mat_Shader_Find (material.name);
+	if (existing)
+		Mat_Shader_Remove (existing);
+	Mat_Shader_Insert (&material);
+
+	return data;
+}
+
+int Mat_Shader_ParseFile (const char *path, const char *data, const char *source_file)
+{
+	int parsed = 0;
+	const char *cursor = data;
+
+	(void) path;
+
+	if (!cursor)
+		return 0;
+
+	while ((cursor = COM_Parse (cursor)) != NULL)
+	{
+		if (!com_token[0])
+			continue;
+		if (!strcmp (com_token, "{"))
+		{
+			cursor = Mat_Shader_SkipBlock (cursor);
+			continue;
+		}
+		{
+			char name[MAX_QPATH];
+			q_strlcpy (name, com_token, sizeof (name));
+			cursor = COM_Parse (cursor);
+			if (!cursor)
+				break;
+			if (strcmp (com_token, "{"))
+				continue;
+			cursor = Mat_Shader_ParseMaterial (cursor, name, source_file);
+			parsed++;
+		}
+	}
+
+	return parsed;
+}

--- a/Quake/mat_shader_parse.h
+++ b/Quake/mat_shader_parse.h
@@ -1,0 +1,28 @@
+/*
+Copyright (C) 2024
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+*/
+
+#ifndef MAT_SHADER_PARSE_H
+#define MAT_SHADER_PARSE_H
+
+#include "mat_shader.h"
+
+int Mat_Shader_ParseFile (const char *path, const char *data, const char *source_file);
+
+#endif // MAT_SHADER_PARSE_H

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -23,6 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // r_world.c: world model rendering
 
 #include "quakedef.h"
+#include "mat_shader.h"
 
 extern cvar_t gl_fullbrights, r_oldskyleaf, r_showtris; //johnfitz
 extern cvar_t r_godrays_emit_sky;
@@ -444,6 +445,12 @@ static void R_FlushBModelCalls (void)
 #define CALLFLAG_ALPHA_TEST      (1u << 4)
 #define CALLFLAG_GODRAYS_LIGHT   (1u << 5)
 #define CALLFLAG_GODRAYS_EMISSIVE (1u << 6)
+#define CALLFLAG_MAT_BLOOM       (1u << 7)
+#define CALLFLAG_MAT_EMISSIVE    (1u << 8)
+#define CALLFLAG_MAT_GODRAY      (1u << 9)
+#define CALLFLAG_MAT_TRANS       (1u << 10)
+#define CALLFLAG_MAT_SKY         (1u << 11)
+#define CALLFLAG_MAT_HAS_SHADER  (1u << 12)
 
 static qboolean R_GodraysNameMatch (const char *name)
 {
@@ -505,6 +512,12 @@ qboolean R_TextureEmitsGodrays (texture_t *t)
 
 	if (!R_ValidPtr (t))
 		return false;
+
+	if (r_shaders.value > 0.f && t->shader && (t->shader_flags & MAT_SHADERFLAG_GODRAY) == 0u)
+		return false;
+
+	if (r_shaders.value > 0.f && (t->shader_flags & MAT_SHADERFLAG_GODRAY))
+		return true;
 
 	if (r_godrays_emit_emissive.value > 0.f
 		&& (R_ValidPtr (t->fullbright) || R_ValidPtr (t->emissive)))
@@ -818,17 +831,42 @@ GL_Bind (GL_TEXTURE2, skybox->cubemap);
 			texture_t *t = R_GetUsedTexture (model, j, &texnum);
 			unsigned extra_flags = 0u;
 			qboolean force_fullbright = false;
+			unsigned mat_flags = 0u;
+			unsigned mat_call_flags = 0u;
 
 			if (!t || !R_ValidPtr (t))
 				continue;
+
+			mat_flags = (r_shaders.value > 0.f) ? t->shader_flags : 0u;
+			if (mat_flags & MAT_SHADERFLAG_NODRAW)
+				continue;
+
+			if (r_shaders.value > 0.f && t->shader)
+				mat_call_flags |= CALLFLAG_MAT_HAS_SHADER;
+			if (mat_flags & MAT_SHADERFLAG_BLOOM)
+				mat_call_flags |= CALLFLAG_MAT_BLOOM;
+			if (mat_flags & MAT_SHADERFLAG_EMISSIVE)
+				mat_call_flags |= CALLFLAG_MAT_EMISSIVE;
+			if (mat_flags & MAT_SHADERFLAG_GODRAY)
+				mat_call_flags |= CALLFLAG_MAT_GODRAY;
+			if (mat_flags & MAT_SHADERFLAG_TRANS)
+				mat_call_flags |= CALLFLAG_MAT_TRANS;
+			if (mat_flags & MAT_SHADERFLAG_SKY)
+				mat_call_flags |= CALLFLAG_MAT_SKY;
 
 			if (pass == BP_GODRAYS)
 			{
 				if (!t)
 					continue;
+				if (r_shaders.value > 0.f && t->shader && (mat_flags & MAT_SHADERFLAG_GODRAY) == 0u)
+					continue;
 				qboolean emissive = (r_godrays_emit_emissive.value > 0.f
 					&& (R_ValidPtr (t->fullbright) || R_ValidPtr (t->emissive)));
 				qboolean lighttex = false;
+				qboolean force_emissive = (mat_flags & MAT_SHADERFLAG_EMISSIVE) != 0u
+					&& r_godrays_emit_emissive.value > 0.f;
+				qboolean force_lighttex = (mat_flags & MAT_SHADERFLAG_GODRAY) != 0u
+					&& r_godrays_emit_lighttex.value > 0.f;
 
 				if (r_godrays_emit_lighttex.value > 0.f && t)
 				{
@@ -836,9 +874,11 @@ GL_Bind (GL_TEXTURE2, skybox->cubemap);
 						lighttex = true;
 					else if ((t->type != TEXTYPE_SKY) && r_godrays_lighttex_name_match.value > 0.f && R_GodraysNameMatch (t->name))
 						lighttex = true;
+					else if (force_lighttex)
+						lighttex = true;
 				}
 
-				if (emissive)
+				if (emissive || force_emissive)
 				{
 					extra_flags |= CALLFLAG_GODRAYS_EMISSIVE;
 					force_fullbright = true;
@@ -851,6 +891,7 @@ GL_Bind (GL_TEXTURE2, skybox->cubemap);
 					continue;
 			}
 
+			extra_flags |= mat_call_flags;
 			R_AddBModelCall (model->firstcmd + j, baseinst, numinst,
 				pass != BP_SHOWTRIS ? R_TextureAnimation (t, frame) : 0,
 				zfix, -1, extra_flags, force_fullbright);
@@ -955,16 +996,34 @@ GL_Upload (GL_SHADER_STORAGE_BUFFER, bmodel_instances, sizeof(bmodel_instances[0
 		for (j = model->texofs[TEXTYPE_FIRSTLIQUID]; j < model->texofs[TEXTYPE_LASTLIQUID+1]; j++)
 		{
 			texture_t *t = R_GetUsedTexture (model, j, NULL);
+			unsigned extra_flags = 0u;
+			unsigned mat_flags = 0u;
 
 			if (!t)
 				continue;
+			if (r_shaders.value > 0.f && (t->shader_flags & MAT_SHADERFLAG_NODRAW))
+				continue;
+
+			mat_flags = (r_shaders.value > 0.f) ? t->shader_flags : 0u;
+			if (r_shaders.value > 0.f && t->shader)
+				extra_flags |= CALLFLAG_MAT_HAS_SHADER;
+			if (mat_flags & MAT_SHADERFLAG_BLOOM)
+				extra_flags |= CALLFLAG_MAT_BLOOM;
+			if (mat_flags & MAT_SHADERFLAG_EMISSIVE)
+				extra_flags |= CALLFLAG_MAT_EMISSIVE;
+			if (mat_flags & MAT_SHADERFLAG_GODRAY)
+				extra_flags |= CALLFLAG_MAT_GODRAY;
+			if (mat_flags & MAT_SHADERFLAG_TRANS)
+				extra_flags |= CALLFLAG_MAT_TRANS;
+			if (mat_flags & MAT_SHADERFLAG_SKY)
+				extra_flags |= CALLFLAG_MAT_SKY;
 
 			float alpha = GL_WaterAlphaForEntityTextureType (e, t->type);
 			if ((alpha < 1.f) != translucent)
 				continue;
 			R_AddBModelCall (model->firstcmd + j, baseinst, numinst,
 				R_TextureAnimation (t, frame),
-				!isworld, alpha, 0u, false);
+				!isworld, alpha, extra_flags, false);
 		}
 
 		baseinst += numinst;

--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -190,7 +190,7 @@ void main()
         vec2 velocityOut = vec2(0.0);
         if (viewModelMask < 0.5 && result.a >= 0.999)
                 velocityOut = velocity * result.a;
-        out_velocity = vec4(velocityOut, viewModelMask, 0.0);
+        out_velocity = vec4(velocityOut, viewModelMask, 1.0);
 #endif
 #if MODE == 1 || MODE == 2
 	// Note: sign bit is used as overbright flag

--- a/Quake/shaders/bloom_extract.frag
+++ b/Quake/shaders/bloom_extract.frag
@@ -25,7 +25,11 @@ void main()
                         vec4 sampleColor = texelFetch(SceneTexture, ivec2(sampleCoord), 0);
                         float mask = 1.0;
                         if (maskEnabled > 0.5)
-                                mask = step(0.5, texelFetch(MaskTexture, ivec2(sampleCoord), 0).w);
+                        {
+                                float rawMask = texelFetch(MaskTexture, ivec2(sampleCoord), 0).w;
+                                int maskBits = int(floor(rawMask + 0.5));
+                                mask = ((maskBits & 1) != 0) ? 1.0 : 0.0;
+                        }
                         accum += sampleColor.rgb * mask;
                         weight += mask;
                 }

--- a/Quake/shaders/frame_uniforms.glsl
+++ b/Quake/shaders/frame_uniforms.glsl
@@ -23,6 +23,7 @@ layout(std140, binding=0) uniform FrameDataUBO
         vec4    LightgridParams;
         vec4    DLightParams;
         vec4    ColorSpaceParams;
+        vec4    ShaderParams;
         uint    NumLights;
         uint    PrevFrameValid;
         uint    _Pad1;

--- a/Quake/shaders/particles.frag
+++ b/Quake/shaders/particles.frag
@@ -102,7 +102,7 @@ void main()
 {
 	out_fragcolor = in_color;
 #if !OIT
-        out_velocity = vec4(0.0);
+        out_velocity = vec4(0.0, 0.0, 0.0, 1.0);
 #endif
 	out_fragcolor.rgb = ApplyFog(out_fragcolor.rgb, in_pos);
 	float radius = length(in_uv);

--- a/Quake/shaders/postprocess.frag
+++ b/Quake/shaders/postprocess.frag
@@ -356,14 +356,14 @@ void main()
         bool hasVelocityTexture = MotionParams1.z > 0.5;
         vec2 velocity = vec2(0.0);
         float viewModelMask = 0.0;
-        float materialMask = 0.0;
+        int materialMask = 0;
         if (hasVelocityTexture && inView)
         {
                 vec2 velocityUV = clamp((uv - viewMin) * invScale, vec2(0.0), viewSize * invScale);
                 vec4 velocitySample = texture(VelocityTexture, velocityUV);
                 velocity = velocitySample.xy;
                 viewModelMask = velocitySample.z;
-                materialMask = velocitySample.w;
+                materialMask = int(floor(velocitySample.w + 0.5));
         }
 
         if (MotionParams0.x > 0.5 && inView && hasVelocityTexture && viewModelMask < 0.5 && centerOpaque)
@@ -539,7 +539,7 @@ void main()
                 float ssaoIntensity = SSAOParams.x;
                 int ssaoDebugMode = int(floor(SSAOParams.y + 0.5));
                 bool ssaoInView = inView;
-                bool ssaoAllowed = materialMask < 0.5;
+                bool ssaoAllowed = (materialMask & 2) == 0;
                 if ((ssaoDebugMode > 0 || ssaoIntensity > 0.0) && ssaoInView)
                 {
                         if (!ssaoAllowed)

--- a/Quake/shaders/sky_boxside.frag
+++ b/Quake/shaders/sky_boxside.frag
@@ -60,7 +60,7 @@ layout(location=1) out vec4 out_velocity;
 void main()
 {
 	out_fragcolor = texture(Tex, in_uv);
-        out_velocity = vec4(0.0, 0.0, 0.0, 1.0);
+        out_velocity = vec4(0.0, 0.0, 0.0, 3.0);
 	out_fragcolor.rgb = mix(out_fragcolor.rgb, Fog.rgb, Fog.w);
 #if DITHER
 	out_fragcolor.rgb = sqrt(out_fragcolor.rgb);

--- a/Quake/shaders/sky_cubemap.frag
+++ b/Quake/shaders/sky_cubemap.frag
@@ -78,10 +78,10 @@ void main()
 	layer2.rgb *= layer2.a;
 	vec4 combined = layer1 + layer2;
 	out_fragcolor = vec4(base.rgb * (1.0 - combined.a) + combined.rgb, 1);
-	out_velocity = vec4(0.0, 0.0, 0.0, 1.0);
+	out_velocity = vec4(0.0, 0.0, 0.0, 3.0);
 #else
 	out_fragcolor = texture(Skybox, in_dir);
-        out_velocity = vec4(0.0, 0.0, 0.0, 1.0);
+        out_velocity = vec4(0.0, 0.0, 0.0, 3.0);
 #endif
 	out_fragcolor.rgb = mix(out_fragcolor.rgb, SkyFog.rgb, SkyFog.a);
 #if DITHER

--- a/Quake/shaders/sky_layers.frag
+++ b/Quake/shaders/sky_layers.frag
@@ -82,6 +82,6 @@ void main()
 	result.rgb = mix(result.rgb, layer.rgb, layer.a);
 	result.rgb = mix(result.rgb, SkyFog.rgb, SkyFog.a);
 	out_fragcolor = result;
-        out_velocity = vec4(0.0, 0.0, 0.0, 1.0);
+        out_velocity = vec4(0.0, 0.0, 0.0, 3.0);
 	out_fragcolor.rgb += SUPPRESS_BANDING() * ScreenDither;
 }

--- a/Quake/shaders/sprites.frag
+++ b/Quake/shaders/sprites.frag
@@ -76,7 +76,7 @@ void main()
 
         result.rgb = ApplyFog(result.rgb, in_pos);
         out_fragcolor = result;
-        out_velocity = vec4(0.0);
+        out_velocity = vec4(0.0, 0.0, 0.0, 1.0);
 #if DITHER
 	if (Fog.w > 0.)
 	{

--- a/Quake/shaders/water.frag
+++ b/Quake/shaders/water.frag
@@ -13,7 +13,9 @@ const uint
         CF_USE_FULLBRIGHT = 2u,
         CF_NOLIGHTMAP = 4u,
         CF_USE_EMISSIVE = 8u,
-        CF_ALPHA_TEST = 16u
+        CF_ALPHA_TEST = 16u,
+        CF_MAT_BLOOM = 128u,
+        CF_MAT_HAS_SHADER = 4096u
 ;
 
 // ALU-only 16x16 Bayer matrix
@@ -171,7 +173,9 @@ void main()
         vec2 velocityOut = vec2(0.0);
         if (result.a >= 0.999)
                 velocityOut = velocity * result.a;
-        out_velocity = vec4(velocityOut, 0.0, 1.0);
+        float bloomMask = (((in_flags & CF_MAT_HAS_SHADER) == 0u) || ((in_flags & CF_MAT_BLOOM) != 0u)) ? 1.0 : 0.0;
+        float materialMask = 2.0 + bloomMask;
+        out_velocity = vec4(velocityOut, 0.0, materialMask);
 #endif
 #if DITHER
 	if (Fog.w > 0.)

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -61,7 +61,13 @@ const uint
 	CF_USE_FULLBRIGHT = 2u,
 	CF_NOLIGHTMAP = 4u,
 	CF_USE_EMISSIVE = 8u,
-	CF_ALPHA_TEST = 16u;
+	CF_ALPHA_TEST = 16u,
+	CF_MAT_BLOOM = 128u,
+	CF_MAT_EMISSIVE = 256u,
+	CF_MAT_GODRAY = 512u,
+	CF_MAT_TRANS = 1024u,
+	CF_MAT_SKY = 2048u,
+	CF_MAT_HAS_SHADER = 4096u;
 
 layout(std430, binding=1) restrict readonly buffer CallBuffer
 {
@@ -293,6 +299,29 @@ void main()
                 return;
         }
 
+        int shader_debug = int(ShaderParams.x + 0.5);
+        if (shader_debug >= 2)
+        {
+                vec3 debug_color = vec3(0.0);
+                if ((in_flags & CF_MAT_BLOOM) != 0u)
+                        debug_color += vec3(1.0, 0.0, 1.0);
+                if ((in_flags & CF_MAT_EMISSIVE) != 0u)
+                        debug_color += vec3(1.0, 1.0, 0.0);
+                if ((in_flags & CF_MAT_GODRAY) != 0u)
+                        debug_color += vec3(0.0, 1.0, 1.0);
+                if ((in_flags & CF_MAT_TRANS) != 0u)
+                        debug_color += vec3(0.0, 1.0, 0.0);
+                if ((in_flags & CF_MAT_SKY) != 0u)
+                        debug_color += vec3(0.0, 0.0, 1.0);
+                if (all(lessThanEqual(debug_color, vec3(0.0))))
+                        debug_color = result.rgb;
+                out_fragcolor = vec4(clamp(debug_color, 0.0, 1.0), 1.0);
+#if !OIT
+                out_velocity = vec4(0.0);
+#endif
+                return;
+        }
+
         bool additive_dlights = DLightParams.x > 0.5;
         bool dlight_debug = DLightParams.y > 0.5;
 
@@ -502,7 +531,8 @@ void main()
 #if !OIT
 	vec2 velocity = ComputeVelocity(in_curr_clip, in_prev_clip);
 	vec2 velocityOut = (result.a >= 0.999) ? (velocity * result.a) : vec2(0.0);
-	out_velocity = vec4(velocityOut, 0.0, 0.0);
+	float materialMask = (((in_flags & CF_MAT_HAS_SHADER) == 0u) || ((in_flags & CF_MAT_BLOOM) != 0u)) ? 1.0 : 0.0;
+	out_velocity = vec4(velocityOut, 0.0, materialMask);
 #endif
 
 	// Dithering

--- a/Quake/shaders/world_dlight.frag
+++ b/Quake/shaders/world_dlight.frag
@@ -83,7 +83,7 @@ void main()
         if (debug_mode == 1)
         {
                 out_fragcolor = vec4(albedo, 1.0);
-                out_velocity = vec4(0.0);
+                out_velocity = vec4(0.0, 0.0, 0.0, 1.0);
                 return;
         }
         vec3 surface_normal = normalize(in_normal);
@@ -148,5 +148,5 @@ void main()
         color = ApplyFog(color, in_pos - EyePos);
 
         out_fragcolor = vec4(color, 0.0);
-        out_velocity = vec4(0.0);
+        out_velocity = vec4(0.0, 0.0, 0.0, 1.0);
 }

--- a/Quake/shaders/world_dlight_hybrid.frag
+++ b/Quake/shaders/world_dlight_hybrid.frag
@@ -98,7 +98,7 @@ void main()
         if (debug_mode == 1)
         {
                 out_fragcolor = vec4(albedo, 1.0);
-                out_velocity = vec4(0.0);
+                out_velocity = vec4(0.0, 0.0, 0.0, 1.0);
                 return;
         }
         vec3 surface_normal = normalize(in_normal);
@@ -185,5 +185,5 @@ void main()
         color = ApplyFog(color, in_pos - EyePos);
 
         out_fragcolor = vec4(color, 0.0);
-        out_velocity = vec4(0.0);
+        out_velocity = vec4(0.0, 0.0, 0.0, 1.0);
 }


### PR DESCRIPTION
### Motivation
- Provide a minimal, Quake3-inspired shader script system for per-material metadata (surfaceparms, emissive, bloom, godray) without implementing the full Q3 stage system.
- Allow shader scripts to optionally override base diffuse maps and to act as metadata masks for bloom/godray pipelines.
- Keep design minimal, robust and future-proof: single visible stage used (`stage0`) while storing parsed extra stages, with canonicalization and caching.
- Expose runtime control and debug inspection via cvars and console commands for content authors and developers.

### Description
- Added a small shader module with API and parser: `Quake/mat_shader.h`, `Quake/mat_shader.c`, `Quake/mat_shader_parse.h`, and `Quake/mat_shader_parse.c` which parse `scripts/*.shader` entries and store `shader_material_t` entries (name, editor image, surfaceparms, emissive/bloom/godray flags/scales, `stage0.map_path`, and a stage list).
- Wired parsing + DB into engine: load-on-demand and `Mat_Shader_LoadAll` with console commands `shaderlist` and `shaderprint`, cvars `r_shaders` and `r_shader_debug`, and `r_reloadshaders` callback.
- Integrated materials into texture/model loading and rendering: extended `texture_t` with `shader`, `shader_map`, and `shader_flags`; call `Mat_Shader_ApplyToTexture` in `Mod_LoadTextures` (map override if `stage0.map_path`); added shader-driven flags to `r_world.c` and water/brushed model draw paths (CALLFLAGs) to influence godrays/bloom inclusion and nodraw/sky/trans stubs.
- Shader pipeline and GLSL updates: added call flags -> shader-side `CF_` constants and `Call`/`FrameData` fields for debug/mask usage; updated `frame_uniforms.glsl`, `world.frag`, `water.frag`, `postprocess.frag`, `bloom_extract.frag` and several other shader sources to carry material mask bits, include simple debug overlay colorization and encode material masks into the velocity/material mask channel used by postprocessing.
- Small engine lifecycle changes: register `Mat_Shader_Init` in `R_Init`, call `Mat_Shader_Shutdown` in `Mod_ClearAll`, and added sources to Makefiles (`mat_shader.o`, `mat_shader_parse.o`).

### Testing
- Automated tests: none were run for this change set.
- Manual checks performed during rollout: parser and code were added and integrated into the build tree and source files were committed; no compile or runtime validation was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952a7654c8c832e85cf190b4a70c0db)