### PR TITLE
Add alias model shadow casting and receiving (STAGE2)

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -257,10 +257,13 @@ cvar_t	r_shadow_sun = { "r_shadow_sun", "1", CVAR_ARCHIVE };
 cvar_t	r_shadowmap_size = { "r_shadowmap_size", "2048", CVAR_ARCHIVE };
 cvar_t	r_shadow_bias = { "r_shadow_bias", "0.001", CVAR_ARCHIVE };
 cvar_t	r_shadow_normalbias = { "r_shadow_normalbias", "1.0", CVAR_ARCHIVE };
+cvar_t	r_shadow_bias_mdl = { "r_shadow_bias_mdl", "0.001", CVAR_ARCHIVE };
+cvar_t	r_shadow_normalbias_mdl = { "r_shadow_normalbias_mdl", "1.0", CVAR_ARCHIVE };
 cvar_t	r_shadow_pcf = { "r_shadow_pcf", "1", CVAR_ARCHIVE };
 cvar_t	r_shadow_pcf_taps = { "r_shadow_pcf_taps", "4", CVAR_ARCHIVE };
 cvar_t	r_shadow_debug = { "r_shadow_debug", "0", CVAR_NONE };
 cvar_t	r_shadow_sun_dir = { "r_shadow_sun_dir", "0.3 0.5 -1.0", CVAR_ARCHIVE };
+cvar_t	r_shadow_twosided_mdl = { "r_shadow_twosided_mdl", "0", CVAR_ARCHIVE };
 cvar_t	r_novis = { "r_novis","0",CVAR_ARCHIVE };
 #if defined(USE_SIMD)
 cvar_t	r_simd = { "r_simd","1",CVAR_ARCHIVE };

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -81,10 +81,13 @@ extern cvar_t r_shadow_sun;
 extern cvar_t r_shadowmap_size;
 extern cvar_t r_shadow_bias;
 extern cvar_t r_shadow_normalbias;
+extern cvar_t r_shadow_bias_mdl;
+extern cvar_t r_shadow_normalbias_mdl;
 extern cvar_t r_shadow_pcf;
 extern cvar_t r_shadow_pcf_taps;
 extern cvar_t r_shadow_debug;
 extern cvar_t r_shadow_sun_dir;
+extern cvar_t r_shadow_twosided_mdl;
 //johnfitz
 extern cvar_t gl_zfix; // QuakeSpasm z-fighting fix
 extern cvar_t r_alphasort;
@@ -562,10 +565,13 @@ Cvar_RegisterVariable (&r_drawviewmodel);
         Cvar_RegisterVariable (&r_shadowmap_size);
         Cvar_RegisterVariable (&r_shadow_bias);
         Cvar_RegisterVariable (&r_shadow_normalbias);
+        Cvar_RegisterVariable (&r_shadow_bias_mdl);
+        Cvar_RegisterVariable (&r_shadow_normalbias_mdl);
         Cvar_RegisterVariable (&r_shadow_pcf);
         Cvar_RegisterVariable (&r_shadow_pcf_taps);
         Cvar_RegisterVariable (&r_shadow_debug);
         Cvar_RegisterVariable (&r_shadow_sun_dir);
+        Cvar_RegisterVariable (&r_shadow_twosided_mdl);
 	DLightPool_RegisterCvars ();
         Cvar_RegisterVariable (&r_novis);
 #if defined(USE_SIMD)

--- a/Quake/gl_shaders.c
+++ b/Quake/gl_shaders.c
@@ -537,6 +537,8 @@ void GL_CreateShaders (void)
                 glprogs.world_dlight_hybrid[alphatest] = GL_CreateProgram (GLSL_PATH("world_dlight.vert"), GLSL_PATH("world_dlight_hybrid.frag"), "world dlight hybrid|ALPHATEST %d", alphatest);
 
         glprogs.shadow_depth = GL_CreateProgram (GLSL_PATH("shadow_depth.vert"), GLSL_PATH("shadow_depth.frag"), "shadow depth");
+	for (md5 = 0; md5 < 2; md5++)
+		glprogs.shadow_depth_alias[md5] = GL_CreateProgram (GLSL_PATH("shadow_depth_alias.vert"), GLSL_PATH("shadow_depth.frag"), "shadow depth alias|MD5 %d", md5);
 	glprogs.dlight_composite = GL_CreateProgram (GLSL_PATH("postprocess.vert"), GLSL_PATH("dlight_composite.frag"), "dlight composite");
 
 	for (dither = 0; dither < 2; dither++)

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -487,6 +487,7 @@ void R_DrawBrushModels_SkyCubemap (entity_t **ents, int count);
 void R_DrawBrushModels_SkyStencil (entity_t **ents, int count);
 void R_DrawBrushModels_Shadow (entity_t **ents, int count);
 void R_DrawAliasModels (entity_t **ents, int count);
+void R_DrawAliasModels_Shadow (entity_t **ents, int count);
 void R_DrawSpriteModels (entity_t **ents, int count);
 void R_DrawBrushModels_ShowTris (entity_t **ents, int count);
 void R_DrawAliasModels_ShowTris (entity_t **ents, int count);
@@ -577,6 +578,7 @@ typedef struct glprogs_s {
 	GLuint		world_dlight_hybrid[2];		// [alpha test]
 	GLuint		water[2][2];		// [OIT][dither]
 	GLuint		shadow_depth;
+	GLuint		shadow_depth_alias[2]; // [md5]
 	GLuint		shadow_debug;
 	GLuint		skystencil;
 	GLuint		skylayers[2];		// [dither]

--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -31,6 +31,11 @@ extern cvar_t r_oit;
 extern cvar_t r_lightgrid;
 extern cvar_t r_lightgrid_force;
 extern cvar_t r_lightgrid_debug;
+extern cvar_t r_shadow_bias_mdl;
+extern cvar_t r_shadow_normalbias_mdl;
+extern cvar_t r_shadow_pcf;
+extern cvar_t r_shadow_pcf_taps;
+extern cvar_t r_shadow_twosided_mdl;
 
 //up to 16 color translated skins
 gltexture_t *playertextures[MAX_SCOREBOARD]; //johnfitz -- changed to an array of pointers
@@ -86,7 +91,11 @@ struct ibuf_s {
 		float	dither;
 		float	overbright;
 		float	half_lambert;
-		float	_padding[5]; // keep std430 layout in sync with InstanceBuffer in alias shaders
+		float	_pad1;
+		float	shadow_viewproj[16];
+		vec4_t	shadow_params;
+		vec4_t	shadow_debug;
+		vec4_t	shadow_sun_dir;
 	} global;
 	aliasinstance_t inst[MAX_ALIAS_INSTANCES];
 } ibuf;
@@ -560,6 +569,13 @@ gl_overbright_models.value ?
 ibuf.global.overbright = gl_overbright_models.value > 0.f ? r_framedata.dither[2] : 1.f;
 ibuf.global.dither = r_framedata.dither[0];
 ibuf.global.half_lambert = CLAMP (0.f, r_model_halflambert.value, 1.f);
+	memcpy (ibuf.global.shadow_viewproj, r_framedata.shadow_viewproj, sizeof (r_framedata.shadow_viewproj));
+	ibuf.global.shadow_params[0] = r_shadow_bias_mdl.value;
+	ibuf.global.shadow_params[1] = r_shadow_normalbias_mdl.value;
+	ibuf.global.shadow_params[2] = r_shadow_pcf.value > 0.f ? 1.f : 0.f;
+	ibuf.global.shadow_params[3] = r_shadow_pcf_taps.value;
+	memcpy (ibuf.global.shadow_debug, r_framedata.shadow_debug, sizeof (r_framedata.shadow_debug));
+	memcpy (ibuf.global.shadow_sun_dir, r_framedata.shadow_sun_dir, sizeof (r_framedata.shadow_sun_dir));
 
 	ibuf_size = sizeof(ibuf.global) + sizeof(ibuf.inst[0]) * ibuf.count;
 	GL_Upload (GL_SHADER_STORAGE_BUFFER, &ibuf.global, ibuf_size, &buf, &ofs);
@@ -570,6 +586,7 @@ ibuf.global.half_lambert = CLAMP (0.f, r_model_halflambert.value, 1.f);
 
 	GL_BindBuffer (GL_ARRAY_BUFFER, model->meshvbo);
 	GL_BindBuffer (GL_ELEMENT_ARRAY_BUFFER, model->meshindexesvbo);
+	R_Shadow_BindShadowMap (GL_TEXTURE5);
 
 	for (hdr = mainhdr; hdr; hdr = hdr->nextsurface ? (aliashdr_t *) ((byte *)hdr + hdr->nextsurface) : NULL)
 	{
@@ -641,6 +658,104 @@ ibuf.global.half_lambert = CLAMP (0.f, r_model_halflambert.value, 1.f);
 		}
 
 		GL_BindTextures (0, 3, textures);
+
+		GL_DrawElementsInstancedFunc (GL_TRIANGLES, hdr->numindexes, GL_UNSIGNED_SHORT, (void *)hdr->eboofs, ibuf.count);
+
+		rs_aliaspasses += hdr->numtris * ibuf.count;
+	}
+
+	ibuf.count = 0;
+
+	GL_EndGroup();
+}
+
+/*
+=================
+R_FlushAliasInstances_Shadow
+=================
+*/
+static void R_FlushAliasInstances_Shadow (void)
+{
+	qmodel_t	*model;
+	aliashdr_t	*mainhdr, *hdr;
+	qboolean	md5;
+	unsigned	state;
+	GLuint		buf;
+	GLbyte		*ofs;
+	size_t		ibuf_size;
+	GLuint		buffers[2];
+	GLintptr	offsets[2];
+	GLsizeiptr	sizes[2];
+
+	if (!ibuf.count)
+		return;
+
+	model = ibuf.ent->model;
+	mainhdr = (aliashdr_t *)Mod_Extradata (model);
+	md5 = mainhdr->poseverttype == PV_IQM;
+
+	GL_BeginGroup (model->name);
+
+	GL_UseProgram (glprogs.shadow_depth_alias[md5]);
+
+	if (md5)
+		state = GLS_ATTRIBS(5);
+	else
+		state = GLS_ATTRIBS(1);
+
+	if (r_shadow_twosided_mdl.value > 0.f)
+		state |= GLS_CULL_NONE;
+	else
+		state |= GLS_CULL_FRONT;
+
+	state |= GLS_BLEND_OPAQUE;
+	GL_SetState (state);
+
+	memcpy (ibuf.global.matviewproj, r_matviewproj, sizeof (r_matviewproj));
+	memcpy (ibuf.global.prev_matviewproj, r_framedata.prev_viewproj, sizeof (r_framedata.prev_viewproj));
+	memcpy (ibuf.global.eyepos, r_refdef.vieworg, sizeof (r_refdef.vieworg));
+	memcpy (ibuf.global.shadow_viewproj, r_framedata.shadow_viewproj, sizeof (r_framedata.shadow_viewproj));
+	ibuf.global.shadow_params[0] = r_shadow_bias_mdl.value;
+	ibuf.global.shadow_params[1] = r_shadow_normalbias_mdl.value;
+	ibuf.global.shadow_params[2] = r_shadow_pcf.value > 0.f ? 1.f : 0.f;
+	ibuf.global.shadow_params[3] = r_shadow_pcf_taps.value;
+	memcpy (ibuf.global.shadow_debug, r_framedata.shadow_debug, sizeof (r_framedata.shadow_debug));
+	memcpy (ibuf.global.shadow_sun_dir, r_framedata.shadow_sun_dir, sizeof (r_framedata.shadow_sun_dir));
+
+	ibuf_size = sizeof(ibuf.global) + sizeof(ibuf.inst[0]) * ibuf.count;
+	GL_Upload (GL_SHADER_STORAGE_BUFFER, &ibuf.global, ibuf_size, &buf, &ofs);
+
+	buffers[0] = buf;
+	offsets[0] = (GLintptr) ofs;
+	sizes[0] = ibuf_size;
+
+	GL_BindBuffer (GL_ARRAY_BUFFER, model->meshvbo);
+	GL_BindBuffer (GL_ELEMENT_ARRAY_BUFFER, model->meshindexesvbo);
+
+	for (hdr = mainhdr; hdr; hdr = hdr->nextsurface ? (aliashdr_t *) ((byte *)hdr + hdr->nextsurface) : NULL)
+	{
+		if (md5)
+		{
+			GL_VertexAttribPointerFunc  (0, 3, GL_FLOAT,			GL_FALSE, sizeof (iqmvert_t), (void *) (hdr->vbovertofs + offsetof (iqmvert_t, xyz)));
+			GL_VertexAttribPointerFunc  (1, 4, GL_BYTE,				GL_TRUE,  sizeof (iqmvert_t), (void *) (hdr->vbovertofs + offsetof (iqmvert_t, norm)));
+			GL_VertexAttribPointerFunc  (2, 2, GL_FLOAT,			GL_FALSE, sizeof (iqmvert_t), (void *) (hdr->vbovertofs + offsetof (iqmvert_t, st)));
+			GL_VertexAttribPointerFunc  (3, 4, GL_UNSIGNED_BYTE,	GL_TRUE,  sizeof (iqmvert_t), (void *) (hdr->vbovertofs + offsetof (iqmvert_t, weight)));
+			GL_VertexAttribIPointerFunc (4, 4, GL_UNSIGNED_BYTE,	          sizeof (iqmvert_t), (void *) (hdr->vbovertofs + offsetof (iqmvert_t, idx)));
+
+			buffers[1] = model->meshvbo;
+			offsets[1] = hdr->vboposeofs;
+			sizes[1] = sizeof (bonepose_t) * hdr->numbones * hdr->numboneposes;
+		}
+		else
+		{
+			GL_VertexAttribPointerFunc (0, 2, GL_FLOAT, GL_FALSE, sizeof (meshst_t), (void *) hdr->vbostofs);
+
+			buffers[1] = model->meshvbo;
+			offsets[1] = hdr->vbovertofs;
+			sizes[1] = sizeof (meshxyz_t) * hdr->numverts_vbo * hdr->numposes;
+		}
+
+		GL_BindBuffersRange (GL_SHADER_STORAGE_BUFFER, 1, 2, buffers, offsets, sizes);
 
 		GL_DrawElementsInstancedFunc (GL_TRIANGLES, hdr->numindexes, GL_UNSIGNED_SHORT, (void *)hdr->eboofs, ibuf.count);
 
@@ -838,6 +953,78 @@ if (!Q_strncmp (e->model->name, "progs/bolt", 10))
 
 /*
 =================
+R_DrawAliasModel_Shadow_Real
+=================
+*/
+static void R_DrawAliasModel_Shadow_Real (entity_t *e)
+{
+	aliashdr_t	*paliashdr;
+	lerpdata_t	lerpdata;
+	float		model_matrix[16];
+	aliasinstance_t	*instance;
+	float		entalpha;
+
+	if (!e || !e->model)
+		return;
+
+	if (e == &cl.viewent)
+		return;
+
+	if (e->model->flags & MOD_NOSHADOW)
+		return;
+
+	paliashdr = (aliashdr_t *)Mod_Extradata (e->model);
+
+	R_SetupAliasFrame (e, paliashdr, &lerpdata);
+	R_SetupEntityTransform (e, &lerpdata);
+
+	if (lerpdata.pose1 == lerpdata.pose2)
+		lerpdata.blend = 0.f;
+
+	if (R_CullModelForEntity (e))
+		return;
+
+	R_EntityMatrix (model_matrix, lerpdata.origin, lerpdata.angles, e->scale);
+	ApplyTranslation (model_matrix, paliashdr->scale_origin[0], paliashdr->scale_origin[1], paliashdr->scale_origin[2]);
+	ApplyScale (model_matrix, paliashdr->scale[0], paliashdr->scale[1], paliashdr->scale[2]);
+
+	entalpha = ENTALPHA_DECODE (e->alpha);
+	if (entalpha == 0.f)
+		return;
+
+	if (!R_Alias_CanAddToBatch (e))
+		R_FlushAliasInstances_Shadow ();
+
+	if (!ibuf.count)
+		ibuf.ent = e;
+
+	instance = &ibuf.inst[ibuf.count++];
+	instance->flags = ALIAS_INSTANCE_FLAG_NONE;
+
+	MatrixTranspose4x3 (model_matrix, instance->worldmatrix);
+	MatrixTranspose4x3 (model_matrix, instance->prev_worldmatrix);
+
+	VectorClear (instance->lightcolor);
+	VectorClear (instance->dlightcolor);
+	instance->alpha = entalpha;
+	instance->pose1 = lerpdata.pose1;
+	instance->pose2 = lerpdata.pose2;
+	instance->blend = lerpdata.blend;
+
+	if (paliashdr->poseverttype == PV_QUAKE1)
+	{
+		instance->pose1 *= paliashdr->numverts_vbo;
+		instance->pose2 *= paliashdr->numverts_vbo;
+	}
+	else
+	{
+		instance->pose1 *= paliashdr->numbones;
+		instance->pose2 *= paliashdr->numbones;
+	}
+}
+
+/*
+=================
 R_DrawAliasModels
 =================
 */
@@ -847,6 +1034,19 @@ void R_DrawAliasModels (entity_t **ents, int count)
         for (i = 0; i < count; i++)
                 R_DrawAliasModel_Real (ents[i], false);
         R_FlushAliasInstances (false);
+}
+
+/*
+=================
+R_DrawAliasModels_Shadow
+=================
+*/
+void R_DrawAliasModels_Shadow (entity_t **ents, int count)
+{
+	int i;
+	for (i = 0; i < count; i++)
+		R_DrawAliasModel_Shadow_Real (ents[i]);
+	R_FlushAliasInstances_Shadow ();
 }
 
 /*

--- a/Quake/r_shadow.c
+++ b/Quake/r_shadow.c
@@ -338,6 +338,11 @@ void R_Shadow_SunPass (void)
 		entity_t **ents = R_GetVisEntities (mod_brush, false, &count);
 		R_DrawBrushModels_Shadow (ents, count);
 	}
+	{
+		int count = 0;
+		entity_t **ents = R_GetVisEntities (mod_alias, false, &count);
+		R_DrawAliasModels_Shadow (ents, count);
+	}
 
 	GL_EndGroup ();
 }

--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -20,7 +20,11 @@ layout(std430, binding=1) restrict readonly buffer InstanceBuffer
 	float	ScreenDither;
 	float	Overbright;
 	float	ModelHalfLambert;
-	float   _Pad[5];
+	float	_Pad1;
+	mat4	ShadowViewProj;
+	vec4	ShadowParams;
+	vec4	ShadowDebug;
+	vec4	ShadowSunDir;
 	InstanceData instances[];
 };
 // ALU-only 16x16 Bayer matrix
@@ -95,6 +99,9 @@ const int ALIAS_FLAG_LIGHTNING = 4;
 layout(binding=0) uniform sampler2D Tex;
 layout(binding=1) uniform sampler2D FullbrightTex;
 layout(binding=2) uniform sampler2D EmissiveTex;
+layout(binding=5) uniform sampler2D ShadowMap;
+
+#include "shadow_sample.glsl"
 
 #if MODE == 2
 	layout(location=0) noperspective in vec2 in_texcoord;
@@ -106,6 +113,7 @@ layout(location=2) in vec3 in_pos;
 layout(location=3) noperspective in vec4 in_curr_clip;
 layout(location=4) noperspective in vec4 in_prev_clip;
 layout(location=5) flat in int in_flags;
+layout(location=6) in vec3 in_normal;
 
 #define OUT_COLOR out_fragcolor
 #if OIT
@@ -150,6 +158,26 @@ void main()
 {
         vec2 uv = in_texcoord;
         vec3 emissive = vec3(0.0);
+        float shadow_range = 1.0;
+        float shadow_term = 1.0;
+	vec4 lit_color = in_color;
+
+	if (ShadowDebug.x > 0.5 && (in_flags & ALIAS_FLAG_VIEWMODEL) == 0)
+	{
+		vec3 world_pos = in_pos + EyePos;
+		vec3 shadow_normal = gl_FrontFacing ? in_normal : -in_normal;
+		shadow_term = ShadowVisibility(world_pos, shadow_normal, shadow_range);
+		if (ShadowDebug.y > 1.5)
+		{
+			float debug_value = (ShadowDebug.y > 2.5) ? shadow_range : shadow_term;
+			out_fragcolor = vec4(vec3(debug_value), 1.0);
+#if !OIT
+			out_velocity = vec4(0.0);
+#endif
+			return;
+		}
+		lit_color.rgb *= shadow_term;
+	}
 #if MODE == 2
         uv -= 0.5 / vec2(textureSize(Tex, 0).xy);
         vec4 result = textureLod(Tex, uv, 0.);
@@ -159,11 +187,11 @@ void main()
 #if ALPHATEST
 	if (result.a < 0.666)
 		discard;
-	result.rgb *= in_color.rgb;
+	result.rgb *= lit_color.rgb;
 #else
-	result.rgb = mix(result.rgb, result.rgb * in_color.rgb, result.a);
+	result.rgb = mix(result.rgb, result.rgb * lit_color.rgb, result.a);
 #endif
-	result.a = in_color.a; // FIXME: This will make almost transparent things cut holes though heavy fog
+	result.a = lit_color.a; // FIXME: This will make almost transparent things cut holes though heavy fog
         vec3 fullbright;
 #if MODE == 2
         fullbright = textureLod(FullbrightTex, uv, 0.).rgb;
@@ -182,6 +210,7 @@ void main()
                 result.rgb += ghost * vec3(0.5, 0.7, 1.3);
         }
         result.rgb = clamp(result.rgb, 0.0, 1.0);
+
         result.rgb = ApplyFog(result.rgb, in_pos);
         out_fragcolor = result;
 #if !OIT

--- a/Quake/shaders/alias.vert
+++ b/Quake/shaders/alias.vert
@@ -20,7 +20,11 @@ layout(std430, binding=1) restrict readonly buffer InstanceBuffer
 	float	ScreenDither;
 	float	Overbright;
 	float	ModelHalfLambert;
-	float   _Pad[5];
+	float	_Pad1;
+	mat4	ShadowViewProj;
+	vec4	ShadowParams;
+	vec4	ShadowDebug;
+	vec4	ShadowSunDir;
 	InstanceData instances[];
 };
 
@@ -91,6 +95,7 @@ layout(location=2) out vec3 out_pos;
 layout(location=3) noperspective out vec4 out_curr_clip;
 layout(location=4) noperspective out vec4 out_prev_clip;
 layout(location=5) flat out int out_flags;
+layout(location=6) out vec3 out_normal;
 
 const int ALIAS_FLAG_VIEWMODEL = 2;
 
@@ -131,4 +136,5 @@ void main()
         bool is_viewmodel = (inst.Flags & ALIAS_FLAG_VIEWMODEL) != 0;
         vec3 final_color = is_viewmodel ? base_color + vec3(rim) : base_color;
         out_color = clamp(vec4(final_color, inst.LightColor.a), 0.0, Overbright);
+	out_normal = world_normal;
 }

--- a/Quake/shaders/shadow_depth_alias.vert
+++ b/Quake/shaders/shadow_depth_alias.vert
@@ -1,0 +1,87 @@
+struct InstanceData
+{
+	vec4	WorldMatrix[3];
+	vec4	PrevWorldMatrix[3];
+	vec4	LightColor; // xyz=LightColor w=Alpha
+	vec4	DLightColor; // xyz=DLightColor
+	int		Pose1;
+	int		Pose2;
+	float	Blend;
+	int		Flags;
+};
+
+layout(std430, binding=1) restrict readonly buffer InstanceBuffer
+{
+	mat4	ViewProj;
+	mat4	PrevViewProj;
+	vec3	EyePos;
+	float	_Pad0;
+	vec4	Fog;
+	float	ScreenDither;
+	float	Overbright;
+	float	ModelHalfLambert;
+	float	_Pad1;
+	mat4	ShadowViewProj;
+	vec4	ShadowParams;
+	vec4	ShadowDebug;
+	vec4	ShadowSunDir;
+	InstanceData instances[];
+};
+
+struct PoseVertex
+{
+	vec3 pos;
+	vec3 nor;
+};
+
+#if MD5
+	layout(location=0) in vec3 in_pos;
+	layout(location=1) in vec4 in_nor;
+	layout(location=2) in vec2 in_uv;
+	layout(location=3) in vec4 in_weights;
+	layout(location=4) in ivec4 in_indices;
+
+	layout(std430, binding=2) restrict readonly buffer PoseBuffer
+	{
+		mat3x4 BonePoses[];
+	};
+
+	PoseVertex GetPoseVertex(uint pose)
+	{
+		mat3x4 blendmat = BonePoses[pose + in_indices.x] * in_weights.x;
+		blendmat += BonePoses[pose + in_indices.y] * in_weights.y;
+		if (in_weights.z + in_weights.w > 0.0)
+		{
+			blendmat += BonePoses[pose + in_indices.z] * in_weights.z;
+			blendmat += BonePoses[pose + in_indices.w] * in_weights.w;
+		}
+		mat4x3 anim = transpose(blendmat);
+		return PoseVertex((anim * vec4(in_pos, 1.0)).xyz, (anim * vec4(in_nor.xyz, 0.0)).xyz);
+	}
+
+#else
+	layout(location=0) in vec2 in_uv;
+
+	layout(std430, binding=2) restrict readonly buffer BlendShapeBuffer
+	{
+		uvec2 PackedPosNor[];
+	};
+
+	PoseVertex GetPoseVertex(uint pose)
+	{
+		uvec2 data = PackedPosNor[pose + gl_VertexID];
+		return PoseVertex(vec3((data.xxx >> uvec3(0, 8, 16)) & 255), unpackSnorm4x8(data.y).xyz);
+	}
+
+#endif // MD5
+
+void main()
+{
+	InstanceData inst = instances[gl_InstanceID];
+	PoseVertex pose1 = GetPoseVertex(inst.Pose1);
+	PoseVertex pose2 = GetPoseVertex(inst.Pose2);
+	vec3 local_vert = mix(pose1.pos, pose2.pos, inst.Blend);
+	mat4x3 worldmatrix = transpose(mat3x4(inst.WorldMatrix[0], inst.WorldMatrix[1], inst.WorldMatrix[2]));
+	vec3 world_vert = (worldmatrix * vec4(local_vert, 1.0)).xyz;
+	gl_Position = ShadowViewProj * vec4(world_vert, 1.0);
+}


### PR DESCRIPTION
### Motivation

- Implement STAGE2 of the shadowmap rollout: include alias (MDL/IQM) models as shadow casters and receivers for the sun/directional shadow map.
- Allow model-specific shadow bias and normal-bias tuning to reduce acne/peter-panning on skinned/posed models.
- Exclude viewmodel from receiving/casting by default and provide a two-sided option for thin models.
- Integrate with the existing simple single shadowmap pipeline without major renderer refactors.

### Description

- Added a dedicated alias depth vertex shader `shaders/shadow_depth_alias.vert` and hooked it up as `glprogs.shadow_depth_alias[md5]` in `gl_shaders.c` so alias models can be rendered into the shadow map.
- Extended alias GPU instance layout and shader interfaces to include `ShadowViewProj`, `ShadowParams`, `ShadowDebug`, and `ShadowSunDir`, and made the alias vertex shader export world-space normals to the fragment shader for biasing; updated `shaders/alias.vert` and `shaders/alias.frag` to sample the shadow map via `shadow_sample.glsl` and apply the shadow term (with viewmodel exclusion).
- Implemented shadow batching and draw path for alias models in `r_alias.c` (`R_DrawAliasModels_Shadow`, `R_DrawAliasModel_Shadow_Real`, and `R_FlushAliasInstances_Shadow`) and bind the shadow map when drawing alias instances; included checks for `MOD_NOSHADOW` and a `r_shadow_twosided_mdl` option.
- Added model-specific CVARs (`r_shadow_bias_mdl`, `r_shadow_normalbias_mdl`, and `r_shadow_twosided_mdl`) and wired registration/usage in `gl_rmain.c` / `gl_rmisc.c` and frame upload (`r_alias.c`), and included alias models in the sun shadow pass in `r_shadow.c`.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69567ba1ef90832ebd972cec674f159b)