### PR TITLE
Add `Vector4Copy` macro for vec4_t support

### DIFF
--- a/Quake/mathlib.h
+++ b/Quake/mathlib.h
@@ -59,6 +59,7 @@ static inline int IS_NAN (float x) {
 #define VectorSubtract(a,b,dst)			do {(dst)[0]=(a)[0]-(b)[0];(dst)[1]=(a)[1]-(b)[1];(dst)[2]=(a)[2]-(b)[2];} while (0)
 #define VectorAdd(a,b,dst)				do {(dst)[0]=(a)[0]+(b)[0];(dst)[1]=(a)[1]+(b)[1];(dst)[2]=(a)[2]+(b)[2];} while (0)
 #define VectorCopy(src,dst)				do {(dst)[0]=(src)[0];(dst)[1]=(src)[1];(dst)[2]=(src)[2];} while (0)
+#define Vector4Copy(src,dst)			do {(dst)[0]=(src)[0];(dst)[1]=(src)[1];(dst)[2]=(src)[2];(dst)[3]=(src)[3];} while (0)
 #define VectorSet(v,x,y,z)				do {(v)[0]=(x);(v)[1]=(y);(v)[2]=(z);} while (0)
 #define VectorClear(v)                             do {(v)[0] = (v)[1] = (v)[2] = 0.f;} while (0)
 #define VectorLengthSquared(v)			DotProduct(v,v)
@@ -173,4 +174,3 @@ qboolean RayVsBox (const vec3_t org, const vec3_t rcpdelta, const vec3_t mins, c
 /*==========================================================================*/
 
 #endif	/* __MATHLIB_H */
-


### PR DESCRIPTION
### Motivation
- Fix a build failure where `Vector4Copy` was referenced but not defined, causing `C4013` and `C2220` errors during compilation.  
- Provide a helper matching existing 3-component vector macros for use with `vec4_t` values.  
- Ensure `mat_shader.c` and other code that copies 4-component vectors compile cleanly.  

### Description
- Added a new macro `Vector4Copy(src,dst)` to `Quake/mathlib.h` that copies four float components.  
- Placed the macro alongside other vector helper macros (`VectorCopy`, `VectorAdd`, etc.) for consistency.  
- This addresses direct uses of `Vector4Copy` in `Quake/mat_shader.c` (e.g. color copy paths).  

### Testing
- No automated tests were run for this change.  
- The change is a small header-only macro addition and is expected to resolve the previously reported compiler warnings/errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695313bcfe8c832e8346066ea9488f1d)