### PR TITLE
Add tileable 3D value noise + noise-mode stub for fog volumes

### DIFF
--- a/Quake/r_fogvol.c
+++ b/Quake/r_fogvol.c
@@ -42,6 +42,7 @@ cvar_t r_fogvol = { "r_fogvol", "0", CVAR_ARCHIVE };
 cvar_t r_fogvol_steps = { "r_fogvol_steps", "32", CVAR_ARCHIVE };
 cvar_t r_fogvol_halfres = { "r_fogvol_halfres", "0", CVAR_ARCHIVE };
 cvar_t r_fogvol_noise = { "r_fogvol_noise", "1", CVAR_ARCHIVE };
+cvar_t r_fogvol_noisemode = { "r_fogvol_noisemode", "0", CVAR_ARCHIVE };
 cvar_t r_fogvol_debug = { "r_fogvol_debug", "0", CVAR_ARCHIVE };
 
 static qboolean R_FogVol_MatrixInverse4x4 (const float m[16], float out[16])
@@ -113,6 +114,7 @@ void R_FogVol_Init (void)
 	Cvar_RegisterVariable (&r_fogvol_steps);
 	Cvar_RegisterVariable (&r_fogvol_halfres);
 	Cvar_RegisterVariable (&r_fogvol_noise);
+	Cvar_RegisterVariable (&r_fogvol_noisemode);
 	Cvar_RegisterVariable (&r_fogvol_debug);
 }
 
@@ -135,31 +137,31 @@ void R_FogVol_AddTestVolumes (void)
 	VectorCopy (r_refdef.vieworg, origin);
 
 	memset (&volume, 0, sizeof (volume));
-	VectorSet (volume.color, 0.7f, 0.8f, 1.0f);
-	volume.density = 0.15f;
-	volume.noiseScale = 0.05f;
-	volume.noiseAmount = 0.5f;
+	VectorSet (volume.color, 0.8f, 0.85f, 0.9f);
+	volume.density = 0.35f;
+	volume.noiseScale = 0.08f;
+	volume.noiseAmount = 0.85f;
 	volume.noiseBias = 0.0f;
-	VectorSet (volume.velocity, 4.f, 0.f, 0.f);
+	VectorSet (volume.velocity, 0.f, 0.f, 6.f);
 	volume.maxDistance = 0.f;
 	volume.priority = 0;
 	volume.enabled = 1;
-	VectorSet (volume.mins, origin[0] - 64.f, origin[1] - 64.f, origin[2] - 32.f);
-	VectorSet (volume.maxs, origin[0] + 64.f, origin[1] + 64.f, origin[2] + 96.f);
+	VectorSet (volume.mins, origin[0] - 32.f, origin[1] - 32.f, origin[2] - 16.f);
+	VectorSet (volume.maxs, origin[0] + 32.f, origin[1] + 32.f, origin[2] + 48.f);
 	R_FogVol_AddVolume (&volume);
 
 	memset (&volume, 0, sizeof (volume));
-	VectorSet (volume.color, 0.8f, 0.6f, 0.4f);
-	volume.density = 0.2f;
-	volume.noiseScale = 0.08f;
-	volume.noiseAmount = 0.6f;
+	VectorSet (volume.color, 0.7f, 0.75f, 0.85f);
+	volume.density = 0.05f;
+	volume.noiseScale = 0.02f;
+	volume.noiseAmount = 0.25f;
 	volume.noiseBias = 0.0f;
-	VectorSet (volume.velocity, -2.f, 1.f, 0.f);
+	VectorSet (volume.velocity, -1.f, 0.5f, 0.f);
 	volume.maxDistance = 0.f;
 	volume.priority = 1;
 	volume.enabled = 1;
-	VectorSet (volume.mins, origin[0] + 96.f, origin[1] - 96.f, origin[2] - 16.f);
-	VectorSet (volume.maxs, origin[0] + 192.f, origin[1] + 0.f, origin[2] + 64.f);
+	VectorSet (volume.mins, origin[0] - 256.f, origin[1] - 256.f, origin[2] - 128.f);
+	VectorSet (volume.maxs, origin[0] + 256.f, origin[1] + 256.f, origin[2] + 128.f);
 	R_FogVol_AddVolume (&volume);
 }
 
@@ -329,8 +331,8 @@ void R_FogVol_Render (void)
 		gpu->color_density[2] = v->color[2];
 		gpu->color_density[3] = v->density;
 
-		gpu->noise_params[0] = v->noiseScale;
-		gpu->noise_params[1] = v->noiseAmount;
+		gpu->noise_params[0] = CLAMP (0.005f, v->noiseScale, 0.5f);
+		gpu->noise_params[1] = CLAMP (0.f, v->noiseAmount, 1.f);
 		gpu->noise_params[2] = v->noiseBias;
 		gpu->noise_params[3] = v->maxDistance;
 
@@ -354,6 +356,7 @@ void R_FogVol_Render (void)
 	GL_Uniform1iFunc (0, steps);
 	GL_Uniform1iFunc (1, r_fogvol_noise.value > 0.f ? 1 : 0);
 	GL_Uniform1iFunc (2, mode);
+	GL_Uniform1iFunc (5, (int)Q_rint (r_fogvol_noisemode.value));
 	GL_UniformMatrix4fvFunc (4, 1, GL_FALSE, inv_viewproj);
 	GL_Uniform3fFunc (8, r_refdef.vieworg[0], r_refdef.vieworg[1], r_refdef.vieworg[2]);
 	GL_Uniform4fFunc (9, (float)glwidth, (float)glheight, 1.f / (float)glwidth, 1.f / (float)glheight);

--- a/Quake/shaders/fogvol.frag
+++ b/Quake/shaders/fogvol.frag
@@ -4,6 +4,7 @@
 
 layout(binding=0) uniform sampler2D SceneColor;
 layout(binding=1) uniform sampler2D SceneDepth;
+layout(binding=3) uniform sampler3D FogNoiseTex;
 
 struct FogVolume
 {
@@ -25,33 +26,57 @@ layout(location=1) uniform int FogNoiseEnabled;
 layout(location=2) uniform int FogDebugMode;
 layout(location=3) uniform int FogVolumeIndex;
 layout(location=4) uniform mat4 FogInvViewProj;
+layout(location=5) uniform int FogNoiseMode;
 layout(location=8) uniform vec3 FogCameraPosWS;
 layout(location=9) uniform vec4 FogViewportParams; // xy: size, zw: inv size
 
 layout(location=0) out vec4 FragColor;
 
-float Hash3(vec3 p)
+const int NOISE_PERIOD = 64;
+const float NOISE_SCALE_MIN = 0.005;
+const float NOISE_SCALE_MAX = 0.5;
+const float LUT_PERIOD = 64.0;
+
+int WrapIndex(int v, int period)
 {
-	return fract(sin(dot(p, vec3(127.1, 311.7, 74.7))) * 43758.5453123);
+	int r = v % period;
+	return (r < 0) ? (r + period) : r;
 }
 
-float ValueNoise(vec3 p, float period)
+ivec3 WrapIndex(ivec3 v, int period)
+{
+	return ivec3(WrapIndex(v.x, period), WrapIndex(v.y, period), WrapIndex(v.z, period));
+}
+
+uint HashU32(ivec3 p)
+{
+	uvec3 x = uvec3(p);
+	x = (x ^ (x.yzx * 0x27d4eb2du)) * 0x165667b1u;
+	return x.x ^ x.y ^ x.z;
+}
+
+float Hash31(ivec3 p)
+{
+	return float(HashU32(p)) / 4294967295.0;
+}
+
+float ValueNoise(vec3 p)
 {
 	vec3 i = floor(p);
 	vec3 f = fract(p);
 	vec3 w = f * f * (3.0 - 2.0 * f);
 
-	vec3 i0 = mod(i, period);
-	vec3 i1 = mod(i0 + 1.0, period);
+	ivec3 i0 = WrapIndex(ivec3(i), NOISE_PERIOD);
+	ivec3 i1 = WrapIndex(i0 + ivec3(1), NOISE_PERIOD);
 
-	float n000 = Hash3(i0);
-	float n100 = Hash3(vec3(i1.x, i0.y, i0.z));
-	float n010 = Hash3(vec3(i0.x, i1.y, i0.z));
-	float n110 = Hash3(vec3(i1.x, i1.y, i0.z));
-	float n001 = Hash3(vec3(i0.x, i0.y, i1.z));
-	float n101 = Hash3(vec3(i1.x, i0.y, i1.z));
-	float n011 = Hash3(vec3(i0.x, i1.y, i1.z));
-	float n111 = Hash3(i1);
+	float n000 = Hash31(i0);
+	float n100 = Hash31(ivec3(i1.x, i0.y, i0.z));
+	float n010 = Hash31(ivec3(i0.x, i1.y, i0.z));
+	float n110 = Hash31(ivec3(i1.x, i1.y, i0.z));
+	float n001 = Hash31(ivec3(i0.x, i0.y, i1.z));
+	float n101 = Hash31(ivec3(i1.x, i0.y, i1.z));
+	float n011 = Hash31(ivec3(i0.x, i1.y, i1.z));
+	float n111 = Hash31(i1);
 
 	float nx00 = mix(n000, n100, w.x);
 	float nx10 = mix(n010, n110, w.x);
@@ -64,19 +89,25 @@ float ValueNoise(vec3 p, float period)
 
 float FBM(vec3 p)
 {
-	const float period = 16.0;
 	float sum = 0.0;
 	float amp = 0.5;
 	float freq = 1.0;
 	float norm = 0.0;
 	for (int i = 0; i < 3; ++i)
 	{
-		sum += amp * ValueNoise(p * freq, period * freq);
+		sum += amp * ValueNoise(p * freq);
 		norm += amp;
 		freq *= 2.0;
 		amp *= 0.5;
 	}
 	return sum / max(norm, 1e-5);
+}
+
+float FogNoise(vec3 p)
+{
+	if (FogNoiseMode == 1)
+		return texture(FogNoiseTex, fract(p / LUT_PERIOD)).r;
+	return FBM(p);
 }
 
 float DepthToNdcZ(float depth)
@@ -184,11 +215,14 @@ void main()
 		float noiseFactor = 1.0;
 		if (FogNoiseEnabled != 0)
 		{
-			vec3 noisePos = p * volume.noise_params.x + volume.velocity.xyz * Time;
-			float n = FBM(noisePos);
-			float biased = max(0.0, n + volume.noise_params.z);
+			float noiseScale = clamp(volume.noise_params.x, NOISE_SCALE_MIN, NOISE_SCALE_MAX);
+			vec3 noisePos = p * noiseScale + volume.velocity.xyz * Time * noiseScale;
+			float n = FogNoise(noisePos);
+			float noiseBias = clamp(volume.noise_params.z, 0.0, 1.0);
+			if (noiseBias > 0.0)
+				n = smoothstep(noiseBias, 1.0, n);
 			float amt = clamp(volume.noise_params.y, 0.0, 1.0);
-			noiseFactor = mix(1.0, biased, amt);
+			noiseFactor = mix(1.0, n, amt);
 		}
 
 		float sigma = density * noiseFactor;
@@ -207,8 +241,9 @@ void main()
 	}
 	if (FogDebugMode == 4)
 	{
-		vec3 noisePos = (ro + rd * (tEnter + 0.5 * stepLen)) * volume.noise_params.x + volume.velocity.xyz * Time;
-		float n = FBM(noisePos);
+		float noiseScale = clamp(volume.noise_params.x, NOISE_SCALE_MIN, NOISE_SCALE_MAX);
+		vec3 noisePos = (ro + rd * (tEnter + 0.5 * stepLen)) * noiseScale + volume.velocity.xyz * Time * noiseScale;
+		float n = FogNoise(noisePos);
 		FragColor = vec4(vec3(n), 1.0);
 		return;
 	}


### PR DESCRIPTION
### Motivation
- Provide procedural, tileable 3D value noise + fBm as the MVP noise source for local screen-space fog/steam volumes.
- Allow an interchangeable “Ultra” path (3D LUT) later without changing authoring or volume parameters.
- Keep noise sampling stable with world-space scrolling and consistent motion when `noiseScale` changes.
- Add debug modes and safe parameter clamps to avoid shimmer and runaway costs.

### Description
- Shader `Quake/shaders/fogvol.frag`: added `sampler3D FogNoiseTex`, `FogNoiseMode` uniform, and implemented tileable integer wrapping, `HashU32`/`Hash31`, `ValueNoise`, 3-octave `FBM`, and `FogNoise` which selects procedural vs LUT sampling; added clamps and LUT stubbing (`LUT_PERIOD`).
- Shader: world-space sampling now uses `noiseScale` clamped to `[0.005,0.5]`, velocity is scaled with `noiseScale` for consistent motion, `noiseBias` shaping via `smoothstep`, and `r_fogvol_noise` debug path preserved; debug visualization `FogDebugMode == 4` shows the noise field.
- C code `Quake/r_fogvol.c`: added `cvar_t r_fogvol_noisemode`, clamp volume parameters uploaded to GPU (`noiseScale` and `noiseAmount`), and pass `r_fogvol_noisemode` into the shader via uniform binding.
- Test volume presets updated: added two sample volumes (steam/haze) with tuned `color`, `density`, `noiseScale`, `noiseAmount`, `velocity`, and extents to exercise small clumpy steam and wide haze.

### Testing
- No automated tests were executed for this change.
- Runtime behavior and visual validation are expected to be verified manually (not included here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bda4cb6a0832e97ad23bbc224d988)