### PR TITLE
Fix shadow compare depth bias in sampling

### DIFF
--- a/Quake/shaders/shadow_sample.glsl
+++ b/Quake/shaders/shadow_sample.glsl
@@ -28,11 +28,7 @@ void ShadowCoord(vec3 world_pos, out vec2 uv, out float reference, out float in_
 
 float ShadowSampleRaw(vec2 uv, float reference, float bias)
 {
-#if REVERSED_Z
-	float compare_depth = reference + bias;
-#else
 	float compare_depth = reference - bias;
-#endif
 	return texture(ShadowMap, vec3(uv, compare_depth));
 }
 
@@ -138,11 +134,7 @@ vec3 ShadowDebugColor(vec3 world_pos, float shadow_term)
 #ifdef SHADOW_DLIGHT
 float ShadowSampleRawDlight(vec2 uv, float reference, float bias)
 {
-#if REVERSED_Z
-	float compare_depth = reference + bias;
-#else
 	float compare_depth = reference - bias;
-#endif
 	return texture(ShadowDlightMap, vec3(uv, compare_depth));
 }
 


### PR DESCRIPTION
### Motivation
- Fix incorrect compare depth bias handling that could produce shadow artifacts under different Z conventions.
- Ensure the same bias sign is applied for both sun and dynamic light shadow maps.
- Make sampling behavior predictable for the `sampler2DShadow` lookups used elsewhere in the shaders.

### Description
- Removed the `#if REVERSED_Z` branches in `ShadowSampleRaw` and `ShadowSampleRawDlight` so `compare_depth = reference - bias` is always used.
- Kept sampling calls as `texture(ShadowMap, vec3(uv, compare_depth))` and `texture(ShadowDlightMap, vec3(uv, compare_depth))` to preserve `sampler2DShadow` usage.
- Change is localized to `Quake/shaders/shadow_sample.glsl`.

### Testing
- No automated tests were run for this change.
- Shader compilation and runtime validation were not performed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69569816c8f0832e967933b0a5690cea)