### PR TITLE
Fix SSAO fog damping order and depth binding

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -2334,7 +2334,8 @@ void GL_PostProcess (void)
 
 	depth_texture = 0;
 	{
-		qboolean ssao_needs_depth = (ssao_texture != 0 && (r_ssao_halfres.value > 0.f || ssao_debug_mode == 8.f));
+		qboolean ssao_needs_depth = (ssao_texture != 0
+			&& (r_ssao_halfres.value > 0.f || ssao_debug_mode == 8.f || ssao_fog_strength > 0.f));
 		if (framebufs.composite.depth_stencil_tex && (dof_enabled || screen_darken_enabled || (motion_enabled && motion_depth_threshold > 0.f) || ssao_needs_depth))
 			depth_texture = framebufs.composite.depth_stencil_tex;
 	}

--- a/Quake/shaders/postprocess.frag
+++ b/Quake/shaders/postprocess.frag
@@ -12,6 +12,7 @@ layout(std430, binding=0) restrict readonly buffer PaletteBuffer
 {
 	uint Palette[256];
 };
+#include "frame_uniforms.glsl"
 
 uvec3 UnpackRGB8(uint c)
 {
@@ -227,6 +228,15 @@ float FogTransmittanceFromDepth(float depth, float fogStrength)
         float fogFactor = clamp(depth / 2048.0, 0.0, 1.0);
         fogFactor = clamp(fogFactor * fogStrength, 0.0, 1.0);
         return 1.0 - fogFactor;
+}
+
+float FogTransmittanceFromGlobalFog(float depth)
+{
+        float density = abs(Fog.w);
+        if (density <= 0.0)
+                return 1.0;
+        float fog = exp2(-density * depth * depth);
+        return clamp(fog, 0.0, 1.0);
 }
 
 float SampleSSAO(vec2 uv, DepthSamplingInfo info, float centerDepth, bool useDepth)
@@ -634,10 +644,16 @@ void main()
                                 float ao = SampleSSAO(uv, depthInfo, ssaoCenterDepth, useDepthUpscale);
                                 float ssaoFogStrength = clamp(SSAOParams.w, 0.0, 1.0);
                                 float ssaoFogPower = max(SSAOBlurParams.w, 0.01);
-                                float fogStrength = clamp(PostFXParams4.z, 0.0, 1.0);
                                 float fogTransmittance = 1.0;
-                                if (ssaoUseDepth && fogStrength > 0.0)
-                                        fogTransmittance = FogTransmittanceFromDepth(ssaoCenterDepth, fogStrength);
+                                if (ssaoUseDepth)
+                                {
+                                        float fogStrength = clamp(PostFXParams4.z, 0.0, 1.0);
+                                        float underwaterTransmittance = 1.0;
+                                        if (fogStrength > 0.0)
+                                                underwaterTransmittance = FogTransmittanceFromDepth(ssaoCenterDepth, fogStrength);
+                                        float globalTransmittance = FogTransmittanceFromGlobalFog(ssaoCenterDepth);
+                                        fogTransmittance = globalTransmittance * underwaterTransmittance;
+                                }
                                 float aoFogMask = pow(clamp(fogTransmittance, 0.0, 1.0), ssaoFogPower);
                                 float aoFogged = mix(1.0, ao, aoFogMask);
                                 float aoDamped = mix(ao, aoFogged, ssaoFogStrength);


### PR DESCRIPTION
### Motivation
- Ensure SSAO fog damping is applied before scene fog so AO is correctly attenuated by both global and underwater fog.
- Make SSAO fog-related cvars actually take effect by guaranteeing the depth texture is bound when SSAO fog damping is active.
- Expose global fog parameters to the postprocess shader so SSAO can sample global fog transmittance.
- Improve visual correctness of SSAO in foggy environments by combining global and underwater fog contributions.

### Description
- Added `#include "frame_uniforms.glsl"` to `Quake/shaders/postprocess.frag` to access the global `Fog` uniform.
- Implemented `FogTransmittanceFromGlobalFog()` in `postprocess.frag` and combined its result with underwater fog transmittance when computing SSAO fog damping.
- Updated SSAO fog logic in `postprocess.frag` to multiply global and underwater transmittance and use that for AO damping and debug modes.
- Changed `Quake/gl_rmain.c` to treat SSAO fog damping as a reason to bind the depth texture by adding `ssao_fog_strength > 0.f` to the `ssao_needs_depth` condition.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b832b8384832e8668866265ca88fb)