### PR TITLE
Support polygonOffset factor/units in materials and apply at render

### DIFF
--- a/Quake/mat_shader.c
+++ b/Quake/mat_shader.c
@@ -98,7 +98,7 @@ static const mat_shader_keyword_def_t mat_shader_keyword_table[] =
 	{ "surfaceparm", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Surface flags; see surfaceparm scope." },
 	{ "cull", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL, MAT_SHADER_KEYWORD_STATUS_PARTIAL, "Modes: back/front/none." },
 	{ "sort", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL, MAT_SHADER_KEYWORD_STATUS_PARTIAL, "Keys: sky/opaque/seeThrough/decal/banner/underwater/additive/nearest or numeric." },
-	{ "polygonOffset", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Optional boolean." },
+	{ "polygonOffset", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Optional boolean or factor/units pair." },
 	{ "emissive", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Non-Q3 extension." },
 	{ "bloom", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Non-Q3 extension." },
 	{ "godray", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Non-Q3 extension." },
@@ -1282,7 +1282,11 @@ void Mat_Shader_Print (const shader_material_t *material)
 	Con_Printf ("  content flags: 0x%08x\n", material->content_flags);
 	Con_Printf ("  cull: %s\n", cull_names[q_min ((int)material->cull_mode, (int)countof (cull_names) - 1)]);
 	Con_Printf ("  sort: %s\n", Mat_Shader_SortName (material->sort_key));
-	Con_Printf ("  polygon offset: %s\n", material->polygon_offset ? "on" : "off");
+	if (material->polygon_offset)
+		Con_Printf ("  polygon offset: on (factor %.2f units %.2f)\n",
+			material->polygon_offset_factor, material->polygon_offset_units);
+	else
+		Con_Printf ("  polygon offset: off\n");
 	Con_Printf ("  emissive: %s (scale %.2f)\n", material->emissive_enable ? "on" : "off", material->emissive_scale);
 	Con_Printf ("  bloom: %s (scale %.2f)\n", material->bloom_enable ? "on" : "off", material->bloom_scale);
 	Con_Printf ("  godray: %s (scale %.2f)\n", material->godray_enable ? "on" : "off", material->godray_scale);

--- a/Quake/mat_shader.h
+++ b/Quake/mat_shader.h
@@ -234,6 +234,8 @@ typedef struct shader_material_s
 	mat_cull_mode_t		cull_mode;
 	mat_sort_key_t		sort_key;
 	qboolean		polygon_offset;
+	float			polygon_offset_factor;
+	float			polygon_offset_units;
 	qboolean		emissive_enable;
 	qboolean		bloom_enable;
 	qboolean		godray_enable;

--- a/Quake/mat_shader_parse.c
+++ b/Quake/mat_shader_parse.c
@@ -1630,6 +1630,8 @@ static const char *ParseMaterialBlock (const char *data, const char *name, const
 	material.cull_mode = MAT_CULL_BACK;
 	material.sort_key = MAT_SORT_OPAQUE;
 	material.polygon_offset = false;
+	material.polygon_offset_factor = 0.f;
+	material.polygon_offset_units = 1.f;
 
 	while ((data = Mat_Shader_ParseToken (data, state)) != NULL)
 	{
@@ -1721,11 +1723,72 @@ static const char *ParseMaterialBlock (const char *data, const char *name, const
 		if (!q_strcasecmp (com_token, "polygonOffset"))
 		{
 			Mat_Shader_MarkKeywordSeen ("polygonOffset", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL);
-			qboolean parsed = false;
 			qboolean value_bool = true;
+			float factor = material.polygon_offset_factor;
+			float units = material.polygon_offset_units;
+			const char *cursor = Mat_Shader_ParseToken (data, NULL);
 
-			parsed = ParseOptionalBool (&data, &value_bool, state);
-			material.polygon_offset = parsed ? value_bool : true;
+			if (!cursor || !com_token[0] || Mat_Shader_IsBraceToken (com_token))
+			{
+				material.polygon_offset = true;
+				continue;
+			}
+
+			if (!Mat_Shader_IsNumericToken (com_token) && Mat_Shader_IsBoolToken (com_token))
+			{
+				if (!ParseRequiredBool (&data, &value_bool, state))
+				{
+					data = ResyncMaterialBlock (data, state);
+					break;
+				}
+				material.polygon_offset = value_bool;
+				if (!value_bool)
+					continue;
+
+				cursor = Mat_Shader_ParseToken (data, NULL);
+				if (cursor && com_token[0] && Mat_Shader_IsNumericToken (com_token))
+				{
+					const char *next = Mat_Shader_ParseToken (cursor, NULL);
+					if (next && com_token[0] && Mat_Shader_IsNumericToken (com_token))
+					{
+						if (!ParseFloat (&data, &factor, state) || !ParseFloat (&data, &units, state))
+						{
+							data = ResyncMaterialBlock (data, state);
+							break;
+						}
+						material.polygon_offset_factor = factor;
+						material.polygon_offset_units = units;
+					}
+				}
+				continue;
+			}
+
+			if (Mat_Shader_IsNumericToken (com_token))
+			{
+				const char *next = Mat_Shader_ParseToken (cursor, NULL);
+				if (next && com_token[0] && Mat_Shader_IsNumericToken (com_token))
+				{
+					if (!ParseFloat (&data, &factor, state) || !ParseFloat (&data, &units, state))
+					{
+						data = ResyncMaterialBlock (data, state);
+						break;
+					}
+					material.polygon_offset = true;
+					material.polygon_offset_factor = factor;
+					material.polygon_offset_units = units;
+					continue;
+				}
+
+				if (!ParseRequiredBool (&data, &value_bool, state))
+				{
+					data = ResyncMaterialBlock (data, state);
+					break;
+				}
+				material.polygon_offset = value_bool;
+				continue;
+			}
+
+			material.polygon_offset = true;
 			continue;
 		}
 		if (!q_strcasecmp (com_token, "emissive"))

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -284,7 +284,7 @@ typedef struct bmodel_gpu_instance_s {
 typedef struct bmodel_bindless_gpu_call_s {
 	GLuint		flags;
 	GLfloat		alpha;
-	GLfloat		_pad0[2];
+	GLfloat		polygon_offset[2];
 	GLfloat		stage_color[4];
 	GLuint64	texture;
 	GLuint64	fullbright;
@@ -295,7 +295,7 @@ typedef struct bmodel_bindless_gpu_call_s {
 typedef struct bmodel_bound_gpu_call_s {
 	GLuint		flags;
 	GLfloat		alpha;
-	GLfloat		_pad0[2];
+	GLfloat		polygon_offset[2];
 	GLfloat		stage_color[4];
 	GLint		baseinstance;
 	GLint		padding[3];
@@ -319,6 +319,27 @@ static union {
 static bmodel_gpu_call_remap_t		bmodel_call_remap[MAX_BMODEL_DRAWS];
 static int							num_bmodel_calls;
 static GLuint						bmodel_batch_program;
+
+static void R_GetPolygonOffsetValues (const shader_material_t *material, qboolean use_offset,
+	float *factor, float *units)
+{
+	if (!factor || !units)
+		return;
+	if (!use_offset)
+	{
+		*factor = 0.f;
+		*units = 0.f;
+		return;
+	}
+	if (material && material->polygon_offset)
+	{
+		*factor = material->polygon_offset_factor;
+		*units = material->polygon_offset_units;
+		return;
+	}
+	*factor = 0.f;
+	*units = 1.f;
+}
 
 /*
 =============
@@ -538,8 +559,9 @@ qboolean R_SurfaceEmitsGodrays (msurface_t *s)
 R_AddBModelCall
 =============
 */
-static void R_AddBModelCall (int index, int first_instance, int num_instances, texture_t *t, qboolean zfix, float alpha_override,
-	unsigned extra_flags, qboolean force_fullbright)
+static void R_AddBModelCall (int index, int first_instance, int num_instances, texture_t *t, qboolean zfix,
+	float polygon_offset_factor, float polygon_offset_units, float alpha_override, unsigned extra_flags,
+	qboolean force_fullbright)
 {
 	GLuint		flags;
 	float		alpha;
@@ -590,6 +612,8 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
 		bmodel_bindless_gpu_call_t *call = &bmodel_calls.bindless.params[num_bmodel_calls];
 		call->flags = flags;
 		call->alpha = alpha;
+		call->polygon_offset[0] = polygon_offset_factor;
+		call->polygon_offset[1] = polygon_offset_units;
 		call->stage_color[0] = 1.f;
 		call->stage_color[1] = 1.f;
 		call->stage_color[2] = 1.f;
@@ -605,6 +629,8 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
 		gltexture_t **textures = bmodel_calls.bound.textures[num_bmodel_calls];
 		call->flags = flags;
 		call->alpha = alpha;
+		call->polygon_offset[0] = polygon_offset_factor;
+		call->polygon_offset[1] = polygon_offset_units;
 		call->stage_color[0] = 1.f;
 		call->stage_color[1] = 1.f;
 		call->stage_color[2] = 1.f;
@@ -627,7 +653,8 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
 }
 
 static void R_AddBModelCallWithTextures (int index, int first_instance, int num_instances, gltexture_t *tx, gltexture_t *fb, gltexture_t *em,
-	qboolean zfix, float alpha_override, unsigned extra_flags, const vec4_t stage_color)
+	qboolean zfix, float polygon_offset_factor, float polygon_offset_units, float alpha_override, unsigned extra_flags,
+	const vec4_t stage_color)
 {
 	GLuint flags;
 	float alpha;
@@ -650,6 +677,8 @@ static void R_AddBModelCallWithTextures (int index, int first_instance, int num_
 		bmodel_bindless_gpu_call_t *call = &bmodel_calls.bindless.params[num_bmodel_calls];
 		call->flags = flags;
 		call->alpha = alpha;
+		call->polygon_offset[0] = polygon_offset_factor;
+		call->polygon_offset[1] = polygon_offset_units;
 		call->stage_color[0] = stage_color ? stage_color[0] : 1.f;
 		call->stage_color[1] = stage_color ? stage_color[1] : 1.f;
 		call->stage_color[2] = stage_color ? stage_color[2] : 1.f;
@@ -665,6 +694,8 @@ static void R_AddBModelCallWithTextures (int index, int first_instance, int num_
 		gltexture_t **textures = bmodel_calls.bound.textures[num_bmodel_calls];
 		call->flags = flags;
 		call->alpha = alpha;
+		call->polygon_offset[0] = polygon_offset_factor;
+		call->polygon_offset[1] = polygon_offset_units;
 		call->stage_color[0] = stage_color ? stage_color[0] : 1.f;
 		call->stage_color[1] = stage_color ? stage_color[1] : 1.f;
 		call->stage_color[2] = stage_color ? stage_color[2] : 1.f;
@@ -1099,9 +1130,16 @@ static void R_DrawBrushModels_MaterialStages (entity_t **ents, int count, brushp
 					current_blend_dst = stage->blend_dst;
 				}
 
-				R_AddBModelCallWithTextures (model->firstcmd + j, baseinst, numinst,
-					stage_tex, fb, em,
-					zfix || material->polygon_offset, -1.f, extra_flags, stage_color);
+				{
+					float polygon_offset_factor;
+					float polygon_offset_units;
+					qboolean use_polygon_offset = zfix || material->polygon_offset;
+
+					R_GetPolygonOffsetValues (material, use_polygon_offset, &polygon_offset_factor, &polygon_offset_units);
+					R_AddBModelCallWithTextures (model->firstcmd + j, baseinst, numinst,
+						stage_tex, fb, em,
+						use_polygon_offset, polygon_offset_factor, polygon_offset_units, -1.f, extra_flags, stage_color);
+				}
 			}
 		}
 
@@ -1257,9 +1295,16 @@ static void R_DrawBrushModels_GodrayStages (entity_t **ents, int count)
 				if (t->type == TEXTYPE_CUTOUT)
 					extra_flags |= CALLFLAG_ALPHA_TEST;
 
-				R_AddBModelCallWithTextures (model->firstcmd + j, baseinst, numinst,
-					stage_tex, fb, em,
-					zfix || material->polygon_offset, -1.f, extra_flags, NULL);
+				{
+					float polygon_offset_factor;
+					float polygon_offset_units;
+					qboolean use_polygon_offset = zfix || material->polygon_offset;
+
+					R_GetPolygonOffsetValues (material, use_polygon_offset, &polygon_offset_factor, &polygon_offset_units);
+					R_AddBModelCallWithTextures (model->firstcmd + j, baseinst, numinst,
+						stage_tex, fb, em,
+						use_polygon_offset, polygon_offset_factor, polygon_offset_units, -1.f, extra_flags, NULL);
+				}
 			}
 		}
 
@@ -1467,9 +1512,16 @@ GL_Bind (GL_TEXTURE2, skybox->cubemap);
 				zfix = true;
 
 			extra_flags |= mat_call_flags;
-			R_AddBModelCall (model->firstcmd + j, baseinst, numinst,
-				pass != BP_SHOWTRIS ? R_TextureAnimation (t, frame) : 0,
-				zfix, -1, extra_flags, force_fullbright);
+			{
+				float polygon_offset_factor;
+				float polygon_offset_units;
+				const shader_material_t *material = (r_shaders.value > 0.f) ? t->shader : NULL;
+
+				R_GetPolygonOffsetValues (material, zfix, &polygon_offset_factor, &polygon_offset_units);
+				R_AddBModelCall (model->firstcmd + j, baseinst, numinst,
+					pass != BP_SHOWTRIS ? R_TextureAnimation (t, frame) : 0,
+					zfix, polygon_offset_factor, polygon_offset_units, -1, extra_flags, force_fullbright);
+			}
 		}
 		
 		baseinst += numinst;
@@ -1611,9 +1663,17 @@ GL_Upload (GL_SHADER_STORAGE_BUFFER, bmodel_instances, sizeof(bmodel_instances[0
 			float alpha = GL_WaterAlphaForEntityTextureType (e, t->type);
 			if ((alpha < 1.f) != translucent)
 				continue;
-			R_AddBModelCall (model->firstcmd + j, baseinst, numinst,
-				R_TextureAnimation (t, frame),
-				!isworld, alpha, extra_flags, false);
+			{
+				float polygon_offset_factor;
+				float polygon_offset_units;
+				qboolean zfix = !isworld;
+				const shader_material_t *material = (r_shaders.value > 0.f) ? t->shader : NULL;
+
+				R_GetPolygonOffsetValues (material, zfix, &polygon_offset_factor, &polygon_offset_units);
+				R_AddBModelCall (model->firstcmd + j, baseinst, numinst,
+					R_TextureAnimation (t, frame),
+					zfix, polygon_offset_factor, polygon_offset_units, alpha, extra_flags, false);
+			}
 		}
 
 		baseinst += numinst;

--- a/Quake/shaders/sky_cubemap.vert
+++ b/Quake/shaders/sky_cubemap.vert
@@ -19,6 +19,7 @@ struct Call
 {
 	uint	flags;
 	float	wateralpha;
+	vec2	polygon_offset;
 	vec4	stage_color;
 #if BINDLESS
 	uvec2	txhandle;

--- a/Quake/shaders/sky_layers.vert
+++ b/Quake/shaders/sky_layers.vert
@@ -19,6 +19,7 @@ struct Call
 {
 	uint	flags;
 	float	wateralpha;
+	vec2	polygon_offset;
 	vec4	stage_color;
 #if BINDLESS
 	uvec2	txhandle;

--- a/Quake/shaders/skystencil.vert
+++ b/Quake/shaders/skystencil.vert
@@ -19,6 +19,7 @@ struct Call
 {
 	uint	flags;
 	float	wateralpha;
+	vec2	polygon_offset;
 	vec4	stage_color;
 #if BINDLESS
 	uvec2	txhandle;

--- a/Quake/shaders/water.vert
+++ b/Quake/shaders/water.vert
@@ -19,6 +19,7 @@ struct Call
 {
 	uint	flags;
 	float	wateralpha;
+	vec2	polygon_offset;
 	vec4	stage_color;
 #if BINDLESS
 	uvec2	txhandle;

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -46,6 +46,7 @@ struct Call
 {
 	uint	flags;
 	float	wateralpha;
+	vec2	polygon_offset;
 	vec4	stage_color;
 #if BINDLESS
 	uvec2	txhandle;

--- a/Quake/shaders/world.vert
+++ b/Quake/shaders/world.vert
@@ -48,6 +48,7 @@ struct Call
 {
 	uint	flags;
 	float	wateralpha;
+	vec2	polygon_offset;
 	vec4	stage_color;
 #if BINDLESS
 	uvec2	txhandle;
@@ -161,8 +162,10 @@ void main()
 #endif
 	if ((call.flags & CF_USE_POLYGON_OFFSET) != 0u)
 	{
-		curr_clip.z += ZBIAS;
-		prev_clip.z += ZBIAS;
+		float zoffset = (call.polygon_offset.x + call.polygon_offset.y) * ZBIAS;
+
+		curr_clip.z += zoffset;
+		prev_clip.z += zoffset;
 	}
 	gl_Position = curr_clip;
         out_curr_clip = curr_clip;

--- a/Quake/shaders/world_dlight.vert
+++ b/Quake/shaders/world_dlight.vert
@@ -35,6 +35,7 @@ struct Call
 {
         uint    flags;
         float   wateralpha;
+        vec2    polygon_offset;
         vec4    stage_color;
 #if BINDLESS
         uvec2   txhandle;
@@ -129,7 +130,9 @@ void main()
 #endif
         if ((call.flags & CF_USE_POLYGON_OFFSET) != 0u)
         {
-                curr_clip.z += ZBIAS;
+                float zoffset = (call.polygon_offset.x + call.polygon_offset.y) * ZBIAS;
+
+                curr_clip.z += zoffset;
         }
         gl_Position = curr_clip;
         out_pos = world_pos;


### PR DESCRIPTION
### Motivation
- Extend `polygonOffset` support so shader materials can optionally specify numeric `factor` and `units` parameters in addition to a boolean flag.
- Store per-material offset parameters and ensure they are available when creating GPU draw calls for brush models.
- Apply the per-material offset bias in the world vertex shaders so the offset affects clip-space position consistently.

### Description
- Add `polygon_offset_factor` and `polygon_offset_units` fields to `shader_material_t` in `Quake/mat_shader.h` and initialize defaults in `ParseMaterialBlock` in `Quake/mat_shader_parse.c`.
- Extend `ParseMaterialBlock` to accept optional numeric `factor`/`units` pairs for the `polygonOffset` directive and keep backward-compatible boolean parsing via `ParseFloat`/`ParseRequiredBool`.
- Propagate offset values into drawcall structures and call paths by adding `polygon_offset` slots to the GPU call structs and `Call` buffer layout, adding `R_GetPolygonOffsetValues`, and changing `R_AddBModelCall`/`R_AddBModelCallWithTextures` call sites in `Quake/r_world.c`.
- Update shader `Call` definitions and vertex shaders (e.g. `world.vert`, `world_dlight.vert`, `water.vert`, etc.) to include `polygon_offset` and apply a combined Z bias (`factor + units`) to clip-space Z when `CF_USE_POLYGON_OFFSET` is set, and update `Mat_Shader` messaging to reflect the new option.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69566dd580b4832ea400c5adb2c4f9a4)