### PR TITLE
Handle GL_ClipControl failures and fall back to safe depth state

### DIFF
--- a/Quake/gl_vidsdl.c
+++ b/Quake/gl_vidsdl.c
@@ -1253,6 +1253,14 @@ static void GL_SetupState (void)
 	if (gl_clipcontrol_able)
 	{
 		GL_ClipControlFunc (GL_LOWER_LEFT, GL_ZERO_TO_ONE);
+		if (glGetError () != GL_NO_ERROR)
+		{
+			Con_Warning ("GL_ClipControl failed; disabling clip control.\n");
+			gl_clipcontrol_able = false;
+		}
+	}
+	if (gl_clipcontrol_able)
+	{
 		glClearDepth (0.f);
 		glDepthFunc (GL_GEQUAL);
 	}


### PR DESCRIPTION
### Motivation

- Prevent a black-only render (UI visible) when `GL_ClipControl` fails on some drivers by avoiding an inconsistent clip/depth state.  
- Make GL setup more robust by detecting and disabling clip control if the GL call reports an error.

### Description

- Added an error check after `GL_ClipControlFunc (GL_LOWER_LEFT, GL_ZERO_TO_ONE)` that calls `glGetError()` and disables `gl_clipcontrol_able` on failure, with a `Con_Warning` message.  
- Reworked the control flow so `glClearDepth`/`glDepthFunc` are only set under the (possibly updated) `gl_clipcontrol_able` flag and otherwise use the safe fallback values.  
- Change is localized to `Quake/gl_vidsdl.c` inside `GL_SetupState`.

### Testing

- No automated tests were run for this change.  
- The change is limited to GL initialization logic and emits a warning when `GL_ClipControl` fails.  
- Manual runtime verification is recommended on drivers that previously exhibited the black-screen symptom.  
- No regressions detected by automated test suite because none were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c30f4e518832e9ec308934982ce97)