### PR TITLE
Add material/stage fields and parsing for blend, depth, cull, sort and map types

### DIFF
--- a/Quake/mat_shader.c
+++ b/Quake/mat_shader.c
@@ -518,7 +518,9 @@ const shader_material_t *Mat_Shader_FindForTextureName (const char *texname, con
 
 const char *Mat_Shader_GetStage0Map (const shader_material_t *material, const char *texname)
 {
-	if (!material || !material->stage0.map_path || !material->stage0.map_path[0])
+	if (!material || (material->stage0.map_type != MAT_MAP_MAP && material->stage0.map_type != MAT_MAP_CLAMPMAP))
+		return NULL;
+	if (!material->stage0.map_path || !material->stage0.map_path[0])
 		return NULL;
 
 	if (texname && texname[0])
@@ -625,6 +627,12 @@ void Mat_Shader_ApplyToTexture (texture_t *tex, const char *mapname)
 
 void Mat_Shader_Print (const shader_material_t *material)
 {
+	static const char *const cull_names[] = { "back", "front", "none" };
+	static const char *const sort_names[] = { "opaque", "decal", "additive", "nearest" };
+	static const char *const blend_names[] = { "replace", "alpha", "add", "mult", "premult", "custom" };
+	static const char *const depth_names[] = { "lequal", "equal", "always" };
+	static const char *const map_names[] = { "map", "clampmap", "lightmap", "white", "black" };
+
 	if (!material)
 		return;
 
@@ -636,11 +644,21 @@ void Mat_Shader_Print (const shader_material_t *material)
 	Con_Printf ("  surfaceparms: 0x%08x\n", material->surfaceparms);
 	Con_Printf ("  render flags: 0x%08x\n", material->render_flags);
 	Con_Printf ("  content flags: 0x%08x\n", material->content_flags);
+	Con_Printf ("  cull: %s\n", cull_names[q_min ((int)material->cull_mode, (int)countof (cull_names) - 1)]);
+	Con_Printf ("  sort: %s\n", sort_names[q_min ((int)material->sort_key, (int)countof (sort_names) - 1)]);
+	Con_Printf ("  polygon offset: %s\n", material->polygon_offset ? "on" : "off");
 	Con_Printf ("  emissive: %s (scale %.2f)\n", material->emissive_enable ? "on" : "off", material->emissive_scale);
 	Con_Printf ("  bloom: %s (scale %.2f)\n", material->bloom_enable ? "on" : "off", material->bloom_scale);
 	Con_Printf ("  godray: %s (scale %.2f)\n", material->godray_enable ? "on" : "off", material->godray_scale);
-	if (material->stage0.map_path)
-		Con_Printf ("  stage0 map: %s\n", material->stage0.map_path);
+	if (material->stage0.map_path || material->stage0.map_type != MAT_MAP_MAP)
+	{
+		const char *map_name = map_names[q_min ((int)material->stage0.map_type, (int)countof (map_names) - 1)];
+		Con_Printf ("  stage0 map: %s (%s)\n", material->stage0.map_path ? material->stage0.map_path : "<builtin>", map_name);
+		Con_Printf ("  stage0 blend: %s\n", blend_names[q_min ((int)material->stage0.blend_mode, (int)countof (blend_names) - 1)]);
+		Con_Printf ("  stage0 depth: %s (write %s)\n",
+			depth_names[q_min ((int)material->stage0.depth_func, (int)countof (depth_names) - 1)],
+			material->stage0.depth_write ? "on" : "off");
+	}
 }
 
 void Mat_Shader_Insert (shader_material_t *material)

--- a/Quake/mat_shader.h
+++ b/Quake/mat_shader.h
@@ -62,6 +62,47 @@ typedef enum
 
 typedef enum
 {
+	MAT_CULL_BACK = 0,
+	MAT_CULL_FRONT,
+	MAT_CULL_NONE
+} mat_cull_mode_t;
+
+typedef enum
+{
+	MAT_SORT_OPAQUE = 0,
+	MAT_SORT_DECAL,
+	MAT_SORT_ADDITIVE,
+	MAT_SORT_NEAREST
+} mat_sort_key_t;
+
+typedef enum
+{
+	MAT_BLEND_REPLACE = 0,
+	MAT_BLEND_ALPHA,
+	MAT_BLEND_ADD,
+	MAT_BLEND_MULT,
+	MAT_BLEND_PREMULT,
+	MAT_BLEND_CUSTOM
+} mat_blend_mode_t;
+
+typedef enum
+{
+	MAT_DEPTHFUNC_LEQUAL = 0,
+	MAT_DEPTHFUNC_EQUAL,
+	MAT_DEPTHFUNC_ALWAYS
+} mat_depthfunc_t;
+
+typedef enum
+{
+	MAT_MAP_MAP = 0,
+	MAT_MAP_CLAMPMAP,
+	MAT_MAP_LIGHTMAP,
+	MAT_MAP_WHITE,
+	MAT_MAP_BLACK
+} mat_map_type_t;
+
+typedef enum
+{
 	MAT_SHADERFLAG_NODRAW		= (1u << 0),
 	MAT_SHADERFLAG_SKY		= (1u << 1),
 	MAT_SHADERFLAG_TRANS		= (1u << 2),
@@ -81,6 +122,12 @@ typedef struct mat_shader_stage_s
 {
 	char		*map_path;
 	mat_rgbgen_t	rgbgen;
+	mat_blend_mode_t	blend_mode;
+	int			blend_src;
+	int			blend_dst;
+	qboolean		depth_write;
+	mat_depthfunc_t		depth_func;
+	mat_map_type_t		map_type;
 } mat_shader_stage_t;
 
 typedef struct shader_material_s
@@ -91,6 +138,9 @@ typedef struct shader_material_s
 	unsigned int		surfaceparms;
 	unsigned int		content_flags;
 	unsigned int		render_flags;
+	mat_cull_mode_t		cull_mode;
+	mat_sort_key_t		sort_key;
+	qboolean		polygon_offset;
 	qboolean		emissive_enable;
 	qboolean		bloom_enable;
 	qboolean		godray_enable;

--- a/Quake/mat_shader_parse.c
+++ b/Quake/mat_shader_parse.c
@@ -55,6 +55,53 @@ static qboolean Mat_Shader_ParseBool (const char *token, qboolean default_value)
 	return Q_atof (token) != 0.f;
 }
 
+static qboolean Mat_Shader_IsNumericToken (const char *token)
+{
+	size_t i;
+
+	if (!token || !token[0])
+		return false;
+
+	for (i = 0; token[i]; ++i)
+	{
+		if ((token[i] >= '0' && token[i] <= '9') || token[i] == '+' || token[i] == '-' || token[i] == '.' || token[i] == 'e' || token[i] == 'E')
+			continue;
+		return false;
+	}
+
+	return true;
+}
+
+static qboolean Mat_Shader_IsBoolToken (const char *token)
+{
+	if (!token || !token[0])
+		return false;
+	if (!q_strcasecmp (token, "true") || !q_strcasecmp (token, "false") ||
+		!q_strcasecmp (token, "yes") || !q_strcasecmp (token, "no") ||
+		!q_strcasecmp (token, "on") || !q_strcasecmp (token, "off"))
+		return true;
+	return Mat_Shader_IsNumericToken (token);
+}
+
+static qboolean ParseOptionalBool (const char **data, qboolean *out)
+{
+	const char *cursor;
+
+	if (!data || !*data || !out)
+		return false;
+
+	cursor = COM_Parse (*data);
+	if (!cursor || !com_token[0])
+		return false;
+
+	if (!Mat_Shader_IsBoolToken (com_token))
+		return false;
+
+	*out = Mat_Shader_ParseBool (com_token, false);
+	*data = cursor;
+	return true;
+}
+
 static qboolean ParseIdent (const char **data, const char **out)
 {
 	const char *cursor;
@@ -107,6 +154,142 @@ static qboolean ExpectToken (const char **data, const char *token)
 
 	*data = cursor;
 	return !strcmp (com_token, token);
+}
+
+static qboolean Mat_Shader_ParseCullMode (const char *token, mat_cull_mode_t *out)
+{
+	if (!token || !out)
+		return false;
+	if (!q_strcasecmp (token, "back"))
+	{
+		*out = MAT_CULL_BACK;
+		return true;
+	}
+	if (!q_strcasecmp (token, "front"))
+	{
+		*out = MAT_CULL_FRONT;
+		return true;
+	}
+	if (!q_strcasecmp (token, "none"))
+	{
+		*out = MAT_CULL_NONE;
+		return true;
+	}
+	return false;
+}
+
+static qboolean Mat_Shader_ParseSortKey (const char *token, mat_sort_key_t *out)
+{
+	if (!token || !out)
+		return false;
+	if (!q_strcasecmp (token, "opaque"))
+	{
+		*out = MAT_SORT_OPAQUE;
+		return true;
+	}
+	if (!q_strcasecmp (token, "decal"))
+	{
+		*out = MAT_SORT_DECAL;
+		return true;
+	}
+	if (!q_strcasecmp (token, "additive"))
+	{
+		*out = MAT_SORT_ADDITIVE;
+		return true;
+	}
+	if (!q_strcasecmp (token, "nearest"))
+	{
+		*out = MAT_SORT_NEAREST;
+		return true;
+	}
+	return false;
+}
+
+static qboolean Mat_Shader_ParseBlendFactor (const char *token, int *out)
+{
+	const char *name;
+
+	if (!token || !out)
+		return false;
+
+	if (!q_strncasecmp (token, "GL_", 3))
+		name = token + 3;
+	else
+		name = token;
+
+	if (!q_strcasecmp (name, "ONE"))
+		*out = GL_ONE;
+	else if (!q_strcasecmp (name, "ZERO"))
+		*out = GL_ZERO;
+	else if (!q_strcasecmp (name, "SRC_ALPHA"))
+		*out = GL_SRC_ALPHA;
+	else if (!q_strcasecmp (name, "ONE_MINUS_SRC_ALPHA"))
+		*out = GL_ONE_MINUS_SRC_ALPHA;
+	else if (!q_strcasecmp (name, "DST_ALPHA"))
+		*out = GL_DST_ALPHA;
+	else if (!q_strcasecmp (name, "ONE_MINUS_DST_ALPHA"))
+		*out = GL_ONE_MINUS_DST_ALPHA;
+	else if (!q_strcasecmp (name, "SRC_COLOR"))
+		*out = GL_SRC_COLOR;
+	else if (!q_strcasecmp (name, "ONE_MINUS_SRC_COLOR"))
+		*out = GL_ONE_MINUS_SRC_COLOR;
+	else if (!q_strcasecmp (name, "DST_COLOR"))
+		*out = GL_DST_COLOR;
+	else if (!q_strcasecmp (name, "ONE_MINUS_DST_COLOR"))
+		*out = GL_ONE_MINUS_DST_COLOR;
+	else
+		return false;
+
+	return true;
+}
+
+static qboolean Mat_Shader_ParseBlendMode (const char *token, mat_blend_mode_t *out)
+{
+	if (!token || !out)
+		return false;
+	if (!q_strcasecmp (token, "add"))
+	{
+		*out = MAT_BLEND_ADD;
+		return true;
+	}
+	if (!q_strcasecmp (token, "filter") || !q_strcasecmp (token, "multiply") || !q_strcasecmp (token, "mult"))
+	{
+		*out = MAT_BLEND_MULT;
+		return true;
+	}
+	if (!q_strcasecmp (token, "blend") || !q_strcasecmp (token, "alpha"))
+	{
+		*out = MAT_BLEND_ALPHA;
+		return true;
+	}
+	if (!q_strcasecmp (token, "premult") || !q_strcasecmp (token, "premultiplied"))
+	{
+		*out = MAT_BLEND_PREMULT;
+		return true;
+	}
+	return false;
+}
+
+static qboolean Mat_Shader_ParseDepthFunc (const char *token, mat_depthfunc_t *out)
+{
+	if (!token || !out)
+		return false;
+	if (!q_strcasecmp (token, "lequal"))
+	{
+		*out = MAT_DEPTHFUNC_LEQUAL;
+		return true;
+	}
+	if (!q_strcasecmp (token, "equal"))
+	{
+		*out = MAT_DEPTHFUNC_EQUAL;
+		return true;
+	}
+	if (!q_strcasecmp (token, "always"))
+	{
+		*out = MAT_DEPTHFUNC_ALWAYS;
+		return true;
+	}
+	return false;
 }
 
 static void Mat_Shader_ApplySurfaceParm (shader_material_t *material, const char *token)
@@ -172,6 +355,12 @@ static const char *ParseStageBlock (const char *data, shader_material_t *materia
 
 	memset (&stage, 0, sizeof (stage));
 	stage.rgbgen = MAT_RGBGEN_DEFAULT;
+	stage.blend_mode = MAT_BLEND_REPLACE;
+	stage.depth_write = true;
+	stage.depth_func = MAT_DEPTHFUNC_LEQUAL;
+	stage.map_type = MAT_MAP_MAP;
+	stage.blend_src = GL_ONE;
+	stage.blend_dst = GL_ZERO;
 
 	while ((data = COM_Parse (data)) != NULL)
 	{
@@ -185,6 +374,30 @@ static const char *ParseStageBlock (const char *data, shader_material_t *materia
 		{
 			if (!ParseIdent (&data, &value))
 				break;
+			if (!q_strcasecmp (value, "$lightmap"))
+			{
+				stage.map_type = MAT_MAP_LIGHTMAP;
+			}
+			else if (!q_strcasecmp (value, "$whiteimage") || !q_strcasecmp (value, "$white"))
+			{
+				stage.map_type = MAT_MAP_WHITE;
+			}
+			else if (!q_strcasecmp (value, "$blackimage") || !q_strcasecmp (value, "$black"))
+			{
+				stage.map_type = MAT_MAP_BLACK;
+			}
+			else
+			{
+				stage.map_type = MAT_MAP_MAP;
+				stage.map_path = Mat_Shader_DupString (value);
+			}
+			continue;
+		}
+		if (!q_strcasecmp (com_token, "clampmap"))
+		{
+			if (!ParseIdent (&data, &value))
+				break;
+			stage.map_type = MAT_MAP_CLAMPMAP;
 			stage.map_path = Mat_Shader_DupString (value);
 			continue;
 		}
@@ -196,12 +409,87 @@ static const char *ParseStageBlock (const char *data, shader_material_t *materia
 				stage.rgbgen = MAT_RGBGEN_IDENTITY;
 			continue;
 		}
+		if (!q_strcasecmp (com_token, "blendFunc"))
+		{
+			int src;
+			int dst;
+
+			if (!ParseIdent (&data, &value))
+				break;
+
+			if (Mat_Shader_ParseBlendMode (value, &stage.blend_mode))
+			{
+				switch (stage.blend_mode)
+				{
+				case MAT_BLEND_ALPHA:
+					stage.blend_src = GL_SRC_ALPHA;
+					stage.blend_dst = GL_ONE_MINUS_SRC_ALPHA;
+					break;
+				case MAT_BLEND_ADD:
+					stage.blend_src = GL_ONE;
+					stage.blend_dst = GL_ONE;
+					break;
+				case MAT_BLEND_MULT:
+					stage.blend_src = GL_ZERO;
+					stage.blend_dst = GL_SRC_COLOR;
+					break;
+				case MAT_BLEND_PREMULT:
+					stage.blend_src = GL_ONE;
+					stage.blend_dst = GL_ONE_MINUS_SRC_ALPHA;
+					break;
+				default:
+					stage.blend_src = GL_ONE;
+					stage.blend_dst = GL_ZERO;
+					break;
+				}
+				continue;
+			}
+
+			if (Mat_Shader_ParseBlendFactor (value, &src))
+			{
+				if (!ParseIdent (&data, &value))
+					break;
+				if (!Mat_Shader_ParseBlendFactor (value, &dst))
+				{
+					Mat_Shader_ReportUnknownToken (value, material->name);
+					break;
+				}
+				stage.blend_mode = MAT_BLEND_CUSTOM;
+				stage.blend_src = src;
+				stage.blend_dst = dst;
+				continue;
+			}
+
+			Mat_Shader_ReportUnknownToken (value, material->name);
+			continue;
+		}
+		if (!q_strcasecmp (com_token, "depthWrite"))
+		{
+			qboolean parsed = false;
+			qboolean value_bool = true;
+
+			parsed = ParseOptionalBool (&data, &value_bool);
+			stage.depth_write = parsed ? value_bool : true;
+			continue;
+		}
+		if (!q_strcasecmp (com_token, "depthFunc"))
+		{
+			if (!ParseIdent (&data, &value))
+				break;
+			if (Mat_Shader_ParseDepthFunc (value, &stage.depth_func))
+				continue;
+			Mat_Shader_ReportUnknownToken (value, material->name);
+			continue;
+		}
 
 		Mat_Shader_ReportUnknownToken (com_token, material->name);
 		data = SkipUnknownBlockOrLine (data, false);
 		if (!data)
 			break;
 	}
+
+	if (stage.blend_mode != MAT_BLEND_REPLACE || !stage.depth_write || stage.depth_func != MAT_DEPTHFUNC_LEQUAL)
+		material->render_flags |= MAT_RENDER_TRANS;
 
 	if (!material->stages)
 		material->stages = NULL;
@@ -227,6 +515,9 @@ static const char *ParseMaterialBlock (const char *data, const char *name, const
 	material.emissive_scale = 1.f;
 	material.bloom_scale = 1.f;
 	material.godray_scale = 1.f;
+	material.cull_mode = MAT_CULL_BACK;
+	material.sort_key = MAT_SORT_OPAQUE;
+	material.polygon_offset = false;
 
 	while ((data = COM_Parse (data)) != NULL)
 	{
@@ -254,6 +545,37 @@ static const char *ParseMaterialBlock (const char *data, const char *name, const
 			if (!ParseIdent (&data, &value))
 				break;
 			Mat_Shader_ApplySurfaceParm (&material, value);
+			continue;
+		}
+		if (!q_strcasecmp (com_token, "cull"))
+		{
+			if (!ParseIdent (&data, &value))
+				break;
+			if (Mat_Shader_ParseCullMode (value, &material.cull_mode))
+				continue;
+			Mat_Shader_ReportUnknownToken (value, material.name);
+			continue;
+		}
+		if (!q_strcasecmp (com_token, "sort"))
+		{
+			if (!ParseIdent (&data, &value))
+				break;
+			if (Mat_Shader_ParseSortKey (value, &material.sort_key))
+			{
+				if (material.sort_key != MAT_SORT_OPAQUE)
+					material.render_flags |= MAT_RENDER_TRANS;
+				continue;
+			}
+			Mat_Shader_ReportUnknownToken (value, material.name);
+			continue;
+		}
+		if (!q_strcasecmp (com_token, "polygonOffset"))
+		{
+			qboolean parsed = false;
+			qboolean value_bool = true;
+
+			parsed = ParseOptionalBool (&data, &value_bool);
+			material.polygon_offset = parsed ? value_bool : true;
 			continue;
 		}
 		if (!q_strcasecmp (com_token, "emissive"))


### PR DESCRIPTION
### Motivation
- Introduce basic Q3/Quake-style material features (blend modes, depth write/func, cull, sort, polygon offset and map variants) to enable multi-stage materials and correct render state selection.
- Provide a minimal, Quake1-optimized set of blend and depth behaviors (alpha, add, multiply, premult) and map types to support lightmaps and builtins.

### Description
- Added enums and fields to `shader_material_t` and `mat_shader_stage_t` in `Quake/mat_shader.h` to represent `cull_mode`, `sort_key`, `polygon_offset`, `blend_mode`, `blend_src`, `blend_dst`, `depth_write`, `depth_func`, and `map_type`.
- Extended the parser in `Quake/mat_shader_parse.c` to accept top-level `cull`, `sort`, and `polygonOffset`, and stage-level `map`/`clampmap` (`$lightmap`/`$whiteimage`/`$blackimage`), `blendFunc` (friendly names or `GL_*` factors), `depthWrite`, and `depthFunc` tokens and to set sensible defaults and `MAT_RENDER_TRANS` when needed.
- Updated behavior and debug output in `Quake/mat_shader.c` so `Mat_Shader_GetStage0Map` respects `map_type` and `Mat_Shader_Print` shows the new material/stage metadata (cull, sort, polygon offset, stage map/blend/depth).
- Implemented lightweight parsing helpers for numeric/bool tokens and mapping of textual blend/depth/cull/sort tokens to internal enums and GL blend factors in the parser.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952fbc60054832e97c515f5fccd93e6)