### PR TITLE
Add temporal accumulation and history buffers for volumetric fog

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -785,6 +785,14 @@ void GL_CreateFrameBuffers (void)
 			framebufs.fogvol.height, GL_NEAREST, suffix);
 		framebufs.fogvol.fbo[i] = GL_CreateSimpleFBO (GL_TEXTURE_2D, framebufs.fogvol.color_tex[i], 0, 0, fbo_suffix);
 	}
+	for (int i = 0; i < 2; ++i)
+	{
+		const char *suffix = (i == 0) ? "fogvol history 0" : "fogvol history 1";
+		const char *fbo_suffix = (i == 0) ? "fogvol history fbo 0" : "fogvol history fbo 1";
+		framebufs.fogvol.history_tex[i] = GL_CreateTexture2D (GL_RGBA16F, framebufs.fogvol.width,
+			framebufs.fogvol.height, GL_NEAREST, suffix);
+		framebufs.fogvol.history_fbo[i] = GL_CreateSimpleFBO (GL_TEXTURE_2D, framebufs.fogvol.history_tex[i], 0, 0, fbo_suffix);
+	}
 
 	framebufs.autoexposure.width = 16;
 	framebufs.autoexposure.height = 16;
@@ -918,6 +926,7 @@ void GL_DeleteFrameBuffers (void)
 	GL_DeleteFramebuffersFunc (1, &framebufs.dlight.fbo);
 	GL_DeleteFramebuffersFunc (1, &framebufs.composite.fbo);
 	GL_DeleteFramebuffersFunc (2, framebufs.fogvol.fbo);
+	GL_DeleteFramebuffersFunc (2, framebufs.fogvol.history_fbo);
 	GL_DeleteFramebuffersFunc (1, &framebufs.autoexposure.fbo);
 	GL_DeleteFramebuffersFunc (1, &framebufs.bloom.extract_fbo);
 	GL_DeleteFramebuffersFunc (1, &framebufs.bloom.pingpong_fbo[0]);
@@ -936,6 +945,8 @@ void GL_DeleteFrameBuffers (void)
 	GL_DeleteNativeTexture (framebufs.resolved_scene.velocity_tex);
 	GL_DeleteNativeTexture (framebufs.fogvol.color_tex[0]);
 	GL_DeleteNativeTexture (framebufs.fogvol.color_tex[1]);
+	GL_DeleteNativeTexture (framebufs.fogvol.history_tex[0]);
+	GL_DeleteNativeTexture (framebufs.fogvol.history_tex[1]);
 	GL_DeleteNativeTexture (framebufs.oit.revealage_tex);
 	GL_DeleteNativeTexture (framebufs.oit.accum_tex);
 	GL_DeleteNativeTexture (framebufs.scene.depth_stencil_tex);

--- a/Quake/gl_shaders.c
+++ b/Quake/gl_shaders.c
@@ -525,6 +525,7 @@ void GL_CreateShaders (void)
 	glprogs.godrays_source_sky = GL_CreateProgram (GLSL_PATH("postprocess.vert"), GLSL_PATH("godrays_source_sky.frag"), "godrays source sky");
 	glprogs.fogvol = GL_CreateProgram (GLSL_PATH("postprocess.vert"), GLSL_PATH("fogvol.frag"), "fog volumes");
 	glprogs.fogvol_upsample = GL_CreateProgram (GLSL_PATH("postprocess.vert"), GLSL_PATH("fogvol_upsample.frag"), "fog volumes upsample");
+	glprogs.fogvol_temporal = GL_CreateProgram (GLSL_PATH("postprocess.vert"), GLSL_PATH("fogvol_temporal.frag"), "fog volumes temporal");
         for (mode = 0; mode < 2; mode++)
                 glprogs.oit_resolve[mode] = GL_CreateProgram (GLSL_PATH("oit_resolve.vert"), GLSL_PATH("oit_resolve.frag"), "oit resolve|MSAA %d", mode);
 

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -583,6 +583,7 @@ typedef struct glprogs_s {
 	GLuint		godrays_source_sky;
 	GLuint		fogvol;
 	GLuint		fogvol_upsample;
+	GLuint		fogvol_temporal;
 	GLuint		oit_resolve[2];		// [msaa]
 
 	/* 3d */
@@ -650,6 +651,8 @@ typedef struct glframebufs_s {
 	struct {
 		GLuint		color_tex[2];
 		GLuint		fbo[2];
+		GLuint		history_tex[2];
+		GLuint		history_fbo[2];
 		int			width;
 		int			height;
 	}				fogvol;

--- a/Quake/r_fogvol.c
+++ b/Quake/r_fogvol.c
@@ -52,6 +52,13 @@ cvar_t r_fogvol_noisemode = { "r_fogvol_noisemode", "0", CVAR_ARCHIVE };
 cvar_t r_fogvol_debug = { "r_fogvol_debug", "0", CVAR_ARCHIVE };
 cvar_t r_fogvol_testvolumes = { "r_fogvol_testvolumes", "0", CVAR_ARCHIVE };
 cvar_t r_fogvol_physblend = { "r_fogvol_physblend", "1", CVAR_ARCHIVE };
+cvar_t r_fogvol_temporal_alpha = { "r_fogvol_temporal_alpha", "0.9", CVAR_ARCHIVE };
+cvar_t r_fogvol_temporal_depth_reject = { "r_fogvol_temporal_depth_reject", "0.01", CVAR_ARCHIVE };
+cvar_t r_fogvol_jitter = { "r_fogvol_jitter", "1", CVAR_ARCHIVE };
+
+static int r_fogvol_history_index = 0;
+static int r_fogvol_history_width = 0;
+static int r_fogvol_history_height = 0;
 
 static qboolean R_FogVol_MatrixInverse4x4 (const float m[16], float out[16])
 {
@@ -130,6 +137,9 @@ void R_FogVol_Init (void)
 	Cvar_RegisterVariable (&r_fogvol_debug);
 	Cvar_RegisterVariable (&r_fogvol_testvolumes);
 	Cvar_RegisterVariable (&r_fogvol_physblend);
+	Cvar_RegisterVariable (&r_fogvol_temporal_alpha);
+	Cvar_RegisterVariable (&r_fogvol_temporal_depth_reject);
+	Cvar_RegisterVariable (&r_fogvol_jitter);
 }
 
 void R_FogVol_Clear (void)
@@ -142,18 +152,32 @@ static void R_FogVol_ClearEntities (void)
 	r_fogvolume_entity_count = 0;
 }
 
+static void R_FogVol_ClampVolume (fog_volume_t *volume)
+{
+	volume->density = CLAMP (0.f, volume->density, 10.f);
+	volume->falloff = CLAMP (0.f, volume->falloff, 256.f);
+}
+
 static void R_FogVol_AddVolume (const fog_volume_t *volume)
 {
+	fog_volume_t clamped;
+
 	if (r_fogvolume_count >= MAX_FOGVOLUMES)
 		return;
-	r_fogvolumes[r_fogvolume_count++] = *volume;
+	clamped = *volume;
+	R_FogVol_ClampVolume (&clamped);
+	r_fogvolumes[r_fogvolume_count++] = clamped;
 }
 
 static void R_FogVol_AddEntityVolume (const fog_volume_t *volume)
 {
+	fog_volume_t clamped;
+
 	if (r_fogvolume_entity_count >= MAX_FOGVOLUMES)
 		return;
-	r_fogvolume_entities[r_fogvolume_entity_count++] = *volume;
+	clamped = *volume;
+	R_FogVol_ClampVolume (&clamped);
+	r_fogvolume_entities[r_fogvolume_entity_count++] = clamped;
 }
 
 static void R_FogVol_ParseColor (const char *value, vec3_t color)
@@ -161,6 +185,7 @@ static void R_FogVol_ParseColor (const char *value, vec3_t color)
 	float r = 1.f, g = 1.f, b = 1.f;
 	if (value && sscanf (value, "%f %f %f", &r, &g, &b) == 3)
 	{
+		// Inputs are assumed to be linear; 0..255 values are normalized to 0..1.
 		if (r > 2.f || g > 2.f || b > 2.f)
 		{
 			r *= 1.f / 255.f;
@@ -521,7 +546,6 @@ void R_FogVol_Render (void)
 	GLuint dst_tex;
 	GLuint dst_fbo;
 	GLuint depth_tex;
-	qboolean dst_is_composite;
 	qboolean has_drawn = false;
 	qboolean use_halfres;
 	int fog_width;
@@ -604,6 +628,7 @@ void R_FogVol_Render (void)
 	GL_Uniform1iFunc (2, mode);
 	GL_Uniform1iFunc (5, (int)Q_rint (r_fogvol_noisemode.value));
 	GL_Uniform1iFunc (6, r_fogvol_physblend.value > 0.f ? 1 : 0);
+	GL_Uniform1iFunc (7, r_fogvol_jitter.value > 0.f ? 1 : 0);
 	GL_UniformMatrix4fvFunc (4, 1, GL_FALSE, inv_viewproj);
 	GL_Uniform3fFunc (8, r_refdef.vieworg[0], r_refdef.vieworg[1], r_refdef.vieworg[2]);
 	GL_Uniform4fFunc (9, (float)fog_width, (float)fog_height, 1.f / (float)fog_width, 1.f / (float)fog_height);
@@ -616,9 +641,7 @@ void R_FogVol_Render (void)
 		glViewport (glx, gly, glwidth, glheight);
 	depth_tex = framebufs.composite.depth_stencil_tex;
 	src_tex = framebufs.composite.color_tex;
-	dst_tex = framebufs.fogvol.color_tex[0];
-	dst_fbo = framebufs.fogvol.fbo[0];
-	dst_is_composite = false;
+	final_tex = 0;
 
 	for (int i = 0; i < r_fogvolume_count; ++i)
 	{
@@ -652,17 +675,14 @@ void R_FogVol_Render (void)
 			R_DebugDrawWireBox (v->mins, v->maxs, color, true);
 		}
 
-		if (use_halfres)
-		{
-			fog_dst_index = (i == 0) ? 0 : (1 - fog_src_index);
-			dst_tex = framebufs.fogvol.color_tex[fog_dst_index];
-			dst_fbo = framebufs.fogvol.fbo[fog_dst_index];
-		}
+		fog_dst_index = (i == 0) ? 0 : (1 - fog_src_index);
+		dst_tex = framebufs.fogvol.color_tex[fog_dst_index];
+		dst_fbo = framebufs.fogvol.fbo[fog_dst_index];
 		GL_BindFramebufferFunc (GL_FRAMEBUFFER, dst_fbo);
 		glDrawBuffer (GL_COLOR_ATTACHMENT0);
 		glReadBuffer (GL_COLOR_ATTACHMENT0);
 
-		if (use_halfres && i > 0)
+		if (i > 0)
 			src_tex = framebufs.fogvol.color_tex[fog_src_index];
 		GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, src_tex);
 		GL_BindNative (GL_TEXTURE1, GL_TEXTURE_2D, depth_tex);
@@ -670,57 +690,87 @@ void R_FogVol_Render (void)
 		GL_Uniform1iFunc (3, i);
 		glDrawArrays (GL_TRIANGLES, 0, 3);
 
-		if (use_halfres)
-		{
-			fog_src_index = fog_dst_index;
-			final_tex = framebufs.fogvol.color_tex[fog_src_index];
-		}
-		else
-		{
-			GLuint tmp_tex = src_tex;
-			src_tex = dst_tex;
-			dst_tex = tmp_tex;
-			dst_is_composite = !dst_is_composite;
-			dst_fbo = dst_is_composite ? framebufs.composite.fbo : framebufs.fogvol.fbo[0];
-		}
+		fog_src_index = fog_dst_index;
+		final_tex = framebufs.fogvol.color_tex[fog_src_index];
 		has_drawn = true;
 	}
 	glDisable (GL_SCISSOR_TEST);
+	GLuint final_fbo = framebufs.fogvol.fbo[fog_src_index];
 
-	if (has_drawn && !use_halfres && src_tex != framebufs.composite.color_tex)
+	if (has_drawn && glprogs.fogvol_temporal && final_tex)
 	{
-		GL_BindFramebufferFunc (GL_READ_FRAMEBUFFER, framebufs.fogvol.fbo[0]);
-		GL_BindFramebufferFunc (GL_DRAW_FRAMEBUFFER, framebufs.composite.fbo);
-		GL_BlitFramebufferFunc (0, 0, glwidth, glheight,
-			0, 0, glwidth, glheight,
-			GL_COLOR_BUFFER_BIT, GL_NEAREST);
+		int history_valid = (r_fogvol_history_width == fog_width && r_fogvol_history_height == fog_height);
+		int history_src = r_fogvol_history_index;
+		int history_dst = 1 - history_src;
+		if (!history_valid)
+		{
+			r_fogvol_history_width = fog_width;
+			r_fogvol_history_height = fog_height;
+			history_src = 0;
+			history_dst = 1;
+			r_fogvol_history_index = history_src;
+		}
+
+		GL_UseProgram (glprogs.fogvol_temporal);
+		GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
+		GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.fogvol.history_fbo[history_dst]);
+		glDrawBuffer (GL_COLOR_ATTACHMENT0);
+		glReadBuffer (GL_COLOR_ATTACHMENT0);
+		glViewport (0, 0, fog_width, fog_height);
+		GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, final_tex);
+		GL_BindNative (GL_TEXTURE1, GL_TEXTURE_2D, framebufs.fogvol.history_tex[history_src]);
+		GL_BindNative (GL_TEXTURE2, GL_TEXTURE_2D, depth_tex);
+		GL_Uniform1fFunc (0, r_fogvol_temporal_alpha.value);
+		GL_Uniform1fFunc (1, r_fogvol_temporal_depth_reject.value);
+		GL_Uniform1iFunc (2, mode);
+		GL_UniformMatrix4fvFunc (3, 1, GL_FALSE, inv_viewproj);
+		GL_Uniform4fFunc (4, (float)fog_width, (float)fog_height, 1.f / (float)fog_width, 1.f / (float)fog_height);
+		GL_Uniform2fFunc (5, depth_scale_x, depth_scale_y);
+		GL_Uniform1iFunc (6, history_valid ? 1 : 0);
+		glDrawArrays (GL_TRIANGLES, 0, 3);
+
+		final_tex = framebufs.fogvol.history_tex[history_dst];
+		final_fbo = framebufs.fogvol.history_fbo[history_dst];
+		r_fogvol_history_index = history_dst;
 	}
-	else if (has_drawn && use_halfres)
+
+	if (has_drawn)
 	{
 		GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.composite.fbo);
 		glDrawBuffer (GL_COLOR_ATTACHMENT0);
 		glReadBuffer (GL_COLOR_ATTACHMENT0);
 		glViewport (glx, gly, glwidth, glheight);
-		if (r_fogvol_upsample.value > 0.f && glprogs.fogvol_upsample)
+		if (use_halfres)
 		{
-			int taps = (int)Q_rint (r_fogvol_upsample_taps.value);
-			taps = (taps == 9) ? 9 : 4;
-			GL_UseProgram (glprogs.fogvol_upsample);
-			GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
-			GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, final_tex);
-			GL_BindNative (GL_TEXTURE1, GL_TEXTURE_2D, depth_tex);
-			GL_Uniform4fFunc (0, (float)glwidth, (float)glheight, (float)fog_width, (float)fog_height);
-			GL_Uniform1fFunc (1, r_fogvol_upsample_k.value);
-			GL_Uniform1iFunc (2, taps);
-			glDrawArrays (GL_TRIANGLES, 0, 3);
+			if (r_fogvol_upsample.value > 0.f && glprogs.fogvol_upsample)
+			{
+				int taps = (int)Q_rint (r_fogvol_upsample_taps.value);
+				taps = (taps == 9) ? 9 : 4;
+				GL_UseProgram (glprogs.fogvol_upsample);
+				GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
+				GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, final_tex);
+				GL_BindNative (GL_TEXTURE1, GL_TEXTURE_2D, depth_tex);
+				GL_Uniform4fFunc (0, (float)glwidth, (float)glheight, (float)fog_width, (float)fog_height);
+				GL_Uniform1fFunc (1, r_fogvol_upsample_k.value);
+				GL_Uniform1iFunc (2, taps);
+				glDrawArrays (GL_TRIANGLES, 0, 3);
+			}
+			else
+			{
+				GL_BindFramebufferFunc (GL_READ_FRAMEBUFFER, final_fbo);
+				GL_BindFramebufferFunc (GL_DRAW_FRAMEBUFFER, framebufs.composite.fbo);
+				GL_BlitFramebufferFunc (0, 0, fog_width, fog_height,
+					0, 0, glwidth, glheight,
+					GL_COLOR_BUFFER_BIT, GL_LINEAR);
+			}
 		}
 		else
 		{
-			GL_BindFramebufferFunc (GL_READ_FRAMEBUFFER, framebufs.fogvol.fbo[fog_src_index]);
+			GL_BindFramebufferFunc (GL_READ_FRAMEBUFFER, final_fbo);
 			GL_BindFramebufferFunc (GL_DRAW_FRAMEBUFFER, framebufs.composite.fbo);
-			GL_BlitFramebufferFunc (0, 0, fog_width, fog_height,
+			GL_BlitFramebufferFunc (0, 0, glwidth, glheight,
 				0, 0, glwidth, glheight,
-				GL_COLOR_BUFFER_BIT, GL_LINEAR);
+				GL_COLOR_BUFFER_BIT, GL_NEAREST);
 		}
 	}
 
@@ -728,4 +778,11 @@ void R_FogVol_Render (void)
 		R_DebugFlushGeometry ();
 
 	GL_EndGroup ();
+}
+
+void R_FogVol_InjectIntoGrid (froxel_grid_t *grid, const fog_volume_t *vols, int num)
+{
+	(void)grid;
+	(void)vols;
+	(void)num;
 }

--- a/Quake/r_fogvol.h
+++ b/Quake/r_fogvol.h
@@ -22,6 +22,8 @@ typedef struct fog_volume_s
 	float heightScale;
 } fog_volume_t;
 
+typedef struct froxel_grid_s froxel_grid_t;
+
 extern cvar_t r_fogvol;
 extern cvar_t r_fogvol_halfres;
 
@@ -32,6 +34,7 @@ void R_FogVol_BuildList (void);
 void R_FogVol_AddTestVolumes (void);
 void R_FogVol_Render (void);
 void R_FogVol_DrawDebug2D (void);
+void R_FogVol_InjectIntoGrid (froxel_grid_t *grid, const fog_volume_t *vols, int num);
 qboolean R_FogVol_ProjectAABBToScreenRect (const fog_volume_t *v, int *x0, int *y0, int *x1, int *y1, qboolean fullres);
 
 #endif // R_FOGVOL_H

--- a/Quake/shaders/fogvol.frag
+++ b/Quake/shaders/fogvol.frag
@@ -28,6 +28,7 @@ layout(location=3) uniform int FogVolumeIndex;
 layout(location=4) uniform mat4 FogInvViewProj;
 layout(location=5) uniform int FogNoiseMode;
 layout(location=6) uniform int FogPhysBlend;
+layout(location=7) uniform int FogJitterEnabled;
 layout(location=8) uniform vec3 FogCameraPosWS;
 layout(location=9) uniform vec4 FogViewportParams; // xy: size, zw: inv size
 layout(location=10) uniform vec2 FogDepthScale;
@@ -147,6 +148,21 @@ float Dither(vec2 pixel)
 	return fract(sin(dot(pixel, vec2(12.9898, 78.233)) + Time) * 43758.5453);
 }
 
+float InterleavedGradientNoise(vec2 p)
+{
+	return fract(52.9829189 * fract(0.06711056 * p.x + 0.00583715 * p.y));
+}
+
+vec3 DebugVolumeColor(float id, float priority)
+{
+	vec3 base = vec3(
+		fract(id * 0.754877666),
+		fract(id * 0.569840296),
+		fract(id * 0.885943821));
+	float tint = fract(priority * 0.6180339887);
+	return mix(base, vec3(1.0, 1.0 - tint, tint), 0.35);
+}
+
 float FogEdgeFade(vec3 p, vec3 bmin, vec3 bmax, float falloff)
 {
 	float edgeThickness = max(falloff, 0.0);
@@ -210,7 +226,12 @@ void main()
 	float len = tExit - tEnter;
 	float stepLen = len / stepCount;
 	if (FogNoiseEnabled != 0)
-		tEnter += (Dither(gl_FragCoord.xy) - 0.5) * stepLen;
+	{
+		float jitter = Dither(gl_FragCoord.xy);
+		if (FogJitterEnabled != 0)
+			jitter = InterleavedGradientNoise(gl_FragCoord.xy + vec2(Time * 12.3, Time * 4.7));
+		tEnter += jitter * stepLen;
+	}
 
 	vec3 scatterColor = volume.color_density.rgb;
 	float density = max(volume.color_density.a, 0.0);
@@ -221,12 +242,15 @@ void main()
 	float tau = 0.0;
 	float edgeFadeSum = 0.0;
 	float edgeFadeSamples = 0.0;
+	float stepsTaken = 0.0;
+	bool earlyTerminated = false;
 
 	for (int i = 0; i < FogSteps; ++i)
 	{
 		float t = tEnter + (float(i) + 0.5) * stepLen;
 		if (t >= tExit)
 			break;
+		stepsTaken += 1.0;
 
 		vec3 p = ro + rd * t;
 		float edgeFade = FogEdgeFade(p, volume.mins.xyz, volume.maxs.xyz, falloff);
@@ -252,9 +276,18 @@ void main()
 		edgeFadeSum += edgeFade;
 		edgeFadeSamples += 1.0;
 		if (transmittance < 0.01)
+		{
+			earlyTerminated = true;
 			break;
+		}
 	}
 
+	if (FogDebugMode == 5)
+	{
+		vec3 debugColor = DebugVolumeColor(float(FogVolumeIndex), volume.misc.x);
+		FragColor = vec4(debugColor, 1.0);
+		return;
+	}
 	if (FogDebugMode == 3)
 	{
 		float tauViz = tau / (1.0 + tau);
@@ -267,6 +300,13 @@ void main()
 		FragColor = vec4(vec3(fadeViz), 1.0);
 		return;
 	}
+	if (FogDebugMode == 8)
+	{
+		float stepViz = stepsTaken / max(stepCount, 1.0);
+		float earlyViz = earlyTerminated ? 1.0 : 0.0;
+		FragColor = vec4(stepViz, earlyViz, 0.0, 1.0);
+		return;
+	}
 
 	vec3 scene = texture(SceneColor, uv).rgb;
 	vec3 outColor;
@@ -274,5 +314,5 @@ void main()
 		outColor = scene * transmittance + accum;
 	else
 		outColor = mix(scene, scatterColor, clamp(tau, 0.0, 1.0));
-	FragColor = vec4(outColor, 1.0);
+	FragColor = vec4(outColor, transmittance);
 }

--- a/Quake/shaders/fogvol_temporal.frag
+++ b/Quake/shaders/fogvol_temporal.frag
@@ -1,0 +1,111 @@
+#include "frame_uniforms.glsl"
+
+layout(binding=0) uniform sampler2D FogCurrent;
+layout(binding=1) uniform sampler2D FogHistory;
+layout(binding=2) uniform sampler2D SceneDepth;
+
+layout(location=0) uniform float FogTemporalAlpha;
+layout(location=1) uniform float FogTemporalDepthReject;
+layout(location=2) uniform int FogDebugMode;
+layout(location=3) uniform mat4 FogInvViewProj;
+layout(location=4) uniform vec4 FogViewportParams; // xy: size, zw: inv size
+layout(location=5) uniform vec2 FogDepthScale;
+layout(location=6) uniform int FogHistoryValid;
+
+layout(location=0) out vec4 OutColor;
+
+float DepthToNdcZ(float depth)
+{
+#if REVERSED_Z
+	return depth;
+#else
+	return depth * 2.0 - 1.0;
+#endif
+}
+
+bool Reproject(vec2 uv, float depthNdc, out vec2 prevUv, out float prevDepthNdc)
+{
+	vec4 clip = vec4(uv * 2.0 - 1.0, depthNdc, 1.0);
+	vec4 world = FogInvViewProj * clip;
+	if (abs(world.w) < 1e-6)
+		return false;
+	vec4 prevClip = PrevViewProj * vec4(world.xyz / world.w, 1.0);
+	if (abs(prevClip.w) < 1e-6)
+		return false;
+	vec3 prevNdc = prevClip.xyz / prevClip.w;
+	prevUv = prevNdc.xy * 0.5 + 0.5;
+	prevDepthNdc = prevNdc.z;
+	return true;
+}
+
+void main()
+{
+	vec2 invViewport = FogViewportParams.zw;
+	vec2 uv = gl_FragCoord.xy * invViewport;
+	vec4 current = texture(FogCurrent, uv);
+
+	if (FogHistoryValid == 0 || PrevFrameValid == 0u || FogTemporalAlpha <= 0.0 || FogDebugMode == 5 || FogDebugMode == 8)
+	{
+		OutColor = current;
+		return;
+	}
+
+	ivec2 depthCoord = ivec2(gl_FragCoord.xy * FogDepthScale);
+	float depth = texelFetch(SceneDepth, depthCoord, 0).r;
+	float depthNdc = DepthToNdcZ(depth);
+
+	vec2 prevUv;
+	float prevDepthNdc;
+	bool valid = Reproject(uv, depthNdc, prevUv, prevDepthNdc);
+	valid = valid && all(greaterThanEqual(prevUv, vec2(0.0))) && all(lessThanEqual(prevUv, vec2(1.0)));
+
+	vec4 history = vec4(0.0);
+	if (valid)
+	{
+		ivec2 prevCoord = ivec2(prevUv * FogViewportParams.xy);
+		prevCoord = clamp(prevCoord, ivec2(0), ivec2(FogViewportParams.xy) - ivec2(1));
+		float depthPrev = texelFetch(SceneDepth, ivec2(vec2(prevCoord) * FogDepthScale), 0).r;
+		float depthPrevNdc = DepthToNdcZ(depthPrev);
+		float depthReject = max(FogTemporalDepthReject, 0.0);
+		if (abs(depthPrevNdc - prevDepthNdc) > depthReject)
+			valid = false;
+	}
+
+	if (valid)
+		history = texture(FogHistory, prevUv);
+
+	if (FogDebugMode == 6)
+	{
+		OutColor = vec4(vec3(valid ? 1.0 : 0.0), 1.0);
+		return;
+	}
+
+	vec3 minColor = current.rgb;
+	vec3 maxColor = current.rgb;
+	for (int j = -1; j <= 1; ++j)
+	{
+		for (int i = -1; i <= 1; ++i)
+		{
+			vec2 offset = vec2(i, j) * invViewport;
+			vec3 tap = texture(FogCurrent, uv + offset).rgb;
+			minColor = min(minColor, tap);
+			maxColor = max(maxColor, tap);
+		}
+	}
+	history.rgb = clamp(history.rgb, minColor, maxColor);
+
+	float motionPx = length((prevUv - uv) * FogViewportParams.xy);
+	float motionFactor = clamp(1.0 - motionPx * 0.1, 0.0, 1.0);
+	float alpha = (valid ? FogTemporalAlpha : 0.0) * motionFactor;
+	alpha = clamp(alpha, 0.0, 1.0);
+
+	if (FogDebugMode == 7)
+	{
+		OutColor = vec4(vec3(alpha), 1.0);
+		return;
+	}
+
+	vec3 blended = mix(current.rgb, history.rgb, alpha);
+	float blendedAlpha = mix(current.a, history.a, alpha);
+	OutColor = vec4(blended, blendedAlpha);
+}


### PR DESCRIPTION
### Motivation
- Reduce temporal noise in volumetric fog by accumulating previous-frame contributions and rejecting ghosting from disocclusions and motion.
- Provide anti‑ghosting via neighborhood clamping and motion-aware blend reduction to stabilize low-step/noisy rendering.
- Expose controls for temporal blending, depth rejection and jitter to tune quality versus responsiveness.
- Prepare for future froxel injection by keeping `fog_volume_t` as the single authoring structure and adding a small stub hook.

### Description
- Add history render targets and FBOs to the framebuffers (`framebufs.fogvol.history_tex[]/history_fbo[]`) and register a new shader program `glprogs.fogvol_temporal` in `gl_shaders.c`.
- Implement a temporal composite shader `shaders/fogvol_temporal.frag` that reprojects current pixels to previous-frame UVs, performs depth rejection, neighborhood clamp, motion-aware alpha, and outputs blended fog + transmittance.
- Wire the temporal pass into `R_FogVol_Render` in `r_fogvol.c`, allocate/rotate history buffers, and use the temporal result for upsampling/blit to the composite buffer.
- Add cvars `r_fogvol_temporal_alpha`, `r_fogvol_temporal_depth_reject`, `r_fogvol_jitter`, introduce jitter support and new debug modes in `shaders/fogvol.frag`, clamp volume parameters on add/parse, and add a `R_FogVol_InjectIntoGrid` stub in `r_fogvol.h`/`.c`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695be7dc31fc832e8f47c03db2a9c6c6)