### PR TITLE
Limit SSAO to opaque geometry and exclude translucent/particle/sprite/viewmodel pixels

### DIFF
--- a/Quake/shaders/particles.frag
+++ b/Quake/shaders/particles.frag
@@ -102,7 +102,7 @@ void main()
 {
 	out_fragcolor = in_color;
 #if !OIT
-        out_velocity = vec4(0.0, 0.0, 0.0, 1.0);
+        out_velocity = vec4(0.0, 0.0, 0.0, 2.0);
 #endif
 	out_fragcolor.rgb = ApplyFog(out_fragcolor.rgb, in_pos);
 	float radius = length(in_uv);

--- a/Quake/shaders/postprocess.frag
+++ b/Quake/shaders/postprocess.frag
@@ -537,7 +537,7 @@ void main()
                 float ssaoIntensity = SSAOParams.x;
                 int ssaoDebugMode = int(floor(SSAOParams.y + 0.5));
                 bool ssaoInView = inView;
-                bool ssaoAllowed = (materialMask & 2) == 0;
+                bool ssaoAllowed = (materialMask & 2) == 0 && viewModelMask < 0.5;
                 if ((ssaoDebugMode > 0 || ssaoIntensity > 0.0) && ssaoInView)
                 {
                         if (!ssaoAllowed)

--- a/Quake/shaders/sprites.frag
+++ b/Quake/shaders/sprites.frag
@@ -76,7 +76,7 @@ void main()
 
         result.rgb = ApplyFog(result.rgb, in_pos);
         out_fragcolor = result;
-        out_velocity = vec4(0.0, 0.0, 0.0, 1.0);
+        out_velocity = vec4(0.0, 0.0, 0.0, 2.0);
 #if DITHER
 	if (Fog.w > 0.)
 	{

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -532,6 +532,8 @@ void main()
 	vec2 velocity = ComputeVelocity(in_curr_clip, in_prev_clip);
 	vec2 velocityOut = (result.a >= 0.999) ? (velocity * result.a) : vec2(0.0);
 	float materialMask = (((in_flags & CF_MAT_HAS_SHADER) == 0u) || ((in_flags & CF_MAT_BLOOM) != 0u)) ? 1.0 : 0.0;
+	if ((in_flags & CF_MAT_TRANS) != 0u)
+		materialMask += 2.0;
 	out_velocity = vec4(velocityOut, 0.0, materialMask);
 #endif
 


### PR DESCRIPTION
### Motivation
- Prevent ambient occlusion (AO/SSAO) from darkening non-opaque surfaces such as additive/translucent materials, particles, sprites, and viewmodel pixels.
- Avoid visual artifacts where SSAO is incorrectly applied to overlays and blended objects.

### Description
- Mark translucent world materials by adding `2.0` to `materialMask` in `world.frag` when `CF_MAT_TRANS` is set so they are excluded from SSAO.
- Tag particles and sprites as SSAO-excluded by setting `out_velocity.w` to `2.0` in `particles.frag` and `sprites.frag` respectively.
- Tighten the postprocess SSAO gate in `postprocess.frag` so SSAO is only allowed when `(materialMask & 2) == 0` and `viewModelMask < 0.5` to skip viewmodel pixels.

### Testing
- No automated tests were executed for this change.
- Changes were committed locally and touch the GLSL shader files `world.frag`, `particles.frag`, `sprites.frag`, and `postprocess.frag`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952d7946998832e84e6bdd53da7a813)