### PR TITLE
Implement tcGen environment mapping

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -3248,7 +3248,7 @@ void R_SetupView (void)
         r_framedata.colorspace_params[2] = 0.f;
         r_framedata.colorspace_params[3] = 0.f;
         r_framedata.shader_params[0] = r_shader_debug.value;
-        r_framedata.shader_params[1] = 0.f;
+        r_framedata.shader_params[1] = r_tcgen_debug.value;
         r_framedata.shader_params[2] = 0.f;
         r_framedata.shader_params[3] = 0.f;
         r_framedata.shadow_params[0] = r_shadow_bias.value;

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -441,7 +441,7 @@ typedef struct gpuframedata_s {
         vec4_t          lightgrid_params; // x: enabled, yzw: unused
         vec4_t          dlight_params;  // x: style, y: debug view, z: pass selector, w: padding
         vec4_t          colorspace_params; // x: debug mode, y: manual gamma, z: output sRGB, w: unused
-        vec4_t          shader_params;  // x: shader debug, yzw: unused
+        vec4_t          shader_params;  // x: shader debug, y: tcgen debug, zw: unused
         float           shadow_viewproj[16];
         vec4_t          shadow_params; // x: bias, y: normal bias, z: pcf enabled, w: pcf taps
         vec4_t          shadow_debug;  // x: enabled, y: debug mode, zw: unused
@@ -455,6 +455,13 @@ typedef struct gpuframedata_s {
         unsigned int    _padding1;
         unsigned int    _padding2;
 } gpuframedata_t;
+
+typedef enum
+{
+	TCGEN_BASE = 0,
+	TCGEN_LIGHTMAP = 1,
+	TCGEN_ENVIRONMENT = 2,
+} tcgen_mode_t;
 
 extern gpulightbuffer_t r_lightbuffer;
 extern gpuframedata_t r_framedata;

--- a/Quake/mat_shader.c
+++ b/Quake/mat_shader.c
@@ -144,6 +144,7 @@ static qboolean mat_shader_keyword_seen[countof (mat_shader_keyword_table)];
 
 cvar_t r_shaders = { "r_shaders", "1", CVAR_ARCHIVE };
 cvar_t r_shader_debug = { "r_shader_debug", "0", CVAR_ARCHIVE };
+cvar_t r_tcgen_debug = { "r_tcgen_debug", "0", CVAR_ARCHIVE };
 cvar_t r_matshader_debug_parse = { "r_matshader_debug_parse", "0", CVAR_ARCHIVE };
 static cvar_t r_reloadshaders = { "r_reloadshaders", "0", CVAR_NONE };
 static cvar_t r_matshader_fuzz = { "r_matshader_fuzz", "0", CVAR_NONE };
@@ -1063,6 +1064,7 @@ void Mat_Shader_Init (void)
 {
 	Cvar_RegisterVariable (&r_shaders);
 	Cvar_RegisterVariable (&r_shader_debug);
+	Cvar_RegisterVariable (&r_tcgen_debug);
 	Cvar_RegisterVariable (&r_matshader_debug_parse);
 	Cvar_RegisterVariable (&r_reloadshaders);
 	Cvar_RegisterVariable (&r_matshader_fuzz);

--- a/Quake/mat_shader.h
+++ b/Quake/mat_shader.h
@@ -256,6 +256,7 @@ typedef struct texture_s texture_t;
 
 extern cvar_t r_shaders;
 extern cvar_t r_shader_debug;
+extern cvar_t r_tcgen_debug;
 extern cvar_t r_matshader_debug_parse;
 
 typedef enum

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -283,8 +283,11 @@ typedef struct bmodel_gpu_instance_s {
 
 typedef struct bmodel_bindless_gpu_call_s {
 	GLuint		flags;
+	GLuint		tcgen;
 	GLfloat		alpha;
+	GLfloat		_pad0;
 	GLfloat		polygon_offset[2];
+	GLfloat		_pad1[2];
 	GLfloat		stage_color[4];
 	GLuint64	texture;
 	GLuint64	fullbright;
@@ -294,8 +297,11 @@ typedef struct bmodel_bindless_gpu_call_s {
 
 typedef struct bmodel_bound_gpu_call_s {
 	GLuint		flags;
+	GLuint		tcgen;
 	GLfloat		alpha;
+	GLfloat		_pad0;
 	GLfloat		polygon_offset[2];
+	GLfloat		_pad1[2];
 	GLfloat		stage_color[4];
 	GLint		baseinstance;
 	GLint		padding[3];
@@ -611,9 +617,13 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
 	{
 		bmodel_bindless_gpu_call_t *call = &bmodel_calls.bindless.params[num_bmodel_calls];
 		call->flags = flags;
+		call->tcgen = TCGEN_BASE;
 		call->alpha = alpha;
+		call->_pad0 = 0.f;
 		call->polygon_offset[0] = polygon_offset_factor;
 		call->polygon_offset[1] = polygon_offset_units;
+		call->_pad1[0] = 0.f;
+		call->_pad1[1] = 0.f;
 		call->stage_color[0] = 1.f;
 		call->stage_color[1] = 1.f;
 		call->stage_color[2] = 1.f;
@@ -628,9 +638,13 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
 		bmodel_bound_gpu_call_t *call = &bmodel_calls.bound.params[num_bmodel_calls];
 		gltexture_t **textures = bmodel_calls.bound.textures[num_bmodel_calls];
 		call->flags = flags;
+		call->tcgen = TCGEN_BASE;
 		call->alpha = alpha;
+		call->_pad0 = 0.f;
 		call->polygon_offset[0] = polygon_offset_factor;
 		call->polygon_offset[1] = polygon_offset_units;
+		call->_pad1[0] = 0.f;
+		call->_pad1[1] = 0.f;
 		call->stage_color[0] = 1.f;
 		call->stage_color[1] = 1.f;
 		call->stage_color[2] = 1.f;
@@ -653,7 +667,7 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
 }
 
 static void R_AddBModelCallWithTextures (int index, int first_instance, int num_instances, gltexture_t *tx, gltexture_t *fb, gltexture_t *em,
-	qboolean zfix, float polygon_offset_factor, float polygon_offset_units, float alpha_override, unsigned extra_flags,
+	tcgen_mode_t tcgen, qboolean zfix, float polygon_offset_factor, float polygon_offset_units, float alpha_override, unsigned extra_flags,
 	const vec4_t stage_color)
 {
 	GLuint flags;
@@ -676,9 +690,13 @@ static void R_AddBModelCallWithTextures (int index, int first_instance, int num_
 	{
 		bmodel_bindless_gpu_call_t *call = &bmodel_calls.bindless.params[num_bmodel_calls];
 		call->flags = flags;
+		call->tcgen = tcgen;
 		call->alpha = alpha;
+		call->_pad0 = 0.f;
 		call->polygon_offset[0] = polygon_offset_factor;
 		call->polygon_offset[1] = polygon_offset_units;
+		call->_pad1[0] = 0.f;
+		call->_pad1[1] = 0.f;
 		call->stage_color[0] = stage_color ? stage_color[0] : 1.f;
 		call->stage_color[1] = stage_color ? stage_color[1] : 1.f;
 		call->stage_color[2] = stage_color ? stage_color[2] : 1.f;
@@ -693,9 +711,13 @@ static void R_AddBModelCallWithTextures (int index, int first_instance, int num_
 		bmodel_bound_gpu_call_t *call = &bmodel_calls.bound.params[num_bmodel_calls];
 		gltexture_t **textures = bmodel_calls.bound.textures[num_bmodel_calls];
 		call->flags = flags;
+		call->tcgen = tcgen;
 		call->alpha = alpha;
+		call->_pad0 = 0.f;
 		call->polygon_offset[0] = polygon_offset_factor;
 		call->polygon_offset[1] = polygon_offset_units;
+		call->_pad1[0] = 0.f;
+		call->_pad1[1] = 0.f;
 		call->stage_color[0] = stage_color ? stage_color[0] : 1.f;
 		call->stage_color[1] = stage_color ? stage_color[1] : 1.f;
 		call->stage_color[2] = stage_color ? stage_color[2] : 1.f;
@@ -881,6 +903,28 @@ static qboolean R_StageUsesLightmap (const mat_shader_stage_t *stage, size_t sta
 	if (stage_index == 0 && stage->blend_mode == MAT_BLEND_REPLACE)
 		return true;
 	return false;
+}
+
+static tcgen_mode_t R_ResolveStageTcGen (const mat_shader_stage_t *stage)
+{
+	if (!stage)
+		return TCGEN_BASE;
+
+	switch (stage->tcgen)
+	{
+	case MAT_TCGEN_ENVIRONMENT:
+		return TCGEN_ENVIRONMENT;
+	case MAT_TCGEN_LIGHTMAP:
+		return TCGEN_LIGHTMAP;
+	case MAT_TCGEN_BASE:
+	default:
+		break;
+	}
+
+	if (stage->map_type == MAT_MAP_LIGHTMAP)
+		return TCGEN_LIGHTMAP;
+
+	return TCGEN_BASE;
 }
 
 static qboolean R_StageIsOpaqueBase (const shader_material_t *material)
@@ -1138,7 +1182,7 @@ static void R_DrawBrushModels_MaterialStages (entity_t **ents, int count, brushp
 
 					R_GetPolygonOffsetValues (material, use_polygon_offset, &polygon_offset_factor, &polygon_offset_units);
 					R_AddBModelCallWithTextures (model->firstcmd + j, baseinst, numinst,
-						stage_tex, fb, em,
+						stage_tex, fb, em, R_ResolveStageTcGen (stage),
 						use_polygon_offset, polygon_offset_factor, polygon_offset_units, -1.f, extra_flags, stage_color);
 				}
 			}
@@ -1310,7 +1354,7 @@ static void R_DrawBrushModels_GodrayStages (entity_t **ents, int count)
 
 					R_GetPolygonOffsetValues (material, use_polygon_offset, &polygon_offset_factor, &polygon_offset_units);
 					R_AddBModelCallWithTextures (model->firstcmd + j, baseinst, numinst,
-						stage_tex, fb, em,
+						stage_tex, fb, em, R_ResolveStageTcGen (stage),
 						use_polygon_offset, polygon_offset_factor, polygon_offset_units, -1.f, extra_flags, stage_color);
 				}
 			}

--- a/Quake/shaders/shadow_depth.vert
+++ b/Quake/shaders/shadow_depth.vert
@@ -11,7 +11,9 @@
 struct Call
 {
 	uint	flags;
+	uint	tcgen;
 	float	wateralpha;
+	float	_pad0;
 	vec2	polygon_offset;
 	vec4	stage_color;
 #if BINDLESS

--- a/Quake/shaders/sky_cubemap.vert
+++ b/Quake/shaders/sky_cubemap.vert
@@ -18,7 +18,9 @@ vec3 ApplyFog(vec3 clr, vec3 p)
 struct Call
 {
 	uint	flags;
+	uint	tcgen;
 	float	wateralpha;
+	float	_pad0;
 	vec2	polygon_offset;
 	vec4	stage_color;
 #if BINDLESS

--- a/Quake/shaders/sky_layers.vert
+++ b/Quake/shaders/sky_layers.vert
@@ -18,7 +18,9 @@ vec3 ApplyFog(vec3 clr, vec3 p)
 struct Call
 {
 	uint	flags;
+	uint	tcgen;
 	float	wateralpha;
+	float	_pad0;
 	vec2	polygon_offset;
 	vec4	stage_color;
 #if BINDLESS

--- a/Quake/shaders/skystencil.vert
+++ b/Quake/shaders/skystencil.vert
@@ -18,7 +18,9 @@ vec3 ApplyFog(vec3 clr, vec3 p)
 struct Call
 {
 	uint	flags;
+	uint	tcgen;
 	float	wateralpha;
+	float	_pad0;
 	vec2	polygon_offset;
 	vec4	stage_color;
 #if BINDLESS

--- a/Quake/shaders/water.vert
+++ b/Quake/shaders/water.vert
@@ -18,7 +18,9 @@ vec3 ApplyFog(vec3 clr, vec3 p)
 struct Call
 {
 	uint	flags;
+	uint	tcgen;
 	float	wateralpha;
+	float	_pad0;
 	vec2	polygon_offset;
 	vec4	stage_color;
 #if BINDLESS

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -48,7 +48,9 @@ layout(rg32ui, binding=0) uniform readonly uimage3D LightClusters;
 struct Call
 {
 	uint	flags;
+	uint	tcgen;
 	float	wateralpha;
+	float	_pad0;
 	vec2	polygon_offset;
 	vec4	stage_color;
 #if BINDLESS
@@ -73,6 +75,11 @@ const uint
 	CF_MAT_TRANS = 1024u,
 	CF_MAT_SKY = 2048u,
 	CF_MAT_HAS_SHADER = 4096u;
+
+const uint
+	TCGEN_BASE = 0u,
+	TCGEN_LIGHTMAP = 1u,
+	TCGEN_ENVIRONMENT = 2u;
 
 layout(std430, binding=1) restrict readonly buffer CallBuffer
 {
@@ -139,6 +146,7 @@ layout(location=12) noperspective in vec4 in_prev_clip;
 layout(location=13) in vec3 in_normal;
 layout(location=14) in vec3 in_lightgrid;
 layout(location=15) flat in vec4 in_stage_color;
+layout(location=16) flat in uint in_tcgen;
 
 // Utility: ALU-only 16x16 Bayer matrix
 float bayer01(ivec2 coord)
@@ -261,6 +269,15 @@ void main()
 #if MODE == 2
 	uv = uv * 2.0 + 0.125 * sin(uv.yx * (3.14159265 * 2.0) + Time);
 #endif
+	int tcgen_debug = int(ShaderParams.y + 0.5);
+	if (tcgen_debug > 0 && in_tcgen == TCGEN_ENVIRONMENT)
+	{
+		OUT_COLOR = vec4(fract(uv), 0.0, 1.0);
+#if !OIT
+		out_velocity = vec4(0.0);
+#endif
+		return;
+	}
 
 	// Sample textures
 #if BINDLESS

--- a/Quake/shaders/world.vert
+++ b/Quake/shaders/world.vert
@@ -47,7 +47,9 @@ float GetLightStyle(int index)
 struct Call
 {
 	uint	flags;
+	uint	tcgen;
 	float	wateralpha;
+	float	_pad0;
 	vec2	polygon_offset;
 	vec4	stage_color;
 #if BINDLESS
@@ -66,6 +68,11 @@ const uint
 	CF_USE_EMISSIVE = 8u,
 	CF_ALPHA_TEST = 16u
 ;
+
+const uint
+	TCGEN_BASE = 0u,
+	TCGEN_LIGHTMAP = 1u,
+	TCGEN_ENVIRONMENT = 2u;
 
 layout(std430, binding=1) restrict readonly buffer CallBuffer
 {
@@ -144,6 +151,15 @@ layout(location=12) noperspective out vec4 out_prev_clip;
 layout(location=13) out vec3 out_normal;
 layout(location=14) out vec3 out_lightgrid;
 layout(location=15) flat out vec4 out_stage_color;
+layout(location=16) flat out uint out_tcgen;
+
+vec2 ComputeEnvUV(vec3 world_pos, vec3 world_normal)
+{
+	vec3 view_dir = normalize(EyePos - world_pos);
+	vec3 refl = reflect(-view_dir, normalize(world_normal));
+	float m = 2.0 * sqrt(refl.x * refl.x + refl.y * refl.y + (refl.z + 1.0) * (refl.z + 1.0));
+	return refl.xy / max(m, 1e-6) + 0.5;
+}
 
 void main()
 {
@@ -173,7 +189,12 @@ void main()
         out_pos = world_pos;
         out_normal = normalize(world_normal);
         out_lightgrid = in_lightgrid;
-        out_uv = in_uv.xy;
+	vec2 uv = in_uv.xy;
+	if (call.tcgen == TCGEN_LIGHTMAP)
+		uv = in_uv.zw;
+	else if (call.tcgen == TCGEN_ENVIRONMENT)
+		uv = ComputeEnvUV(world_pos, world_normal);
+        out_uv = uv;
 	out_lmuv = in_uv.zw;
 	out_depth = gl_Position.w;
 	out_coord = (gl_Position.xy / gl_Position.w * 0.5 + 0.5) * vec2(LIGHT_TILES_X, LIGHT_TILES_Y);
@@ -199,6 +220,7 @@ void main()
 		out_styles.xy = vec2(1., -1.);
 	out_lmofs = in_lmofs;
 	out_stage_color = call.stage_color;
+	out_tcgen = call.tcgen;
 #if BINDLESS
 	out_samplers0.xy = call.txhandle;
 	if ((call.flags & CF_USE_FULLBRIGHT) != 0u)

--- a/Quake/shaders/world_dlight.vert
+++ b/Quake/shaders/world_dlight.vert
@@ -34,7 +34,9 @@ layout(std430, binding=0) restrict readonly buffer LightBuffer
 struct Call
 {
         uint    flags;
+        uint    tcgen;
         float   wateralpha;
+        float   _pad0;
         vec2    polygon_offset;
         vec4    stage_color;
 #if BINDLESS
@@ -53,6 +55,11 @@ const uint
         CF_USE_EMISSIVE = 8u,
         CF_ALPHA_TEST = 16u
 ;
+
+const uint
+	TCGEN_BASE = 0u,
+	TCGEN_LIGHTMAP = 1u,
+	TCGEN_ENVIRONMENT = 2u;
 
 layout(std430, binding=1) restrict readonly buffer CallBuffer
 {
@@ -115,6 +122,14 @@ layout(location=6) out vec3 out_normal;
         layout(location=8) flat out uvec2 out_samplers1;
 #endif
 
+vec2 ComputeEnvUV(vec3 world_pos, vec3 world_normal)
+{
+	vec3 view_dir = normalize(EyePos - world_pos);
+	vec3 refl = reflect(-view_dir, normalize(world_normal));
+	float m = 2.0 * sqrt(refl.x * refl.x + refl.y * refl.y + (refl.z + 1.0) * (refl.z + 1.0));
+	return refl.xy / max(m, 1e-6) + 0.5;
+}
+
 void main()
 {
         Call call = call_data[DRAW_ID];
@@ -137,7 +152,12 @@ void main()
         gl_Position = curr_clip;
         out_pos = world_pos;
         out_normal = normalize(world_normal);
-        out_uv = in_uv.xy;
+	vec2 uv = in_uv.xy;
+	if (call.tcgen == TCGEN_LIGHTMAP)
+		uv = in_uv.zw;
+	else if (call.tcgen == TCGEN_ENVIRONMENT)
+		uv = ComputeEnvUV(world_pos, world_normal);
+        out_uv = uv;
         out_depth = gl_Position.w;
         out_coord = (gl_Position.xy / gl_Position.w * 0.5 + 0.5) * vec2(LIGHT_TILES_X, LIGHT_TILES_Y);
         out_flags = call.flags;


### PR DESCRIPTION
### Motivation
- Make `tcGen environment` parsed in materials actually generate view-dependent environment UVs for material stages. 
- Prefer classic Q3 sphere-map behavior as a baseline and provide a debug visualization to verify generated coordinates. 
- Wire parsed `stage.tcgen` into the GPU draw call path so shader programs can act on the mode. 

### Description
- Add `tcgen_mode_t` and `TCGEN_*` constants and extend `gpuframedata_t` shader params with `r_tcgen_debug`, then expose a new `r_tcgen_debug` cvar wired into `r_framedata.shader_params[1]`. 
- Extend GPU call structures and buffers to carry a `tcgen` field and padding, and update `R_AddBModelCall*` to set a default `TCGEN_BASE` or explicit mode via a new `R_ResolveStageTcGen` helper that maps `mat_shader_stage_t.tcgen` to `tcgen_mode_t`. 
- Propagate stage tcgen into draw calls when building bmodel calls by calling `R_ResolveStageTcGen(stage)` and passing the result through to the shaders. 
- Implement environment UV generation in vertex shaders (`world.vert`, `world_dlight.vert`, and related vert shaders) via a `ComputeEnvUV` helper (reflection-based sphere-map formula) and select the UV set per-call (`base`, `lightmap`, or `environment`), and add a fragment-shader debug path in `world.frag` that shows `fract(uv)` when `r_tcgen_debug` is enabled. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e50ec3580832eb1cbf42c1d678dee)