### PR TITLE
Add shader keyword tracking and deterministic report generation

### DIFF
--- a/Quake/mat_shader.c
+++ b/Quake/mat_shader.c
@@ -23,10 +23,12 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "mat_shader_parse.h"
 #include "miniz.h"
 #include <math.h>
+#include <stdarg.h>
 
 #define MAT_SHADER_HASH_SIZE 256
 #define MAT_SHADER_LIST_LIMIT 64
 #define MAT_TEXMOD_PI 3.14159265358979323846f
+#define MAT_SHADER_UNKNOWN_LIMIT 256
 
 typedef struct mat_shader_entry_s
 {
@@ -40,14 +42,78 @@ typedef struct mat_shader_warn_s
 	char *token;
 } mat_shader_warn_t;
 
+typedef struct mat_shader_keyword_def_s
+{
+	const char *keyword;
+	mat_shader_keyword_scope_t scope;
+	mat_shader_keyword_status_t status;
+	const char *notes;
+} mat_shader_keyword_def_t;
+
+typedef struct mat_shader_unknown_s
+{
+	char *token;
+	mat_shader_keyword_scope_t scope;
+	unsigned int count;
+	char *first_context;
+	char *first_source;
+} mat_shader_unknown_t;
+
 static mat_shader_entry_t *mat_shader_hash[MAT_SHADER_HASH_SIZE];
 static shader_material_t **mat_shader_list;
 static mat_shader_warn_t *mat_shader_warned;
+static mat_shader_unknown_t *mat_shader_unknowns;
 static qboolean mat_shader_loaded;
+static qboolean mat_shader_unknown_overflow;
+
+static const mat_shader_keyword_def_t mat_shader_keyword_table[] =
+{
+	{ "qer_editorimage", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Editor preview texture." },
+	{ "surfaceparm", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Surface flags; see surfaceparm scope." },
+	{ "cull", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL, MAT_SHADER_KEYWORD_STATUS_PARTIAL, "Modes: back/front/none." },
+	{ "sort", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL, MAT_SHADER_KEYWORD_STATUS_PARTIAL, "Keys: opaque/decal/additive/nearest." },
+	{ "polygonOffset", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Optional boolean." },
+	{ "emissive", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Non-Q3 extension." },
+	{ "bloom", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Non-Q3 extension." },
+	{ "godray", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Non-Q3 extension." },
+	{ "emissive_scale", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Non-Q3 extension." },
+	{ "bloom_scale", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Non-Q3 extension." },
+	{ "godray_scale", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Non-Q3 extension." },
+	{ "skyParms", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL, MAT_SHADER_KEYWORD_STATUS_KNOWN_UNIMPLEMENTED, "Q3 sky parameters." },
+	{ "fogParms", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL, MAT_SHADER_KEYWORD_STATUS_KNOWN_UNIMPLEMENTED, "Q3 fog parameters." },
+	{ "deformVertexes", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL, MAT_SHADER_KEYWORD_STATUS_KNOWN_UNIMPLEMENTED, "Q3 vertex deformation." },
+	{ "q3map_*", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL, MAT_SHADER_KEYWORD_STATUS_KNOWN_UNIMPLEMENTED, "Q3Map compile-time directives." },
+
+	{ "map", MAT_SHADER_KEYWORD_SCOPE_STAGE, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Supports $lightmap/$white/$black and textures." },
+	{ "clampmap", MAT_SHADER_KEYWORD_SCOPE_STAGE, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Clamp-wrapped texture." },
+	{ "animMap", MAT_SHADER_KEYWORD_SCOPE_STAGE, MAT_SHADER_KEYWORD_STATUS_PARTIAL, "FPS + frame list only." },
+	{ "rgbGen", MAT_SHADER_KEYWORD_SCOPE_STAGE, MAT_SHADER_KEYWORD_STATUS_PARTIAL, "Supports identity only." },
+	{ "alphaGen", MAT_SHADER_KEYWORD_SCOPE_STAGE, MAT_SHADER_KEYWORD_STATUS_KNOWN_UNIMPLEMENTED, "Q3 alpha generator." },
+	{ "blendFunc", MAT_SHADER_KEYWORD_SCOPE_STAGE, MAT_SHADER_KEYWORD_STATUS_PARTIAL, "Supports add/filter/blend/premult or explicit factors." },
+	{ "depthWrite", MAT_SHADER_KEYWORD_SCOPE_STAGE, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Optional boolean." },
+	{ "depthFunc", MAT_SHADER_KEYWORD_SCOPE_STAGE, MAT_SHADER_KEYWORD_STATUS_PARTIAL, "Modes: lequal/equal/always." },
+	{ "alphaFunc", MAT_SHADER_KEYWORD_SCOPE_STAGE, MAT_SHADER_KEYWORD_STATUS_KNOWN_UNIMPLEMENTED, "Q3 alpha test." },
+	{ "tcGen", MAT_SHADER_KEYWORD_SCOPE_STAGE, MAT_SHADER_KEYWORD_STATUS_PARTIAL, "Modes: base/environment/lightmap." },
+	{ "tcMod", MAT_SHADER_KEYWORD_SCOPE_STAGE, MAT_SHADER_KEYWORD_STATUS_PARTIAL, "Types: scroll/scale/rotate/turb/stretch." },
+
+	{ "solid", MAT_SHADER_KEYWORD_SCOPE_SURFACEPARM, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Surface solid." },
+	{ "nonsolid", MAT_SHADER_KEYWORD_SCOPE_SURFACEPARM, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Surface non-solid." },
+	{ "playerclip", MAT_SHADER_KEYWORD_SCOPE_SURFACEPARM, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Blocks players." },
+	{ "monsterclip", MAT_SHADER_KEYWORD_SCOPE_SURFACEPARM, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Blocks monsters." },
+	{ "trans", MAT_SHADER_KEYWORD_SCOPE_SURFACEPARM, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Marks transparent." },
+	{ "alphashadow", MAT_SHADER_KEYWORD_SCOPE_SURFACEPARM, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Alpha shadow hint." },
+	{ "sky", MAT_SHADER_KEYWORD_SCOPE_SURFACEPARM, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Sky surface." },
+	{ "fog", MAT_SHADER_KEYWORD_SCOPE_SURFACEPARM, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Fog surface." },
+	{ "nodraw", MAT_SHADER_KEYWORD_SCOPE_SURFACEPARM, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "No draw surface." },
+	{ "stone", MAT_SHADER_KEYWORD_SCOPE_SURFACEPARM, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Footstep hint." }
+};
+
+static qboolean mat_shader_keyword_seen[countof (mat_shader_keyword_table)];
 
 cvar_t r_shaders = { "r_shaders", "1", CVAR_ARCHIVE };
 cvar_t r_shader_debug = { "r_shader_debug", "0", CVAR_ARCHIVE };
 static cvar_t r_reloadshaders = { "r_reloadshaders", "0", CVAR_NONE };
+static cvar_t r_matshader_report = { "r_matshader_report", "0", CVAR_NONE };
 
 char *Mat_Shader_DupString (const char *value)
 {
@@ -125,6 +191,20 @@ static void Mat_Shader_Reset (void)
 			Z_Free (mat_shader_warned[i].token);
 	}
 	VEC_FREE (mat_shader_warned);
+
+	for (i = 0; i < VEC_SIZE (mat_shader_unknowns); ++i)
+	{
+		if (mat_shader_unknowns[i].token)
+			Z_Free (mat_shader_unknowns[i].token);
+		if (mat_shader_unknowns[i].first_context)
+			Z_Free (mat_shader_unknowns[i].first_context);
+		if (mat_shader_unknowns[i].first_source)
+			Z_Free (mat_shader_unknowns[i].first_source);
+	}
+	VEC_FREE (mat_shader_unknowns);
+	mat_shader_unknown_overflow = false;
+
+	memset (mat_shader_keyword_seen, 0, sizeof (mat_shader_keyword_seen));
 }
 
 static unsigned int Mat_Shader_Hash (const char *name)
@@ -161,6 +241,282 @@ static void Mat_Shader_WarnOnce (const char *warn_key, const char *token, const 
 
 	Mat_Shader_AddWarned (warn_key);
 	Con_Warning ("MatShader: unknown token '%s' in %s\n", token, context ? context : "shader");
+}
+
+static const char *Mat_Shader_ScopeName (mat_shader_keyword_scope_t scope)
+{
+	switch (scope)
+	{
+	case MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL:
+		return "top-level";
+	case MAT_SHADER_KEYWORD_SCOPE_STAGE:
+		return "stage";
+	case MAT_SHADER_KEYWORD_SCOPE_SURFACEPARM:
+		return "surfaceparm";
+	default:
+		return "unknown";
+	}
+}
+
+static const char *Mat_Shader_StatusName (mat_shader_keyword_status_t status)
+{
+	switch (status)
+	{
+	case MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED:
+		return "Implemented";
+	case MAT_SHADER_KEYWORD_STATUS_PARTIAL:
+		return "Partial";
+	case MAT_SHADER_KEYWORD_STATUS_KNOWN_UNIMPLEMENTED:
+		return "Known-but-Unimplemented";
+	default:
+		return "Unknown";
+	}
+}
+
+void Mat_Shader_MarkKeywordSeen (const char *keyword, mat_shader_keyword_scope_t scope)
+{
+	size_t i;
+
+	if (!keyword || !keyword[0])
+		return;
+
+	for (i = 0; i < countof (mat_shader_keyword_table); ++i)
+	{
+		if (mat_shader_keyword_table[i].scope != scope)
+			continue;
+		if (!q_strcasecmp (mat_shader_keyword_table[i].keyword, keyword))
+		{
+			mat_shader_keyword_seen[i] = true;
+			return;
+		}
+	}
+}
+
+static void Mat_Shader_RecordUnknownToken (const char *token, mat_shader_keyword_scope_t scope, const char *context, const char *source_file)
+{
+	size_t i;
+
+	if (!token || !token[0])
+		return;
+
+	for (i = 0; i < VEC_SIZE (mat_shader_unknowns); ++i)
+	{
+		if (mat_shader_unknowns[i].scope == scope && !q_strcasecmp (mat_shader_unknowns[i].token, token))
+		{
+			mat_shader_unknowns[i].count++;
+			return;
+		}
+	}
+
+	if (VEC_SIZE (mat_shader_unknowns) >= MAT_SHADER_UNKNOWN_LIMIT)
+	{
+		mat_shader_unknown_overflow = true;
+		return;
+	}
+
+	{
+		mat_shader_unknown_t entry;
+
+		memset (&entry, 0, sizeof (entry));
+		entry.token = Mat_Shader_DupString (token);
+		entry.scope = scope;
+		entry.count = 1;
+		entry.first_context = Mat_Shader_DupString (context ? context : "");
+		entry.first_source = Mat_Shader_DupString (source_file ? source_file : "");
+		VEC_PUSH (mat_shader_unknowns, entry);
+	}
+}
+
+static void Mat_Shader_ReportAppend (char **buffer, size_t *len, size_t *cap, const char *fmt, ...)
+{
+	char temp[1024];
+	va_list args;
+	size_t add;
+
+	if (!buffer || !len || !cap)
+		return;
+
+	va_start (args, fmt);
+	q_vsnprintf (temp, sizeof (temp), fmt, args);
+	va_end (args);
+
+	add = strlen (temp);
+	if (*len + add + 1 > *cap)
+	{
+		size_t newcap = *cap ? *cap : 1024;
+		while (newcap < *len + add + 1)
+			newcap *= 2;
+		{
+			char *newbuf = (char *) realloc (*buffer, newcap);
+			if (!newbuf)
+				return;
+			*buffer = newbuf;
+			*cap = newcap;
+		}
+	}
+
+	memcpy (*buffer + *len, temp, add);
+	*len += add;
+	(*buffer)[*len] = '\0';
+}
+
+typedef struct mat_shader_keyword_row_s
+{
+	const mat_shader_keyword_def_t *def;
+	qboolean seen;
+} mat_shader_keyword_row_t;
+
+static int Mat_Shader_CompareKeywordRows (const void *a, const void *b)
+{
+	const mat_shader_keyword_row_t *left = (const mat_shader_keyword_row_t *) a;
+	const mat_shader_keyword_row_t *right = (const mat_shader_keyword_row_t *) b;
+	int scope_cmp = (int)left->def->scope - (int)right->def->scope;
+
+	if (scope_cmp != 0)
+		return scope_cmp;
+	return q_strcasecmp (left->def->keyword, right->def->keyword);
+}
+
+static int Mat_Shader_CompareUnknowns (const void *a, const void *b)
+{
+	const mat_shader_unknown_t *const *left = (const mat_shader_unknown_t *const *) a;
+	const mat_shader_unknown_t *const *right = (const mat_shader_unknown_t *const *) b;
+	int scope_cmp = (int)(*left)->scope - (int)(*right)->scope;
+
+	if (scope_cmp != 0)
+		return scope_cmp;
+	return q_strcasecmp ((*left)->token, (*right)->token);
+}
+
+static void Mat_Shader_ReportKeywords (char **buffer, size_t *len, size_t *cap, const mat_shader_keyword_row_t *rows, size_t row_count, mat_shader_keyword_status_t status)
+{
+	size_t i;
+	int printed = 0;
+
+	Mat_Shader_ReportAppend (buffer, len, cap, "## %s\n", Mat_Shader_StatusName (status));
+
+	for (i = 0; i < row_count; ++i)
+	{
+		const mat_shader_keyword_row_t *row = &rows[i];
+		if (row->def->status != status)
+			continue;
+		printed++;
+		Mat_Shader_ReportAppend (buffer, len, cap, "- `%s` (%s) — Seen: %s",
+			row->def->keyword,
+			Mat_Shader_ScopeName (row->def->scope),
+			row->seen ? "yes" : "no");
+		if (row->def->notes && row->def->notes[0])
+			Mat_Shader_ReportAppend (buffer, len, cap, ". Notes: %s", row->def->notes);
+		Mat_Shader_ReportAppend (buffer, len, cap, "\n");
+	}
+
+	if (!printed)
+		Mat_Shader_ReportAppend (buffer, len, cap, "_None._\n");
+
+	Mat_Shader_ReportAppend (buffer, len, cap, "\n");
+}
+
+static void Mat_Shader_WriteReport (void)
+{
+	const char *path = "docs/mat_shader_report.md";
+	const size_t keyword_count = countof (mat_shader_keyword_table);
+	mat_shader_keyword_row_t *rows = NULL;
+	mat_shader_unknown_t **unknown_rows = NULL;
+	size_t unknown_count = VEC_SIZE (mat_shader_unknowns);
+	char *report = NULL;
+	size_t len = 0;
+	size_t cap = 0;
+	size_t i;
+
+	rows = (mat_shader_keyword_row_t *) malloc (keyword_count * sizeof (*rows));
+	if (!rows)
+		return;
+
+	for (i = 0; i < keyword_count; ++i)
+	{
+		rows[i].def = &mat_shader_keyword_table[i];
+		rows[i].seen = mat_shader_keyword_seen[i];
+	}
+	qsort (rows, keyword_count, sizeof (*rows), Mat_Shader_CompareKeywordRows);
+
+	Mat_Shader_ReportAppend (&report, &len, &cap, "# Material Shader Keyword Report\n\n");
+	Mat_Shader_ReportAppend (&report, &len, &cap, "Tracked keywords are grouped by implementation status and scope.\n\n");
+
+	Mat_Shader_ReportKeywords (&report, &len, &cap, rows, keyword_count, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED);
+	Mat_Shader_ReportKeywords (&report, &len, &cap, rows, keyword_count, MAT_SHADER_KEYWORD_STATUS_PARTIAL);
+	Mat_Shader_ReportKeywords (&report, &len, &cap, rows, keyword_count, MAT_SHADER_KEYWORD_STATUS_KNOWN_UNIMPLEMENTED);
+
+	Mat_Shader_ReportAppend (&report, &len, &cap, "## Unknown-Seen\n");
+	if (unknown_count > 0)
+	{
+		unknown_rows = (mat_shader_unknown_t **) malloc (unknown_count * sizeof (*unknown_rows));
+		if (unknown_rows)
+		{
+			for (i = 0; i < unknown_count; ++i)
+				unknown_rows[i] = &mat_shader_unknowns[i];
+			qsort (unknown_rows, unknown_count, sizeof (*unknown_rows), Mat_Shader_CompareUnknowns);
+
+			for (i = 0; i < unknown_count; ++i)
+			{
+				const mat_shader_unknown_t *entry = unknown_rows[i];
+				Mat_Shader_ReportAppend (&report, &len, &cap,
+					"- `%s` (%s) — Count: %u. First seen in %s (material: %s)\n",
+					entry->token,
+					Mat_Shader_ScopeName (entry->scope),
+					entry->count,
+					entry->first_source && entry->first_source[0] ? entry->first_source : "<unknown source>",
+					entry->first_context && entry->first_context[0] ? entry->first_context : "<unknown>");
+			}
+		}
+		else
+		{
+			for (i = 0; i < unknown_count; ++i)
+			{
+				const mat_shader_unknown_t *entry = &mat_shader_unknowns[i];
+				Mat_Shader_ReportAppend (&report, &len, &cap,
+					"- `%s` (%s) — Count: %u. First seen in %s (material: %s)\n",
+					entry->token,
+					Mat_Shader_ScopeName (entry->scope),
+					entry->count,
+					entry->first_source && entry->first_source[0] ? entry->first_source : "<unknown source>",
+					entry->first_context && entry->first_context[0] ? entry->first_context : "<unknown>");
+			}
+		}
+		if (mat_shader_unknown_overflow)
+			Mat_Shader_ReportAppend (&report, &len, &cap, "- _Unknown token limit reached; additional tokens omitted._\n");
+	}
+	else
+	{
+		Mat_Shader_ReportAppend (&report, &len, &cap, "_None._\n");
+	}
+	Mat_Shader_ReportAppend (&report, &len, &cap, "\n");
+
+	Mat_Shader_ReportAppend (&report, &len, &cap, "## Wishlist / reference (Q3 keywords)\n");
+	Mat_Shader_ReportAppend (&report, &len, &cap, "- blendFunc (add, filter, blend, custom factors)\n");
+	Mat_Shader_ReportAppend (&report, &len, &cap, "- rgbGen modes (identity, identityLighting, entity, oneMinusEntity, vertex, exactVertex, lightingDiffuse)\n");
+	Mat_Shader_ReportAppend (&report, &len, &cap, "- alphaGen modes (identity, entity, oneMinusEntity, vertex, lightingSpecular, portal, wave)\n");
+	Mat_Shader_ReportAppend (&report, &len, &cap, "- tcGen / tcMod (base, lightmap, environment, vector; scroll/scale/rotate/stretch/transform/turb)\n");
+	Mat_Shader_ReportAppend (&report, &len, &cap, "- animMap / clampmap\n");
+	Mat_Shader_ReportAppend (&report, &len, &cap, "- depthFunc / depthWrite / alphaFunc\n");
+	Mat_Shader_ReportAppend (&report, &len, &cap, "- cull / sort / polygonOffset\n");
+	Mat_Shader_ReportAppend (&report, &len, &cap, "- deformVertexes\n");
+	Mat_Shader_ReportAppend (&report, &len, &cap, "- skyParms / fogParms / q3map_*\n");
+
+	if (report && len > 0)
+		COM_WriteFile (path, report, (int)len);
+
+	free (unknown_rows);
+	free (rows);
+	free (report);
+}
+
+static qboolean Mat_Shader_ShouldWriteReport (void)
+{
+#if defined(_DEBUG) || defined(DEBUG)
+	return true;
+#else
+	return r_matshader_report.value > 0.f;
+#endif
 }
 
 static void Mat_MatrixIdentity (mat_texmatrix_t *out)
@@ -457,6 +813,9 @@ static void Mat_Shader_LoadAll (void)
 	}
 
 	VEC_FREE (paths);
+
+	if (Mat_Shader_ShouldWriteReport ())
+		Mat_Shader_WriteReport ();
 }
 
 static void Mat_Shader_Reload_f (cvar_t *var)
@@ -510,6 +869,7 @@ void Mat_Shader_Init (void)
 	Cvar_RegisterVariable (&r_shaders);
 	Cvar_RegisterVariable (&r_shader_debug);
 	Cvar_RegisterVariable (&r_reloadshaders);
+	Cvar_RegisterVariable (&r_matshader_report);
 	Cvar_SetCallback (&r_reloadshaders, Mat_Shader_Reload_f);
 
 	Cmd_AddCommand ("shaderlist", Mat_Shader_List_f);
@@ -765,16 +1125,24 @@ void Mat_Shader_Remove (const shader_material_t *material)
 	Mat_Shader_FreeMaterial ((shader_material_t *) material);
 }
 
-void Mat_Shader_ReportUnknownToken (const char *token, const char *context)
+void Mat_Shader_ReportUnknownToken (const char *token, mat_shader_keyword_scope_t scope, const char *context, const char *source_file)
 {
-	char warn_key[MAX_QPATH * 2];
+	char warn_key[MAX_QPATH * 3];
+	char warn_context[MAX_QPATH * 2];
+	const char *scope_name = Mat_Shader_ScopeName (scope);
 
 	if (context && context[0])
-		q_snprintf (warn_key, sizeof (warn_key), "%s::%s", context, token);
+		q_snprintf (warn_key, sizeof (warn_key), "%s::%s::%s", scope_name, context, token);
 	else
-		q_snprintf (warn_key, sizeof (warn_key), "%s", token);
+		q_snprintf (warn_key, sizeof (warn_key), "%s::%s", scope_name, token);
 
-	Mat_Shader_WarnOnce (warn_key, token, context);
+	if (context && context[0])
+		q_snprintf (warn_context, sizeof (warn_context), "%s (%s)", context, scope_name);
+	else
+		q_snprintf (warn_context, sizeof (warn_context), "shader (%s)", scope_name);
+
+	Mat_Shader_WarnOnce (warn_key, token, warn_context);
+	Mat_Shader_RecordUnknownToken (token, scope, context, source_file);
 }
 
 static int Mat_Shader_TimeBucket (float time, float fps_hint)

--- a/Quake/mat_shader.h
+++ b/Quake/mat_shader.h
@@ -198,6 +198,20 @@ typedef struct texture_s texture_t;
 extern cvar_t r_shaders;
 extern cvar_t r_shader_debug;
 
+typedef enum
+{
+	MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL = 0,
+	MAT_SHADER_KEYWORD_SCOPE_STAGE,
+	MAT_SHADER_KEYWORD_SCOPE_SURFACEPARM
+} mat_shader_keyword_scope_t;
+
+typedef enum
+{
+	MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED = 0,
+	MAT_SHADER_KEYWORD_STATUS_PARTIAL,
+	MAT_SHADER_KEYWORD_STATUS_KNOWN_UNIMPLEMENTED
+} mat_shader_keyword_status_t;
+
 void Mat_Shader_Init (void);
 void Mat_Shader_Shutdown (void);
 void Mat_Shader_Reload (void);
@@ -216,6 +230,7 @@ int MatStage_EvalAnimMapFrame (mat_shader_stage_t *stage, float time);
 const char *MatStage_GetAnimMapPath (mat_shader_stage_t *stage, float time);
 void Mat_Shader_Insert (shader_material_t *material);
 void Mat_Shader_Remove (const shader_material_t *material);
-void Mat_Shader_ReportUnknownToken (const char *token, const char *context);
+void Mat_Shader_MarkKeywordSeen (const char *keyword, mat_shader_keyword_scope_t scope);
+void Mat_Shader_ReportUnknownToken (const char *token, mat_shader_keyword_scope_t scope, const char *context, const char *source_file);
 
 #endif // MAT_SHADER_H

--- a/Quake/mat_shader_parse.c
+++ b/Quake/mat_shader_parse.c
@@ -546,6 +546,7 @@ static void Mat_Shader_ApplySurfaceParm (shader_material_t *material, const char
 	{
 		if (!q_strcasecmp (token, mat_surfaceparm_table[i].name))
 		{
+			Mat_Shader_MarkKeywordSeen (mat_surfaceparm_table[i].name, MAT_SHADER_KEYWORD_SCOPE_SURFACEPARM);
 			material->surfaceparms |= mat_surfaceparm_table[i].surfaceparm;
 			material->render_flags |= mat_surfaceparm_table[i].render_flags;
 			material->content_flags |= mat_surfaceparm_table[i].content_flags;
@@ -553,7 +554,7 @@ static void Mat_Shader_ApplySurfaceParm (shader_material_t *material, const char
 		}
 	}
 
-	Mat_Shader_ReportUnknownToken (token, material->name);
+	Mat_Shader_ReportUnknownToken (token, MAT_SHADER_KEYWORD_SCOPE_SURFACEPARM, material->name, material->source_file);
 }
 
 static const char *SkipUnknownBlockOrLine (const char *data, qboolean already_open, mat_shader_parse_state_t *state)
@@ -668,6 +669,7 @@ static const char *ParseStageBlock (const char *data, shader_material_t *materia
 			break;
 		if (!q_strcasecmp (com_token, "map"))
 		{
+			Mat_Shader_MarkKeywordSeen ("map", MAT_SHADER_KEYWORD_SCOPE_STAGE);
 			if (!ParseIdentExpected (&data, &value, state, "map path"))
 			{
 				valid = false;
@@ -695,6 +697,7 @@ static const char *ParseStageBlock (const char *data, shader_material_t *materia
 		}
 		if (!q_strcasecmp (com_token, "clampmap"))
 		{
+			Mat_Shader_MarkKeywordSeen ("clampmap", MAT_SHADER_KEYWORD_SCOPE_STAGE);
 			if (!ParseIdentExpected (&data, &value, state, "map path"))
 			{
 				valid = false;
@@ -707,6 +710,7 @@ static const char *ParseStageBlock (const char *data, shader_material_t *materia
 		}
 		if (!q_strcasecmp (com_token, "rgbGen"))
 		{
+			Mat_Shader_MarkKeywordSeen ("rgbGen", MAT_SHADER_KEYWORD_SCOPE_STAGE);
 			if (!ParseIdentExpected (&data, &value, state, "rgbGen mode"))
 			{
 				valid = false;
@@ -719,6 +723,7 @@ static const char *ParseStageBlock (const char *data, shader_material_t *materia
 		}
 		if (!q_strcasecmp (com_token, "blendFunc"))
 		{
+			Mat_Shader_MarkKeywordSeen ("blendFunc", MAT_SHADER_KEYWORD_SCOPE_STAGE);
 			int src;
 			int dst;
 
@@ -767,7 +772,7 @@ static const char *ParseStageBlock (const char *data, shader_material_t *materia
 				}
 				if (!Mat_Shader_ParseBlendFactor (value, &dst))
 				{
-					Mat_Shader_ReportUnknownToken (value, material->name);
+					Mat_Shader_ReportUnknownToken (value, MAT_SHADER_KEYWORD_SCOPE_STAGE, material->name, material->source_file);
 					break;
 				}
 				stage.blend_mode = MAT_BLEND_CUSTOM;
@@ -776,11 +781,12 @@ static const char *ParseStageBlock (const char *data, shader_material_t *materia
 				continue;
 			}
 
-			Mat_Shader_ReportUnknownToken (value, material->name);
+			Mat_Shader_ReportUnknownToken (value, MAT_SHADER_KEYWORD_SCOPE_STAGE, material->name, material->source_file);
 			continue;
 		}
 		if (!q_strcasecmp (com_token, "depthWrite"))
 		{
+			Mat_Shader_MarkKeywordSeen ("depthWrite", MAT_SHADER_KEYWORD_SCOPE_STAGE);
 			qboolean parsed = false;
 			qboolean value_bool = true;
 
@@ -790,6 +796,7 @@ static const char *ParseStageBlock (const char *data, shader_material_t *materia
 		}
 		if (!q_strcasecmp (com_token, "depthFunc"))
 		{
+			Mat_Shader_MarkKeywordSeen ("depthFunc", MAT_SHADER_KEYWORD_SCOPE_STAGE);
 			if (!ParseIdentExpected (&data, &value, state, "depthFunc mode"))
 			{
 				valid = false;
@@ -798,11 +805,12 @@ static const char *ParseStageBlock (const char *data, shader_material_t *materia
 			}
 			if (Mat_Shader_ParseDepthFunc (value, &stage.depth_func))
 				continue;
-			Mat_Shader_ReportUnknownToken (value, material->name);
+			Mat_Shader_ReportUnknownToken (value, MAT_SHADER_KEYWORD_SCOPE_STAGE, material->name, material->source_file);
 			continue;
 		}
 		if (!q_strcasecmp (com_token, "tcGen"))
 		{
+			Mat_Shader_MarkKeywordSeen ("tcGen", MAT_SHADER_KEYWORD_SCOPE_STAGE);
 			if (!ParseIdentExpected (&data, &value, state, "tcGen mode"))
 			{
 				valid = false;
@@ -810,11 +818,12 @@ static const char *ParseStageBlock (const char *data, shader_material_t *materia
 				break;
 			}
 			if (!Mat_Shader_ParseTcGen (value, &stage.tcgen))
-				Mat_Shader_ReportUnknownToken (value, material->name);
+				Mat_Shader_ReportUnknownToken (value, MAT_SHADER_KEYWORD_SCOPE_STAGE, material->name, material->source_file);
 			continue;
 		}
 		if (!q_strcasecmp (com_token, "tcMod"))
 		{
+			Mat_Shader_MarkKeywordSeen ("tcMod", MAT_SHADER_KEYWORD_SCOPE_STAGE);
 			if (!ParseIdentExpected (&data, &value, state, "tcMod type"))
 			{
 				valid = false;
@@ -891,11 +900,12 @@ static const char *ParseStageBlock (const char *data, shader_material_t *materia
 				Mat_Shader_PushTcMod (&stage, MAT_TCMOD_STRETCH, stretch, 4);
 				continue;
 			}
-			Mat_Shader_ReportUnknownToken (value, material->name);
+			Mat_Shader_ReportUnknownToken (value, MAT_SHADER_KEYWORD_SCOPE_STAGE, material->name, material->source_file);
 			continue;
 		}
 		if (!q_strcasecmp (com_token, "animMap"))
 		{
+			Mat_Shader_MarkKeywordSeen ("animMap", MAT_SHADER_KEYWORD_SCOPE_STAGE);
 			float fps = 0.f;
 			float validated_fps = 0.f;
 			int frames = 0;
@@ -945,7 +955,7 @@ static const char *ParseStageBlock (const char *data, shader_material_t *materia
 			continue;
 		}
 
-		Mat_Shader_ReportUnknownToken (com_token, material->name);
+		Mat_Shader_ReportUnknownToken (com_token, MAT_SHADER_KEYWORD_SCOPE_STAGE, material->name, material->source_file);
 		data = SkipUnknownBlockOrLine (data, false, state);
 		if (!data)
 		{
@@ -1032,6 +1042,7 @@ static const char *ParseMaterialBlock (const char *data, const char *name, const
 		}
 		if (!q_strcasecmp (com_token, "qer_editorimage"))
 		{
+			Mat_Shader_MarkKeywordSeen ("qer_editorimage", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL);
 			if (!ParseIdentExpected (&data, &value, state, "qer_editorimage path"))
 			{
 				data = ResyncMaterialBlock (data, state);
@@ -1042,6 +1053,7 @@ static const char *ParseMaterialBlock (const char *data, const char *name, const
 		}
 		if (!q_strcasecmp (com_token, "surfaceparm"))
 		{
+			Mat_Shader_MarkKeywordSeen ("surfaceparm", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL);
 			if (!ParseIdentExpected (&data, &value, state, "surfaceparm value"))
 			{
 				data = ResyncMaterialBlock (data, state);
@@ -1052,6 +1064,7 @@ static const char *ParseMaterialBlock (const char *data, const char *name, const
 		}
 		if (!q_strcasecmp (com_token, "cull"))
 		{
+			Mat_Shader_MarkKeywordSeen ("cull", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL);
 			if (!ParseIdentExpected (&data, &value, state, "cull mode"))
 			{
 				data = ResyncMaterialBlock (data, state);
@@ -1059,11 +1072,12 @@ static const char *ParseMaterialBlock (const char *data, const char *name, const
 			}
 			if (Mat_Shader_ParseCullMode (value, &material.cull_mode))
 				continue;
-			Mat_Shader_ReportUnknownToken (value, material.name);
+			Mat_Shader_ReportUnknownToken (value, MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL, material.name, material.source_file);
 			continue;
 		}
 		if (!q_strcasecmp (com_token, "sort"))
 		{
+			Mat_Shader_MarkKeywordSeen ("sort", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL);
 			if (!ParseIdentExpected (&data, &value, state, "sort key"))
 			{
 				data = ResyncMaterialBlock (data, state);
@@ -1075,11 +1089,12 @@ static const char *ParseMaterialBlock (const char *data, const char *name, const
 					material.render_flags |= MAT_RENDER_TRANS;
 				continue;
 			}
-			Mat_Shader_ReportUnknownToken (value, material.name);
+			Mat_Shader_ReportUnknownToken (value, MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL, material.name, material.source_file);
 			continue;
 		}
 		if (!q_strcasecmp (com_token, "polygonOffset"))
 		{
+			Mat_Shader_MarkKeywordSeen ("polygonOffset", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL);
 			qboolean parsed = false;
 			qboolean value_bool = true;
 
@@ -1089,6 +1104,7 @@ static const char *ParseMaterialBlock (const char *data, const char *name, const
 		}
 		if (!q_strcasecmp (com_token, "emissive"))
 		{
+			Mat_Shader_MarkKeywordSeen ("emissive", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL);
 			if (!ParseRequiredBool (&data, &material.emissive_enable, state))
 			{
 				data = ResyncMaterialBlock (data, state);
@@ -1098,6 +1114,7 @@ static const char *ParseMaterialBlock (const char *data, const char *name, const
 		}
 		if (!q_strcasecmp (com_token, "bloom"))
 		{
+			Mat_Shader_MarkKeywordSeen ("bloom", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL);
 			if (!ParseRequiredBool (&data, &material.bloom_enable, state))
 			{
 				data = ResyncMaterialBlock (data, state);
@@ -1107,6 +1124,7 @@ static const char *ParseMaterialBlock (const char *data, const char *name, const
 		}
 		if (!q_strcasecmp (com_token, "godray"))
 		{
+			Mat_Shader_MarkKeywordSeen ("godray", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL);
 			if (!ParseRequiredBool (&data, &material.godray_enable, state))
 			{
 				data = ResyncMaterialBlock (data, state);
@@ -1116,6 +1134,7 @@ static const char *ParseMaterialBlock (const char *data, const char *name, const
 		}
 		if (!q_strcasecmp (com_token, "emissive_scale"))
 		{
+			Mat_Shader_MarkKeywordSeen ("emissive_scale", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL);
 			float validated_scale = 1.f;
 			if (!ParseFloat (&data, &scale, state))
 			{
@@ -1128,6 +1147,7 @@ static const char *ParseMaterialBlock (const char *data, const char *name, const
 		}
 		if (!q_strcasecmp (com_token, "bloom_scale"))
 		{
+			Mat_Shader_MarkKeywordSeen ("bloom_scale", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL);
 			float validated_scale = 1.f;
 			if (!ParseFloat (&data, &scale, state))
 			{
@@ -1140,6 +1160,7 @@ static const char *ParseMaterialBlock (const char *data, const char *name, const
 		}
 		if (!q_strcasecmp (com_token, "godray_scale"))
 		{
+			Mat_Shader_MarkKeywordSeen ("godray_scale", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL);
 			float validated_scale = 1.f;
 			if (!ParseFloat (&data, &scale, state))
 			{
@@ -1150,7 +1171,7 @@ static const char *ParseMaterialBlock (const char *data, const char *name, const
 			material.godray_scale = CLAMP (0.f, validated_scale, MAT_SHADER_SCALE_MAX);
 			continue;
 		}
-		Mat_Shader_ReportUnknownToken (com_token, material.name);
+		Mat_Shader_ReportUnknownToken (com_token, MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL, material.name, material.source_file);
 		data = SkipUnknownBlockOrLine (data, false, state);
 		if (!data)
 			break;


### PR DESCRIPTION
### Motivation

- Provide a single authoritative table of recognized material shader keywords with scope and implementation status to aid maintenance and future work.
- Track which keywords are actually seen while parsing (top-level, stage, surfaceparm) so coverage can be measured.
- Collect and bound unknown tokens with counts and first-seen locations to prioritize parser improvements.
- Emit a deterministic human-readable report after loading shaders to document implemented/partial/unimplemented/unknown keywords and a Q3 wishlist.

### Description

- Added enums and API in `mat_shader.h`: `mat_shader_keyword_scope_t`, `mat_shader_keyword_status_t`, `Mat_Shader_MarkKeywordSeen`, and an extended `Mat_Shader_ReportUnknownToken` signature that accepts a `scope` and `source_file`.
- Implemented a central `mat_shader_keyword_table[]` in `Quake/mat_shader.c` with entries (keyword, scope, status, notes) and a `mat_shader_keyword_seen[]` array to mark seen keywords.
- Added unknown-token tracking via a bounded vector `mat_shader_unknowns` and bookkeeping functions `Mat_Shader_RecordUnknownToken` and `Mat_Shader_ReportUnknownToken` that also call `Mat_Shader_WarnOnce`.
- Implemented deterministic report generation (`Mat_Shader_WriteReport`) that writes `docs/mat_shader_report.md` and is triggered at the end of `Mat_Shader_LoadAll()` when `r_matshader_report` is enabled or in debug builds; added helper `Mat_Shader_ShouldWriteReport` and `r_matshader_report` cvar.
- Updated parser (`Quake/mat_shader_parse.c`) to call `Mat_Shader_MarkKeywordSeen` for handled keywords (e.g. `map`, `clampmap`, `rgbGen`, `blendFunc`, `depthWrite`, `depthFunc`, `tcGen`, `tcMod`, `animMap`, and top-level directives like `qer_editorimage`, `surfaceparm`, `cull`, `sort`, `polygonOffset`, `emissive`, `bloom`, `godray`, `*_scale`) and to call the new `Mat_Shader_ReportUnknownToken` with proper `scope` and `source_file` when encountering unrecognized tokens.
- Memory cleanup: unknowns are freed in `Mat_Shader_Reset()` and the `mat_shader_keyword_seen` array is reset there.

### Testing

- No automated tests were run for this change.
- The change was compiled into the working tree and committed (development commit created), but no CI/build verification was executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953a7a0b484832e8d4a04006bddb0e1)