### PR TITLE
Resolve composite depth for fog volumes when MSAA is enabled

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -4579,7 +4579,7 @@ void R_WarpScaleView (void)
 		}
 	}
 
-	if (need_depth_resolve && (!msaa || needwarpscale))
+	if (need_depth_resolve)
 	{
 		int dstw = (r_refdef.scale != 1) ? r_refdef.vrect.width : srcw;
 		int dsth = (r_refdef.scale != 1) ? r_refdef.vrect.height : srch;


### PR DESCRIPTION
### Motivation
- Volumetric fog could render black because composite depth was not resolved in some MSAA configurations, leaving fog passes with invalid depth.
- The code previously required `(!msaa || needwarpscale)` in addition to `need_depth_resolve`, which skipped the depth blit when MSAA was enabled and warpscale was not needed.

### Description
- Change in `R_WarpScaleView` (`Quake/gl_rmain.c`): remove the `(!msaa || needwarpscale)` condition so the depth resolve runs whenever `need_depth_resolve` is true.
- This makes the code always perform the depth blit from `framebufs.scene.fbo` to `framebufs.composite.fbo` when depth resolve is required, ensuring fog shaders receive correct depth.
- The change is a single conditional adjustment and does not modify shader code or framebuffer creation.

### Testing
- No automated tests were run for this change.
- The patch is a minimal, focused runtime/logic fix affecting the depth blit path only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d1695295c832eacbc0ca38ea911b3)