### PR TITLE
Fix shadow depth encoding alignment

### DIFF
--- a/Quake/r_shadow.c
+++ b/Quake/r_shadow.c
@@ -435,7 +435,7 @@ static void R_Shadow_ResizeDlightAtlasIfNeeded (void)
 		glTexParameterfv (GL_TEXTURE_2D, GL_TEXTURE_BORDER_COLOR, border);
 	}
 	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE, GL_COMPARE_REF_TO_TEXTURE);
-	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_FUNC, gl_clipcontrol_able ? GL_GEQUAL : GL_LEQUAL);
+	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_FUNC, GL_LEQUAL);
 	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0);
 
 	GL_GenFramebuffersFunc (1, &shadow_dlight_fbo);
@@ -535,14 +535,14 @@ void R_Shadow_BindShadowMap (GLenum texunit)
 {
 	GL_BindNative (texunit, GL_TEXTURE_2D, shadow_depth_tex);
 	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE, GL_COMPARE_REF_TO_TEXTURE);
-	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_FUNC, gl_clipcontrol_able ? GL_GEQUAL : GL_LEQUAL);
+	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_FUNC, GL_LEQUAL);
 }
 
 void R_Shadow_BindShadowMapRaw (GLenum texunit)
 {
 	GL_BindNative (texunit, GL_TEXTURE_2D, shadow_depth_tex);
 	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE, GL_NONE);
-	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_FUNC, gl_clipcontrol_able ? GL_GEQUAL : GL_LEQUAL);
+	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_FUNC, GL_LEQUAL);
 }
 
 void R_Shadow_BindDlightShadowMap (GLenum texunit)
@@ -551,7 +551,7 @@ void R_Shadow_BindDlightShadowMap (GLenum texunit)
 	{
 		GL_BindNative (texunit, GL_TEXTURE_2D, shadow_dlight_depth_tex);
 		glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE, GL_COMPARE_REF_TO_TEXTURE);
-		glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_FUNC, gl_clipcontrol_able ? GL_GEQUAL : GL_LEQUAL);
+		glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_FUNC, GL_LEQUAL);
 	}
 	else
 		GL_BindNative (texunit, GL_TEXTURE_2D, 0);

--- a/Quake/shaders/shadow_debug.frag
+++ b/Quake/shaders/shadow_debug.frag
@@ -5,8 +5,5 @@ layout(location=0) out vec4 out_fragcolor;
 void main()
 {
 	float depth = texture(ShadowMapDepth, v_uv).r;
-#if REVERSED_Z
-	depth = 1.0 - depth;
-#endif
 	out_fragcolor = vec4(vec3(depth), 1.0);
 }

--- a/Quake/shaders/shadow_depth.frag
+++ b/Quake/shaders/shadow_depth.frag
@@ -1,3 +1,18 @@
+layout(location=0) in vec4 v_light_clip;
+
 void main()
 {
+	float ndc_z = v_light_clip.z / v_light_clip.w;
+	float depth01 =
+#if CLIP_Z_ZERO_TO_ONE
+		ndc_z;
+#else
+		ndc_z * 0.5 + 0.5;
+#endif
+
+#if REVERSED_Z
+	gl_FragDepth = 1.0 - depth01;
+#else
+	gl_FragDepth = depth01;
+#endif
 }

--- a/Quake/shaders/shadow_depth.vert
+++ b/Quake/shaders/shadow_depth.vert
@@ -60,6 +60,7 @@ vec3 TransformPosition(vec3 p, vec4 mat[3])
 }
 
 layout(location=0) in vec3 in_pos;
+layout(location=0) out vec4 v_light_clip;
 
 void main()
 {
@@ -78,5 +79,6 @@ void main()
 		float zoffset = (call.polygon_offset.x + call.polygon_offset.y) * ZBIAS;
 		clip.z += zoffset;
 	}
+	v_light_clip = clip;
 	gl_Position = clip;
 }

--- a/Quake/shaders/shadow_depth_alias.vert
+++ b/Quake/shaders/shadow_depth_alias.vert
@@ -35,6 +35,8 @@ struct PoseVertex
 	vec3 nor;
 };
 
+layout(location=0) out vec4 v_light_clip;
+
 #if MD5
 	layout(location=0) in vec3 in_pos;
 	layout(location=1) in vec4 in_weights;
@@ -85,5 +87,6 @@ void main()
 		vec4(inst.WorldMatrix[0].w, inst.WorldMatrix[1].w, inst.WorldMatrix[2].w, 1.0)
 	);
 	vec3 world_pos = (model * vec4(alias_pos, 1.0)).xyz;
-	gl_Position = ShadowViewProj * vec4(world_pos, 1.0);
+	v_light_clip = ShadowViewProj * vec4(world_pos, 1.0);
+	gl_Position = v_light_clip;
 }

--- a/Quake/shaders/shadow_sample.glsl
+++ b/Quake/shaders/shadow_sample.glsl
@@ -21,7 +21,11 @@ void ShadowCoordFromClip(vec4 clip, out vec2 uv, out float reference, out float 
 		ndc.z * 0.5 + 0.5;
 #endif
 
+#if REVERSED_Z
+	reference = 1.0 - depth01;
+#else
 	reference = depth01;
+#endif
 
 	bool inside = all(greaterThanEqual(uv, vec2(0.0))) &&
 		all(lessThanEqual(uv, vec2(1.0))) &&
@@ -257,7 +261,11 @@ float ShadowVisibilityDlight(vec3 world_pos, vec3 normal, vec3 light_pos, uint l
 		ndc.z * 0.5 + 0.5;
 #endif
 
+#if REVERSED_Z
+	float reference = 1.0 - depth01;
+#else
 	float reference = depth01;
+#endif
 
 	vec4 atlas = ShadowDlightAtlas[shadow_index];
 	vec2 uv = base_uv;


### PR DESCRIPTION
### Motivation
- Ensure the shadow depth written during the light depth pass is bit-for-bit identical to the reference value computed when sampling so comparisons are valid.
- Remove reliance on implicit fixed-function depth writes and `gl_FragCoord.z` to make the depth encoding deterministic across GL clip conventions.
- Correct handling of `CLIP_Z_ZERO_TO_ONE` and `REVERSED_Z` so both depth writing and sampling use the same transform.
- Make the debug path read the same stored depth without performing its own inverted math.

### Description
- Pass the light clip coordinate through the depth vertex shaders by adding `v_light_clip` in `shadow_depth.vert` and `shadow_depth_alias.vert` and use it in `shadow_depth.frag`.
- Write explicit `gl_FragDepth` in `shadow_depth.frag` computed from `v_light_clip` using the `CLIP_Z_ZERO_TO_ONE` and `REVERSED_Z` macros so the depth encoding matches the sampling reference.
- Mirror reversed-Z handling in `Quake/shaders/shadow_sample.glsl` (including dlight code paths) so `reference` is calculated the same way as the depth pass.
- Remove the extra inversion from `shadow_debug.frag` and standardize texture compare configuration to `GL_LEQUAL` in `Quake/r_shadow.c` for shadow maps and dlight shadow maps.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956e547d610832ea16ba4d29a192d51)