### PR TITLE
Parse and apply stage-level emissive/bloom/godray shader keywords

### DIFF
--- a/Quake/mat_shader.c
+++ b/Quake/mat_shader.c
@@ -96,6 +96,9 @@ static const mat_shader_keyword_def_t mat_shader_keyword_table[] =
 	{ "alphaFunc", MAT_SHADER_KEYWORD_SCOPE_STAGE, MAT_SHADER_KEYWORD_STATUS_KNOWN_UNIMPLEMENTED, "Q3 alpha test." },
 	{ "tcGen", MAT_SHADER_KEYWORD_SCOPE_STAGE, MAT_SHADER_KEYWORD_STATUS_PARTIAL, "Modes: base/environment/lightmap." },
 	{ "tcMod", MAT_SHADER_KEYWORD_SCOPE_STAGE, MAT_SHADER_KEYWORD_STATUS_PARTIAL, "Types: scroll/scale/rotate/turb/stretch." },
+	{ "emissive", MAT_SHADER_KEYWORD_SCOPE_STAGE, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Stage-level emissive toggle." },
+	{ "bloom", MAT_SHADER_KEYWORD_SCOPE_STAGE, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Stage-level bloom toggle." },
+	{ "godray", MAT_SHADER_KEYWORD_SCOPE_STAGE, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Stage-level godray toggle." },
 
 	{ "solid", MAT_SHADER_KEYWORD_SCOPE_SURFACEPARM, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Surface solid." },
 	{ "nonsolid", MAT_SHADER_KEYWORD_SCOPE_SURFACEPARM, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Surface non-solid." },

--- a/Quake/mat_shader_parse.c
+++ b/Quake/mat_shader_parse.c
@@ -1095,6 +1095,48 @@ static const char *ParseStageBlock (const char *data, shader_material_t *materia
 			}
 			continue;
 		}
+		if (!q_strcasecmp (com_token, "emissive"))
+		{
+			Mat_Shader_MarkKeywordSeen ("emissive", MAT_SHADER_KEYWORD_SCOPE_STAGE);
+			qboolean parsed = false;
+			qboolean value_bool = true;
+
+			parsed = ParseOptionalBool (&data, &value_bool, state);
+			if (!parsed)
+				value_bool = true;
+
+			if (value_bool)
+				material->emissive_enable = true;
+			continue;
+		}
+		if (!q_strcasecmp (com_token, "bloom"))
+		{
+			Mat_Shader_MarkKeywordSeen ("bloom", MAT_SHADER_KEYWORD_SCOPE_STAGE);
+			qboolean parsed = false;
+			qboolean value_bool = true;
+
+			parsed = ParseOptionalBool (&data, &value_bool, state);
+			if (!parsed)
+				value_bool = true;
+
+			if (value_bool)
+				material->bloom_enable = true;
+			continue;
+		}
+		if (!q_strcasecmp (com_token, "godray"))
+		{
+			Mat_Shader_MarkKeywordSeen ("godray", MAT_SHADER_KEYWORD_SCOPE_STAGE);
+			qboolean parsed = false;
+			qboolean value_bool = true;
+
+			parsed = ParseOptionalBool (&data, &value_bool, state);
+			if (!parsed)
+				value_bool = true;
+
+			if (value_bool)
+				material->godray_enable = true;
+			continue;
+		}
 
 		Mat_Shader_ReportUnknownToken (com_token, MAT_SHADER_KEYWORD_SCOPE_STAGE, material->name,
 			state ? state->source_file : material->source_file,


### PR DESCRIPTION
### Motivation
- Some shader collections use stage-level `emissive`, `bloom` and `godray` directives inside stage blocks to indicate that a material should be emissive/blooming/godray-enabled.
- The parser previously only recognized those keywords at the top-level, so stage declarations were ignored and the material flags were not being set.
- Materials that rely on stage-level toggles (example shader listing included) need these flags applied so rendering paths (emissive, bloom, godrays) trigger correctly.
- Improve the keyword reporting so stage-level uses of these tokens are tracked in reports.

### Description
- Added stage-scope entries for `emissive`, `bloom`, and `godray` to the keyword table in `Quake/mat_shader.c` so they are recognized and reported when used inside stage blocks.
- Extended `ParseStageBlock` in `Quake/mat_shader_parse.c` to accept optional boolean `emissive`, `bloom`, and `godray` tokens using `ParseOptionalBool` and to set the corresponding `material->emissive_enable`, `material->bloom_enable`, and `material->godray_enable` flags when enabled.
- Parsing behavior preserves the existing top-level handling and treats a stage token with no explicit value as enabled (default true), matching common shader usage.
- No changes to material storage layout were made; the parser simply enables the existing material flags when stage-level tokens are encountered.

### Testing
- No automated tests were executed for this change.
- A build or CI run was not performed as part of this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695452cde078832ea03b89b5693ec980)