### PR TITLE
Implement half-resolution fog volume rendering with depth-aware upsample

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -770,8 +770,21 @@ void GL_CreateFrameBuffers (void)
 		framebufs.composite.depth_stencil_tex,
 		"composite fbo"
 	);
-	framebufs.fogvol.color_tex = GL_CreateTexture2D (GL_RGBA16F, vid.width, vid.height, GL_NEAREST, "fogvol color");
-	framebufs.fogvol.fbo = GL_CreateSimpleFBO (GL_TEXTURE_2D, framebufs.fogvol.color_tex, 0, 0, "fogvol fbo");
+	framebufs.fogvol.width = vid.width;
+	framebufs.fogvol.height = vid.height;
+	if (r_fogvol_halfres.value > 0.f)
+	{
+		framebufs.fogvol.width = q_max (1, vid.width / 2);
+		framebufs.fogvol.height = q_max (1, vid.height / 2);
+	}
+	for (int i = 0; i < 2; ++i)
+	{
+		const char *suffix = (i == 0) ? "fogvol color 0" : "fogvol color 1";
+		const char *fbo_suffix = (i == 0) ? "fogvol fbo 0" : "fogvol fbo 1";
+		framebufs.fogvol.color_tex[i] = GL_CreateTexture2D (GL_RGBA16F, framebufs.fogvol.width,
+			framebufs.fogvol.height, GL_NEAREST, suffix);
+		framebufs.fogvol.fbo[i] = GL_CreateSimpleFBO (GL_TEXTURE_2D, framebufs.fogvol.color_tex[i], 0, 0, fbo_suffix);
+	}
 
 	framebufs.autoexposure.width = 16;
 	framebufs.autoexposure.height = 16;
@@ -904,7 +917,7 @@ void GL_DeleteFrameBuffers (void)
 	GL_DeleteFramebuffersFunc (1, &framebufs.scene.fbo);
 	GL_DeleteFramebuffersFunc (1, &framebufs.dlight.fbo);
 	GL_DeleteFramebuffersFunc (1, &framebufs.composite.fbo);
-	GL_DeleteFramebuffersFunc (1, &framebufs.fogvol.fbo);
+	GL_DeleteFramebuffersFunc (2, framebufs.fogvol.fbo);
 	GL_DeleteFramebuffersFunc (1, &framebufs.autoexposure.fbo);
 	GL_DeleteFramebuffersFunc (1, &framebufs.bloom.extract_fbo);
 	GL_DeleteFramebuffersFunc (1, &framebufs.bloom.pingpong_fbo[0]);
@@ -921,7 +934,8 @@ void GL_DeleteFrameBuffers (void)
 
 	GL_DeleteNativeTexture (framebufs.resolved_scene.color_tex);
 	GL_DeleteNativeTexture (framebufs.resolved_scene.velocity_tex);
-	GL_DeleteNativeTexture (framebufs.fogvol.color_tex);
+	GL_DeleteNativeTexture (framebufs.fogvol.color_tex[0]);
+	GL_DeleteNativeTexture (framebufs.fogvol.color_tex[1]);
 	GL_DeleteNativeTexture (framebufs.oit.revealage_tex);
 	GL_DeleteNativeTexture (framebufs.oit.accum_tex);
 	GL_DeleteNativeTexture (framebufs.scene.depth_stencil_tex);

--- a/Quake/gl_shaders.c
+++ b/Quake/gl_shaders.c
@@ -524,6 +524,7 @@ void GL_CreateShaders (void)
 	glprogs.godrays_source = GL_CreateProgram (GLSL_PATH("world.vert"), GLSL_PATH("godrays_source.frag"), "world godrays|MODE 0; DITHER 0");
 	glprogs.godrays_source_sky = GL_CreateProgram (GLSL_PATH("postprocess.vert"), GLSL_PATH("godrays_source_sky.frag"), "godrays source sky");
 	glprogs.fogvol = GL_CreateProgram (GLSL_PATH("postprocess.vert"), GLSL_PATH("fogvol.frag"), "fog volumes");
+	glprogs.fogvol_upsample = GL_CreateProgram (GLSL_PATH("postprocess.vert"), GLSL_PATH("fogvol_upsample.frag"), "fog volumes upsample");
         for (mode = 0; mode < 2; mode++)
                 glprogs.oit_resolve[mode] = GL_CreateProgram (GLSL_PATH("oit_resolve.vert"), GLSL_PATH("oit_resolve.frag"), "oit resolve|MSAA %d", mode);
 

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -582,6 +582,7 @@ typedef struct glprogs_s {
 	GLuint		godrays_source;
 	GLuint		godrays_source_sky;
 	GLuint		fogvol;
+	GLuint		fogvol_upsample;
 	GLuint		oit_resolve[2];		// [msaa]
 
 	/* 3d */
@@ -647,8 +648,10 @@ typedef struct glframebufs_s {
 	}				composite;
 
 	struct {
-		GLuint		color_tex;
-		GLuint		fbo;
+		GLuint		color_tex[2];
+		GLuint		fbo[2];
+		int			width;
+		int			height;
 	}				fogvol;
 
 	struct {

--- a/Quake/r_fogvol.c
+++ b/Quake/r_fogvol.c
@@ -43,6 +43,10 @@ static int r_fogvolume_entity_count = 0;
 cvar_t r_fogvol = { "r_fogvol", "0", CVAR_ARCHIVE };
 cvar_t r_fogvol_steps = { "r_fogvol_steps", "32", CVAR_ARCHIVE };
 cvar_t r_fogvol_halfres = { "r_fogvol_halfres", "0", CVAR_ARCHIVE };
+cvar_t r_fogvol_upsample = { "r_fogvol_upsample", "1", CVAR_ARCHIVE };
+cvar_t r_fogvol_upsample_k = { "r_fogvol_upsample_k", "100", CVAR_ARCHIVE };
+cvar_t r_fogvol_upsample_taps = { "r_fogvol_upsample_taps", "4", CVAR_ARCHIVE };
+cvar_t r_fogvol_steps_scale_halfres = { "r_fogvol_steps_scale_halfres", "0.5", CVAR_ARCHIVE };
 cvar_t r_fogvol_noise = { "r_fogvol_noise", "1", CVAR_ARCHIVE };
 cvar_t r_fogvol_noisemode = { "r_fogvol_noisemode", "0", CVAR_ARCHIVE };
 cvar_t r_fogvol_debug = { "r_fogvol_debug", "0", CVAR_ARCHIVE };
@@ -117,6 +121,10 @@ void R_FogVol_Init (void)
 	Cvar_RegisterVariable (&r_fogvol);
 	Cvar_RegisterVariable (&r_fogvol_steps);
 	Cvar_RegisterVariable (&r_fogvol_halfres);
+	Cvar_RegisterVariable (&r_fogvol_upsample);
+	Cvar_RegisterVariable (&r_fogvol_upsample_k);
+	Cvar_RegisterVariable (&r_fogvol_upsample_taps);
+	Cvar_RegisterVariable (&r_fogvol_steps_scale_halfres);
 	Cvar_RegisterVariable (&r_fogvol_noise);
 	Cvar_RegisterVariable (&r_fogvol_noisemode);
 	Cvar_RegisterVariable (&r_fogvol_debug);
@@ -515,6 +523,14 @@ void R_FogVol_Render (void)
 	GLuint depth_tex;
 	qboolean dst_is_composite;
 	qboolean has_drawn = false;
+	qboolean use_halfres;
+	int fog_width;
+	int fog_height;
+	float depth_scale_x;
+	float depth_scale_y;
+	int fog_src_index = 0;
+	int fog_dst_index = 0;
+	GLuint final_tex = 0;
 
 	if (r_fogvol.value <= 0.f)
 		return;
@@ -522,14 +538,23 @@ void R_FogVol_Render (void)
 		return;
 	if (r_fogvolume_count <= 0)
 		return;
-	if (framebufs.composite.color_tex == 0 || framebufs.fogvol.color_tex == 0)
+	if (framebufs.composite.color_tex == 0 || framebufs.fogvol.color_tex[0] == 0)
 		return;
 	if (framebufs.composite.depth_stencil_tex == 0)
 		return;
 	if (!R_FogVol_MatrixInverse4x4 (r_matviewproj, inv_viewproj))
 		return;
 
-	steps = (int)Q_rint (r_fogvol_steps.value);
+	use_halfres = (r_fogvol_halfres.value > 0.f);
+	fog_width = use_halfres ? framebufs.fogvol.width : glwidth;
+	fog_height = use_halfres ? framebufs.fogvol.height : glheight;
+	depth_scale_x = (float)glwidth / (float)fog_width;
+	depth_scale_y = (float)glheight / (float)fog_height;
+
+	if (use_halfres && r_fogvol_steps_scale_halfres.value > 0.f)
+		steps = (int)Q_rint (r_fogvol_steps.value * r_fogvol_steps_scale_halfres.value);
+	else
+		steps = (int)Q_rint (r_fogvol_steps.value);
 	steps = CLAMP (8, steps, 128);
 
 	for (int i = 0; i < r_fogvolume_count; ++i)
@@ -581,14 +606,18 @@ void R_FogVol_Render (void)
 	GL_Uniform1iFunc (6, r_fogvol_physblend.value > 0.f ? 1 : 0);
 	GL_UniformMatrix4fvFunc (4, 1, GL_FALSE, inv_viewproj);
 	GL_Uniform3fFunc (8, r_refdef.vieworg[0], r_refdef.vieworg[1], r_refdef.vieworg[2]);
-	GL_Uniform4fFunc (9, (float)glwidth, (float)glheight, 1.f / (float)glwidth, 1.f / (float)glheight);
+	GL_Uniform4fFunc (9, (float)fog_width, (float)fog_height, 1.f / (float)fog_width, 1.f / (float)fog_height);
+	GL_Uniform2fFunc (10, depth_scale_x, depth_scale_y);
 
 	glEnable (GL_SCISSOR_TEST);
-	glViewport (glx, gly, glwidth, glheight);
+	if (use_halfres)
+		glViewport (0, 0, fog_width, fog_height);
+	else
+		glViewport (glx, gly, glwidth, glheight);
 	depth_tex = framebufs.composite.depth_stencil_tex;
 	src_tex = framebufs.composite.color_tex;
-	dst_tex = framebufs.fogvol.color_tex;
-	dst_fbo = framebufs.fogvol.fbo;
+	dst_tex = framebufs.fogvol.color_tex[0];
+	dst_fbo = framebufs.fogvol.fbo[0];
 	dst_is_composite = false;
 
 	for (int i = 0; i < r_fogvolume_count; ++i)
@@ -600,6 +629,21 @@ void R_FogVol_Render (void)
 			continue;
 		if (!R_FogVol_ProjectAABBToScreenRect (v, &x0, &y0, &x1, &y1, true))
 			continue;
+		if (use_halfres)
+		{
+			float scale_x = (float)fog_width / (float)glwidth;
+			float scale_y = (float)fog_height / (float)glheight;
+			int hx0 = (int)floorf ((float)x0 * scale_x);
+			int hy0 = (int)floorf ((float)y0 * scale_y);
+			int hx1 = (int)ceilf ((float)x1 * scale_x);
+			int hy1 = (int)ceilf ((float)y1 * scale_y);
+			x0 = CLAMP (0, hx0, fog_width);
+			y0 = CLAMP (0, hy0, fog_height);
+			x1 = CLAMP (0, hx1, fog_width);
+			y1 = CLAMP (0, hy1, fog_height);
+			if (x1 <= x0 || y1 <= y0)
+				continue;
+		}
 
 		if (mode == 1)
 		{
@@ -608,34 +652,76 @@ void R_FogVol_Render (void)
 			R_DebugDrawWireBox (v->mins, v->maxs, color, true);
 		}
 
+		if (use_halfres)
+		{
+			fog_dst_index = (i == 0) ? 0 : (1 - fog_src_index);
+			dst_tex = framebufs.fogvol.color_tex[fog_dst_index];
+			dst_fbo = framebufs.fogvol.fbo[fog_dst_index];
+		}
 		GL_BindFramebufferFunc (GL_FRAMEBUFFER, dst_fbo);
 		glDrawBuffer (GL_COLOR_ATTACHMENT0);
 		glReadBuffer (GL_COLOR_ATTACHMENT0);
 
+		if (use_halfres && i > 0)
+			src_tex = framebufs.fogvol.color_tex[fog_src_index];
 		GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, src_tex);
 		GL_BindNative (GL_TEXTURE1, GL_TEXTURE_2D, depth_tex);
 		glScissor (x0, y0, x1 - x0, y1 - y0);
 		GL_Uniform1iFunc (3, i);
 		glDrawArrays (GL_TRIANGLES, 0, 3);
 
+		if (use_halfres)
+		{
+			fog_src_index = fog_dst_index;
+			final_tex = framebufs.fogvol.color_tex[fog_src_index];
+		}
+		else
 		{
 			GLuint tmp_tex = src_tex;
 			src_tex = dst_tex;
 			dst_tex = tmp_tex;
 			dst_is_composite = !dst_is_composite;
-			dst_fbo = dst_is_composite ? framebufs.composite.fbo : framebufs.fogvol.fbo;
+			dst_fbo = dst_is_composite ? framebufs.composite.fbo : framebufs.fogvol.fbo[0];
 		}
 		has_drawn = true;
 	}
 	glDisable (GL_SCISSOR_TEST);
 
-	if (has_drawn && src_tex != framebufs.composite.color_tex)
+	if (has_drawn && !use_halfres && src_tex != framebufs.composite.color_tex)
 	{
-		GL_BindFramebufferFunc (GL_READ_FRAMEBUFFER, framebufs.fogvol.fbo);
+		GL_BindFramebufferFunc (GL_READ_FRAMEBUFFER, framebufs.fogvol.fbo[0]);
 		GL_BindFramebufferFunc (GL_DRAW_FRAMEBUFFER, framebufs.composite.fbo);
 		GL_BlitFramebufferFunc (0, 0, glwidth, glheight,
 			0, 0, glwidth, glheight,
 			GL_COLOR_BUFFER_BIT, GL_NEAREST);
+	}
+	else if (has_drawn && use_halfres)
+	{
+		GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.composite.fbo);
+		glDrawBuffer (GL_COLOR_ATTACHMENT0);
+		glReadBuffer (GL_COLOR_ATTACHMENT0);
+		glViewport (glx, gly, glwidth, glheight);
+		if (r_fogvol_upsample.value > 0.f && glprogs.fogvol_upsample)
+		{
+			int taps = (int)Q_rint (r_fogvol_upsample_taps.value);
+			taps = (taps == 9) ? 9 : 4;
+			GL_UseProgram (glprogs.fogvol_upsample);
+			GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
+			GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, final_tex);
+			GL_BindNative (GL_TEXTURE1, GL_TEXTURE_2D, depth_tex);
+			GL_Uniform4fFunc (0, (float)glwidth, (float)glheight, (float)fog_width, (float)fog_height);
+			GL_Uniform1fFunc (1, r_fogvol_upsample_k.value);
+			GL_Uniform1iFunc (2, taps);
+			glDrawArrays (GL_TRIANGLES, 0, 3);
+		}
+		else
+		{
+			GL_BindFramebufferFunc (GL_READ_FRAMEBUFFER, framebufs.fogvol.fbo[fog_src_index]);
+			GL_BindFramebufferFunc (GL_DRAW_FRAMEBUFFER, framebufs.composite.fbo);
+			GL_BlitFramebufferFunc (0, 0, fog_width, fog_height,
+				0, 0, glwidth, glheight,
+				GL_COLOR_BUFFER_BIT, GL_LINEAR);
+		}
 	}
 
 	if (mode == 1)

--- a/Quake/r_fogvol.h
+++ b/Quake/r_fogvol.h
@@ -23,6 +23,7 @@ typedef struct fog_volume_s
 } fog_volume_t;
 
 extern cvar_t r_fogvol;
+extern cvar_t r_fogvol_halfres;
 
 void R_FogVol_Init (void);
 void R_FogVol_Clear (void);

--- a/Quake/shaders/fogvol.frag
+++ b/Quake/shaders/fogvol.frag
@@ -30,6 +30,7 @@ layout(location=5) uniform int FogNoiseMode;
 layout(location=6) uniform int FogPhysBlend;
 layout(location=8) uniform vec3 FogCameraPosWS;
 layout(location=9) uniform vec4 FogViewportParams; // xy: size, zw: inv size
+layout(location=10) uniform vec2 FogDepthScale;
 
 layout(location=0) out vec4 FragColor;
 
@@ -168,7 +169,8 @@ void main()
 		return;
 	}
 
-	float depth = texelFetch(SceneDepth, ivec2(gl_FragCoord.xy), 0).r;
+	ivec2 depthCoord = ivec2(gl_FragCoord.xy * FogDepthScale);
+	float depth = texelFetch(SceneDepth, depthCoord, 0).r;
 	float ndcDepth = DepthToNdcZ(depth);
 	vec4 clip = vec4(uv * 2.0 - 1.0, ndcDepth, 1.0);
 	vec4 world = FogInvViewProj * clip;

--- a/Quake/shaders/fogvol_upsample.frag
+++ b/Quake/shaders/fogvol_upsample.frag
@@ -1,0 +1,59 @@
+layout(binding=0) uniform sampler2D FogColor;
+layout(binding=1) uniform sampler2D SceneDepth;
+
+layout(location=0) uniform vec4 FogUpsampleSize; // xy: full size, zw: half size
+layout(location=1) uniform float FogUpsampleK;
+layout(location=2) uniform int FogUpsampleTaps;
+
+layout(location=0) out vec4 outColor;
+
+void main()
+{
+	ivec2 fullSize = ivec2(FogUpsampleSize.xy);
+	ivec2 halfSize = ivec2(FogUpsampleSize.zw);
+	ivec2 fullCoord = ivec2(gl_FragCoord.xy);
+	ivec2 halfCoord = ivec2(gl_FragCoord.xy * 0.5);
+	halfCoord = clamp(halfCoord, ivec2(0), halfSize - ivec2(1));
+
+	float depthCenter = texelFetch(SceneDepth, fullCoord, 0).r;
+	vec3 accum = vec3(0.0);
+	float weightSum = 0.0;
+
+	if (FogUpsampleTaps == 9)
+	{
+		for (int j = -1; j <= 1; ++j)
+		{
+			for (int i = -1; i <= 1; ++i)
+			{
+				ivec2 offset = ivec2(i, j);
+				ivec2 tapCoord = clamp(halfCoord + offset, ivec2(0), halfSize - ivec2(1));
+				ivec2 fullTap = (tapCoord * 2) + ivec2(1, 1);
+				fullTap = clamp(fullTap, ivec2(0), fullSize - ivec2(1));
+				float depthTap = texelFetch(SceneDepth, fullTap, 0).r;
+				float weight = exp(-abs(depthTap - depthCenter) * FogUpsampleK);
+				accum += texelFetch(FogColor, tapCoord, 0).rgb * weight;
+				weightSum += weight;
+			}
+		}
+	}
+	else
+	{
+		for (int j = 0; j < 2; ++j)
+		{
+			for (int i = 0; i < 2; ++i)
+			{
+				ivec2 offset = ivec2(i, j);
+				ivec2 tapCoord = clamp(halfCoord + offset, ivec2(0), halfSize - ivec2(1));
+				ivec2 fullTap = (tapCoord * 2) + ivec2(1, 1);
+				fullTap = clamp(fullTap, ivec2(0), fullSize - ivec2(1));
+				float depthTap = texelFetch(SceneDepth, fullTap, 0).r;
+				float weight = exp(-abs(depthTap - depthCenter) * FogUpsampleK);
+				accum += texelFetch(FogColor, tapCoord, 0).rgb * weight;
+				weightSum += weight;
+			}
+		}
+	}
+
+	vec3 color = (weightSum > 0.0) ? (accum / weightSum) : vec3(0.0);
+	outColor = vec4(color, 1.0);
+}


### PR DESCRIPTION
### Motivation
- Reduce fog volume rendering cost by optionally rendering the fog pass at half resolution while preserving visual quality via a depth-aware upsample. 
- Provide tunable controls to trade quality vs. performance for upsampling and marching steps. 

### Description
- Wire `r_fogvol_halfres` into the render path and allocate ping-pong half-resolution targets `framebufs.fogvol.color_tex[2]` with `framebufs.fogvol.width/height` chosen based on `r_fogvol_halfres`. 
- Sample full-resolution depth from the fog shader using a `FogDepthScale` uniform so half-res fog can use proper scene depth without an explicit depth downsample. 
- Add a depth-aware bilateral upsample shader `shaders/fogvol_upsample.frag` and program `glprogs.fogvol_upsample` driven by cvars `r_fogvol_upsample`, `r_fogvol_upsample_k`, and `r_fogvol_upsample_taps`, and composite the upsampled fog into the main `composite` buffer. 
- Add `r_fogvol_steps_scale_halfres` to optionally scale marching `r_fogvol_steps` when half-res is enabled and adjust uniforms/viewport handling and ping-pong logic in `r_fogvol.c`/`gl_rmain.c`/`glquake.h`/shader changes. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695be53dbbd8832eadd07a8646bf573e)