### PR TITLE
Fix missing GL and debug declarations

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -67,6 +67,9 @@ static qboolean r_frame_rendered_this_update;
 static qboolean r_dlight_buffered_frame = false;
 static qboolean r_ssao_underwater_blocked = false;
 
+extern cvar_t r_dof_debug_state;
+static void GL_SetFramebufferSRGB (qboolean enable);
+
 typedef struct godrays_stabilization_s
 {
 	qboolean	valid;
@@ -2562,7 +2565,7 @@ void GL_PostProcess (void)
 		// Temporary debug guard to confirm state leaks from DoF/postprocess.
 		if (r_dof_debug_state.value >= 2.f)
 		{
-			glUseProgram (0);
+			GL_UseProgramFunc (0);
 			GL_BindFramebufferFunc (GL_FRAMEBUFFER, 0);
 			glActiveTexture (GL_TEXTURE0);
 		}

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -173,6 +173,7 @@ extern	const char	*gl_version;
 	x(void,			VertexAttribPointer, (GLuint index, GLint size, GLenum type, GLboolean normalized, GLsizei stride, const GLvoid *pointer))\
 	x(void,			VertexAttribIPointer, (GLuint index, GLint size, GLenum type, GLsizei stride, const GLvoid *pointer))\
 	x(GLint,		GetUniformLocation, (GLuint program, const GLchar *name))\
+	x(void,			GetUniformiv, (GLuint program, GLint location, GLint *params))\
 	x(void,			GetActiveUniform, (GLuint program, GLuint index, GLsizei bufSize, GLsizei *length, GLint *size, GLenum *type, GLchar *name))\
 	x(void,			Uniform1i, (GLint location, GLint v0))\
 	x(void,			Uniform1f, (GLint location, GLfloat v0))\

--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -40,6 +40,8 @@ extern cvar_t r_shadow_pcf_taps;
 extern cvar_t r_shadow_twosided_mdl;
 extern cvar_t r_dof_debug_state;
 
+static qboolean R_Alias_ShouldDebugMagenta (void);
+
 //up to 16 color translated skins
 gltexture_t *playertextures[MAX_SCOREBOARD]; //johnfitz -- changed to an array of pointers
 


### PR DESCRIPTION
### Motivation

- Resolve MSVC compile errors and implicit-declaration warnings for GL helpers and debug cvars.  
- Avoid using raw `glUseProgram` where the GL loader wrapper is expected.  
- Provide missing forward declarations used across translation units to prevent redefinition/implicit-declaration issues.  

### Description

- Add `extern cvar_t r_dof_debug_state;` and forward-declare `GL_SetFramebufferSRGB` in `Quake/gl_rmain.c`.  
- Replace direct `glUseProgram(0)` usage with the loader wrapper `GL_UseProgramFunc(0)` in `Quake/gl_rmain.c`.  
- Add `GetUniformiv` function entry to the QGL declarations in `Quake/glquake.h` as `x(void, GetUniformiv, (GLuint program, GLint location, GLint *params))`.  
- Add prototype `static qboolean R_Alias_ShouldDebugMagenta(void);` to `Quake/r_alias.c` to avoid implicit declaration warnings.  

### Testing

- No automated tests were executed on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958f3c7bf88832e8e93c79f1fbadd61)