### PR TITLE
Fix Windows GL active texture linkage

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -151,7 +151,7 @@ static void GL_RestoreState (const gl_state_guard_t *state)
 	state->cull ? glEnable (GL_CULL_FACE) : glDisable (GL_CULL_FACE);
 	state->scissor ? glEnable (GL_SCISSOR_TEST) : glDisable (GL_SCISSOR_TEST);
 	GL_SetFramebufferSRGB (state->srgb);
-	glActiveTexture (state->active_texture);
+	GL_ActiveTextureFunc (state->active_texture);
 }
 
 static qboolean GL_StateMatches (const gl_state_guard_t *state)
@@ -251,14 +251,14 @@ static void GL_LogState (const char *tag)
 	{
 		GLint tex_binding = 0;
 		GLint sampler_binding = 0;
-		glActiveTexture (GL_TEXTURE0 + i);
+		GL_ActiveTextureFunc (GL_TEXTURE0 + i);
 		glGetIntegerv (GL_TEXTURE_BINDING_2D, &tex_binding);
 #ifdef GL_SAMPLER_BINDING
 		glGetIntegerv (GL_SAMPLER_BINDING, &sampler_binding);
 #endif
 		Con_Printf ("  texunit %d: tex2D=%d sampler=%d\n", i, tex_binding, sampler_binding);
 	}
-	glActiveTexture (prev_active);
+	GL_ActiveTextureFunc (prev_active);
 
 	GL_LogSamplerUniform (program, "Tex");
 	GL_LogSamplerUniform (program, "FullbrightTex");
@@ -2567,7 +2567,7 @@ void GL_PostProcess (void)
 		{
 			GL_UseProgramFunc (0);
 			GL_BindFramebufferFunc (GL_FRAMEBUFFER, 0);
-			glActiveTexture (GL_TEXTURE0);
+			GL_ActiveTextureFunc (GL_TEXTURE0);
 		}
 
 		// DoF postprocess touched GL_ACTIVE_TEXTURE/viewport/FBO state; restore to avoid leaking into viewmodel/UI passes.

--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -621,9 +621,9 @@ ibuf.global.half_lambert = CLAMP (0.f, r_model_halflambert.value, 1.f);
 		GLint bound = 0;
 		GLint prev_active = 0;
 		glGetIntegerv (GL_ACTIVE_TEXTURE, &prev_active);
-		glActiveTexture (GL_TEXTURE0 + TEXUNIT_SHADOW);
+		GL_ActiveTextureFunc (GL_TEXTURE0 + TEXUNIT_SHADOW);
 		glGetIntegerv (GL_TEXTURE_BINDING_2D, &bound);
-		glActiveTexture (prev_active);
+		GL_ActiveTextureFunc (prev_active);
 		if (bound == 0)
 			Con_DWarning ("Shadow map unit %d not bound for alias pass\n", TEXUNIT_SHADOW);
 	}
@@ -851,9 +851,9 @@ static qboolean R_Alias_ShouldDebugMagenta (void)
 
 	glGetIntegerv (GL_ACTIVE_TEXTURE, &active);
 	prev_active = active;
-	glActiveTexture (GL_TEXTURE0);
+	GL_ActiveTextureFunc (GL_TEXTURE0);
 	glGetIntegerv (GL_TEXTURE_BINDING_2D, &bound);
-	glActiveTexture (prev_active);
+	GL_ActiveTextureFunc (prev_active);
 
 	return active != GL_TEXTURE0 || bound == 0;
 }

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -1461,9 +1461,9 @@ static void R_DrawBrushModels_Real (entity_t **ents, int count, brushpass_t pass
 			GLint bound = 0;
 			GLint prev_active = 0;
 			glGetIntegerv (GL_ACTIVE_TEXTURE, &prev_active);
-			glActiveTexture (GL_TEXTURE0 + TEXUNIT_SHADOW);
+			GL_ActiveTextureFunc (GL_TEXTURE0 + TEXUNIT_SHADOW);
 			glGetIntegerv (GL_TEXTURE_BINDING_2D, &bound);
-			glActiveTexture (prev_active);
+			GL_ActiveTextureFunc (prev_active);
 			if (bound == 0)
 				Con_DWarning ("Shadow map unit %d not bound for world pass\n", TEXUNIT_SHADOW);
 		}


### PR DESCRIPTION
### Motivation
- Fix a Windows linker error for `glActiveTexture` unresolved symbol by routing calls through the dynamically loaded function pointer.
- The project uses function-pointer dispatch for GL entry points (declared via `GL_ActiveTextureFunc`) to support runtime loading on Windows.
- Several render paths directly called `glActiveTexture`, which caused the unresolved external when linking against the Windows build.

### Description
- Replace direct calls to `glActiveTexture` with the function-pointer wrapper `GL_ActiveTextureFunc` in three rendering sources.
- Updated files: `Quake/gl_rmain.c`, `Quake/r_alias.c`, and `Quake/r_world.c` to use `GL_ActiveTextureFunc` consistently.
- Ensures calls go through the existing dynamic GL loader (functions declared in `Quake/glquake.h` and registered in `gl_vidsdl.c`).

### Testing
- No automated tests were executed as part of this change.
- A local build was not performed by the automated workflow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958f54a536c832e8a9d74534e087365)