### PR TITLE
Fix shadow mapping depth and debug handling

### DIFF
--- a/Quake/r_shadow.c
+++ b/Quake/r_shadow.c
@@ -521,18 +521,16 @@ void R_ResizeShadowMapIfNeeded (void)
 
 void R_Shadow_BindShadowMap (GLenum texunit)
 {
-	float debug_mode = r_shadowmap_debug.value > 0.f ? r_shadowmap_debug.value : r_shadow_debug.value;
 	GL_BindNative (texunit, GL_TEXTURE_2D, shadow_depth_tex);
-	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE,
-		(debug_mode > 3.5f) ? GL_NONE : GL_COMPARE_REF_TO_TEXTURE);
-	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_FUNC, gl_clipcontrol_able ? GL_GREATER : GL_LESS);
+	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE, GL_COMPARE_REF_TO_TEXTURE);
+	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_FUNC, gl_clipcontrol_able ? GL_GEQUAL : GL_LEQUAL);
 }
 
 void R_Shadow_BindShadowMapRaw (GLenum texunit)
 {
 	GL_BindNative (texunit, GL_TEXTURE_2D, shadow_depth_tex);
 	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE, GL_NONE);
-	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_FUNC, gl_clipcontrol_able ? GL_GREATER : GL_LESS);
+	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_FUNC, gl_clipcontrol_able ? GL_GEQUAL : GL_LEQUAL);
 }
 
 void R_Shadow_BindDlightShadowMap (GLenum texunit)
@@ -541,7 +539,7 @@ void R_Shadow_BindDlightShadowMap (GLenum texunit)
 	{
 		GL_BindNative (texunit, GL_TEXTURE_2D, shadow_dlight_depth_tex);
 		glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE, GL_COMPARE_REF_TO_TEXTURE);
-		glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_FUNC, gl_clipcontrol_able ? GL_GREATER : GL_LESS);
+		glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_FUNC, gl_clipcontrol_able ? GL_GEQUAL : GL_LEQUAL);
 	}
 	else
 		GL_BindNative (texunit, GL_TEXTURE_2D, 0);

--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -102,13 +102,18 @@ void ShadowCoordFromClip(vec4 clip, out vec2 uv, out float reference, out float 
 		return;
 	}
 
-	vec3 shadow_coord = clip.xyz / clip.w;
-	shadow_coord = shadow_coord * 0.5 + 0.5;
-	uv = shadow_coord.xy;
-	reference = shadow_coord.z;
+	vec3 shadow_ndc = clip.xyz / clip.w;
+	uv = shadow_ndc.xy * 0.5 + 0.5;
+	float depth01 =
+#if CLIP_Z_ZERO_TO_ONE
+		shadow_ndc.z;
+#else
+		shadow_ndc.z * 0.5 + 0.5;
+#endif
+	reference = depth01;
 
-	bool inside = all(greaterThanEqual(shadow_coord, vec3(0.0))) &&
-		all(lessThanEqual(shadow_coord, vec3(1.0)));
+	bool inside = all(greaterThanEqual(uv, vec2(0.0))) &&
+		all(lessThanEqual(uv, vec2(1.0)));
 	in_range = inside ? 1.0 : 0.0;
 }
 
@@ -137,7 +142,7 @@ layout(location=4) noperspective in vec4 in_prev_clip;
 layout(location=5) flat in int in_flags;
 layout(location=6) in vec3 in_normal;
 layout(location=7) in vec3 in_direct;
-layout(location=8) noperspective in vec4 in_shadow_clip;
+layout(location=8) in vec4 in_shadow_clip;
 
 #define OUT_COLOR out_fragcolor
 #if OIT
@@ -207,12 +212,12 @@ void main()
 	{
 		vec3 world_pos = in_pos + EyePos;
 		vec3 shadow_normal = gl_FrontFacing ? in_normal : -in_normal;
-		if (shadow_mode != 4 && shadow_receiver)
+		if (shadow_receiver && (shadow_mode == 0 || shadow_mode == 4))
 		{
 			vec2 shadow_uv;
 			float shadow_ref;
 			ShadowCoordFromClip(in_shadow_clip, shadow_uv, shadow_ref, shadow_range);
-			if (shadow_range >= 0.5 && shadow_mode <= 3)
+			if (shadow_range >= 0.5 && (shadow_mode == 0 || shadow_mode == 4))
 			{
 				float ndotl = dot(shadow_normal, ShadowSunDir.xyz);
 				float bias = ShadowParams.x + ShadowParams.y * max(0.0, 1.0 - ndotl);
@@ -222,7 +227,7 @@ void main()
 					shadow_term = ShadowSampleRaw(shadow_uv, shadow_ref, bias);
 			}
 		}
-		if (shadow_mode >= 2)
+		if (shadow_mode >= 1)
 		{
 			out_fragcolor = vec4(ShadowDebugColor(world_pos, shadow_term), 1.0);
 #if !OIT

--- a/Quake/shaders/alias.vert
+++ b/Quake/shaders/alias.vert
@@ -97,7 +97,7 @@ layout(location=4) noperspective out vec4 out_prev_clip;
 layout(location=5) flat out int out_flags;
 layout(location=6) out vec3 out_normal;
 layout(location=7) out vec3 out_direct;
-layout(location=8) noperspective out vec4 out_shadow_clip;
+layout(location=8) out vec4 out_shadow_clip;
 
 const int ALIAS_FLAG_VIEWMODEL = 2;
 

--- a/Quake/shaders/shadow_depth.vert
+++ b/Quake/shaders/shadow_depth.vert
@@ -66,8 +66,6 @@ void main()
 	Call call = call_data[DRAW_ID];
 	vec3 world_pos = in_pos;
 	vec4 clip = ShadowViewProj * vec4(world_pos, 1.0);
-	if (int(ShadowDebug.y + 0.5) == 5)
-		clip.z = world_pos.z * clip.w;
 #if REVERSED_Z
 	const float ZBIAS = -1.0 / 1024.0;
 #else

--- a/Quake/shaders/shadow_depth_alias.vert
+++ b/Quake/shaders/shadow_depth_alias.vert
@@ -84,8 +84,5 @@ void main()
 		vec4(inst.WorldMatrix[0].w, inst.WorldMatrix[1].w, inst.WorldMatrix[2].w, 1.0)
 	);
 	vec3 world_pos = (model * vec4(alias_pos, 1.0)).xyz;
-	vec4 clip = ShadowViewProj * vec4(world_pos, 1.0);
-	if (int(ShadowDebug.y + 0.5) == 5)
-		clip.z = world_pos.z * clip.w;
-	gl_Position = clip;
+	gl_Position = ShadowViewProj * vec4(world_pos, 1.0);
 }

--- a/Quake/shaders/shadow_sample.glsl
+++ b/Quake/shaders/shadow_sample.glsl
@@ -22,21 +22,21 @@ void ShadowCoord(vec3 world_pos, out vec2 uv, out float reference, out float in_
 		proj.z * 0.5 + 0.5;
 #endif
 
-#if REVERSED_Z
-		reference = 1.0 - depth01;
-#else
-		reference = depth01;
-#endif
+	reference = depth01;
 
-	bool inside = all(greaterThanEqual(vec3(uv, reference), vec3(0.0))) &&
-		all(lessThanEqual(vec3(uv, reference), vec3(1.0)));
+	bool inside = all(greaterThanEqual(uv, vec2(0.0))) &&
+		all(lessThanEqual(uv, vec2(1.0)));
 	in_range = inside ? 1.0 : 0.0;
 }
 
 float ShadowSampleRaw(vec2 uv, float reference, float bias)
 {
 	float compare_depth = reference - bias;
+#if REVERSED_Z
+	return 1.0 - texture(ShadowMap, vec3(uv, compare_depth));
+#else
 	return texture(ShadowMap, vec3(uv, compare_depth));
+#endif
 }
 
 float ShadowSamplePCF(vec2 uv, float reference, float bias, int taps)
@@ -99,9 +99,6 @@ float ShadowVisibility(vec3 world_pos, vec3 normal, out float in_range)
 	if (in_range < 0.5)
 		return 1.0;
 
-	if (ShadowDebug.y > 3.5)
-		return 1.0;
-
 	float ndotl = dot(normal, ShadowSunDir.xyz);
 	float bias = ShadowParams.x + ShadowParams.y * max(0.0, 1.0 - ndotl);
 
@@ -122,17 +119,22 @@ vec3 ShadowDebugColor(vec3 world_pos, float shadow_term)
 	if (in_range < 0.5)
 		return vec3(1.0, 0.0, 0.0);
 
+	if (mode == 1)
+	{
+		float depth = texture(ShadowMapDepth, uv).r;
+		return vec3(depth);
+	}
 	if (mode == 2)
 		return vec3(uv, 0.0);
 	if (mode == 3)
-		return vec3(shadow_term);
-	if (mode == 4)
 	{
 		float depth = texture(ShadowMapDepth, uv).r;
 		float diff = reference - depth;
 		float scaled = clamp(diff * 10.0 + 0.5, 0.0, 1.0);
 		return vec3(scaled);
 	}
+	if (mode == 4)
+		return vec3(shadow_term);
 
 	return vec3(shadow_term);
 }

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -434,11 +434,11 @@ void main()
 		shadow_receiver = shadow_receiver && (in_flags & CF_MAT_EMISSIVE) == 0u;
 		shadow_receiver = shadow_receiver && (in_flags & CF_USE_EMISSIVE) == 0u;
 		shadow_receiver = shadow_receiver && (in_flags & CF_MAT_NO_SHADOW_RECEIVE) == 0u;
-		if (shadow_enabled && shadow_mode != 4 && shadow_receiver)
+		if (shadow_enabled && shadow_receiver && (shadow_mode == 0 || shadow_mode == 4))
 			shadow_term = ShadowVisibility(in_pos, surface_normal, shadow_range);
 		bool lightgrid_shadow = LightgridParams.z > 0.5 && LightgridParams.x > 0.5;
 
-		if (shadow_enabled && shadow_mode >= 2)
+		if (shadow_enabled && shadow_mode >= 1)
 		{
 			out_fragcolor = vec4(ShadowDebugColor(in_pos, shadow_term), 1.0);
 #if !OIT


### PR DESCRIPTION
### Motivation

- Prevent corruption of clip-space Z in the shadow depth pass which caused empty/uniform debug views and incorrect shadowing.  
- Ensure shadow coordinates and UVs are computed perspective-correctly and bias only affects depth.  
- Align shadow compare behavior with the engine's reversed-Z configuration so depth tests are correct.  
- Move shadow debug visualization to receiver shaders so the depth-only pass never branches on debug state. 

### Description

- Removed debug overrides to `clip.z` in `Quake/shaders/shadow_depth.vert` and `shadow_depth_alias.vert` and now emit pure light-space clip positions via `gl_Position = ShadowViewProj * vec4(...);`.  
- Reworked `ShadowCoord`/`ShadowCoordFromClip` logic in `Quake/shaders/shadow_sample.glsl` and `Quake/shaders/alias.frag` to perform the perspective divide first, compute `uv = ndc.xy * 0.5 + 0.5`, compute `depth01` properly, and only test `uv` bounds for in-range.  
- Fixed reversed-Z sampling semantics by returning `1.0 - texture(ShadowMap, ...)` under `REVERSED_Z` in `ShadowSampleRaw`, and changed GL compare func usage to `GL_GEQUAL`/`GL_LEQUAL` and always enable `GL_COMPARE_REF_TO_TEXTURE` for the shadow map binding in `Quake/r_shadow.c`.  
- Moved and adjusted debug visualization modes into receiver shaders (`world.frag`, `alias.frag`, `shadow_sample.glsl`) and remapped debug modes so the depth pass no longer branches or alters output; also adjusted alias shader I/O qualifiers so shadow clip is passed correctly. 

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956b13f9c2c832e90c586a80e1669e7)