### PR TITLE
Add GL loader for framebuffer attachment query

### DIFF
--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -189,6 +189,7 @@ extern	const char	*gl_version;
 	x(void,			DeleteFramebuffers, (GLsizei n, const GLuint *framebuffers))\
 	x(void,			FramebufferTexture2D, (GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level))\
 	x(void,			FramebufferTextureLayer, (GLenum target, GLenum attachment, GLuint texture, GLint level, GLint layer))\
+	x(void,			GetFramebufferAttachmentParameteriv, (GLenum target, GLenum attachment, GLenum pname, GLint *params))\
 	x(GLenum,		CheckFramebufferStatus, (GLenum target))\
 	x(void,			BlitFramebuffer, (GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0, GLint dstX1, GLint dstY1, GLbitfield mask, GLenum filter))\
 	x(void,			DrawBuffers, (GLsizei n, const GLenum *bufs))\

--- a/Quake/r_shadow.c
+++ b/Quake/r_shadow.c
@@ -120,9 +120,9 @@ static void R_Shadow_LogFboInfo (const char *label, int width, int height, GLuin
 	GLint read_buffer = 0;
 
 	glGetTexLevelParameteriv (GL_TEXTURE_2D, 0, GL_TEXTURE_INTERNAL_FORMAT, &internal_format);
-	glGetFramebufferAttachmentParameteriv (GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
+	GL_GetFramebufferAttachmentParameterivFunc (GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
 		GL_FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE, &attachment_type);
-	glGetFramebufferAttachmentParameteriv (GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
+	GL_GetFramebufferAttachmentParameterivFunc (GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
 		GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME, &attachment_name);
 	glGetIntegerv (GL_DRAW_BUFFER, &draw_buffer);
 	glGetIntegerv (GL_READ_BUFFER, &read_buffer);


### PR DESCRIPTION
### Motivation
- Resolve compiler warnings/errors from using `glGetFramebufferAttachmentParameteriv` directly on some platforms by providing a loaded function pointer. 
- Make shadow FBO diagnostic code use the same GL loader mechanism as other GL functions to improve portability. 

### Description
- Add `GetFramebufferAttachmentParameteriv` to the GL function list in `Quake/glquake.h` so it is resolved via the loader.  
- Replace direct calls to `glGetFramebufferAttachmentParameteriv` in `Quake/r_shadow.c` with `GL_GetFramebufferAttachmentParameterivFunc`.  
- Update shadow FBO logging to use the loaded function pointer for attachment queries.  

### Testing
- No automated tests were run.  
- The change was committed locally after applying the edits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69570afc8b64832e87c40675106eeff4)