### PR TITLE
Fix shadow pass depth state and scissor handling

### DIFF
--- a/Quake/r_shadow.c
+++ b/Quake/r_shadow.c
@@ -636,12 +636,11 @@ void R_Shadow_SunPass (void)
 	glViewport (0, 0, shadowmap_size, shadowmap_size);
 	glDrawBuffer (GL_NONE);
 	glReadBuffer (GL_NONE);
-	if (r_shadowmap_force_disable_scissor.value > 0.f)
-		glDisable (GL_SCISSOR_TEST);
+	glDisable (GL_SCISSOR_TEST);
 	glColorMask (GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
 	glDepthMask (GL_TRUE);
 	glEnable (GL_DEPTH_TEST);
-	glDepthFunc (gl_clipcontrol_able ? GL_GEQUAL : GL_LEQUAL);
+	glDepthFunc (GL_LEQUAL);
 
 	GL_UseProgram (glprogs.shadow_depth);
 	GL_SetState (GLS_BLEND_OPAQUE |
@@ -792,11 +791,11 @@ void R_Shadow_DlightPass (void)
 	GL_BindFramebufferFunc (GL_FRAMEBUFFER, shadow_dlight_fbo);
 	glDrawBuffer (GL_NONE);
 	glReadBuffer (GL_NONE);
-	glEnable (GL_SCISSOR_TEST);
+	glDisable (GL_SCISSOR_TEST);
 	glColorMask (GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
 	glDepthMask (GL_TRUE);
 	glEnable (GL_DEPTH_TEST);
-	glDepthFunc (gl_clipcontrol_able ? GL_GEQUAL : GL_LEQUAL);
+	glDepthFunc (GL_LEQUAL);
 
 	grid = shadow_dlight_atlas_size / shadow_dlight_tile_size;
 	if (grid < 1)
@@ -827,6 +826,7 @@ void R_Shadow_DlightPass (void)
 		memcpy (r_framedata.shadow_viewproj, viewproj, sizeof (viewproj));
 		R_UploadFrameData ();
 
+		glEnable (GL_SCISSOR_TEST);
 		glViewport (tile_x * shadow_dlight_tile_size, tile_y * shadow_dlight_tile_size,
 			shadow_dlight_tile_size, shadow_dlight_tile_size);
 		glScissor (tile_x * shadow_dlight_tile_size, tile_y * shadow_dlight_tile_size,


### PR DESCRIPTION
### Motivation

- Ensure the shadow map render passes write depth reliably by making the depth test and scissor behavior explicit. 
- Remove conditional/implicit scissor behavior that could leave the shadow FBO with scissor enabled and prevent full-tile depth writes. 
- Use a consistent depth function for shadow rendering so depth comparisons are stable across paths. 
- Keep prior GL state saved and restored around the shadow passes to avoid side effects on the rest of the renderer.

### Description

- In `R_Shadow_SunPass` unconditionally call `glDisable(GL_SCISSOR_TEST)` and set `glDepthFunc(GL_LEQUAL)` before drawing the shadow FBO. 
- In `R_Shadow_DlightPass` disable scissor at the FBO setup, set `glDepthFunc(GL_LEQUAL)`, and re-enable scissor per tile immediately before each tile's `glViewport`/`glScissor` and draw. 
- Preserve the use of `R_Shadow_SaveState` and `R_Shadow_RestoreState` so the previous framebuffer, viewport, scissor, color/depth masks and depth test state are restored after the shadow passes. 
- Changes are limited to `Quake/r_shadow.c` and focus on explicit GL state for shadow map rendering.

### Testing

- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695695295fa8832ea698bd8300ebd22c)