### PR TITLE
Unify shadow depth sampling, add R32F shadow debug output, and enforce reversed-Z state

### DIFF
--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -606,8 +606,7 @@ ibuf.global.half_lambert = CLAMP (0.f, r_model_halflambert.value, 1.f);
 
 	GL_BindBuffer (GL_ARRAY_BUFFER, model->meshvbo);
 	GL_BindBuffer (GL_ELEMENT_ARRAY_BUFFER, model->meshindexesvbo);
-	R_Shadow_BindShadowMap (GL_TEXTURE0 + TEXUNIT_SHADOW);
-	R_Shadow_BindShadowMapRaw (GL_TEXTURE0 + TEXUNIT_SHADOW_DEPTH);
+	R_Shadow_BindShadowMapRaw (GL_TEXTURE0 + TEXUNIT_SHADOW);
 #ifndef NDEBUG
 	{
 		GLint bound = 0;

--- a/Quake/r_shadow.c
+++ b/Quake/r_shadow.c
@@ -41,6 +41,7 @@ extern dlight_t *r_dlight_sources[DLIGHT_GPU_MAX];
 
 static GLuint shadow_fbo;
 static GLuint shadow_depth_tex;
+static GLuint shadow_debug_tex;
 static GLuint shadow_compare_sampler;
 static GLuint shadow_raw_sampler;
 static int shadowmap_size;
@@ -238,6 +239,11 @@ static void R_Shadow_DestroyResources (void)
 	{
 		GL_DeleteNativeTexture (shadow_depth_tex);
 		shadow_depth_tex = 0;
+	}
+	if (shadow_debug_tex)
+	{
+		GL_DeleteNativeTexture (shadow_debug_tex);
+		shadow_debug_tex = 0;
 	}
 	if (shadow_compare_sampler)
 	{
@@ -559,6 +565,7 @@ void R_InitShadow (void)
 {
 	shadow_fbo = 0;
 	shadow_depth_tex = 0;
+	shadow_debug_tex = 0;
 	shadow_compare_sampler = 0;
 	shadow_raw_sampler = 0;
 	shadowmap_size = 0;
@@ -648,10 +655,21 @@ void R_ResizeShadowMapIfNeeded (void)
 		GL_SamplerParameteriFunc (shadow_raw_sampler, GL_TEXTURE_COMPARE_MODE, GL_NONE);
 	}
 
+	glGenTextures (1, &shadow_debug_tex);
+	GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, shadow_debug_tex);
+	GL_ObjectLabelFunc (GL_TEXTURE, shadow_debug_tex, -1, "shadowmap debug depth");
+	GL_TexStorage2DFunc (GL_TEXTURE_2D, 1, GL_R32F, desired, desired);
+	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0);
+
 	GL_GenFramebuffersFunc (1, &shadow_fbo);
 	GL_BindFramebufferFunc (GL_FRAMEBUFFER, shadow_fbo);
 	GL_ObjectLabelFunc (GL_FRAMEBUFFER, shadow_fbo, -1, "shadowmap fbo");
 	GL_FramebufferTexture2DFunc (GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, shadow_depth_tex, 0);
+	GL_FramebufferTexture2DFunc (GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, shadow_debug_tex, 0);
 	glDrawBuffer (GL_NONE);
 	glReadBuffer (GL_NONE);
 
@@ -668,13 +686,13 @@ void R_ResizeShadowMapIfNeeded (void)
 void R_Shadow_BindShadowMap (GLenum texunit)
 {
 	GL_BindNative (texunit, GL_TEXTURE_2D, shadow_depth_tex);
-	GL_BindSamplerFunc (texunit - GL_TEXTURE0, shadow_compare_sampler);
+	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE, GL_NONE);
+	GL_BindSamplerFunc (texunit - GL_TEXTURE0, shadow_raw_sampler);
 }
 
 void R_Shadow_BindShadowMapRaw (GLenum texunit)
 {
-	GL_BindNative (texunit, GL_TEXTURE_2D, shadow_depth_tex);
-	GL_BindSamplerFunc (texunit - GL_TEXTURE0, shadow_raw_sampler);
+	R_Shadow_BindShadowMap (texunit);
 }
 
 void R_Shadow_BindDlightShadowMap (GLenum texunit)
@@ -696,6 +714,7 @@ void R_Shadow_SunPass (void)
 	float debug_mode = r_shadowmap_debug.value > 0.f ? r_shadowmap_debug.value : r_shadow_debug.value;
 	static int last_debug_mode = -1;
 	static qboolean logged_state = false;
+	qboolean debug_depth = r_shadow_debug_depthview.value > 0.f;
 	shadow_state_t prev_state;
 
 	r_framedata.shadow_debug[0] = 0.f;
@@ -733,16 +752,26 @@ void R_Shadow_SunPass (void)
 	R_Shadow_SaveState (&prev_state);
 	GL_BindFramebufferFunc (GL_FRAMEBUFFER, shadow_fbo);
 	glViewport (0, 0, shadowmap_size, shadowmap_size);
-	glDrawBuffer (GL_NONE);
-	glReadBuffer (GL_NONE);
+	if (debug_depth && shadow_debug_tex)
+	{
+		const GLenum buffers[1] = { GL_COLOR_ATTACHMENT0 };
+		GL_DrawBuffersFunc (1, buffers);
+		glReadBuffer (GL_NONE);
+		glColorMask (GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+	}
+	else
+	{
+		glDrawBuffer (GL_NONE);
+		glReadBuffer (GL_NONE);
+		glColorMask (GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
+	}
 	glDisable (GL_SCISSOR_TEST);
 	glDisable (GL_BLEND);
-	glColorMask (GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
 	glDepthMask (GL_TRUE);
 	glEnable (GL_DEPTH_TEST);
 	glDepthRange (0.0, 1.0);
 	glClearDepth (gl_clipcontrol_able ? 0.f : 1.f);
-	glDepthFunc (gl_clipcontrol_able ? GL_GEQUAL : GL_LEQUAL);
+	glDepthFunc (gl_clipcontrol_able ? GL_GREATER : GL_LEQUAL);
 	if (!logged_state)
 	{
 		R_Shadow_LogPassState ("sun");
@@ -750,8 +779,10 @@ void R_Shadow_SunPass (void)
 	}
 
 	GL_UseProgram (glprogs.shadow_depth);
+	GL_Uniform1iFunc (1, debug_depth ? 1 : 0);
 	GL_SetState (GLS_BLEND_OPAQUE |
-		(r_shadowmap_cull_front.value > 0.f ? GLS_CULL_FRONT : GLS_CULL_BACK) |
+		(debug_depth ? GLS_CULL_NONE :
+			(r_shadowmap_cull_front.value > 0.f ? GLS_CULL_FRONT : GLS_CULL_BACK)) |
 		GLS_ATTRIBS (6));
 	glClear (GL_DEPTH_BUFFER_BIT);
 
@@ -912,7 +943,7 @@ void R_Shadow_DlightPass (void)
 	glEnable (GL_DEPTH_TEST);
 	glDepthRange (0.0, 1.0);
 	glClearDepth (gl_clipcontrol_able ? 0.f : 1.f);
-	glDepthFunc (gl_clipcontrol_able ? GL_GEQUAL : GL_LEQUAL);
+	glDepthFunc (gl_clipcontrol_able ? GL_GREATER : GL_LEQUAL);
 	if (!logged_state)
 	{
 		R_Shadow_LogPassState ("dlights");
@@ -956,6 +987,7 @@ void R_Shadow_DlightPass (void)
 		glClear (GL_DEPTH_BUFFER_BIT);
 
 		GL_UseProgram (glprogs.shadow_depth);
+		GL_Uniform1iFunc (1, 0);
 		GL_SetState (GLS_BLEND_OPAQUE |
 			(r_shadowmap_cull_front.value > 0.f ? GLS_CULL_FRONT : GLS_CULL_BACK) |
 			GLS_ATTRIBS (6));
@@ -1030,19 +1062,17 @@ void R_Shadow_DrawDepthDebugQuad (void)
 	GL_UseProgram (glprogs.shadow_depth_debug);
 	GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
 	GL_Uniform1fFunc (0, r_shadow_debug_depthview_invert.value > 0.f ? 1.f : 0.f);
+	GL_Uniform1fFunc (1, 0.f);
+	GL_Uniform1fFunc (2, 0.f);
+	if (shadow_debug_tex)
 	{
-		GLint compare_mode = GL_NONE;
-		GLint compare_func = GL_LEQUAL;
-		if (shadow_compare_sampler)
-		{
-			compare_mode = GL_COMPARE_REF_TO_TEXTURE;
-			compare_func = gl_clipcontrol_able ? GL_GEQUAL : GL_LEQUAL;
-		}
-		GL_Uniform1fFunc (1, compare_mode == GL_COMPARE_REF_TO_TEXTURE ? 1.f : 0.f);
-		GL_Uniform1fFunc (2, (compare_func == GL_GEQUAL || compare_func == GL_GREATER) ? 1.f : 0.f);
+		GL_BindNative (GL_TEXTURE0 + TEXUNIT_SHADOW, GL_TEXTURE_2D, shadow_debug_tex);
+		GL_BindSamplerFunc (TEXUNIT_SHADOW, shadow_raw_sampler);
 	}
-	R_Shadow_BindShadowMap (GL_TEXTURE0 + TEXUNIT_SHADOW);
-	R_Shadow_BindShadowMapRaw (GL_TEXTURE0 + TEXUNIT_SHADOW_DEPTH);
+	else
+	{
+		R_Shadow_BindShadowMapRaw (GL_TEXTURE0 + TEXUNIT_SHADOW);
+	}
 	glDrawArrays (GL_TRIANGLES, 0, 3);
 
 	GL_EndGroup ();

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -1455,8 +1455,7 @@ static void R_DrawBrushModels_Real (entity_t **ents, int count, brushpass_t pass
 	{
 		GL_Bind (GL_TEXTURE0 + TEXUNIT_LIGHTMAP, r_fullbright_cheatsafe ? greytexture : lightmap_texture);
 		GL_Bind (GL_TEXTURE0 + TEXUNIT_LIGHTDIR, (r_lightingdir.value > 0.f && lightmap_dir_texture) ? lightmap_dir_texture : greytexture);
-		R_Shadow_BindShadowMap (GL_TEXTURE0 + TEXUNIT_SHADOW);
-		R_Shadow_BindShadowMapRaw (GL_TEXTURE0 + TEXUNIT_SHADOW_DEPTH);
+		R_Shadow_BindShadowMapRaw (GL_TEXTURE0 + TEXUNIT_SHADOW);
 #ifndef NDEBUG
 		{
 			GLint bound = 0;

--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -102,8 +102,7 @@ const int ALIAS_FLAG_LIGHTNING = 4;
 layout(binding=TEXUNIT_BASE) uniform sampler2D Tex;
 layout(binding=TEXUNIT_FULLBRIGHT) uniform sampler2D FullbrightTex;
 layout(binding=TEXUNIT_EMISSIVE) uniform sampler2D EmissiveTex;
-layout(binding=TEXUNIT_SHADOW) uniform sampler2DShadow ShadowMapCmp;
-layout(binding=TEXUNIT_SHADOW_DEPTH) uniform sampler2D ShadowMapDepth;
+layout(binding=TEXUNIT_SHADOW) uniform sampler2D ShadowMap;
 
 #define SHADOW_SUN 1
 #include "shadow_sample.glsl"

--- a/Quake/shaders/shadow_debug.frag
+++ b/Quake/shaders/shadow_debug.frag
@@ -1,9 +1,9 @@
-layout(binding=0) uniform sampler2D ShadowMapDepth;
+layout(binding=0) uniform sampler2D ShadowMap;
 layout(location=0) in vec2 v_uv;
 layout(location=0) out vec4 out_fragcolor;
 
 void main()
 {
-	float depth = texture(ShadowMapDepth, v_uv).r;
+	float depth = texture(ShadowMap, v_uv).r;
 	out_fragcolor = vec4(vec3(depth), 1.0);
 }

--- a/Quake/shaders/shadow_depth.frag
+++ b/Quake/shaders/shadow_depth.frag
@@ -1,5 +1,25 @@
 layout(location=0) in vec4 v_light_clip;
+layout(location=0) out float out_depth_debug;
+layout(location=1) uniform int uShadowWriteDebug;
 
 void main()
 {
+	if (uShadowWriteDebug != 0)
+	{
+		float depth01 = 1.0;
+		if (v_light_clip.w > 0.0)
+		{
+			float ndc = v_light_clip.z / v_light_clip.w;
+#if CLIP_Z_ZERO_TO_ONE
+			depth01 = ndc;
+#else
+			depth01 = ndc * 0.5 + 0.5;
+#endif
+		}
+		out_depth_debug = depth01;
+	}
+	else
+	{
+		out_depth_debug = 0.0;
+	}
 }

--- a/Quake/shaders/shadow_depth_debug.frag
+++ b/Quake/shaders/shadow_depth_debug.frag
@@ -1,7 +1,6 @@
 #include "texunits.glsl"
 
-layout(binding=TEXUNIT_SHADOW) uniform sampler2DShadow ShadowMapCmp;
-layout(binding=TEXUNIT_SHADOW_DEPTH) uniform sampler2D ShadowMapDepth;
+layout(binding=TEXUNIT_SHADOW) uniform sampler2D ShadowMap;
 layout(location=0) uniform float InvertDepth;
 layout(location=1) uniform float UseCompare;
 layout(location=2) uniform float CompareGreater;
@@ -10,36 +9,7 @@ layout(location=0) out vec4 out_fragcolor;
 
 void main()
 {
-	float depth;
-	if (UseCompare > 0.5)
-	{
-		float low = 0.0;
-		float high = 1.0;
-		for (int i = 0; i < 8; ++i)
-		{
-			float mid = (low + high) * 0.5;
-			float pass = texture(ShadowMapCmp, vec3(v_uv, mid));
-			if (CompareGreater > 0.5)
-			{
-				if (pass > 0.5)
-					high = mid;
-				else
-					low = mid;
-			}
-			else
-			{
-				if (pass > 0.5)
-					low = mid;
-				else
-					high = mid;
-			}
-		}
-		depth = (low + high) * 0.5;
-	}
-	else
-	{
-		depth = texture(ShadowMapDepth, v_uv).r;
-	}
+	float depth = texture(ShadowMap, v_uv).r;
 	if (InvertDepth > 0.5)
 		depth = 1.0 - depth;
 	out_fragcolor = vec4(vec3(depth), 1.0);

--- a/Quake/shaders/shadow_sample.glsl
+++ b/Quake/shaders/shadow_sample.glsl
@@ -38,12 +38,17 @@ void ShadowCoord(vec3 world_pos, out vec2 uv, out float reference, out float in_
 float ShadowSampleRaw(vec2 uv, float reference, float bias)
 {
 	float compare_depth = reference - bias;
-	return texture(ShadowMapCmp, vec3(uv, compare_depth));
+	float depth = texture(ShadowMap, uv).r;
+#if REVERSED_Z
+	return depth > compare_depth ? 1.0 : 0.0;
+#else
+	return depth < compare_depth ? 1.0 : 0.0;
+#endif
 }
 
 float ShadowSamplePCF(vec2 uv, float reference, float bias, int taps)
 {
-	vec2 texel = 1.0 / vec2(textureSize(ShadowMapCmp, 0));
+	vec2 texel = 1.0 / vec2(textureSize(ShadowMap, 0));
 	float sum = 0.0;
 	int count = 0;
 
@@ -97,12 +102,7 @@ float ShadowVisibility(vec3 world_pos, vec3 normal, out float in_range)
 	if (in_range < 0.5)
 		return 1.0;
 
-	float ndotl = dot(normal, ShadowSunDir.xyz);
-	float bias = ShadowParams.x + ShadowParams.y * max(0.0, 1.0 - ndotl);
-
-	if (ShadowParams.z > 0.5)
-		return ShadowSamplePCF(uv, reference, bias, int(ShadowParams.w + 0.5));
-
+	float bias = 0.001;
 	return ShadowSampleRaw(uv, reference, bias);
 }
 
@@ -125,7 +125,7 @@ vec3 ShadowDebugColor(vec3 world_pos, float shadow_term)
 			return vec3(1.0, 0.0, 1.0);
 
 		vec2 clamped_uv = clamp(uv, vec2(0.0), vec2(1.0));
-		float depth = texture(ShadowMapDepth, clamped_uv).r;
+		float depth = texture(ShadowMap, clamped_uv).r;
 		if (depth <= 0.0001 || depth >= 0.9999)
 			return vec3(0.0, 1.0, 1.0);
 
@@ -144,9 +144,15 @@ vec3 ShadowDebugColor(vec3 world_pos, float shadow_term)
 		return vec3(reference);
 	if (mode == 4)
 	{
-		float sampled_depth = texture(ShadowMapDepth, uv).r;
+		float sampled_depth = texture(ShadowMap, uv).r;
 		float diff = abs(reference - sampled_depth);
 		return vec3(diff);
+	}
+	if (mode == 10)
+	{
+		vec2 clamped_uv = clamp(uv, vec2(0.0), vec2(1.0));
+		float sampled_depth = texture(ShadowMap, clamped_uv).r;
+		return vec3(sampled_depth);
 	}
 
 	return vec3(shadow_term);
@@ -159,7 +165,7 @@ vec4 ShadowDebugSample(vec3 world_pos)
 	float in_range;
 	ShadowCoord(world_pos, uv, reference, in_range);
 	vec2 clamped_uv = clamp(uv, vec2(0.0), vec2(1.0));
-	float depth = texture(ShadowMapDepth, clamped_uv).r;
+	float depth = texture(ShadowMap, clamped_uv).r;
 	return vec4(depth, reference, in_range, 1.0);
 }
 #endif

--- a/Quake/shaders/texunits.glsl
+++ b/Quake/shaders/texunits.glsl
@@ -7,6 +7,5 @@
 #define TEXUNIT_LIGHTDIR    3
 #define TEXUNIT_EMISSIVE    4
 #define TEXUNIT_SHADOW      5
-#define TEXUNIT_SHADOW_DEPTH 6
 
 #endif

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -8,8 +8,7 @@
 #endif
 layout(binding=TEXUNIT_LIGHTMAP) uniform sampler2D LMTex;
 layout(binding=TEXUNIT_LIGHTDIR) uniform sampler2D LMTexDir;
-layout(binding=TEXUNIT_SHADOW) uniform sampler2DShadow ShadowMapCmp;
-layout(binding=TEXUNIT_SHADOW_DEPTH) uniform sampler2D ShadowMapDepth;
+layout(binding=TEXUNIT_SHADOW) uniform sampler2D ShadowMap;
 #include "frame_uniforms.glsl"
 #define SHADOW_SUN 1
 #include "shadow_sample.glsl"


### PR DESCRIPTION
### Motivation
- Shadow debug views were showing solid white because depth sampling could read the wrong texture or use the GPU compare sampler incorrectly.  
- A single deterministic path is needed to prove the shadow FBO is written, the same texture is sampled in shaders, and reversed-Z depth state is correct.  
- Provide an undeniable depth->color debug output so `r_shadow_debug_depthview 1` becomes meaningful.  

### Description
- Switch `world.frag` and `alias.frag` to a single `layout(binding=TEXUNIT_SHADOW) uniform sampler2D ShadowMap` and remove the dual `sampler2DShadow`/`sampler2D` ambiguity.  
- Update `shadow_sample.glsl` to sample `texture(ShadowMap, uv).r` and perform a manual compare with `#if REVERSED_Z` logic, add debug mode `ShadowControl.y == 10` to output raw depth, and simplify `ShadowVisibility()` to a tiny constant bias and single-tap compare for deterministic verification.  
- Add a debug color attachment `shadow_debug_tex` (GL_R32F) and `out_depth_debug` + `uShadowWriteDebug` in `shadow_depth.frag`, attach it to the shadow FBO and conditionally enable a color draw buffer when `r_shadow_debug_depthview` is active.  
- Enforce CPU-side binding/state changes: set `GL_TEXTURE_COMPARE_MODE` to `GL_NONE` in `R_Shadow_BindShadowMap`, bind the single depth texture at `TEXUNIT_SHADOW` for main passes, attach or bind `shadow_debug_tex` for debug quad rendering, and explicitly set reversed-Z depth state (`glClearDepth(0.0)` / `glDepthFunc(GL_GREATER)` when applicable).  

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695783321904832eb85a7df9c6588583)