### PR TITLE
Fix shadow sampling and world-space coords

### DIFF
--- a/Quake/shaders/shadow_sample.glsl
+++ b/Quake/shaders/shadow_sample.glsl
@@ -42,11 +42,7 @@ void ShadowCoord(vec3 world_pos, out vec2 uv, out float reference, out float in_
 float ShadowSampleRaw(vec2 uv, float reference, float bias)
 {
 	float compare_depth = reference - bias;
-#if REVERSED_Z
-	return 1.0 - texture(ShadowMap, vec3(uv, compare_depth));
-#else
 	return texture(ShadowMap, vec3(uv, compare_depth));
-#endif
 }
 
 float ShadowSamplePCF(vec2 uv, float reference, float bias, int taps)
@@ -117,16 +113,12 @@ float ShadowVisibility(vec3 world_pos, vec3 normal, out float in_range)
 vec3 ShadowDebugColor(vec3 world_pos, float shadow_term)
 {
 	int mode = int(ShadowControl.y + 0.5);
+	vec4 lightClip = ShadowViewProj * vec4(world_pos, 1.0);
 	vec2 uv;
 	float reference;
 	float in_range;
-
-	ShadowCoord(world_pos, uv, reference, in_range);
-	vec4 lightClip = ShadowViewProj * vec4(world_pos, 1.0);
-	vec3 lightNDC = lightClip.xyz / lightClip.w;
-	vec3 shadowUVZ = lightNDC * 0.5 + 0.5;
-	bool uv_outside = any(lessThan(shadowUVZ.xy, vec2(0.0))) ||
-		any(greaterThan(shadowUVZ.xy, vec2(1.0)));
+	ShadowCoordFromClip(lightClip, uv, reference, in_range);
+	bool uv_outside = (in_range < 0.5);
 	if (mode == 6)
 	{
 		float matrix_sum = 0.0;
@@ -150,9 +142,6 @@ vec3 ShadowDebugColor(vec3 world_pos, float shadow_term)
 	if (mode == 1)
 	{
 		float depth = texture(ShadowMapDepth, uv).r;
-#if REVERSED_Z
-		depth = 1.0 - depth;
-#endif
 		return vec3(depth);
 	}
 	if (mode == 2)
@@ -161,15 +150,15 @@ vec3 ShadowDebugColor(vec3 world_pos, float shadow_term)
 	{
 		if (uv_outside)
 			return vec3(0.0, 0.0, 1.0);
-		return vec3(shadowUVZ.xy, 0.0);
+		return vec3(uv, 0.0);
 	}
 	if (mode == 4)
 	{
 		if (uv_outside)
 			return vec3(0.0, 0.0, 1.0);
-		float sampled_depth = texture(ShadowMapDepth, shadowUVZ.xy).r;
-		float diff = abs(shadowUVZ.z - sampled_depth);
-		return vec3(shadowUVZ.z, sampled_depth, diff);
+		float sampled_depth = texture(ShadowMapDepth, uv).r;
+		float diff = abs(reference - sampled_depth);
+		return vec3(reference, sampled_depth, diff);
 	}
 
 	return vec3(shadow_term);
@@ -180,11 +169,7 @@ vec3 ShadowDebugColor(vec3 world_pos, float shadow_term)
 float ShadowSampleRawDlight(vec2 uv, float reference, float bias)
 {
 	float compare_depth = reference - bias;
-#if REVERSED_Z
-	return 1.0 - texture(ShadowDlightMap, vec3(uv, compare_depth));
-#else
 	return texture(ShadowDlightMap, vec3(uv, compare_depth));
-#endif
 }
 
 float ShadowSamplePCFDlight(vec2 uv, float reference, float bias, int taps)

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -438,8 +438,9 @@ void main()
 		shadow_receiver = shadow_receiver && (in_flags & CF_MAT_EMISSIVE) == 0u;
 		shadow_receiver = shadow_receiver && (in_flags & CF_USE_EMISSIVE) == 0u;
 		shadow_receiver = shadow_receiver && (in_flags & CF_MAT_NO_SHADOW_RECEIVE) == 0u;
+		vec3 shadow_world_pos = in_pos + EyePos;
 		if (shadow_receiver && (shadow_enabled || shadow_mode >= 2) && (shadow_mode == 0 || shadow_mode == 3))
-			shadow_term = ShadowVisibility(in_pos, surface_normal, shadow_range);
+			shadow_term = ShadowVisibility(shadow_world_pos, surface_normal, shadow_range);
 		bool lightgrid_shadow = LightgridParams.z > 0.5 && LightgridParams.x > 0.5;
 
 		if (shadow_mode == 1)
@@ -464,7 +465,7 @@ void main()
 
 		if (shadow_mode >= 3)
 		{
-			out_fragcolor = vec4(ShadowDebugColor(in_pos, shadow_term), 1.0);
+			out_fragcolor = vec4(ShadowDebugColor(shadow_world_pos, shadow_term), 1.0);
 #if !OIT
 			out_velocity = vec4(0.0);
 #endif


### PR DESCRIPTION
### Motivation
- Debug shadow modes showed solid colors due to inconsistent UV/reference computation and coordinate-space mismatches between the shadow depth pass and lighting pass.
- Shadow sampling was being inverted again for `REVERSED_Z` even though `ShadowCoordFromClip` already flips the reference, causing visibility to be wrong.
- Lighting shaders used eye-relative positions for shadow lookups while the depth pass used world-space, producing near-constant UVs in debug modes.

### Description
- Removed the extra `REVERSED_Z` invert in `ShadowSampleRaw` and `ShadowSampleRawDlight` so `sampler2DShadow` results are used directly (`Quake/shaders/shadow_sample.glsl`).
- Unified debug coordinate generation to use `ShadowCoordFromClip` and the already-computed `reference` so modes 1..4 sample/compare in the same Z-space (`Quake/shaders/shadow_sample.glsl`).
- Replaced fragile manual `lightClip`->`shadowUVZ` handling in debug code and switched debug mode 3/4 outputs to use the canonical `uv`/`reference` values (`Quake/shaders/shadow_sample.glsl`).
- Use absolute world positions for shadow visibility and debug in the main world lighting pass by computing `shadow_world_pos = in_pos + EyePos` and passing it to `ShadowVisibility`/`ShadowDebugColor` (`Quake/shaders/world.frag`).

### Testing
- No automated tests were run as part of this change.
- Shader compilation and runtime validation were not executed in CI for this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956dcc56714832eb7a670e96e43744b)