### PR TITLE
Add view matrix and view-space sphere mapping for environment tcgen

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -2998,6 +2998,7 @@ void R_SetFrustum (void)
 	logznear = log2f (znear);
 	logzfar = log2f (zfar);
         memcpy (r_framedata.viewproj, r_matviewproj, 16 * sizeof (float));
+        memcpy (r_framedata.view, r_matview, 16 * sizeof (float));
         r_framedata.zparams[0] = LIGHT_TILES_Z / (logzfar - logznear);
         r_framedata.zparams[1] = -r_framedata.zparams[0] * logznear;
 }

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -430,6 +430,7 @@ typedef struct gpuframedata_s {
         // Fields are grouped into vec4-aligned blocks to match the std140 layout in frame_uniforms.glsl.
         float           viewproj[16];
         float           prev_viewproj[16];
+        float           view[16];
         float           fogdata[4];
         float           skyfogdata[4];
         vec4_t          wind;           // xyz: winddir, w: windphase

--- a/Quake/shaders/frame_uniforms.glsl
+++ b/Quake/shaders/frame_uniforms.glsl
@@ -7,6 +7,7 @@ layout(std140, binding=0) uniform FrameDataUBO
 {
         mat4    ViewProj;
         mat4    PrevViewProj;
+        mat4    View;
         vec4    Fog;
         vec4    SkyFog;
         vec3    WindDir;

--- a/Quake/shaders/world.vert
+++ b/Quake/shaders/world.vert
@@ -157,8 +157,9 @@ vec2 ComputeEnvUV(vec3 world_pos, vec3 world_normal)
 {
 	vec3 view_dir = normalize(EyePos - world_pos);
 	vec3 refl = reflect(-view_dir, normalize(world_normal));
-	float m = 2.0 * sqrt(refl.x * refl.x + refl.y * refl.y + (refl.z + 1.0) * (refl.z + 1.0));
-	return refl.xy / max(m, 1e-6) + 0.5;
+	vec3 refl_view = mat3(View) * refl;
+	float m = 2.0 * sqrt(refl_view.x * refl_view.x + refl_view.y * refl_view.y + (refl_view.z + 1.0) * (refl_view.z + 1.0));
+	return refl_view.xy / max(m, 1e-6) + 0.5;
 }
 
 void main()

--- a/Quake/shaders/world_dlight.vert
+++ b/Quake/shaders/world_dlight.vert
@@ -126,8 +126,9 @@ vec2 ComputeEnvUV(vec3 world_pos, vec3 world_normal)
 {
 	vec3 view_dir = normalize(EyePos - world_pos);
 	vec3 refl = reflect(-view_dir, normalize(world_normal));
-	float m = 2.0 * sqrt(refl.x * refl.x + refl.y * refl.y + (refl.z + 1.0) * (refl.z + 1.0));
-	return refl.xy / max(m, 1e-6) + 0.5;
+	vec3 refl_view = mat3(View) * refl;
+	float m = 2.0 * sqrt(refl_view.x * refl_view.x + refl_view.y * refl_view.y + (refl_view.z + 1.0) * (refl_view.z + 1.0));
+	return refl_view.xy / max(m, 1e-6) + 0.5;
 }
 
 void main()


### PR DESCRIPTION
### Motivation

- Implement environment texture coordinate generation (sphere map) in the vertex stage so `TCGEN_ENVIRONMENT` produces stable, view-oriented UVs.
- Provide shaders access to the current view transform so reflection vectors can be converted into view space for correct sphere mapping.
- Keep `tcgen` selection behavior unchanged and compute environment UVs only when `TCGEN_ENVIRONMENT` is active.
- Avoid extra shader permutations by using a uniform-backed frame matrix that shaders can read each frame.

### Description

- Add `mat4 View` to the `FrameDataUBO` in `Quake/shaders/frame_uniforms.glsl` and the corresponding `float view[16]` field to `gpuframedata_t` in `Quake/glquake.h`.
- Copy the runtime view matrix `r_matview` into `r_framedata.view` in `R_SetFrustum` in `Quake/gl_rmain.c` using `memcpy`.
- Change `ComputeEnvUV` in `Quake/shaders/world.vert` and `Quake/shaders/world_dlight.vert` to transform the reflection vector into view space with `mat3(View)` and compute the classic sphere-map UVs from that view-space reflection.
- No changes were made to the `tcgen` selection logic; environment UVs are computed only when `call.tcgen == TCGEN_ENVIRONMENT`.

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e54f72b64832e9acb8d5a63e10c3e)