### PR TITLE
Screen-space fog volumes: post-process raymarch resolve with 3D fBm noise

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -770,6 +770,8 @@ void GL_CreateFrameBuffers (void)
 		framebufs.composite.depth_stencil_tex,
 		"composite fbo"
 	);
+	framebufs.fogvol.color_tex = GL_CreateTexture2D (GL_RGBA16F, vid.width, vid.height, GL_NEAREST, "fogvol color");
+	framebufs.fogvol.fbo = GL_CreateSimpleFBO (GL_TEXTURE_2D, framebufs.fogvol.color_tex, 0, 0, "fogvol fbo");
 
 	framebufs.autoexposure.width = 16;
 	framebufs.autoexposure.height = 16;
@@ -902,6 +904,7 @@ void GL_DeleteFrameBuffers (void)
 	GL_DeleteFramebuffersFunc (1, &framebufs.scene.fbo);
 	GL_DeleteFramebuffersFunc (1, &framebufs.dlight.fbo);
 	GL_DeleteFramebuffersFunc (1, &framebufs.composite.fbo);
+	GL_DeleteFramebuffersFunc (1, &framebufs.fogvol.fbo);
 	GL_DeleteFramebuffersFunc (1, &framebufs.autoexposure.fbo);
 	GL_DeleteFramebuffersFunc (1, &framebufs.bloom.extract_fbo);
 	GL_DeleteFramebuffersFunc (1, &framebufs.bloom.pingpong_fbo[0]);
@@ -918,6 +921,7 @@ void GL_DeleteFrameBuffers (void)
 
 	GL_DeleteNativeTexture (framebufs.resolved_scene.color_tex);
 	GL_DeleteNativeTexture (framebufs.resolved_scene.velocity_tex);
+	GL_DeleteNativeTexture (framebufs.fogvol.color_tex);
 	GL_DeleteNativeTexture (framebufs.oit.revealage_tex);
 	GL_DeleteNativeTexture (framebufs.oit.accum_tex);
 	GL_DeleteNativeTexture (framebufs.scene.depth_stencil_tex);
@@ -2982,6 +2986,8 @@ qboolean GL_NeedsPostprocess (void)
 		return true;
 	if (r_godrays.value > 0.f)
 		return true;
+	if (r_fogvol.value > 0.f)
+		return true;
 	return false;
 }
 
@@ -4443,8 +4449,6 @@ void R_RenderScene (void)
 	R_DrawParticles (false);
 	Sky_DrawSky (); //johnfitz
 	R_DrawWater (false);
-	R_FogVol_BuildList ();
-	R_FogVol_Render ();
 	R_BeginTranslucency ();
 	R_DrawWater (true);
 	R_DrawEntitiesOnList (true); //johnfitz -- true means this is the pass for alpha entities
@@ -4626,6 +4630,8 @@ void R_RenderView (void)
         Fog_EnableGFog ();
         R_RenderScene ();
         R_WarpScaleView ();
+        R_FogVol_BuildList ();
+        R_FogVol_Render ();
         Fog_DisableGFog (); // Leave fog disabled for 2D overlays
 	R_Shadow_DrawDebug ();
 

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -647,6 +647,11 @@ typedef struct glframebufs_s {
 	}				composite;
 
 	struct {
+		GLuint		color_tex;
+		GLuint		fbo;
+	}				fogvol;
+
+	struct {
 		GLuint		extract_tex;
 		GLuint		pingpong_tex[2];
 		GLuint		extract_fbo;

--- a/Quake/r_fogvol.c
+++ b/Quake/r_fogvol.c
@@ -23,6 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "quakedef.h"
 #include "draw.h"
 #include "r_fogvol.h"
+#include <math.h>
 
 typedef struct fog_volume_gpu_s
 {
@@ -42,6 +43,57 @@ cvar_t r_fogvol_steps = { "r_fogvol_steps", "32", CVAR_ARCHIVE };
 cvar_t r_fogvol_halfres = { "r_fogvol_halfres", "0", CVAR_ARCHIVE };
 cvar_t r_fogvol_noise = { "r_fogvol_noise", "1", CVAR_ARCHIVE };
 cvar_t r_fogvol_debug = { "r_fogvol_debug", "0", CVAR_ARCHIVE };
+
+static qboolean R_FogVol_MatrixInverse4x4 (const float m[16], float out[16])
+{
+	float inv[16];
+	float det;
+
+	inv[0] = m[5] * m[10] * m[15] - m[5] * m[11] * m[14] - m[9] * m[6] * m[15] +
+		m[9] * m[7] * m[14] + m[13] * m[6] * m[11] - m[13] * m[7] * m[10];
+	inv[4] = -m[4] * m[10] * m[15] + m[4] * m[11] * m[14] + m[8] * m[6] * m[15]
+		- m[8] * m[7] * m[14] - m[12] * m[6] * m[11] + m[12] * m[7] * m[10];
+	inv[8] = m[4] * m[9] * m[15] - m[4] * m[11] * m[13] - m[8] * m[5] * m[15]
+		+ m[8] * m[7] * m[13] + m[12] * m[5] * m[11] - m[12] * m[7] * m[9];
+	inv[12] = -m[4] * m[9] * m[14] + m[4] * m[10] * m[13] + m[8] * m[5] * m[14]
+		- m[8] * m[6] * m[13] - m[12] * m[5] * m[10] + m[12] * m[6] * m[9];
+
+	inv[1] = -m[1] * m[10] * m[15] + m[1] * m[11] * m[14] + m[9] * m[2] * m[15]
+		- m[9] * m[3] * m[14] - m[13] * m[2] * m[11] + m[13] * m[3] * m[10];
+	inv[5] = m[0] * m[10] * m[15] - m[0] * m[11] * m[14] - m[8] * m[2] * m[15]
+		+ m[8] * m[3] * m[14] + m[12] * m[2] * m[11] - m[12] * m[3] * m[10];
+	inv[9] = -m[0] * m[9] * m[15] + m[0] * m[11] * m[13] + m[8] * m[1] * m[15]
+		- m[8] * m[3] * m[13] - m[12] * m[1] * m[11] + m[12] * m[3] * m[9];
+	inv[13] = m[0] * m[9] * m[14] - m[0] * m[10] * m[13] - m[8] * m[1] * m[14]
+		+ m[8] * m[2] * m[13] + m[12] * m[1] * m[10] - m[12] * m[2] * m[9];
+
+	inv[2] = m[1] * m[6] * m[15] - m[1] * m[7] * m[14] - m[5] * m[2] * m[15]
+		+ m[5] * m[3] * m[14] + m[13] * m[2] * m[7] - m[13] * m[3] * m[6];
+	inv[6] = -m[0] * m[6] * m[15] + m[0] * m[7] * m[14] + m[4] * m[2] * m[15]
+		- m[4] * m[3] * m[14] - m[12] * m[2] * m[7] + m[12] * m[3] * m[6];
+	inv[10] = m[0] * m[5] * m[15] - m[0] * m[7] * m[13] - m[4] * m[1] * m[15]
+		+ m[4] * m[3] * m[13] + m[12] * m[1] * m[7] - m[12] * m[3] * m[5];
+	inv[14] = -m[0] * m[5] * m[14] + m[0] * m[6] * m[13] + m[4] * m[1] * m[14]
+		- m[4] * m[2] * m[13] - m[12] * m[1] * m[6] + m[12] * m[2] * m[5];
+
+	inv[3] = -m[1] * m[6] * m[11] + m[1] * m[7] * m[10] + m[5] * m[2] * m[11]
+		- m[5] * m[3] * m[10] - m[9] * m[2] * m[7] + m[9] * m[3] * m[6];
+	inv[7] = m[0] * m[6] * m[11] - m[0] * m[7] * m[10] - m[4] * m[2] * m[11]
+		+ m[4] * m[3] * m[10] + m[8] * m[2] * m[7] - m[8] * m[3] * m[6];
+	inv[11] = -m[0] * m[5] * m[11] + m[0] * m[7] * m[9] + m[4] * m[1] * m[11]
+		- m[4] * m[3] * m[9] - m[8] * m[1] * m[7] + m[8] * m[3] * m[5];
+	inv[15] = m[0] * m[5] * m[10] - m[0] * m[6] * m[9] - m[4] * m[1] * m[10]
+		+ m[4] * m[2] * m[9] + m[8] * m[1] * m[6] - m[8] * m[2] * m[5];
+
+	det = m[0] * inv[0] + m[1] * inv[4] + m[2] * inv[8] + m[3] * inv[12];
+	if (fabsf (det) < 1e-8f)
+		return false;
+
+	det = 1.f / det;
+	for (int i = 0; i < 16; ++i)
+		out[i] = inv[i] * det;
+	return true;
+}
 
 static int R_FogVol_ComparePriority (const void *a, const void *b)
 {
@@ -124,7 +176,7 @@ void R_FogVol_BuildList (void)
 		qsort (r_fogvolumes, r_fogvolume_count, sizeof (fog_volume_t), R_FogVol_ComparePriority);
 }
 
-qboolean R_FogVol_ProjectAABBToScreenRect (const fog_volume_t *v, int *x0, int *y0, int *x1, int *y1)
+qboolean R_FogVol_ProjectAABBToScreenRect (const fog_volume_t *v, int *x0, int *y0, int *x1, int *y1, qboolean fullres)
 {
 	vec3_t corners[8];
 	vec3_t proj;
@@ -138,7 +190,7 @@ qboolean R_FogVol_ProjectAABBToScreenRect (const fog_volume_t *v, int *x0, int *
 	int view_h = r_refdef.vrect.height / q_max (1, r_refdef.scale);
 	int valid = 0;
 
-	if (!GL_NeedsSceneEffects ())
+	if (fullres || !GL_NeedsSceneEffects ())
 	{
 		view_x = glx + r_refdef.vrect.x;
 		view_y = gly + glheight - r_refdef.vrect.y - r_refdef.vrect.height;
@@ -213,7 +265,7 @@ void R_FogVol_DrawDebug2D (void)
 
 		if (!v->enabled)
 			continue;
-		if (!R_FogVol_ProjectAABBToScreenRect (v, &x0, &y0, &x1, &y1))
+		if (!R_FogVol_ProjectAABBToScreenRect (v, &x0, &y0, &x1, &y1, true))
 			continue;
 
 		color[0] = v->color[0];
@@ -233,12 +285,25 @@ void R_FogVol_Render (void)
 	GLbyte *ofs;
 	fog_volume_gpu_t gpu_volumes[MAX_FOGVOLUMES];
 	int mode = (int)Q_rint (r_fogvol_debug.value);
+	float inv_viewproj[16];
+	GLuint src_tex;
+	GLuint dst_tex;
+	GLuint dst_fbo;
+	GLuint depth_tex;
+	qboolean dst_is_composite;
+	qboolean has_drawn = false;
 
 	if (r_fogvol.value <= 0.f)
 		return;
 	if (!glprogs.fogvol)
 		return;
 	if (r_fogvolume_count <= 0)
+		return;
+	if (framebufs.composite.color_tex == 0 || framebufs.fogvol.color_tex == 0)
+		return;
+	if (framebufs.composite.depth_stencil_tex == 0)
+		return;
+	if (!R_FogVol_MatrixInverse4x4 (r_matviewproj, inv_viewproj))
 		return;
 
 	steps = (int)Q_rint (r_fogvol_steps.value);
@@ -285,12 +350,22 @@ void R_FogVol_Render (void)
 
 	GL_BeginGroup ("Fog volumes");
 	GL_UseProgram (glprogs.fogvol);
-	GL_SetState (GLS_BLEND_ALPHA | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
+	GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
 	GL_Uniform1iFunc (0, steps);
 	GL_Uniform1iFunc (1, r_fogvol_noise.value > 0.f ? 1 : 0);
 	GL_Uniform1iFunc (2, mode);
+	GL_UniformMatrix4fvFunc (4, 1, GL_FALSE, inv_viewproj);
+	GL_Uniform3fFunc (8, r_refdef.vieworg[0], r_refdef.vieworg[1], r_refdef.vieworg[2]);
+	GL_Uniform4fFunc (9, (float)glwidth, (float)glheight, 1.f / (float)glwidth, 1.f / (float)glheight);
 
 	glEnable (GL_SCISSOR_TEST);
+	glViewport (glx, gly, glwidth, glheight);
+	depth_tex = framebufs.composite.depth_stencil_tex;
+	src_tex = framebufs.composite.color_tex;
+	dst_tex = framebufs.fogvol.color_tex;
+	dst_fbo = framebufs.fogvol.fbo;
+	dst_is_composite = false;
+
 	for (int i = 0; i < r_fogvolume_count; ++i)
 	{
 		fog_volume_t *v = &r_fogvolumes[i];
@@ -298,7 +373,7 @@ void R_FogVol_Render (void)
 
 		if (!v->enabled)
 			continue;
-		if (!R_FogVol_ProjectAABBToScreenRect (v, &x0, &y0, &x1, &y1))
+		if (!R_FogVol_ProjectAABBToScreenRect (v, &x0, &y0, &x1, &y1, true))
 			continue;
 
 		if (mode == 1)
@@ -308,15 +383,38 @@ void R_FogVol_Render (void)
 			R_DebugDrawWireBox (v->mins, v->maxs, color, true);
 		}
 
+		GL_BindFramebufferFunc (GL_FRAMEBUFFER, dst_fbo);
+		glDrawBuffer (GL_COLOR_ATTACHMENT0);
+		glReadBuffer (GL_COLOR_ATTACHMENT0);
+
+		GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, src_tex);
+		GL_BindNative (GL_TEXTURE1, GL_TEXTURE_2D, depth_tex);
 		glScissor (x0, y0, x1 - x0, y1 - y0);
 		GL_Uniform1iFunc (3, i);
 		glDrawArrays (GL_TRIANGLES, 0, 3);
+
+		{
+			GLuint tmp_tex = src_tex;
+			src_tex = dst_tex;
+			dst_tex = tmp_tex;
+			dst_is_composite = !dst_is_composite;
+			dst_fbo = dst_is_composite ? framebufs.composite.fbo : framebufs.fogvol.fbo;
+		}
+		has_drawn = true;
 	}
 	glDisable (GL_SCISSOR_TEST);
+
+	if (has_drawn && src_tex != framebufs.composite.color_tex)
+	{
+		GL_BindFramebufferFunc (GL_READ_FRAMEBUFFER, framebufs.fogvol.fbo);
+		GL_BindFramebufferFunc (GL_DRAW_FRAMEBUFFER, framebufs.composite.fbo);
+		GL_BlitFramebufferFunc (0, 0, glwidth, glheight,
+			0, 0, glwidth, glheight,
+			GL_COLOR_BUFFER_BIT, GL_NEAREST);
+	}
 
 	if (mode == 1)
 		R_DebugFlushGeometry ();
 
 	GL_EndGroup ();
 }
-

--- a/Quake/r_fogvol.h
+++ b/Quake/r_fogvol.h
@@ -18,12 +18,14 @@ typedef struct fog_volume_s
 	int enabled;
 } fog_volume_t;
 
+extern cvar_t r_fogvol;
+
 void R_FogVol_Init (void);
 void R_FogVol_Clear (void);
 void R_FogVol_BuildList (void);
 void R_FogVol_AddTestVolumes (void);
 void R_FogVol_Render (void);
 void R_FogVol_DrawDebug2D (void);
-qboolean R_FogVol_ProjectAABBToScreenRect (const fog_volume_t *v, int *x0, int *y0, int *x1, int *y1);
+qboolean R_FogVol_ProjectAABBToScreenRect (const fog_volume_t *v, int *x0, int *y0, int *x1, int *y1, qboolean fullres);
 
 #endif // R_FOGVOL_H

--- a/Quake/shaders/fogvol.frag
+++ b/Quake/shaders/fogvol.frag
@@ -2,6 +2,9 @@
 
 #define MAX_FOGVOLUMES 64
 
+layout(binding=0) uniform sampler2D SceneColor;
+layout(binding=1) uniform sampler2D SceneDepth;
+
 struct FogVolume
 {
 	vec4 mins;
@@ -21,32 +24,196 @@ layout(location=0) uniform int FogSteps;
 layout(location=1) uniform int FogNoiseEnabled;
 layout(location=2) uniform int FogDebugMode;
 layout(location=3) uniform int FogVolumeIndex;
+layout(location=4) uniform mat4 FogInvViewProj;
+layout(location=8) uniform vec3 FogCameraPosWS;
+layout(location=9) uniform vec4 FogViewportParams; // xy: size, zw: inv size
 
 layout(location=0) out vec4 FragColor;
 
+float Hash3(vec3 p)
+{
+	return fract(sin(dot(p, vec3(127.1, 311.7, 74.7))) * 43758.5453123);
+}
+
+float ValueNoise(vec3 p, float period)
+{
+	vec3 i = floor(p);
+	vec3 f = fract(p);
+	vec3 w = f * f * (3.0 - 2.0 * f);
+
+	vec3 i0 = mod(i, period);
+	vec3 i1 = mod(i0 + 1.0, period);
+
+	float n000 = Hash3(i0);
+	float n100 = Hash3(vec3(i1.x, i0.y, i0.z));
+	float n010 = Hash3(vec3(i0.x, i1.y, i0.z));
+	float n110 = Hash3(vec3(i1.x, i1.y, i0.z));
+	float n001 = Hash3(vec3(i0.x, i0.y, i1.z));
+	float n101 = Hash3(vec3(i1.x, i0.y, i1.z));
+	float n011 = Hash3(vec3(i0.x, i1.y, i1.z));
+	float n111 = Hash3(i1);
+
+	float nx00 = mix(n000, n100, w.x);
+	float nx10 = mix(n010, n110, w.x);
+	float nx01 = mix(n001, n101, w.x);
+	float nx11 = mix(n011, n111, w.x);
+	float nxy0 = mix(nx00, nx10, w.y);
+	float nxy1 = mix(nx01, nx11, w.y);
+	return mix(nxy0, nxy1, w.z);
+}
+
+float FBM(vec3 p)
+{
+	const float period = 16.0;
+	float sum = 0.0;
+	float amp = 0.5;
+	float freq = 1.0;
+	float norm = 0.0;
+	for (int i = 0; i < 3; ++i)
+	{
+		sum += amp * ValueNoise(p * freq, period * freq);
+		norm += amp;
+		freq *= 2.0;
+		amp *= 0.5;
+	}
+	return sum / max(norm, 1e-5);
+}
+
+float DepthToNdcZ(float depth)
+{
+#if REVERSED_Z
+	return depth;
+#else
+	return depth * 2.0 - 1.0;
+#endif
+}
+
+bool IsSkyDepth(float depth)
+{
+#if REVERSED_Z
+	return depth <= 0.0001;
+#else
+	return depth >= 0.9999;
+#endif
+}
+
+bool RayAABB(vec3 ro, vec3 rd, vec3 bmin, vec3 bmax, out float tEnter, out float tExit)
+{
+	vec3 invRd = 1.0 / rd;
+	vec3 t0 = (bmin - ro) * invRd;
+	vec3 t1 = (bmax - ro) * invRd;
+	vec3 tmin = min(t0, t1);
+	vec3 tmax = max(t0, t1);
+	tEnter = max(max(tmin.x, tmin.y), tmin.z);
+	tExit = min(min(tmax.x, tmax.y), tmax.z);
+	return tExit > max(tEnter, 0.0);
+}
+
+float Dither(vec2 pixel)
+{
+	return fract(sin(dot(pixel, vec2(12.9898, 78.233)) + Time) * 43758.5453);
+}
+
 void main()
 {
+	vec2 invViewport = FogViewportParams.zw;
+	vec2 uv = gl_FragCoord.xy * invViewport;
+
 	FogVolume volume = FogVolumes[FogVolumeIndex];
+	if (volume.misc.y <= 0.0)
+	{
+		FragColor = vec4(texture(SceneColor, uv).rgb, 1.0);
+		return;
+	}
+
+	float depth = texelFetch(SceneDepth, ivec2(gl_FragCoord.xy), 0).r;
+	float ndcDepth = DepthToNdcZ(depth);
+	vec4 clip = vec4(uv * 2.0 - 1.0, ndcDepth, 1.0);
+	vec4 world = FogInvViewProj * clip;
+	if (abs(world.w) < 1e-6)
+	{
+		FragColor = vec4(texture(SceneColor, uv).rgb, 1.0);
+		return;
+	}
+	vec3 worldPos = world.xyz / world.w;
+
+	vec3 ro = FogCameraPosWS;
+	vec3 rd = normalize(worldPos - ro);
+	float tScene = length(worldPos - ro);
+	if (IsSkyDepth(depth))
+		tScene = 1e6;
+
+	float tEnter;
+	float tExit;
+	if (!RayAABB(ro, rd, volume.mins.xyz, volume.maxs.xyz, tEnter, tExit))
+	{
+		FragColor = vec4(texture(SceneColor, uv).rgb, 1.0);
+		return;
+	}
+
+	tEnter = max(tEnter, 0.0);
+	tExit = min(tExit, tScene);
+	float maxDistance = volume.noise_params.w;
+	if (maxDistance > 0.0)
+		tExit = min(tExit, maxDistance);
+	if (tExit <= tEnter)
+	{
+		FragColor = vec4(texture(SceneColor, uv).rgb, 1.0);
+		return;
+	}
+
+	float stepCount = max(float(FogSteps), 1.0);
+	float len = tExit - tEnter;
+	float stepLen = len / stepCount;
+	if (FogNoiseEnabled != 0)
+		tEnter += (Dither(gl_FragCoord.xy) - 0.5) * stepLen;
+
+	vec3 scatterColor = volume.color_density.rgb;
 	float density = max(volume.color_density.a, 0.0);
-	float step_factor = clamp(float(FogSteps) / 128.0, 0.0, 1.0);
-	float alpha = clamp(density * 0.25, 0.0, 0.6) * mix(0.8, 1.0, step_factor);
-	vec3 color = volume.color_density.rgb;
+
+	vec3 accum = vec3(0.0);
+	float transmittance = 1.0;
+
+	for (int i = 0; i < FogSteps; ++i)
+	{
+		float t = tEnter + (float(i) + 0.5) * stepLen;
+		if (t >= tExit)
+			break;
+
+		vec3 p = ro + rd * t;
+		float noiseFactor = 1.0;
+		if (FogNoiseEnabled != 0)
+		{
+			vec3 noisePos = p * volume.noise_params.x + volume.velocity.xyz * Time;
+			float n = FBM(noisePos);
+			float biased = max(0.0, n + volume.noise_params.z);
+			float amt = clamp(volume.noise_params.y, 0.0, 1.0);
+			noiseFactor = mix(1.0, biased, amt);
+		}
+
+		float sigma = density * noiseFactor;
+		float att = exp(-sigma * stepLen);
+		vec3 stepScatter = (1.0 - att) * scatterColor;
+		accum += transmittance * stepScatter;
+		transmittance *= att;
+		if (transmittance < 0.01)
+			break;
+	}
 
 	if (FogDebugMode == 3)
 	{
-		color = vec3(density);
-		alpha = 1.0;
+		FragColor = vec4(vec3(1.0 - transmittance), 1.0);
+		return;
 	}
-	else if (FogDebugMode == 4)
+	if (FogDebugMode == 4)
 	{
-		float n = fract(sin(dot(gl_FragCoord.xy, vec2(12.9898, 78.233)) + Time) * 43758.5453);
-		color = vec3(n);
-		alpha = 1.0;
-	}
-	else if (FogNoiseEnabled == 0)
-	{
-		alpha *= 0.9;
+		vec3 noisePos = (ro + rd * (tEnter + 0.5 * stepLen)) * volume.noise_params.x + volume.velocity.xyz * Time;
+		float n = FBM(noisePos);
+		FragColor = vec4(vec3(n), 1.0);
+		return;
 	}
 
-	FragColor = vec4(color, alpha);
+	vec3 scene = texture(SceneColor, uv).rgb;
+	vec3 outColor = scene * transmittance + accum;
+	FragColor = vec4(outColor, 1.0);
 }


### PR DESCRIPTION
### Motivation

- Provide local, authorable volumetric fog/steam volumes rendered as a screen-space post pass (no global fog).
- Ensure correct depth occlusion so fog is clipped by scene geometry and composite happens in linear HDR before tonemap.
- Use a procedural, tileable 3D value-noise + fBm MVP implementation with a clear upgrade path to a 3D LUT later.
- Keep per-volume scissor/ping-pong compositing to avoid full-screen work for small volumes and provide debug visualization modes.

### Description

- Added a dedicated post resolve pass that raymarches AABB fog volumes and composites into the linear `framebufs.composite` target, implemented in `R_FogVol_Render` in `Quake/r_fogvol.c` and the fragment shader `Quake/shaders/fogvol.frag`.
- Introduced a fog-volume ping-pong framebuffer/texture in `framebufs.fogvol` (`Quake/glquake.h`, `Quake/gl_rmain.c`) and enabled postprocess when `r_fogvol` is active so the pass runs with the post pipeline.
- Implemented ray reconstruction (inverse view-proj), world-space ray/AABB slab intersection, raymarch Beer–Lambert accumulation, depth occlusion clamping to scene depth, optional jitter, and debug modes in `fogvol.frag`; the shader provides procedural tileable 3D value noise + 3-octave fBm that is parameterized by volume fields.
- Exposed and registered CVars and GPU data: `r_fogvol`, `r_fogvol_steps`, `r_fogvol_halfres`, `r_fogvol_noise`, `r_fogvol_debug`, and upload of `FogVolume` UBO data with per-volume params (mins/maxs, color+density, noise params, velocity, etc.).

### Testing

- No automated tests were run as part of this change set (no CI/build tests executed).
- Manual smoke/test volumes are created by `R_FogVol_AddTestVolumes` and can be exercised via `r_fogvol` and debug CVars at runtime (not automated).
- The patch compiles locally in the development environment used for the rollout (no formal test harness results collected).
- Developer visual verification expected: AABB fog only appears inside projected bounds, respects scene depth occlusion, and responds to `r_fogvol_steps`, `r_fogvol_noise`, `r_fogvol_debug` settings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bd6dbc314832e8260457b29a41ca7)