### PR TITLE
Guard postprocess when composite framebuffer is unavailable

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -2042,7 +2042,7 @@ static float GL_UpdateAutoExposure (void)
 
 
 void GL_PostProcess (void)
-	{
+{
 	int palidx, variant;
 	float dither;
 	qboolean dof_enabled;
@@ -2102,8 +2102,10 @@ void GL_PostProcess (void)
 	float dv_quality;
 	float dv_debug;
 	float dv_time;
-        r_color_saturation.value = CLAMP (0.9f, r_color_saturation.value, 1.2f);
+	r_color_saturation.value = CLAMP (0.9f, r_color_saturation.value, 1.2f);
 	if (!GL_NeedsPostprocess ())
+		return;
+	if (framebufs.composite.fbo == 0 || framebufs.composite.color_tex == 0)
 		return;
 
 	GL_BeginGroup ("Postprocess");

--- a/Quake/gl_vidsdl.c
+++ b/Quake/gl_vidsdl.c
@@ -1382,7 +1382,12 @@ void GL_BeginRendering (int *x, int *y, int *width, int *height)
 	GLPalette_UpdateLookupTable ();
 	TexMgr_ApplySettings ();
 
-	GL_BindFramebufferFunc (GL_FRAMEBUFFER, GL_NeedsPostprocess () ? framebufs.composite.fbo : 0);
+	{
+		qboolean use_postprocess = GL_NeedsPostprocess ()
+			&& framebufs.composite.fbo
+			&& framebufs.composite.color_tex;
+		GL_BindFramebufferFunc (GL_FRAMEBUFFER, use_postprocess ? framebufs.composite.fbo : 0);
+	}
 }
 
 /*


### PR DESCRIPTION
### Motivation
- Prevent rendering a completely black screen when postprocess tries to sample or bind a missing composite framebuffer/texture.
- Ensure postprocessing is only performed when the composite FBO and its color texture are present.
- Avoid undefined behavior from binding an invalid framebuffer during `GL_BeginRendering`.

### Description
- Add an early-return guard in `GL_PostProcess` that skips postprocessing if `framebufs.composite.fbo` or `framebufs.composite.color_tex` is missing in `Quake/gl_rmain.c`.
- Replace the unconditional framebuffer bind in `GL_BeginRendering` with a conditional bind that only selects the composite FBO when `GL_NeedsPostprocess()` is true and the composite FBO/texture exist in `Quake/gl_vidsdl.c`.
- Normalize the brace style for the `GL_PostProcess` function header as part of the edit. 
- Modified files: `Quake/gl_rmain.c` and `Quake/gl_vidsdl.c`.

### Testing
- No automated tests were executed for this change.
- Runtime behavior observed in development: commit was made after local edits (no CI/test output to report).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bf7e67f98832e9ca270836ac2fb8e)