### PR TITLE
Add missing PostFX sources to Windows Visual Studio project

### DIFF
--- a/Windows/VisualStudio/ironwail.vcxproj
+++ b/Windows/VisualStudio/ironwail.vcxproj
@@ -241,6 +241,7 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
     <ClCompile Include="..\..\Quake\cl_input.c" />
     <ClCompile Include="..\..\Quake\cl_main.c" />
     <ClCompile Include="..\..\Quake\cl_parse.c" />
+    <ClCompile Include="..\..\Quake\cl_postfx.c" />
     <ClCompile Include="..\..\Quake\cl_tent.c" />
     <ClCompile Include="..\..\Quake\cmd.c" />
     <ClCompile Include="..\..\Quake\common.c" />
@@ -312,6 +313,7 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
     <ClCompile Include="..\..\Quake\r_brush.c" />
     <ClCompile Include="..\..\Quake\r_dlight_pool.c" />
     <ClCompile Include="..\..\Quake\r_maptex_export.c" />
+    <ClCompile Include="..\..\Quake\r_postfx.c" />
     <ClCompile Include="..\..\Quake\r_part.c" />
     <ClCompile Include="..\..\Quake\r_sprite.c" />
     <ClCompile Include="..\..\Quake\r_world.c" />


### PR DESCRIPTION
### Motivation

- Windows builds produced unresolved externals for PostFX symbols such as `CL_PostFX_Init` and `R_PostFX_GetLUTTexture` due to missing source files in the project.
- The Visual Studio project did not include the client- and renderer-side PostFX implementation files `cl_postfx.c` and `r_postfx.c`.
- Including those sources ensures the PostFX implementations are compiled and linked into the Windows binary.

### Description

- Added `<ClCompile Include="..\..\Quake\cl_postfx.c" />` to `Windows/VisualStudio/ironwail.vcxproj`.
- Added `<ClCompile Include="..\..\Quake\r_postfx.c" />` to `Windows/VisualStudio/ironwail.vcxproj`.
- The change only updates the Visual Studio project file and does not modify any source logic.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69532fa2bd48832eab42b055a8f2320f)