### PR TITLE
Use correct fragment output in fog temporal debug macro

### DIFF
--- a/Quake/shaders/fogvol_temporal.frag
+++ b/Quake/shaders/fogvol_temporal.frag
@@ -12,7 +12,7 @@ float dbg_nan_guard_f(float v) {
     return v;
 }
 
-#define DBG_EARLY_OUT_COLOR(c) { fragColor = vec4(c, 1.0); return; }
+#define DBG_EARLY_OUT_COLOR(c) { OutColor = vec4(c, 1.0); return; }
 
 #include "frame_uniforms.glsl"
 


### PR DESCRIPTION
### Motivation
- The OpenGL build reported a compile error for the fog volumes temporal fragment shader due to an undefined variable `fragColor`.
- The shader declares `OutColor` as its fragment output, but the debug macro `DBG_EARLY_OUT_COLOR` was writing to `fragColor` instead of `OutColor`.
- Fixing the macro removes the mismatch that caused the shader compilation failure on some drivers.

### Description
- Updated the macro `DBG_EARLY_OUT_COLOR` in `Quake/shaders/fogvol_temporal.frag` to assign to `OutColor` instead of `fragColor`.
- This is a single-line change replacing `fragColor` with `OutColor` inside the macro definition.
- No other shader logic or behavior was modified.

### Testing
- No automated tests were run for this change.
- The change is minimal and intended to resolve the shader compile error reported by the renderer.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d4bab0830832e9dc2fa385c7ed6a6)