### PR TITLE
Restore scissor and color mask before fog volume rendering

### DIFF
--- a/Quake/r_fogvol.c
+++ b/Quake/r_fogvol.c
@@ -597,6 +597,8 @@ void R_FogVol_Render (void)
 	GL_BeginGroup ("Fog volumes");
 	GL_UseProgram (glprogs.fogvol);
 	GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
+	glDisable (GL_SCISSOR_TEST);
+	glColorMask (GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
 	GL_Uniform1iFunc (0, steps);
 	GL_Uniform1iFunc (1, r_fogvol_noise.value > 0.f ? 1 : 0);
 	GL_Uniform1iFunc (2, mode);


### PR DESCRIPTION
### Motivation
- Volumetric fog rendering could leave the scene black while UI remains visible due to stale GL state (scissor or color mask) from previous passes. 
- The fog pass must guarantee it can write full-screen pixels and read the scene/depth targets correctly to avoid presenting an empty/black target. 
- Resetting GL state before the fog draw prevents subtle FBO/ping-pong and masking bugs that cause missing scene color. 

### Description
- Enabled a deterministic GL state at the start of the fog pass by calling `glDisable(GL_SCISSOR_TEST)` in `R_FogVol_Render`. 
- Restored color writes by calling `glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE)` in `R_FogVol_Render`. 
- Change applied to `Quake/r_fogvol.c` inside the `R_FogVol_Render` function and does not alter fog algorithm logic. 

### Testing
- No automated tests were run for this change. 
- No CI or build steps were executed as part of this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d03c702e4832ea7990f200897a164)