### PR TITLE
Add tcGen/tcMod/animMap parsing and texmatrix evaluation for material stages

### DIFF
--- a/Quake/mat_shader.c
+++ b/Quake/mat_shader.c
@@ -22,9 +22,11 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "mat_shader.h"
 #include "mat_shader_parse.h"
 #include "miniz.h"
+#include <math.h>
 
 #define MAT_SHADER_HASH_SIZE 256
 #define MAT_SHADER_LIST_LIMIT 64
+#define MAT_TEXMOD_PI 3.14159265358979323846f
 
 typedef struct mat_shader_entry_s
 {
@@ -73,6 +75,16 @@ static void Mat_Shader_FreeMaterial (shader_material_t *material)
 		mat_shader_stage_t *stage = &material->stages[i];
 		if (stage->map_path)
 			Z_Free (stage->map_path);
+		if (stage->anim_map_frames)
+		{
+			size_t j;
+			for (j = 0; j < VEC_SIZE (stage->anim_map_frames); ++j)
+			{
+				if (stage->anim_map_frames[j])
+					Z_Free (stage->anim_map_frames[j]);
+			}
+			VEC_FREE (stage->anim_map_frames);
+		}
 	}
 	VEC_FREE (material->stages);
 
@@ -149,6 +161,72 @@ static void Mat_Shader_WarnOnce (const char *warn_key, const char *token, const 
 
 	Mat_Shader_AddWarned (warn_key);
 	Con_Warning ("MatShader: unknown token '%s' in %s\n", token, context ? context : "shader");
+}
+
+static void Mat_MatrixIdentity (mat_texmatrix_t *out)
+{
+	if (!out)
+		return;
+	memset (out, 0, sizeof (*out));
+	out->m[0][0] = 1.f;
+	out->m[1][1] = 1.f;
+	out->m[2][2] = 1.f;
+}
+
+static void Mat_MatrixMultiply (mat_texmatrix_t *out, const mat_texmatrix_t *a, const mat_texmatrix_t *b)
+{
+	mat_texmatrix_t result;
+	int r;
+	int c;
+
+	for (r = 0; r < 3; ++r)
+	{
+		for (c = 0; c < 3; ++c)
+		{
+			result.m[r][c] = a->m[r][0] * b->m[0][c] + a->m[r][1] * b->m[1][c] + a->m[r][2] * b->m[2][c];
+		}
+	}
+
+	*out = result;
+}
+
+static void Mat_MatrixTranslate (mat_texmatrix_t *out, float s, float t)
+{
+	Mat_MatrixIdentity (out);
+	out->m[0][2] = s;
+	out->m[1][2] = t;
+}
+
+static void Mat_MatrixScale (mat_texmatrix_t *out, float s, float t)
+{
+	Mat_MatrixIdentity (out);
+	out->m[0][0] = s;
+	out->m[1][1] = t;
+}
+
+static void Mat_MatrixRotate (mat_texmatrix_t *out, float degrees)
+{
+	float radians = degrees * (float)M_PI / 180.f;
+	float c = cosf (radians);
+	float s = sinf (radians);
+
+	Mat_MatrixIdentity (out);
+	out->m[0][0] = c;
+	out->m[0][1] = -s;
+	out->m[1][0] = s;
+	out->m[1][1] = c;
+}
+
+static void Mat_MatrixAroundCenter (mat_texmatrix_t *out, const mat_texmatrix_t *inner)
+{
+	mat_texmatrix_t tmp;
+	mat_texmatrix_t translate_to;
+	mat_texmatrix_t translate_back;
+
+	Mat_MatrixTranslate (&translate_to, -0.5f, -0.5f);
+	Mat_MatrixTranslate (&translate_back, 0.5f, 0.5f);
+	Mat_MatrixMultiply (&tmp, inner, &translate_to);
+	Mat_MatrixMultiply (out, &translate_back, &tmp);
 }
 
 static void Mat_Shader_Register (shader_material_t *material)
@@ -697,4 +775,125 @@ void Mat_Shader_ReportUnknownToken (const char *token, const char *context)
 		q_snprintf (warn_key, sizeof (warn_key), "%s", token);
 
 	Mat_Shader_WarnOnce (warn_key, token, context);
+}
+
+static int Mat_Shader_TimeBucket (float time, float fps_hint)
+{
+	float fps = fps_hint > 0.f ? fps_hint : 60.f;
+	if (fps < 1.f)
+		fps = 1.f;
+	return (int)floorf (time * fps);
+}
+
+const mat_texmatrix_t *MatStage_EvalTexMatrix (mat_shader_stage_t *stage, float time)
+{
+	mat_texmatrix_t matrix;
+	mat_texmatrix_t tmp;
+	int bucket;
+	int i;
+
+	if (!stage)
+		return NULL;
+
+	bucket = Mat_Shader_TimeBucket (time, 60.f);
+	if (stage->texmatrix_time_bucket == bucket)
+		return &stage->texmatrix_cache;
+
+	Mat_MatrixIdentity (&matrix);
+
+	for (i = 0; i < stage->tcmod_count; ++i)
+	{
+		const mat_tcmod_t *mod = &stage->tcmods[i];
+		switch (mod->type)
+		{
+		case MAT_TCMOD_SCROLL:
+			Mat_MatrixTranslate (&tmp, mod->args[0] * time, mod->args[1] * time);
+			Mat_MatrixMultiply (&matrix, &tmp, &matrix);
+			break;
+		case MAT_TCMOD_SCALE:
+			Mat_MatrixScale (&tmp, mod->args[0], mod->args[1]);
+			Mat_MatrixMultiply (&matrix, &tmp, &matrix);
+			break;
+		case MAT_TCMOD_ROTATE:
+		{
+			float degrees = mod->args[0] * time;
+			mat_texmatrix_t rot;
+			Mat_MatrixRotate (&rot, degrees);
+			Mat_MatrixAroundCenter (&tmp, &rot);
+			Mat_MatrixMultiply (&matrix, &tmp, &matrix);
+			break;
+		}
+		case MAT_TCMOD_TURB:
+		{
+			float phase = mod->args[2];
+			float freq = mod->args[3];
+			float value = mod->args[0] + sinf ((time * freq + phase) * 2.f * MAT_TEXMOD_PI) * mod->args[1];
+			Mat_MatrixTranslate (&tmp, value, value);
+			Mat_MatrixMultiply (&matrix, &tmp, &matrix);
+			break;
+		}
+		case MAT_TCMOD_STRETCH:
+		{
+			float phase = mod->args[2];
+			float freq = mod->args[3];
+			float value = mod->args[0] + sinf ((time * freq + phase) * 2.f * MAT_TEXMOD_PI) * mod->args[1];
+			mat_texmatrix_t scale;
+			Mat_MatrixScale (&scale, value, value);
+			Mat_MatrixAroundCenter (&tmp, &scale);
+			Mat_MatrixMultiply (&matrix, &tmp, &matrix);
+			break;
+		}
+		default:
+			break;
+		}
+	}
+
+	stage->texmatrix_cache = matrix;
+	stage->texmatrix_time_bucket = bucket;
+	return &stage->texmatrix_cache;
+}
+
+int MatStage_EvalAnimMapFrame (mat_shader_stage_t *stage, float time)
+{
+	int bucket;
+	int frame_count;
+	int frame;
+
+	if (!stage || stage->anim_map_fps <= 0.f)
+		return 0;
+
+	frame_count = (int)VEC_SIZE (stage->anim_map_frames);
+	if (frame_count <= 0)
+		return 0;
+
+	bucket = Mat_Shader_TimeBucket (time, stage->anim_map_fps);
+	if (stage->anim_map_time_bucket == bucket)
+		return stage->anim_map_frame;
+
+	frame = bucket % frame_count;
+	if (frame < 0)
+		frame += frame_count;
+
+	stage->anim_map_time_bucket = bucket;
+	stage->anim_map_frame = frame;
+	return frame;
+}
+
+const char *MatStage_GetAnimMapPath (mat_shader_stage_t *stage, float time)
+{
+	int frame;
+	int frame_count;
+
+	if (!stage)
+		return NULL;
+
+	frame_count = (int)VEC_SIZE (stage->anim_map_frames);
+	if (frame_count <= 0)
+		return NULL;
+
+	frame = MatStage_EvalAnimMapFrame (stage, time);
+	if (frame < 0 || frame >= frame_count)
+		return NULL;
+
+	return stage->anim_map_frames[frame];
 }

--- a/Quake/mat_shader.h
+++ b/Quake/mat_shader.h
@@ -103,6 +103,34 @@ typedef enum
 
 typedef enum
 {
+	MAT_TCGEN_BASE = 0,
+	MAT_TCGEN_ENVIRONMENT,
+	MAT_TCGEN_LIGHTMAP
+} mat_tcgen_t;
+
+typedef enum
+{
+	MAT_TCMOD_NONE = 0,
+	MAT_TCMOD_SCROLL,
+	MAT_TCMOD_SCALE,
+	MAT_TCMOD_ROTATE,
+	MAT_TCMOD_TURB,
+	MAT_TCMOD_STRETCH
+} mat_tcmod_type_t;
+
+typedef struct mat_tcmod_s
+{
+	mat_tcmod_type_t type;
+	float args[4];
+} mat_tcmod_t;
+
+typedef struct mat_texmatrix_s
+{
+	float m[3][3];
+} mat_texmatrix_t;
+
+typedef enum
+{
 	MAT_SHADERFLAG_NODRAW		= (1u << 0),
 	MAT_SHADERFLAG_SKY		= (1u << 1),
 	MAT_SHADERFLAG_TRANS		= (1u << 2),
@@ -128,6 +156,15 @@ typedef struct mat_shader_stage_s
 	qboolean		depth_write;
 	mat_depthfunc_t		depth_func;
 	mat_map_type_t		map_type;
+	mat_tcgen_t		tcgen;
+	int			tcmod_count;
+	mat_tcmod_t		tcmods[4];
+	float			anim_map_fps;
+	char			**anim_map_frames;
+	int			texmatrix_time_bucket;
+	int			anim_map_time_bucket;
+	int			anim_map_frame;
+	mat_texmatrix_t	texmatrix_cache;
 } mat_shader_stage_t;
 
 typedef struct shader_material_s
@@ -174,6 +211,9 @@ unsigned int Mat_Shader_GetTextureFlags (const shader_material_t *material);
 void Mat_Shader_ApplyToTexture (texture_t *tex, const char *mapname);
 void Mat_Shader_Print (const shader_material_t *material);
 char *Mat_Shader_DupString (const char *value);
+const mat_texmatrix_t *MatStage_EvalTexMatrix (mat_shader_stage_t *stage, float time);
+int MatStage_EvalAnimMapFrame (mat_shader_stage_t *stage, float time);
+const char *MatStage_GetAnimMapPath (mat_shader_stage_t *stage, float time);
 void Mat_Shader_Insert (shader_material_t *material);
 void Mat_Shader_Remove (const shader_material_t *material);
 void Mat_Shader_ReportUnknownToken (const char *token, const char *context);

--- a/Quake/mat_shader_parse.c
+++ b/Quake/mat_shader_parse.c
@@ -141,6 +141,57 @@ static qboolean ParseVec2 (const char **data, vec2_t out)
 	return true;
 }
 
+static qboolean ParseVec4 (const char **data, vec4_t out)
+{
+	if (!ParseFloat (data, &out[0]))
+		return false;
+	if (!ParseFloat (data, &out[1]))
+		return false;
+	if (!ParseFloat (data, &out[2]))
+		return false;
+	if (!ParseFloat (data, &out[3]))
+		return false;
+	return true;
+}
+
+static qboolean Mat_Shader_ParseTcGen (const char *token, mat_tcgen_t *out)
+{
+	if (!token || !out)
+		return false;
+	if (!q_strcasecmp (token, "base"))
+	{
+		*out = MAT_TCGEN_BASE;
+		return true;
+	}
+	if (!q_strcasecmp (token, "environment"))
+	{
+		*out = MAT_TCGEN_ENVIRONMENT;
+		return true;
+	}
+	if (!q_strcasecmp (token, "lightmap"))
+	{
+		*out = MAT_TCGEN_LIGHTMAP;
+		return true;
+	}
+	return false;
+}
+
+static void Mat_Shader_PushTcMod (mat_shader_stage_t *stage, mat_tcmod_type_t type, const float *args, int arg_count)
+{
+	mat_tcmod_t mod;
+	int i;
+
+	if (!stage || stage->tcmod_count >= (int)countof (stage->tcmods))
+		return;
+
+	memset (&mod, 0, sizeof (mod));
+	mod.type = type;
+	for (i = 0; i < arg_count && i < (int)countof (mod.args); ++i)
+		mod.args[i] = args[i];
+
+	stage->tcmods[stage->tcmod_count++] = mod;
+}
+
 static qboolean ExpectToken (const char **data, const char *token)
 {
 	const char *cursor;
@@ -361,6 +412,11 @@ static const char *ParseStageBlock (const char *data, shader_material_t *materia
 	stage.map_type = MAT_MAP_MAP;
 	stage.blend_src = GL_ONE;
 	stage.blend_dst = GL_ZERO;
+	stage.tcgen = MAT_TCGEN_BASE;
+	stage.anim_map_fps = 0.f;
+	stage.anim_map_frame = 0;
+	stage.texmatrix_time_bucket = -1;
+	stage.anim_map_time_bucket = -1;
 
 	while ((data = COM_Parse (data)) != NULL)
 	{
@@ -479,6 +535,89 @@ static const char *ParseStageBlock (const char *data, shader_material_t *materia
 			if (Mat_Shader_ParseDepthFunc (value, &stage.depth_func))
 				continue;
 			Mat_Shader_ReportUnknownToken (value, material->name);
+			continue;
+		}
+		if (!q_strcasecmp (com_token, "tcGen"))
+		{
+			if (!ParseIdent (&data, &value))
+				break;
+			if (!Mat_Shader_ParseTcGen (value, &stage.tcgen))
+				Mat_Shader_ReportUnknownToken (value, material->name);
+			continue;
+		}
+		if (!q_strcasecmp (com_token, "tcMod"))
+		{
+			if (!ParseIdent (&data, &value))
+				break;
+			if (!q_strcasecmp (value, "scroll"))
+			{
+				vec2_t scroll = { 0.f, 0.f };
+				if (!ParseVec2 (&data, scroll))
+					break;
+				Mat_Shader_PushTcMod (&stage, MAT_TCMOD_SCROLL, scroll, 2);
+				continue;
+			}
+			if (!q_strcasecmp (value, "scale"))
+			{
+				vec2_t scale = { 1.f, 1.f };
+				if (!ParseVec2 (&data, scale))
+					break;
+				Mat_Shader_PushTcMod (&stage, MAT_TCMOD_SCALE, scale, 2);
+				continue;
+			}
+			if (!q_strcasecmp (value, "rotate"))
+			{
+				float deg_per_sec = 0.f;
+				if (!ParseFloat (&data, &deg_per_sec))
+					break;
+				Mat_Shader_PushTcMod (&stage, MAT_TCMOD_ROTATE, &deg_per_sec, 1);
+				continue;
+			}
+			if (!q_strcasecmp (value, "turb"))
+			{
+				vec4_t turb = { 0.f, 0.f, 0.f, 0.f };
+				if (!ParseVec4 (&data, turb))
+					break;
+				Mat_Shader_PushTcMod (&stage, MAT_TCMOD_TURB, turb, 4);
+				continue;
+			}
+			if (!q_strcasecmp (value, "stretch"))
+			{
+				vec4_t stretch = { 0.f, 0.f, 0.f, 0.f };
+				if (!ParseVec4 (&data, stretch))
+					break;
+				Mat_Shader_PushTcMod (&stage, MAT_TCMOD_STRETCH, stretch, 4);
+				continue;
+			}
+			Mat_Shader_ReportUnknownToken (value, material->name);
+			continue;
+		}
+		if (!q_strcasecmp (com_token, "animMap"))
+		{
+			float fps = 0.f;
+			int frames = 0;
+			const char *cursor = data;
+
+			if (!ParseFloat (&cursor, &fps))
+				break;
+
+			while (1)
+			{
+				const char *next = COM_Parse (cursor);
+				if (!next || !com_token[0])
+					break;
+				if (!strcmp (com_token, "{") || !strcmp (com_token, "}"))
+					break;
+				VEC_PUSH (stage.anim_map_frames, Mat_Shader_DupString (com_token));
+				frames++;
+				cursor = next;
+			}
+
+			if (frames > 0)
+			{
+				stage.anim_map_fps = fps;
+				data = cursor;
+			}
 			continue;
 		}
 


### PR DESCRIPTION
### Motivation
- Support Quake-style stage texture coordinate generation and modification directives (`tcGen`, `tcMod`, `animMap`) for richer material effects like scrolling water and animated maps.
- Provide a runtime path to evaluate texture transform matrices once per material per frame and to select `animMap` frames efficiently.
- Cache results by time buckets to avoid per-triangle or per-surface CPU churn for console/switch triggered animated maps.
- Expose helpers so render code can obtain a 3x3 texture matrix and current animMap frame/path for a stage.

### Description
- Added new types and fields in `mat_shader.h`: `mat_tcgen_t`, `mat_tcmod_t`, `mat_tcmod_type_t`, `mat_texmatrix_t`, and per-stage fields like `tcgen`, `tcmods[]`, `anim_map_fps`, `anim_map_frames`, and cached `texmatrix_cache` with time-bucket state.
- Implemented parsing in `mat_shader_parse.c` for `tcGen`, `tcMod` (supported: `scroll`, `scale`, `rotate`, `turb`, `stretch`) and `animMap` plus helpers `ParseVec4`, `Mat_Shader_ParseTcGen`, and `Mat_Shader_PushTcMod` to populate stage data.
- Implemented runtime evaluation in `mat_shader.c`: matrix helpers (`Mat_MatrixIdentity/Translate/Scale/Rotate/Multiply/AroundCenter`), `MatStage_EvalTexMatrix` to compute a 3x3 texture matrix from tcMods, and `MatStage_EvalAnimMapFrame` / `MatStage_GetAnimMapPath` to pick `animMap` frames using integer time-bucket caching.
- Added memory management for `anim_map_frames` in `Mat_Shader_FreeMaterial` so frame strings are freed when a material is removed.

### Testing
- No automated tests were executed as part of this change.
- Basic static inspection and local compile-ready changes were made (no build invoked).
- Parsing and runtime behavior were implemented with time-bucket caching designed to be stable for typical `fps` and `time` inputs.
- No unit tests or integration tests were added for matrix math or parsing in this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952ff5f2dcc832ea74aaa12cb45b4f5)