### PR TITLE
Allow lightgrid dynamic lights when dlight style is active

### DIFF
--- a/Quake/gl_rlight.c
+++ b/Quake/gl_rlight.c
@@ -781,7 +781,7 @@ static void R_AddDynamicLights_LightgridArray (const dlight_t *const *lights, in
 
 void R_AddDynamicLights_Lightgrid (const vec3_t pos, vec3_t lightcolor)
 {
-	if (!r_dynamic.value)
+	if (r_dynamic.value <= 0.f && r_dlight_style.value <= 0.f)
 		return;
 
 	int count = 0;


### PR DESCRIPTION
### Motivation

- Persistent/rt/dynamic lights produced by rtlights/dlight-style were not contributing to alias models or the viewmodel when `r_dynamic` was disabled, making their contribution barely visible or absent.
- The `r_dlight_style` (Quake3-style additive dlight path) requires the dlight list even if `r_dynamic` is off, so lightgrid sampling should respect that.

### Description

- Change the guard in `R_AddDynamicLights_Lightgrid` so dynamic lightgrid contributions are applied when either `r_dynamic` is enabled or `r_dlight_style` is enabled by replacing `if (!r_dynamic.value)` with `if (r_dynamic.value <= 0.f && r_dlight_style.value <= 0.f)`.
- The edit is a single-line change in `Quake/gl_rlight.c` inside the `R_AddDynamicLights_Lightgrid` function.
- This preserves existing behavior when both cvars are disabled and enables light contributions for alias models/viewmodel when `r_dlight_style` is active.

### Testing

- No automated tests were run for this change.
- Manual runtime validation was not recorded in automated logs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69584f1ea32c832eacccf1e095a69987)