### PR TITLE
Ensure fog volumes force composite path and depth resolve

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -3002,6 +3002,9 @@ qboolean GL_NeedsSceneEffects (void)
         if (R_DoFEnabled ())
 		return true;
 
+	if (r_fogvol.value > 0.f)
+		return true;
+
 	return false;
 }
 
@@ -4535,7 +4538,8 @@ void R_WarpScaleView (void)
 
 	needwarpscale = r_refdef.scale != 1 || water_warp;
 	fbodest = GL_NeedsPostprocess () ? framebufs.composite.fbo : 0;
-        need_depth_resolve = (fbodest == framebufs.composite.fbo) && (R_DoFEnabled () || r_ssao.value > 0.f || r_ssao_debug.value > 0.f);
+	need_depth_resolve = (fbodest == framebufs.composite.fbo)
+		&& (R_DoFEnabled () || r_ssao.value > 0.f || r_ssao_debug.value > 0.f || r_fogvol.value > 0.f);
 
 	if (msaa)
 	{


### PR DESCRIPTION
### Motivation

- Volumetric fog sampling requires the scene color/depth to be available in the composite target so the fog shader reads valid inputs and doesn't produce a black image.
- The renderer previously didn’t force postprocess/composite when fog volumes were enabled, and depth was not guaranteed to be resolved into the composite framebuffer.

### Description

- Add a check for `r_fogvol` in `GL_NeedsSceneEffects` to force scene effects when fog volumes are enabled.
- Include `r_fogvol` in the `need_depth_resolve` condition in `R_WarpScaleView` so depth is resolved into `framebufs.composite.fbo` when fog volumes are active.
- The changes are implemented in `Quake/gl_rmain.c` and ensure the fog pass can sample valid scene color and depth during rendering.

### Testing

- No automated tests were run for this change.
- The patch was compiled/committed locally (no CI results reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695cf052ad10832eae3816fa195fdd1d)