### PR TITLE
Reduce texture upload logging to debug output

### DIFF
--- a/Quake/gl_ktx2.c
+++ b/Quake/gl_ktx2.c
@@ -360,7 +360,7 @@ gltexture_t *R_LoadKTX2Texture(const char *name, const uint8_t *data, size_t siz
 
     KTX2_FreeDecodedImage(&decoded);
 
-    Con_Printf("Texture %s: %s, %s\n", name, srgb ? "sRGB" : "linear", srgb ? "GL_SRGB8_ALPHA8" : "GL_RGBA8");
+    Con_DPrintf("Texture %s: %s, %s\n", name, srgb ? "sRGB" : "linear", srgb ? "GL_SRGB8_ALPHA8" : "GL_RGBA8");
     KTX2_LogInfo("Finished uploading KTX2 texture '%s' (%dx%d, mips=%d)", name, tex->width, tex->height, tex->mipmap);
     return tex;
 }
@@ -372,7 +372,7 @@ void KTX2_LogInfo(const char *fmt, ...)
 
     va_start(argptr, fmt);
     q_vsnprintf(msg, sizeof(msg), fmt, argptr);
-    Con_Printf("KTX2-INFO: %s\n", msg);
+    Con_DPrintf("KTX2-INFO: %s\n", msg);
     va_end(argptr);
 }
 

--- a/Quake/gl_texmgr.c
+++ b/Quake/gl_texmgr.c
@@ -917,7 +917,7 @@ void TexMgr_LightmapLinearCompat_f (cvar_t *var)
 static void TexMgr_LogTextureUpload (const gltexture_t *glt)
 {
 	const char *colorspace = (glt->flags & TEXPREF_SRGB) ? "sRGB" : "linear";
-	Con_Printf ("Texture %s: %s, %s\n", glt->name, colorspace, TexMgr_InternalFormatName (glt->internal_format));
+	Con_DPrintf ("Texture %s: %s, %s\n", glt->name, colorspace, TexMgr_InternalFormatName (glt->internal_format));
 }
 
 static byte *TexMgr_LoadFileWithSize (const char *path, size_t *size_out)


### PR DESCRIPTION
### Motivation
- Prevent excessive console spam from texture upload/format messages during normal runtime.
- Keep KTX2 decoder informational messages out of standard console output.
- Ensure texture diagnostics remain available to developers via debug logs instead of normal prints.

### Description
- Replace `Con_Printf` with `Con_DPrintf` for texture upload/format messages in `TexMgr_LogTextureUpload` (in `Quake/gl_texmgr.c`).
- Replace `Con_Printf` with `Con_DPrintf` for KTX2 texture load and info logging in `Quake/gl_ktx2.c` and make `KTX2_LogInfo` use `Con_DPrintf`.
- Changes limit normal-console output while preserving developer-visible debug information.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ade5f7714832e9667993edca02ba8)