### PR TITLE
Restore fog volume render state when nothing is drawn

### DIFF
--- a/Quake/r_fogvol.c
+++ b/Quake/r_fogvol.c
@@ -671,6 +671,16 @@ void R_FogVol_Render (void)
 	glDisable (GL_SCISSOR_TEST);
 	GLuint final_fbo = framebufs.fogvol.fbo[fog_src_index];
 
+	if (!has_drawn)
+	{
+		GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.composite.fbo);
+		glDrawBuffer (GL_COLOR_ATTACHMENT0);
+		glReadBuffer (GL_COLOR_ATTACHMENT0);
+		glViewport (glx, gly, glwidth, glheight);
+		GL_EndGroup ();
+		return;
+	}
+
 	if (has_drawn && glprogs.fogvol_temporal && final_tex)
 	{
 		int history_valid = (r_fogvol_history_width == fog_width && r_fogvol_history_height == fog_height);


### PR DESCRIPTION
### Motivation

- Prevent leaving the renderer in a half-resolution or incorrect framebuffer/viewport state when no fog volumes are visible.
- Avoid leaving the fog volume render group open if the pass exits early without drawing anything.

### Description

- Add an early-exit path in `R_FogVol_Render` that checks `has_drawn` and, if false, restores the composite framebuffer and viewport and calls `GL_EndGroup()` before returning.
- The change is implemented in `Quake/r_fogvol.c` inside `R_FogVol_Render` and runs before the temporal/upsample stages.
- This ensures the fog volume pass cleans up GL state (bind `framebufs.composite.fbo`, set draw/read buffers, and `glViewport`) when all volumes are culled.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c403ee990832eba4186c946ec3e7d)