### PR TITLE
Fix shadow map disable behavior and dlight sampler binding

### DIFF
--- a/Quake/r_shadow.c
+++ b/Quake/r_shadow.c
@@ -597,7 +597,7 @@ void R_ResizeShadowMapIfNeeded (void)
 	if (desired > gl_max_texture_size)
 		desired = gl_max_texture_size;
 
-	if (desired < 256)
+	if (desired > 0 && desired < 256)
 		desired = 256;
 
 	if (desired == shadowmap_size && shadow_depth_tex)
@@ -702,9 +702,13 @@ void R_Shadow_BindDlightShadowMap (GLenum texunit)
 		GL_BindNative (texunit, GL_TEXTURE_2D, shadow_dlight_depth_tex);
 		glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE, GL_COMPARE_REF_TO_TEXTURE);
 		glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_FUNC, gl_clipcontrol_able ? GL_GEQUAL : GL_LEQUAL);
+		GL_BindSamplerFunc (texunit - GL_TEXTURE0, 0);
 	}
 	else
+	{
 		GL_BindNative (texunit, GL_TEXTURE_2D, 0);
+		GL_BindSamplerFunc (texunit - GL_TEXTURE0, 0);
+	}
 }
 
 void R_Shadow_SunPass (void)


### PR DESCRIPTION
### Motivation
- Allow the sun shadow map to be disabled by respecting a requested size of `0` instead of forcing the minimum size.
- Ensure dlight shadow sampling uses the intended sampler state so depth-compare sampling behaves consistently.
- Prevent unexpected sampler overrides on the shadow texture unit when binding or unbinding dlight shadow maps.

### Description
- Change in `R_ResizeShadowMapIfNeeded`: only clamp the shadow map size up to the minimum when `desired > 0` so a `0` request disables the shadow map.
- Added `GL_BindSamplerFunc(texunit - GL_TEXTURE0, 0)` in `R_Shadow_BindDlightShadowMap` to clear any bound sampler when binding or unbinding the dlight atlas.
- Fixed branching/braces in the dlight bind path to ensure the sampler reset is applied in both code paths.

### Testing
- No automated tests were run for this change.
- The change was compiled and committed in the working tree (no runtime test harness executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957f687e458832ebf03c67724bb5940)