### PR TITLE
Fix fog volume viewport and depth reprojection mapping

### DIFF
--- a/Quake/r_fogvol.c
+++ b/Quake/r_fogvol.c
@@ -526,6 +526,10 @@ void R_FogVol_Render (void)
 	int fog_height;
 	float depth_scale_x;
 	float depth_scale_y;
+	float view_x;
+	float view_y;
+	float view_w;
+	float view_h;
 	int fog_src_index = 0;
 	int fog_dst_index = 0;
 	GLuint final_tex = 0;
@@ -548,6 +552,10 @@ void R_FogVol_Render (void)
 	fog_height = use_halfres ? framebufs.fogvol.height : glheight;
 	depth_scale_x = (float)glwidth / (float)fog_width;
 	depth_scale_y = (float)glheight / (float)fog_height;
+	view_x = (float)(glx + r_refdef.vrect.x);
+	view_y = (float)(gly + glheight - r_refdef.vrect.y - r_refdef.vrect.height);
+	view_w = (float)r_refdef.vrect.width;
+	view_h = (float)r_refdef.vrect.height;
 
 	if (use_halfres && r_fogvol_steps_scale_halfres.value > 0.f)
 		steps = (int)Q_rint (r_fogvol_steps.value * r_fogvol_steps_scale_halfres.value);
@@ -607,8 +615,9 @@ void R_FogVol_Render (void)
 	GL_Uniform1iFunc (7, r_fogvol_jitter.value > 0.f ? 1 : 0);
 	GL_UniformMatrix4fvFunc (4, 1, GL_FALSE, inv_viewproj);
 	GL_Uniform3fFunc (8, r_refdef.vieworg[0], r_refdef.vieworg[1], r_refdef.vieworg[2]);
-	GL_Uniform4fFunc (9, (float)fog_width, (float)fog_height, 1.f / (float)fog_width, 1.f / (float)fog_height);
+	GL_Uniform4fFunc (9, (float)glwidth, (float)glheight, 1.f / (float)glwidth, 1.f / (float)glheight);
 	GL_Uniform2fFunc (10, depth_scale_x, depth_scale_y);
+	GL_Uniform4fFunc (11, view_x, view_y, 1.f / view_w, 1.f / view_h);
 
 	if (use_halfres)
 		glViewport (0, 0, fog_width, fog_height);
@@ -731,9 +740,10 @@ void R_FogVol_Render (void)
 		GL_Uniform1fFunc (1, r_fogvol_temporal_depth_reject.value);
 		GL_Uniform1iFunc (2, mode);
 		GL_UniformMatrix4fvFunc (3, 1, GL_FALSE, inv_viewproj);
-		GL_Uniform4fFunc (4, (float)fog_width, (float)fog_height, 1.f / (float)fog_width, 1.f / (float)fog_height);
+		GL_Uniform4fFunc (4, (float)glwidth, (float)glheight, 1.f / (float)glwidth, 1.f / (float)glheight);
 		GL_Uniform2fFunc (5, depth_scale_x, depth_scale_y);
 		GL_Uniform1iFunc (6, history_valid ? 1 : 0);
+		GL_Uniform4fFunc (7, view_x, view_y, 1.f / view_w, 1.f / view_h);
 		glDrawArrays (GL_TRIANGLES, 0, 3);
 
 		final_tex = framebufs.fogvol.history_tex[history_dst];

--- a/Quake/shaders/fogvol.frag
+++ b/Quake/shaders/fogvol.frag
@@ -30,8 +30,9 @@ layout(location=5) uniform int FogNoiseMode;
 layout(location=6) uniform int FogPhysBlend;
 layout(location=7) uniform int FogJitterEnabled;
 layout(location=8) uniform vec3 FogCameraPosWS;
-layout(location=9) uniform vec4 FogViewportParams; // xy: size, zw: inv size
+layout(location=9) uniform vec4 FogViewportParams; // xy: screen size, zw: inv screen size
 layout(location=10) uniform vec2 FogDepthScale;
+layout(location=11) uniform vec4 FogViewParams; // xy: view origin in screen px, zw: inv view size
 
 layout(location=0) out vec4 FragColor;
 
@@ -175,24 +176,26 @@ float FogEdgeFade(vec3 p, vec3 bmin, vec3 bmax, float falloff)
 
 void main()
 {
-	vec2 invViewport = FogViewportParams.zw;
-	vec2 uv = gl_FragCoord.xy * invViewport;
+	vec2 screenPos = gl_FragCoord.xy * FogDepthScale;
+	vec2 invScreen = FogViewportParams.zw;
+	vec2 screenUv = screenPos * invScreen;
+	vec2 viewUv = (screenPos - FogViewParams.xy) * FogViewParams.zw;
 
 	FogVolume volume = FogVolumes[FogVolumeIndex];
 	if (volume.misc.y <= 0.0)
 	{
-		FragColor = vec4(texture(SceneColor, uv).rgb, 1.0);
+		FragColor = vec4(texture(SceneColor, screenUv).rgb, 1.0);
 		return;
 	}
 
-	ivec2 depthCoord = ivec2(gl_FragCoord.xy * FogDepthScale);
+	ivec2 depthCoord = ivec2(screenPos);
 	float depth = texelFetch(SceneDepth, depthCoord, 0).r;
 	float ndcDepth = DepthToNdcZ(depth);
-	vec4 clip = vec4(uv * 2.0 - 1.0, ndcDepth, 1.0);
+	vec4 clip = vec4(viewUv * 2.0 - 1.0, ndcDepth, 1.0);
 	vec4 world = FogInvViewProj * clip;
 	if (abs(world.w) < 1e-6)
 	{
-		FragColor = vec4(texture(SceneColor, uv).rgb, 1.0);
+		FragColor = vec4(texture(SceneColor, screenUv).rgb, 1.0);
 		return;
 	}
 	vec3 worldPos = world.xyz / world.w;
@@ -207,7 +210,7 @@ void main()
 	float tExit;
 	if (!RayAABB(ro, rd, volume.mins.xyz, volume.maxs.xyz, tEnter, tExit))
 	{
-		FragColor = vec4(texture(SceneColor, uv).rgb, 1.0);
+		FragColor = vec4(texture(SceneColor, screenUv).rgb, 1.0);
 		return;
 	}
 
@@ -218,7 +221,7 @@ void main()
 		tExit = min(tExit, maxDistance);
 	if (tExit <= tEnter)
 	{
-		FragColor = vec4(texture(SceneColor, uv).rgb, 1.0);
+		FragColor = vec4(texture(SceneColor, screenUv).rgb, 1.0);
 		return;
 	}
 
@@ -308,7 +311,7 @@ void main()
 		return;
 	}
 
-	vec3 scene = texture(SceneColor, uv).rgb;
+	vec3 scene = texture(SceneColor, screenUv).rgb;
 	vec3 outColor;
 	if (FogPhysBlend != 0)
 		outColor = scene * transmittance + accum;

--- a/Quake/shaders/fogvol_temporal.frag
+++ b/Quake/shaders/fogvol_temporal.frag
@@ -8,9 +8,10 @@ layout(location=0) uniform float FogTemporalAlpha;
 layout(location=1) uniform float FogTemporalDepthReject;
 layout(location=2) uniform int FogDebugMode;
 layout(location=3) uniform mat4 FogInvViewProj;
-layout(location=4) uniform vec4 FogViewportParams; // xy: size, zw: inv size
+layout(location=4) uniform vec4 FogViewportParams; // xy: screen size, zw: inv screen size
 layout(location=5) uniform vec2 FogDepthScale;
 layout(location=6) uniform int FogHistoryValid;
+layout(location=7) uniform vec4 FogViewParams; // xy: view origin in screen px, zw: inv view size
 
 layout(location=0) out vec4 OutColor;
 
@@ -23,9 +24,9 @@ float DepthToNdcZ(float depth)
 #endif
 }
 
-bool Reproject(vec2 uv, float depthNdc, out vec2 prevUv, out float prevDepthNdc)
+bool Reproject(vec2 viewUv, float depthNdc, out vec2 prevViewUv, out float prevDepthNdc)
 {
-	vec4 clip = vec4(uv * 2.0 - 1.0, depthNdc, 1.0);
+	vec4 clip = vec4(viewUv * 2.0 - 1.0, depthNdc, 1.0);
 	vec4 world = FogInvViewProj * clip;
 	if (abs(world.w) < 1e-6)
 		return false;
@@ -33,16 +34,19 @@ bool Reproject(vec2 uv, float depthNdc, out vec2 prevUv, out float prevDepthNdc)
 	if (abs(prevClip.w) < 1e-6)
 		return false;
 	vec3 prevNdc = prevClip.xyz / prevClip.w;
-	prevUv = prevNdc.xy * 0.5 + 0.5;
+	prevViewUv = prevNdc.xy * 0.5 + 0.5;
 	prevDepthNdc = prevNdc.z;
 	return true;
 }
 
 void main()
 {
-	vec2 invViewport = FogViewportParams.zw;
-	vec2 uv = gl_FragCoord.xy * invViewport;
-	vec4 current = texture(FogCurrent, uv);
+	vec2 screenPos = gl_FragCoord.xy * FogDepthScale;
+	vec2 invScreen = FogViewportParams.zw;
+	vec2 screenUv = screenPos * invScreen;
+	vec2 viewUv = (screenPos - FogViewParams.xy) * FogViewParams.zw;
+	vec2 viewSize = 1.0 / max(FogViewParams.zw, vec2(1e-6));
+	vec4 current = texture(FogCurrent, screenUv);
 
 	if (FogHistoryValid == 0 || PrevFrameValid == 0u || FogTemporalAlpha <= 0.0 || FogDebugMode == 5 || FogDebugMode == 8)
 	{
@@ -50,21 +54,23 @@ void main()
 		return;
 	}
 
-	ivec2 depthCoord = ivec2(gl_FragCoord.xy * FogDepthScale);
+	ivec2 depthCoord = ivec2(screenPos);
 	float depth = texelFetch(SceneDepth, depthCoord, 0).r;
 	float depthNdc = DepthToNdcZ(depth);
 
-	vec2 prevUv;
+	vec2 prevViewUv;
 	float prevDepthNdc;
-	bool valid = Reproject(uv, depthNdc, prevUv, prevDepthNdc);
-	valid = valid && all(greaterThanEqual(prevUv, vec2(0.0))) && all(lessThanEqual(prevUv, vec2(1.0)));
+	bool valid = Reproject(viewUv, depthNdc, prevViewUv, prevDepthNdc);
+	valid = valid && all(greaterThanEqual(prevViewUv, vec2(0.0))) && all(lessThanEqual(prevViewUv, vec2(1.0)));
 
 	vec4 history = vec4(0.0);
+	vec2 prevScreenUv = vec2(0.0);
 	if (valid)
 	{
-		ivec2 prevCoord = ivec2(prevUv * FogViewportParams.xy);
+		prevScreenUv = (prevViewUv * viewSize + FogViewParams.xy) * invScreen;
+		ivec2 prevCoord = ivec2(prevScreenUv * FogViewportParams.xy);
 		prevCoord = clamp(prevCoord, ivec2(0), ivec2(FogViewportParams.xy) - ivec2(1));
-		float depthPrev = texelFetch(SceneDepth, ivec2(vec2(prevCoord) * FogDepthScale), 0).r;
+		float depthPrev = texelFetch(SceneDepth, prevCoord, 0).r;
 		float depthPrevNdc = DepthToNdcZ(depthPrev);
 		float depthReject = max(FogTemporalDepthReject, 0.0);
 		if (abs(depthPrevNdc - prevDepthNdc) > depthReject)
@@ -72,7 +78,7 @@ void main()
 	}
 
 	if (valid)
-		history = texture(FogHistory, prevUv);
+		history = texture(FogHistory, prevScreenUv);
 
 	if (FogDebugMode == 6)
 	{
@@ -86,15 +92,15 @@ void main()
 	{
 		for (int i = -1; i <= 1; ++i)
 		{
-			vec2 offset = vec2(i, j) * invViewport;
-			vec3 tap = texture(FogCurrent, uv + offset).rgb;
+			vec2 offset = vec2(i, j) * invScreen;
+			vec3 tap = texture(FogCurrent, screenUv + offset).rgb;
 			minColor = min(minColor, tap);
 			maxColor = max(maxColor, tap);
 		}
 	}
 	history.rgb = clamp(history.rgb, minColor, maxColor);
 
-	float motionPx = length((prevUv - uv) * FogViewportParams.xy);
+	float motionPx = length((prevScreenUv - screenUv) * FogViewportParams.xy);
 	float motionFactor = clamp(1.0 - motionPx * 0.1, 0.0, 1.0);
 	float alpha = (valid ? FogTemporalAlpha : 0.0) * motionFactor;
 	alpha = clamp(alpha, 0.0, 1.0);


### PR DESCRIPTION
### Motivation
- Fog volumes were rendering with incorrect FOV/viewport mapping and sampling which produced visual artifacts (white boxes, wrong FOV, missing fog). 
- The root cause was mismatched coordinate spaces between depth reconstruction/reprojection and the scene color/depth sampling for the fog passes. 
- The change aligns shader sampling and reprojection with the view-rect used for rendering so world-space reconstruction and temporal reprojection are correct. 

### Description
- Updated `Quake/r_fogvol.c` to pass full-screen and view-rect parameters to the fog shaders via new uniforms (`FogViewportParams` now holds screen size/inv size and added `FogViewParams` for view origin and inv view size). 
- Modified `Quake/shaders/fogvol.frag` to compute `screenPos`, `screenUv` (for sampling `SceneColor`) and `viewUv` (for depth/world reconstruction) and use `viewUv` for the `FogInvViewProj` transform. 
- Modified `Quake/shaders/fogvol_temporal.frag` to reprojection in view-rect UV space and to map between view UVs and screen UVs for history lookups and neighborhood taps. 
- Kept existing behavior for half-res and upsample paths while ensuring depth texel coordinates are computed from the same screen-space mapping (`screenPos`). 

### Testing
- No automated tests were executed as part of this change. 
- Changes were limited to runtime shader and uniform updates and committed after local verification steps (no CI run reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695da8186248832eb3d86b8b4ae8cab6)