### PR TITLE
Skip DoF for alias/viewmodel models

### DIFF
--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -97,6 +97,7 @@ vec2 ComputeVelocity(vec4 curr_clip, vec4 prev_clip)
 
 const int ALIAS_FLAG_NO_MOTION_BLUR = 1;
 const int ALIAS_FLAG_VIEWMODEL = 2;
+const float ALIAS_MATERIAL_MASK = 8.0;
 const int ALIAS_FLAG_LIGHTNING = 4;
 
 layout(binding=TEXUNIT_BASE) uniform sampler2D Tex;
@@ -261,7 +262,7 @@ void main()
         vec2 velocityOut = vec2(0.0);
         if (viewModelMask < 0.5 && result.a >= 0.999)
                 velocityOut = velocity * result.a;
-        out_velocity = vec4(velocityOut, viewModelMask, 1.0);
+        out_velocity = vec4(velocityOut, viewModelMask, ALIAS_MATERIAL_MASK);
 #endif
 #if MODE == 1 || MODE == 2
 	// Note: sign bit is used as overbright flag

--- a/Quake/shaders/postprocess.frag
+++ b/Quake/shaders/postprocess.frag
@@ -153,6 +153,7 @@ layout(location=25) uniform vec4 DamageDVParams0; // x: trauma, y: strength, z: 
 layout(location=26) uniform vec4 DamageDVParams1; // x: time, y: quality, z: debug, w: unused
 
 const int MOTION_MAX_SAMPLES = 64;
+const int MATERIAL_MASK_NO_DOF = 8;
 const float OPAQUE_ALPHA_THRESHOLD = 0.999;
 
 struct DepthSamplingInfo
@@ -452,7 +453,8 @@ void main()
                 }
         }
 
-        if (DoFParams0.x > 0.5 && inView && depthInfo.valid && viewModelMask < 0.5 && centerOpaque)
+        if (DoFParams0.x > 0.5 && inView && depthInfo.valid && viewModelMask < 0.5 && centerOpaque
+                && (materialMask & MATERIAL_MASK_NO_DOF) == 0)
         {
                 float linearDepth = SampleLinearDepth(gl_FragCoord.xy, depthInfo);
                 float focusDistance = DoFParams0.y;


### PR DESCRIPTION
### Motivation
- Depth-of-field (`r_dof`) was causing visual artifacts and mismatched colors on alias models such as player weapons and viewmodels. 
- The goal is to prevent postprocess DoF from sampling/blurring pixels produced by alias shaders to avoid those artifacts. 

### Description
- Added a material mask bit by defining `ALIAS_MATERIAL_MASK` in `Quake/shaders/alias.frag` and writing it into the velocity output's fourth component via `out_velocity = vec4(..., ALIAS_MATERIAL_MASK)`. 
- Introduced `MATERIAL_MASK_NO_DOF` in `Quake/shaders/postprocess.frag` and updated the DoF branch to skip processing when `(materialMask & MATERIAL_MASK_NO_DOF) != 0`. 
- Changes touch `Quake/shaders/alias.frag` and `Quake/shaders/postprocess.frag` to mark alias pixels and gate DoF accordingly. 

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958527289a0832e9e82dbde06ca7655)