### PR TITLE
Add `r_envmap_source` toggle and sample skybox cubemap for environment tcGen

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -3250,7 +3250,7 @@ void R_SetupView (void)
         r_framedata.colorspace_params[3] = 0.f;
         r_framedata.shader_params[0] = r_shader_debug.value;
         r_framedata.shader_params[1] = r_tcgen_debug.value;
-        r_framedata.shader_params[2] = 0.f;
+        r_framedata.shader_params[2] = (r_envmap_source.value > 0.f && skybox && skybox->cubemap) ? 1.f : 0.f;
         r_framedata.shader_params[3] = 0.f;
         r_framedata.shadow_params[0] = r_shadow_bias.value;
         r_framedata.shadow_params[1] = r_shadow_normalbias.value;

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -442,7 +442,7 @@ typedef struct gpuframedata_s {
         vec4_t          lightgrid_params; // x: enabled, yzw: unused
         vec4_t          dlight_params;  // x: style, y: debug view, z: pass selector, w: padding
         vec4_t          colorspace_params; // x: debug mode, y: manual gamma, z: output sRGB, w: unused
-        vec4_t          shader_params;  // x: shader debug, y: tcgen debug, zw: unused
+        vec4_t          shader_params;  // x: shader debug, y: tcgen debug, z: envmap source, w: unused
         float           shadow_viewproj[16];
         vec4_t          shadow_params; // x: bias, y: normal bias, z: pcf enabled, w: pcf taps
         vec4_t          shadow_debug;  // x: enabled, y: debug mode, zw: unused

--- a/Quake/mat_shader.c
+++ b/Quake/mat_shader.c
@@ -145,6 +145,7 @@ static qboolean mat_shader_keyword_seen[countof (mat_shader_keyword_table)];
 cvar_t r_shaders = { "r_shaders", "1", CVAR_ARCHIVE };
 cvar_t r_shader_debug = { "r_shader_debug", "0", CVAR_ARCHIVE };
 cvar_t r_tcgen_debug = { "r_tcgen_debug", "0", CVAR_ARCHIVE };
+cvar_t r_envmap_source = { "r_envmap_source", "0", CVAR_ARCHIVE };
 cvar_t r_matshader_debug_parse = { "r_matshader_debug_parse", "0", CVAR_ARCHIVE };
 static cvar_t r_reloadshaders = { "r_reloadshaders", "0", CVAR_NONE };
 static cvar_t r_matshader_fuzz = { "r_matshader_fuzz", "0", CVAR_NONE };
@@ -1065,6 +1066,7 @@ void Mat_Shader_Init (void)
 	Cvar_RegisterVariable (&r_shaders);
 	Cvar_RegisterVariable (&r_shader_debug);
 	Cvar_RegisterVariable (&r_tcgen_debug);
+	Cvar_RegisterVariable (&r_envmap_source);
 	Cvar_RegisterVariable (&r_matshader_debug_parse);
 	Cvar_RegisterVariable (&r_reloadshaders);
 	Cvar_RegisterVariable (&r_matshader_fuzz);

--- a/Quake/mat_shader.h
+++ b/Quake/mat_shader.h
@@ -257,6 +257,7 @@ typedef struct texture_s texture_t;
 extern cvar_t r_shaders;
 extern cvar_t r_shader_debug;
 extern cvar_t r_tcgen_debug;
+extern cvar_t r_envmap_source;
 extern cvar_t r_matshader_debug_parse;
 
 typedef enum

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -70,6 +70,12 @@ static qboolean R_BrushModelHasTextureTables (const qmodel_t *model)
 		&& model->usedtextures;
 }
 
+static void R_BindEnvmapCubemap (void)
+{
+	if (r_envmap_source.value > 0.f && skybox && skybox->cubemap)
+		GL_Bind (GL_TEXTURE6, skybox->cubemap);
+}
+
 static texture_t *R_GetUsedTexture (const qmodel_t *model, int used_index, int *out_texnum)
 {
 	int used_count;
@@ -1032,6 +1038,7 @@ static void R_DrawBrushModels_MaterialStages (entity_t **ents, int count, brushp
 	R_ResetBModelCalls (program);
 	GL_Bind (GL_TEXTURE2, r_fullbright_cheatsafe ? greytexture : lightmap_texture);
 	GL_Bind (GL_TEXTURE3, (r_lightingdir.value > 0.f && lightmap_dir_texture) ? lightmap_dir_texture : greytexture);
+	R_BindEnvmapCubemap ();
 
 	GL_Upload (GL_SHADER_STORAGE_BUFFER, bmodel_instances, sizeof (bmodel_instances[0]) * totalinst, &buf, &ofs);
 	GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 2, buf, (GLintptr)ofs, sizeof (bmodel_instances[0]) * totalinst);
@@ -1479,12 +1486,13 @@ static void R_DrawBrushModels_Real (entity_t **ents, int count, brushpass_t pass
         else
                 state |= GLS_BLEND_ALPHA_OIT | GLS_NO_ZWRITE;
 
-        R_ResetBModelCalls (program);
-        GL_SetState (state);
+R_ResetBModelCalls (program);
+GL_SetState (state);
 if (pass <= BP_ALPHATEST)
 {
 GL_Bind (GL_TEXTURE2, r_fullbright_cheatsafe ? greytexture : lightmap_texture);
 GL_Bind (GL_TEXTURE3, (r_lightingdir.value > 0.f && lightmap_dir_texture) ? lightmap_dir_texture : greytexture);
+R_BindEnvmapCubemap ();
 R_Shadow_BindShadowMap (GL_TEXTURE5);
 }
 else if (pass == BP_DLIGHT_SOLID || pass == BP_DLIGHT_ALPHA)
@@ -1685,6 +1693,7 @@ R_ResetBModelCalls (program);
 GL_SetState (state);
 GL_Bind (GL_TEXTURE2, r_fullbright_cheatsafe ? greytexture : lightmap_texture);
 GL_Bind (GL_TEXTURE3, (r_lightingdir.value > 0.f && lightmap_dir_texture) ? lightmap_dir_texture : greytexture);
+R_BindEnvmapCubemap ();
 
 GL_Upload (GL_SHADER_STORAGE_BUFFER, bmodel_instances, sizeof(bmodel_instances[0]) * totalinst, &buf, &ofs);
 	GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 2, buf, (GLintptr)ofs, sizeof(bmodel_instances[0]) * totalinst);

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -8,6 +8,7 @@
 layout(binding=2) uniform sampler2D LMTex;
 layout(binding=3) uniform sampler2D LMTexDir;
 layout(binding=5) uniform sampler2D ShadowMap;
+layout(binding=6) uniform samplerCube EnvmapCube;
 #include "frame_uniforms.glsl"
 #define SHADOW_SUN 1
 #include "shadow_sample.glsl"
@@ -224,6 +225,15 @@ float DepthToCanonical(float depth)
 #endif
 }
 
+vec3 ComputeEnvCubeDir(vec3 world_pos, vec3 world_normal)
+{
+	vec3 view_dir = normalize(EyePos - world_pos);
+	vec3 refl = reflect(-view_dir, normalize(world_normal));
+	vec3 refl_view = mat3(View) * refl;
+	vec3 dir = normalize(refl_view);
+	return vec3(-dir.y, dir.z, dir.x);
+}
+
 vec3 ComputeSunLight(vec3 world_pos, vec3 normal)
 {
 	return vec3(0.0);
@@ -265,6 +275,7 @@ void main()
 	vec3 fullbright = vec3(0.0);
 	vec3 emissive = vec3(0.0);
 	vec2 uv = in_uv;
+	bool use_envmap = (in_tcgen == TCGEN_ENVIRONMENT) && (ShaderParams.z > 0.5);
 	
 #if MODE == 2
 	uv = uv * 2.0 + 0.125 * sin(uv.yx * (3.14159265 * 2.0) + Time);
@@ -282,30 +293,39 @@ void main()
 	// Sample textures
 #if BINDLESS
 	sampler2D Tex = sampler2D(in_samplers0.xy);
-	if ((in_flags & CF_USE_FULLBRIGHT) != 0u)
+	if (!use_envmap && (in_flags & CF_USE_FULLBRIGHT) != 0u)
 	{
 		sampler2D FullbrightTex = sampler2D(in_samplers0.zw);
 		fullbright = texture(FullbrightTex, uv).rgb;
 	}
-	if ((in_flags & CF_USE_EMISSIVE) != 0u)
+	if (!use_envmap && (in_flags & CF_USE_EMISSIVE) != 0u)
 	{
 		sampler2D EmissiveSampler = sampler2D(in_samplers1.xy);
 		emissive = texture(EmissiveSampler, uv).rgb;
 	}
 #else
-	if ((in_flags & CF_USE_FULLBRIGHT) != 0u)
+	if (!use_envmap && (in_flags & CF_USE_FULLBRIGHT) != 0u)
 		fullbright = texture(FullbrightTex, uv).rgb;
-	if ((in_flags & CF_USE_EMISSIVE) != 0u)
+	if (!use_envmap && (in_flags & CF_USE_EMISSIVE) != 0u)
 		emissive = texture(EmissiveTex, uv).rgb;
 #endif
 
+	vec4 result;
+	if (use_envmap)
+	{
+		vec3 env_dir = ComputeEnvCubeDir(in_pos, in_normal);
+		result = texture(EnvmapCube, env_dir);
+	}
+	else
+	{
 #if DITHER >= 2
-	vec4 result = texture(Tex, uv, -1.0);
+		result = texture(Tex, uv, -1.0);
 #elif DITHER
-	vec4 result = texture(Tex, uv, -0.5);
+		result = texture(Tex, uv, -0.5);
 #else
-	vec4 result = texture(Tex, uv);
+		result = texture(Tex, uv);
 #endif
+	}
 
 #if MODE == 1
 	if (result.a < 0.666)


### PR DESCRIPTION
### Motivation

- Provide a quick way to use the loaded skybox cubemap as a default reflection texture for `tcGen environment` stages for debugging and quick verification.
- Allow switching between the stage-provided 2D environment map and the skybox cubemap via a runtime toggle.

### Description

- Add `r_envmap_source` cvar and register it in `Mat_Shader_Init` to control envmap source and expose it via the frame uniform `shader_params.z` in `R_SetupView`.
- Wire a new `EnvmapCube` sampler into `shaders/world.frag`, add `ComputeEnvCubeDir()` to compute the cube lookup direction, and sample the skybox cubemap when `tcGen == TCGEN_ENVIRONMENT` and `ShaderParams.z` is set.
- Bind the skybox cubemap to `GL_TEXTURE6` via a new helper `R_BindEnvmapCubemap()` and call it where world/material draw passes are prepared (`R_DrawBrushModels_*`, water, material stages, etc.).
- Export the new cvar in `mat_shader.h` and update `glquake.h` frame uniform layout comment to document `shader_params.z` usage.

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e56126cd0832ea9955c9773f874ee)