### PR TITLE
Remove forced shadow debug output from world shader

### DIFF
--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -16,8 +16,6 @@ layout(binding=6) uniform sampler2D ShadowMapDepth;
 // Stage 1 shadow debug guards (temporary).
 // Toggle FORCE_WORLD_MAGENTA to confirm this permutation is bound at runtime.
 const bool FORCE_WORLD_MAGENTA = false;
-// Toggle FORCE_SHADOW_DEBUG to force a constant shadow debug output.
-const bool FORCE_SHADOW_DEBUG = true;
 
 vec3 ApplyFog(vec3 clr, vec3 p)
 {
@@ -444,19 +442,6 @@ void main()
 
 		if (!gl_FrontFacing)
 			surface_normal = -surface_normal;
-
-		if (FORCE_SHADOW_DEBUG)
-		{
-			bool shadow_enabled = true;
-			int shadow_mode = 3;
-			float shadow_term = 0.25;
-			bool shadow_receiver = true;
-			out_fragcolor = vec4(vec3(shadow_term), 1.0);
-#if !OIT
-			out_velocity = vec4(0.0);
-#endif
-			return;
-		}
 
 		bool shadow_enabled = ShadowControl.x > 0.5;
 		int shadow_mode = int(ShadowControl.y + 0.5);


### PR DESCRIPTION
### Motivation

- A temporary forced shadow debug constant and early-exit branch in the world shader produced a constant debug output that interferes with normal shadow rendering.
- The hard-coded `FORCE_SHADOW_DEBUG` permutation prevented runtime shadow control and debug modes from working as intended.

### Description

- Removed the `const bool FORCE_SHADOW_DEBUG = true;` declaration from `Quake/shaders/world.frag`.
- Deleted the `if (FORCE_SHADOW_DEBUG)` early-exit block that set `out_fragcolor` to a constant debug value and returned early.
- Only `Quake/shaders/world.frag` was modified to restore the normal shadow control flow using `ShadowControl` and related logic.

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956c6f1d7e0832e9bca0db6f491096c)