### PR TITLE
Define MAX_TOKEN_CHARS from `com_token` to fix shader parser buffer sizes

### DIFF
--- a/Quake/mat_shader_parse.c
+++ b/Quake/mat_shader_parse.c
@@ -66,6 +66,7 @@ typedef struct
 
 #define MAT_SHADER_SCALE_MAX 64.f
 #define MAT_SHADER_TCMOD_MAX_ABS 64.f
+#define MAX_TOKEN_CHARS Q_COUNTOF(com_token)
 
 static size_t mat_shader_parse_warnings;
 static size_t mat_shader_parse_errors;


### PR DESCRIPTION
### Motivation

- The build was failing with undeclared `MAX_TOKEN_CHARS` and zero-size array errors in `Quake/mat_shader_parse.c` when sizing local token buffers.
- Several local buffers (e.g. `mode_buffer`, `src_buffer`, `dst_buffer`) rely on a compile-time token size constant.
- The project already exposes a global token buffer `com_token`, so deriving the size from it keeps sizes consistent.

### Description

- Added `#define MAX_TOKEN_CHARS Q_COUNTOF(com_token)` at the top of `Quake/mat_shader_parse.c` to provide the missing constant.
- This ensures declarations like `char mode_buffer[MAX_TOKEN_CHARS];` and other local token buffers have a valid compile-time size.
- No parsing logic or behavior was changed beyond introducing the constant.

### Testing

- Ran `rg` searches to locate all uses of `MAX_TOKEN_CHARS` and confirm `com_token` is defined globally.
- The failure mode was reproduced earlier where the build emitted multiple `C2065/C2057/C2466` errors for `MAX_TOKEN_CHARS` being undefined.
- No automated build or unit tests were executed after this change.
- The patch was committed to the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69546db82c44832e98a1b4d211f975e4)