### PR TITLE
Limit pickup postfx stacking to avoid ghosting

### DIFF
--- a/Quake/cl_postfx.c
+++ b/Quake/cl_postfx.c
@@ -281,12 +281,29 @@ void CL_PostFX_PushPickup (void)
 	postfx_event_t *event;
 	float duration;
 	float intensity;
+	int i;
 
 	if (r_postfx.value <= 0.f || r_postfx_pickup.value <= 0.f)
 		return;
 
 	duration = q_max (0.05f, r_postfx_pickup_duration.value);
 	intensity = PostFX_Saturate (r_postfx_pickup.value);
+
+	for (i = 0; i < POSTFX_MAX_EVENTS; ++i)
+	{
+		if (!postfx_events[i].active || postfx_events[i].type != PFX_EVENT_PICKUP)
+			continue;
+
+		postfx_events[i].start_time = cl.time;
+		postfx_events[i].last_update = cl.time;
+		postfx_events[i].duration = duration;
+		postfx_events[i].attack = duration * 0.2f;
+		postfx_events[i].decay = duration * 0.8f;
+		postfx_events[i].intensity = q_max (postfx_events[i].intensity, intensity);
+		postfx_events[i].params[0] = r_postfx_pickup_exposure.value;
+		postfx_events[i].params[1] = r_postfx_pickup_bloom.value;
+		return;
+	}
 
 	event = PostFX_AllocEvent ();
 	memset (event, 0, sizeof (*event));


### PR DESCRIPTION
### Motivation

- Picking up multiple items in quick succession caused multiple overlapping pickup postfx events which produced visible ghost/double images in the final postprocess.
- The intent is to avoid stacking identical pickup events and instead refresh or strengthen the existing pickup event so postfx remain bounded and visually stable.

### Description

- Modified `CL_PostFX_PushPickup` to scan for an existing active `PFX_EVENT_PICKUP` and refresh its `start_time`, `last_update`, `duration`, `attack`, and `decay` instead of allocating a new event.
- When refreshing an existing pickup event the code now clamps intensity using `q_max` to keep the pickup strength bounded and updates `params[0]`/`params[1]` with `r_postfx_pickup_exposure.value` and `r_postfx_pickup_bloom.value`.
- If no existing pickup event is active the function still allocates and initializes a new event as before using `PostFX_AllocEvent` and the same parameter layout.
- This change prevents rapid accumulation of pickup events that caused the ghosting artifact without changing the damage or powerup postfx paths.

### Testing

- No automated tests were executed for this change.
- A compile/test run was not requested as part of this rollout, so behavior was validated by code review only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956f731240c832eae1f0a3ed1b66b53)