### PR TITLE
Add Q3-style demo shader at scripts/demo.shader

### DIFF
--- a/scripts/demo.shader
+++ b/scripts/demo.shader
@@ -1,0 +1,30 @@
+// Q3-style shader demo for Ironwail
+// Uses all supported keywords and functions in the current parser.
+
+textures/demo/q3_shader_all
+{
+    qer_editorimage textures/demo/q3_shader_all
+
+    surfaceparm solid
+    surfaceparm nonsolid
+    surfaceparm playerclip
+    surfaceparm monsterclip
+    surfaceparm trans
+    surfaceparm alphashadow
+    surfaceparm sky
+    surfaceparm fog
+    surfaceparm nodraw
+    surfaceparm stone
+
+    emissive true
+    bloom true
+    godray true
+    emissive_scale 1.25
+    bloom_scale 0.85
+    godray_scale 1.1
+
+    {
+        map textures/demo/q3_shader_all
+        rgbGen identity
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a reference Q3-style shader that exercises the engine's Quake III shader parser and supported tokens.
- Offer a minimal example for content authors and for validating shader parsing and material features.
- Make it easy to load a single example via the existing `q3shader` tooling described in docs.

### Description
- Add a new file `scripts/demo.shader` containing the shader `textures/demo/q3_shader_all` as a comprehensive demo.
- The shader includes `qer_editorimage`, many `surfaceparm` entries, boolean flags `emissive`, `bloom`, `godray`, and numeric scales `emissive_scale`, `bloom_scale`, and `godray_scale`.
- It defines one stage block with `map textures/demo/q3_shader_all` and `rgbGen identity` to exercise stage parsing.
- A `scripts` directory is created (if absent) and the demo shader file is added under it.

### Testing
- No automated tests were executed for this content-only addition.
- The change is purely a data file intended for manual or integration testing via the engine's `q3shader` loader.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952f81d35a4832e958dd5040b7175d2)