### PR TITLE
Add rgbGen/alphaGen const and wave support for material stages

### DIFF
--- a/Quake/mat_shader.c
+++ b/Quake/mat_shader.c
@@ -88,8 +88,8 @@ static const mat_shader_keyword_def_t mat_shader_keyword_table[] =
 	{ "map", MAT_SHADER_KEYWORD_SCOPE_STAGE, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Supports $lightmap/$white/$black and textures." },
 	{ "clampmap", MAT_SHADER_KEYWORD_SCOPE_STAGE, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Clamp-wrapped texture." },
 	{ "animMap", MAT_SHADER_KEYWORD_SCOPE_STAGE, MAT_SHADER_KEYWORD_STATUS_PARTIAL, "FPS + frame list only." },
-	{ "rgbGen", MAT_SHADER_KEYWORD_SCOPE_STAGE, MAT_SHADER_KEYWORD_STATUS_PARTIAL, "Supports identity only." },
-	{ "alphaGen", MAT_SHADER_KEYWORD_SCOPE_STAGE, MAT_SHADER_KEYWORD_STATUS_KNOWN_UNIMPLEMENTED, "Q3 alpha generator." },
+	{ "rgbGen", MAT_SHADER_KEYWORD_SCOPE_STAGE, MAT_SHADER_KEYWORD_STATUS_PARTIAL, "Modes: identity/vertex/const/wave." },
+	{ "alphaGen", MAT_SHADER_KEYWORD_SCOPE_STAGE, MAT_SHADER_KEYWORD_STATUS_PARTIAL, "Modes: identity/vertex/const/wave." },
 	{ "blendFunc", MAT_SHADER_KEYWORD_SCOPE_STAGE, MAT_SHADER_KEYWORD_STATUS_PARTIAL, "Supports add/filter/blend/premult or explicit factors." },
 	{ "depthWrite", MAT_SHADER_KEYWORD_SCOPE_STAGE, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Optional boolean." },
 	{ "depthFunc", MAT_SHADER_KEYWORD_SCOPE_STAGE, MAT_SHADER_KEYWORD_STATUS_PARTIAL, "Modes: lequal/equal/always." },
@@ -1322,6 +1322,40 @@ static int Mat_Shader_TimeBucket (float time, float fps_hint)
 	if (fps < 1.f)
 		fps = 1.f;
 	return (int)floorf (time * fps);
+}
+
+float Mat_Shader_EvalWaveValue (const mat_wave_t *wave, float time)
+{
+	float t;
+	float phase;
+	float value;
+
+	if (!wave)
+		return 0.f;
+
+	t = time * wave->freq + wave->phase;
+
+	switch (wave->type)
+	{
+	case MAT_WAVE_TRIANGLE:
+		phase = t - floorf (t + 0.5f);
+		value = 1.f - 4.f * fabsf (phase);
+		break;
+	case MAT_WAVE_SAW:
+		phase = t - floorf (t);
+		value = phase * 2.f - 1.f;
+		break;
+	case MAT_WAVE_INVERSESAW:
+		phase = t - floorf (t);
+		value = 1.f - phase * 2.f;
+		break;
+	case MAT_WAVE_SIN:
+	default:
+		value = sinf (t * 2.f * MAT_TEXMOD_PI);
+		break;
+	}
+
+	return wave->base + value * wave->amp;
 }
 
 const mat_texmatrix_t *MatStage_EvalTexMatrix (mat_shader_stage_t *stage, float time)

--- a/Quake/mat_shader.h
+++ b/Quake/mat_shader.h
@@ -56,9 +56,36 @@ typedef enum
 
 typedef enum
 {
-	MAT_RGBGEN_DEFAULT = 0,
-	MAT_RGBGEN_IDENTITY
+	MAT_RGBGEN_IDENTITY = 0,
+	MAT_RGBGEN_VERTEX,
+	MAT_RGBGEN_CONST,
+	MAT_RGBGEN_WAVE
 } mat_rgbgen_t;
+
+typedef enum
+{
+	MAT_ALPHAGEN_IDENTITY = 0,
+	MAT_ALPHAGEN_VERTEX,
+	MAT_ALPHAGEN_CONST,
+	MAT_ALPHAGEN_WAVE
+} mat_alphagen_t;
+
+typedef enum
+{
+	MAT_WAVE_SIN = 0,
+	MAT_WAVE_TRIANGLE,
+	MAT_WAVE_SAW,
+	MAT_WAVE_INVERSESAW
+} mat_wave_type_t;
+
+typedef struct mat_wave_s
+{
+	mat_wave_type_t	type;
+	float		base;
+	float		amp;
+	float		phase;
+	float		freq;
+} mat_wave_t;
 
 typedef enum
 {
@@ -150,6 +177,11 @@ typedef struct mat_shader_stage_s
 {
 	char		*map_path;
 	mat_rgbgen_t	rgbgen;
+	mat_alphagen_t	alphagen;
+	float		const_color[3];
+	float		const_alpha;
+	mat_wave_t	rgb_wave;
+	mat_wave_t	alpha_wave;
 	mat_blend_mode_t	blend_mode;
 	int			blend_src;
 	int			blend_dst;
@@ -229,6 +261,7 @@ char *Mat_Shader_DupString (const char *value);
 const mat_texmatrix_t *MatStage_EvalTexMatrix (mat_shader_stage_t *stage, float time);
 int MatStage_EvalAnimMapFrame (mat_shader_stage_t *stage, float time);
 const char *MatStage_GetAnimMapPath (mat_shader_stage_t *stage, float time);
+float Mat_Shader_EvalWaveValue (const mat_wave_t *wave, float time);
 void Mat_Shader_Insert (shader_material_t *material);
 void Mat_Shader_Remove (const shader_material_t *material);
 void Mat_Shader_MarkKeywordSeen (const char *keyword, mat_shader_keyword_scope_t scope);

--- a/Quake/mat_shader_parse.c
+++ b/Quake/mat_shader_parse.c
@@ -396,6 +396,33 @@ static qboolean ParseVec4 (const char **data, vec4_t out, mat_shader_parse_state
 	return true;
 }
 
+static qboolean ParseWaveType (const char *token, mat_wave_type_t *out)
+{
+	if (!token || !token[0])
+		return false;
+	if (!q_strcasecmp (token, "sin"))
+	{
+		*out = MAT_WAVE_SIN;
+		return true;
+	}
+	if (!q_strcasecmp (token, "triangle"))
+	{
+		*out = MAT_WAVE_TRIANGLE;
+		return true;
+	}
+	if (!q_strcasecmp (token, "saw"))
+	{
+		*out = MAT_WAVE_SAW;
+		return true;
+	}
+	if (!q_strcasecmp (token, "inversesaw"))
+	{
+		*out = MAT_WAVE_INVERSESAW;
+		return true;
+	}
+	return false;
+}
+
 static qboolean ParseRequiredBool (const char **data, qboolean *out, mat_shader_parse_state_t *state)
 {
 	const char *token;
@@ -771,7 +798,14 @@ static const char *ParseStageBlock (const char *data, shader_material_t *materia
 	qboolean valid = true;
 
 	memset (&stage, 0, sizeof (stage));
-	stage.rgbgen = MAT_RGBGEN_DEFAULT;
+	stage.rgbgen = MAT_RGBGEN_IDENTITY;
+	stage.alphagen = MAT_ALPHAGEN_IDENTITY;
+	stage.const_color[0] = 1.f;
+	stage.const_color[1] = 1.f;
+	stage.const_color[2] = 1.f;
+	stage.const_alpha = 1.f;
+	stage.rgb_wave.type = MAT_WAVE_SIN;
+	stage.alpha_wave.type = MAT_WAVE_SIN;
 	stage.blend_mode = MAT_BLEND_REPLACE;
 	stage.depth_write = true;
 	stage.depth_func = MAT_DEPTHFUNC_LEQUAL;
@@ -850,6 +884,206 @@ static const char *ParseStageBlock (const char *data, shader_material_t *materia
 			}
 			if (!q_strcasecmp (value, "identity"))
 				stage.rgbgen = MAT_RGBGEN_IDENTITY;
+			else if (!q_strcasecmp (value, "vertex"))
+				stage.rgbgen = MAT_RGBGEN_VERTEX;
+			else if (!q_strcasecmp (value, "const"))
+			{
+				const char *token;
+				float color[3];
+
+				if (!ParseIdentExpected (&data, &token, state, "rgbGen const"))
+				{
+					valid = false;
+					data = SkipUnknownBlockOrLine (data, true, state);
+					break;
+				}
+
+				if (!q_strcasecmp (token, "("))
+				{
+					if (!ParseFloat (&data, &color[0], state)
+						|| !ParseFloat (&data, &color[1], state)
+						|| !ParseFloat (&data, &color[2], state))
+					{
+						valid = false;
+						data = SkipUnknownBlockOrLine (data, true, state);
+						break;
+					}
+					if (!ExpectToken (&data, ")", state))
+					{
+						valid = false;
+						data = SkipUnknownBlockOrLine (data, true, state);
+						break;
+					}
+				}
+				else
+				{
+					if (!Mat_Shader_IsNumericToken (token))
+					{
+						Mat_Shader_WarnExpectedToken (state, "float", token);
+						valid = false;
+						data = SkipUnknownBlockOrLine (data, true, state);
+						break;
+					}
+					color[0] = Q_atof (token);
+					if (!ParseFloat (&data, &color[1], state)
+						|| !ParseFloat (&data, &color[2], state))
+					{
+						valid = false;
+						data = SkipUnknownBlockOrLine (data, true, state);
+						break;
+					}
+				}
+
+				stage.rgbgen = MAT_RGBGEN_CONST;
+				stage.const_color[0] = color[0];
+				stage.const_color[1] = color[1];
+				stage.const_color[2] = color[2];
+			}
+			else if (!q_strcasecmp (value, "wave"))
+			{
+				mat_wave_type_t wave_type;
+				float base;
+				float amp;
+				float phase;
+				float freq;
+
+				if (!ParseIdentExpected (&data, &value, state, "rgbGen wave type"))
+				{
+					valid = false;
+					data = SkipUnknownBlockOrLine (data, true, state);
+					break;
+				}
+				if (!ParseWaveType (value, &wave_type))
+				{
+					Mat_Shader_ReportUnknownToken (value, MAT_SHADER_KEYWORD_SCOPE_STAGE, material->name,
+						state ? state->source_file : material->source_file,
+						state ? state->token_line : 0u);
+					continue;
+				}
+				if (!ParseFloat (&data, &base, state)
+					|| !ParseFloat (&data, &amp, state)
+					|| !ParseFloat (&data, &phase, state)
+					|| !ParseFloat (&data, &freq, state))
+				{
+					valid = false;
+					data = SkipUnknownBlockOrLine (data, true, state);
+					break;
+				}
+
+				Mat_Shader_ValidateFiniteFloat (state, "rgbGen wave base", base, 0.f, &stage.rgb_wave.base);
+				Mat_Shader_ValidateFiniteFloat (state, "rgbGen wave amp", amp, 0.f, &stage.rgb_wave.amp);
+				Mat_Shader_ValidateFiniteFloat (state, "rgbGen wave phase", phase, 0.f, &stage.rgb_wave.phase);
+				Mat_Shader_ValidateFiniteFloat (state, "rgbGen wave freq", freq, 0.f, &stage.rgb_wave.freq);
+				stage.rgb_wave.type = wave_type;
+				stage.rgbgen = MAT_RGBGEN_WAVE;
+			}
+			else
+			{
+				Mat_Shader_ReportUnknownToken (value, MAT_SHADER_KEYWORD_SCOPE_STAGE, material->name,
+					state ? state->source_file : material->source_file,
+					state ? state->token_line : 0u);
+			}
+			continue;
+		}
+		if (!q_strcasecmp (com_token, "alphaGen"))
+		{
+			Mat_Shader_MarkKeywordSeen ("alphaGen", MAT_SHADER_KEYWORD_SCOPE_STAGE);
+			if (!ParseIdentExpected (&data, &value, state, "alphaGen mode"))
+			{
+				valid = false;
+				data = SkipUnknownBlockOrLine (data, true, state);
+				break;
+			}
+			if (!q_strcasecmp (value, "identity"))
+				stage.alphagen = MAT_ALPHAGEN_IDENTITY;
+			else if (!q_strcasecmp (value, "vertex"))
+				stage.alphagen = MAT_ALPHAGEN_VERTEX;
+			else if (!q_strcasecmp (value, "const"))
+			{
+				const char *token;
+				float alpha;
+
+				if (!ParseIdentExpected (&data, &token, state, "alphaGen const"))
+				{
+					valid = false;
+					data = SkipUnknownBlockOrLine (data, true, state);
+					break;
+				}
+
+				if (!q_strcasecmp (token, "("))
+				{
+					if (!ParseFloat (&data, &alpha, state))
+					{
+						valid = false;
+						data = SkipUnknownBlockOrLine (data, true, state);
+						break;
+					}
+					if (!ExpectToken (&data, ")", state))
+					{
+						valid = false;
+						data = SkipUnknownBlockOrLine (data, true, state);
+						break;
+					}
+				}
+				else
+				{
+					if (!Mat_Shader_IsNumericToken (token))
+					{
+						Mat_Shader_WarnExpectedToken (state, "float", token);
+						valid = false;
+						data = SkipUnknownBlockOrLine (data, true, state);
+						break;
+					}
+					alpha = Q_atof (token);
+				}
+
+				stage.alphagen = MAT_ALPHAGEN_CONST;
+				stage.const_alpha = alpha;
+			}
+			else if (!q_strcasecmp (value, "wave"))
+			{
+				mat_wave_type_t wave_type;
+				float base;
+				float amp;
+				float phase;
+				float freq;
+
+				if (!ParseIdentExpected (&data, &value, state, "alphaGen wave type"))
+				{
+					valid = false;
+					data = SkipUnknownBlockOrLine (data, true, state);
+					break;
+				}
+				if (!ParseWaveType (value, &wave_type))
+				{
+					Mat_Shader_ReportUnknownToken (value, MAT_SHADER_KEYWORD_SCOPE_STAGE, material->name,
+						state ? state->source_file : material->source_file,
+						state ? state->token_line : 0u);
+					continue;
+				}
+				if (!ParseFloat (&data, &base, state)
+					|| !ParseFloat (&data, &amp, state)
+					|| !ParseFloat (&data, &phase, state)
+					|| !ParseFloat (&data, &freq, state))
+				{
+					valid = false;
+					data = SkipUnknownBlockOrLine (data, true, state);
+					break;
+				}
+
+				Mat_Shader_ValidateFiniteFloat (state, "alphaGen wave base", base, 0.f, &stage.alpha_wave.base);
+				Mat_Shader_ValidateFiniteFloat (state, "alphaGen wave amp", amp, 0.f, &stage.alpha_wave.amp);
+				Mat_Shader_ValidateFiniteFloat (state, "alphaGen wave phase", phase, 0.f, &stage.alpha_wave.phase);
+				Mat_Shader_ValidateFiniteFloat (state, "alphaGen wave freq", freq, 0.f, &stage.alpha_wave.freq);
+				stage.alpha_wave.type = wave_type;
+				stage.alphagen = MAT_ALPHAGEN_WAVE;
+			}
+			else
+			{
+				Mat_Shader_ReportUnknownToken (value, MAT_SHADER_KEYWORD_SCOPE_STAGE, material->name,
+					state ? state->source_file : material->source_file,
+					state ? state->token_line : 0u);
+			}
 			continue;
 		}
 		if (!q_strcasecmp (com_token, "blendFunc"))

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -284,6 +284,7 @@ typedef struct bmodel_gpu_instance_s {
 typedef struct bmodel_bindless_gpu_call_s {
 	GLuint		flags;
 	GLfloat		alpha;
+	GLfloat		stage_color[4];
 	GLuint64	texture;
 	GLuint64	fullbright;
 	GLuint64	emissive;
@@ -292,6 +293,7 @@ typedef struct bmodel_bindless_gpu_call_s {
 typedef struct bmodel_bound_gpu_call_s {
 	GLuint		flags;
 	GLfloat		alpha;
+	GLfloat		stage_color[4];
 	GLint		baseinstance;
 	GLint		padding;
 } bmodel_bound_gpu_call_t;
@@ -554,6 +556,10 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
 		bmodel_bindless_gpu_call_t *call = &bmodel_calls.bindless.params[num_bmodel_calls];
 		call->flags = flags;
 		call->alpha = alpha;
+		call->stage_color[0] = 1.f;
+		call->stage_color[1] = 1.f;
+		call->stage_color[2] = 1.f;
+		call->stage_color[3] = 1.f;
 		call->texture = tx ? tx->bindless_handle : greytexture->bindless_handle;
 		call->fullbright = fb ? fb->bindless_handle : blacktexture->bindless_handle;
 		call->emissive = em ? em->bindless_handle : blacktexture->bindless_handle;
@@ -564,6 +570,10 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
 		gltexture_t **textures = bmodel_calls.bound.textures[num_bmodel_calls];
 		call->flags = flags;
 		call->alpha = alpha;
+		call->stage_color[0] = 1.f;
+		call->stage_color[1] = 1.f;
+		call->stage_color[2] = 1.f;
+		call->stage_color[3] = 1.f;
 		call->baseinstance = first_instance;
 		call->padding = 0;
 		textures[0] = tx ? tx : greytexture;
@@ -580,7 +590,7 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
 }
 
 static void R_AddBModelCallWithTextures (int index, int first_instance, int num_instances, gltexture_t *tx, gltexture_t *fb, gltexture_t *em,
-	qboolean zfix, float alpha_override, unsigned extra_flags)
+	qboolean zfix, float alpha_override, unsigned extra_flags, const vec4_t stage_color)
 {
 	GLuint flags;
 	float alpha;
@@ -603,6 +613,10 @@ static void R_AddBModelCallWithTextures (int index, int first_instance, int num_
 		bmodel_bindless_gpu_call_t *call = &bmodel_calls.bindless.params[num_bmodel_calls];
 		call->flags = flags;
 		call->alpha = alpha;
+		call->stage_color[0] = stage_color ? stage_color[0] : 1.f;
+		call->stage_color[1] = stage_color ? stage_color[1] : 1.f;
+		call->stage_color[2] = stage_color ? stage_color[2] : 1.f;
+		call->stage_color[3] = stage_color ? stage_color[3] : 1.f;
 		call->texture = tx ? tx->bindless_handle : greytexture->bindless_handle;
 		call->fullbright = fb ? fb->bindless_handle : blacktexture->bindless_handle;
 		call->emissive = em ? em->bindless_handle : blacktexture->bindless_handle;
@@ -613,6 +627,10 @@ static void R_AddBModelCallWithTextures (int index, int first_instance, int num_
 		gltexture_t **textures = bmodel_calls.bound.textures[num_bmodel_calls];
 		call->flags = flags;
 		call->alpha = alpha;
+		call->stage_color[0] = stage_color ? stage_color[0] : 1.f;
+		call->stage_color[1] = stage_color ? stage_color[1] : 1.f;
+		call->stage_color[2] = stage_color ? stage_color[2] : 1.f;
+		call->stage_color[3] = stage_color ? stage_color[3] : 1.f;
 		call->baseinstance = first_instance;
 		call->padding = 0;
 		textures[0] = tx ? tx : greytexture;
@@ -639,6 +657,74 @@ static GLenum R_MapDepthFunc (mat_depthfunc_t depth_func)
 	case MAT_DEPTHFUNC_LEQUAL:
 	default:
 		return gl_clipcontrol_able ? GL_GEQUAL : GL_LEQUAL;
+	}
+}
+
+static float R_Clamp01 (float value)
+{
+	if (value < 0.f)
+		return 0.f;
+	if (value > 1.f)
+		return 1.f;
+	return value;
+}
+
+static void R_EvalStageColorAlpha (const mat_shader_stage_t *stage, float time, vec4_t out)
+{
+	static qboolean warned_vertex_color = false;
+	float wave_value;
+
+	out[0] = 1.f;
+	out[1] = 1.f;
+	out[2] = 1.f;
+	out[3] = 1.f;
+
+	if (!stage)
+		return;
+
+	switch (stage->rgbgen)
+	{
+	case MAT_RGBGEN_VERTEX:
+		if (!warned_vertex_color)
+		{
+			Con_Warning ("MatShader: rgbGen/alphaGen vertex requested but vertex colors are unavailable; using identity.\n");
+			warned_vertex_color = true;
+		}
+		break;
+	case MAT_RGBGEN_CONST:
+		out[0] = stage->const_color[0];
+		out[1] = stage->const_color[1];
+		out[2] = stage->const_color[2];
+		break;
+	case MAT_RGBGEN_WAVE:
+		wave_value = R_Clamp01 (Mat_Shader_EvalWaveValue (&stage->rgb_wave, time));
+		out[0] = wave_value;
+		out[1] = wave_value;
+		out[2] = wave_value;
+		break;
+	case MAT_RGBGEN_IDENTITY:
+	default:
+		break;
+	}
+
+	switch (stage->alphagen)
+	{
+	case MAT_ALPHAGEN_VERTEX:
+		if (!warned_vertex_color)
+		{
+			Con_Warning ("MatShader: rgbGen/alphaGen vertex requested but vertex colors are unavailable; using identity.\n");
+			warned_vertex_color = true;
+		}
+		break;
+	case MAT_ALPHAGEN_CONST:
+		out[3] = stage->const_alpha;
+		break;
+	case MAT_ALPHAGEN_WAVE:
+		out[3] = R_Clamp01 (Mat_Shader_EvalWaveValue (&stage->alpha_wave, time));
+		break;
+	case MAT_ALPHAGEN_IDENTITY:
+	default:
+		break;
 	}
 }
 
@@ -907,6 +993,7 @@ static void R_DrawBrushModels_MaterialStages (entity_t **ents, int count, brushp
 				gltexture_t *stage_tex;
 				gltexture_t *fb = NULL;
 				gltexture_t *em = NULL;
+				vec4_t stage_color;
 				unsigned extra_flags = mat_call_flags;
 				unsigned stage_state;
 				GLenum depth_func;
@@ -924,6 +1011,8 @@ static void R_DrawBrushModels_MaterialStages (entity_t **ents, int count, brushp
 
 				if (!stage_tex)
 					continue;
+
+				R_EvalStageColorAlpha (stage, cl.time, stage_color);
 
 				if (stage_index == 0 && stage_tex == t->gltexture)
 				{
@@ -970,7 +1059,7 @@ static void R_DrawBrushModels_MaterialStages (entity_t **ents, int count, brushp
 
 				R_AddBModelCallWithTextures (model->firstcmd + j, baseinst, numinst,
 					stage_tex, fb, em,
-					zfix || material->polygon_offset, -1.f, extra_flags);
+					zfix || material->polygon_offset, -1.f, extra_flags, stage_color);
 			}
 		}
 

--- a/Quake/shaders/sky_cubemap.vert
+++ b/Quake/shaders/sky_cubemap.vert
@@ -19,6 +19,7 @@ struct Call
 {
 	uint	flags;
 	float	wateralpha;
+	vec4	stage_color;
 #if BINDLESS
 	uvec2	txhandle;
 	uvec2	fbhandle;

--- a/Quake/shaders/sky_layers.vert
+++ b/Quake/shaders/sky_layers.vert
@@ -19,6 +19,7 @@ struct Call
 {
 	uint	flags;
 	float	wateralpha;
+	vec4	stage_color;
 #if BINDLESS
 	uvec2	txhandle;
 	uvec2	fbhandle;

--- a/Quake/shaders/skystencil.vert
+++ b/Quake/shaders/skystencil.vert
@@ -19,6 +19,7 @@ struct Call
 {
 	uint	flags;
 	float	wateralpha;
+	vec4	stage_color;
 #if BINDLESS
 	uvec2	txhandle;
 	uvec2	fbhandle;

--- a/Quake/shaders/water.vert
+++ b/Quake/shaders/water.vert
@@ -19,6 +19,7 @@ struct Call
 {
 	uint	flags;
 	float	wateralpha;
+	vec4	stage_color;
 #if BINDLESS
 	uvec2	txhandle;
 	uvec2	fbhandle;

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -46,6 +46,7 @@ struct Call
 {
 	uint	flags;
 	float	wateralpha;
+	vec4	stage_color;
 #if BINDLESS
 	uvec2	txhandle;
 	uvec2	fbhandle;
@@ -133,6 +134,7 @@ layout(location=11) noperspective in vec4 in_curr_clip;
 layout(location=12) noperspective in vec4 in_prev_clip;
 layout(location=13) in vec3 in_normal;
 layout(location=14) in vec3 in_lightgrid;
+layout(location=15) flat in vec4 in_stage_color;
 
 // Utility: ALU-only 16x16 Bayer matrix
 float bayer01(ivec2 coord)
@@ -529,10 +531,11 @@ void main()
 	if (LightmapParams.y > 0.5)
 		result.rgb = result.rgb / (vec3(1.0) + result.rgb);
 	
+	result.rgb *= in_stage_color.rgb;
+	result.a = in_alpha * in_stage_color.a;
 	result = clamp(result, 0.0, 1.0);
 	result.rgb = ApplyFog(result.rgb, in_pos - EyePos);
 
-	result.a = in_alpha;
 	out_fragcolor = result;
 
 #if !OIT

--- a/Quake/shaders/world.vert
+++ b/Quake/shaders/world.vert
@@ -48,6 +48,7 @@ struct Call
 {
 	uint	flags;
 	float	wateralpha;
+	vec4	stage_color;
 #if BINDLESS
 	uvec2	txhandle;
 	uvec2	fbhandle;
@@ -141,6 +142,7 @@ layout(location=11) noperspective out vec4 out_curr_clip;
 layout(location=12) noperspective out vec4 out_prev_clip;
 layout(location=13) out vec3 out_normal;
 layout(location=14) out vec3 out_lightgrid;
+layout(location=15) flat out vec4 out_stage_color;
 
 void main()
 {
@@ -193,6 +195,7 @@ void main()
 	if ((call.flags & CF_NOLIGHTMAP) != 0u)
 		out_styles.xy = vec2(1., -1.);
 	out_lmofs = in_lmofs;
+	out_stage_color = call.stage_color;
 #if BINDLESS
 	out_samplers0.xy = call.txhandle;
 	if ((call.flags & CF_USE_FULLBRIGHT) != 0u)

--- a/Quake/shaders/world_dlight.vert
+++ b/Quake/shaders/world_dlight.vert
@@ -35,6 +35,7 @@ struct Call
 {
         uint    flags;
         float   wateralpha;
+        vec4    stage_color;
 #if BINDLESS
         uvec2   txhandle;
         uvec2   fbhandle;


### PR DESCRIPTION
### Motivation

- Implement richer stage color/alpha generators (identity/vertex/const/wave) so materials can express pulsating lights and alpha fades without extra textures or special-case code.  
- Provide a compact, Quake1-friendly subset (const + wave) plus vertex fallback behavior for compatibility.  
- Expose wave parameters to the runtime so shaders can evaluate time-based modulation on the CPU and pass results to GPU draw calls.  

### Description

- Added enums/structs in `mat_shader.h`: `mat_rgbgen_t`, `mat_alphagen_t`, `mat_wave_type_t` and `mat_wave_t`, plus per-stage fields `alphagen`, `const_color`, `const_alpha`, `rgb_wave`, and `alpha_wave`.  
- Parser extended in `mat_shader_parse.c` to accept `rgbGen` and `alphaGen` modes: `identity`, `vertex`, `const (r g b)` / `const <alpha>`, and `wave <type> <base> <amp> <phase> <freq>`, with validation and defaults.  
- Runtime evaluation: added `Mat_Shader_EvalWaveValue` in `mat_shader.c` and `R_EvalStageColorAlpha` in `r_world.c` to compute clamped color/alpha values (with a one-time warning when `vertex` is requested but per-vertex colors are unavailable).  
- Data/driver path: extended bmodel call structs to carry a `stage_color` vec4, updated `R_AddBModelCallWithTextures` and call sites to include the evaluated `stage_color`, and updated multiple vertex/fragment shader `Call` layout and varyings (`out_stage_color` / `in_stage_color`) so `world.frag` multiplies `result.rgb` and scales `result.a` by the per-stage values.  

### Testing

- No automated tests were executed on this changeset.
- Manual verification steps (not run here) would include building and running the renderer to confirm pulsating rgb/alpha waves and `const` modulation behave as expected in shaders.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695455cc5b50832ea8893f6c63acffe7)