### PR TITLE
Restore shadow debug visualization in world and alias shaders

### DIFF
--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -106,10 +106,6 @@ layout(binding=6) uniform sampler2D ShadowMapDepth;
 #define SHADOW_SUN 1
 #include "shadow_sample.glsl"
 
-// Stage 1 shadow debug guards (temporary).
-// Toggle FORCE_ALIAS_MAGENTA to confirm this permutation is bound at runtime.
-const bool FORCE_ALIAS_MAGENTA = true;
-
 #if MODE == 2
 	layout(location=0) noperspective in vec2 in_texcoord;
 #else
@@ -173,15 +169,6 @@ void main()
 	int shadow_mode = int(ShadowControl.y + 0.5);
 	vec4 lit_color = in_color;
 
-	if (FORCE_ALIAS_MAGENTA && (in_flags & ALIAS_FLAG_VIEWMODEL) == 0)
-	{
-		out_fragcolor = vec4(1.0, 0.0, 1.0, 1.0);
-#if !OIT
-		out_velocity = vec4(0.0);
-#endif
-		return;
-	}
-
 #if MODE == 2
         uv -= 0.5 / vec2(textureSize(Tex, 0).xy);
 #endif
@@ -215,7 +202,25 @@ void main()
 				shadow_term = ShadowSampleRaw(shadow_uv, shadow_ref, bias);
 		}
 	}
-	if (shadow_mode >= 2 && allow_debug)
+	if (shadow_mode == 1 && allow_debug)
+	{
+		out_fragcolor = vec4(vec3(shadow_term), 1.0);
+#if !OIT
+		out_velocity = vec4(0.0);
+#endif
+		return;
+	}
+	if (shadow_mode == 2 && allow_debug)
+	{
+		out_fragcolor = shadow_term < 0.5
+			? vec4(1.0, 0.0, 0.0, 1.0)
+			: vec4(0.0, 1.0, 0.0, 1.0);
+#if !OIT
+		out_velocity = vec4(0.0);
+#endif
+		return;
+	}
+	if (shadow_mode >= 3 && allow_debug)
 	{
 		out_fragcolor = vec4(ShadowDebugColor(world_pos, shadow_term), 1.0);
 #if !OIT

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -13,10 +13,6 @@ layout(binding=6) uniform sampler2D ShadowMapDepth;
 #define SHADOW_SUN 1
 #include "shadow_sample.glsl"
 
-// Stage 1 shadow debug guards (temporary).
-// Toggle FORCE_WORLD_MAGENTA to confirm this permutation is bound at runtime.
-const bool FORCE_WORLD_MAGENTA = false;
-
 vec3 ApplyFog(vec3 clr, vec3 p)
 {
 	float fog = exp2(-abs(Fog.w) * dot(p, p));
@@ -270,15 +266,6 @@ void main()
 	vec3 emissive = vec3(0.0);
 	vec2 uv = in_uv;
 
-	if (FORCE_WORLD_MAGENTA)
-	{
-		out_fragcolor = vec4(1.0, 0.0, 1.0, 1.0);
-#if !OIT
-		out_velocity = vec4(0.0);
-#endif
-		return;
-	}
-	
 #if MODE == 2
 	uv = uv * 2.0 + 0.125 * sin(uv.yx * (3.14159265 * 2.0) + Time);
 #endif
@@ -455,7 +442,27 @@ void main()
 			shadow_term = ShadowVisibility(in_pos, surface_normal, shadow_range);
 		bool lightgrid_shadow = LightgridParams.z > 0.5 && LightgridParams.x > 0.5;
 
-		if (shadow_mode >= 2)
+		if (shadow_mode == 1)
+		{
+			out_fragcolor = vec4(vec3(shadow_term), 1.0);
+#if !OIT
+			out_velocity = vec4(0.0);
+#endif
+			return;
+		}
+
+		if (shadow_mode == 2)
+		{
+			out_fragcolor = shadow_term < 0.5
+				? vec4(1.0, 0.0, 0.0, 1.0)
+				: vec4(0.0, 1.0, 0.0, 1.0);
+#if !OIT
+			out_velocity = vec4(0.0);
+#endif
+			return;
+		}
+
+		if (shadow_mode >= 3)
 		{
 			out_fragcolor = vec4(ShadowDebugColor(in_pos, shadow_term), 1.0);
 #if !OIT


### PR DESCRIPTION
### Motivation
- Shadow debug output (`r_shadow_debug`) was broken because unconditional magenta early-outs in the world and alias fragment shaders short-circuited shadow sampling and visualization.
- The intent is to restore shader-side shadow debug visualization without touching uniform layouts, texture bindings, FBO setup, or CPU render code.
- Keep the fix minimal, reversible, and limited to GLSL so subsequent stages can address bias/projection issues.

### Description
- Removed the `FORCE_WORLD_MAGENTA` and `FORCE_ALIAS_MAGENTA` unconditional short-circuits from `Quake/shaders/world.frag` and `Quake/shaders/alias.frag` so shader execution proceeds to shadow sampling.
- Added scoped debug branches after shadow sampling: `shadow_mode == 1` outputs the grayscale shadow factor (`vec3(shadow_term)`), and `shadow_mode == 2` outputs a red/green comparison visualization, while retaining the existing `shadow_mode >= 3` `ShadowDebugColor` behavior.
- Changes are GLSL-only and limited to `Quake/shaders/world.frag` and `Quake/shaders/alias.frag`, preserving all uniform bindings and CPU-side logic.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956cdb60980832e9c7bb84f4bb0a161)