### PR TITLE
Enable godrays source generation for debug

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -2039,6 +2039,8 @@ void GL_PostProcess (void)
 	float teleport_fade;
 	float teleport_blur;
 	qboolean godrays_enabled;
+	qboolean godrays_debug_enabled;
+	qboolean godrays_preview;
 	float godrays_debug;
 	float godrays_debug_source;
 	float ssao_intensity;
@@ -2151,10 +2153,12 @@ void GL_PostProcess (void)
 	godrays_enabled = (r_godrays.value > 0.f && R_GodraysReady ());
 	godrays_debug = (r_godrays_debug.value > 0.f) ? 1.f : 0.f;
 	godrays_debug_source = CLAMP (0.f, r_godrays_debug_source.value, 2.f);
+	godrays_debug_enabled = (godrays_debug > 0.f || godrays_debug_source > 0.f);
+	godrays_preview = (godrays_enabled || (godrays_debug_enabled && R_GodraysReady ()));
 	godrays_texture = 0;
 	godrays_mask = 0;
 	godrays_source = 0;
-	if (godrays_enabled)
+	if (godrays_preview)
 	{
 		godrays_texture = GL_GenerateGodraysTexture (&godrays_mask);
 		godrays_source = framebufs.godrays.source_tex;


### PR DESCRIPTION
### Motivation
- Debugging with `r_godrays_debug` / `r_godrays_debug_source` produced no visible godray sources because source/mask generation was gated on runtime godrays being enabled.  
- Developers need to preview godray source and mask textures even when full godray scattering is disabled.  
- The change should not alter normal rendering behavior when godrays are disabled and debug is off.  

### Description
- Add local flags `godrays_debug_enabled` and `godrays_preview` to track when debug preview or normal godrays should generate source textures.  
- Replace the previous `if (godrays_enabled)` gate with `if (godrays_preview)` so source/mask textures are generated when debug preview is requested.  
- Initialize and clamp debug/source cvars as before and keep existing generation logic (`GL_GenerateGodraysTexture`) unchanged.  

### Testing
- No automated tests were run for this change.  
- The patch was applied and committed to the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695af9098278832ebdba1a2cdab8cc50)