### PR TITLE
Fix postprocess shader uniform conflict

### DIFF
--- a/Quake/shaders/postprocess.frag
+++ b/Quake/shaders/postprocess.frag
@@ -144,7 +144,6 @@ layout(location=15) uniform vec4 FilmGrainParams2; // x: frame, yzw: unused
 layout(location=16) uniform vec4 GodraysParams; // x: enabled, y: debug, z: debug source mode, w: unused
 layout(location=17) uniform vec4 SSAOParams; // x: intensity, y: debug mode, z: upscale nearest, w: fog damp strength
 layout(location=18) uniform vec4 SSAOBlurParams; // x: blur sigma, y: blur radius, z: depth threshold scale, w: fog damp power
-layout(location=19) uniform vec4 ColorSpaceParams; // x: debug mode, y: unused, z: output sRGB conversion, w: reserved
 layout(location=20) uniform float u_midtone;
 layout(location=21) uniform vec4 PostFXParams3; // x: exposure add (stops), y: bloom boost, z: emissive boost, w: damage tint
 layout(location=22) uniform vec4 PostFXParams4; // x: lut strength, y: underwater grade strength, z: underwater fog strength, w: vignette softness


### PR DESCRIPTION
### Motivation
- Remove a duplicate `ColorSpaceParams` uniform declaration that caused GLSL compilation errors due to conflicting declarations.
- Prevent OpenGL initialization failures triggered by shader compilation errors referencing `ColorSpaceParams`.
- Rely on the packed `FrameDataUBO` declaration in `frame_uniforms.glsl` as the single source of `ColorSpaceParams`.

### Description
- Deleted the `layout(location=19) uniform vec4 ColorSpaceParams;` line from `Quake/shaders/postprocess.frag`.
- The shader now uses the `ColorSpaceParams` field provided by the `FrameDataUBO` in `Quake/shaders/frame_uniforms.glsl` to avoid duplicate symbols.
- Change is limited to a single-line removal in `postprocess.frag` to resolve the naming conflict.

### Testing
- No automated tests were run for this shader-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bf651a12c832ea1c2f030860702de)