### PR TITLE
Fix rtlight_parse compiler warnings and undefined symbols

### DIFF
--- a/Quake/rtlight_parse.c
+++ b/Quake/rtlight_parse.c
@@ -7,7 +7,7 @@
 static void RTLight_Warnf (rtlight_list_t *out, const char *fmt, ...)
 {
 	va_list argptr;
-	char msg[MAXPRINTMSG];
+	char msg[1024];
 
 	if (out)
 		out->warnings++;
@@ -193,10 +193,10 @@ static qboolean RTLight_ParseLine (const char *line, rtlight_t *out_light, int d
 	}
 
 	out_light->radius = CLAMP (0.001f, out_light->radius, 100000.0f);
-	out_light->color[0] = MAX (0.0f, out_light->color[0]);
-	out_light->color[1] = MAX (0.0f, out_light->color[1]);
-	out_light->color[2] = MAX (0.0f, out_light->color[2]);
-	out_light->intensity = MAX (0.0f, out_light->intensity);
+	out_light->color[0] = q_max (0.0f, out_light->color[0]);
+	out_light->color[1] = q_max (0.0f, out_light->color[1]);
+	out_light->color[2] = q_max (0.0f, out_light->color[2]);
+	out_light->intensity = q_max (0.0f, out_light->intensity);
 
 	for (i = 8; i < num_tokens; i++)	
 	{
@@ -307,7 +307,7 @@ void RTLight_ParseFile (const char *mapname, rtlight_list_t *out)
 		return;
 
 	q_snprintf (filename, sizeof(filename), "maps/%s.rtlight", mapname);
-	data = (char *) COM_LoadFile (filename, NULL);
+	data = (char *) COM_LoadMallocFile (filename, NULL);
 	if (!data)
 		return;
 
@@ -348,5 +348,5 @@ void RTLight_ParseFile (const char *mapname, rtlight_list_t *out)
 	Con_Printf ("Loaded %d rtlights from %s (skipped %d, warnings %d)\n",
 		out->count, filename, out->skipped_lines, out->warnings);
 
-	COM_FreeFile (data);
+	free (data);
 }


### PR DESCRIPTION
### Motivation

- The build failed due to undefined/incorrect symbols used in `rtlight_parse.c` (`MAXPRINTMSG`, `MAX`, and `COM_LoadFile`/`COM_FreeFile`).
- Avoid relying on macros or functions not available in this translation unit and align with the project's `COM_*` API variants.

### Description

- Replace the `RTLight_Warnf` buffer from `MAXPRINTMSG` to a local `char msg[1024]` to remove the dependency on `MAXPRINTMSG`.
- Replace uses of the undefined `MAX` macro with the existing `q_max` helper (`q_max(0.0f, ...)`).
- Use `COM_LoadMallocFile` to load the `.rtlight` file and `free` to release it instead of `COM_LoadFile`/`COM_FreeFile`.

### Testing

- No automated tests were run for this change.
- The changes were committed to the branch for further verification and CI/build testing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695802e1e408832ea8388cacc1126968)