### PR TITLE
Fix reversed‑Z shadow ortho near/far handling

### DIFF
--- a/Quake/r_shadow.c
+++ b/Quake/r_shadow.c
@@ -272,7 +272,19 @@ static void R_Shadow_BuildViewProj (float out_viewproj[16], vec4_t out_sun_dir)
 	view[13] = -DotProduct (light_up, eye);
 	view[14] = -DotProduct (sun_dir, eye);
 
-	R_Shadow_OrthoMatrix (ortho, -shadow_radius, shadow_radius, -shadow_radius, shadow_radius, 0.f, shadow_radius * 2.f);
+	{
+		float znear = 0.f;
+		float zfar = shadow_radius * 2.f;
+
+		if (gl_clipcontrol_able)
+		{
+			float tmp = znear;
+			znear = zfar;
+			zfar = tmp;
+		}
+
+		R_Shadow_OrthoMatrix (ortho, -shadow_radius, shadow_radius, -shadow_radius, shadow_radius, znear, zfar);
+	}
 
 	memcpy (out_viewproj, ortho, sizeof (ortho));
 	MatrixMultiply (out_viewproj, view);


### PR DESCRIPTION
### Motivation
- The sun shadow orthographic projection used classic near/far ordering which is incorrect when the renderer uses reversed‑Z (`gl_clipcontrol_able`).
- With the wrong near/far mapping the shadow depth distribution is inverted/compressed causing shadow sampling to produce all‑0 or all‑1 results.

### Description
- Update `R_Shadow_BuildViewProj` in `Quake/r_shadow.c` to compute `znear`/`zfar` and swap them when `gl_clipcontrol_able` (reversed‑Z) is active.
- Pass the corrected `znear`/`zfar` into `R_Shadow_OrthoMatrix` so the shadow orthographic projection maps near→1 and far→0 under reversed‑Z.
- No changes were made to the shadow sampling or depth clear/func logic beyond supplying the corrected projection values.

### Testing
- No automated tests or CI runs were executed for this change.
- The change was committed to the local branch after verification of the source edit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956c84326d0832e93b61ad429b56a5f)