### PR TITLE
Gate godrays debug uniforms on preview (fix black screen)

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -2039,6 +2039,8 @@ void GL_PostProcess (void)
 	float teleport_fade;
 	float teleport_blur;
 	qboolean godrays_enabled;
+	qboolean godrays_debug_enabled;
+	qboolean godrays_preview;
 	float godrays_debug;
 	float godrays_debug_source;
 	float ssao_intensity;
@@ -2151,10 +2153,17 @@ void GL_PostProcess (void)
 	godrays_enabled = (r_godrays.value > 0.f && R_GodraysReady ());
 	godrays_debug = (r_godrays_debug.value > 0.f) ? 1.f : 0.f;
 	godrays_debug_source = CLAMP (0.f, r_godrays_debug_source.value, 2.f);
+	godrays_debug_enabled = (godrays_debug > 0.f || godrays_debug_source > 0.f);
+	godrays_preview = (godrays_enabled || (godrays_debug_enabled && R_GodraysReady ()));
+	if (!godrays_preview)
+	{
+		godrays_debug = 0.f;
+		godrays_debug_source = 0.f;
+	}
 	godrays_texture = 0;
 	godrays_mask = 0;
 	godrays_source = 0;
-	if (godrays_enabled)
+	if (godrays_preview)
 	{
 		godrays_texture = GL_GenerateGodraysTexture (&godrays_mask);
 		godrays_source = framebufs.godrays.source_tex;


### PR DESCRIPTION
### Motivation
- A previous change enabled godrays source generation for debug, but debug uniforms were still applied even when the preview path was inactive, producing a black screen.
- The rendering path must only apply godrays debug uniforms when the preview/textures are actually generated so normal rendering remains unaffected.

### Description
- Add local flags `godrays_debug_enabled` and `godrays_preview` in `Quake/gl_rmain.c` and compute preview readiness using `R_GodraysReady()`.
- When `!godrays_preview` clear `godrays_debug` and `godrays_debug_source` to prevent debug uniforms from being applied.
- Replace the `if (godrays_enabled)` gate with `if (godrays_preview)` so `GL_GenerateGodraysTexture` and `framebufs.godrays.source_tex` are only used when preview is active.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695af9098278832ebdba1a2cdab8cc50)