### PR TITLE
Honor and expose dlight cvars to shader path; centralize dlight config

### DIFF
--- a/Quake/gl_rlight.c
+++ b/Quake/gl_rlight.c
@@ -358,8 +358,7 @@ static void R_PushDlightArray (dlight_t *const *lights, int count)
 			radius = l->baseradius * (1.f + 0.1f * (float) sin (cl.time * 9.0 + l->flicker_seed));
 		else
 			radius = l->baseradius;
-		if (r_dlight_mode.value > 0.f)
-			radius *= q_max (0.f, r_dlight_radius_scale.value);
+		radius *= q_max (0.f, r_dlight_radius_scale.value);
 		radius = q_max (radius, 0.f);
 		l->radius = radius;
 

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -4255,6 +4255,19 @@ static void R_EndTranslucency (void)
 // contributions (albedo * dlight) in a separate pass to preserve contrast of
 // the baked lighting while avoiding gamma artifacts from modulating the base
 // color. Static lighting remains untouched in the base pass.
+static void R_SetDlightConfig (GLuint program, float scale, float falloff, float expval,
+			       float core_boost, float core_exp, float knee, float ndotl,
+			       float satchop)
+{
+	if (!program)
+		return;
+
+	GL_UseProgram (program);
+	GL_Uniform4fFunc (0, scale, r_dlight_radius_scale.value, falloff, expval);
+	GL_Uniform4fFunc (1, core_boost, core_exp, knee, ndotl);
+	GL_Uniform4fFunc (2, satchop, 0.f, 0.f, 0.f);
+}
+
 static void R_DrawDLightPass (void)
 {
         int count = 0;
@@ -4296,7 +4309,6 @@ static void R_DrawDLightPass (void)
                 GL_BindBufferRange (GL_UNIFORM_BUFFER, 0, buf, (GLintptr)ofs, sizeof (r_framedata));
         }
 
-	if (r_dlight_mode.value > 0.f && (glprogs.world_dlight_hybrid[0] || glprogs.world_dlight_hybrid[1]))
 	{
 		float scale = use_buffer ? 1.f : q_max (0.f, r_dlight_scale.value);
 		float falloff = (float)CLAMP (0, (int)Q_rint (r_dlight_falloff.value), 3);
@@ -4306,21 +4318,17 @@ static void R_DrawDLightPass (void)
 		float knee = q_max (0.f, r_dlight_softknee.value);
 		float ndotl = CLAMP (0.f, r_dlight_ndotl.value, 1.f);
 		float satchop = CLAMP (0.f, r_dlight_satchop.value, 1.f);
-		float radius_scale = q_max (0.f, r_dlight_radius_scale.value);
 
-		if (glprogs.world_dlight_hybrid[0])
+		R_SetDlightConfig (glprogs.world_dlight[0], scale, falloff, expval,
+			core_boost, core_exp, knee, ndotl, satchop);
+		R_SetDlightConfig (glprogs.world_dlight[1], scale, falloff, expval,
+			core_boost, core_exp, knee, ndotl, satchop);
+		if (r_dlight_mode.value > 0.f)
 		{
-			GL_UseProgram (glprogs.world_dlight_hybrid[0]);
-			GL_Uniform4fFunc (0, scale, radius_scale, falloff, expval);
-			GL_Uniform4fFunc (1, core_boost, core_exp, knee, ndotl);
-			GL_Uniform4fFunc (2, satchop, 0.f, 0.f, 0.f);
-		}
-		if (glprogs.world_dlight_hybrid[1])
-		{
-			GL_UseProgram (glprogs.world_dlight_hybrid[1]);
-			GL_Uniform4fFunc (0, scale, radius_scale, falloff, expval);
-			GL_Uniform4fFunc (1, core_boost, core_exp, knee, ndotl);
-			GL_Uniform4fFunc (2, satchop, 0.f, 0.f, 0.f);
+			R_SetDlightConfig (glprogs.world_dlight_hybrid[0], scale, falloff, expval,
+				core_boost, core_exp, knee, ndotl, satchop);
+			R_SetDlightConfig (glprogs.world_dlight_hybrid[1], scale, falloff, expval,
+				core_boost, core_exp, knee, ndotl, satchop);
 		}
 	}
 

--- a/Quake/shaders/world_dlight.frag
+++ b/Quake/shaders/world_dlight.frag
@@ -12,6 +12,10 @@ layout(binding=3) uniform sampler2D LMTexDir; // unused
 #define ALPHATEST 0
 #endif
 
+layout(location=0) uniform vec4 DLightConfig0; // x: scale, y: radius scale, z: falloff mode, w: exp
+layout(location=1) uniform vec4 DLightConfig1; // x: core boost, y: core exp, z: soft knee, w: ndotl mix
+layout(location=2) uniform vec4 DLightConfig2; // x: saturation chop
+
 vec3 ApplyFog(vec3 clr, vec3 p)
 {
         float fog = exp2(-abs(Fog.w) * dot(p, p));
@@ -62,6 +66,17 @@ float whitenoise01(vec2 p)
         return fract((p3.x + p3.y) * p3.z);
 }
 
+float ComputeFalloff(float x, float mode, float expval)
+{
+        if (mode < 0.5)
+                return x;
+        if (mode < 1.5)
+                return x * x;
+        if (mode < 2.5)
+                return x * x * (3.0 - 2.0 * x);
+        return pow(max(x, 0.0), expval);
+}
+
 void main()
 {
         vec2 uv = in_uv;
@@ -105,6 +120,12 @@ void main()
                 {
                         float dynamic_light_noise = 1.0 - whitenoise01(in_pos.xy) * 0.15;
                         vec4 plane = vec4(surface_normal, dot(in_pos, surface_normal));
+                        float falloff_mode = DLightConfig0.z;
+                        float falloff_exp = max(DLightConfig0.w, 0.01);
+                        float core_boost = max(DLightConfig1.x, 0.0);
+                        float core_exp = max(DLightConfig1.y, 0.01);
+                        float knee = max(DLightConfig1.z, 0.0);
+                        float ndotl_mix = clamp(DLightConfig1.w, 0.0, 1.0);
 
                         for (uint i = 0u, ofs = 0u; i < 2u; i++, ofs += 32u)
                         {
@@ -129,20 +150,35 @@ void main()
                                         float surface_dist = length(light_vec);
                                         float attenuation = clamp((minlight - surface_dist) / 16.0, 0.0, 1.0);
                                         float normalized_dist = surface_dist / rad;
-                                        float falloff = pow(1.0 - clamp(normalized_dist, 0.0, 1.0), 1.5);
+                                        float x = clamp(1.0 - clamp(normalized_dist, 0.0, 1.0), 0.0, 1.0);
+                                        float falloff = ComputeFalloff(x, falloff_mode, falloff_exp);
+                                        float intensity = attenuation * falloff;
+                                        float core = 1.0 + core_boost * pow(max(x, 0.0), core_exp);
+                                        float core_intensity = intensity * core;
+                                        float shaped = (knee > 0.0) ? (core_intensity / (core_intensity + knee)) : core_intensity;
+                                        float ndotl = 1.0;
                                         if (surface_dist > 0.0)
                                         {
                                                 vec3 light_dir = light_vec / surface_dist;
-                                                float ndotl = max(dot(surface_normal, light_dir), 0.0);
-                                                vec3 light_contrib = attenuation * falloff * l.color * dynamic_light_noise * ndotl;
-                                                dynamic_light += light_contrib;
+                                                float ndotl_raw = max(dot(surface_normal, light_dir), 0.0);
+                                                ndotl = mix(1.0, ndotl_raw, ndotl_mix);
                                         }
+
+                                        vec3 light_contrib = shaped * ndotl * l.color * dynamic_light_noise;
+                                        dynamic_light += light_contrib;
                                 }
                         }
                 }
         }
 
-        vec3 contrib = clamp(dynamic_light * Overbright, 0.0, Overbright);
+        float satchop = clamp(DLightConfig2.x, 0.0, 1.0);
+        if (satchop > 0.0)
+        {
+                float luma = dot(dynamic_light, vec3(0.299, 0.587, 0.114));
+                dynamic_light = mix(dynamic_light, vec3(luma), satchop);
+        }
+
+        vec3 contrib = clamp(dynamic_light * DLightConfig0.x * Overbright, 0.0, Overbright);
         vec3 color = albedo * contrib;
 
         color = ApplyFog(color, in_pos - EyePos);


### PR DESCRIPTION
### Motivation
- Dynamic light tuning cvars were not producing visible changes in rendering, so dlight parameters need to be honored and exposed to the shader code.
- Consolidate per-program uniform setup so both the standard and hybrid dlight shader paths receive the same configuration.

### Description
- Apply radius scaling unconditionally in `R_PushDlightArray` by multiplying `radius` with `r_dlight_radius_scale.value` (file: `Quake/gl_rlight.c`).
- Add a helper `R_SetDlightConfig` and use it to upload dlight uniforms for both `world_dlight` and `world_dlight_hybrid` programs, centralizing configuration (file: `Quake/gl_rmain.c`).
- Extend `world_dlight.frag` with `DLightConfig0/1/2` uniforms, implement `ComputeFalloff`, add core/soft-knee/ndotl mixing and saturation-chop (`satchop`) logic, and apply the configured scale when producing `contrib` (file: `Quake/shaders/world_dlight.frag`).

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69552b6d44b8832e9f10ee28be9c45e6)