### PR TITLE
Include rtlight sources in Visual Studio project to fix linker errors

### DIFF
--- a/Windows/VisualStudio/ironwail.vcxproj
+++ b/Windows/VisualStudio/ironwail.vcxproj
@@ -313,6 +313,8 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
     <ClCompile Include="..\..\Quake\r_brush.c" />
     <ClCompile Include="..\..\Quake\r_dlight_pool.c" />
     <ClCompile Include="..\..\Quake\r_shadow.c" />
+    <ClCompile Include="..\..\Quake\rtlight.c" />
+    <ClCompile Include="..\..\Quake\rtlight_parse.c" />
     <ClCompile Include="..\..\Quake\r_maptex_export.c" />
     <ClCompile Include="..\..\Quake\r_postfx.c" />
     <ClCompile Include="..\..\Quake\r_part.c" />


### PR DESCRIPTION
### Motivation
- Resolve unresolved linker symbols (`RTLight_GetActive`, `r_rtlights`, `r_coronas`, `r_envmap_lights`, etc.) that caused Windows build failures.
- Ensure the runtime light implementation is compiled into the Visual Studio build by including its source files.
- Fix LNK2001/LNK1120 errors caused by missing `rtlight` sources in the project file.

### Description
- Updated `Windows/VisualStudio/ironwail.vcxproj` to add `<ClCompile Include="..\..\Quake\rtlight.c" />` and `<ClCompile Include="..\..\Quake\rtlight_parse.c" />`.
- This exposes the `RTLight_*` functions and related `cvar_t` symbols to the linker so the unresolved externals are provided.
- No other source code logic changes were made.

### Testing
- No automated tests or CI jobs were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695802549910832e94b565147d6ceb22)