### PR TITLE
Fix lmsize scope in world fragment shader

### DIFF
--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -329,11 +329,13 @@ void main()
 	vec2 lmuv = in_lmuv;
 	vec3 total_lightmap = vec3(1.0);
 	vec3 specular_light = vec3(0.0);
+#if DITHER
+	vec2 lmsize = vec2(textureSize(LMTex, 0).xy) * 16.0;
+#endif
 
 	if ((in_flags & CF_NOLIGHTMAP) == 0u)
 	{
 #if DITHER
-		vec2 lmsize = vec2(textureSize(LMTex, 0).xy) * 16.0;
 		lmuv = (floor(lmuv * lmsize) + 0.5) / lmsize;
 #endif
 


### PR DESCRIPTION
### Motivation
- Fix a shader compilation failure (`error C1503: undefined variable "lmsize"`) caused by `lmsize` being declared in a narrower preprocessor scope than where it is later referenced.
- Ensure the same `lmsize` value is used for lightmap sampling and subsequent dithering/noise calculations to avoid undefined behavior.

### Description
- Move the `vec2 lmsize = vec2(textureSize(LMTex, 0).xy) * 16.0;` declaration to an earlier `#if DITHER` scope so it is available where needed.
- Remove the duplicate inner declaration so `lmuv` and later dithering code reference the same `lmsize` variable.
- Updated file: `Quake/shaders/world.frag`.

### Testing
- No automated tests were executed for this change.
- Shader compilation/runtime checks were not run as part of this commit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695415eaf110832ebdcb2680d85fdb44)