### PR TITLE
Fix fog volume fragment shader struct parsing

### DIFF
--- a/Quake/shaders/fogvol.frag
+++ b/Quake/shaders/fogvol.frag
@@ -24,11 +24,6 @@ layout(binding=3) uniform sampler3D FogNoiseTex;
 
 struct FogVolume
 {
-    // DBG_FOG_MODES
-    if (FogDebugMode == 1) DBG_EARLY_OUT_COLOR(vec3(1,0,0));
-    if (FogDebugMode == 2) DBG_EARLY_OUT_COLOR(vec3(0,1,0));
-    if (FogDebugMode == 3) DBG_EARLY_OUT_COLOR(vec3(0,0,1));
-
 	vec4 mins;
 	vec4 maxs;
 	vec4 color_density;


### PR DESCRIPTION
### Motivation
- The `FogVolume` GLSL struct in `Quake/shaders/fogvol.frag` accidentally contained debug-only conditional code which is invalid inside a GLSL `struct` and prevents shader compilation.
- Restoring a valid struct layout is required so the fog volume uniform buffer (`FogVolumeUBO`) can be uploaded and used by the renderer.

### Description
- Removed debug conditional statements that were mistakenly placed inside the `FogVolume` struct in `Quake/shaders/fogvol.frag`.
- Kept the original field layout (`mins`, `maxs`, `color_density`, `noise_params`, `velocity`, `misc`) so the `std140` uniform block layout remains unchanged.
- No runtime behavior changes to fog sampling logic outside of restoring a compilable shader.

### Testing
- No automated tests were executed for this change.
- The change is a small syntactic fix limited to the shader source to resolve compilation errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d4953113c832e94a19e58d01cbd50)