### PR TITLE
Simplify color controls and fix SSAO scaling

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -206,7 +206,6 @@ mleaf_t* r_viewleaf, * r_oldviewleaf;
 int		d_lightstylevalue[256];	// 8.8 fraction of base light value
 
 static qboolean gl_framebuffer_srgb_enabled = false;
-static qboolean gl_srgb_policy_warned = false;
 static qboolean gl_srgb_capability_warned = false;
 
 
@@ -222,14 +221,9 @@ cvar_t	r_lightmap_mipmaps = { "r_lightmap_mipmaps", "1", CVAR_ARCHIVE };
 cvar_t	r_lightmap16f = { "r_lightmap16f", "0", CVAR_ARCHIVE };
 cvar_t	r_lightingdir = { "r_lightingdir", "0", CVAR_ARCHIVE };
 cvar_t	r_rgblighting_enable = { "r_rgblighting_enable", "1", CVAR_ARCHIVE };
-cvar_t	r_saturation = { "r_saturation", "1", CVAR_ARCHIVE };
 cvar_t	r_srgb_textures = { "r_srgb_textures", "1", CVAR_ARCHIVE };
 cvar_t	r_srgb_framebuffer = { "r_srgb_framebuffer", "1", CVAR_ARCHIVE };
-cvar_t	r_manual_gamma = { "r_manual_gamma", "0", CVAR_ARCHIVE };
-cvar_t	r_gamma = { "r_gamma", "2.2", CVAR_ARCHIVE };
 cvar_t	r_debug_colorspace = { "r_debug_colorspace", "0", CVAR_ARCHIVE };
-cvar_t	r_post_contrast = { "r_post_contrast", "1.0", CVAR_ARCHIVE };
-cvar_t	r_post_saturation = { "r_post_saturation", "1.05", CVAR_ARCHIVE };
 cvar_t	r_color_midtone = { "r_color_midtone", "1.0", CVAR_ARCHIVE };
 cvar_t	r_color_contrast = { "r_color_contrast", "1.0", CVAR_ARCHIVE };
 cvar_t	r_color_saturation = { "r_color_saturation", "1.05", CVAR_ARCHIVE };
@@ -329,7 +323,6 @@ cvar_t	r_godrays_lighttex_intensity = { "r_godrays_lighttex_intensity", "1.0", C
 cvar_t	r_godrays_emissive_threshold = { "r_godrays_emissive_threshold", "0.4", CVAR_ARCHIVE };
 cvar_t	r_godrays_light_threshold = { "r_godrays_light_threshold", "0.6", CVAR_ARCHIVE };
 cvar_t	r_godrays_mask_knee = { "r_godrays_mask_knee", "0.0", CVAR_ARCHIVE };
-cvar_t	r_godrays_mask_gamma = { "r_godrays_mask_gamma", "1.0", CVAR_ARCHIVE };
 cvar_t	r_godrays_blur = { "r_godrays_blur", "1.5", CVAR_ARCHIVE };
 cvar_t	r_godrays_lighttex_name_match = { "r_godrays_lighttex_name_match", "1", CVAR_ARCHIVE };
 cvar_t	r_godrays_samples = { "r_godrays_samples", "48", CVAR_ARCHIVE };
@@ -1469,7 +1462,6 @@ static void GL_GenerateGodraysSource (qboolean draw_sky, qboolean draw_brush)
 	if (!draw_sky && !draw_brush)
 		return;
 	float mask_knee = q_max (0.f, r_godrays_mask_knee.value);
-	float mask_gamma = q_max (0.f, r_godrays_mask_gamma.value);
 
 	GL_BeginGroup ("Godrays source");
 	GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.godrays.source_fbo);
@@ -1494,7 +1486,7 @@ static void GL_GenerateGodraysSource (qboolean draw_sky, qboolean draw_brush)
 			GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, framebufs.composite.depth_stencil_tex);
 			GL_Uniform4fFunc (0, sky_depth_cutoff, sky_intensity, reversed_z, sky_threshold);
 			GL_Uniform4fFunc (1, tint[0], tint[1], tint[2], 0.f);
-			GL_Uniform4fFunc (2, mask_knee, mask_gamma, 0.f, 0.f);
+			GL_Uniform4fFunc (2, mask_knee, 0.f, 0.f, 0.f);
 			glDrawArrays (GL_TRIANGLES, 0, 3);
 		}
 	}
@@ -1512,7 +1504,7 @@ static void GL_GenerateGodraysSource (qboolean draw_sky, qboolean draw_brush)
 				q_max (0.f, r_godrays_lighttex_intensity.value),
 				q_max (0.f, r_godrays_emissive_threshold.value),
 				q_max (0.f, r_godrays_light_threshold.value));
-			GL_Uniform4fFunc (1, mask_knee, mask_gamma, 0.f, 0.f);
+			GL_Uniform4fFunc (1, mask_knee, 0.f, 0.f, 0.f);
 			R_DrawBrushModels_Godrays (ents, count);
 		}
 	}
@@ -1678,19 +1670,11 @@ static void GL_SetFramebufferSRGB (qboolean enable)
 #endif
 }
 
-static qboolean GL_UseManualGamma (void)
+static qboolean GL_UseSRGBFramebuffer (void)
 {
-	if (r_srgb_framebuffer.value > 0.f && r_manual_gamma.value > 0.f)
-	{
-		if (!gl_srgb_policy_warned)
-		{
-			Con_Warning ("Both r_srgb_framebuffer and r_manual_gamma are enabled; disabling r_manual_gamma.\n");
-			gl_srgb_policy_warned = true;
-		}
-		Cvar_SetValueQuick (&r_manual_gamma, 0.f);
-	}
-
-	if (r_srgb_framebuffer.value > 0.f && !vid_framebuffer_srgb_capable)
+	if (r_srgb_framebuffer.value <= 0.f)
+		return false;
+	if (!vid_framebuffer_srgb_capable)
 	{
 		if (!gl_srgb_capability_warned)
 		{
@@ -1698,9 +1682,9 @@ static qboolean GL_UseManualGamma (void)
 			gl_srgb_capability_warned = true;
 		}
 		Cvar_SetValueQuick (&r_srgb_framebuffer, 0.f);
+		return false;
 	}
-
-	return r_manual_gamma.value > 0.f;
+	return true;
 }
 
 static void GL_PostProcessFallback (void)
@@ -1726,15 +1710,12 @@ static void GL_PostProcessFallback (void)
 	glReadBuffer (GL_BACK);
 	glPixelStorei (GL_UNPACK_ALIGNMENT, 1);
 	{
-		qboolean manual_gamma = GL_UseManualGamma ();
-		qboolean srgb_output = (r_srgb_framebuffer.value > 0.f) && !manual_gamma;
+		qboolean srgb_output = GL_UseSRGBFramebuffer ();
 		GL_SetFramebufferSRGB (srgb_output);
 	}
 
 	float sat = CLAMP (0.9f, r_color_saturation.value, 1.2f);
 	float post_contrast = CLAMP (0.8f, r_color_contrast.value, 1.2f);
-	qboolean manual_gamma = GL_UseManualGamma ();
-	float gamma = manual_gamma ? (1.0f / q_max (0.1f, r_gamma.value)) : 1.0f;
 	float midtone = q_max (0.1f, r_color_midtone.value);
 	qboolean output_srgb = (r_srgb_framebuffer.value <= 0.f);
 	if (vid_framebuffer_srgb_capable && r_srgb_framebuffer.value > 0.f)
@@ -1765,12 +1746,6 @@ static void GL_PostProcessFallback (void)
 			color[0] = l + (color[0] - l) * sat;
 			color[1] = l + (color[1] - l) * sat;
 			color[2] = l + (color[2] - l) * sat;
-		}
-		if (manual_gamma)
-		{
-			color[0] = powf (color[0], gamma);
-			color[1] = powf (color[1], gamma);
-			color[2] = powf (color[2], gamma);
 		}
 		if (output_srgb)
 		{
@@ -2096,10 +2071,9 @@ void GL_PostProcess (void)
 	GL_BindFramebufferFunc (GL_FRAMEBUFFER, 0);
 	glViewport (glx, gly, glwidth, glheight);
 	{
-		qboolean manual_gamma = GL_UseManualGamma ();
 		int debug_mode = (int)Q_rint (CLAMP (0.f, r_debug_colorspace.value, 4.f));
 		qboolean linear_debug = (debug_mode == 2);
-		qboolean srgb_output = (r_srgb_framebuffer.value > 0.f) && !manual_gamma && !linear_debug;
+		qboolean srgb_output = GL_UseSRGBFramebuffer () && !linear_debug;
 		GL_SetFramebufferSRGB (srgb_output);
 	}
 
@@ -2123,19 +2097,16 @@ void GL_PostProcess (void)
 	GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 0, gl_palette_buffer[palidx], 0, 256 * sizeof (GLuint));
 	if (variant != 2) // some AMD drivers optimize out the uniform in variant #2
 	{
-		qboolean manual_gamma = GL_UseManualGamma ();
-		float gamma = manual_gamma ? (1.0f / q_max (0.1f, r_gamma.value)) : 1.0f;
 		float post_contrast = CLAMP (0.8f, r_color_contrast.value, 1.2f);
-		GL_Uniform4fFunc (0, gamma, post_contrast, 1.f / r_refdef.scale, dither);
+		GL_Uniform4fFunc (0, 1.f, post_contrast, 1.f / r_refdef.scale, dither);
 	}
 	{
-		qboolean manual_gamma = GL_UseManualGamma ();
 		int debug_mode = (int)Q_rint (CLAMP (0.f, r_debug_colorspace.value, 4.f));
 		qboolean linear_debug = (debug_mode == 2);
 		qboolean output_srgb = (r_srgb_framebuffer.value <= 0.f) || !vid_framebuffer_srgb_capable;
 		if (linear_debug)
 			output_srgb = false;
-		GL_Uniform4fFunc (19, (float)debug_mode, manual_gamma ? 1.f : 0.f, output_srgb ? 1.f : 0.f, 0.f);
+		GL_Uniform4fFunc (19, (float)debug_mode, 0.f, output_srgb ? 1.f : 0.f, 0.f);
 	}
 	GL_Uniform3fFunc (5, bloom_intensity, exposure, tonemap_mode);
 	GL_Uniform4fFunc (6, motion_enabled ? 1.f : 0.f, motion_effective_shutter, motion_min_velocity, motion_depth_threshold);
@@ -2821,7 +2792,7 @@ qboolean GL_NeedsPostprocess (void)
 	r_color_saturation.value = saturation;
 	if (softemu || R_GetEffectiveAlphaMode () == ALPHAMODE_OIT || R_DoFEnabled ())
 		return true;
-	if (r_manual_gamma.value > 0.f || r_debug_colorspace.value > 0.f)
+	if (r_debug_colorspace.value > 0.f)
 		return true;
 	if (r_tonemap.value > 0.f || r_bloom.value > 0.f || r_color_contrast.value != 1.f || saturation != 1.f || r_color_midtone.value != 1.f || GL_ShouldApplyMotionBlur ())
 		return true;
@@ -2846,8 +2817,8 @@ COLOR-SPACE POLICY (HYBRID LINEAR)
 3) Lightmaps are controlled by r_lightmap_colorspace (srgb|linear). "srgb" assumes gamma-encoded
    bakes and decodes on sampling; "linear" bypasses conversion.
 4) UI/HUD/2D is mixed AFTER tone mapping in LDR space (postprocess output).
-5) Exactly one output transform: postprocess applies the Quake curve + optional legacy gamma, then
-   performs linear->sRGB conversion if the backbuffer is not sRGB-capable.
+5) Exactly one output transform: postprocess applies the Quake curve, then performs linear->sRGB
+   conversion if the backbuffer is not sRGB-capable.
 ====================================================================================================
 */
 
@@ -2885,8 +2856,7 @@ void R_SetupGL (void)
 	if (!GL_NeedsSceneEffects ())
 	{
 		GLuint target = GL_NeedsPostprocess () ? framebufs.composite.fbo : 0u;
-		qboolean manual_gamma = GL_UseManualGamma ();
-		qboolean srgb_output = (target == 0u) && (r_srgb_framebuffer.value > 0.f) && !manual_gamma;
+		qboolean srgb_output = (target == 0u) && GL_UseSRGBFramebuffer ();
 
 		GL_BindFramebufferFunc (GL_FRAMEBUFFER, target);
 		GL_SetFramebufferSRGB (srgb_output);
@@ -4353,11 +4323,14 @@ void R_WarpScaleView (void)
 
 	if (need_depth_resolve && (!msaa || needwarpscale))
 	{
+		int dstw = (r_refdef.scale != 1) ? r_refdef.vrect.width : srcw;
+		int dsth = (r_refdef.scale != 1) ? r_refdef.vrect.height : srch;
+
 		GL_BindFramebufferFunc (GL_READ_FRAMEBUFFER, framebufs.scene.fbo);
 		glReadBuffer (GL_COLOR_ATTACHMENT0);
 		GL_BindFramebufferFunc (GL_DRAW_FRAMEBUFFER, framebufs.composite.fbo);
 		glDrawBuffer (GL_COLOR_ATTACHMENT0);
-		GL_BlitFramebufferFunc (0, 0, srcw, srch, srcx, srcy, srcx + srcw, srcy + srch, GL_DEPTH_BUFFER_BIT, GL_NEAREST);
+		GL_BlitFramebufferFunc (0, 0, srcw, srch, srcx, srcy, srcx + dstw, srcy + dsth, GL_DEPTH_BUFFER_BIT, GL_NEAREST);
 	}
 
 	if (!msaa && !needwarpscale)

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -101,14 +101,9 @@ extern cvar_t r_exposure_speed_up;
 extern cvar_t r_exposure_speed_down;
 extern cvar_t r_exposure_lock;
 extern cvar_t r_exposure_debug;
-extern cvar_t r_saturation;
 extern cvar_t r_srgb_textures;
 extern cvar_t r_srgb_framebuffer;
-extern cvar_t r_manual_gamma;
-extern cvar_t r_gamma;
 extern cvar_t r_debug_colorspace;
-extern cvar_t r_post_contrast;
-extern cvar_t r_post_saturation;
 extern cvar_t r_color_midtone;
 extern cvar_t r_color_contrast;
 extern cvar_t r_color_saturation;
@@ -157,7 +152,6 @@ extern cvar_t r_godrays_lighttex_intensity;
 extern cvar_t r_godrays_emissive_threshold;
 extern cvar_t r_godrays_light_threshold;
 extern cvar_t r_godrays_mask_knee;
-extern cvar_t r_godrays_mask_gamma;
 extern cvar_t r_godrays_blur;
 extern cvar_t r_godrays_lighttex_name_match;
 extern cvar_t r_godrays_samples;
@@ -209,25 +203,6 @@ extern cvar_t r_simd;
 qboolean use_simd;
 
 extern gltexture_t *playertextures[MAX_SCOREBOARD]; //johnfitz
-
-static qboolean r_color_syncing = false;
-
-static void R_ColorCurveSync_f (cvar_t *var)
-{
-	if (r_color_syncing)
-		return;
-
-	r_color_syncing = true;
-	if (var == &r_post_contrast)
-		Cvar_SetValueQuick (&r_color_contrast, r_post_contrast.value);
-	else if (var == &r_color_contrast)
-		Cvar_SetValueQuick (&r_post_contrast, r_color_contrast.value);
-	else if (var == &r_post_saturation)
-		Cvar_SetValueQuick (&r_color_saturation, r_post_saturation.value);
-	else if (var == &r_color_saturation)
-		Cvar_SetValueQuick (&r_post_saturation, r_color_saturation.value);
-	r_color_syncing = false;
-}
 
 extern char r_showbboxes_filter_strings[MAXCMDLINE];
 extern qboolean r_showbboxes_filter_byindex;
@@ -552,22 +527,13 @@ Cvar_RegisterVariable (&r_exposure_speed_up);
 Cvar_RegisterVariable (&r_exposure_speed_down);
 Cvar_RegisterVariable (&r_exposure_lock);
 Cvar_RegisterVariable (&r_exposure_debug);
-Cvar_RegisterVariable (&r_saturation);
 Cvar_RegisterVariable (&r_srgb_textures);
 Cvar_SetCallback (&r_srgb_textures, TexMgr_SRGBTextures_f);
 Cvar_RegisterVariable (&r_srgb_framebuffer);
-Cvar_RegisterVariable (&r_manual_gamma);
-Cvar_RegisterVariable (&r_gamma);
 Cvar_RegisterVariable (&r_debug_colorspace);
-Cvar_RegisterVariable (&r_post_contrast);
-Cvar_RegisterVariable (&r_post_saturation);
 Cvar_RegisterVariable (&r_color_midtone);
 Cvar_RegisterVariable (&r_color_contrast);
 Cvar_RegisterVariable (&r_color_saturation);
-Cvar_SetCallback (&r_post_contrast, R_ColorCurveSync_f);
-Cvar_SetCallback (&r_post_saturation, R_ColorCurveSync_f);
-Cvar_SetCallback (&r_color_contrast, R_ColorCurveSync_f);
-Cvar_SetCallback (&r_color_saturation, R_ColorCurveSync_f);
 Cvar_RegisterVariable (&r_bloom);
 Cvar_RegisterVariable (&r_bloom_threshold);
 Cvar_RegisterVariable (&r_ssao);
@@ -608,7 +574,6 @@ Cvar_RegisterVariable (&r_godrays);
 	Cvar_RegisterVariable (&r_godrays_emissive_threshold);
 	Cvar_RegisterVariable (&r_godrays_light_threshold);
 	Cvar_RegisterVariable (&r_godrays_mask_knee);
-	Cvar_RegisterVariable (&r_godrays_mask_gamma);
 	Cvar_RegisterVariable (&r_godrays_blur);
 Cvar_RegisterVariable (&r_godrays_lighttex_name_match);
 Cvar_RegisterVariable (&r_godrays_samples);

--- a/Quake/gl_texmgr.c
+++ b/Quake/gl_texmgr.c
@@ -37,8 +37,6 @@ extern cvar_t r_lightmap16f;
 extern cvar_t r_lightmap_linear;
 extern cvar_t r_lightmap_colorspace;
 extern cvar_t r_srgb_textures;
-extern cvar_t r_manual_gamma;
-extern cvar_t r_gamma;
 extern cvar_t r_color_contrast;
 
 typedef struct {
@@ -2909,7 +2907,6 @@ GLuint gl_palette_buffer[2]; // original + postprocessed
 
 static unsigned int cached_palette[256];
 static softemu_metric_t cached_softemu_metric = SOFTEMU_METRIC_INVALID;
-static float cached_gamma;
 static float cached_contrast;
 static vec4_t cached_blendcolor;
 
@@ -2921,7 +2918,6 @@ GLPalette_DeleteResources
 static void GLPalette_InvalidateRemapped (void)
 {
 	int i;
-	cached_gamma = -1.f;
 	cached_contrast = -1.f;
 	for (i = 0; i < 4; i++)
 		cached_blendcolor[i] = -1.f;
@@ -3044,19 +3040,15 @@ Returns index of palette buffer to use:
 
 	/* can we use the original palette? */
 	{
-		float gamma = (r_manual_gamma.value > 0.f) ? (1.0f / q_max (0.1f, r_gamma.value)) : 1.0f;
 		float contrast = r_color_contrast.value;
-		if (gamma == 1.f && contrast == 1.f &&
-		blend[3] == 0.f)
+		if (contrast == 1.f && blend[3] == 0.f)
 			return 0;
 
 		/* no change since last time? */
-		if (cached_gamma == gamma &&
-			cached_contrast == contrast &&
+		if (cached_contrast == contrast &&
 		memcmp (cached_blendcolor, blend, 4 * sizeof (float)) == 0)
 			return 1;
 
-		cached_gamma = gamma;
 		cached_contrast = contrast;
 	}
 	memcpy (cached_blendcolor, blend, 4 * sizeof (float));
@@ -3067,10 +3059,8 @@ Returns index of palette buffer to use:
 	GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 0, gl_palette_buffer[0], 0, 256 * sizeof (GLuint));
 	GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 1, gl_palette_buffer[1], 0, 256 * sizeof (GLuint));
 	{
-		float gamma = (r_manual_gamma.value > 0.f) ? (1.0f / q_max (0.1f, r_gamma.value)) : 1.0f;
 		float contrast = CLAMP (0.1f, r_color_contrast.value, 2.0f);
-		GL_Uniform2fFunc (0, gamma, contrast);
-		GL_Uniform1fFunc (2, r_manual_gamma.value > 0.f ? 1.f : 0.f);
+		GL_Uniform1fFunc (0, contrast);
 	}
 	GL_Uniform4fvFunc (1, 1, blend);
 	GL_DispatchComputeFunc (256/64, 1, 1);

--- a/Quake/shaders/godrays_source.frag
+++ b/Quake/shaders/godrays_source.frag
@@ -7,7 +7,7 @@
 #endif
 
 layout(location=0) uniform vec4 GodraysSourceParams0; // x: emissive intensity, y: light intensity, z: emissive threshold, w: light threshold
-layout(location=1) uniform vec4 GodraysSourceParams1; // x: mask knee, y: mask gamma, z: unused, w: unused
+layout(location=1) uniform vec4 GodraysSourceParams1; // x: mask knee, yzw: unused
 
 const uint
 	CF_USE_FULLBRIGHT = 2u,
@@ -25,13 +25,11 @@ layout(location=3) in vec2 in_uv;
 
 layout(location=0) out vec4 outColor;
 
-float BrightPartMask(vec3 color, float threshold, float knee, float gamma)
+float BrightPartMask(vec3 color, float threshold, float knee)
 {
 	float luma = dot(color, vec3(0.2126, 0.7152, 0.0722));
 	float k = (knee > 0.0) ? knee : max(threshold * 0.5, 1e-5);
 	float mask = smoothstep(threshold - k, threshold + k, luma);
-	if (gamma > 0.0 && abs(gamma - 1.0) > 1e-4)
-		mask = pow(mask, gamma);
 	return mask;
 }
 
@@ -73,18 +71,17 @@ void main()
 	float light_mask = 0.0;
 	float emissive_mask = 0.0;
 	float knee = GodraysSourceParams1.x;
-	float gamma = GodraysSourceParams1.y;
 
 	if ((in_flags & CF_GODRAYS_LIGHT) != 0u)
 	{
 		light_color = base.rgb;
 		light_strength = GodraysSourceParams0.y;
-		light_mask = BrightPartMask(light_color, GodraysSourceParams0.w, knee, gamma);
+		light_mask = BrightPartMask(light_color, GodraysSourceParams0.w, knee);
 	}
 	if ((in_flags & CF_GODRAYS_EMISSIVE) != 0u)
 	{
 		emissive_strength = GodraysSourceParams0.x;
-		emissive_mask = BrightPartMask(emissive_color, GodraysSourceParams0.z, knee, gamma);
+		emissive_mask = BrightPartMask(emissive_color, GodraysSourceParams0.z, knee);
 	}
 
 	vec3 color = vec3(0.0);

--- a/Quake/shaders/godrays_source_sky.frag
+++ b/Quake/shaders/godrays_source_sky.frag
@@ -1,17 +1,15 @@
 layout(binding=0) uniform sampler2D DepthTexture;
 layout(location=0) uniform vec4 SkyParams; // x: depth cutoff, y: sky intensity, z: reversed z flag, w: sky threshold
 layout(location=1) uniform vec4 SkyTint; // rgb: sky tint
-layout(location=2) uniform vec4 SkyMaskParams; // x: mask knee, y: mask gamma, zw: unused
+layout(location=2) uniform vec4 SkyMaskParams; // x: mask knee, yzw: unused
 
 layout(location=0) out vec4 outColor;
 
-float BrightPartMask(vec3 color, float threshold, float knee, float gamma)
+float BrightPartMask(vec3 color, float threshold, float knee)
 {
 	float luma = dot(color, vec3(0.2126, 0.7152, 0.0722));
 	float k = (knee > 0.0) ? knee : max(threshold * 0.5, 1e-5);
 	float mask = smoothstep(threshold - k, threshold + k, luma);
-	if (gamma > 0.0 && abs(gamma - 1.0) > 1e-4)
-		mask = pow(mask, gamma);
 	return mask;
 }
 
@@ -22,7 +20,7 @@ void main()
 	bool isSky = (SkyParams.z > 0.5) ? (depth <= SkyParams.x) : (depth >= SkyParams.x);
 	float mask = 0.0;
 	if (isSky)
-		mask = BrightPartMask(SkyTint.rgb, SkyParams.w, SkyMaskParams.x, SkyMaskParams.y);
+		mask = BrightPartMask(SkyTint.rgb, SkyParams.w, SkyMaskParams.x);
 	vec3 color = SkyTint.rgb * SkyParams.y * mask;
 	outColor = vec4(color, mask);
 }

--- a/Quake/shaders/palette_postprocess.comp
+++ b/Quake/shaders/palette_postprocess.comp
@@ -1,8 +1,7 @@
 layout(local_size_x=64) in;
 
-layout(location=0) uniform vec2 GammmaContrast;
+layout(location=0) uniform float Contrast;
 layout(location=1) uniform vec4 BlendColor;
-layout(location=2) uniform float ManualGamma;
 
 layout(std430, binding=0) restrict readonly buffer PaletteBuffer
 {
@@ -22,16 +21,13 @@ layout(std430, binding=1) restrict writeonly buffer DstPaletteBuffer
 
 void main()
 {
-	float gamma = GammmaContrast.x;
-	float contrast = GammmaContrast.y;
+	float contrast = Contrast;
 	uint idx = gl_GlobalInvocationID.x;
 	if (idx >= 256u)
 		return;
 	vec3 color = vec3(UnpackRGB8(Palette[idx])) * (1./255.);
 	color = mix(color, BlendColor.rgb, BlendColor.a);
 	color *= contrast;
-	if (ManualGamma > 0.5)
-		color = pow(color, vec3(gamma));
 	uvec3 dst = uvec3(clamp(color, 0., 1.) * 255. + .5);
 	DstPalette[idx] = dst.r | (dst.g << 8) | (dst.b << 16) | 0xff000000u;
 }

--- a/Quake/shaders/postprocess.frag
+++ b/Quake/shaders/postprocess.frag
@@ -142,7 +142,7 @@ layout(location=15) uniform vec4 FilmGrainParams2; // x: frame, yzw: unused
 layout(location=16) uniform vec4 GodraysParams; // x: enabled, y: debug, z: debug source mode, w: unused
 layout(location=17) uniform vec4 SSAOParams; // x: intensity, y: debug mode, z: upscale nearest, w: unused
 layout(location=18) uniform vec4 SSAOBlurParams; // x: blur sigma, y: blur radius, z: depth threshold scale, w: unused
-layout(location=19) uniform vec4 ColorSpaceParams; // x: debug mode, y: manual gamma enabled, z: output sRGB conversion, w: reserved
+layout(location=19) uniform vec4 ColorSpaceParams; // x: debug mode, y: unused, z: output sRGB conversion, w: reserved
 layout(location=20) uniform float u_midtone;
 
 const int MOTION_MAX_SAMPLES = 64;
@@ -314,12 +314,10 @@ layout(location=0) out vec4 out_fragcolor;
 
 void main()
 {
-        float gamma = Params.x;
         float postContrast = Params.y;
         float scale = Params.z;
         float dither = Params.w;
         int debugMode = int(floor(ColorSpaceParams.x + 0.5));
-        float manualGamma = ColorSpaceParams.y;
         float outputSrgb = ColorSpaceParams.z;
         ivec2 pixel = ivec2(gl_FragCoord.xy);
         vec4 color = texelFetch(GammaTexture, pixel, 0);
@@ -673,8 +671,6 @@ void main()
                 mapped = pow(mapped, vec3(1.0 / midtone));
         mapped = ApplyPostContrast(mapped, postContrast);
         mapped = ApplySaturation(mapped, u_saturation);
-        if (manualGamma > 0.5)
-                mapped = pow(mapped, vec3(gamma));
         if (outputSrgb > 0.5)
                 mapped = LinearToSRGB(mapped);
         out_fragcolor = vec4(mapped, 1.0);


### PR DESCRIPTION
### Motivation
- Remove legacy/duplicate color controls and code paths (legacy gamma, post-saturation/contrast, etc.) to keep a single coherent color control surface using `r_color_*` cvars.
- Eliminate confusing manual-gamma policy interactions and streamline sRGB/backbuffer handling.
- Fix SSAO failing to sample depth correctly when the 3D view is rendered at reduced resolution via `r_scale` by ensuring depth is resolved/scaled to the full view rect.
- Simplify godrays mask handling by dropping the mask-gamma parameter from the CPU and shader paths.

### Description
- Deleted legacy cvars and code that exposed `r_saturation`, `r_manual_gamma`, `r_gamma`, `r_post_contrast`, `r_post_saturation`, `r_godrays_mask_gamma`, and related sync callbacks, leaving only `r_color_saturation`, `r_color_midtone`, and `r_color_contrast` for color tuning.
- Replaced `GL_UseManualGamma` with `GL_UseSRGBFramebuffer` and removed manual-gamma code paths from postprocess, palette, and fallback code, consolidating sRGB/backbuffer decisions into a single check (`GL_UseSRGBFramebuffer`).
- Simplified palette postprocess: the palette compute shader now takes only a `Contrast` uniform and the CPU-side palette code no longer stores or uses `cached_gamma` or manual-gamma flags.
- Removed manual-gamma branching from `postprocess.frag` and removed `gamma`/`manualGamma` usage there; kept midtone/contrast/saturation handling via `r_color_*` and the postprocess uniforms.
- Removed `mask_gamma` usage from godrays code and updated `godrays_source.frag` / `godrays_source_sky.frag` to drop the gamma parameter and use the knee only, and set the godrays mask uniform to neutral on the CPU side.
- Fixed SSAO/depth resolution for reduced-resolution rendering (`r_scale > 1`) by scaling the depth blit destination to the full view rectangle when resolving depth between scene and composite framebuffers.

### Testing
- No automated tests were executed for this change set (none were requested during the rollout).
- The changes were compiled/committed locally during development to validate source edits (no runtime or CI test results are included here).
- Manual code inspection targeted shader uniforms and FBO blit coordinates to ensure `r_color_*` paths and SSAO depth blits are consistent with `r_scale`.
- Shader sources and affected registration/callback sites were updated to remove now-unused cvars and callbacks to avoid runtime lookups of removed variables.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952c8e1f398832eb5ab7abb29064a27)