### PR TITLE
Fix shadow reference depth mapping for reversed-Z and add CLIP_Z_ZERO_TO_ONE define

### DIFF
--- a/Quake/gl_shaders.c
+++ b/Quake/gl_shaders.c
@@ -141,8 +141,10 @@ static GLuint GL_CreateShader (GLenum type, const char *source, const char *extr
 		"#version 430\n"
 		"\n"
 		"#define BINDLESS %d\n"
-		"#define REVERSED_Z %d\n",
+		"#define REVERSED_Z %d\n"
+		"#define CLIP_Z_ZERO_TO_ONE %d\n",
 		gl_bindless_able,
+		gl_clipcontrol_able,
 		gl_clipcontrol_able
 	);
 	strings[numstrings++] = header;

--- a/Quake/shaders/shadow_sample.glsl
+++ b/Quake/shaders/shadow_sample.glsl
@@ -21,11 +21,7 @@ void ShadowCoordFromClip(vec4 clip, out vec2 uv, out float reference, out float 
 		ndc.z * 0.5 + 0.5;
 #endif
 
-#if REVERSED_Z
-	reference = 1.0 - depth01;
-#else
 	reference = depth01;
-#endif
 
 	bool inside = all(greaterThanEqual(uv, vec2(0.0))) &&
 		all(lessThanEqual(uv, vec2(1.0))) &&
@@ -261,12 +257,7 @@ float ShadowVisibilityDlight(vec3 world_pos, vec3 normal, vec3 light_pos, uint l
 		ndc.z * 0.5 + 0.5;
 #endif
 
-	float reference =
-#if REVERSED_Z
-		1.0 - depth01;
-#else
-		depth01;
-#endif
+	float reference = depth01;
 
 	vec4 atlas = ShadowDlightAtlas[shadow_index];
 	vec2 uv = base_uv;


### PR DESCRIPTION
### Motivation
- Debug shadow modes and shadow sampling produced near-constant full-color outputs due to inconsistent depth reference handling under reversed-Z and missing clip-space Z range definition.  
- The stored shadow depth and shader `reference` value were sometimes in different Z conventions, causing incorrect compare results and debug overlays.  
- The shader lacked an explicit `CLIP_Z_ZERO_TO_ONE` define tied to runtime clip control, making depth unpacking fragile across GL clip control modes.  

### Description
- In `Quake/shaders/shadow_sample.glsl` made `ShadowCoordFromClip` assign `reference = depth01;` unconditionally so the shader reference matches the stored shadow depth convention.  
- Updated the DLight path in `ShadowVisibilityDlight` to use `float reference = depth01;` to match the sun-path fix.  
- In `Quake/gl_shaders.c` added a `#define CLIP_Z_ZERO_TO_ONE %d` macro in the shader header and pass `gl_clipcontrol_able` so shaders know the runtime NDC Z-range at compile time.  
- Changes ensure the shader-side depth reference and compile-time macros are consistent with runtime clip control and reversed-Z handling.  

### Testing
- No automated tests were run against these changes.  
- Runtime shader compilation will now receive `CLIP_Z_ZERO_TO_ONE` based on `gl_clipcontrol_able`, but no automated shader/GL validation was executed.  
- Manual runtime verification is recommended to confirm `r_shadow_debug` modes and alias shadows behave correctly under both clip control and non-clip-control setups.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956e0912d8c832ea6233b8bc1c53bf9)