### PR TITLE
Reduce texture debug logging

### DIFF
--- a/Quake/gl_ktx2.c
+++ b/Quake/gl_ktx2.c
@@ -360,7 +360,7 @@ gltexture_t *R_LoadKTX2Texture(const char *name, const uint8_t *data, size_t siz
 
     KTX2_FreeDecodedImage(&decoded);
 
-    Con_Printf("Texture %s: %s, %s\n", name, srgb ? "sRGB" : "linear", srgb ? "GL_SRGB8_ALPHA8" : "GL_RGBA8");
+    Con_DPrintf("Texture %s: %s, %s\n", name, srgb ? "sRGB" : "linear", srgb ? "GL_SRGB8_ALPHA8" : "GL_RGBA8");
     KTX2_LogInfo("Finished uploading KTX2 texture '%s' (%dx%d, mips=%d)", name, tex->width, tex->height, tex->mipmap);
     return tex;
 }
@@ -372,7 +372,7 @@ void KTX2_LogInfo(const char *fmt, ...)
 
     va_start(argptr, fmt);
     q_vsnprintf(msg, sizeof(msg), fmt, argptr);
-    Con_Printf("KTX2-INFO: %s\n", msg);
+    Con_DPrintf("KTX2-INFO: %s\n", msg);
     va_end(argptr);
 }
 
@@ -383,7 +383,7 @@ void KTX2_LogError(const char *fmt, ...)
 
     va_start(argptr, fmt);
     q_vsnprintf(msg, sizeof(msg), fmt, argptr);
-    Con_Printf("KTX2-ERROR: %s\n", msg);
+    Con_DPrintf("KTX2-ERROR: %s\n", msg);
     va_end(argptr);
 }
 

--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -1155,7 +1155,7 @@ static gltexture_t *Mod_LoadKTX2Texture(const char *name)
                         free(rawbuf);
                         return gltex;
                 }
-                Con_Printf("KTX2 load failed, falling back.\n");
+                Con_DPrintf("KTX2 load failed, falling back.\n");
         }
 
         free(rawbuf);

--- a/Quake/gl_texmgr.c
+++ b/Quake/gl_texmgr.c
@@ -917,7 +917,7 @@ void TexMgr_LightmapLinearCompat_f (cvar_t *var)
 static void TexMgr_LogTextureUpload (const gltexture_t *glt)
 {
 	const char *colorspace = (glt->flags & TEXPREF_SRGB) ? "sRGB" : "linear";
-	Con_Printf ("Texture %s: %s, %s\n", glt->name, colorspace, TexMgr_InternalFormatName (glt->internal_format));
+	Con_DPrintf ("Texture %s: %s, %s\n", glt->name, colorspace, TexMgr_InternalFormatName (glt->internal_format));
 }
 
 static byte *TexMgr_LoadFileWithSize (const char *path, size_t *size_out)


### PR DESCRIPTION
### Motivation

- Reduce console spam from texture operations so normal runs are not flooded with load/convert/lookup messages.
- Make texture upload and KTX2-related logs developer-only to preserve debug output when needed.
- Avoid noisy messages during map/model loading and KTX2 transcoding unless `developer` logging is enabled.

### Description

- Replaced `Con_Printf` with `Con_DPrintf` in `TexMgr_LogTextureUpload` in `Quake/gl_texmgr.c` so texture upload reports are developer-only.
- Switched KTX2 messages and helpers to `Con_DPrintf` in `Quake/gl_ktx2.c` so `KTX2_LogInfo`/`KTX2_LogError` and per-texture prints are quiet by default.
- Changed the KTX2 fallback message in `Quake/gl_model.c` from `Con_Printf` to `Con_DPrintf` to silence normal runs.
- Commit message: `Reduce texture debug logging` (3 files modified: `gl_texmgr.c`, `gl_ktx2.c`, `gl_model.c`).

### Testing

- No automated tests were run for this change.
- Changes are limited to logging calls and should not affect runtime behavior when `developer` is enabled.
- Manual runtime verification is recommended to confirm desired verbosity under different `developer` levels.
- Build/test CI was not executed as part of this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695808523634832ebb05e7d25eaf0eac)