### PR TITLE
Fix shadow sampling guards for dlight shaders

### DIFF
--- a/Quake/gl_rlight.c
+++ b/Quake/gl_rlight.c
@@ -45,6 +45,7 @@ cvar_t r_model_lightgrid = { "r_model_lightgrid", "1", CVAR_ARCHIVE };
 
 gpulightbuffer_t r_lightbuffer;
 float r_lightstyle_framefrac;
+dlight_t *r_dlight_sources[DLIGHT_GPU_MAX];
 
 static qboolean R_IsFinite (float v)
 {
@@ -375,6 +376,7 @@ static void R_PushDlightArray (dlight_t *const *lights, int count)
 			continue;
 
 		out = &r_lightbuffer.lights[r_framedata.numlights++];
+		r_dlight_sources[r_framedata.numlights - 1] = l;
 		const vec3_t *temp = R_GetDynamicLightTemperature (l->type);
 		float radiusFactor = q_min (1.f, q_max (radius / 350.f, 0.2f));
 		vec3_t finalcolor;
@@ -419,6 +421,7 @@ void R_PushDlights (void)
 	dlight_t *submit[DLIGHT_GPU_MAX];
 
 	r_framedata.numlights = 0;
+	memset (r_dlight_sources, 0, sizeof (r_dlight_sources));
 
         // Collect dynamic lights both when the legacy r_dynamic toggle is
         // enabled and when the Quake3-style additive path is requested via

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -264,6 +264,12 @@ cvar_t	r_shadow_pcf_taps = { "r_shadow_pcf_taps", "4", CVAR_ARCHIVE };
 cvar_t	r_shadow_debug = { "r_shadow_debug", "0", CVAR_NONE };
 cvar_t	r_shadow_sun_dir = { "r_shadow_sun_dir", "0.3 0.5 -1.0", CVAR_ARCHIVE };
 cvar_t	r_shadow_twosided_mdl = { "r_shadow_twosided_mdl", "0", CVAR_ARCHIVE };
+cvar_t	r_shadow_dlights = { "r_shadow_dlights", "0", CVAR_ARCHIVE };
+cvar_t	r_shadow_dlight_max = { "r_shadow_dlight_max", "2", CVAR_ARCHIVE };
+cvar_t	r_shadow_dlight_size = { "r_shadow_dlight_size", "256", CVAR_ARCHIVE };
+cvar_t	r_shadow_dlight_distance = { "r_shadow_dlight_distance", "1024", CVAR_ARCHIVE };
+cvar_t	r_shadow_dlight_bias = { "r_shadow_dlight_bias", "0.0025", CVAR_ARCHIVE };
+cvar_t	r_shadow_dlight_pcf_taps = { "r_shadow_dlight_pcf_taps", "4", CVAR_ARCHIVE };
 cvar_t	r_novis = { "r_novis","0",CVAR_ARCHIVE };
 #if defined(USE_SIMD)
 cvar_t	r_simd = { "r_simd","1",CVAR_ARCHIVE };
@@ -3160,6 +3166,10 @@ void R_SetupView (void)
         r_framedata.shadow_debug[1] = r_shadow_debug.value;
         r_framedata.shadow_debug[2] = 0.f;
         r_framedata.shadow_debug[3] = 0.f;
+        r_framedata.shadow_dlight_params[0] = r_shadow_dlight_bias.value;
+        r_framedata.shadow_dlight_params[1] = r_shadow_dlight_pcf_taps.value;
+        r_framedata.shadow_dlight_params[2] = (r_shadows.value > 0.f && r_shadow_dlights.value > 0.f) ? 1.f : 0.f;
+        r_framedata.shadow_dlight_params[3] = 0.f;
 
 	double prev_delta = cl.time - r_prev_frame_time;
 	qboolean prev_valid = r_prev_frame_valid && prev_delta > 0.0;
@@ -4389,6 +4399,7 @@ void R_RenderScene (void)
 {
 	R_SetupScene (); //johnfitz -- this does everything that should be done once per call to RenderScene
 	R_Shadow_SunPass ();
+	R_Shadow_DlightPass ();
 	R_SetupGL ();
 	R_Clear ();
 	

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -88,6 +88,12 @@ extern cvar_t r_shadow_pcf_taps;
 extern cvar_t r_shadow_debug;
 extern cvar_t r_shadow_sun_dir;
 extern cvar_t r_shadow_twosided_mdl;
+extern cvar_t r_shadow_dlights;
+extern cvar_t r_shadow_dlight_max;
+extern cvar_t r_shadow_dlight_size;
+extern cvar_t r_shadow_dlight_distance;
+extern cvar_t r_shadow_dlight_bias;
+extern cvar_t r_shadow_dlight_pcf_taps;
 //johnfitz
 extern cvar_t gl_zfix; // QuakeSpasm z-fighting fix
 extern cvar_t r_alphasort;
@@ -572,6 +578,12 @@ Cvar_RegisterVariable (&r_drawviewmodel);
         Cvar_RegisterVariable (&r_shadow_debug);
         Cvar_RegisterVariable (&r_shadow_sun_dir);
         Cvar_RegisterVariable (&r_shadow_twosided_mdl);
+        Cvar_RegisterVariable (&r_shadow_dlights);
+        Cvar_RegisterVariable (&r_shadow_dlight_max);
+        Cvar_RegisterVariable (&r_shadow_dlight_size);
+        Cvar_RegisterVariable (&r_shadow_dlight_distance);
+        Cvar_RegisterVariable (&r_shadow_dlight_bias);
+        Cvar_RegisterVariable (&r_shadow_dlight_pcf_taps);
 	DLightPool_RegisterCvars ();
         Cvar_RegisterVariable (&r_novis);
 #if defined(USE_SIMD)

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -39,6 +39,8 @@ extern	int glx, gly, glwidth, glheight;
 
 #define BACKFACE_EPSILON	0.01
 
+typedef struct dlight_s dlight_t;
+
 extern vec3_t *r_pointfile;
 
 void R_TimeRefresh_f (void);
@@ -417,6 +419,8 @@ typedef struct gpulight_s {
 
 #define DLIGHT_GPU_MAX 64
 
+#define SHADOW_DLIGHT_MAX 4
+
 typedef struct gpulightbuffer_s {
 	float		lightstyles[MAX_LIGHTSTYLES * 2];
 	gpulight_t	lights[DLIGHT_GPU_MAX];
@@ -442,6 +446,10 @@ typedef struct gpuframedata_s {
         vec4_t          shadow_params; // x: bias, y: normal bias, z: pcf enabled, w: pcf taps
         vec4_t          shadow_debug;  // x: enabled, y: debug mode, zw: unused
         vec4_t          shadow_sun_dir; // xyz: direction, w: unused
+        float           shadow_dlight_viewproj[SHADOW_DLIGHT_MAX][16];
+        vec4_t          shadow_dlight_atlas[SHADOW_DLIGHT_MAX]; // xy: scale, zw: offset
+        vec4_t          shadow_dlight_info[SHADOW_DLIGHT_MAX]; // x: light index, yzw: unused
+        vec4_t          shadow_dlight_params; // x: bias, y: pcf taps, z: enabled, w: unused
         unsigned int    numlights;
         unsigned int    prev_frame_valid;
         unsigned int    _padding1;
@@ -451,6 +459,7 @@ typedef struct gpuframedata_s {
 extern gpulightbuffer_t r_lightbuffer;
 extern gpuframedata_t r_framedata;
 extern float r_lightstyle_framefrac;
+extern dlight_t *r_dlight_sources[DLIGHT_GPU_MAX];
 
 void R_AnimateLight (void);
 void R_MarkSurfaces (void);
@@ -475,8 +484,10 @@ void R_InitShadow (void);
 void R_ShutdownShadow (void);
 void R_ResizeShadowMapIfNeeded (void);
 void R_Shadow_SunPass (void);
+void R_Shadow_DlightPass (void);
 void R_Shadow_DrawDebug (void);
 void R_Shadow_BindShadowMap (GLenum texunit);
+void R_Shadow_BindDlightShadowMap (GLenum texunit);
 
 void R_DrawBrushModels (entity_t **ents, int count);
 void R_DrawBrushModels_Water (entity_t **ents, int count, qboolean translucent);

--- a/Quake/r_shadow.c
+++ b/Quake/r_shadow.c
@@ -20,10 +20,41 @@ extern cvar_t r_shadow_pcf;
 extern cvar_t r_shadow_pcf_taps;
 extern cvar_t r_shadow_debug;
 extern cvar_t r_shadow_sun_dir;
+extern cvar_t r_shadow_dlights;
+extern cvar_t r_shadow_dlight_max;
+extern cvar_t r_shadow_dlight_size;
+extern cvar_t r_shadow_dlight_distance;
+extern cvar_t r_shadow_dlight_bias;
+extern cvar_t r_shadow_dlight_pcf_taps;
+extern dlight_t *r_dlight_sources[DLIGHT_GPU_MAX];
 
 static GLuint shadow_fbo;
 static GLuint shadow_depth_tex;
 static int shadowmap_size;
+static GLuint shadow_dlight_fbo;
+static GLuint shadow_dlight_depth_tex;
+static int shadow_dlight_atlas_size;
+static int shadow_dlight_tile_size;
+static int shadow_dlight_tile_count;
+static int shadow_dlight_selected_count;
+static int shadow_dlight_light_indices[SHADOW_DLIGHT_MAX];
+
+static void R_Shadow_DestroyDlightResources (void)
+{
+	if (shadow_dlight_fbo)
+	{
+		GL_DeleteFramebuffersFunc (1, &shadow_dlight_fbo);
+		shadow_dlight_fbo = 0;
+	}
+	if (shadow_dlight_depth_tex)
+	{
+		GL_DeleteNativeTexture (shadow_dlight_depth_tex);
+		shadow_dlight_depth_tex = 0;
+	}
+	shadow_dlight_atlas_size = 0;
+	shadow_dlight_tile_size = 0;
+	shadow_dlight_tile_count = 0;
+}
 
 static void R_Shadow_OrthoMatrix (float matrix[16], float left, float right, float bottom, float top, float n, float f)
 {
@@ -69,6 +100,7 @@ static void R_Shadow_DestroyResources (void)
 		shadow_depth_tex = 0;
 	}
 	shadowmap_size = 0;
+	R_Shadow_DestroyDlightResources ();
 }
 
 static void R_Shadow_GetSunDirection (vec3_t out_dir)
@@ -230,11 +262,181 @@ static void R_Shadow_BuildViewProj (float out_viewproj[16], vec4_t out_sun_dir)
 	MatrixMultiply (out_viewproj, view);
 }
 
+static void R_Shadow_PerspectiveMatrix (float matrix[16], float fovx, float fovy, float n, float f)
+{
+	const float w = 1.0f / tanf (fovx * 0.5f);
+	const float h = 1.0f / tanf (fovy * 0.5f);
+
+	memset (matrix, 0, 16 * sizeof (float));
+
+	if (gl_clipcontrol_able)
+	{
+		matrix[0 * 4 + 2] = -n / (f - n);
+		matrix[0 * 4 + 3] = 1.f;
+		matrix[1 * 4 + 0] = -w;
+		matrix[2 * 4 + 1] = h;
+		matrix[3 * 4 + 2] = f * n / (f - n);
+	}
+	else
+	{
+		matrix[0 * 4 + 2] = (f + n) / (f - n);
+		matrix[0 * 4 + 3] = 1.f;
+		matrix[1 * 4 + 0] = -w;
+		matrix[2 * 4 + 1] = h;
+		matrix[3 * 4 + 2] = -2.f * f * n / (f - n);
+	}
+}
+
+static void R_Shadow_BuildDlightViewProj (float out_viewproj[16], const vec3_t origin, float radius)
+{
+	vec3_t target;
+	vec3_t forward;
+	vec3_t up = { 0.f, 0.f, 1.f };
+	vec3_t right;
+	vec3_t light_up;
+	float view[16];
+	float proj[16];
+	float znear;
+	float zfar;
+
+	VectorCopy (r_refdef.vieworg, target);
+	VectorSubtract (target, origin, forward);
+	if (VectorNormalize (forward) == 0.f)
+	{
+		forward[0] = 0.f;
+		forward[1] = 0.f;
+		forward[2] = -1.f;
+	}
+
+	if (fabsf (DotProduct (forward, up)) > 0.95f)
+	{
+		up[0] = 0.f;
+		up[1] = 1.f;
+		up[2] = 0.f;
+	}
+
+	CrossProduct (up, forward, right);
+	VectorNormalize (right);
+	CrossProduct (forward, right, light_up);
+	VectorNormalize (light_up);
+
+	memset (view, 0, sizeof (view));
+	view[0] = right[0];
+	view[1] = right[1];
+	view[2] = right[2];
+	view[4] = light_up[0];
+	view[5] = light_up[1];
+	view[6] = light_up[2];
+	view[8] = forward[0];
+	view[9] = forward[1];
+	view[10] = forward[2];
+	view[15] = 1.f;
+	view[12] = -DotProduct (right, origin);
+	view[13] = -DotProduct (light_up, origin);
+	view[14] = -DotProduct (forward, origin);
+
+	znear = 4.f;
+	zfar = q_max (radius, znear + 1.f);
+	R_Shadow_PerspectiveMatrix (proj, DEG2RAD (90.f), DEG2RAD (90.f), znear, zfar);
+
+	memcpy (out_viewproj, proj, sizeof (proj));
+	MatrixMultiply (out_viewproj, view);
+}
+
+static void R_Shadow_ResizeDlightAtlasIfNeeded (void)
+{
+	int max_tiles;
+	int tile_size;
+	int grid;
+	int atlas_size;
+
+	max_tiles = CLAMP (0, (int)r_shadow_dlight_max.value, SHADOW_DLIGHT_MAX);
+	if (r_shadow_dlight_size.value <= 0.f || max_tiles <= 0)
+	{
+		if (shadow_dlight_depth_tex || shadow_dlight_fbo)
+			R_Shadow_DestroyDlightResources ();
+		return;
+	}
+
+	tile_size = (int)r_shadow_dlight_size.value;
+	if (tile_size < 64)
+		tile_size = 64;
+	if (tile_size > gl_max_texture_size)
+		tile_size = gl_max_texture_size;
+
+	grid = 1;
+	while (grid * grid < max_tiles)
+		grid++;
+
+	if (grid < 1)
+		grid = 1;
+
+	atlas_size = tile_size * grid;
+	if (atlas_size > gl_max_texture_size)
+	{
+		tile_size = gl_max_texture_size / grid;
+		if (tile_size < 64)
+			tile_size = 64;
+		atlas_size = tile_size * grid;
+		if (atlas_size > gl_max_texture_size)
+		{
+			grid = 1;
+			atlas_size = tile_size;
+		}
+	}
+
+	if (shadow_dlight_depth_tex && shadow_dlight_fbo &&
+		shadow_dlight_atlas_size == atlas_size &&
+		shadow_dlight_tile_size == tile_size &&
+		shadow_dlight_tile_count == grid * grid)
+		return;
+
+	if (shadow_dlight_depth_tex || shadow_dlight_fbo)
+		R_Shadow_DestroyDlightResources ();
+
+	glGenTextures (1, &shadow_dlight_depth_tex);
+	GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, shadow_dlight_depth_tex);
+	GL_ObjectLabelFunc (GL_TEXTURE, shadow_dlight_depth_tex, -1, "shadowmap dlight depth");
+	GL_TexStorage2DFunc (GL_TEXTURE_2D, 1, GL_DEPTH_COMPONENT24, atlas_size, atlas_size);
+	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
+	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
+	{
+		const float border[4] = { 1.f, 1.f, 1.f, 1.f };
+		glTexParameterfv (GL_TEXTURE_2D, GL_TEXTURE_BORDER_COLOR, border);
+	}
+	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE, GL_NONE);
+	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0);
+
+	GL_GenFramebuffersFunc (1, &shadow_dlight_fbo);
+	GL_BindFramebufferFunc (GL_FRAMEBUFFER, shadow_dlight_fbo);
+	GL_ObjectLabelFunc (GL_FRAMEBUFFER, shadow_dlight_fbo, -1, "shadowmap dlight fbo");
+	GL_FramebufferTexture2DFunc (GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, shadow_dlight_depth_tex, 0);
+	glDrawBuffer (GL_NONE);
+	glReadBuffer (GL_NONE);
+
+	{
+		GLenum status = GL_CheckFramebufferStatusFunc (GL_FRAMEBUFFER);
+		if (status != GL_FRAMEBUFFER_COMPLETE)
+			Sys_Error ("Failed to create dlight shadowmap FBO (status code 0x%X)", status);
+	}
+
+	shadow_dlight_atlas_size = atlas_size;
+	shadow_dlight_tile_size = tile_size;
+	shadow_dlight_tile_count = grid * grid;
+}
 void R_InitShadow (void)
 {
 	shadow_fbo = 0;
 	shadow_depth_tex = 0;
 	shadowmap_size = 0;
+	shadow_dlight_fbo = 0;
+	shadow_dlight_depth_tex = 0;
+	shadow_dlight_atlas_size = 0;
+	shadow_dlight_tile_size = 0;
+	shadow_dlight_tile_count = 0;
+	shadow_dlight_selected_count = 0;
 }
 
 void R_ShutdownShadow (void)
@@ -301,6 +503,14 @@ void R_Shadow_BindShadowMap (GLenum texunit)
 	GL_BindNative (texunit, GL_TEXTURE_2D, shadow_depth_tex);
 }
 
+void R_Shadow_BindDlightShadowMap (GLenum texunit)
+{
+	if (shadow_dlight_depth_tex)
+		GL_BindNative (texunit, GL_TEXTURE_2D, shadow_dlight_depth_tex);
+	else
+		GL_BindNative (texunit, GL_TEXTURE_2D, 0);
+}
+
 void R_Shadow_SunPass (void)
 {
 	qboolean enabled = r_shadows.value > 0.f && r_shadow_sun.value > 0.f;
@@ -321,6 +531,7 @@ void R_Shadow_SunPass (void)
 	r_framedata.shadow_debug[0] = 1.f;
 	VectorCopy (sun_dir, r_framedata.shadow_sun_dir);
 	r_framedata.shadow_sun_dir[3] = 0.f;
+	R_UploadFrameData ();
 
 	GL_BeginGroup ("Shadow map (sun)");
 
@@ -347,18 +558,182 @@ void R_Shadow_SunPass (void)
 	GL_EndGroup ();
 }
 
+void R_Shadow_DlightPass (void)
+{
+	qboolean enabled = r_shadows.value > 0.f && r_shadow_dlights.value > 0.f;
+	float sun_viewproj[16];
+	int max_tiles;
+	int grid;
+	int tiles_used = 0;
+
+	shadow_dlight_selected_count = 0;
+
+	for (int i = 0; i < SHADOW_DLIGHT_MAX; ++i)
+	{
+		IdentityMatrix (r_framedata.shadow_dlight_viewproj[i]);
+		r_framedata.shadow_dlight_atlas[i][0] = 0.f;
+		r_framedata.shadow_dlight_atlas[i][1] = 0.f;
+		r_framedata.shadow_dlight_atlas[i][2] = 0.f;
+		r_framedata.shadow_dlight_atlas[i][3] = 0.f;
+		r_framedata.shadow_dlight_info[i][0] = -1.f;
+		r_framedata.shadow_dlight_info[i][1] = 0.f;
+		r_framedata.shadow_dlight_info[i][2] = 0.f;
+		r_framedata.shadow_dlight_info[i][3] = 0.f;
+		shadow_dlight_light_indices[i] = -1;
+	}
+
+	if (!enabled || !glprogs.shadow_depth)
+		return;
+
+	R_Shadow_ResizeDlightAtlasIfNeeded ();
+	if (!shadow_dlight_depth_tex || !shadow_dlight_fbo)
+		return;
+
+	max_tiles = CLAMP (0, (int)r_shadow_dlight_max.value, SHADOW_DLIGHT_MAX);
+	if (shadow_dlight_tile_count > 0)
+		max_tiles = q_min (max_tiles, shadow_dlight_tile_count);
+	if (max_tiles <= 0)
+		return;
+
+	if (r_framedata.numlights == 0)
+		return;
+
+	{
+		float scores[SHADOW_DLIGHT_MAX];
+		for (int i = 0; i < SHADOW_DLIGHT_MAX; ++i)
+			scores[i] = -FLT_MAX;
+
+		for (unsigned int i = 0; i < r_framedata.numlights; ++i)
+		{
+			dlight_t *dl = r_dlight_sources[i];
+			const gpulight_t *glight = &r_lightbuffer.lights[i];
+			float dist;
+			float score;
+			vec3_t delta;
+
+			if (!dl)
+				continue;
+
+			VectorSubtract (glight->pos, r_refdef.vieworg, delta);
+			dist = VectorLength (delta);
+			if (r_shadow_dlight_distance.value > 0.f && dist > r_shadow_dlight_distance.value + glight->radius)
+				continue;
+
+			score = (glight->radius * (glight->color[0] + glight->color[1] + glight->color[2])) / (1.f + dist);
+
+			for (int slot = 0; slot < max_tiles; ++slot)
+			{
+				if (score > scores[slot])
+				{
+					for (int move = max_tiles - 1; move > slot; --move)
+					{
+						scores[move] = scores[move - 1];
+						shadow_dlight_light_indices[move] = shadow_dlight_light_indices[move - 1];
+					}
+					scores[slot] = score;
+					shadow_dlight_light_indices[slot] = (int)i;
+					break;
+				}
+			}
+		}
+	}
+
+	for (int i = 0; i < max_tiles; ++i)
+	{
+		if (shadow_dlight_light_indices[i] >= 0)
+			tiles_used++;
+	}
+	shadow_dlight_selected_count = tiles_used;
+
+	if (!tiles_used)
+		return;
+
+	memcpy (sun_viewproj, r_framedata.shadow_viewproj, sizeof (sun_viewproj));
+
+	GL_BeginGroup ("Shadow map (dlights)");
+
+	GL_BindFramebufferFunc (GL_FRAMEBUFFER, shadow_dlight_fbo);
+	glDrawBuffer (GL_NONE);
+	glReadBuffer (GL_NONE);
+	glEnable (GL_SCISSOR_TEST);
+
+	grid = shadow_dlight_atlas_size / shadow_dlight_tile_size;
+	if (grid < 1)
+		grid = 1;
+
+	for (int i = 0; i < max_tiles; ++i)
+	{
+		int light_index = shadow_dlight_light_indices[i];
+		if (light_index < 0)
+			continue;
+
+		const gpulight_t *glight = &r_lightbuffer.lights[light_index];
+		float viewproj[16];
+		int tile_x = i % grid;
+		int tile_y = i / grid;
+		float scale = (float)shadow_dlight_tile_size / (float)shadow_dlight_atlas_size;
+		float offset_x = tile_x * scale;
+		float offset_y = tile_y * scale;
+
+		R_Shadow_BuildDlightViewProj (viewproj, glight->pos, glight->radius);
+		memcpy (r_framedata.shadow_dlight_viewproj[i], viewproj, sizeof (viewproj));
+		r_framedata.shadow_dlight_atlas[i][0] = scale;
+		r_framedata.shadow_dlight_atlas[i][1] = scale;
+		r_framedata.shadow_dlight_atlas[i][2] = offset_x;
+		r_framedata.shadow_dlight_atlas[i][3] = offset_y;
+		r_framedata.shadow_dlight_info[i][0] = (float)light_index;
+
+		memcpy (r_framedata.shadow_viewproj, viewproj, sizeof (viewproj));
+		R_UploadFrameData ();
+
+		glViewport (tile_x * shadow_dlight_tile_size, tile_y * shadow_dlight_tile_size,
+			shadow_dlight_tile_size, shadow_dlight_tile_size);
+		glScissor (tile_x * shadow_dlight_tile_size, tile_y * shadow_dlight_tile_size,
+			shadow_dlight_tile_size, shadow_dlight_tile_size);
+		glClear (GL_DEPTH_BUFFER_BIT);
+
+		GL_UseProgram (glprogs.shadow_depth);
+		GL_SetState (GLS_BLEND_OPAQUE | GLS_CULL_FRONT | GLS_ATTRIBS (6));
+
+		{
+			int count = 0;
+			entity_t **ents = R_GetVisEntities (mod_brush, false, &count);
+			R_DrawBrushModels_Shadow (ents, count);
+		}
+		{
+			int count = 0;
+			entity_t **ents = R_GetVisEntities (mod_alias, false, &count);
+			R_DrawAliasModels_Shadow (ents, count);
+		}
+	}
+
+	glDisable (GL_SCISSOR_TEST);
+
+	memcpy (r_framedata.shadow_viewproj, sun_viewproj, sizeof (sun_viewproj));
+
+	GL_EndGroup ();
+}
+
 void R_Shadow_DrawDebug (void)
 {
-	if ((int)r_shadow_debug.value != 1)
+	int mode = (int)r_shadow_debug.value;
+	if (mode != 1 && mode != 4)
 		return;
-	if (!shadow_depth_tex || !glprogs.shadow_debug)
+	if (!glprogs.shadow_debug)
+		return;
+	if (mode == 1 && !shadow_depth_tex)
+		return;
+	if (mode == 4 && !shadow_dlight_depth_tex)
 		return;
 
 	GL_BeginGroup ("Shadow map debug");
 
 	GL_UseProgram (glprogs.shadow_debug);
 	GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
-	GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, shadow_depth_tex);
+	if (mode == 1)
+		GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, shadow_depth_tex);
+	else
+		GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, shadow_dlight_depth_tex);
 	glDrawArrays (GL_TRIANGLES, 0, 3);
 
 	GL_EndGroup ();

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -1436,6 +1436,10 @@ GL_Bind (GL_TEXTURE2, r_fullbright_cheatsafe ? greytexture : lightmap_texture);
 GL_Bind (GL_TEXTURE3, (r_lightingdir.value > 0.f && lightmap_dir_texture) ? lightmap_dir_texture : greytexture);
 R_Shadow_BindShadowMap (GL_TEXTURE5);
 }
+else if (pass == BP_DLIGHT_SOLID || pass == BP_DLIGHT_ALPHA)
+{
+R_Shadow_BindDlightShadowMap (GL_TEXTURE5);
+}
 else if (pass == BP_SKYCUBEMAP)
 GL_Bind (GL_TEXTURE2, skybox->cubemap);
 

--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -101,6 +101,7 @@ layout(binding=1) uniform sampler2D FullbrightTex;
 layout(binding=2) uniform sampler2D EmissiveTex;
 layout(binding=5) uniform sampler2D ShadowMap;
 
+#define SHADOW_SUN 1
 #include "shadow_sample.glsl"
 
 #if MODE == 2

--- a/Quake/shaders/frame_uniforms.glsl
+++ b/Quake/shaders/frame_uniforms.glsl
@@ -1,6 +1,8 @@
 #ifndef FRAME_UNIFORMS_GLSL
 #define FRAME_UNIFORMS_GLSL
 
+#define SHADOW_DLIGHT_MAX 4
+
 layout(std140, binding=0) uniform FrameDataUBO
 {
         mat4    ViewProj;
@@ -28,6 +30,10 @@ layout(std140, binding=0) uniform FrameDataUBO
         vec4    ShadowParams;
         vec4    ShadowDebug;
         vec4    ShadowSunDir;
+        mat4    ShadowDlightViewProj[SHADOW_DLIGHT_MAX];
+        vec4    ShadowDlightAtlas[SHADOW_DLIGHT_MAX];
+        vec4    ShadowDlightInfo[SHADOW_DLIGHT_MAX];
+        vec4    ShadowDlightParams;
         uint    NumLights;
         uint    PrevFrameValid;
         uint    _Pad1;

--- a/Quake/shaders/shadow_sample.glsl
+++ b/Quake/shaders/shadow_sample.glsl
@@ -1,6 +1,7 @@
 #ifndef SHADOW_SAMPLE_GLSL
 #define SHADOW_SAMPLE_GLSL
 
+#ifdef SHADOW_SUN
 float ShadowCompare(float depth, float reference, float bias)
 {
 #if REVERSED_Z
@@ -99,5 +100,131 @@ float ShadowVisibility(vec3 world_pos, vec3 normal, out float in_range)
 
 	return ShadowSampleRaw(uv, reference, bias);
 }
+#endif
+
+#ifdef SHADOW_DLIGHT
+float ShadowCompare(float depth, float reference, float bias)
+{
+#if REVERSED_Z
+	return (reference >= (depth - bias)) ? 1.0 : 0.0;
+#else
+	return (reference <= (depth + bias)) ? 1.0 : 0.0;
+#endif
+}
+
+float ShadowSampleRawDlight(vec2 uv, float reference, float bias)
+{
+	float depth = texture(ShadowDlightMap, uv).r;
+	return ShadowCompare(depth, reference, bias);
+}
+
+float ShadowSamplePCFDlight(vec2 uv, float reference, float bias, int taps)
+{
+	vec2 texel = 1.0 / vec2(textureSize(ShadowDlightMap, 0));
+	float sum = 0.0;
+	int count = 0;
+
+	if (taps <= 2)
+	{
+		vec2 offsets[4] = vec2[4](
+			vec2(-0.5, -0.5),
+			vec2(0.5, -0.5),
+			vec2(-0.5, 0.5),
+			vec2(0.5, 0.5)
+		);
+		for (int i = 0; i < 4; ++i)
+		{
+			sum += ShadowSampleRawDlight(uv + offsets[i] * texel, reference, bias);
+		}
+		return sum * 0.25;
+	}
+
+	if (taps <= 4)
+	{
+		for (int y = -1; y <= 1; ++y)
+		{
+			for (int x = -1; x <= 1; ++x)
+			{
+				sum += ShadowSampleRawDlight(uv + vec2(x, y) * texel, reference, bias);
+				++count;
+			}
+		}
+		return sum / float(count);
+	}
+
+	for (int y = -2; y <= 2; ++y)
+	{
+		for (int x = -2; x <= 2; ++x)
+		{
+			sum += ShadowSampleRawDlight(uv + vec2(x, y) * texel, reference, bias);
+			++count;
+		}
+	}
+
+	return sum / float(count);
+}
+
+float ShadowVisibilityDlight(vec3 world_pos, vec3 normal, vec3 light_pos, uint light_index, out float in_range)
+{
+	if (ShadowDlightParams.z < 0.5)
+	{
+		in_range = 1.0;
+		return 1.0;
+	}
+
+	int shadow_index = -1;
+	for (int i = 0; i < SHADOW_DLIGHT_MAX; ++i)
+	{
+		if (ShadowDlightInfo[i].x < 0.0)
+			continue;
+		int idx = int(ShadowDlightInfo[i].x + 0.5);
+		if (idx == int(light_index))
+		{
+			shadow_index = i;
+			break;
+		}
+	}
+
+	if (shadow_index < 0)
+	{
+		in_range = 0.0;
+		return 1.0;
+	}
+
+	vec4 clip = ShadowDlightViewProj[shadow_index] * vec4(world_pos, 1.0);
+	if (clip.w <= 0.0)
+	{
+		in_range = 0.0;
+		return 1.0;
+	}
+
+	vec3 proj = clip.xyz / clip.w;
+	vec2 uv = proj.xy * 0.5 + 0.5;
+#if REVERSED_Z
+	float reference = proj.z;
+#else
+	float reference = proj.z * 0.5 + 0.5;
+#endif
+
+	vec4 atlas = ShadowDlightAtlas[shadow_index];
+	uv = uv * atlas.xy + atlas.zw;
+
+	bool inside = all(greaterThanEqual(vec3(uv, reference), vec3(0.0))) &&
+		all(lessThanEqual(vec3(uv, reference), vec3(1.0)));
+	in_range = inside ? 1.0 : 0.0;
+	if (!inside)
+		return 1.0;
+
+	vec3 light_dir = normalize(light_pos - world_pos);
+	float ndotl = clamp(dot(normal, light_dir), 0.0, 1.0);
+	float bias = ShadowDlightParams.x * (1.0 - ndotl);
+
+	int taps = int(ShadowDlightParams.y + 0.5);
+	if (taps > 0)
+		return ShadowSamplePCFDlight(uv, reference, bias, taps);
+
+	return ShadowSampleRawDlight(uv, reference, bias);
+}
+#endif
 
 #endif

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -9,6 +9,7 @@ layout(binding=2) uniform sampler2D LMTex;
 layout(binding=3) uniform sampler2D LMTexDir;
 layout(binding=5) uniform sampler2D ShadowMap;
 #include "frame_uniforms.glsl"
+#define SHADOW_SUN 1
 #include "shadow_sample.glsl"
 
 vec3 ApplyFog(vec3 clr, vec3 p)

--- a/Quake/shaders/world_dlight.frag
+++ b/Quake/shaders/world_dlight.frag
@@ -5,8 +5,11 @@ layout(binding=0) uniform sampler2D Tex;
 #endif
 layout(binding=2) uniform sampler2D LMTex; // unused, kept for binding slot consistency
 layout(binding=3) uniform sampler2D LMTexDir; // unused
+layout(binding=5) uniform sampler2D ShadowDlightMap;
 
 #include "frame_uniforms.glsl"
+#define SHADOW_DLIGHT 1
+#include "shadow_sample.glsl"
 
 #ifndef ALPHATEST
 #define ALPHATEST 0
@@ -164,7 +167,9 @@ void main()
                                                 ndotl = mix(1.0, ndotl_raw, ndotl_mix);
                                         }
 
-                                        vec3 light_contrib = shaped * ndotl * l.color * dynamic_light_noise;
+                                        float shadow_range = 1.0;
+                                        float shadow_term = ShadowVisibilityDlight(in_pos, surface_normal, l.origin, ofs + uint(j), shadow_range);
+                                        vec3 light_contrib = shaped * ndotl * shadow_term * l.color * dynamic_light_noise;
                                         dynamic_light += light_contrib;
                                 }
                         }

--- a/Quake/shaders/world_dlight_hybrid.frag
+++ b/Quake/shaders/world_dlight_hybrid.frag
@@ -5,8 +5,11 @@ layout(binding=0) uniform sampler2D Tex;
 #endif
 layout(binding=2) uniform sampler2D LMTex; // unused, kept for binding slot consistency
 layout(binding=3) uniform sampler2D LMTexDir; // unused
+layout(binding=5) uniform sampler2D ShadowDlightMap;
 
 #include "frame_uniforms.glsl"
+#define SHADOW_DLIGHT 1
+#include "shadow_sample.glsl"
 
 #ifndef ALPHATEST
 #define ALPHATEST 0
@@ -165,7 +168,9 @@ void main()
                                                 ndotl = mix(1.0, ndotl_raw, ndotl_mix);
                                         }
 
-                                        vec3 light_contrib = shaped * ndotl * l.color * dynamic_light_noise;
+                                        float shadow_range = 1.0;
+                                        float shadow_term = ShadowVisibilityDlight(in_pos, surface_normal, l.origin, ofs + uint(j), shadow_range);
+                                        vec3 light_contrib = shaped * ndotl * shadow_term * l.color * dynamic_light_noise;
                                         dynamic_light += light_contrib;
                                 }
                         }


### PR DESCRIPTION
### Motivation

- Prevent shader compilation errors caused by references to `ShadowMap` when compiling shaders that only need dlight shadow sampling.
- Keep sun shadow sampling logic isolated so dlight-only shaders do not require the sun shadow sampler or symbols.
- Ensure the dlight shadow sampling path provides its own compare and sampling helpers.

### Description

- Guarded the sun shadow sampling code in `shaders/shadow_sample.glsl` behind `#ifdef SHADOW_SUN` and moved the sun `ShadowCompare`/sampling functions into that block.
- Added a dlight-specific `ShadowCompare` and dlight sampling helpers in `shaders/shadow_sample.glsl` and exposed `ShadowDlightMap` usage via `SHADOW_DLIGHT` for the dlight fragment shaders.
- Enabled `SHADOW_SUN` in `shaders/world.frag` and `shaders/alias.frag`, and enabled `SHADOW_DLIGHT` plus bound `ShadowDlightMap` in `shaders/world_dlight.frag` and `shaders/world_dlight_hybrid.frag` to select the appropriate sampling code per shader.

### Testing

- No automated tests were run for these changes.
- The change was committed and the shader source files were updated to fix the reported compile-time undefined symbol errors during OpenGL shader compilation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69568040e0a8832ea1de4d99ef7ca075)