### PR TITLE
Reorder render passes in R_RenderScene and move viewmodel draw after translucency

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -4426,15 +4426,14 @@ R_RenderScene
 void R_RenderScene (void)
 {
 	R_SetupScene (); //johnfitz -- this does everything that should be done once per call to RenderScene
-	R_Shadow_SunPass ();
-	R_Shadow_DlightPass ();
 	R_SetupGL ();
 	R_Clear ();
-	
+
 	// Upload frame data after fog has been set up to ensure fog parameters
 	// are available to all draw calls, even when light clustering is skipped.
 	R_UploadFrameData ();
-	R_DrawViewModel (); //johnfitz -- moved here from R_RenderView
+	R_Shadow_SunPass ();
+	R_Shadow_DlightPass ();
 	S_ExtraUpdate (); // don't let sound get messed up if going slow
 	R_DrawEntitiesOnList (false); //johnfitz -- false means this is the pass for nonalpha entities
 	R_DrawDLightPass ();
@@ -4447,6 +4446,7 @@ void R_RenderScene (void)
 	R_DrawParticles (true);
 	R_DrawRTLightCoronas ();
 	R_EndTranslucency ();
+	R_DrawViewModel (); //johnfitz -- moved here from R_RenderView
 	R_ShowTris (); //johnfitz
 	R_ShowBoundingBoxes (); //johnfitz
 	R_ShowPointFile ();


### PR DESCRIPTION
### Motivation

- Ensure GL state and per-frame buffers are established before shadowmap rendering so shadow passes have correct bindings and fog/frame data.
- Avoid shadow passes running with incomplete per-frame UBO/SSBO state by uploading frame data prior to shadow rendering.
- Draw the view model after translucency so it renders on top of translucent elements and avoids depth/alpha ordering issues.
- Improve predictable ordering of scene setup, shadow, and main rendering passes in `R_RenderScene`.

### Description

- In `Quake/gl_rmain.c` moved `R_Shadow_SunPass` and `R_Shadow_DlightPass` to after `R_SetupGL()` and `R_UploadFrameData()` inside `R_RenderScene`.
- Relocated `R_DrawViewModel()` from the early part of `R_RenderScene` to immediately after `R_EndTranslucency()` and before `R_ShowTris()`.
- Adjusted surrounding call order to preserve other passes (`R_DrawEntitiesOnList`, `R_DrawParticles`, `Sky_DrawSky`, `R_DrawWater`, `R_DrawDLightPass`, etc.).
- No other functional changes were made aside from reordering the existing calls.

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957c33e8e4c832eb0ee88ee8deb7c2c)