### PR TITLE
Add lightgrid-aware shadow mode

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -270,6 +270,8 @@ cvar_t	r_shadow_dlight_size = { "r_shadow_dlight_size", "256", CVAR_ARCHIVE };
 cvar_t	r_shadow_dlight_distance = { "r_shadow_dlight_distance", "1024", CVAR_ARCHIVE };
 cvar_t	r_shadow_dlight_bias = { "r_shadow_dlight_bias", "0.0025", CVAR_ARCHIVE };
 cvar_t	r_shadow_dlight_pcf_taps = { "r_shadow_dlight_pcf_taps", "4", CVAR_ARCHIVE };
+cvar_t	r_shadow_lightgrid = { "r_shadow_lightgrid", "0", CVAR_ARCHIVE };
+cvar_t	r_shadow_lightgrid_mode = { "r_shadow_lightgrid_mode", "1", CVAR_ARCHIVE };
 cvar_t	r_novis = { "r_novis","0",CVAR_ARCHIVE };
 #if defined(USE_SIMD)
 cvar_t	r_simd = { "r_simd","1",CVAR_ARCHIVE };
@@ -3144,7 +3146,10 @@ void R_SetupView (void)
         r_framedata.lightmap_params[3] = r_lightstyle_framefrac;
         r_framedata.lightgrid_params[0] = R_LightgridEnabled () ? 1.f : 0.f;
         r_framedata.lightgrid_params[1] = (r_lightgrid_debug.value >= 2.f) ? 1.f : 0.f;
-        r_framedata.lightgrid_params[2] = 0.f;
+        r_framedata.lightgrid_params[2] =
+                (r_shadows.value > 0.f && r_shadow_sun.value > 0.f && r_shadow_lightgrid.value > 0.f)
+                ? CLAMP (0.f, r_shadow_lightgrid_mode.value, 2.f)
+                : 0.f;
         r_framedata.lightgrid_params[3] = 0.f;
         r_framedata.dlight_params[0] = r_dlight_style.value > 0.f ? 1.f : 0.f;
         r_framedata.dlight_params[1] = r_dlight_debug.value > 0.f ? 1.f : 0.f;

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -94,6 +94,8 @@ extern cvar_t r_shadow_dlight_size;
 extern cvar_t r_shadow_dlight_distance;
 extern cvar_t r_shadow_dlight_bias;
 extern cvar_t r_shadow_dlight_pcf_taps;
+extern cvar_t r_shadow_lightgrid;
+extern cvar_t r_shadow_lightgrid_mode;
 //johnfitz
 extern cvar_t gl_zfix; // QuakeSpasm z-fighting fix
 extern cvar_t r_alphasort;
@@ -584,6 +586,8 @@ Cvar_RegisterVariable (&r_drawviewmodel);
         Cvar_RegisterVariable (&r_shadow_dlight_distance);
         Cvar_RegisterVariable (&r_shadow_dlight_bias);
         Cvar_RegisterVariable (&r_shadow_dlight_pcf_taps);
+        Cvar_RegisterVariable (&r_shadow_lightgrid);
+        Cvar_RegisterVariable (&r_shadow_lightgrid_mode);
 	DLightPool_RegisterCvars ();
         Cvar_RegisterVariable (&r_novis);
 #if defined(USE_SIMD)

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -381,8 +381,6 @@ void main()
 			return;
 		}
 
-		static_light *= lightgrid;
-
 		if (dlight_debug)
 		{
 			static_light = vec3(0.0);
@@ -400,7 +398,8 @@ void main()
 
 		if (LightmapParams.x > 0.5)
 		{
-			OUT_COLOR = vec4(clamp(static_light, 0.0, 1.0), 1.0);
+			vec3 static_light_debug = static_light * lightgrid;
+			OUT_COLOR = vec4(clamp(static_light_debug, 0.0, 1.0), 1.0);
 #if !OIT
 			out_velocity = vec4(0.0);
 #endif
@@ -427,6 +426,8 @@ void main()
 
 		float shadow_range = 1.0;
 		float shadow_term = ShadowVisibility(in_pos, surface_normal, shadow_range);
+		bool shadow_enabled = ShadowDebug.x > 0.5;
+		bool lightgrid_shadow = LightgridParams.z > 0.5 && LightgridParams.x > 0.5;
 
 		if (ShadowDebug.x > 0.5 && ShadowDebug.y > 1.5)
 		{
@@ -438,10 +439,23 @@ void main()
 			return;
 		}
 
-		vec3 total_light = clamp(static_light, 0.0, 1.0);
+		vec3 total_light;
+		vec3 clamped_static = clamp(static_light, 0.0, 1.0);
 
-		if (ShadowDebug.x > 0.5)
-			total_light *= shadow_term;
+		if (lightgrid_shadow)
+		{
+			vec3 ambient = clamped_static * lightgrid;
+			vec3 direct = clamped_static - ambient;
+			float shadow_scale = shadow_enabled ? shadow_term : 1.0;
+			total_light = ambient + direct * shadow_scale;
+		}
+		else
+		{
+			total_light = clamped_static;
+			if (shadow_enabled)
+				total_light *= shadow_term;
+			total_light *= lightgrid;
+		}
 	
 	// View direction
 	vec3 to_eye = EyePos - in_pos;


### PR DESCRIPTION
### Motivation
- Provide an optional, cheap interaction between the shadow system and the existing lightgrid so directional shadows can attenuate direct lighting derived from the grid.
- Preserve the lightgrid's ambient/probe contribution while allowing the sun shadow to affect direct illumination to reduce incorrect darkening.
- Expose run-time controls to enable/choose a lightgrid-shadowing mode without changing existing shadow behavior by default.
- Keep changes minimal and localized to frame data plumbing and the world shader.

### Description
- Added two new CVARs: `r_shadow_lightgrid` and `r_shadow_lightgrid_mode`, and exposed them in `gl_rmain.c` and `gl_rmisc.c` so they are registered and available at runtime.
- Packed the chosen lightgrid-shadow mode into `r_framedata.lightgrid_params[2]` when shadows and sun shadowing are active, clamped to valid mode range.
- Updated `Quake/shaders/world.frag` to treat the lightgrid contribution as ambient and split static (lightmap) lighting into ambient vs direct parts, applying shadow scaling only to the direct component when the lightgrid-shadow mode is enabled.
- Added guards so lightgrid-shadowing only applies if the grid is sampled and shadow debug/enable flags indicate shadowing is active, with debug-safe fallbacks.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69568b8eb018832eac5bbe096933bc07)