### PR TITLE
Fix shadow debug sampler parameter query

### DIFF
--- a/Quake/r_shadow.c
+++ b/Quake/r_shadow.c
@@ -1035,8 +1035,8 @@ void R_Shadow_DrawDepthDebugQuad (void)
 		GLint compare_func = GL_LEQUAL;
 		if (shadow_compare_sampler)
 		{
-			glGetSamplerParameteriv (shadow_compare_sampler, GL_TEXTURE_COMPARE_MODE, &compare_mode);
-			glGetSamplerParameteriv (shadow_compare_sampler, GL_TEXTURE_COMPARE_FUNC, &compare_func);
+			compare_mode = GL_COMPARE_REF_TO_TEXTURE;
+			compare_func = gl_clipcontrol_able ? GL_GEQUAL : GL_LEQUAL;
 		}
 		GL_Uniform1fFunc (1, compare_mode == GL_COMPARE_REF_TO_TEXTURE ? 1.f : 0.f);
 		GL_Uniform1fFunc (2, (compare_func == GL_GEQUAL || compare_func == GL_GREATER) ? 1.f : 0.f);


### PR DESCRIPTION
### Motivation
- Prevent MSVC build errors caused by calling the undefined `glGetSamplerParameteriv` in the shadow depth debug path.
- Use the known sampler configuration instead of querying sampler state at runtime since the sampler parameters are set by the code.

### Description
- Replace runtime calls to `glGetSamplerParameteriv` with explicit assignments of `compare_mode = GL_COMPARE_REF_TO_TEXTURE` and `compare_func = gl_clipcontrol_able ? GL_GEQUAL : GL_LEQUAL`.
- Change performed in `R_Shadow_DrawDepthDebugQuad` within `Quake/r_shadow.c` to derive compare mode/func from the established sampler setup.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695712a8b424832ebe1ff4ea013cb988)