### PR TITLE
Print console message when .rtlight file is loaded

### DIFF
--- a/Quake/rtlight_parse.c
+++ b/Quake/rtlight_parse.c
@@ -311,6 +311,8 @@ void RTLight_ParseFile (const char *mapname, rtlight_list_t *out)
 	if (!data)
 		return;
 
+	Con_Printf ("Loaded rtlights file %s\n", filename);
+
 	max_lights = (int) r_rtlights_max.value;
 	if (max_lights <= 0)
 		max_lights = 1024;


### PR DESCRIPTION
### Motivation
- Provide a clear console indication when a `.rtlight` map file is successfully loaded to aid debugging and map development.
- Make it easier to verify which `.rtlight` file was used by the runtime without adding intrusive logging.

### Description
- Added a `Con_Printf` call in `RTLight_ParseFile` in `Quake/rtlight_parse.c` to print `"Loaded rtlights file %s\n"` after a `.rtlight` file is successfully loaded.
- The message is emitted only after `COM_LoadMallocFile` returns non-NULL, so no log is produced for missing or failed loads.
- No other parsing, allocation, or runtime behavior was modified.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69580d4e42f8832e856b88fe4e649bce)