### PR TITLE
Apply material stage color and scale to godrays source pass

### DIFF
--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -1258,6 +1258,7 @@ static void R_DrawBrushModels_GodrayStages (entity_t **ents, int count)
 				gltexture_t *stage_tex;
 				gltexture_t *fb = NULL;
 				gltexture_t *em = NULL;
+				vec4_t stage_color;
 				unsigned extra_flags = CALLFLAG_MAT_HAS_SHADER;
 				qboolean wants_emissive = (stage->outputs & MAT_STAGE_OUT_EMISSIVE) != 0u;
 				qboolean wants_godray = (stage->outputs & MAT_STAGE_OUT_GODRAY_SOURCE) != 0u;
@@ -1272,6 +1273,12 @@ static void R_DrawBrushModels_GodrayStages (entity_t **ents, int count)
 
 				if (!stage_tex)
 					continue;
+
+				R_EvalStageColorAlpha (stage, cl.time, stage_color);
+				stage_color[0] *= stage->godray_scale;
+				stage_color[1] *= stage->godray_scale;
+				stage_color[2] *= stage->godray_scale;
+				stage_color[3] *= stage->godray_scale;
 
 				if (stage_index == 0 && stage_tex == t->gltexture)
 				{
@@ -1304,7 +1311,7 @@ static void R_DrawBrushModels_GodrayStages (entity_t **ents, int count)
 					R_GetPolygonOffsetValues (material, use_polygon_offset, &polygon_offset_factor, &polygon_offset_units);
 					R_AddBModelCallWithTextures (model->firstcmd + j, baseinst, numinst,
 						stage_tex, fb, em,
-						use_polygon_offset, polygon_offset_factor, polygon_offset_units, -1.f, extra_flags, NULL);
+						use_polygon_offset, polygon_offset_factor, polygon_offset_units, -1.f, extra_flags, stage_color);
 				}
 			}
 		}

--- a/Quake/shaders/godrays_source.frag
+++ b/Quake/shaders/godrays_source.frag
@@ -18,6 +18,7 @@ const uint
 
 layout(location=0) flat in uint in_flags;
 layout(location=3) in vec2 in_uv;
+layout(location=15) flat in vec4 in_stage_color;
 #if BINDLESS
 	layout(location=9) flat in uvec4 in_samplers0;
 	layout(location=10) flat in uvec2 in_samplers1;
@@ -64,6 +65,8 @@ void main()
 		emissive = texture(EmissiveTex, in_uv).rgb;
 #endif
 
+	vec3 stage_rgb = in_stage_color.rgb;
+	float stage_alpha = in_stage_color.a;
 	vec3 light_color = vec3(0.0);
 	vec3 emissive_color = fullbright + emissive;
 	float light_strength = 0.0;
@@ -74,14 +77,15 @@ void main()
 
 	if ((in_flags & CF_GODRAYS_LIGHT) != 0u)
 	{
-		light_color = base.rgb;
+		light_color = base.rgb * stage_rgb;
 		light_strength = GodraysSourceParams0.y;
-		light_mask = BrightPartMask(light_color, GodraysSourceParams0.w, knee);
+		light_mask = BrightPartMask(light_color, GodraysSourceParams0.w, knee) * stage_alpha;
 	}
 	if ((in_flags & CF_GODRAYS_EMISSIVE) != 0u)
 	{
 		emissive_strength = GodraysSourceParams0.x;
-		emissive_mask = BrightPartMask(emissive_color, GodraysSourceParams0.z, knee);
+		emissive_color *= stage_rgb;
+		emissive_mask = BrightPartMask(emissive_color, GodraysSourceParams0.z, knee) * stage_alpha;
 	}
 
 	vec3 color = vec3(0.0);


### PR DESCRIPTION
### Motivation
- Godray sources declared in material shaders were not producing visible godrays because stage color/scale modulation was not applied to the godrays generation path. 
- The godrays source pass needs the material stage color/alpha and `godray_scale` to correctly weight light and emissive contributions. 

### Description
- In `Quake/r_world.c` evaluate stage color/alpha via `R_EvalStageColorAlpha` and multiply RGB and alpha by the stage `godray_scale`, then pass the resulting `stage_color` into `R_AddBModelCallWithTextures` for godray source draw calls. 
- In `Quake/shaders/godrays_source.frag` add `layout(location=15) flat in vec4 in_stage_color;` and use `in_stage_color` to modulate `light_color` and `emissive_color` and to scale the bright-part masks used for godray extraction. 
- Ensure the godray source output (`outColor`) is computed from the stage-modulated colors and masks so stage-level color/intensity and alpha affect final godray contribution. 

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695af51301d4832e920a0b8d49374c24)