### PR TITLE
Apply view-blend overlays after postprocess to prevent SSAO/tonemap punch-through

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -4262,7 +4262,7 @@ void R_WarpScaleView (void)
 	srcw = r_refdef.vrect.width / r_refdef.scale;
 	srch = r_refdef.vrect.height / r_refdef.scale;
 
-	needwarpscale = r_refdef.scale != 1 || water_warp || (v_blend[3] && gl_polyblend.value && !softemu);
+	needwarpscale = r_refdef.scale != 1 || water_warp;
 	fbodest = GL_NeedsPostprocess () ? framebufs.composite.fbo : 0;
         need_depth_resolve = (fbodest == framebufs.composite.fbo) && (R_DoFEnabled () || r_ssao.value > 0.f || r_ssao_debug.value > 0.f);
 
@@ -4359,10 +4359,8 @@ void R_WarpScaleView (void)
 
 	t = M_ForcedUnderwater () ? realtime : cl.time;
 	GL_Uniform4fFunc (0, smax, tmax, water_warp ? 1.f / 256.f : 0.f, (float)t);
-	if (v_blend[3] && gl_polyblend.value && !softemu)
-		GL_Uniform4fvFunc (1, 1, v_blend);
-	else
-		GL_Uniform4fFunc (1, 0.f, 0.f, 0.f, 0.f);
+	// View blends are applied after postprocess/UI to avoid AO/tone-map affecting overlays.
+	GL_Uniform4fFunc (1, 0.f, 0.f, 0.f, 0.f);
 	GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, msaa ? framebufs.resolved_scene.color_tex : framebufs.scene.color_tex);
 	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, water_warp && msaa ? GL_LINEAR : GL_NEAREST);
 	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, water_warp && msaa ? GL_LINEAR : GL_NEAREST);

--- a/Quake/gl_screen.c
+++ b/Quake/gl_screen.c
@@ -2149,6 +2149,8 @@ void SCR_UpdateScreen (void)
 
        GL_PostProcess ();
 
+       V_PolyBlend ();
+
        R_StorePrevFrameState ();
 
        GL_BeginGroup ("2D");

--- a/Quake/view.c
+++ b/Quake/view.c
@@ -621,14 +621,8 @@ void V_PolyBlend (void)
 		if (!cshift_empty.percent || maxcolor > 0)
 			return;
 	}
-	else
-	{
-		// If we're already rendering to an intermediate FBO (for warp/scale/MSAA)
-		// then we can apply the color blending when blitting the intermediate texture
-		// (to save the memory bandwidth an extra full-screen alpha blend would consume)
-		if (GL_NeedsSceneEffects ())
-			return;
-	}
+	// Blend happens as a late overlay to keep postprocess (e.g. SSAO/tonemap) from
+	// affecting UI-style color shifts like pickups or damage flashes.
 
 	GL_UseProgram (glprogs.viewblend);
 	GL_SetState (GLS_BLEND_ALPHA | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS(0));
@@ -1092,8 +1086,6 @@ void V_RenderView (void)
 	//johnfitz -- removed lcd code
 
 	R_RenderView ();
-
-	V_PolyBlend (); //johnfitz -- moved here from R_Renderview ();
 }
 
 /*

--- a/Quake/view.h
+++ b/Quake/view.h
@@ -30,6 +30,7 @@ extern float v_blend[4];
 
 void V_Init (void);
 void V_RenderView (void);
+void V_PolyBlend (void);
 void V_CalcBlend (void);
 void V_UpdateBlend (void);
 void V_ResetEffects (void);
@@ -37,4 +38,3 @@ float V_CalcRoll (vec3_t angles, vec3_t velocity);
 void V_RestoreAngles (void);
 
 #endif	/* _QUAKE_VIEW_H */
-


### PR DESCRIPTION
### Motivation
- Fix a visual bug where fullscreen UI blends (weapon pickup / damage flash) become "milky" or cause SSAO/AO contrast to punch through when underwater or warped.
- Ensure overlays like pickup/hurt flashes are not modulated by scene-space postprocess effects such as SSAO or tone mapping.
- Provide a minimal, robust change by reordering passes rather than large subsystem refactors.

### Description
- Move application of the view blend overlay out of the warp/scale scene pass so it is not sampled/tonemapped by postprocessing, by clearing the `v_blend` injection in `R_WarpScaleView` (`Quake/gl_rmain.c`).
- Call `V_PolyBlend` after `GL_PostProcess` in the main screen update flow (`Quake/gl_screen.c`) so view blends run as a late 2D overlay.
- Update `V_PolyBlend` semantics in `Quake/view.c` to always apply as a late overlay (remove the early-return path that attempted to apply it during scene blits) and keep the API available by adding `void V_PolyBlend(void);` to `Quake/view.h`.
- Small comment and state updates explaining the reason: overlays must be applied after AO/tonemap/postprocess to avoid AO being multiplied into overlays.

### Testing
- No automated tests were executed for this change (no CI/test run was requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953268b2eb4832e8b11ee94c5c2f4ac)