### PR TITLE
Mat_Shader_ParseCullMode: accept disable/off/disabled as synonyms for none

### DIFF
--- a/Quake/mat_shader_parse.c
+++ b/Quake/mat_shader_parse.c
@@ -600,7 +600,10 @@ static qboolean Mat_Shader_ParseCullMode (const char *token, mat_cull_mode_t *ou
 		*out = MAT_CULL_FRONT;
 		return true;
 	}
-	if (!q_strcasecmp (token, "none"))
+	if (!q_strcasecmp (token, "none")
+		|| !q_strcasecmp (token, "disable")
+		|| !q_strcasecmp (token, "disabled")
+		|| !q_strcasecmp (token, "off"))
 	{
 		*out = MAT_CULL_NONE;
 		return true;


### PR DESCRIPTION
### Motivation
- Material shader parsing should accept common synonyms for disabling face culling so that `cull disable` / `cull off` behave like `cull none`.
- Improve robustness and compatibility with shader files that use alternate keywords for disabling culling.

### Description
- Updated `Quake/mat_shader_parse.c` to expand `Mat_Shader_ParseCullMode` to treat `"disable"`, `"disabled"`, and `"off"` (case-insensitive) as aliases for `"none"`.
- The function still sets `MAT_CULL_NONE` for these tokens, preserving existing behavior for `"none"`.
- Matching continues to use the existing `q_strcasecmp` case-insensitive comparisons and no other parsing logic was changed.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69546aeeeba0832e96578895ba12400d)