### PR TITLE
Add rgbGen/alphaGen (const/wave/vertex/identity) and propagate stage color to shaders

### DIFF
--- a/Quake/mat_shader.c
+++ b/Quake/mat_shader.c
@@ -163,6 +163,16 @@ static void Mat_Shader_WarnOnce (const char *warn_key, const char *token, const 
 	Con_Warning ("MatShader: unknown token '%s' in %s\n", token, context ? context : "shader");
 }
 
+void Mat_Shader_ReportWarningOnce (const char *warn_key, const char *message)
+{
+	if (!warn_key || !warn_key[0] || !message || !message[0])
+		return;
+	if (Mat_Shader_TokenWarned (warn_key))
+		return;
+	Mat_Shader_AddWarned (warn_key);
+	Con_Warning ("MatShader: %s\n", message);
+}
+
 static void Mat_MatrixIdentity (mat_texmatrix_t *out)
 {
 	if (!out)
@@ -785,6 +795,41 @@ static int Mat_Shader_TimeBucket (float time, float fps_hint)
 	return (int)floorf (time * fps);
 }
 
+static float Mat_Shader_EvalWave (const mat_wave_t *wave, float time)
+{
+	float t;
+	float frac;
+	float wave_value;
+
+	if (!wave)
+		return 0.f;
+
+	switch (wave->type)
+	{
+	case MAT_WAVE_TRIANGLE:
+		t = time * wave->freq + wave->phase;
+		frac = t - floorf (t);
+		wave_value = (1.f - fabsf (frac * 2.f - 1.f)) * 2.f - 1.f;
+		break;
+	case MAT_WAVE_SAW:
+		t = time * wave->freq + wave->phase;
+		frac = t - floorf (t);
+		wave_value = frac * 2.f - 1.f;
+		break;
+	case MAT_WAVE_INVERSESAW:
+		t = time * wave->freq + wave->phase;
+		frac = t - floorf (t);
+		wave_value = (1.f - frac) * 2.f - 1.f;
+		break;
+	case MAT_WAVE_SIN:
+	default:
+		wave_value = sinf ((time * wave->freq + wave->phase) * 2.f * MAT_TEXMOD_PI);
+		break;
+	}
+
+	return wave->base + wave_value * wave->amp;
+}
+
 const mat_texmatrix_t *MatStage_EvalTexMatrix (mat_shader_stage_t *stage, float time)
 {
 	mat_texmatrix_t matrix;
@@ -896,4 +941,66 @@ const char *MatStage_GetAnimMapPath (mat_shader_stage_t *stage, float time)
 		return NULL;
 
 	return stage->anim_map_frames[frame];
+}
+
+void MatStage_EvalColor (const mat_shader_stage_t *stage, float time, qboolean has_vertex_color, const vec4_t vertex_color, vec4_t out_color)
+{
+	vec4_t color = { 1.f, 1.f, 1.f, 1.f };
+	float value;
+
+	if (!out_color)
+		return;
+
+	if (!stage)
+	{
+		Vector4Copy (color, out_color);
+		return;
+	}
+
+	switch (stage->rgbgen)
+	{
+	case MAT_RGBGEN_VERTEX:
+		if (has_vertex_color)
+		{
+			color[0] = vertex_color[0];
+			color[1] = vertex_color[1];
+			color[2] = vertex_color[2];
+		}
+		break;
+	case MAT_RGBGEN_CONST:
+		color[0] = stage->const_color[0];
+		color[1] = stage->const_color[1];
+		color[2] = stage->const_color[2];
+		break;
+	case MAT_RGBGEN_WAVE:
+		value = Mat_Shader_EvalWave (&stage->rgb_wave, time);
+		value = CLAMP (0.f, value, 1.f);
+		color[0] = value;
+		color[1] = value;
+		color[2] = value;
+		break;
+	case MAT_RGBGEN_IDENTITY:
+	default:
+		break;
+	}
+
+	switch (stage->alphagen)
+	{
+	case MAT_ALPHAGEN_VERTEX:
+		if (has_vertex_color)
+			color[3] = vertex_color[3];
+		break;
+	case MAT_ALPHAGEN_CONST:
+		color[3] = stage->const_alpha;
+		break;
+	case MAT_ALPHAGEN_WAVE:
+		value = Mat_Shader_EvalWave (&stage->alpha_wave, time);
+		color[3] = CLAMP (0.f, value, 1.f);
+		break;
+	case MAT_ALPHAGEN_IDENTITY:
+	default:
+		break;
+	}
+
+	Vector4Copy (color, out_color);
 }

--- a/Quake/mat_shader.h
+++ b/Quake/mat_shader.h
@@ -56,9 +56,36 @@ typedef enum
 
 typedef enum
 {
-	MAT_RGBGEN_DEFAULT = 0,
-	MAT_RGBGEN_IDENTITY
+	MAT_RGBGEN_IDENTITY = 0,
+	MAT_RGBGEN_VERTEX,
+	MAT_RGBGEN_CONST,
+	MAT_RGBGEN_WAVE
 } mat_rgbgen_t;
+
+typedef enum
+{
+	MAT_ALPHAGEN_IDENTITY = 0,
+	MAT_ALPHAGEN_VERTEX,
+	MAT_ALPHAGEN_CONST,
+	MAT_ALPHAGEN_WAVE
+} mat_alphagen_t;
+
+typedef enum
+{
+	MAT_WAVE_SIN = 0,
+	MAT_WAVE_TRIANGLE,
+	MAT_WAVE_SAW,
+	MAT_WAVE_INVERSESAW
+} mat_wave_type_t;
+
+typedef struct mat_wave_s
+{
+	mat_wave_type_t	type;
+	float		base;
+	float		amp;
+	float		phase;
+	float		freq;
+} mat_wave_t;
 
 typedef enum
 {
@@ -150,6 +177,11 @@ typedef struct mat_shader_stage_s
 {
 	char		*map_path;
 	mat_rgbgen_t	rgbgen;
+	mat_alphagen_t	alphagen;
+	float		const_color[3];
+	float		const_alpha;
+	mat_wave_t	rgb_wave;
+	mat_wave_t	alpha_wave;
 	mat_blend_mode_t	blend_mode;
 	int			blend_src;
 	int			blend_dst;
@@ -214,8 +246,10 @@ char *Mat_Shader_DupString (const char *value);
 const mat_texmatrix_t *MatStage_EvalTexMatrix (mat_shader_stage_t *stage, float time);
 int MatStage_EvalAnimMapFrame (mat_shader_stage_t *stage, float time);
 const char *MatStage_GetAnimMapPath (mat_shader_stage_t *stage, float time);
+void MatStage_EvalColor (const mat_shader_stage_t *stage, float time, qboolean has_vertex_color, const vec4_t vertex_color, vec4_t out_color);
 void Mat_Shader_Insert (shader_material_t *material);
 void Mat_Shader_Remove (const shader_material_t *material);
 void Mat_Shader_ReportUnknownToken (const char *token, const char *context);
+void Mat_Shader_ReportWarningOnce (const char *warn_key, const char *message);
 
 #endif // MAT_SHADER_H

--- a/Quake/mat_shader_parse.c
+++ b/Quake/mat_shader_parse.c
@@ -141,6 +141,17 @@ static qboolean ParseVec2 (const char **data, vec2_t out)
 	return true;
 }
 
+static qboolean ParseVec3 (const char **data, vec3_t out)
+{
+	if (!ParseFloat (data, &out[0]))
+		return false;
+	if (!ParseFloat (data, &out[1]))
+		return false;
+	if (!ParseFloat (data, &out[2]))
+		return false;
+	return true;
+}
+
 static qboolean ParseVec4 (const char **data, vec4_t out)
 {
 	if (!ParseFloat (data, &out[0]))
@@ -171,6 +182,33 @@ static qboolean Mat_Shader_ParseTcGen (const char *token, mat_tcgen_t *out)
 	if (!q_strcasecmp (token, "lightmap"))
 	{
 		*out = MAT_TCGEN_LIGHTMAP;
+		return true;
+	}
+	return false;
+}
+
+static qboolean Mat_Shader_ParseWaveType (const char *token, mat_wave_type_t *out)
+{
+	if (!token || !out)
+		return false;
+	if (!q_strcasecmp (token, "sin"))
+	{
+		*out = MAT_WAVE_SIN;
+		return true;
+	}
+	if (!q_strcasecmp (token, "triangle"))
+	{
+		*out = MAT_WAVE_TRIANGLE;
+		return true;
+	}
+	if (!q_strcasecmp (token, "saw"))
+	{
+		*out = MAT_WAVE_SAW;
+		return true;
+	}
+	if (!q_strcasecmp (token, "inversesaw"))
+	{
+		*out = MAT_WAVE_INVERSESAW;
 		return true;
 	}
 	return false;
@@ -405,7 +443,14 @@ static const char *ParseStageBlock (const char *data, shader_material_t *materia
 	mat_shader_stage_t stage;
 
 	memset (&stage, 0, sizeof (stage));
-	stage.rgbgen = MAT_RGBGEN_DEFAULT;
+	stage.rgbgen = MAT_RGBGEN_IDENTITY;
+	stage.alphagen = MAT_ALPHAGEN_IDENTITY;
+	stage.const_color[0] = 1.f;
+	stage.const_color[1] = 1.f;
+	stage.const_color[2] = 1.f;
+	stage.const_alpha = 1.f;
+	stage.rgb_wave.type = MAT_WAVE_SIN;
+	stage.alpha_wave.type = MAT_WAVE_SIN;
 	stage.blend_mode = MAT_BLEND_REPLACE;
 	stage.depth_write = true;
 	stage.depth_func = MAT_DEPTHFUNC_LEQUAL;
@@ -462,7 +507,138 @@ static const char *ParseStageBlock (const char *data, shader_material_t *materia
 			if (!ParseIdent (&data, &value))
 				break;
 			if (!q_strcasecmp (value, "identity"))
+			{
 				stage.rgbgen = MAT_RGBGEN_IDENTITY;
+				continue;
+			}
+			if (!q_strcasecmp (value, "vertex"))
+			{
+				stage.rgbgen = MAT_RGBGEN_VERTEX;
+				continue;
+			}
+			if (!q_strcasecmp (value, "const"))
+			{
+				const char *cursor = data;
+				const char *token = NULL;
+				vec3_t color = { 1.f, 1.f, 1.f };
+				if (!ParseIdent (&cursor, &token))
+					break;
+				if (!strcmp (token, "("))
+				{
+					if (!ParseVec3 (&cursor, color))
+						break;
+					if (!ExpectToken (&cursor, ")"))
+						break;
+				}
+				else
+				{
+					color[0] = Q_atof (token);
+					if (!ParseFloat (&cursor, &color[1]))
+						break;
+					if (!ParseFloat (&cursor, &color[2]))
+						break;
+				}
+
+				stage.rgbgen = MAT_RGBGEN_CONST;
+				stage.const_color[0] = color[0];
+				stage.const_color[1] = color[1];
+				stage.const_color[2] = color[2];
+				data = cursor;
+				continue;
+			}
+			if (!q_strcasecmp (value, "wave"))
+			{
+				mat_wave_t wave;
+				const char *wave_type = NULL;
+
+				memset (&wave, 0, sizeof (wave));
+				if (!ParseIdent (&data, &wave_type))
+					break;
+				if (!Mat_Shader_ParseWaveType (wave_type, &wave.type))
+				{
+					Mat_Shader_ReportUnknownToken (wave_type, material->name);
+					continue;
+				}
+				if (!ParseFloat (&data, &wave.base))
+					break;
+				if (!ParseFloat (&data, &wave.amp))
+					break;
+				if (!ParseFloat (&data, &wave.phase))
+					break;
+				if (!ParseFloat (&data, &wave.freq))
+					break;
+				stage.rgbgen = MAT_RGBGEN_WAVE;
+				stage.rgb_wave = wave;
+				continue;
+			}
+			Mat_Shader_ReportUnknownToken (value, material->name);
+			continue;
+		}
+		if (!q_strcasecmp (com_token, "alphaGen"))
+		{
+			if (!ParseIdent (&data, &value))
+				break;
+			if (!q_strcasecmp (value, "identity"))
+			{
+				stage.alphagen = MAT_ALPHAGEN_IDENTITY;
+				continue;
+			}
+			if (!q_strcasecmp (value, "vertex"))
+			{
+				stage.alphagen = MAT_ALPHAGEN_VERTEX;
+				continue;
+			}
+			if (!q_strcasecmp (value, "const"))
+			{
+				const char *cursor = data;
+				const char *token = NULL;
+				float alpha = 1.f;
+
+				if (!ParseIdent (&cursor, &token))
+					break;
+				if (!strcmp (token, "("))
+				{
+					if (!ParseFloat (&cursor, &alpha))
+						break;
+					if (!ExpectToken (&cursor, ")"))
+						break;
+				}
+				else
+				{
+					alpha = Q_atof (token);
+				}
+
+				stage.alphagen = MAT_ALPHAGEN_CONST;
+				stage.const_alpha = alpha;
+				data = cursor;
+				continue;
+			}
+			if (!q_strcasecmp (value, "wave"))
+			{
+				mat_wave_t wave;
+				const char *wave_type = NULL;
+
+				memset (&wave, 0, sizeof (wave));
+				if (!ParseIdent (&data, &wave_type))
+					break;
+				if (!Mat_Shader_ParseWaveType (wave_type, &wave.type))
+				{
+					Mat_Shader_ReportUnknownToken (wave_type, material->name);
+					continue;
+				}
+				if (!ParseFloat (&data, &wave.base))
+					break;
+				if (!ParseFloat (&data, &wave.amp))
+					break;
+				if (!ParseFloat (&data, &wave.phase))
+					break;
+				if (!ParseFloat (&data, &wave.freq))
+					break;
+				stage.alphagen = MAT_ALPHAGEN_WAVE;
+				stage.alpha_wave = wave;
+				continue;
+			}
+			Mat_Shader_ReportUnknownToken (value, material->name);
 			continue;
 		}
 		if (!q_strcasecmp (com_token, "blendFunc"))

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -284,6 +284,7 @@ typedef struct bmodel_gpu_instance_s {
 typedef struct bmodel_bindless_gpu_call_s {
 	GLuint		flags;
 	GLfloat		alpha;
+	GLfloat		stage_color[4];
 	GLuint64	texture;
 	GLuint64	fullbright;
 	GLuint64	emissive;
@@ -292,6 +293,7 @@ typedef struct bmodel_bindless_gpu_call_s {
 typedef struct bmodel_bound_gpu_call_s {
 	GLuint		flags;
 	GLfloat		alpha;
+	GLfloat		stage_color[4];
 	GLint		baseinstance;
 	GLint		padding;
 } bmodel_bound_gpu_call_t;
@@ -506,6 +508,8 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
 {
 	GLuint		flags;
 	float		alpha;
+	vec4_t		stage_color = { 1.f, 1.f, 1.f, 1.f };
+	qboolean	has_vertex_color = false;
 	gltexture_t	*tx, *fb, *em;
 
 	if (num_bmodel_calls == MAX_BMODEL_DRAWS)
@@ -548,11 +552,33 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
 		alpha = 1.f;
 	}
 
+	if (t && t->shader && r_shaders.value > 0.f)
+	{
+		const mat_shader_stage_t *stage = &t->shader->stage0;
+		if (!has_vertex_color && (stage->rgbgen == MAT_RGBGEN_VERTEX || stage->alphagen == MAT_ALPHAGEN_VERTEX))
+		{
+			char warn_key[MAX_QPATH * 2];
+			char warn_msg[256];
+			const char *shader_name = t->shader->name ? t->shader->name : "shader";
+
+			q_snprintf (warn_key, sizeof (warn_key), "%s::vertexcolor", shader_name);
+			q_snprintf (warn_msg, sizeof (warn_msg),
+				"rgbGen/alphaGen vertex requested for %s without vertex colors (using identity)",
+				shader_name);
+			Mat_Shader_ReportWarningOnce (warn_key, warn_msg);
+		}
+		MatStage_EvalColor (stage, cl.time, has_vertex_color, vec4_origin, stage_color);
+	}
+
 	if (gl_bindless_able)
 	{
 		bmodel_bindless_gpu_call_t *call = &bmodel_calls.bindless.params[num_bmodel_calls];
 		call->flags = flags;
 		call->alpha = alpha;
+		call->stage_color[0] = stage_color[0];
+		call->stage_color[1] = stage_color[1];
+		call->stage_color[2] = stage_color[2];
+		call->stage_color[3] = stage_color[3];
 		call->texture = tx ? tx->bindless_handle : greytexture->bindless_handle;
 		call->fullbright = fb ? fb->bindless_handle : blacktexture->bindless_handle;
 		call->emissive = em ? em->bindless_handle : blacktexture->bindless_handle;
@@ -563,6 +589,10 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
 		gltexture_t **textures = bmodel_calls.bound.textures[num_bmodel_calls];
 		call->flags = flags;
 		call->alpha = alpha;
+		call->stage_color[0] = stage_color[0];
+		call->stage_color[1] = stage_color[1];
+		call->stage_color[2] = stage_color[2];
+		call->stage_color[3] = stage_color[3];
 		call->baseinstance = first_instance;
 		call->padding = 0;
 		textures[0] = tx ? tx : greytexture;

--- a/Quake/shaders/sky_cubemap.vert
+++ b/Quake/shaders/sky_cubemap.vert
@@ -19,6 +19,7 @@ struct Call
 {
 	uint	flags;
 	float	wateralpha;
+	vec4	stage_color;
 #if BINDLESS
 	uvec2	txhandle;
 	uvec2	fbhandle;

--- a/Quake/shaders/sky_layers.vert
+++ b/Quake/shaders/sky_layers.vert
@@ -19,6 +19,7 @@ struct Call
 {
 	uint	flags;
 	float	wateralpha;
+	vec4	stage_color;
 #if BINDLESS
 	uvec2	txhandle;
 	uvec2	fbhandle;

--- a/Quake/shaders/skystencil.vert
+++ b/Quake/shaders/skystencil.vert
@@ -19,6 +19,7 @@ struct Call
 {
 	uint	flags;
 	float	wateralpha;
+	vec4	stage_color;
 #if BINDLESS
 	uvec2	txhandle;
 	uvec2	fbhandle;

--- a/Quake/shaders/water.frag
+++ b/Quake/shaders/water.frag
@@ -86,6 +86,7 @@ layout(location=3) in vec3 in_pos;
 #endif
 layout(location=6) noperspective in vec4 in_curr_clip;
 layout(location=7) noperspective in vec4 in_prev_clip;
+layout(location=8) flat in vec4 in_stage_color;
 
 #define OUT_COLOR out_fragcolor
 #if OIT
@@ -150,6 +151,7 @@ void main()
                 emissive = texture(EmissiveTex, uv).rgb;
 #endif
         vec4 result = texture(Tex, uv);
+        result.rgb *= in_stage_color.rgb;
         int debug_mode = int(ColorSpaceParams.x + 0.5);
         if (debug_mode == 1)
         {

--- a/Quake/shaders/water.vert
+++ b/Quake/shaders/water.vert
@@ -19,6 +19,7 @@ struct Call
 {
 	uint	flags;
 	float	wateralpha;
+	vec4	stage_color;
 #if BINDLESS
 	uvec2	txhandle;
 	uvec2	fbhandle;
@@ -93,6 +94,7 @@ layout(location=3) out vec3 out_pos;
 #endif
 layout(location=6) noperspective out vec4 out_curr_clip;
 layout(location=7) noperspective out vec4 out_prev_clip;
+layout(location=8) flat out vec4 out_stage_color;
 
 void main()
 {
@@ -109,7 +111,8 @@ void main()
         out_flags = call.flags;
         out_uv = in_uv.xy;
         out_pos = world_pos;
-        out_alpha = instance.alpha < 0.0 ? call.wateralpha : instance.alpha;
+        out_alpha = (instance.alpha < 0.0 ? call.wateralpha : instance.alpha) * call.stage_color.a;
+        out_stage_color = call.stage_color;
 #if BINDLESS
         out_samplers0.xy = call.txhandle;
         if ((call.flags & CF_USE_FULLBRIGHT) != 0u)

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -46,6 +46,7 @@ struct Call
 {
 	uint	flags;
 	float	wateralpha;
+	vec4	stage_color;
 #if BINDLESS
 	uvec2	txhandle;
 	uvec2	fbhandle;
@@ -133,6 +134,7 @@ layout(location=11) noperspective in vec4 in_curr_clip;
 layout(location=12) noperspective in vec4 in_prev_clip;
 layout(location=13) in vec3 in_normal;
 layout(location=14) in vec3 in_lightgrid;
+layout(location=15) flat in vec4 in_stage_color;
 
 // Utility: ALU-only 16x16 Bayer matrix
 float bayer01(ivec2 coord)
@@ -283,6 +285,7 @@ void main()
 #else
 	vec4 result = texture(Tex, uv);
 #endif
+	result.rgb *= in_stage_color.rgb;
 
 #if MODE == 1
 	if (result.a < 0.666)

--- a/Quake/shaders/world.vert
+++ b/Quake/shaders/world.vert
@@ -48,6 +48,7 @@ struct Call
 {
 	uint	flags;
 	float	wateralpha;
+	vec4	stage_color;
 #if BINDLESS
 	uvec2	txhandle;
 	uvec2	fbhandle;
@@ -141,6 +142,7 @@ layout(location=11) noperspective out vec4 out_curr_clip;
 layout(location=12) noperspective out vec4 out_prev_clip;
 layout(location=13) out vec3 out_normal;
 layout(location=14) out vec3 out_lightgrid;
+layout(location=15) flat out vec4 out_stage_color;
 
 void main()
 {
@@ -174,10 +176,11 @@ void main()
 	out_coord = (gl_Position.xy / gl_Position.w * 0.5 + 0.5) * vec2(LIGHT_TILES_X, LIGHT_TILES_Y);
 	out_flags = call.flags;
 #if MODE == 2
-	out_alpha = instance.alpha < 0.0 ? call.wateralpha : instance.alpha;
+	out_alpha = (instance.alpha < 0.0 ? call.wateralpha : instance.alpha) * call.stage_color.a;
 #else
-	out_alpha = instance.alpha < 0.0 ? 1.0 : instance.alpha;
+	out_alpha = (instance.alpha < 0.0 ? 1.0 : instance.alpha) * call.stage_color.a;
 #endif
+	out_stage_color = call.stage_color;
 	out_styles.x = GetLightStyle(in_styles.x);
 	if (in_styles.y == 255)
 		out_styles.yzw = vec3(-1.);

--- a/Quake/shaders/world_dlight.vert
+++ b/Quake/shaders/world_dlight.vert
@@ -35,6 +35,7 @@ struct Call
 {
         uint    flags;
         float   wateralpha;
+        vec4    stage_color;
 #if BINDLESS
         uvec2   txhandle;
         uvec2   fbhandle;


### PR DESCRIPTION
### Motivation

- Extend material stages to support per-stage RGB and alpha generators so classic Quake-style `rgbGen`/`alphaGen` behaviors can be expressed. 
- Provide `const` and `wave` generators (including `sin`, `triangle`, `saw`, `inversesaw`) for pulsating lights and alpha fades without extra textures or bespoke code. 
- Ensure the evaluated stage color/alpha can be passed to GPU draw calls so world and water shaders can apply the result at render time. 
- Emit a one-time warning when a shader requests `vertex` color generation but vertex colors are not present, falling back to identity.

### Description

- Added new enums, structs and fields in `mat_shader.h`: `mat_alphagen_t`, `mat_wave_type_t`, `mat_wave_t`, `const_color`, `const_alpha`, `rgb_wave` and `alpha_wave`, and updated `mat_shader_stage_t` and API with `MatStage_EvalColor` and `Mat_Shader_ReportWarningOnce`.
- Extended parser in `Quake/mat_shader_parse.c` to handle `rgbGen` and `alphaGen` directives with `identity`, `vertex`, `const (r g b)` and `wave <type> <base> <amp> <phase> <freq>` syntax and added helpers `ParseVec3` and `Mat_Shader_ParseWaveType`.
- Implemented runtime evaluation in `Quake/mat_shader.c`: `Mat_Shader_EvalWave` computes the wave value (sin/triangle/saw/inversesaw) and `MatStage_EvalColor` produces the final RGBA for a stage (clamping wave outputs where appropriate) and added `Mat_Shader_ReportWarningOnce` to warn about missing vertex colors.
- Propagated the computed `stage_color` into draw call structures and GPU pipeline: added `stage_color` to bmodel call structs in `Quake/r_world.c`, filled the color in `R_AddBModelCall`, extended `Call` buffer to include `stage_color`, and used it in vertex/fragment shaders (`world*.vert/frag`, `water*.vert/frag`) to multiply surface color and factor stage alpha into `out_alpha`.

### Testing

- No automated tests were executed as part of this change set.
- The patch was built into the working tree and committed, but no CI/build verification was run automatically.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695300fccb44832e882da67bf71ca823)