### PR TITLE
Stage 1: add shadow debug overrides for world & alias shaders

### DIFF
--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -105,6 +105,10 @@ layout(binding=6) uniform sampler2D ShadowMapDepth;
 #define SHADOW_SUN 1
 #include "shadow_sample.glsl"
 
+// Stage 1 shadow debug guards (temporary).
+// Toggle FORCE_ALIAS_MAGENTA to confirm this permutation is bound at runtime.
+const bool FORCE_ALIAS_MAGENTA = true;
+
 #if MODE == 2
 	layout(location=0) noperspective in vec2 in_texcoord;
 #else
@@ -167,6 +171,15 @@ void main()
         float shadow_term = 1.0;
 	int shadow_mode = int(ShadowDebug.y + 0.5);
 	vec4 lit_color = in_color;
+
+	if (FORCE_ALIAS_MAGENTA && (in_flags & ALIAS_FLAG_VIEWMODEL) == 0)
+	{
+		out_fragcolor = vec4(1.0, 0.0, 1.0, 1.0);
+#if !OIT
+		out_velocity = vec4(0.0);
+#endif
+		return;
+	}
 
 #if MODE == 2
         uv -= 0.5 / vec2(textureSize(Tex, 0).xy);

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -13,6 +13,12 @@ layout(binding=6) uniform sampler2D ShadowMapDepth;
 #define SHADOW_SUN 1
 #include "shadow_sample.glsl"
 
+// Stage 1 shadow debug guards (temporary).
+// Toggle FORCE_WORLD_MAGENTA to confirm this permutation is bound at runtime.
+const bool FORCE_WORLD_MAGENTA = false;
+// Toggle FORCE_SHADOW_DEBUG to force a constant shadow debug output.
+const bool FORCE_SHADOW_DEBUG = true;
+
 vec3 ApplyFog(vec3 clr, vec3 p)
 {
 	float fog = exp2(-abs(Fog.w) * dot(p, p));
@@ -265,6 +271,15 @@ void main()
 	vec3 fullbright = vec3(0.0);
 	vec3 emissive = vec3(0.0);
 	vec2 uv = in_uv;
+
+	if (FORCE_WORLD_MAGENTA)
+	{
+		out_fragcolor = vec4(1.0, 0.0, 1.0, 1.0);
+#if !OIT
+		out_velocity = vec4(0.0);
+#endif
+		return;
+	}
 	
 #if MODE == 2
 	uv = uv * 2.0 + 0.125 * sin(uv.yx * (3.14159265 * 2.0) + Time);
@@ -429,6 +444,19 @@ void main()
 
 		if (!gl_FrontFacing)
 			surface_normal = -surface_normal;
+
+		if (FORCE_SHADOW_DEBUG)
+		{
+			bool shadow_enabled = true;
+			int shadow_mode = 3;
+			float shadow_term = 0.25;
+			bool shadow_receiver = true;
+			out_fragcolor = vec4(vec3(shadow_term), 1.0);
+#if !OIT
+			out_velocity = vec4(0.0);
+#endif
+			return;
+		}
 
 		bool shadow_enabled = ShadowDebug.x > 0.5;
 		int shadow_mode = int(ShadowDebug.y + 0.5);


### PR DESCRIPTION
### Motivation
- Shadows and the shadow debug overlay are currently showing no output, so we need to confirm whether the shader permutations in use are the ones being edited.
- Provide deterministic, early-out visual indicators to prove the running fragment shaders and debug paths are reached.
- Enable a quick way to distinguish between "shader not bound" vs "uniform/binding mismatch" during runtime debugging.
- Make the first-stage changes minimal and reversible so subsequent stages can iterate on actual fixes.

### Description
- Add temporary stage-1 debug guards to `Quake/shaders/world.frag` including `const bool FORCE_WORLD_MAGENTA` and `const bool FORCE_SHADOW_DEBUG` and an early-out magenta/gray output to validate the running permutation and shadow debug path.
- Add a temporary stage-1 guard to `Quake/shaders/alias.frag` with `const bool FORCE_ALIAS_MAGENTA` and an early-out magenta output for non-viewmodel alias fragments.
- Comments and toggles accompany the guards to allow enabling/disabling the checks without removing code.
- Changes are limited to shader early-outs and do not attempt to change uniform layout, binding logic, or CPU-side upload yet.

### Testing
- No automated tests were executed for this change.
- The patch compiles as a source edit and was committed; please run the renderer to visually verify magenta/gray outputs for the active permutations.
- Follow-up stages will add uniform/block fixes and texture-binding checks and include automated/engine-side validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956bef666c4832eb03d95f1b12ccaa0)