### PR TITLE
Reduce global fog density scaling

### DIFF
--- a/Quake/gl_fog.c
+++ b/Quake/gl_fog.c
@@ -308,7 +308,7 @@ void Fog_SetupFrame (void)
 {
 	const float ExpAdjustment = 1.20112241f; // sqrt(log2(e))
 	const float SphericalCorrection = 0.85f; // compensate higher perceived density with spherical fog
-	const float DensityScale = ExpAdjustment * SphericalCorrection / 64.0f;
+	const float DensityScale = ExpAdjustment * SphericalCorrection / 96.0f;
 	float density = Fog_GetDensity() * DensityScale;
 	memcpy(r_framedata.fogdata, Fog_GetColor(), 3 * sizeof(float));
 	memcpy(r_framedata.skyfogdata, r_framedata.fogdata, 3 * sizeof(float));


### PR DESCRIPTION
### Motivation

- Very low fog values (for example `0.025`) appeared too dense and close to the camera due to the global density scaling factor. 
- The intent is to make small fog densities feel less strong and increase the perceived distance before heavy fog takes effect.

### Description

- Reduce the global density scale divisor from `64.0f` to `96.0f` in `Quake/gl_fog.c` used by `Fog_SetupFrame`. 
- This change lowers the effective fog density applied to `r_framedata.fogdata[3]` by scaling the output of `Fog_GetDensity()`.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69552761d538832e8989918d2f30177c)