### PR TITLE
Stage-level emissive / bloom / godray outputs with per-stage scales

### DIFF
--- a/Quake/mat_shader.c
+++ b/Quake/mat_shader.c
@@ -622,6 +622,32 @@ const char *Mat_Shader_GetStage0Map (const shader_material_t *material, const ch
 	return material->stage0.map_path;
 }
 
+static qboolean Mat_Shader_StageHasOutput (const mat_shader_stage_t *stage, unsigned int output_flag)
+{
+	if (!stage)
+		return false;
+	return (stage->output_flags & output_flag) != 0u;
+}
+
+static qboolean Mat_Shader_MaterialHasOutput (const shader_material_t *material, unsigned int output_flag)
+{
+	size_t i;
+
+	if (!material)
+		return false;
+
+	if (VEC_SIZE (material->stages) == 0)
+		return Mat_Shader_StageHasOutput (&material->stage0, output_flag);
+
+	for (i = 0; i < VEC_SIZE (material->stages); ++i)
+	{
+		if (Mat_Shader_StageHasOutput (&material->stages[i], output_flag))
+			return true;
+	}
+
+	return false;
+}
+
 unsigned int Mat_Shader_GetTextureFlags (const shader_material_t *material)
 {
 	unsigned int flags = 0u;
@@ -649,11 +675,11 @@ unsigned int Mat_Shader_GetTextureFlags (const shader_material_t *material)
 		flags |= MAT_SHADERFLAG_MONSTERCLIP;
 	if (material->surfaceparms & MAT_SURFPARM_STONE)
 		flags |= MAT_SHADERFLAG_STONE;
-	if (material->emissive_enable)
+	if (Mat_Shader_MaterialHasOutput (material, MAT_STAGE_OUTPUT_EMISSIVE))
 		flags |= MAT_SHADERFLAG_EMISSIVE;
-	if (material->bloom_enable)
+	if (Mat_Shader_MaterialHasOutput (material, MAT_STAGE_OUTPUT_BLOOM))
 		flags |= MAT_SHADERFLAG_BLOOM;
-	if (material->godray_enable)
+	if (Mat_Shader_MaterialHasOutput (material, MAT_STAGE_OUTPUT_GODRAY_SOURCE))
 		flags |= MAT_SHADERFLAG_GODRAY;
 
 	return flags;

--- a/Quake/mat_shader.h
+++ b/Quake/mat_shader.h
@@ -173,6 +173,14 @@ typedef enum
 	MAT_SHADERFLAG_GODRAY		= (1u << 12)
 } mat_shader_flags_t;
 
+typedef enum
+{
+	MAT_STAGE_OUTPUT_COLOR		= (1u << 0),
+	MAT_STAGE_OUTPUT_EMISSIVE	= (1u << 1),
+	MAT_STAGE_OUTPUT_BLOOM		= (1u << 2),
+	MAT_STAGE_OUTPUT_GODRAY_SOURCE	= (1u << 3)
+} mat_stage_output_t;
+
 typedef struct mat_shader_stage_s
 {
 	char		*map_path;
@@ -197,6 +205,12 @@ typedef struct mat_shader_stage_s
 	int			anim_map_time_bucket;
 	int			anim_map_frame;
 	mat_texmatrix_t	texmatrix_cache;
+	unsigned int		output_flags;
+	unsigned int		output_override_flags;
+	unsigned int		scale_override_flags;
+	float			emissive_scale;
+	float			bloom_scale;
+	float			godray_scale;
 } mat_shader_stage_t;
 
 typedef struct shader_material_s
@@ -223,6 +237,7 @@ typedef struct shader_material_s
 // Developer note:
 // Supported directives: qer_editorimage, surfaceparm, emissive, bloom, godray, emissive_scale,
 // bloom_scale, godray_scale, and a single stage block with map + rgbGen identity.
+// Stage directives: emissive, bloom, godray, emissiveScale, bloomScale, godrayScale.
 // To add new surfaceparms, extend mat_surfaceparm_table in mat_shader_parse.c and map to flags.
 
 typedef struct texture_s texture_t;

--- a/Quake/mat_shader_parse.c
+++ b/Quake/mat_shader_parse.c
@@ -462,10 +462,15 @@ static const char *ParseStageBlock (const char *data, shader_material_t *materia
 	stage.anim_map_frame = 0;
 	stage.texmatrix_time_bucket = -1;
 	stage.anim_map_time_bucket = -1;
+	stage.output_flags = MAT_STAGE_OUTPUT_COLOR;
+	stage.emissive_scale = material->emissive_scale;
+	stage.bloom_scale = material->bloom_scale;
+	stage.godray_scale = material->godray_scale;
 
 	while ((data = COM_Parse (data)) != NULL)
 	{
 		const char *value;
+		float scale;
 
 		if (!com_token[0])
 			continue;
@@ -768,6 +773,63 @@ static const char *ParseStageBlock (const char *data, shader_material_t *materia
 			Mat_Shader_ReportUnknownToken (value, material->name);
 			continue;
 		}
+		if (!q_strcasecmp (com_token, "emissive"))
+		{
+			if (!ParseIdent (&data, &value))
+				break;
+			stage.output_override_flags |= MAT_STAGE_OUTPUT_EMISSIVE;
+			if (Mat_Shader_ParseBool (value, false))
+				stage.output_flags |= MAT_STAGE_OUTPUT_EMISSIVE;
+			else
+				stage.output_flags &= ~MAT_STAGE_OUTPUT_EMISSIVE;
+			continue;
+		}
+		if (!q_strcasecmp (com_token, "bloom"))
+		{
+			if (!ParseIdent (&data, &value))
+				break;
+			stage.output_override_flags |= MAT_STAGE_OUTPUT_BLOOM;
+			if (Mat_Shader_ParseBool (value, false))
+				stage.output_flags |= MAT_STAGE_OUTPUT_BLOOM;
+			else
+				stage.output_flags &= ~MAT_STAGE_OUTPUT_BLOOM;
+			continue;
+		}
+		if (!q_strcasecmp (com_token, "godray"))
+		{
+			if (!ParseIdent (&data, &value))
+				break;
+			stage.output_override_flags |= MAT_STAGE_OUTPUT_GODRAY_SOURCE;
+			if (Mat_Shader_ParseBool (value, false))
+				stage.output_flags |= MAT_STAGE_OUTPUT_GODRAY_SOURCE;
+			else
+				stage.output_flags &= ~MAT_STAGE_OUTPUT_GODRAY_SOURCE;
+			continue;
+		}
+		if (!q_strcasecmp (com_token, "emissiveScale") || !q_strcasecmp (com_token, "emissive_scale"))
+		{
+			if (!ParseFloat (&data, &scale))
+				break;
+			stage.emissive_scale = scale;
+			stage.scale_override_flags |= MAT_STAGE_OUTPUT_EMISSIVE;
+			continue;
+		}
+		if (!q_strcasecmp (com_token, "bloomScale") || !q_strcasecmp (com_token, "bloom_scale"))
+		{
+			if (!ParseFloat (&data, &scale))
+				break;
+			stage.bloom_scale = scale;
+			stage.scale_override_flags |= MAT_STAGE_OUTPUT_BLOOM;
+			continue;
+		}
+		if (!q_strcasecmp (com_token, "godrayScale") || !q_strcasecmp (com_token, "godray_scale"))
+		{
+			if (!ParseFloat (&data, &scale))
+				break;
+			stage.godray_scale = scale;
+			stage.scale_override_flags |= MAT_STAGE_OUTPUT_GODRAY_SOURCE;
+			continue;
+		}
 		if (!q_strcasecmp (com_token, "animMap"))
 		{
 			float fps = 0.f;
@@ -814,6 +876,87 @@ static const char *ParseStageBlock (const char *data, shader_material_t *materia
 		material->stage0 = stage;
 
 	return data;
+}
+
+static void Mat_Shader_ApplyStageDefaults (shader_material_t *material)
+{
+	size_t i;
+
+	if (!material)
+		return;
+
+	for (i = 0; i < VEC_SIZE (material->stages); ++i)
+	{
+		mat_shader_stage_t *stage = &material->stages[i];
+
+		stage->output_flags |= MAT_STAGE_OUTPUT_COLOR;
+
+		if ((stage->output_override_flags & MAT_STAGE_OUTPUT_EMISSIVE) == 0u)
+		{
+			if (material->emissive_enable)
+				stage->output_flags |= MAT_STAGE_OUTPUT_EMISSIVE;
+			else
+				stage->output_flags &= ~MAT_STAGE_OUTPUT_EMISSIVE;
+		}
+		if ((stage->output_override_flags & MAT_STAGE_OUTPUT_BLOOM) == 0u)
+		{
+			if (material->bloom_enable)
+				stage->output_flags |= MAT_STAGE_OUTPUT_BLOOM;
+			else
+				stage->output_flags &= ~MAT_STAGE_OUTPUT_BLOOM;
+		}
+		if ((stage->output_override_flags & MAT_STAGE_OUTPUT_GODRAY_SOURCE) == 0u)
+		{
+			if (material->godray_enable)
+				stage->output_flags |= MAT_STAGE_OUTPUT_GODRAY_SOURCE;
+			else
+				stage->output_flags &= ~MAT_STAGE_OUTPUT_GODRAY_SOURCE;
+		}
+
+		if ((stage->scale_override_flags & MAT_STAGE_OUTPUT_EMISSIVE) == 0u)
+			stage->emissive_scale = material->emissive_scale;
+		if ((stage->scale_override_flags & MAT_STAGE_OUTPUT_BLOOM) == 0u)
+			stage->bloom_scale = material->bloom_scale;
+		if ((stage->scale_override_flags & MAT_STAGE_OUTPUT_GODRAY_SOURCE) == 0u)
+			stage->godray_scale = material->godray_scale;
+	}
+
+	if (VEC_SIZE (material->stages) > 0)
+		material->stage0 = material->stages[0];
+	else
+	{
+		mat_shader_stage_t *stage = &material->stage0;
+
+		stage->output_flags |= MAT_STAGE_OUTPUT_COLOR;
+		if ((stage->output_override_flags & MAT_STAGE_OUTPUT_EMISSIVE) == 0u)
+		{
+			if (material->emissive_enable)
+				stage->output_flags |= MAT_STAGE_OUTPUT_EMISSIVE;
+			else
+				stage->output_flags &= ~MAT_STAGE_OUTPUT_EMISSIVE;
+		}
+		if ((stage->output_override_flags & MAT_STAGE_OUTPUT_BLOOM) == 0u)
+		{
+			if (material->bloom_enable)
+				stage->output_flags |= MAT_STAGE_OUTPUT_BLOOM;
+			else
+				stage->output_flags &= ~MAT_STAGE_OUTPUT_BLOOM;
+		}
+		if ((stage->output_override_flags & MAT_STAGE_OUTPUT_GODRAY_SOURCE) == 0u)
+		{
+			if (material->godray_enable)
+				stage->output_flags |= MAT_STAGE_OUTPUT_GODRAY_SOURCE;
+			else
+				stage->output_flags &= ~MAT_STAGE_OUTPUT_GODRAY_SOURCE;
+		}
+
+		if ((stage->scale_override_flags & MAT_STAGE_OUTPUT_EMISSIVE) == 0u)
+			stage->emissive_scale = material->emissive_scale;
+		if ((stage->scale_override_flags & MAT_STAGE_OUTPUT_BLOOM) == 0u)
+			stage->bloom_scale = material->bloom_scale;
+		if ((stage->scale_override_flags & MAT_STAGE_OUTPUT_GODRAY_SOURCE) == 0u)
+			stage->godray_scale = material->godray_scale;
+	}
 }
 
 static const char *ParseMaterialBlock (const char *data, const char *name, const char *source_file)
@@ -941,6 +1084,7 @@ static const char *ParseMaterialBlock (const char *data, const char *name, const
 			break;
 	}
 
+	Mat_Shader_ApplyStageDefaults (&material);
 	existing = Mat_Shader_Find (material.name);
 	if (existing)
 		Mat_Shader_Remove (existing);

--- a/Quake/shaders/water.frag
+++ b/Quake/shaders/water.frag
@@ -15,6 +15,7 @@ const uint
         CF_USE_EMISSIVE = 8u,
         CF_ALPHA_TEST = 16u,
         CF_MAT_BLOOM = 128u,
+        CF_MAT_EMISSIVE = 256u,
         CF_MAT_HAS_SHADER = 4096u
 ;
 
@@ -175,7 +176,7 @@ void main()
         vec2 velocityOut = vec2(0.0);
         if (result.a >= 0.999)
                 velocityOut = velocity * result.a;
-        float bloomMask = ((in_flags & CF_MAT_BLOOM) != 0u) ? 1.0 : 0.0;
+        float bloomMask = ((in_flags & (CF_MAT_BLOOM | CF_MAT_EMISSIVE)) != 0u) ? 1.0 : 0.0;
         float materialMask = 2.0 + bloomMask;
         out_velocity = vec4(velocityOut, 0.0, materialMask);
 #endif

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -534,7 +534,7 @@ void main()
 #if !OIT
 	vec2 velocity = ComputeVelocity(in_curr_clip, in_prev_clip);
 	vec2 velocityOut = (result.a >= 0.999) ? (velocity * result.a) : vec2(0.0);
-	float materialMask = ((in_flags & CF_MAT_BLOOM) != 0u) ? 1.0 : 0.0;
+	float materialMask = ((in_flags & (CF_MAT_BLOOM | CF_MAT_EMISSIVE)) != 0u) ? 1.0 : 0.0;
 	if ((in_flags & CF_MAT_TRANS) != 0u)
 		materialMask += 2.0;
 	out_velocity = vec4(velocityOut, 0.0, materialMask);


### PR DESCRIPTION
### Motivation
- Top-level boolean flags for `emissive`/`bloom`/`godray` were too coarse and caused unintended scene-wide bloom/godrays. 
- Emitters must be chosen per-stage (or by clear top-level defaults) so only explicitly marked shader stages write to postprocess sources. 
- Provide per-stage scale overrides that fall back to material/global values. 
- Preserve compatibility by mapping legacy material-level flags to stage defaults when stages do not override.

### Description
- Add `mat_stage_output_t` and new per-stage fields (`output_flags`, `output_override_flags`, `scale_override_flags`, `emissive_scale`, `bloom_scale`, `godray_scale`) to `mat_shader_stage_t` in `Quake/mat_shader.h` and initialize them in the parser. 
- Extend the parser in `Quake/mat_shader_parse.c` to accept stage keywords `emissive`, `bloom`, `godray`, and scale variants `emissiveScale`/`emissive_scale`, `bloomScale`/`bloom_scale`, `godrayScale`/`godray_scale`, and add `Mat_Shader_ApplyStageDefaults` to map material defaults to stages. 
- Use stage output metadata in runtime by adding helper functions `Mat_Shader_StageHasOutput`/`Mat_Shader_MaterialHasOutput` and switch `Mat_Shader_GetTextureFlags` to derive `MAT_SHADERFLAG_EMISSIVE`/`BLOOM`/`GODRAY` from stage outputs in `Quake/mat_shader.c`. 
- Update shaders `Quake/shaders/world.frag` and `Quake/shaders/water.frag` so bloom masking includes emissive-marked stages (change material mask computation) to ensure bloom/godray extraction uses stage-marked sources only.

### Testing
- No automated tests were executed for these changes. 
- Changes were compiled and committed locally (no CI run reported). 
- Manual shader parsing paths were exercised in code review to ensure legacy material-level flags are applied to stages as defaults. 
- Runtime visual verification is suggested to confirm that unmarked bright surfaces no longer generate bloom/godrays unless a stage explicitly enables them.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953054155b8832ea58e3d0eec7682aa)