### PR TITLE
Use GL_TexImage3DFunc for LUT 3D texture upload to fix Windows link error

### DIFF
--- a/Quake/r_postfx.c
+++ b/Quake/r_postfx.c
@@ -153,7 +153,7 @@ void R_PostFX_ReloadLUTs (void)
 	glTexParameteri (GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 	glTexParameteri (GL_TEXTURE_2D_ARRAY, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
 	glTexParameteri (GL_TEXTURE_2D_ARRAY, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-	glTexImage3D (GL_TEXTURE_2D_ARRAY, 0, GL_RGBA8, size * size, size, PFX_LUT_COUNT, 0, GL_RGBA, GL_UNSIGNED_BYTE, lut_storage);
+	GL_TexImage3DFunc (GL_TEXTURE_2D_ARRAY, 0, GL_RGBA8, size * size, size, PFX_LUT_COUNT, 0, GL_RGBA, GL_UNSIGNED_BYTE, lut_storage);
 	GL_ObjectLabelFunc (GL_TEXTURE, r_postfx_lut_tex, -1, "postfx lut");
 
 	free (lut_storage);


### PR DESCRIPTION
### Motivation

- Prevent an unresolved external linker error for `glTexImage3D` on Windows by avoiding a direct link to the symbol.
- Ensure the LUT array texture upload uses the platform-appropriate OpenGL function pointer wrapper.

### Description

- Replaced the direct call `glTexImage3D(...)` with the function-pointer wrapper `GL_TexImage3DFunc(...)` in `Quake/r_postfx.c`.
- This change updates the LUT 3D texture upload path to use the project's GL function dispatch (`GL_TexImage3DFunc`) so the implementation uses runtime-resolved GL entry points.
- One-line change in `R_PostFX_ReloadLUTs` to perform the 3D texture upload via the wrapper.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695330a274b8832ea99648ec61a85e5f)