### PR TITLE
Map-authored fog volumes, edge falloff, and physical compositing

### DIFF
--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -999,6 +999,7 @@ void R_NewMap (void)
         Fog_NewMap (); //johnfitz -- global fog in worldspawn
         R_ParseWorldspawn (); //ericw -- wateralpha, telealpha, slimealpha in worldspawn
         R_ParseDlightEntities (); // persistent dlights from BSP entities
+        R_FogVol_ParseEntities (); // fog volume entities from BSP
 
 	// Load pointfile if map has no vis data and either developer mode is on or the game was started from a map editing tool
 	if (developer.value || map_checks.value)

--- a/Quake/r_fogvol.c
+++ b/Quake/r_fogvol.c
@@ -37,6 +37,8 @@ typedef struct fog_volume_gpu_s
 
 static fog_volume_t r_fogvolumes[MAX_FOGVOLUMES];
 static int r_fogvolume_count = 0;
+static fog_volume_t r_fogvolume_entities[MAX_FOGVOLUMES];
+static int r_fogvolume_entity_count = 0;
 
 cvar_t r_fogvol = { "r_fogvol", "0", CVAR_ARCHIVE };
 cvar_t r_fogvol_steps = { "r_fogvol_steps", "32", CVAR_ARCHIVE };
@@ -44,6 +46,8 @@ cvar_t r_fogvol_halfres = { "r_fogvol_halfres", "0", CVAR_ARCHIVE };
 cvar_t r_fogvol_noise = { "r_fogvol_noise", "1", CVAR_ARCHIVE };
 cvar_t r_fogvol_noisemode = { "r_fogvol_noisemode", "0", CVAR_ARCHIVE };
 cvar_t r_fogvol_debug = { "r_fogvol_debug", "0", CVAR_ARCHIVE };
+cvar_t r_fogvol_testvolumes = { "r_fogvol_testvolumes", "0", CVAR_ARCHIVE };
+cvar_t r_fogvol_physblend = { "r_fogvol_physblend", "1", CVAR_ARCHIVE };
 
 static qboolean R_FogVol_MatrixInverse4x4 (const float m[16], float out[16])
 {
@@ -116,6 +120,8 @@ void R_FogVol_Init (void)
 	Cvar_RegisterVariable (&r_fogvol_noise);
 	Cvar_RegisterVariable (&r_fogvol_noisemode);
 	Cvar_RegisterVariable (&r_fogvol_debug);
+	Cvar_RegisterVariable (&r_fogvol_testvolumes);
+	Cvar_RegisterVariable (&r_fogvol_physblend);
 }
 
 void R_FogVol_Clear (void)
@@ -123,11 +129,206 @@ void R_FogVol_Clear (void)
 	r_fogvolume_count = 0;
 }
 
+static void R_FogVol_ClearEntities (void)
+{
+	r_fogvolume_entity_count = 0;
+}
+
 static void R_FogVol_AddVolume (const fog_volume_t *volume)
 {
 	if (r_fogvolume_count >= MAX_FOGVOLUMES)
 		return;
 	r_fogvolumes[r_fogvolume_count++] = *volume;
+}
+
+static void R_FogVol_AddEntityVolume (const fog_volume_t *volume)
+{
+	if (r_fogvolume_entity_count >= MAX_FOGVOLUMES)
+		return;
+	r_fogvolume_entities[r_fogvolume_entity_count++] = *volume;
+}
+
+static void R_FogVol_ParseColor (const char *value, vec3_t color)
+{
+	float r = 1.f, g = 1.f, b = 1.f;
+	if (value && sscanf (value, "%f %f %f", &r, &g, &b) == 3)
+	{
+		if (r > 2.f || g > 2.f || b > 2.f)
+		{
+			r *= 1.f / 255.f;
+			g *= 1.f / 255.f;
+			b *= 1.f / 255.f;
+		}
+	}
+	color[0] = r;
+	color[1] = g;
+	color[2] = b;
+}
+
+static qboolean R_FogVol_ParseVector (const char *value, vec3_t out)
+{
+	return value && sscanf (value, "%f %f %f", &out[0], &out[1], &out[2]) == 3;
+}
+
+static float R_FogVol_PointAABBDistance (const vec3_t point, const fog_volume_t *volume)
+{
+	float dist2 = 0.f;
+
+	for (int i = 0; i < 3; ++i)
+	{
+		if (point[i] < volume->mins[i])
+		{
+			float d = volume->mins[i] - point[i];
+			dist2 += d * d;
+		}
+		else if (point[i] > volume->maxs[i])
+		{
+			float d = point[i] - volume->maxs[i];
+			dist2 += d * d;
+		}
+	}
+
+	return sqrtf (dist2);
+}
+
+void R_FogVol_ParseEntities (void)
+{
+	const char *data;
+
+	R_FogVol_ClearEntities ();
+
+	if (!cl.worldmodel || !cl.worldmodel->entities)
+		return;
+
+	data = cl.worldmodel->entities;
+	data = COM_Parse (data);
+	while (data && com_token[0])
+	{
+		fog_volume_t volume;
+		qboolean is_fog_volume = false;
+		char modelname[64] = "";
+		vec3_t origin = {0.f, 0.f, 0.f};
+		qboolean has_origin = false;
+
+		if (com_token[0] != '{')
+			break;
+
+		memset (&volume, 0, sizeof (volume));
+		VectorSet (volume.color, 1.f, 1.f, 1.f);
+		volume.density = 0.1f;
+		volume.falloff = 16.f;
+		volume.mode = 0;
+		volume.noiseScale = 0.05f;
+		volume.noiseAmount = 0.5f;
+		volume.noiseBias = 0.f;
+		VectorSet (volume.velocity, 0.f, 0.f, 0.f);
+		volume.maxDistance = 2048.f;
+		volume.priority = 0;
+		volume.enabled = 1;
+		volume.height = 0.f;
+		volume.heightScale = 0.f;
+
+		while (1)
+		{
+			char key[64], value[1024];
+			data = COM_Parse (data);
+			if (!data || !com_token[0])
+				return;
+			if (com_token[0] == '}')
+				break;
+			q_strlcpy (key, com_token, sizeof (key));
+			if (key[0] == '_')
+				memmove (key, key + 1, strlen (key));
+			data = COM_ParseEx (data, CPE_ALLOWTRUNC);
+			if (!data)
+				return;
+			q_strlcpy (value, com_token, sizeof (value));
+
+			if (!strcmp (key, "classname"))
+			{
+				if (!strcmp (value, "func_fog_volume") || !strcmp (value, "trigger_fog_volume"))
+					is_fog_volume = true;
+			}
+			else if (!strcmp (key, "model"))
+			{
+				q_strlcpy (modelname, value, sizeof (modelname));
+			}
+			else if (!strcmp (key, "origin"))
+			{
+				has_origin = R_FogVol_ParseVector (value, origin);
+			}
+			else if (!strcmp (key, "_color") || !strcmp (key, "color"))
+			{
+				R_FogVol_ParseColor (value, volume.color);
+			}
+			else if (!strcmp (key, "density"))
+			{
+				volume.density = atof (value);
+			}
+			else if (!strcmp (key, "falloff"))
+			{
+				volume.falloff = atof (value);
+			}
+			else if (!strcmp (key, "maxdist"))
+			{
+				volume.maxDistance = atof (value);
+			}
+			else if (!strcmp (key, "priority"))
+			{
+				volume.priority = atoi (value);
+			}
+			else if (!strcmp (key, "noise_scale"))
+			{
+				volume.noiseScale = atof (value);
+			}
+			else if (!strcmp (key, "noise_amount"))
+			{
+				volume.noiseAmount = atof (value);
+			}
+			else if (!strcmp (key, "noise_bias"))
+			{
+				volume.noiseBias = atof (value);
+			}
+			else if (!strcmp (key, "velocity"))
+			{
+				R_FogVol_ParseVector (value, volume.velocity);
+			}
+			else if (!strcmp (key, "mode"))
+			{
+				volume.mode = atoi (value);
+			}
+			else if (!strcmp (key, "height"))
+			{
+				volume.height = atof (value);
+			}
+			else if (!strcmp (key, "height_scale"))
+			{
+				volume.heightScale = atof (value);
+			}
+		}
+
+		if (is_fog_volume && modelname[0])
+		{
+			qmodel_t *model = Mod_ForName (modelname, false);
+			if (model && model->type == mod_brush)
+			{
+				vec3_t mins;
+				vec3_t maxs;
+				VectorCopy (model->mins, mins);
+				VectorCopy (model->maxs, maxs);
+				if (has_origin)
+				{
+					VectorAdd (mins, origin, mins);
+					VectorAdd (maxs, origin, maxs);
+				}
+				VectorCopy (mins, volume.mins);
+				VectorCopy (maxs, volume.maxs);
+				R_FogVol_AddEntityVolume (&volume);
+			}
+		}
+
+		data = COM_Parse (data);
+	}
 }
 
 void R_FogVol_AddTestVolumes (void)
@@ -139,6 +340,8 @@ void R_FogVol_AddTestVolumes (void)
 	memset (&volume, 0, sizeof (volume));
 	VectorSet (volume.color, 0.8f, 0.85f, 0.9f);
 	volume.density = 0.35f;
+	volume.falloff = 24.f;
+	volume.mode = 0;
 	volume.noiseScale = 0.08f;
 	volume.noiseAmount = 0.85f;
 	volume.noiseBias = 0.0f;
@@ -153,6 +356,8 @@ void R_FogVol_AddTestVolumes (void)
 	memset (&volume, 0, sizeof (volume));
 	VectorSet (volume.color, 0.7f, 0.75f, 0.85f);
 	volume.density = 0.05f;
+	volume.falloff = 32.f;
+	volume.mode = 0;
 	volume.noiseScale = 0.02f;
 	volume.noiseAmount = 0.25f;
 	volume.noiseBias = 0.0f;
@@ -172,7 +377,23 @@ void R_FogVol_BuildList (void)
 	if (r_fogvol.value <= 0.f)
 		return;
 
-	R_FogVol_AddTestVolumes ();
+	for (int i = 0; i < r_fogvolume_entity_count; ++i)
+	{
+		const fog_volume_t *volume = &r_fogvolume_entities[i];
+
+		if (!volume->enabled)
+			continue;
+		if (volume->maxDistance > 0.f)
+		{
+			float dist = R_FogVol_PointAABBDistance (r_refdef.vieworg, volume);
+			if (dist > volume->maxDistance)
+				continue;
+		}
+		R_FogVol_AddVolume (volume);
+	}
+
+	if (r_fogvol_testvolumes.value > 0.f)
+		R_FogVol_AddTestVolumes ();
 
 	if (r_fogvolume_count > 1)
 		qsort (r_fogvolumes, r_fogvolume_count, sizeof (fog_volume_t), R_FogVol_ComparePriority);
@@ -343,8 +564,8 @@ void R_FogVol_Render (void)
 
 		gpu->misc[0] = (float)v->priority;
 		gpu->misc[1] = (float)v->enabled;
-		gpu->misc[2] = 0.f;
-		gpu->misc[3] = 0.f;
+		gpu->misc[2] = v->falloff;
+		gpu->misc[3] = (float)v->mode;
 	}
 
 	GL_Upload (GL_UNIFORM_BUFFER, gpu_volumes, sizeof (fog_volume_gpu_t) * r_fogvolume_count, &buf, &ofs);
@@ -357,6 +578,7 @@ void R_FogVol_Render (void)
 	GL_Uniform1iFunc (1, r_fogvol_noise.value > 0.f ? 1 : 0);
 	GL_Uniform1iFunc (2, mode);
 	GL_Uniform1iFunc (5, (int)Q_rint (r_fogvol_noisemode.value));
+	GL_Uniform1iFunc (6, r_fogvol_physblend.value > 0.f ? 1 : 0);
 	GL_UniformMatrix4fvFunc (4, 1, GL_FALSE, inv_viewproj);
 	GL_Uniform3fFunc (8, r_refdef.vieworg[0], r_refdef.vieworg[1], r_refdef.vieworg[2]);
 	GL_Uniform4fFunc (9, (float)glwidth, (float)glheight, 1.f / (float)glwidth, 1.f / (float)glheight);

--- a/Quake/r_fogvol.h
+++ b/Quake/r_fogvol.h
@@ -9,6 +9,8 @@ typedef struct fog_volume_s
 	vec3_t maxs;
 	vec3_t color;
 	float density;
+	float falloff;
+	int mode;
 	float noiseScale;
 	float noiseAmount;
 	float noiseBias;
@@ -16,12 +18,15 @@ typedef struct fog_volume_s
 	float maxDistance;
 	int priority;
 	int enabled;
+	float height;
+	float heightScale;
 } fog_volume_t;
 
 extern cvar_t r_fogvol;
 
 void R_FogVol_Init (void);
 void R_FogVol_Clear (void);
+void R_FogVol_ParseEntities (void);
 void R_FogVol_BuildList (void);
 void R_FogVol_AddTestVolumes (void);
 void R_FogVol_Render (void);

--- a/Quake/shaders/fogvol.frag
+++ b/Quake/shaders/fogvol.frag
@@ -27,6 +27,7 @@ layout(location=2) uniform int FogDebugMode;
 layout(location=3) uniform int FogVolumeIndex;
 layout(location=4) uniform mat4 FogInvViewProj;
 layout(location=5) uniform int FogNoiseMode;
+layout(location=6) uniform int FogPhysBlend;
 layout(location=8) uniform vec3 FogCameraPosWS;
 layout(location=9) uniform vec4 FogViewportParams; // xy: size, zw: inv size
 
@@ -145,6 +146,16 @@ float Dither(vec2 pixel)
 	return fract(sin(dot(pixel, vec2(12.9898, 78.233)) + Time) * 43758.5453);
 }
 
+float FogEdgeFade(vec3 p, vec3 bmin, vec3 bmax, float falloff)
+{
+	float edgeThickness = max(falloff, 0.0);
+	if (edgeThickness <= 0.0)
+		return 1.0;
+	vec3 d = min(p - bmin, bmax - p);
+	float edgeDist = min(d.x, min(d.y, d.z));
+	return smoothstep(0.0, edgeThickness, edgeDist);
+}
+
 void main()
 {
 	vec2 invViewport = FogViewportParams.zw;
@@ -201,9 +212,13 @@ void main()
 
 	vec3 scatterColor = volume.color_density.rgb;
 	float density = max(volume.color_density.a, 0.0);
+	float falloff = volume.misc.z;
 
 	vec3 accum = vec3(0.0);
 	float transmittance = 1.0;
+	float tau = 0.0;
+	float edgeFadeSum = 0.0;
+	float edgeFadeSamples = 0.0;
 
 	for (int i = 0; i < FogSteps; ++i)
 	{
@@ -212,6 +227,7 @@ void main()
 			break;
 
 		vec3 p = ro + rd * t;
+		float edgeFade = FogEdgeFade(p, volume.mins.xyz, volume.maxs.xyz, falloff);
 		float noiseFactor = 1.0;
 		if (FogNoiseEnabled != 0)
 		{
@@ -225,30 +241,36 @@ void main()
 			noiseFactor = mix(1.0, n, amt);
 		}
 
-		float sigma = density * noiseFactor;
+		float sigma = density * noiseFactor * edgeFade;
 		float att = exp(-sigma * stepLen);
 		vec3 stepScatter = (1.0 - att) * scatterColor;
 		accum += transmittance * stepScatter;
 		transmittance *= att;
+		tau += sigma * stepLen;
+		edgeFadeSum += edgeFade;
+		edgeFadeSamples += 1.0;
 		if (transmittance < 0.01)
 			break;
 	}
 
 	if (FogDebugMode == 3)
 	{
-		FragColor = vec4(vec3(1.0 - transmittance), 1.0);
+		float tauViz = tau / (1.0 + tau);
+		FragColor = vec4(vec3(tauViz), 1.0);
 		return;
 	}
 	if (FogDebugMode == 4)
 	{
-		float noiseScale = clamp(volume.noise_params.x, NOISE_SCALE_MIN, NOISE_SCALE_MAX);
-		vec3 noisePos = (ro + rd * (tEnter + 0.5 * stepLen)) * noiseScale + volume.velocity.xyz * Time * noiseScale;
-		float n = FogNoise(noisePos);
-		FragColor = vec4(vec3(n), 1.0);
+		float fadeViz = (edgeFadeSamples > 0.0) ? (edgeFadeSum / edgeFadeSamples) : 0.0;
+		FragColor = vec4(vec3(fadeViz), 1.0);
 		return;
 	}
 
 	vec3 scene = texture(SceneColor, uv).rgb;
-	vec3 outColor = scene * transmittance + accum;
+	vec3 outColor;
+	if (FogPhysBlend != 0)
+		outColor = scene * transmittance + accum;
+	else
+		outColor = mix(scene, scatterColor, clamp(tau, 0.0, 1.0));
 	FragColor = vec4(outColor, 1.0);
 }


### PR DESCRIPTION
### Motivation

- Replace hardcoded camera-centered test fog with map-authored brush volumes so level designers can place fog in BSP maps.
- Improve the visual quality by removing hard box edges and using a falloff envelope to smooth transitions. 
- Introduce an option for physically-plausible Beer–Lambert compositing while keeping a legacy blend available behind a cvar. 
- Keep changes incremental and non-invasive so future froxel/grid fog can reuse the same volume definitions. 

### Description

- Parse BSP entity brush models named `func_fog_volume` / `trigger_fog_volume` via `R_FogVol_ParseEntities` and register per-map volumes into a new entity volume list (`r_fogvolume_entities`) with defaults for color, density, `falloff`, `mode`, `height`, `heightScale`, `noise*`, `velocity`, `maxDistance`, and `priority`.
- Wire entity parsing into map load by calling `R_FogVol_ParseEntities` from `R_NewMap` and add entity volumes into the per-frame fog list in `R_FogVol_BuildList` with simple distance culling (`maxDistance`) and an option to still add test volumes controlled by `r_fogvol_testvolumes`.
- Extend `fog_volume_t` (header) and the GPU UBO to carry `falloff` and `mode`, add Cvars `r_fogvol_testvolumes` and `r_fogvol_physblend`, and pass `FogPhysBlend` to the shader.
- Update `shaders/fogvol.frag` with `FogEdgeFade` computation, apply per-sample edge falloff to the extinction (`sigma`), accumulate `tau` for diagnostics, add debug outputs for tau and edge fade, and select between physical Beer–Lambert compositing or legacy mix via `FogPhysBlend`.

### Testing

- No automated tests were executed as part of this change.
- Manual runtime behavior: compilation and shader wiring were validated during rollout (no automated test run to report pass/fail).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695be3def7d4832e85da2a16f1b8c3a2)