### PR TITLE
Add Vector4Copy macro to mathlib.h

### DIFF
--- a/Quake/mathlib.h
+++ b/Quake/mathlib.h
@@ -59,6 +59,7 @@ static inline int IS_NAN (float x) {
 #define VectorSubtract(a,b,dst)			do {(dst)[0]=(a)[0]-(b)[0];(dst)[1]=(a)[1]-(b)[1];(dst)[2]=(a)[2]-(b)[2];} while (0)
 #define VectorAdd(a,b,dst)				do {(dst)[0]=(a)[0]+(b)[0];(dst)[1]=(a)[1]+(b)[1];(dst)[2]=(a)[2]+(b)[2];} while (0)
 #define VectorCopy(src,dst)				do {(dst)[0]=(src)[0];(dst)[1]=(src)[1];(dst)[2]=(src)[2];} while (0)
+#define Vector4Copy(src,dst)			do {(dst)[0]=(src)[0];(dst)[1]=(src)[1];(dst)[2]=(src)[2];(dst)[3]=(src)[3];} while (0)
 #define VectorSet(v,x,y,z)				do {(v)[0]=(x);(v)[1]=(y);(v)[2]=(z);} while (0)
 #define VectorClear(v)                             do {(v)[0] = (v)[1] = (v)[2] = 0.f;} while (0)
 #define VectorLengthSquared(v)			DotProduct(v,v)
@@ -173,4 +174,3 @@ qboolean RayVsBox (const vec3_t org, const vec3_t rcpdelta, const vec3_t mins, c
 /*==========================================================================*/
 
 #endif	/* __MATHLIB_H */
-


### PR DESCRIPTION
### Motivation

- Fix the compiler warning/error about `Vector4Copy` being undefined when compiling `Quake/mat_shader.c`.
- Provide a convenience macro for copying `vec4_t` values analogous to the existing `VectorCopy` for `vec3_t`.
- Keep math utilities consistent and avoid ad-hoc implementations of 4-component copy sites.

### Description

- Add `#define Vector4Copy(src,dst) do {(dst)[0]=(src)[0];(dst)[1]=(src)[1];(dst)[2]=(src)[2];(dst)[3]=(src)[3];} while (0)` to `Quake/mathlib.h`.
- This exposes a single, reusable macro for copying `vec4_t` across the codebase so callers like `MatStage_EvalColor` can use it without a forward declaration.

### Testing

- No automated tests or builds were executed after this change.
- The change was limited to a header macro addition and committed to the branch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695316e46018832e8a963922eab839f5)