### PR TITLE
Align alias shadow transforms and depth state

### DIFF
--- a/Quake/r_shadow.c
+++ b/Quake/r_shadow.c
@@ -525,14 +525,14 @@ void R_Shadow_BindShadowMap (GLenum texunit)
 	GL_BindNative (texunit, GL_TEXTURE_2D, shadow_depth_tex);
 	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE,
 		(debug_mode > 3.5f) ? GL_NONE : GL_COMPARE_REF_TO_TEXTURE);
-	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_FUNC, gl_clipcontrol_able ? GL_GEQUAL : GL_LEQUAL);
+	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_FUNC, gl_clipcontrol_able ? GL_GREATER : GL_LESS);
 }
 
 void R_Shadow_BindShadowMapRaw (GLenum texunit)
 {
 	GL_BindNative (texunit, GL_TEXTURE_2D, shadow_depth_tex);
 	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE, GL_NONE);
-	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_FUNC, gl_clipcontrol_able ? GL_GEQUAL : GL_LEQUAL);
+	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_FUNC, gl_clipcontrol_able ? GL_GREATER : GL_LESS);
 }
 
 void R_Shadow_BindDlightShadowMap (GLenum texunit)
@@ -541,7 +541,7 @@ void R_Shadow_BindDlightShadowMap (GLenum texunit)
 	{
 		GL_BindNative (texunit, GL_TEXTURE_2D, shadow_dlight_depth_tex);
 		glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE, GL_COMPARE_REF_TO_TEXTURE);
-		glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_FUNC, gl_clipcontrol_able ? GL_GEQUAL : GL_LEQUAL);
+		glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_FUNC, gl_clipcontrol_able ? GL_GREATER : GL_LESS);
 	}
 	else
 		GL_BindNative (texunit, GL_TEXTURE_2D, 0);
@@ -596,7 +596,8 @@ void R_Shadow_SunPass (void)
 	glColorMask (GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
 	glDepthMask (GL_TRUE);
 	glEnable (GL_DEPTH_TEST);
-	glDepthFunc (GL_LEQUAL);
+	glClearDepth (gl_clipcontrol_able ? 0.f : 1.f);
+	glDepthFunc (gl_clipcontrol_able ? GL_GEQUAL : GL_LEQUAL);
 
 	GL_UseProgram (glprogs.shadow_depth);
 	GL_SetState (GLS_BLEND_OPAQUE |
@@ -757,7 +758,8 @@ void R_Shadow_DlightPass (void)
 	glColorMask (GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
 	glDepthMask (GL_TRUE);
 	glEnable (GL_DEPTH_TEST);
-	glDepthFunc (GL_LEQUAL);
+	glClearDepth (gl_clipcontrol_able ? 0.f : 1.f);
+	glDepthFunc (gl_clipcontrol_able ? GL_GEQUAL : GL_LEQUAL);
 
 	grid = shadow_dlight_atlas_size / shadow_dlight_tile_size;
 	if (grid < 1)

--- a/Quake/shaders/shadow_depth_alias.vert
+++ b/Quake/shaders/shadow_depth_alias.vert
@@ -77,8 +77,13 @@ void main()
 	PoseVertex pose1 = GetPoseVertex(inst.Pose1);
 	PoseVertex pose2 = GetPoseVertex(inst.Pose2);
 	vec3 alias_pos = mix(pose1.pos, pose2.pos, inst.Blend);
-	mat4x3 worldmatrix = transpose(mat3x4(inst.WorldMatrix[0], inst.WorldMatrix[1], inst.WorldMatrix[2]));
-	vec3 world_pos = (worldmatrix * vec4(alias_pos, 1.0)).xyz;
+	mat4 model = mat4(
+		vec4(inst.WorldMatrix[0].xyz, 0.0),
+		vec4(inst.WorldMatrix[1].xyz, 0.0),
+		vec4(inst.WorldMatrix[2].xyz, 0.0),
+		vec4(inst.WorldMatrix[0].w, inst.WorldMatrix[1].w, inst.WorldMatrix[2].w, 1.0)
+	);
+	vec3 world_pos = (model * vec4(alias_pos, 1.0)).xyz;
 	vec4 clip = ShadowViewProj * vec4(world_pos, 1.0);
 	if (int(ShadowDebug.y + 0.5) == 5)
 		clip.z = world_pos.z * clip.w;

--- a/Quake/shaders/shadow_sample.glsl
+++ b/Quake/shaders/shadow_sample.glsl
@@ -13,13 +13,23 @@ void ShadowCoord(vec3 world_pos, out vec2 uv, out float reference, out float in_
 		return;
 	}
 
-	vec3 shadow_coord = clip.xyz / clip.w;
-	shadow_coord = shadow_coord * 0.5 + 0.5;
-	uv = shadow_coord.xy;
-	reference = shadow_coord.z;
+	vec3 proj = clip.xyz / clip.w;
+	uv = proj.xy * 0.5 + 0.5;
+	float depth01 =
+#if CLIP_Z_ZERO_TO_ONE
+		proj.z;
+#else
+		proj.z * 0.5 + 0.5;
+#endif
 
-	bool inside = all(greaterThanEqual(shadow_coord, vec3(0.0))) &&
-		all(lessThanEqual(shadow_coord, vec3(1.0)));
+#if REVERSED_Z
+		reference = 1.0 - depth01;
+#else
+		reference = depth01;
+#endif
+
+	bool inside = all(greaterThanEqual(vec3(uv, reference), vec3(0.0))) &&
+		all(lessThanEqual(vec3(uv, reference), vec3(1.0)));
 	in_range = inside ? 1.0 : 0.0;
 }
 


### PR DESCRIPTION
### Motivation

- Alias main-pass and alias shadow-pass must use the bit-identical world matrix semantics to avoid incorrect shadow projection.
- Shadow sampling and `ShadowViewProj` must use the same depth semantics so both main and alias shadow passes compare against the same values.
- Depth Z-range and reversed-Z handling must be applied consistently between GLSL sampling and the GL depth state to avoid off-by-range shadow artifacts.

### Description

- Replaced the `mat4x3`/`transpose(mat3x4(...))` world transform in `Quake/shaders/shadow_depth_alias.vert` with an explicit `mat4 model` construction to match `alias.vert` and produce identical semantics for `world_pos`.
- Updated `Quake/shaders/shadow_sample.glsl` to compute `proj`, derive `uv`, compute `depth01` under `#if CLIP_Z_ZERO_TO_ONE`, and apply `#if REVERSED_Z` so shadow reference values match clip-control and reversed-Z modes.
- Adjusted `Quake/r_shadow.c` to set the texture compare function to `GL_GREATER`/`GL_LESS` based on `gl_clipcontrol_able`, and to call `glClearDepth` plus select `glDepthFunc` (`GL_GEQUAL`/`GL_LEQUAL`) accordingly before shadow pass clears and draws.
- Modified files: `Quake/shaders/shadow_depth_alias.vert`, `Quake/shaders/shadow_sample.glsl`, and `Quake/r_shadow.c`.

### Testing

- No automated tests were run for these changes.
- Changes were compiled/committed locally (no CI/test results were produced as part of this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956a70493e8832eabb6cac3927907de)