### PR TITLE
Add material shader fuzz parser and `shaderfuzz` trigger

### DIFF
--- a/Quake/mat_shader.c
+++ b/Quake/mat_shader.c
@@ -115,6 +115,7 @@ cvar_t r_shaders = { "r_shaders", "1", CVAR_ARCHIVE };
 cvar_t r_shader_debug = { "r_shader_debug", "0", CVAR_ARCHIVE };
 cvar_t r_matshader_debug_parse = { "r_matshader_debug_parse", "0", CVAR_ARCHIVE };
 static cvar_t r_reloadshaders = { "r_reloadshaders", "0", CVAR_NONE };
+static cvar_t r_matshader_fuzz = { "r_matshader_fuzz", "0", CVAR_NONE };
 static cvar_t r_matshader_report = { "r_matshader_report", "0", CVAR_NONE };
 
 char *Mat_Shader_DupString (const char *value)
@@ -977,6 +978,14 @@ static void Mat_Shader_Reload_f (cvar_t *var)
 	Mat_Shader_LoadAll ();
 }
 
+static void Mat_Shader_Fuzz_f (cvar_t *var)
+{
+	if (var->value <= 0.f)
+		return;
+	Mat_Shader_DebugFuzzParse ();
+	var->value = 0.f;
+}
+
 static void Mat_Shader_List_f (void)
 {
 	size_t count = Mat_Shader_Count ();
@@ -1014,17 +1023,25 @@ static void Mat_Shader_Print_f (void)
 	Mat_Shader_Print (material);
 }
 
+static void Mat_Shader_FuzzCommand_f (void)
+{
+	Mat_Shader_DebugFuzzParse ();
+}
+
 void Mat_Shader_Init (void)
 {
 	Cvar_RegisterVariable (&r_shaders);
 	Cvar_RegisterVariable (&r_shader_debug);
 	Cvar_RegisterVariable (&r_matshader_debug_parse);
 	Cvar_RegisterVariable (&r_reloadshaders);
+	Cvar_RegisterVariable (&r_matshader_fuzz);
 	Cvar_RegisterVariable (&r_matshader_report);
 	Cvar_SetCallback (&r_reloadshaders, Mat_Shader_Reload_f);
+	Cvar_SetCallback (&r_matshader_fuzz, Mat_Shader_Fuzz_f);
 
 	Cmd_AddCommand ("shaderlist", Mat_Shader_List_f);
 	Cmd_AddCommand ("shaderprint", Mat_Shader_Print_f);
+	Cmd_AddCommand ("shaderfuzz", Mat_Shader_FuzzCommand_f);
 }
 
 void Mat_Shader_Shutdown (void)

--- a/Quake/mat_shader_parse.c
+++ b/Quake/mat_shader_parse.c
@@ -1381,3 +1381,143 @@ int Mat_Shader_ParseFile (const char *path, const char *data, const char *source
 
 	return parsed;
 }
+
+static char *Mat_Shader_BuildLongPathShader (void)
+{
+	const char *prefix = "fuzz_longpath\n{\n { map textures/";
+	const char *suffix = " }\n}\n";
+	const size_t path_len = MAX_QPATH * 4;
+	const size_t total = strlen (prefix) + path_len + strlen (suffix) + 1;
+	char *buffer = (char *) malloc (total);
+	size_t offset = 0;
+
+	if (!buffer)
+		return NULL;
+
+	offset += (size_t) q_snprintf (buffer + offset, total - offset, "%s", prefix);
+	memset (buffer + offset, 'a', path_len);
+	offset += path_len;
+	q_snprintf (buffer + offset, total - offset, "%s", suffix);
+	return buffer;
+}
+
+static char *Mat_Shader_BuildManyStagesShader (void)
+{
+	const char *prefix = "fuzz_many_stages\n{\n";
+	const char *stage = " { map $whiteimage }\n";
+	const char *suffix = "}\n";
+	const size_t stage_count = MAT_SHADER_MAX_STAGES + 2;
+	const size_t total = strlen (prefix) + (stage_count * strlen (stage)) + strlen (suffix) + 1;
+	char *buffer = (char *) malloc (total);
+	size_t offset = 0;
+
+	if (!buffer)
+		return NULL;
+
+	offset += (size_t) q_snprintf (buffer + offset, total - offset, "%s", prefix);
+	for (size_t i = 0; i < stage_count; ++i)
+		offset += (size_t) q_snprintf (buffer + offset, total - offset, "%s", stage);
+	q_snprintf (buffer + offset, total - offset, "%s", suffix);
+	return buffer;
+}
+
+static void Mat_Shader_RemoveFuzzMaterial (const char *name)
+{
+	const shader_material_t *material = Mat_Shader_Find (name);
+
+	if (!material || !material->source_file)
+		return;
+	if (q_strncasecmp (material->source_file, "matshader_fuzz", 14))
+		return;
+
+	Mat_Shader_Remove (material);
+}
+
+void Mat_Shader_DebugFuzzParse (void)
+{
+	const char *fuzz_missing_brace =
+		"fuzz_missing_brace\n"
+		"{\n"
+		" surfaceparm solid\n"
+		" { map textures/test }\n";
+	const char *fuzz_unknown =
+		"fuzz_unknown\n"
+		"{\n"
+		" unknown_key 1\n"
+		" unknown_block { nested 1 }\n"
+		" { map textures/test }\n"
+		"}\n";
+	const char *fuzz_nonfinite =
+		"fuzz_nonfinite\n"
+		"{\n"
+		" emissive_scale nan\n"
+		" bloom_scale inf\n"
+		" godray_scale -inf\n"
+		" { map $whiteimage }\n"
+		"}\n";
+	const char *fuzz_duplicate =
+		"fuzz_duplicate\n"
+		"{\n"
+		" surfaceparm solid\n"
+		" surfaceparm solid\n"
+		" cull none\n"
+		" cull back\n"
+		" emissive_scale 2\n"
+		" emissive_scale 3\n"
+		" { map $whiteimage }\n"
+		"}\n";
+	char *fuzz_longpath = Mat_Shader_BuildLongPathShader ();
+	char *fuzz_many_stages = Mat_Shader_BuildManyStagesShader ();
+	const size_t warnings_before = Mat_Shader_ParseGetWarnings ();
+	const size_t errors_before = Mat_Shader_ParseGetErrors ();
+	const char *names[] =
+	{
+		"fuzz_missing_brace",
+		"fuzz_unknown",
+		"fuzz_longpath",
+		"fuzz_many_stages",
+		"fuzz_nonfinite",
+		"fuzz_duplicate"
+	};
+	struct
+	{
+		const char *label;
+		const char *data;
+	} cases[] =
+	{
+		{ "missing_brace", fuzz_missing_brace },
+		{ "unknown_keywords", fuzz_unknown },
+		{ "long_path", fuzz_longpath },
+		{ "many_stages", fuzz_many_stages },
+		{ "nonfinite_scales", fuzz_nonfinite },
+		{ "duplicate_keys", fuzz_duplicate }
+	};
+
+	Con_Printf ("Material shader fuzz parse begin\n");
+
+	for (size_t i = 0; i < countof (cases); ++i)
+	{
+		char source_label[64];
+		int parsed;
+
+		if (!cases[i].data)
+		{
+			Con_Warning ("Material shader fuzz '%s' skipped (allocation failed)\n", cases[i].label);
+			continue;
+		}
+
+		q_snprintf (source_label, sizeof (source_label), "matshader_fuzz:%s", cases[i].label);
+		parsed = Mat_Shader_ParseFile ("matshader_fuzz", cases[i].data, source_label);
+		Con_Printf ("Material shader fuzz '%s' parsed %d material(s)\n", cases[i].label, parsed);
+	}
+
+	for (size_t i = 0; i < countof (names); ++i)
+		Mat_Shader_RemoveFuzzMaterial (names[i]);
+
+	Con_Printf ("Material shader fuzz end (+%zu warnings, +%zu errors)\n",
+		Mat_Shader_ParseGetWarnings () - warnings_before,
+		Mat_Shader_ParseGetErrors () - errors_before);
+
+	free (fuzz_longpath);
+	free (fuzz_many_stages);
+}

--- a/Quake/mat_shader_parse.h
+++ b/Quake/mat_shader_parse.h
@@ -34,5 +34,6 @@ void Mat_Shader_ParseAddWarning (void);
 void Mat_Shader_ParseAddError (void);
 size_t Mat_Shader_ParseGetWarnings (void);
 size_t Mat_Shader_ParseGetErrors (void);
+void Mat_Shader_DebugFuzzParse (void);
 
 #endif // MAT_SHADER_PARSE_H


### PR DESCRIPTION
### Motivation
- Provide a developer/debug routine to exercise the material shader parser with malformed and edge-case in-memory shader strings to verify parser robustness. 
- Exercise cases such as missing brace, unknown keywords/blocks, excessively long paths, too many stages, non-finite numeric scales, and duplicate keys to ensure no crashes and proper resync/error reporting. 

### Description
- Add `Mat_Shader_DebugFuzzParse()` (declared in `mat_shader_parse.h`) which constructs and parses multiple fuzz shader inputs and reports warnings/errors. 
- Add helpers `Mat_Shader_BuildLongPathShader()` and `Mat_Shader_BuildManyStagesShader()` plus cleanup via `Mat_Shader_RemoveFuzzMaterial()` in `Quake/mat_shader_parse.c`. 
- Expose a cvar `r_matshader_fuzz` and a console command `shaderfuzz` with a callback to trigger the fuzz routine from `Quake/mat_shader.c`. 

### Testing
- No automated tests were run as part of this change. 
- Manual observation: the routine prints parse begin/end and per-case parsed material counts and reports the delta in warnings/errors (no automated verification).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953ad1f4b5c832ebd2453816c1cfde0)