### PR TITLE
Reduce console noise: hide KTX2 color-space print and suppress BSPX missing-lump logs

### DIFF
--- a/Quake/gl_ktx2.c
+++ b/Quake/gl_ktx2.c
@@ -360,7 +360,6 @@ gltexture_t *R_LoadKTX2Texture(const char *name, const uint8_t *data, size_t siz
 
     KTX2_FreeDecodedImage(&decoded);
 
-    Con_Printf("Texture %s: %s, %s\n", name, srgb ? "sRGB" : "linear", srgb ? "GL_SRGB8_ALPHA8" : "GL_RGBA8");
     KTX2_LogInfo("Finished uploading KTX2 texture '%s' (%dx%d, mips=%d)", name, tex->width, tex->height, tex->mipmap);
     return tex;
 }

--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -697,10 +697,7 @@ static void Q1BSPX_LogUsage(const char *modelname)
         int i;
 
         if (!loadmodel || !loadmodel->bspx_entries_count || !bspx_lump_usage_count)
-        {
-                Con_Printf("%s: no BSPX lumps present\n", modelname);
                 return;
-        }
 	Con_Printf("%s BSPX lumps:\n", modelname);
 	for (i = 0; i < bspx_lump_usage_count; i++)
 	{
@@ -1719,9 +1716,6 @@ static void Mod_LoadLighting (lump_t *l)
                 }
 
         }
-        else {
-                Con_DPrintf2("gl_loadlitfiles 0: ignoring BSPX colored lighting lumps\n");
-        }
 
         if (bspx_dlit && l->filelen && !loadmodel->lightdata)
         {
@@ -2387,10 +2381,7 @@ static qboolean Mod_LoadLightgridOctreeFromMap (qmodel_t *mod, const char *mapna
 
 	lglump = BSPX_FindLump (mod->bspx_header, buffer, "LIGHTGRID_OCTREE", &lumpsize);
 	if (!lglump)
-	{
-		Con_Printf ("load_lightgrid_octree: LIGHTGRID_OCTREE not found in %s\n", path);
 		goto done;
-	}
 
 	if (!LightgridOctree_LoadBSPX (mod, lglump, (int)lumpsize))
 	{
@@ -2445,7 +2436,7 @@ static void Mod_LoadLightgridOctree_f (cvar_t *var)
 
 		success = Mod_LoadLightgridOctreeFromMap (cl.worldmodel, mapname);
 		if (!success)
-			failure_reason = "failed to load LIGHTGRID_OCTREE lump";
+			failure_reason = "failed to load lightgrid octree";
 		else if (!Lightgrid_Get () || Lightgrid_Get () == previous)
 			failure_reason = "lightgrid failed to apply";
 	}
@@ -4008,8 +3999,6 @@ static void Mod_LoadBrushModel (qmodel_t *mod, void *buffer)
                 lump = Q1BSPX_FindLump("FACENORMALS", &lumpsize);
                 if (lump && lumpsize > 0)
                         Mod_LoadFaceNormalsBSPX(mod, lump, lumpsize);
-                else
-                        Con_DPrintf("BSPX: no FACENORMALS lump found\n");
         }
 
 	if (mod->bspversion == BSPVERSION && external_vis.value/* && sv.modelname[0] && !q_strcasecmp(loadname, sv.name)*/) // woods allow vis load online


### PR DESCRIPTION
### Motivation
- Reduce noisy console output during texture and BSPX loading by hiding routine informational messages. 
- Avoid printing messages about expected-but-missing optional BSPX lumps so only actually-present lumps are reported. 
- Prevent spurious texture color-space lines for KTX2 uploads that are redundant with structured logs. 

### Description
- Removed the `Con_Printf` that printed texture color-space info from `R_LoadKTX2Texture` in `Quake/gl_ktx2.c`. 
- Suppressed the "no BSPX lumps present" print in `Q1BSPX_LogUsage` so the function simply returns when nothing is present in `Quake/gl_model.c`. 
- Removed debug prints for ignored BSPX lighting lumps and omitted the log when `FACENORMALS` is absent so only present/used/unsupported lumps are listed in `Quake/gl_model.c`. 
- Avoided printing when `LIGHTGRID_OCTREE` is not found and adjusted the failure reason text for lightgrid loading to be less noisy in `Quake/gl_model.c`. 

### Testing
- No automated tests were executed for this change. 
- Local build or runtime verification was not recorded as an automated test. 
- No CI results are available for this PR. 
- Functional behavior is limited to removing/altering console messages and should not change runtime data flows.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695310df2620832ebda61c2f9039b68e)