### PR TITLE
Fix shadow debug depth visualization and reversed-Z handling

### DIFF
--- a/Quake/shaders/shadow_debug.frag
+++ b/Quake/shaders/shadow_debug.frag
@@ -5,5 +5,8 @@ layout(location=0) out vec4 out_fragcolor;
 void main()
 {
 	float depth = texture(ShadowMapDepth, v_uv).r;
+#if REVERSED_Z
+	depth = 1.0 - depth;
+#endif
 	out_fragcolor = vec4(vec3(depth), 1.0);
 }

--- a/Quake/shaders/shadow_sample.glsl
+++ b/Quake/shaders/shadow_sample.glsl
@@ -132,6 +132,9 @@ vec3 ShadowDebugColor(vec3 world_pos, float shadow_term)
 	if (mode == 1)
 	{
 		float depth = texture(ShadowMapDepth, uv).r;
+#if REVERSED_Z
+		depth = 1.0 - depth;
+#endif
 		return vec3(depth);
 	}
 	if (mode == 2)
@@ -139,7 +142,13 @@ vec3 ShadowDebugColor(vec3 world_pos, float shadow_term)
 	if (mode == 3)
 	{
 		float depth = texture(ShadowMapDepth, uv).r;
-		float diff = reference - depth;
+#if REVERSED_Z
+		float receiver_depth = 1.0 - reference;
+		depth = 1.0 - depth;
+#else
+		float receiver_depth = reference;
+#endif
+		float diff = receiver_depth - depth;
 		float scaled = clamp(diff * 10.0 + 0.5, 0.0, 1.0);
 		return vec3(scaled);
 	}


### PR DESCRIPTION
### Motivation
- Debug shadow visualization produced incorrect values when the renderer is built with reversed-Z (`REVERSED_Z`).
- Mode 1 (shadowmap depth) showed raw depth from the depth texture instead of the corrected depth space.
- Mode 3 (receiverDepth - shadowDepth) computed the difference using inconsistent depth conventions leading to misleading visualization.
- The change centralizes correct depth interpretation so debug modes reflect actual shadow values.

### Description
- Update `Quake/shaders/shadow_sample.glsl` to invert sampled `ShadowMapDepth` and to compute `receiver_depth` consistently under `#if REVERSED_Z` for debug modes 1 and 3.
- Update `Quake/shaders/shadow_debug.frag` to invert the sampled depth when `REVERSED_Z` so the standalone debug shader matches the same depth space.
- No runtime logic changes outside the debug visualization paths were made, only shader-side depth interpretation for debugging.

### Testing
- No automated tests were run for this change.
- A local commit was created including `Quake/shaders/shadow_sample.glsl` and `Quake/shaders/shadow_debug.frag` modifications.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956bc1a8b4c832e8210fd524522ae6a)