### PR TITLE
Fix shadowmap depth handling, clip-space Z define, and reversed-Z bias

### DIFF
--- a/Quake/gl_shaders.c
+++ b/Quake/gl_shaders.c
@@ -145,7 +145,7 @@ static GLuint GL_CreateShader (GLenum type, const char *source, const char *extr
 		"#define CLIP_Z_ZERO_TO_ONE %d\n",
 		gl_bindless_able,
 		gl_clipcontrol_able,
-		gl_clipcontrol_able
+		gl_clip_z_01
 	);
 	strings[numstrings++] = header;
 

--- a/Quake/gl_vidsdl.c
+++ b/Quake/gl_vidsdl.c
@@ -89,6 +89,7 @@ qboolean gl_buffer_storage_able = false;
 qboolean gl_multi_bind_able = false;
 qboolean gl_bindless_able = false;
 qboolean gl_clipcontrol_able = false;
+qboolean gl_clip_z_01 = false;
 float gl_max_anisotropy; //johnfitz
 int gl_stencilbits;
 
@@ -1102,10 +1103,12 @@ static void GL_CheckExtensions (void)
 	;
 
 	gl_clipcontrol_able =
+		COM_CheckParm ("-clipcontrol") &&
 		!COM_CheckParm ("-noclipcontrol") &&
 		GL_FindExtension ("GL_ARB_clip_control") &&
 		GL_InitFunctions (gl_arb_clip_control_functions, false)
 	;
+	gl_clip_z_01 = gl_clipcontrol_able;
 }
 
 /*

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -122,6 +122,7 @@ extern	qboolean	gl_buffer_storage_able;
 extern	qboolean	gl_multi_bind_able;
 extern	qboolean	gl_bindless_able;
 extern	qboolean	gl_clipcontrol_able;
+extern	qboolean	gl_clip_z_01;
 
 extern	const char	*gl_vendor;
 extern	const char	*gl_renderer;

--- a/Quake/r_shadow.c
+++ b/Quake/r_shadow.c
@@ -61,10 +61,12 @@ typedef struct shadow_state_s
 	GLint viewport[4];
 	GLint scissor_box[4];
 	GLboolean scissor_enabled;
+	GLboolean blend_enabled;
 	GLboolean color_mask[4];
 	GLboolean depth_mask;
 	GLboolean depth_test;
 	GLint depth_func;
+	GLdouble depth_range[2];
 } shadow_state_t;
 
 static void R_Shadow_SaveState (shadow_state_t *state)
@@ -73,10 +75,12 @@ static void R_Shadow_SaveState (shadow_state_t *state)
 	glGetIntegerv (GL_VIEWPORT, state->viewport);
 	glGetIntegerv (GL_SCISSOR_BOX, state->scissor_box);
 	glGetBooleanv (GL_SCISSOR_TEST, &state->scissor_enabled);
+	glGetBooleanv (GL_BLEND, &state->blend_enabled);
 	glGetBooleanv (GL_COLOR_WRITEMASK, state->color_mask);
 	glGetBooleanv (GL_DEPTH_WRITEMASK, &state->depth_mask);
 	glGetBooleanv (GL_DEPTH_TEST, &state->depth_test);
 	glGetIntegerv (GL_DEPTH_FUNC, &state->depth_func);
+	glGetDoublev (GL_DEPTH_RANGE, state->depth_range);
 }
 
 static void R_Shadow_RestoreState (const shadow_state_t *state)
@@ -88,6 +92,10 @@ static void R_Shadow_RestoreState (const shadow_state_t *state)
 		glEnable (GL_SCISSOR_TEST);
 	else
 		glDisable (GL_SCISSOR_TEST);
+	if (state->blend_enabled)
+		glEnable (GL_BLEND);
+	else
+		glDisable (GL_BLEND);
 	glColorMask (state->color_mask[0], state->color_mask[1], state->color_mask[2], state->color_mask[3]);
 	glDepthMask (state->depth_mask);
 	if (state->depth_test)
@@ -95,6 +103,7 @@ static void R_Shadow_RestoreState (const shadow_state_t *state)
 	else
 		glDisable (GL_DEPTH_TEST);
 	glDepthFunc (state->depth_func);
+	glDepthRange (state->depth_range[0], state->depth_range[1]);
 }
 
 static void R_Shadow_DestroyDlightResources (void)
@@ -434,7 +443,7 @@ static void R_Shadow_ResizeDlightAtlasIfNeeded (void)
 		const float border[4] = { 1.f, 1.f, 1.f, 1.f };
 		glTexParameterfv (GL_TEXTURE_2D, GL_TEXTURE_BORDER_COLOR, border);
 	}
-	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE, GL_COMPARE_REF_TO_TEXTURE);
+	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE, GL_NONE);
 	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_FUNC, gl_clipcontrol_able ? GL_GEQUAL : GL_LEQUAL);
 	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0);
 
@@ -534,7 +543,7 @@ void R_ResizeShadowMapIfNeeded (void)
 void R_Shadow_BindShadowMap (GLenum texunit)
 {
 	GL_BindNative (texunit, GL_TEXTURE_2D, shadow_depth_tex);
-	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE, GL_COMPARE_REF_TO_TEXTURE);
+	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE, GL_NONE);
 	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_FUNC, gl_clipcontrol_able ? GL_GEQUAL : GL_LEQUAL);
 }
 
@@ -603,9 +612,11 @@ void R_Shadow_SunPass (void)
 	glDrawBuffer (GL_NONE);
 	glReadBuffer (GL_NONE);
 	glDisable (GL_SCISSOR_TEST);
+	glDisable (GL_BLEND);
 	glColorMask (GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
 	glDepthMask (GL_TRUE);
 	glEnable (GL_DEPTH_TEST);
+	glDepthRange (0.0, 1.0);
 	glClearDepth (gl_clipcontrol_able ? 0.f : 1.f);
 	glDepthFunc (gl_clipcontrol_able ? GL_GEQUAL : GL_LEQUAL);
 
@@ -765,9 +776,11 @@ void R_Shadow_DlightPass (void)
 	glDrawBuffer (GL_NONE);
 	glReadBuffer (GL_NONE);
 	glDisable (GL_SCISSOR_TEST);
+	glDisable (GL_BLEND);
 	glColorMask (GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
 	glDepthMask (GL_TRUE);
 	glEnable (GL_DEPTH_TEST);
+	glDepthRange (0.0, 1.0);
 	glClearDepth (gl_clipcontrol_able ? 0.f : 1.f);
 	glDepthFunc (gl_clipcontrol_able ? GL_GEQUAL : GL_LEQUAL);
 

--- a/Quake/shaders/shadow_sample.glsl
+++ b/Quake/shaders/shadow_sample.glsl
@@ -41,10 +41,11 @@ void ShadowCoord(vec3 world_pos, out vec2 uv, out float reference, out float in_
 float ShadowSampleRaw(vec2 uv, float reference, float bias)
 {
 	float shadow_depth = texture(ShadowMap, uv).r;
-	float compare_depth = reference - bias;
 #if REVERSED_Z
+	float compare_depth = reference + bias;
 	return step(shadow_depth, compare_depth);
 #else
+	float compare_depth = reference - bias;
 	return step(compare_depth, shadow_depth);
 #endif
 }


### PR DESCRIPTION
### Motivation
- Shadowmaps were producing invalid depth values and debug overlays (cyan/red) due to a mismatch between shader `CLIP_Z_ZERO_TO_ONE` defines and the actual GL clip-space Z convention.
- Reversed-Z handling and bias direction in shadow sampling caused shadows to evaluate incorrectly (never/always).
- Depth-texture compare state and shadow pass GL state (clear, depth func, depth range, blend) needed to be consistent to produce valid shadow depth contents.
- Provide an explicit, central clip-space Z source so shader permutations are correct across backends and platforms.

### Description
- Add a new global flag `gl_clip_z_01` (exposed in `glquake.h`) and make `-clipcontrol` opt-in; `gl_clip_z_01` is set from `gl_clipcontrol_able` and drives `CLIP_Z_ZERO_TO_ONE` in shader compilation via `gl_shaders.c` using `#define CLIP_Z_ZERO_TO_ONE %d`.
- Make shadow depth textures sample raw depth by setting `GL_TEXTURE_COMPARE_MODE` to `GL_NONE` in shadow texture creation and in `R_Shadow_BindShadowMap`, ensuring shader manual comparisons read real depth values.
- Fix reversed-Z bias direction in `Quake/shaders/shadow_sample.glsl` so the compare uses `reference + bias` for `REVERSED_Z` and `reference - bias` for the normal case.
- Harden shadow pass GL state by saving/restoring `GL_BLEND` and `GL_DEPTH_RANGE`, disabling blending, setting `glDepthRange(0.0,1.0)` before clears, and ensuring `glClearDepth`/`glDepthFunc` follow `gl_clipcontrol_able` (reversed-Z aware).

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956fde13d2c832e983e00e4e6f16d26)