### PR TITLE
Fix shadow depth/visibility handling for reversed-Z and clip conventions

### DIFF
--- a/Quake/shaders/shadow_depth.frag
+++ b/Quake/shaders/shadow_depth.frag
@@ -3,6 +3,14 @@ layout(location=0) in vec4 v_light_clip;
 void main()
 {
 	vec3 ndc = v_light_clip.xyz / v_light_clip.w;
+#if CLIP_Z_ZERO_TO_ONE
+	float depth01 = ndc.z;
+#else
 	float depth01 = ndc.z * 0.5 + 0.5;
+#endif
+#if REVERSED_Z
+	gl_FragDepth = clamp(1.0 - depth01, 0.0, 1.0);
+#else
 	gl_FragDepth = clamp(depth01, 0.0, 1.0);
+#endif
 }

--- a/Quake/shaders/shadow_sample.glsl
+++ b/Quake/shaders/shadow_sample.glsl
@@ -15,7 +15,14 @@ void ShadowCoordFromClip(vec4 clip, out vec2 uv, out float reference, out float 
 	vec3 light_ndc = clip.xyz / clip.w;
 	vec3 shadow_uvz;
 	shadow_uvz.xy = light_ndc.xy * 0.5 + 0.5;
+#if CLIP_Z_ZERO_TO_ONE
+	shadow_uvz.z = light_ndc.z;
+#else
 	shadow_uvz.z = light_ndc.z * 0.5 + 0.5;
+#endif
+#if REVERSED_Z
+	shadow_uvz.z = 1.0 - shadow_uvz.z;
+#endif
 	uv = shadow_uvz.xy;
 	reference = shadow_uvz.z;
 
@@ -34,8 +41,12 @@ void ShadowCoord(vec3 world_pos, out vec2 uv, out float reference, out float in_
 float ShadowSampleRaw(vec2 uv, float reference, float bias)
 {
 	float shadow_depth = texture(ShadowMap, uv).r;
-	float compare_depth = reference + bias;
+	float compare_depth = reference - bias;
+#if REVERSED_Z
+	return step(shadow_depth, compare_depth);
+#else
 	return step(compare_depth, shadow_depth);
+#endif
 }
 
 float ShadowSamplePCF(vec2 uv, float reference, float bias, int taps)
@@ -258,6 +269,8 @@ float ShadowVisibilityDlight(vec3 world_pos, vec3 normal, vec3 light_pos, uint l
 
 	bool inside = all(greaterThanEqual(base_uv, vec2(0.0))) &&
 		all(lessThanEqual(base_uv, vec2(1.0))) &&
+		all(greaterThanEqual(uv, vec2(0.0))) &&
+		all(lessThanEqual(uv, vec2(1.0))) &&
 		reference >= 0.0 && reference <= 1.0;
 	in_range = inside ? 1.0 : 0.0;
 	if (!inside)


### PR DESCRIPTION
### Motivation

- Ensure shadow depth is written using the same clip-space Z convention used elsewhere by honoring `CLIP_Z_ZERO_TO_ONE` and `REVERSED_Z` when emitting `gl_FragDepth`.
- Align sun-shadow sampling and bias handling with the reversed-Z depth ordering so comparisons remain correct when `REVERSED_Z` is enabled.
- Make shadow coordinate Z extraction consistent with clip-space conventions in `ShadowCoordFromClip`.
- Prevent sampling outside the intended atlas region by validating UVs after applying the atlas transform.

### Description

- Updated `Quake/shaders/shadow_depth.frag` to map NDC Z to [0,1] using `CLIP_Z_ZERO_TO_ONE` and to invert depth when `REVERSED_Z` is defined before writing `gl_FragDepth`.
- Modified `ShadowCoordFromClip` in `Quake/shaders/shadow_sample.glsl` to compute `shadow_uvz.z` with `CLIP_Z_ZERO_TO_ONE` support and to invert the value when `REVERSED_Z` is set.
- Changed `ShadowSampleRaw` so the bias is applied as `reference - bias` and the depth comparison is flipped under `REVERSED_Z` to maintain correct lit/occluded results.
- Added post-atlas UV bounds checks in `ShadowVisibilityDlight` so the final `uv` (after atlas transform) is validated before sampling.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956f49fd2f4832ea64f7a869762e7c7)