### PR TITLE
Fix shadow mapping: world-space depth, single remap, and correct sun/dlight bias

### DIFF
--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -102,16 +102,13 @@ void ShadowCoordFromClip(vec4 clip, out vec2 uv, out float reference, out float 
 		return;
 	}
 
-	vec3 proj = clip.xyz / clip.w;
-	uv = proj.xy * 0.5 + 0.5;
-#if REVERSED_Z
-	reference = proj.z;
-#else
-	reference = proj.z * 0.5 + 0.5;
-#endif
+	vec3 shadow_coord = clip.xyz / clip.w;
+	shadow_coord = shadow_coord * 0.5 + 0.5;
+	uv = shadow_coord.xy;
+	reference = shadow_coord.z;
 
-	bool inside = all(greaterThanEqual(vec3(uv, reference), vec3(0.0))) &&
-		all(lessThanEqual(vec3(uv, reference), vec3(1.0)));
+	bool inside = all(greaterThanEqual(shadow_coord, vec3(0.0))) &&
+		all(lessThanEqual(shadow_coord, vec3(1.0)));
 	in_range = inside ? 1.0 : 0.0;
 }
 
@@ -201,8 +198,8 @@ void main()
 			ShadowCoordFromClip(in_shadow_clip, shadow_uv, shadow_ref, shadow_range);
 			if (shadow_range >= 0.5 && shadow_mode <= 3)
 			{
-				float ndotl = clamp(dot(shadow_normal, -ShadowSunDir.xyz), 0.0, 1.0);
-				float bias = ShadowParams.x + ShadowParams.y * (1.0 - ndotl);
+				float ndotl = dot(shadow_normal, ShadowSunDir.xyz);
+				float bias = ShadowParams.x + ShadowParams.y * max(0.0, 1.0 - ndotl);
 				if (ShadowParams.z > 0.5)
 					shadow_term = ShadowSamplePCF(shadow_uv, shadow_ref, bias, int(ShadowParams.w + 0.5));
 				else

--- a/Quake/shaders/shadow_depth.vert
+++ b/Quake/shaders/shadow_depth.vert
@@ -64,10 +64,10 @@ layout(location=0) in vec3 in_pos;
 void main()
 {
 	Call call = call_data[DRAW_ID];
-	int instance_id = GET_INSTANCE_ID(call);
-	Instance instance = instance_data[instance_id];
-	vec3 world_pos = TransformPosition(in_pos, instance.mat);
+	vec3 world_pos = in_pos;
 	vec4 clip = ShadowViewProj * vec4(world_pos, 1.0);
+	if (int(ShadowDebug.y + 0.5) == 5)
+		clip.z = world_pos.z * clip.w;
 #if REVERSED_Z
 	const float ZBIAS = -1.0 / 1024.0;
 #else

--- a/Quake/shaders/shadow_depth_alias.vert
+++ b/Quake/shaders/shadow_depth_alias.vert
@@ -78,6 +78,9 @@ void main()
 	PoseVertex pose2 = GetPoseVertex(inst.Pose2);
 	vec3 alias_pos = mix(pose1.pos, pose2.pos, inst.Blend);
 	mat4x3 worldmatrix = transpose(mat3x4(inst.WorldMatrix[0], inst.WorldMatrix[1], inst.WorldMatrix[2]));
-	vec4 world_pos = vec4((worldmatrix * vec4(alias_pos, 1.0)).xyz, 1.0);
-	gl_Position = ShadowViewProj * world_pos;
+	vec3 world_pos = (worldmatrix * vec4(alias_pos, 1.0)).xyz;
+	vec4 clip = ShadowViewProj * vec4(world_pos, 1.0);
+	if (int(ShadowDebug.y + 0.5) == 5)
+		clip.z = world_pos.z * clip.w;
+	gl_Position = clip;
 }

--- a/Quake/shaders/shadow_sample.glsl
+++ b/Quake/shaders/shadow_sample.glsl
@@ -13,16 +13,13 @@ void ShadowCoord(vec3 world_pos, out vec2 uv, out float reference, out float in_
 		return;
 	}
 
-	vec3 proj = clip.xyz / clip.w;
-	uv = proj.xy * 0.5 + 0.5;
-#if REVERSED_Z
-	reference = proj.z;
-#else
-	reference = proj.z * 0.5 + 0.5;
-#endif
+	vec3 shadow_coord = clip.xyz / clip.w;
+	shadow_coord = shadow_coord * 0.5 + 0.5;
+	uv = shadow_coord.xy;
+	reference = shadow_coord.z;
 
-	bool inside = all(greaterThanEqual(vec3(uv, reference), vec3(0.0))) &&
-		all(lessThanEqual(vec3(uv, reference), vec3(1.0)));
+	bool inside = all(greaterThanEqual(shadow_coord, vec3(0.0))) &&
+		all(lessThanEqual(shadow_coord, vec3(1.0)));
 	in_range = inside ? 1.0 : 0.0;
 }
 
@@ -95,8 +92,8 @@ float ShadowVisibility(vec3 world_pos, vec3 normal, out float in_range)
 	if (ShadowDebug.y > 3.5)
 		return 1.0;
 
-	float ndotl = clamp(dot(normal, -ShadowSunDir.xyz), 0.0, 1.0);
-	float bias = ShadowParams.x + ShadowParams.y * (1.0 - ndotl);
+	float ndotl = dot(normal, ShadowSunDir.xyz);
+	float bias = ShadowParams.x + ShadowParams.y * max(0.0, 1.0 - ndotl);
 
 	if (ShadowParams.z > 0.5)
 		return ShadowSamplePCF(uv, reference, bias, int(ShadowParams.w + 0.5));
@@ -218,19 +215,16 @@ float ShadowVisibilityDlight(vec3 world_pos, vec3 normal, vec3 light_pos, uint l
 		return 1.0;
 	}
 
-	vec3 proj = clip.xyz / clip.w;
-	vec2 uv = proj.xy * 0.5 + 0.5;
-#if REVERSED_Z
-	float reference = proj.z;
-#else
-	float reference = proj.z * 0.5 + 0.5;
-#endif
+	vec3 shadow_coord = clip.xyz / clip.w;
+	shadow_coord = shadow_coord * 0.5 + 0.5;
 
 	vec4 atlas = ShadowDlightAtlas[shadow_index];
+	vec2 uv = shadow_coord.xy;
+	float reference = shadow_coord.z;
 	uv = uv * atlas.xy + atlas.zw;
 
-	bool inside = all(greaterThanEqual(vec3(uv, reference), vec3(0.0))) &&
-		all(lessThanEqual(vec3(uv, reference), vec3(1.0)));
+	bool inside = all(greaterThanEqual(shadow_coord, vec3(0.0))) &&
+		all(lessThanEqual(shadow_coord, vec3(1.0)));
 	in_range = inside ? 1.0 : 0.0;
 	if (!inside)
 		return 1.0;


### PR DESCRIPTION
### Motivation
- Shadow mapping produced incorrect results because geometry was not consistently transformed to world space before applying the light view-projection.
- Shadow coordinates were remapped inconsistently leading to wrong UV/z values and out-of-range false occlusion.
- The sun shadow bias used a view-space formula and inverted dot sign, causing incorrect self-shadowing and light leaks.
- Alias (MDL) models and BSP world geometry require distinct, correct world-space handling for stable shadows.

### Description
- Updated `Quake/shaders/shadow_depth.vert` to use `in_pos` as world-space for world geometry and emit `gl_Position = ShadowViewProj * vec4(world_pos, 1.0)`, with a debug override that encodes `world_pos.z` into depth when `ShadowDebug.y == 5`.
- Updated `Quake/shaders/shadow_depth_alias.vert` to compute `world_pos` as `worldmatrix * vec4(alias_pos,1.0)` (world-space), apply `ShadowViewProj` and the same debug depth override before writing `gl_Position`.
- Rewrote `Quake/shaders/shadow_sample.glsl` and `Quake/shaders/alias.frag` shadow coordinate logic to compute `shadow_coord = clip.xyz/clip.w`, apply the NDC-to-UV remap exactly once (`shadow_coord = shadow_coord * 0.5 + 0.5`), use `uv = shadow_coord.xy` and `reference = shadow_coord.z`, and test bounds on the remapped `shadow_coord`.
- Replaced the sun bias formula to use world-space normal and sun dir: compute `ndotl = dot(normal, ShadowSunDir.xyz)` and `bias = ShadowParams.x + ShadowParams.y * max(0.0, 1.0 - ndotl)`, and adjusted DLight shadow coord remap/atlas handling to match the single-remap behavior.

### Testing
- No automated tests were executed for this change (no CI/unit tests run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69569f2a2338832e87a3f49aedc28b75)