### PR TITLE
Fix alias shadow casting and receiving

### DIFF
--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -502,6 +502,8 @@ void R_DrawBrushModels_SkyStencil (entity_t **ents, int count);
 void R_DrawBrushModels_Shadow (entity_t **ents, int count);
 void R_DrawAliasModels (entity_t **ents, int count);
 void R_DrawAliasModels_Shadow (entity_t **ents, int count);
+void R_DrawAliasShadow (entity_t *e);
+void R_FlushAliasShadows (void);
 void R_DrawSpriteModels (entity_t **ents, int count);
 void R_DrawBrushModels_ShowTris (entity_t **ents, int count);
 void R_DrawAliasModels_ShowTris (entity_t **ents, int count);

--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -79,6 +79,22 @@ typedef struct aliasinstance_s {
 #define ALIAS_INSTANCE_FLAG_VIEWMODEL      (1 << 1)
 #define ALIAS_INSTANCE_FLAG_LIGHTNING      (1 << 2)
 
+static int R_Alias_InstanceFlags (const entity_t *e)
+{
+	int flags = ALIAS_INSTANCE_FLAG_NONE;
+
+	if (!e || !e->model)
+		return flags;
+
+	if (e == &cl.viewent)
+		flags |= ALIAS_INSTANCE_FLAG_NO_MOTION_BLUR | ALIAS_INSTANCE_FLAG_VIEWMODEL;
+
+	if (!Q_strncmp (e->model->name, "progs/bolt", 10))
+		flags |= ALIAS_INSTANCE_FLAG_LIGHTNING;
+
+	return flags;
+}
+
 struct ibuf_s {
 	int			count;
 	entity_t	*ent;
@@ -703,7 +719,7 @@ static void R_FlushAliasInstances_Shadow (void)
 	GL_UseProgram (glprogs.shadow_depth_alias[md5]);
 
 	if (md5)
-		state = GLS_ATTRIBS(5);
+		state = GLS_ATTRIBS(3);
 	else
 		state = GLS_ATTRIBS(1);
 
@@ -741,10 +757,8 @@ static void R_FlushAliasInstances_Shadow (void)
 		if (md5)
 		{
 			GL_VertexAttribPointerFunc  (0, 3, GL_FLOAT,			GL_FALSE, sizeof (iqmvert_t), (void *) (hdr->vbovertofs + offsetof (iqmvert_t, xyz)));
-			GL_VertexAttribPointerFunc  (1, 4, GL_BYTE,				GL_TRUE,  sizeof (iqmvert_t), (void *) (hdr->vbovertofs + offsetof (iqmvert_t, norm)));
-			GL_VertexAttribPointerFunc  (2, 2, GL_FLOAT,			GL_FALSE, sizeof (iqmvert_t), (void *) (hdr->vbovertofs + offsetof (iqmvert_t, st)));
-			GL_VertexAttribPointerFunc  (3, 4, GL_UNSIGNED_BYTE,	GL_TRUE,  sizeof (iqmvert_t), (void *) (hdr->vbovertofs + offsetof (iqmvert_t, weight)));
-			GL_VertexAttribIPointerFunc (4, 4, GL_UNSIGNED_BYTE,	          sizeof (iqmvert_t), (void *) (hdr->vbovertofs + offsetof (iqmvert_t, idx)));
+			GL_VertexAttribPointerFunc  (1, 4, GL_UNSIGNED_BYTE,	GL_TRUE,  sizeof (iqmvert_t), (void *) (hdr->vbovertofs + offsetof (iqmvert_t, weight)));
+			GL_VertexAttribIPointerFunc (2, 4, GL_UNSIGNED_BYTE,	          sizeof (iqmvert_t), (void *) (hdr->vbovertofs + offsetof (iqmvert_t, idx)));
 
 			buffers[1] = model->meshvbo;
 			offsets[1] = hdr->vboposeofs;
@@ -891,7 +905,7 @@ static void R_DrawAliasModel_Real (entity_t *e, qboolean showtris)
 		ibuf.ent = e;
 
 	instance = &ibuf.inst[ibuf.count++];
-	instance->flags = ALIAS_INSTANCE_FLAG_NONE;
+	instance->flags = R_Alias_InstanceFlags (e);
 
 	{
 		float prev_model_matrix[16];
@@ -935,10 +949,6 @@ static void R_DrawAliasModel_Real (entity_t *e, qboolean showtris)
         VectorCopy (lightcolor, instance->lightcolor);
         VectorCopy (e->lightcache.dlightcolor, instance->dlightcolor);
         instance->alpha = entalpha;
-        if (e == &cl.viewent)
-                instance->flags |= ALIAS_INSTANCE_FLAG_NO_MOTION_BLUR | ALIAS_INSTANCE_FLAG_VIEWMODEL;
-if (!Q_strncmp (e->model->name, "progs/bolt", 10))
-                instance->flags |= ALIAS_INSTANCE_FLAG_LIGHTNING;
         instance->pose1 = lerpdata.pose1;
         instance->pose2 = lerpdata.pose2;
         instance->blend = lerpdata.blend;
@@ -971,7 +981,7 @@ static void R_DrawAliasModel_Shadow_Real (entity_t *e)
 	if (!e || !e->model)
 		return;
 
-	if (e == &cl.viewent)
+	if (R_Alias_InstanceFlags (e) & ALIAS_INSTANCE_FLAG_VIEWMODEL)
 		return;
 
 	if (e->model->flags & MOD_NOSHADOW)
@@ -1040,6 +1050,16 @@ void R_DrawAliasModels (entity_t **ents, int count)
         R_FlushAliasInstances (false);
 }
 
+void R_DrawAliasShadow (entity_t *e)
+{
+	R_DrawAliasModel_Shadow_Real (e);
+}
+
+void R_FlushAliasShadows (void)
+{
+	R_FlushAliasInstances_Shadow ();
+}
+
 /*
 =================
 R_DrawAliasModels_Shadow
@@ -1049,8 +1069,8 @@ void R_DrawAliasModels_Shadow (entity_t **ents, int count)
 {
 	int i;
 	for (i = 0; i < count; i++)
-		R_DrawAliasModel_Shadow_Real (ents[i]);
-	R_FlushAliasInstances_Shadow ();
+		R_DrawAliasShadow (ents[i]);
+	R_FlushAliasShadows ();
 }
 
 /*

--- a/Quake/r_shadow.c
+++ b/Quake/r_shadow.c
@@ -612,7 +612,13 @@ void R_Shadow_SunPass (void)
 	{
 		int count = 0;
 		entity_t **ents = R_GetVisEntities (mod_alias, false, &count);
-		R_DrawAliasModels_Shadow (ents, count);
+		for (int i = 0; i < count; ++i)
+		{
+			entity_t *ent = ents[i];
+			if (ent && ent->model && ent->model->type == mod_alias)
+				R_DrawAliasShadow (ent);
+		}
+		R_FlushAliasShadows ();
 	}
 
 	R_Shadow_RestoreState (&prev_state);
@@ -802,7 +808,13 @@ void R_Shadow_DlightPass (void)
 		{
 			int count = 0;
 			entity_t **ents = R_GetVisEntities (mod_alias, false, &count);
-			R_DrawAliasModels_Shadow (ents, count);
+			for (int i = 0; i < count; ++i)
+			{
+				entity_t *ent = ents[i];
+				if (ent && ent->model && ent->model->type == mod_alias)
+					R_DrawAliasShadow (ent);
+			}
+			R_FlushAliasShadows ();
 		}
 	}
 

--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -92,6 +92,29 @@ vec2 ComputeVelocity(vec4 curr_clip, vec4 prev_clip)
 	return (curr_ndc - prev_ndc) * 0.5;
 }
 
+void ShadowCoordFromClip(vec4 clip, out vec2 uv, out float reference, out float in_range)
+{
+	if (clip.w <= 0.0)
+	{
+		uv = vec2(0.0);
+		reference = 0.0;
+		in_range = 0.0;
+		return;
+	}
+
+	vec3 proj = clip.xyz / clip.w;
+	uv = proj.xy * 0.5 + 0.5;
+#if REVERSED_Z
+	reference = proj.z;
+#else
+	reference = proj.z * 0.5 + 0.5;
+#endif
+
+	bool inside = all(greaterThanEqual(vec3(uv, reference), vec3(0.0))) &&
+		all(lessThanEqual(vec3(uv, reference), vec3(1.0)));
+	in_range = inside ? 1.0 : 0.0;
+}
+
 const int ALIAS_FLAG_NO_MOTION_BLUR = 1;
 const int ALIAS_FLAG_VIEWMODEL = 2;
 const int ALIAS_FLAG_LIGHTNING = 4;
@@ -116,6 +139,8 @@ layout(location=3) noperspective in vec4 in_curr_clip;
 layout(location=4) noperspective in vec4 in_prev_clip;
 layout(location=5) flat in int in_flags;
 layout(location=6) in vec3 in_normal;
+layout(location=7) in vec3 in_direct;
+layout(location=8) noperspective in vec4 in_shadow_clip;
 
 #define OUT_COLOR out_fragcolor
 #if OIT
@@ -170,7 +195,20 @@ void main()
 		vec3 world_pos = in_pos + EyePos;
 		vec3 shadow_normal = gl_FrontFacing ? in_normal : -in_normal;
 		if (shadow_mode != 4)
-			shadow_term = ShadowVisibility(world_pos, shadow_normal, shadow_range);
+		{
+			vec2 shadow_uv;
+			float shadow_ref;
+			ShadowCoordFromClip(in_shadow_clip, shadow_uv, shadow_ref, shadow_range);
+			if (shadow_range >= 0.5 && shadow_mode <= 3)
+			{
+				float ndotl = clamp(dot(shadow_normal, -ShadowSunDir.xyz), 0.0, 1.0);
+				float bias = ShadowParams.x + ShadowParams.y * (1.0 - ndotl);
+				if (ShadowParams.z > 0.5)
+					shadow_term = ShadowSamplePCF(shadow_uv, shadow_ref, bias, int(ShadowParams.w + 0.5));
+				else
+					shadow_term = ShadowSampleRaw(shadow_uv, shadow_ref, bias);
+			}
+		}
 		if (shadow_mode >= 2)
 		{
 			out_fragcolor = vec4(ShadowDebugColor(world_pos, shadow_term), 1.0);
@@ -179,8 +217,8 @@ void main()
 #endif
 			return;
 		}
-		lit_color.rgb *= shadow_term;
 	}
+	lit_color.rgb = clamp(lit_color.rgb + in_direct * shadow_term, 0.0, Overbright);
 #if MODE == 2
         uv -= 0.5 / vec2(textureSize(Tex, 0).xy);
         vec4 result = textureLod(Tex, uv, 0.);

--- a/Quake/shaders/alias.vert
+++ b/Quake/shaders/alias.vert
@@ -96,6 +96,8 @@ layout(location=3) noperspective out vec4 out_curr_clip;
 layout(location=4) noperspective out vec4 out_prev_clip;
 layout(location=5) flat out int out_flags;
 layout(location=6) out vec3 out_normal;
+layout(location=7) out vec3 out_direct;
+layout(location=8) noperspective out vec4 out_shadow_clip;
 
 const int ALIAS_FLAG_VIEWMODEL = 2;
 
@@ -112,6 +114,7 @@ void main()
 	vec3 prev_world_vert = (prev_worldmatrix * vec4(local_vert, 1.0)).xyz;
 	vec4 curr_clip = ViewProj * vec4(world_vert, 1.0);
 	vec4 prev_clip = PrevViewProj * vec4(prev_world_vert, 1.0);
+	vec4 shadow_clip = ShadowViewProj * vec4(world_vert, 1.0);
 	gl_Position = curr_clip;
 	out_curr_clip = curr_clip;
 	out_prev_clip = prev_clip;
@@ -134,7 +137,11 @@ void main()
         vec3 litDlight = inst.DLightColor.rgb * lighting;
         vec3 base_color = litAmbient + litDlight;
         bool is_viewmodel = (inst.Flags & ALIAS_FLAG_VIEWMODEL) != 0;
-        vec3 final_color = is_viewmodel ? base_color + vec3(rim) : base_color;
-        out_color = clamp(vec4(final_color, inst.LightColor.a), 0.0, Overbright);
+        vec3 ambient_color = litAmbient;
+        if (is_viewmodel)
+                ambient_color += vec3(rim);
+        out_color = clamp(vec4(ambient_color, inst.LightColor.a), 0.0, Overbright);
+	out_direct = litDlight;
 	out_normal = world_normal;
+	out_shadow_clip = shadow_clip;
 }

--- a/Quake/shaders/shadow_depth_alias.vert
+++ b/Quake/shaders/shadow_depth_alias.vert
@@ -36,10 +36,8 @@ struct PoseVertex
 
 #if MD5
 	layout(location=0) in vec3 in_pos;
-	layout(location=1) in vec4 in_nor;
-	layout(location=2) in vec2 in_uv;
-	layout(location=3) in vec4 in_weights;
-	layout(location=4) in ivec4 in_indices;
+	layout(location=1) in vec4 in_weights;
+	layout(location=2) in ivec4 in_indices;
 
 	layout(std430, binding=2) restrict readonly buffer PoseBuffer
 	{
@@ -56,12 +54,10 @@ struct PoseVertex
 			blendmat += BonePoses[pose + in_indices.w] * in_weights.w;
 		}
 		mat4x3 anim = transpose(blendmat);
-		return PoseVertex((anim * vec4(in_pos, 1.0)).xyz, (anim * vec4(in_nor.xyz, 0.0)).xyz);
+		return PoseVertex((anim * vec4(in_pos, 1.0)).xyz, vec3(0.0));
 	}
 
 #else
-	layout(location=0) in vec2 in_uv;
-
 	layout(std430, binding=2) restrict readonly buffer BlendShapeBuffer
 	{
 		uvec2 PackedPosNor[];
@@ -80,8 +76,8 @@ void main()
 	InstanceData inst = instances[gl_InstanceID];
 	PoseVertex pose1 = GetPoseVertex(inst.Pose1);
 	PoseVertex pose2 = GetPoseVertex(inst.Pose2);
-	vec3 local_vert = mix(pose1.pos, pose2.pos, inst.Blend);
+	vec3 alias_pos = mix(pose1.pos, pose2.pos, inst.Blend);
 	mat4x3 worldmatrix = transpose(mat3x4(inst.WorldMatrix[0], inst.WorldMatrix[1], inst.WorldMatrix[2]));
-	vec3 world_vert = (worldmatrix * vec4(local_vert, 1.0)).xyz;
-	gl_Position = ShadowViewProj * vec4(world_vert, 1.0);
+	vec4 world_pos = vec4((worldmatrix * vec4(alias_pos, 1.0)).xyz, 1.0);
+	gl_Position = ShadowViewProj * world_pos;
 }


### PR DESCRIPTION
### Motivation

- Ensure alias models correctly cast and receive shadows by fixing submission and shader transforms.
- Compute shadow coordinates from the model-transformed world position in the alias shaders.
- Fix VAO/attribute bindings so alias position is bound at the correct location for the shadow pass and drop unnecessary attributes.
- Exclude view weapon (viewmodel) entities from casting and receiving shadows via instance flags.

### Description

- Add `R_DrawAliasShadow` and `R_FlushAliasShadows`, iterate alias entities in the shadow pass and call the new helpers from `r_shadow.c` instead of batch-calling the old function.
- Introduce `R_Alias_InstanceFlags` and use instance flags to mark/skip viewmodels and special cases in `r_alias.c`, and set those flags when building instance data.
- Fix alias shadow VAO setup and attribute layout in `R_FlushAliasInstances_Shadow` (adjust `GLS_ATTRIBS` and attribute pointer indices) so the position attribute is bound correctly and unneeded attributes are not used.
- Update shaders: `shaders/shadow_depth_alias.vert` now computes `worldPos = modelMatrix * vec4(aliasPos, 1.0)` and uses that with `ShadowViewProj`; `shaders/alias.vert` now emits `out_direct` and `out_shadow_clip`; `shaders/alias.frag` computes shadow coords from the clip-space `in_shadow_clip`, samples the shadow map, and applies the shadow term only to direct lighting contribution.
- Add prototypes to `glquake.h` and commit changes to `Quake/r_alias.c`, `Quake/r_shadow.c`, `Quake/glquake.h`, `Quake/shaders/alias.vert`, `Quake/shaders/alias.frag`, and `Quake/shaders/shadow_depth_alias.vert`.

### Testing

- No automated tests were executed for this change.
- No CI/build verification was run as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69569934c708832e810f5a3da97507a8)