### PR TITLE
Add missing shader and dlight pool sources to VS project

### DIFF
--- a/Windows/VisualStudio/ironwail.vcxproj
+++ b/Windows/VisualStudio/ironwail.vcxproj
@@ -273,6 +273,8 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
     <ClCompile Include="..\..\Quake\keys.c" />
     <ClCompile Include="..\..\Quake\main_sdl.c" />
     <ClCompile Include="..\..\Quake\mathlib.c" />
+    <ClCompile Include="..\..\Quake\mat_shader.c" />
+    <ClCompile Include="..\..\Quake\mat_shader_parse.c" />
     <ClCompile Include="..\..\Quake\menu.c" />
     <ClCompile Include="..\..\Quake\miniz.c">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
@@ -308,6 +310,7 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
     </ClCompile>
     <ClCompile Include="..\..\Quake\r_alias.c" />
     <ClCompile Include="..\..\Quake\r_brush.c" />
+    <ClCompile Include="..\..\Quake\r_dlight_pool.c" />
     <ClCompile Include="..\..\Quake\r_maptex_export.c" />
     <ClCompile Include="..\..\Quake\r_part.c" />
     <ClCompile Include="..\..\Quake\r_sprite.c" />
@@ -391,6 +394,8 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
     <ClInclude Include="..\..\Quake\json.h" />
     <ClInclude Include="..\..\Quake\keys.h" />
     <ClInclude Include="..\..\Quake\mathlib.h" />
+    <ClInclude Include="..\..\Quake\mat_shader.h" />
+    <ClInclude Include="..\..\Quake\mat_shader_parse.h" />
     <ClInclude Include="..\..\Quake\menu.h" />
     <ClInclude Include="..\..\Quake\miniz.h" />
     <ClInclude Include="..\..\Quake\modelgen.h" />
@@ -411,6 +416,7 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
     <ClInclude Include="..\..\Quake\q_sound.h" />
     <ClInclude Include="..\..\Quake\q_stdinc.h" />
     <ClInclude Include="..\..\Quake\render.h" />
+    <ClInclude Include="..\..\Quake\r_dlight_pool.h" />
     <ClInclude Include="..\..\Quake\resource.h" />
     <ClInclude Include="..\..\Quake\sbar.h" />
     <ClInclude Include="..\..\Quake\screen.h" />

--- a/Windows/VisualStudio/ironwail.vcxproj.filters
+++ b/Windows/VisualStudio/ironwail.vcxproj.filters
@@ -129,6 +129,12 @@
     <ClCompile Include="..\..\Quake\mathlib.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Quake\mat_shader.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Quake\mat_shader_parse.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\Quake\menu.c">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -169,6 +175,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\Quake\r_brush.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Quake\r_dlight_pool.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\Quake\r_part.c">
@@ -359,6 +368,12 @@
     <ClInclude Include="..\..\Quake\mathlib.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\Quake\mat_shader.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Quake\mat_shader_parse.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\Quake\menu.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -414,6 +429,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Quake\render.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Quake\r_dlight_pool.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Quake\resource.h">


### PR DESCRIPTION
### Motivation

- The Windows build was failing with unresolved linker symbols for `Mat_Shader_*` and `DLightPool_*`, indicating shader and dynamic-light sources were not part of the VS build.
- These are project/filters omissions that prevent the compiler/linker from compiling and linking the relevant translation units.

### Description

- Added `mat_shader.c`, `mat_shader_parse.c`, and `r_dlight_pool.c` to `Windows/VisualStudio/ironwail.vcxproj` as `ClCompile` entries so those sources are built.
- Added corresponding entries to `Windows/VisualStudio/ironwail.vcxproj.filters` to make the new source files visible in the VS solution explorer.
- Added `mat_shader.h`, `mat_shader_parse.h`, and `r_dlight_pool.h` to the project `ClInclude` lists so headers appear in the project and filter views.
- Modified files: `Windows/VisualStudio/ironwail.vcxproj` and `Windows/VisualStudio/ironwail.vcxproj.filters`.

### Testing

- No automated tests were run because this change only updates project and filter files and does not change source logic.
- Local build/link verification was not executed as part of the automated pipeline for this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952bb67c5e4832e87d4290667d24394)