### PR TITLE
Decouple shadow enable from debug and restore debug overlay (introduce ShadowControl UBO)

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -3179,10 +3179,14 @@ void R_SetupView (void)
         r_framedata.shadow_params[3] = r_shadow_pcf_taps.value;
         {
                 float debug_mode = r_shadowmap_debug.value > 0.f ? r_shadowmap_debug.value : r_shadow_debug.value;
-                r_framedata.shadow_debug[0] =
+                r_framedata.shadow_control[0] =
                         (r_shadows.value > 0.f && r_shadowmap.value > 0.f && r_shadow_sun.value > 0.f) ? 1.f : 0.f;
-                r_framedata.shadow_debug[1] = debug_mode;
+                r_framedata.shadow_control[1] = debug_mode;
         }
+        r_framedata.shadow_control[2] = 0.f;
+        r_framedata.shadow_control[3] = 0.f;
+        r_framedata.shadow_debug[0] = 1.f;
+        r_framedata.shadow_debug[1] = r_framedata.shadow_control[1];
         r_framedata.shadow_debug[2] = 0.f;
         r_framedata.shadow_debug[3] = 0.f;
         r_framedata.shadow_dlight_params[0] = r_shadow_dlight_bias.value;

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -446,6 +446,7 @@ typedef struct gpuframedata_s {
         vec4_t          shader_params;  // x: shader debug, yzw: unused
         float           shadow_viewproj[16];
         vec4_t          shadow_params; // x: bias, y: normal bias, z: pcf enabled, w: pcf taps
+        vec4_t          shadow_control; // x: enabled, y: debug mode, zw: unused
         vec4_t          shadow_debug;  // x: enabled, y: debug mode, zw: unused
         vec4_t          shadow_sun_dir; // xyz: direction, w: unused
         float           shadow_dlight_viewproj[SHADOW_DLIGHT_MAX][16];

--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -111,6 +111,7 @@ struct ibuf_s {
 		float	_pad1;
 		float	shadow_viewproj[16];
 		vec4_t	shadow_params;
+		vec4_t	shadow_control;
 		vec4_t	shadow_debug;
 		vec4_t	shadow_sun_dir;
 	} global;
@@ -591,6 +592,7 @@ ibuf.global.half_lambert = CLAMP (0.f, r_model_halflambert.value, 1.f);
 	ibuf.global.shadow_params[1] = r_shadowmap_slopebias.value;
 	ibuf.global.shadow_params[2] = r_shadow_pcf.value > 0.f ? 1.f : 0.f;
 	ibuf.global.shadow_params[3] = r_shadow_pcf_taps.value;
+	memcpy (ibuf.global.shadow_control, r_framedata.shadow_control, sizeof (r_framedata.shadow_control));
 	memcpy (ibuf.global.shadow_debug, r_framedata.shadow_debug, sizeof (r_framedata.shadow_debug));
 	memcpy (ibuf.global.shadow_sun_dir, r_framedata.shadow_sun_dir, sizeof (r_framedata.shadow_sun_dir));
 
@@ -739,6 +741,7 @@ static void R_FlushAliasInstances_Shadow (void)
 	ibuf.global.shadow_params[1] = r_shadowmap_slopebias.value;
 	ibuf.global.shadow_params[2] = r_shadow_pcf.value > 0.f ? 1.f : 0.f;
 	ibuf.global.shadow_params[3] = r_shadow_pcf_taps.value;
+	memcpy (ibuf.global.shadow_control, r_framedata.shadow_control, sizeof (r_framedata.shadow_control));
 	memcpy (ibuf.global.shadow_debug, r_framedata.shadow_debug, sizeof (r_framedata.shadow_debug));
 	memcpy (ibuf.global.shadow_sun_dir, r_framedata.shadow_sun_dir, sizeof (r_framedata.shadow_sun_dir));
 

--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -23,6 +23,7 @@ layout(std430, binding=1) restrict readonly buffer InstanceBuffer
 	float	_Pad1;
 	mat4	ShadowViewProj;
 	vec4	ShadowParams;
+	vec4	ShadowControl;
 	vec4	ShadowDebug;
 	vec4	ShadowSunDir;
 	InstanceData instances[];
@@ -169,7 +170,7 @@ void main()
 	vec3 fullbright = vec3(0.0);
         float shadow_range = 1.0;
         float shadow_term = 1.0;
-	int shadow_mode = int(ShadowDebug.y + 0.5);
+	int shadow_mode = int(ShadowControl.y + 0.5);
 	vec4 lit_color = in_color;
 
 	if (FORCE_ALIAS_MAGENTA && (in_flags & ALIAS_FLAG_VIEWMODEL) == 0)
@@ -194,37 +195,35 @@ void main()
 #endif
 
 	bool shadow_receiver = !any(greaterThan(emissive, vec3(0.0)));
-	bool shadow_enabled = ShadowDebug.x > 0.5 && (in_flags & ALIAS_FLAG_VIEWMODEL) == 0;
+	bool shadow_enabled = ShadowControl.x > 0.5 && (in_flags & ALIAS_FLAG_VIEWMODEL) == 0;
+	bool allow_debug = (in_flags & ALIAS_FLAG_VIEWMODEL) == 0;
 
-	if (shadow_enabled)
+	vec3 world_pos = in_pos + EyePos;
+	vec3 shadow_normal = gl_FrontFacing ? in_normal : -in_normal;
+	if (shadow_receiver && (shadow_enabled || shadow_mode >= 2) && (shadow_mode == 0 || shadow_mode == 3))
 	{
-		vec3 world_pos = in_pos + EyePos;
-		vec3 shadow_normal = gl_FrontFacing ? in_normal : -in_normal;
-		if (shadow_receiver && (shadow_mode == 0 || shadow_mode == 4))
+		vec2 shadow_uv;
+		float shadow_ref;
+		ShadowCoordFromClip(in_shadow_clip, shadow_uv, shadow_ref, shadow_range);
+		if (shadow_range >= 0.5 && (shadow_mode == 0 || shadow_mode == 3))
 		{
-			vec2 shadow_uv;
-			float shadow_ref;
-			ShadowCoordFromClip(in_shadow_clip, shadow_uv, shadow_ref, shadow_range);
-			if (shadow_range >= 0.5 && (shadow_mode == 0 || shadow_mode == 4))
-			{
-				float ndotl = dot(shadow_normal, ShadowSunDir.xyz);
-				float bias = ShadowParams.x + ShadowParams.y * max(0.0, 1.0 - ndotl);
-				if (ShadowParams.z > 0.5)
-					shadow_term = ShadowSamplePCF(shadow_uv, shadow_ref, bias, int(ShadowParams.w + 0.5));
-				else
-					shadow_term = ShadowSampleRaw(shadow_uv, shadow_ref, bias);
-			}
-		}
-		if (shadow_mode >= 1)
-		{
-			out_fragcolor = vec4(ShadowDebugColor(world_pos, shadow_term), 1.0);
-#if !OIT
-			out_velocity = vec4(0.0);
-#endif
-			return;
+			float ndotl = dot(shadow_normal, ShadowSunDir.xyz);
+			float bias = ShadowParams.x + ShadowParams.y * max(0.0, 1.0 - ndotl);
+			if (ShadowParams.z > 0.5)
+				shadow_term = ShadowSamplePCF(shadow_uv, shadow_ref, bias, int(ShadowParams.w + 0.5));
+			else
+				shadow_term = ShadowSampleRaw(shadow_uv, shadow_ref, bias);
 		}
 	}
-	lit_color.rgb = clamp(lit_color.rgb + in_direct * shadow_term, 0.0, Overbright);
+	if (shadow_mode >= 2 && allow_debug)
+	{
+		out_fragcolor = vec4(ShadowDebugColor(world_pos, shadow_term), 1.0);
+#if !OIT
+		out_velocity = vec4(0.0);
+#endif
+		return;
+	}
+	lit_color.rgb = clamp(lit_color.rgb + in_direct * (shadow_enabled ? shadow_term : 1.0), 0.0, Overbright);
 #if MODE == 2
         vec4 result = textureLod(Tex, uv, 0.);
 #else

--- a/Quake/shaders/alias.vert
+++ b/Quake/shaders/alias.vert
@@ -23,6 +23,7 @@ layout(std430, binding=1) restrict readonly buffer InstanceBuffer
 	float	_Pad1;
 	mat4	ShadowViewProj;
 	vec4	ShadowParams;
+	vec4	ShadowControl;
 	vec4	ShadowDebug;
 	vec4	ShadowSunDir;
 	InstanceData instances[];

--- a/Quake/shaders/frame_uniforms.glsl
+++ b/Quake/shaders/frame_uniforms.glsl
@@ -28,6 +28,7 @@ layout(std140, binding=0) uniform FrameDataUBO
         vec4    ShaderParams;
         mat4    ShadowViewProj;
         vec4    ShadowParams;
+        vec4    ShadowControl;
         vec4    ShadowDebug;
         vec4    ShadowSunDir;
         mat4    ShadowDlightViewProj[SHADOW_DLIGHT_MAX];

--- a/Quake/shaders/shadow_depth_alias.vert
+++ b/Quake/shaders/shadow_depth_alias.vert
@@ -23,6 +23,7 @@ layout(std430, binding=1) restrict readonly buffer InstanceBuffer
 	float	_Pad1;
 	mat4	ShadowViewProj;
 	vec4	ShadowParams;
+	vec4	ShadowControl;
 	vec4	ShadowDebug;
 	vec4	ShadowSunDir;
 	InstanceData instances[];

--- a/Quake/shaders/shadow_sample.glsl
+++ b/Quake/shaders/shadow_sample.glsl
@@ -97,12 +97,6 @@ float ShadowSamplePCF(vec2 uv, float reference, float bias, int taps)
 
 float ShadowVisibility(vec3 world_pos, vec3 normal, out float in_range)
 {
-	if (ShadowDebug.x < 0.5)
-	{
-		in_range = 1.0;
-		return 1.0;
-	}
-
 	vec2 uv;
 	float reference;
 	ShadowCoord(world_pos, uv, reference, in_range);
@@ -120,12 +114,29 @@ float ShadowVisibility(vec3 world_pos, vec3 normal, out float in_range)
 
 vec3 ShadowDebugColor(vec3 world_pos, float shadow_term)
 {
-	int mode = int(ShadowDebug.y + 0.5);
+	int mode = int(ShadowControl.y + 0.5);
 	vec2 uv;
 	float reference;
 	float in_range;
 
 	ShadowCoord(world_pos, uv, reference, in_range);
+	if (mode == 6)
+	{
+		float matrix_sum = 0.0;
+		matrix_sum += dot(abs(ShadowViewProj[0]), vec4(1.0));
+		matrix_sum += dot(abs(ShadowViewProj[1]), vec4(1.0));
+		matrix_sum += dot(abs(ShadowViewProj[2]), vec4(1.0));
+		matrix_sum += dot(abs(ShadowViewProj[3]), vec4(1.0));
+		if (matrix_sum < 0.001)
+			return vec3(1.0, 0.0, 1.0);
+
+		vec2 clamped_uv = clamp(uv, vec2(0.0), vec2(1.0));
+		float depth = texture(ShadowMapDepth, clamped_uv).r;
+		if (depth <= 0.0001 || depth >= 0.9999)
+			return vec3(0.0, 1.0, 1.0);
+
+		return vec3(0.0, 1.0, 0.0);
+	}
 	if (in_range < 0.5)
 		return vec3(1.0, 0.0, 0.0);
 
@@ -140,6 +151,8 @@ vec3 ShadowDebugColor(vec3 world_pos, float shadow_term)
 	if (mode == 2)
 		return vec3(uv, 0.0);
 	if (mode == 3)
+		return vec3(shadow_term);
+	if (mode == 4)
 	{
 		float depth = texture(ShadowMapDepth, uv).r;
 #if REVERSED_Z
@@ -152,8 +165,6 @@ vec3 ShadowDebugColor(vec3 world_pos, float shadow_term)
 		float scaled = clamp(diff * 10.0 + 0.5, 0.0, 1.0);
 		return vec3(scaled);
 	}
-	if (mode == 4)
-		return vec3(shadow_term);
 
 	return vec3(shadow_term);
 }

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -458,19 +458,19 @@ void main()
 			return;
 		}
 
-		bool shadow_enabled = ShadowDebug.x > 0.5;
-		int shadow_mode = int(ShadowDebug.y + 0.5);
+		bool shadow_enabled = ShadowControl.x > 0.5;
+		int shadow_mode = int(ShadowControl.y + 0.5);
 		float shadow_range = 1.0;
 		float shadow_term = 1.0;
 		bool shadow_receiver = (in_flags & CF_MAT_SKY) == 0u;
 		shadow_receiver = shadow_receiver && (in_flags & CF_MAT_EMISSIVE) == 0u;
 		shadow_receiver = shadow_receiver && (in_flags & CF_USE_EMISSIVE) == 0u;
 		shadow_receiver = shadow_receiver && (in_flags & CF_MAT_NO_SHADOW_RECEIVE) == 0u;
-		if (shadow_enabled && shadow_receiver && (shadow_mode == 0 || shadow_mode == 4))
+		if (shadow_receiver && (shadow_enabled || shadow_mode >= 2) && (shadow_mode == 0 || shadow_mode == 3))
 			shadow_term = ShadowVisibility(in_pos, surface_normal, shadow_range);
 		bool lightgrid_shadow = LightgridParams.z > 0.5 && LightgridParams.x > 0.5;
 
-		if (shadow_enabled && shadow_mode >= 1)
+		if (shadow_mode >= 2)
 		{
 			out_fragcolor = vec4(ShadowDebugColor(in_pos, shadow_term), 1.0);
 #if !OIT
@@ -488,15 +488,13 @@ void main()
 		{
 			ambient_term = clamped_static * lightgrid;
 			direct_term = clamped_static - ambient_term;
-			float shadow_scale = shadow_enabled ? shadow_term : 1.0;
-			total_light = ambient_term + direct_term * shadow_scale;
+			total_light = ambient_term + direct_term * (shadow_enabled ? shadow_term : 1.0);
 		}
 		else
 		{
 			ambient_term = vec3(0.0);
 			direct_term = clamped_static;
-			float shadow_scale = shadow_enabled ? shadow_term : 1.0;
-			total_light = ambient_term + direct_term * shadow_scale;
+			total_light = ambient_term + direct_term * (shadow_enabled ? shadow_term : 1.0);
 			total_light *= lightgrid;
 		}
 	


### PR DESCRIPTION
### Motivation
- Shadowing and the debug overlay were both gated by `ShadowDebug.x`, causing shadows and debug visuals to disappear when the uniform was missing or zeroed.
- The overlay must be visible whenever a debug mode is requested to validate shader paths and bindings independently from shadow enable.
- Add a robust enable flag so missing/incorrect `ShadowDebug` uploads don't silently disable lighting.

### Description
- Introduce a new `ShadowControl` vec4 in the `FrameDataUBO` and `gpuframedata_t` and populate `r_framedata.shadow_control` from existing shadow cvars in `gl_rmain.c` while keeping `shadow_debug` for compatibility.
- Remove the early-out gating on `ShadowDebug.x` in `Quake/shaders/shadow_sample.glsl` so `ShadowVisibility()` always computes visibility, and switch debug mode sampling to use `ShadowControl.y`.
- Update `Quake/shaders/world.frag` and `Quake/shaders/alias.frag` to make debug overlays trigger when `shadow_mode >= 2` regardless of enable, and only apply `shadow_term` to lighting when `ShadowControl.x > 0.5`.
- Wire the new `ShadowControl` through the alias CPU path and shader inputs by updating `r_alias.c`, `Quake/shaders/frame_uniforms.glsl`, `alias.vert`, and `shadow_depth_alias.vert`, and add a binding-sanity debug mode (`mode == 6`) in `shadow_sample.glsl`.

### Testing
- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956c3f7b220832ea9255d243a367f35)