### PR TITLE
Move COM_ReportPak0Integrity after dpackfile_t typedef to fix compile error

### DIFF
--- a/Quake/common.c
+++ b/Quake/common.c
@@ -1519,18 +1519,6 @@ static qboolean COM_IsPak0File (const char *packfile)
 	return !q_strcasecmp (filename, "pak0.pak");
 }
 
-static void COM_ReportPak0Integrity (const char *packfile, const dpackfile_t *info, int dirlen, int numpackfiles)
-{
-	unsigned short crc;
-
-	if (numpackfiles != PAK0_COUNT)
-		Con_Warning ("Integrity report: %s has %i files (expected %i)\n", packfile, numpackfiles, PAK0_COUNT);
-
-	crc = CRC_Block (info, dirlen);
-	if (crc != PAK0_CRC_V106 && crc != PAK0_CRC_V101 && crc != PAK0_CRC_V100)
-		Con_Warning ("Integrity report: %s directory CRC %u does not match known versions\n", packfile, crc);
-}
-
 static void COM_CheckRegistered (void)
 {
 	int		h;
@@ -1732,6 +1720,18 @@ typedef struct
 	int		dirofs;
 	int		dirlen;
 } dpackheader_t;
+
+static void COM_ReportPak0Integrity (const char *packfile, const dpackfile_t *info, int dirlen, int numpackfiles)
+{
+	unsigned short crc;
+
+	if (numpackfiles != PAK0_COUNT)
+		Con_Warning ("Integrity report: %s has %i files (expected %i)\n", packfile, numpackfiles, PAK0_COUNT);
+
+	crc = CRC_Block (info, dirlen);
+	if (crc != PAK0_CRC_V106 && crc != PAK0_CRC_V101 && crc != PAK0_CRC_V100)
+		Con_Warning ("Integrity report: %s directory CRC %u does not match known versions\n", packfile, crc);
+}
 
 #define MAX_FILES_IN_PACK	2048
 


### PR DESCRIPTION
### Motivation
- The Windows build reported errors about a missing type specifier and syntax errors when compiling `common.c` because `COM_ReportPak0Integrity` referenced `dpackfile_t` before it was declared.
- Ensure the `dpackfile_t` type is visible to the function that takes a pointer to it to avoid C default-int / forward-declaration issues.

### Description
- Removed the earlier definition of `COM_ReportPak0Integrity` and reinserted it after the `dpackfile_t` and `dpackheader_t` typedefs. 
- The function signature and implementation were kept unchanged; only the placement in `Quake/common.c` was moved.
- This resolves the use-before-declaration of `dpackfile_t` and keeps the pak integrity checks intact.

### Testing
- No automated tests or CI builds were run for this change.
- The patch was applied and committed to the repository successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695415297984832ebf67ddb0f26baea6)