### PR TITLE
Replace damage desaturation with red tint in postprocess shader

### DIFF
--- a/Quake/shaders/postprocess.frag
+++ b/Quake/shaders/postprocess.frag
@@ -145,7 +145,7 @@ layout(location=17) uniform vec4 SSAOParams; // x: intensity, y: debug mode, z: 
 layout(location=18) uniform vec4 SSAOBlurParams; // x: blur sigma, y: blur radius, z: depth threshold scale, w: unused
 layout(location=19) uniform vec4 ColorSpaceParams; // x: debug mode, y: unused, z: output sRGB conversion, w: reserved
 layout(location=20) uniform float u_midtone;
-layout(location=21) uniform vec4 PostFXParams3; // x: exposure add (stops), y: bloom boost, z: emissive boost, w: desat
+layout(location=21) uniform vec4 PostFXParams3; // x: exposure add (stops), y: bloom boost, z: emissive boost, w: damage tint
 layout(location=22) uniform vec4 PostFXParams4; // x: lut strength, y: underwater grade strength, z: underwater fog strength, w: vignette softness
 layout(location=23) uniform vec4 PostFXLUTParams; // x: lut size, y: lut id, z: unused, w: unused
 layout(location=24) uniform vec4 PostFXFogColor; // rgb: fog color, w: unused
@@ -723,11 +723,11 @@ void main()
                 }
         }
         {
-                float desat = clamp(PostFXParams3.w, 0.0, 1.0);
-                if (desat > 0.0)
+                float damageTint = clamp(PostFXParams3.w, 0.0, 1.0);
+                if (damageTint > 0.0)
                 {
-                        float luma = dot(mapped, vec3(0.299, 0.587, 0.114));
-                        mapped = mix(mapped, vec3(luma), desat);
+                        vec3 tint = vec3(1.0, 0.15, 0.15);
+                        mapped = mix(mapped, mapped * tint, damageTint);
                 }
         }
         if (outputSrgb > 0.5)


### PR DESCRIPTION
### Motivation
- The damage postfx should produce an increasingly red tint effect instead of desaturating the image.
- The previous implementation used the `PostFXParams3.w` field as a desaturation amount, which no longer matches the desired visual.

### Description
- Updated `Quake/shaders/postprocess.frag` to treat `PostFXParams3.w` as a damage tint strength instead of desaturation and updated the uniform comment accordingly.
- Replaced the desaturation code with a red tint blend using a fixed tint vector `vec3(1.0, 0.15, 0.15)` and mixing `mapped` with `mapped * tint` by the damage tint amount.
- Kept the change localized to the postprocess shader so other postfx paths remain unaffected.

### Testing
- No automated tests were executed for this change.
- Shader compilation and runtime verification were not run by the automated pipeline.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695334a11778832e8d2eaa1576285d85)