### PR TITLE
Material shader parser: policies, debug CVars, and test shaders

### DIFF
--- a/Quake/mat_shader.c
+++ b/Quake/mat_shader.c
@@ -47,6 +47,8 @@ static qboolean mat_shader_loaded;
 
 cvar_t r_shaders = { "r_shaders", "1", CVAR_ARCHIVE };
 cvar_t r_shader_debug = { "r_shader_debug", "0", CVAR_ARCHIVE };
+static cvar_t r_matshader_dump = { "r_matshader_dump", "0", CVAR_NONE };
+cvar_t r_matshader_showstage = { "r_matshader_showstage", "-1", CVAR_ARCHIVE };
 static cvar_t r_reloadshaders = { "r_reloadshaders", "0", CVAR_NONE };
 
 char *Mat_Shader_DupString (const char *value)
@@ -171,6 +173,34 @@ void Mat_Shader_ReportWarningOnce (const char *warn_key, const char *message)
 		return;
 	Mat_Shader_AddWarned (warn_key);
 	Con_Warning ("MatShader: %s\n", message);
+}
+
+const mat_shader_stage_t *Mat_Shader_SelectStage (const shader_material_t *material)
+{
+	int stage_index;
+
+	if (!material)
+		return NULL;
+
+	stage_index = (int)floorf (r_matshader_showstage.value);
+	if (stage_index < 0)
+	{
+		if (VEC_SIZE (material->stages) > 0)
+			return &material->stages[0];
+		return &material->stage0;
+	}
+
+	if (VEC_SIZE (material->stages) > 0)
+	{
+		if (stage_index >= 0 && stage_index < (int)VEC_SIZE (material->stages))
+			return &material->stages[stage_index];
+		return &material->stages[0];
+	}
+
+	if (stage_index == 0)
+		return &material->stage0;
+
+	return &material->stage0;
 }
 
 static void Mat_MatrixIdentity (mat_texmatrix_t *out)
@@ -519,6 +549,8 @@ void Mat_Shader_Init (void)
 {
 	Cvar_RegisterVariable (&r_shaders);
 	Cvar_RegisterVariable (&r_shader_debug);
+	Cvar_RegisterVariable (&r_matshader_dump);
+	Cvar_RegisterVariable (&r_matshader_showstage);
 	Cvar_RegisterVariable (&r_reloadshaders);
 	Cvar_SetCallback (&r_reloadshaders, Mat_Shader_Reload_f);
 
@@ -606,9 +638,17 @@ const shader_material_t *Mat_Shader_FindForTextureName (const char *texname, con
 
 const char *Mat_Shader_GetStage0Map (const shader_material_t *material, const char *texname)
 {
-	if (!material || (material->stage0.map_type != MAT_MAP_MAP && material->stage0.map_type != MAT_MAP_CLAMPMAP))
+	const mat_shader_stage_t *stage;
+
+	if (!material)
 		return NULL;
-	if (!material->stage0.map_path || !material->stage0.map_path[0])
+
+	stage = Mat_Shader_SelectStage (material);
+	if (!stage)
+		return NULL;
+	if (stage->map_type != MAT_MAP_MAP && stage->map_type != MAT_MAP_CLAMPMAP)
+		return NULL;
+	if (!stage->map_path || !stage->map_path[0])
 		return NULL;
 
 	if (texname && texname[0])
@@ -619,7 +659,7 @@ const char *Mat_Shader_GetStage0Map (const shader_material_t *material, const ch
 			return NULL;
 	}
 
-	return material->stage0.map_path;
+	return stage->map_path;
 }
 
 static qboolean Mat_Shader_StageHasOutput (const mat_shader_stage_t *stage, unsigned int output_flag)
@@ -746,6 +786,11 @@ void Mat_Shader_Print (const shader_material_t *material)
 	static const char *const blend_names[] = { "replace", "alpha", "add", "mult", "premult", "custom" };
 	static const char *const depth_names[] = { "lequal", "equal", "always" };
 	static const char *const map_names[] = { "map", "clampmap", "lightmap", "white", "black" };
+	static const char *const tcgen_names[] = { "base", "environment", "lightmap" };
+	static const char *const rgbgen_names[] = { "identity", "vertex", "const", "wave" };
+	static const char *const alphagen_names[] = { "identity", "vertex", "const", "wave" };
+	static const char *const tcmod_names[] = { "scroll", "scale", "rotate", "turb", "stretch" };
+	size_t i;
 
 	if (!material)
 		return;
@@ -764,14 +809,67 @@ void Mat_Shader_Print (const shader_material_t *material)
 	Con_Printf ("  emissive: %s (scale %.2f)\n", material->emissive_enable ? "on" : "off", material->emissive_scale);
 	Con_Printf ("  bloom: %s (scale %.2f)\n", material->bloom_enable ? "on" : "off", material->bloom_scale);
 	Con_Printf ("  godray: %s (scale %.2f)\n", material->godray_enable ? "on" : "off", material->godray_scale);
-	if (material->stage0.map_path || material->stage0.map_type != MAT_MAP_MAP)
+
+	if (VEC_SIZE (material->stages) == 0)
 	{
-		const char *map_name = map_names[q_min ((int)material->stage0.map_type, (int)countof (map_names) - 1)];
-		Con_Printf ("  stage0 map: %s (%s)\n", material->stage0.map_path ? material->stage0.map_path : "<builtin>", map_name);
-		Con_Printf ("  stage0 blend: %s\n", blend_names[q_min ((int)material->stage0.blend_mode, (int)countof (blend_names) - 1)]);
+		const mat_shader_stage_t *stage = &material->stage0;
+		const char *map_name = map_names[q_min ((int)stage->map_type, (int)countof (map_names) - 1)];
+		Con_Printf ("  stage0 map: %s (%s)\n", stage->map_path ? stage->map_path : "<builtin>", map_name);
+		Con_Printf ("  stage0 blend: %s\n", blend_names[q_min ((int)stage->blend_mode, (int)countof (blend_names) - 1)]);
 		Con_Printf ("  stage0 depth: %s (write %s)\n",
-			depth_names[q_min ((int)material->stage0.depth_func, (int)countof (depth_names) - 1)],
-			material->stage0.depth_write ? "on" : "off");
+			depth_names[q_min ((int)stage->depth_func, (int)countof (depth_names) - 1)],
+			stage->depth_write ? "on" : "off");
+		Con_Printf ("  stage0 tcgen: %s\n", tcgen_names[q_min ((int)stage->tcgen, (int)countof (tcgen_names) - 1)]);
+		Con_Printf ("  stage0 rgbGen: %s\n", rgbgen_names[q_min ((int)stage->rgbgen, (int)countof (rgbgen_names) - 1)]);
+		Con_Printf ("  stage0 alphaGen: %s\n", alphagen_names[q_min ((int)stage->alphagen, (int)countof (alphagen_names) - 1)]);
+		if (stage->tcmod_count > 0)
+		{
+			int mod_index;
+			Con_Printf ("  stage0 tcmods: %d\n", stage->tcmod_count);
+			for (mod_index = 0; mod_index < stage->tcmod_count; ++mod_index)
+			{
+				const mat_tcmod_t *mod = &stage->tcmods[mod_index];
+				const char *mod_name = tcmod_names[q_min ((int)mod->type, (int)countof (tcmod_names) - 1)];
+				Con_Printf ("    tcmod %d: %s (%.3f %.3f %.3f %.3f)\n",
+					mod_index, mod_name, mod->args[0], mod->args[1], mod->args[2], mod->args[3]);
+			}
+		}
+		if (stage->anim_map_frames)
+			Con_Printf ("  stage0 animMap: %.2f fps (%zu frames)\n", stage->anim_map_fps, VEC_SIZE (stage->anim_map_frames));
+		return;
+	}
+
+	for (i = 0; i < VEC_SIZE (material->stages); ++i)
+	{
+		const mat_shader_stage_t *stage = &material->stages[i];
+		const char *map_name = map_names[q_min ((int)stage->map_type, (int)countof (map_names) - 1)];
+		const char *tcgen_name = tcgen_names[q_min ((int)stage->tcgen, (int)countof (tcgen_names) - 1)];
+		const char *rgbgen_name = rgbgen_names[q_min ((int)stage->rgbgen, (int)countof (rgbgen_names) - 1)];
+		const char *alphagen_name = alphagen_names[q_min ((int)stage->alphagen, (int)countof (alphagen_names) - 1)];
+
+		Con_Printf ("  stage %zu:\n", i);
+		Con_Printf ("    map: %s (%s)\n", stage->map_path ? stage->map_path : "<builtin>", map_name);
+		Con_Printf ("    blend: %s\n", blend_names[q_min ((int)stage->blend_mode, (int)countof (blend_names) - 1)]);
+		Con_Printf ("    depth: %s (write %s)\n",
+			depth_names[q_min ((int)stage->depth_func, (int)countof (depth_names) - 1)],
+			stage->depth_write ? "on" : "off");
+		Con_Printf ("    tcgen: %s\n", tcgen_name);
+		Con_Printf ("    rgbGen: %s\n", rgbgen_name);
+		Con_Printf ("    alphaGen: %s\n", alphagen_name);
+		if (stage->tcmod_count > 0)
+		{
+			int mod_index;
+			Con_Printf ("    tcmods: %d\n", stage->tcmod_count);
+			for (mod_index = 0; mod_index < stage->tcmod_count; ++mod_index)
+			{
+				const mat_tcmod_t *mod = &stage->tcmods[mod_index];
+				const char *mod_name = tcmod_names[q_min ((int)mod->type, (int)countof (tcmod_names) - 1)];
+				Con_Printf ("      tcmod %d: %s (%.3f %.3f %.3f %.3f)\n",
+					mod_index, mod_name, mod->args[0], mod->args[1], mod->args[2], mod->args[3]);
+			}
+		}
+		if (stage->anim_map_frames)
+			Con_Printf ("    animMap: %.2f fps (%zu frames)\n", stage->anim_map_fps, VEC_SIZE (stage->anim_map_frames));
 	}
 }
 
@@ -793,6 +891,9 @@ void Mat_Shader_Insert (shader_material_t *material)
 	owned = (shader_material_t *) Z_Malloc (sizeof (*owned));
 	memcpy (owned, material, sizeof (*owned));
 	Mat_Shader_Register (owned);
+
+	if (r_matshader_dump.value > 0.f)
+		Mat_Shader_Print (owned);
 }
 
 void Mat_Shader_Remove (const shader_material_t *material)

--- a/Quake/mat_shader.h
+++ b/Quake/mat_shader.h
@@ -244,6 +244,9 @@ typedef struct texture_s texture_t;
 
 extern cvar_t r_shaders;
 extern cvar_t r_shader_debug;
+extern cvar_t r_matshader_showstage;
+
+#define MAT_SHADER_MAX_STAGES 8
 
 void Mat_Shader_Init (void);
 void Mat_Shader_Shutdown (void);
@@ -253,6 +256,7 @@ const shader_material_t *Mat_Shader_GetByIndex (size_t index);
 void Mat_Shader_Canonicalize (const char *name, char *out, size_t out_size);
 const shader_material_t *Mat_Shader_Find (const char *name);
 const shader_material_t *Mat_Shader_FindForTextureName (const char *texname, const char *mapname);
+const mat_shader_stage_t *Mat_Shader_SelectStage (const shader_material_t *material);
 const char *Mat_Shader_GetStage0Map (const shader_material_t *material, const char *texname);
 unsigned int Mat_Shader_GetTextureFlags (const shader_material_t *material);
 void Mat_Shader_ApplyToTexture (texture_t *tex, const char *mapname);

--- a/Quake/mat_shader_parse.c
+++ b/Quake/mat_shader_parse.c
@@ -381,6 +381,13 @@ static qboolean Mat_Shader_ParseDepthFunc (const char *token, mat_depthfunc_t *o
 	return false;
 }
 
+static qboolean Mat_Shader_IsLightmapFilterStage (const mat_shader_stage_t *stage)
+{
+	if (!stage)
+		return false;
+	return stage->map_type == MAT_MAP_LIGHTMAP && stage->blend_mode == MAT_BLEND_MULT;
+}
+
 static void Mat_Shader_ApplySurfaceParm (shader_material_t *material, const char *token)
 {
 	for (size_t i = 0; i < countof (mat_surfaceparm_table); ++i)
@@ -865,7 +872,8 @@ static const char *ParseStageBlock (const char *data, shader_material_t *materia
 			break;
 	}
 
-	if (stage.blend_mode != MAT_BLEND_REPLACE || !stage.depth_write || stage.depth_func != MAT_DEPTHFUNC_LEQUAL)
+	if (!Mat_Shader_IsLightmapFilterStage (&stage) &&
+		(stage.blend_mode != MAT_BLEND_REPLACE || !stage.depth_write || stage.depth_func != MAT_DEPTHFUNC_LEQUAL))
 		material->render_flags |= MAT_RENDER_TRANS;
 
 	if (!material->stages)
@@ -964,6 +972,8 @@ static const char *ParseMaterialBlock (const char *data, const char *name, const
 	shader_material_t material;
 	const shader_material_t *existing;
 	int stage_index = 0;
+	qboolean sort_explicit = false;
+	qboolean stage_limit_warned = false;
 	char canonical[MAX_QPATH];
 
 	memset (&material, 0, sizeof (material));
@@ -988,6 +998,25 @@ static const char *ParseMaterialBlock (const char *data, const char *name, const
 			break;
 		if (!strcmp (com_token, "{"))
 		{
+			if (stage_index >= MAT_SHADER_MAX_STAGES)
+			{
+				char warn_key[MAX_QPATH * 2];
+				char warn_msg[256];
+
+				if (!stage_limit_warned)
+				{
+					q_snprintf (warn_key, sizeof (warn_key), "%s::maxstages", material.name ? material.name : "shader");
+					q_snprintf (warn_msg, sizeof (warn_msg),
+						"%s exceeds max stages (%d); extra stages ignored",
+						material.name ? material.name : "shader",
+						MAT_SHADER_MAX_STAGES);
+					Mat_Shader_ReportWarningOnce (warn_key, warn_msg);
+					stage_limit_warned = true;
+				}
+				data = SkipUnknownBlockOrLine (data, true);
+				continue;
+			}
+
 			data = ParseStageBlock (data, &material, (size_t)stage_index++);
 			continue;
 		}
@@ -1022,6 +1051,7 @@ static const char *ParseMaterialBlock (const char *data, const char *name, const
 			{
 				if (material.sort_key != MAT_SORT_OPAQUE)
 					material.render_flags |= MAT_RENDER_TRANS;
+				sort_explicit = true;
 				continue;
 			}
 			Mat_Shader_ReportUnknownToken (value, material.name);
@@ -1085,6 +1115,20 @@ static const char *ParseMaterialBlock (const char *data, const char *name, const
 	}
 
 	Mat_Shader_ApplyStageDefaults (&material);
+
+	if (!sort_explicit)
+	{
+		if (material.polygon_offset)
+		{
+			material.sort_key = MAT_SORT_DECAL;
+			material.render_flags |= MAT_RENDER_TRANS;
+		}
+		else if (material.render_flags & MAT_RENDER_TRANS)
+		{
+			material.sort_key = MAT_SORT_ADDITIVE;
+		}
+	}
+
 	existing = Mat_Shader_Find (material.name);
 	if (existing)
 		Mat_Shader_Remove (existing);

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -554,7 +554,9 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
 
 	if (t && t->shader && r_shaders.value > 0.f)
 	{
-		const mat_shader_stage_t *stage = &t->shader->stage0;
+		const mat_shader_stage_t *stage = Mat_Shader_SelectStage (t->shader);
+		if (!stage)
+			stage = &t->shader->stage0;
 		if (!has_vertex_color && (stage->rgbgen == MAT_RGBGEN_VERTEX || stage->alphagen == MAT_ALPHAGEN_VERTEX))
 		{
 			char warn_key[MAX_QPATH * 2];

--- a/scripts/test_matshaders.shader
+++ b/scripts/test_matshaders.shader
@@ -1,0 +1,67 @@
+// Test shaders for material shader parsing/debug.
+
+textures/test/test_glow_add
+{
+    qer_editorimage textures/test/test_glow_add
+
+    {
+        map textures/test/test_glow_add
+        rgbGen identity
+    }
+    {
+        map textures/test/test_glow_add_glow
+        blendFunc add
+        emissive true
+    }
+}
+
+textures/test/test_lightmap_filter
+{
+    qer_editorimage textures/test/test_lightmap_filter
+
+    {
+        map textures/test/test_lightmap_filter
+        rgbGen identity
+    }
+    {
+        map $lightmap
+        blendFunc filter
+        rgbGen identity
+    }
+}
+
+textures/test/test_scroll_turb_water
+{
+    qer_editorimage textures/test/test_scroll_turb_water
+    surfaceparm trans
+
+    {
+        map textures/test/test_scroll_turb_water
+        blendFunc blend
+        tcMod scroll 0.1 0.05
+        tcMod turb 0.0 0.2 0.0 0.3
+    }
+}
+
+textures/test/test_animmap_console
+{
+    qer_editorimage textures/test/test_animmap_console
+
+    {
+        animMap 8 textures/test/console_01 textures/test/console_02 textures/test/console_03 textures/test/console_04
+        rgbGen identity
+    }
+}
+
+textures/test/test_godray_source_only
+{
+    qer_editorimage textures/test/test_godray_source_only
+    godray true
+    emissive false
+
+    {
+        map textures/test/test_godray_source_only
+        rgbGen identity
+        godray true
+    }
+}


### PR DESCRIPTION
### Motivation
- Add engine-level policies and safety nets for material shaders to avoid pathological or ambiguous stage definitions and make shader behavior more transparent.
- Provide quick debug/inspection tools so parsed material state can be examined without relying on render capture tools.
- Ensure classic Q3-style lightmap/filter interactions and reasonable sort defaults for decals/transparent surfaces.

### Description
- Introduce `MAT_SHADER_MAX_STAGES` (8) and enforce a stage cap in the parser that prints a single warning and ignores extra stages, and add `r_matshader_showstage` and `r_matshader_dump` CVars for stage selection and dump output.
- Add `Mat_Shader_SelectStage` and use it from `Mat_Shader_GetStage0Map` and `r_world.c` so debug selection of a specific stage is respected at lookup/eval time.
- Parser changes: special-case lightmap filter stages to avoid marking them as transparent, derive a fallback `sort` when none is explicit (polygonOffset -> `decal`, otherwise translucent -> `additive`), and skip/warn on excess stage blocks.
- Improve `Mat_Shader_Print` to emit richer per-stage summaries (tcGen, rgb/alphaGen, `tcmod`s with arguments, animMap info) and call it from `Mat_Shader_Insert` when `r_matshader_dump` is enabled.
- Add `scripts/test_matshaders.shader` with sample materials: `test_glow_add`, `test_lightmap_filter`, `test_scroll_turb_water`, `test_animmap_console`, and `test_godray_source_only` to exercise parsing/debug output.

### Testing
- Added the `scripts/test_matshaders.shader` file as a test data set to exercise the parser and debug print features; no automated runner was executed as part of this change.
- No automated tests or CI were run during this change (manual inspection and `r_matshader_dump` can be used to validate parse output at runtime).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953085a7214832e9e472357045e4585)