### PR TITLE
Fix fullbright map generation for BSP textures

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -1335,7 +1335,7 @@ static void Mod_LoadTextures (lump_t *l)
                                         byte *rgba = (byte *) Hunk_AllocNameNoFill (pixels * 4, "tex_rgba");
 
                                         if (has_fullbright)
-                                                palmode = is_cutout ? TEXMGR_PALMODE_NOBRIGHT : TEXMGR_PALMODE_ALPHABRIGHT;
+                                                palmode = TEXMGR_PALMODE_NOBRIGHT;
 
                                         TexMgr_DecodeIndexedToRGBA ((byte *)(tx + 1), pixels, is_cutout ? 255 : -1, palmode, rgba);
 
@@ -1343,10 +1343,10 @@ static void Mod_LoadTextures (lump_t *l)
                                         tx->gltexture = TexMgr_LoadImage (loadmodel, texturename, tx->width, tx->height,
                                                 SRC_RGBA, rgba, "", (src_offset_t)rgba, TEXPREF_MIPMAP | TEXPREF_BINDLESS | (is_cutout ? TEXPREF_ALPHA : 0));
 
-                                        if (has_fullbright && is_cutout)
+                                        if (has_fullbright)
                                         {
                                                 byte *fb_rgba = (byte *) Hunk_AllocNameNoFill (pixels * 4, "tex_fbright");
-                                                TexMgr_BuildFullbrightRGBA ((byte *)(tx + 1), pixels, 255, fb_rgba);
+                                                TexMgr_BuildFullbrightRGBA ((byte *)(tx + 1), pixels, is_cutout ? 255 : -1, fb_rgba);
                                                 q_snprintf (texturename, sizeof(texturename), "%s:%s_glow", loadmodel->name, tx->name);
                                                 tx->fullbright = TexMgr_LoadImage (loadmodel, texturename, tx->width, tx->height,
                                                         SRC_RGBA, fb_rgba, "", (src_offset_t)fb_rgba, TEXPREF_MIPMAP | TEXPREF_BINDLESS);
@@ -1407,7 +1407,7 @@ static void Mod_LoadTextures (lump_t *l)
                                         byte *rgba = (byte *) Hunk_AllocNameNoFill (pixels * 4, "tex_rgba");
 
                                         if (has_fullbright)
-                                                palmode = is_cutout ? TEXMGR_PALMODE_NOBRIGHT : TEXMGR_PALMODE_ALPHABRIGHT;
+                                                palmode = TEXMGR_PALMODE_NOBRIGHT;
 
                                         TexMgr_DecodeIndexedToRGBA ((byte *)(tx + 1), pixels, is_cutout ? 255 : -1, palmode, rgba);
 
@@ -1415,10 +1415,10 @@ static void Mod_LoadTextures (lump_t *l)
                                         tx->gltexture = TexMgr_LoadImage (loadmodel, texturename, tx->width, tx->height,
                                                 SRC_RGBA, rgba, "", (src_offset_t)rgba, TEXPREF_MIPMAP | extraflags | (is_cutout ? TEXPREF_ALPHA : 0));
 
-                                        if (has_fullbright && is_cutout)
+                                        if (has_fullbright)
                                         {
                                                 byte *fb_rgba = (byte *) Hunk_AllocNameNoFill (pixels * 4, "tex_fbright");
-                                                TexMgr_BuildFullbrightRGBA ((byte *)(tx + 1), pixels, 255, fb_rgba);
+                                                TexMgr_BuildFullbrightRGBA ((byte *)(tx + 1), pixels, is_cutout ? 255 : -1, fb_rgba);
                                                 q_snprintf (texturename, sizeof(texturename), "%s:%s_glow", loadmodel->name, tx->name);
                                                 tx->fullbright = TexMgr_LoadImage (loadmodel, texturename, tx->width, tx->height,
                                                         SRC_RGBA, fb_rgba, "", (src_offset_t)fb_rgba, TEXPREF_MIPMAP | extraflags);


### PR DESCRIPTION
### Motivation
- BSP-loaded textures with fullbright pixels were producing incorrect (black) base textures when fullbright pixels were not separated into a glow map.
- The previous code only generated fullbright maps for cutout textures, causing fullbright pixels to remain in the base image for other texture types.
- Transparent index handling needs to be preserved when building fullbright RGBA data to avoid introducing alpha artifacts.

### Description
- In `Mod_LoadTextures` select `TEXMGR_PALMODE_NOBRIGHT` when `has_fullbright` is detected so base textures have fullbright pixels stripped.
- Always generate a fullbright map (`tx->fullbright`) for BSP-sourced textures if `has_fullbright`, instead of only for cutout textures.
- Call `TexMgr_BuildFullbrightRGBA` with `is_cutout ? 255 : -1` so transparent indices are preserved for cutout textures and disabled otherwise.
- The changes are applied in both the liquid and regular texture loading branches of `Quake/gl_model.c`.

### Testing
- No automated tests were run for this change.
- There is no CI result included in this PR description.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695317df50f4832e99cc5a89bcc58cba)