### PR TITLE
Blit scene color into fog FBO before scissored fog draws

### DIFF
--- a/Quake/r_fogvol.c
+++ b/Quake/r_fogvol.c
@@ -621,6 +621,7 @@ void R_FogVol_Render (void)
 	{
 		fog_volume_t *v = &r_fogvolumes[i];
 		int x0, y0, x1, y1;
+		GLuint src_fbo;
 
 		if (!v->enabled)
 			continue;
@@ -652,12 +653,30 @@ void R_FogVol_Render (void)
 		fog_dst_index = (i == 0) ? 0 : (1 - fog_src_index);
 		dst_tex = framebufs.fogvol.color_tex[fog_dst_index];
 		dst_fbo = framebufs.fogvol.fbo[fog_dst_index];
-		GL_BindFramebufferFunc (GL_FRAMEBUFFER, dst_fbo);
-		glDrawBuffer (GL_COLOR_ATTACHMENT0);
-		glReadBuffer (GL_COLOR_ATTACHMENT0);
 
 		if (i > 0)
 			src_tex = framebufs.fogvol.color_tex[fog_src_index];
+		src_fbo = (i == 0) ? framebufs.composite.fbo : framebufs.fogvol.fbo[fog_src_index];
+		GL_BindFramebufferFunc (GL_READ_FRAMEBUFFER, src_fbo);
+		GL_BindFramebufferFunc (GL_DRAW_FRAMEBUFFER, dst_fbo);
+		glReadBuffer (GL_COLOR_ATTACHMENT0);
+		glDrawBuffer (GL_COLOR_ATTACHMENT0);
+		if (use_halfres && i == 0)
+		{
+			GL_BlitFramebufferFunc (0, 0, glwidth, glheight,
+				0, 0, fog_width, fog_height,
+				GL_COLOR_BUFFER_BIT, GL_LINEAR);
+		}
+		else
+		{
+			GL_BlitFramebufferFunc (0, 0, fog_width, fog_height,
+				0, 0, fog_width, fog_height,
+				GL_COLOR_BUFFER_BIT, GL_NEAREST);
+		}
+
+		GL_BindFramebufferFunc (GL_FRAMEBUFFER, dst_fbo);
+		glDrawBuffer (GL_COLOR_ATTACHMENT0);
+		glReadBuffer (GL_COLOR_ATTACHMENT0);
 		GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, src_tex);
 		GL_BindNative (GL_TEXTURE1, GL_TEXTURE_2D, depth_tex);
 		glScissor (x0, y0, x1 - x0, y1 - y0);


### PR DESCRIPTION
### Motivation
- Scissored fog draws were writing into an otherwise-empty DST target and leaving non-fog pixels black instead of the original scene color.
- The fog pass needs the scene color present in the destination before drawing only the fog rect to avoid black holes around scissored regions.
- Half-resolution fog buffers require proper sized copies to preserve visual fidelity when downsampling.

### Description
- Added a `src_fbo` and logic in `Quake/r_fogvol.c` to blit the current scene color into the fog destination before each scissored fog draw. 
- Use `GL_BindFramebufferFunc` to bind read/draw FBOs and `GL_BlitFramebufferFunc` to copy either full-res (`glwidth` x `glheight`) or half-res (`fog_width` x `fog_height`) with `GL_LINEAR` for downsample and `GL_NEAREST` for same-size blits.
- After the blit, re-bind the fog destination FBO/textures and proceed with the scissored draw so unmodified pixels retain the original scene color.
- Changes confined to `Quake/r_fogvol.c` and keep the fog ping-pong indices and temporal/upsample paths intact.

### Testing
- No automated tests were run for this change.
- Manual validation instructions: reproduce the original black-screen-with-UI symptom and verify non-fog pixels remain the scene color after the fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ced835ba4832ea68f324be29f9914)