### PR TITLE
Add per-client snapshot delta protocol with stop-and-wait ACKs

### DIFF
--- a/Quake/cl_main.c
+++ b/Quake/cl_main.c
@@ -119,6 +119,8 @@ void CL_ClearState (void)
 	//johnfitz -- cl_entities is now dynamically allocated
 	cl_max_edicts = CLAMP (MIN_EDICTS,(int)max_edicts.value,MAX_EDICTS);
 	cl_entities = (entity_t *) Hunk_AllocName (cl_max_edicts*sizeof(entity_t), "cl_entities");
+	cl.snapshot_baseline = (snapshot_state_t *) Hunk_AllocName (cl_max_edicts*sizeof(snapshot_state_t), "cl_snap_base");
+	cl.snapshot_present = (byte *) Hunk_AllocName (cl_max_edicts*sizeof(byte), "cl_snap_present");
 	//johnfitz
 
 	memset (v_punchangles, 0, sizeof (v_punchangles));

--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -96,7 +96,9 @@ const char *svc_strings[] =
 	"svc_chat", // 53
 	"svc_levelcompleted", // 54
 	"svc_backtolobby", // 55
-	"svc_localsound" // 56
+	"svc_localsound", // 56
+	"svc_snapshot_full", // 57
+	"svc_snapshot_delta" // 58
 };
 #define NUM_SVC_STRINGS Q_COUNTOF(svc_strings)
 
@@ -674,6 +676,171 @@ void CL_ParseUpdate (int bits)
 	}
 }
 
+static void CL_SendSnapshotAck (unsigned int seq)
+{
+	if (cls.demoplayback || cls.state != ca_connected)
+		return;
+	MSG_WriteByte (&cls.message, clc_snapshot_ack);
+	MSG_WriteLong (&cls.message, (int)seq);
+}
+
+static void CL_ReadSnapshotState (snapshot_state_t *state)
+{
+	int i;
+
+	for (i = 0; i < 3; i++)
+	{
+		state->state.origin[i] = MSG_ReadCoord (cl.protocolflags);
+		state->state.angles[i] = MSG_ReadAngle (cl.protocolflags);
+	}
+	state->state.modelindex = (unsigned short)MSG_ReadShort ();
+	state->state.frame = (unsigned short)MSG_ReadShort ();
+	state->state.colormap = (unsigned char)MSG_ReadByte ();
+	state->state.skin = (unsigned char)MSG_ReadByte ();
+	state->state.effects = MSG_ReadByte ();
+	state->state.alpha = (unsigned char)MSG_ReadByte ();
+	state->state.scale = (unsigned char)MSG_ReadByte ();
+	state->step = (byte)MSG_ReadByte ();
+}
+
+static void CL_ReadSnapshotDeltaFields (snapshot_state_t *state, unsigned int mask)
+{
+	if (mask & SNAP_ORIGIN1)
+		state->state.origin[0] = MSG_ReadCoord (cl.protocolflags);
+	if (mask & SNAP_ORIGIN2)
+		state->state.origin[1] = MSG_ReadCoord (cl.protocolflags);
+	if (mask & SNAP_ORIGIN3)
+		state->state.origin[2] = MSG_ReadCoord (cl.protocolflags);
+	if (mask & SNAP_ANGLE1)
+		state->state.angles[0] = MSG_ReadAngle (cl.protocolflags);
+	if (mask & SNAP_ANGLE2)
+		state->state.angles[1] = MSG_ReadAngle (cl.protocolflags);
+	if (mask & SNAP_ANGLE3)
+		state->state.angles[2] = MSG_ReadAngle (cl.protocolflags);
+	if (mask & SNAP_MODEL)
+		state->state.modelindex = (unsigned short)MSG_ReadShort ();
+	if (mask & SNAP_FRAME)
+		state->state.frame = (unsigned short)MSG_ReadShort ();
+	if (mask & SNAP_COLORMAP)
+		state->state.colormap = (unsigned char)MSG_ReadByte ();
+	if (mask & SNAP_SKIN)
+		state->state.skin = (unsigned char)MSG_ReadByte ();
+	if (mask & SNAP_EFFECTS)
+		state->state.effects = MSG_ReadByte ();
+	if (mask & SNAP_ALPHA)
+		state->state.alpha = (unsigned char)MSG_ReadByte ();
+	if (mask & SNAP_SCALE)
+		state->state.scale = (unsigned char)MSG_ReadByte ();
+	if (mask & SNAP_STEP)
+		state->step = (byte)MSG_ReadByte ();
+}
+
+static void CL_ClearSnapshotEntity (int entnum)
+{
+	entity_t *ent;
+
+	if (entnum <= 0 || entnum >= cl_max_edicts)
+		return;
+	ent = &cl_entities[entnum];
+
+	ent->model = NULL;
+	ent->effects = 0;
+	ent->forcelink = true;
+}
+
+static void CL_ApplySnapshotState (int entnum, const snapshot_state_t *state)
+{
+	entity_t	*ent;
+	qboolean	forcelink;
+	double		oldtime;
+	int			i;
+	int			skin;
+	model_t		*model;
+
+	ent = CL_EntityNum (entnum);
+	forcelink = (ent->msgtime != cl.mtime[1]);
+	oldtime = ent->msgtime;
+
+	if (oldtime + 0.2 < cl.mtime[0])
+		ent->lerpflags |= LERP_RESETANIM;
+
+	ent->msgtime = cl.mtime[0];
+
+	VectorCopy (ent->msg_origins[0], ent->msg_origins[1]);
+	VectorCopy (ent->msg_angles[0], ent->msg_angles[1]);
+
+	ent->frame = state->state.frame;
+	ent->effects = state->state.effects;
+	ent->alpha = state->state.alpha;
+	ent->scale = state->state.scale;
+
+	i = state->state.colormap;
+	if (!i)
+		ent->colormap = vid.colormap;
+	else
+	{
+		if (i > cl.maxclients)
+			Sys_Error ("CL_ApplySnapshotState: i >= cl.maxclients");
+		ent->colormap = cl.scores[i-1].translations;
+	}
+
+	skin = state->state.skin;
+	if (skin != ent->skinnum)
+	{
+		ent->skinnum = skin;
+		if (entnum > 0 && entnum <= cl.maxclients)
+			R_TranslateNewPlayerSkin (entnum - 1);
+	}
+
+	for (i = 0; i < 3; i++)
+	{
+		ent->msg_origins[0][i] = state->state.origin[i];
+		ent->msg_angles[0][i] = state->state.angles[i];
+	}
+
+	if (state->step)
+	{
+		ent->lerpflags |= LERP_MOVESTEP;
+		ent->forcelink = true;
+	}
+	else
+		ent->lerpflags &= ~LERP_MOVESTEP;
+
+	model = cl.model_precache[state->state.modelindex];
+	if (model != ent->model)
+	{
+		ent->model = model;
+		if (model)
+		{
+			if (model->synctype == ST_FRAMETIME)
+				ent->syncbase = -cl.time;
+			else if (model->synctype == ST_RAND)
+				ent->syncbase = (float)(rand()&0x7fff) / 0x7fff;
+			else
+				ent->syncbase = 0.0;
+		}
+		else
+			forcelink = true;
+		if (entnum > 0 && entnum <= cl.maxclients)
+			R_TranslateNewPlayerSkin (entnum - 1);
+
+		ent->lerpflags |= LERP_RESETANIM;
+	}
+	else if (model && model->synctype == ST_FRAMETIME)
+		ent->syncbase = -cl.time;
+
+	ent->baseline = state->state;
+
+	if (forcelink)
+	{
+		VectorCopy (ent->msg_origins[0], ent->msg_origins[1]);
+		VectorCopy (ent->msg_origins[0], ent->origin);
+		VectorCopy (ent->msg_angles[0], ent->msg_angles[1]);
+		VectorCopy (ent->msg_angles[0], ent->angles);
+		ent->forcelink = true;
+	}
+}
+
 /*
 ==================
 CL_ParseBaseline
@@ -700,6 +867,107 @@ void CL_ParseBaseline (entity_t *ent, int version) //johnfitz -- added argument
 
 	ent->baseline.alpha = (bits & B_ALPHA) ? MSG_ReadByte() : ENTALPHA_DEFAULT; //johnfitz -- PROTOCOL_FITZQUAKE
 	ent->baseline.scale = (bits & B_SCALE) ? MSG_ReadByte() : ENTSCALE_DEFAULT;
+}
+
+static void CL_ParseSnapshotFull (void)
+{
+	unsigned int seq;
+	int count;
+	int i;
+
+	seq = (unsigned int)MSG_ReadLong ();
+	count = (unsigned short)MSG_ReadShort ();
+
+	memset (cl.snapshot_present, 0, cl_max_edicts * sizeof(byte));
+	for (i = 1; i < cl_max_edicts; i++)
+		CL_ClearSnapshotEntity (i);
+
+	for (i = 0; i < count; i++)
+	{
+		int entnum;
+		snapshot_state_t state;
+
+		entnum = (unsigned short)MSG_ReadShort ();
+		if (entnum <= 0 || entnum >= cl_max_edicts)
+			Host_Error ("CL_ParseSnapshotFull: entnum out of range");
+		CL_ReadSnapshotState (&state);
+		cl.snapshot_baseline[entnum] = state;
+		cl.snapshot_present[entnum] = 1;
+		CL_ApplySnapshotState (entnum, &state);
+	}
+
+	cl.snapshot_baseline_seq = seq;
+	CL_SendSnapshotAck (seq);
+}
+
+static void CL_ParseSnapshotDelta (void)
+{
+	unsigned int seq;
+	unsigned int baseline_seq;
+	unsigned int mask;
+	int count;
+	int i;
+	qboolean baseline_match;
+
+	seq = (unsigned int)MSG_ReadLong ();
+	baseline_seq = (unsigned int)MSG_ReadLong ();
+	baseline_match = (baseline_seq != 0 && baseline_seq == cl.snapshot_baseline_seq);
+
+	count = (unsigned short)MSG_ReadShort ();
+	for (i = 0; i < count; i++)
+	{
+		int entnum = (unsigned short)MSG_ReadShort ();
+		if (baseline_match && entnum > 0 && entnum < cl_max_edicts)
+		{
+			cl.snapshot_present[entnum] = 0;
+			CL_ClearSnapshotEntity (entnum);
+		}
+	}
+
+	count = (unsigned short)MSG_ReadShort ();
+	for (i = 0; i < count; i++)
+	{
+		int entnum = (unsigned short)MSG_ReadShort ();
+		snapshot_state_t state;
+
+		CL_ReadSnapshotState (&state);
+		if (baseline_match && entnum > 0 && entnum < cl_max_edicts)
+		{
+			cl.snapshot_baseline[entnum] = state;
+			cl.snapshot_present[entnum] = 1;
+			CL_ApplySnapshotState (entnum, &state);
+		}
+	}
+
+	count = (unsigned short)MSG_ReadShort ();
+	for (i = 0; i < count; i++)
+	{
+		int entnum = (unsigned short)MSG_ReadShort ();
+		mask = (unsigned int)MSG_ReadLong ();
+		if (baseline_match && entnum > 0 && entnum < cl_max_edicts && cl.snapshot_present[entnum])
+		{
+			snapshot_state_t state = cl.snapshot_baseline[entnum];
+			CL_ReadSnapshotDeltaFields (&state, mask);
+			cl.snapshot_baseline[entnum] = state;
+			CL_ApplySnapshotState (entnum, &state);
+		}
+		else
+		{
+			snapshot_state_t scratch;
+			memset (&scratch, 0, sizeof(scratch));
+			CL_ReadSnapshotDeltaFields (&scratch, mask);
+		}
+	}
+
+	if (baseline_match)
+	{
+		cl.snapshot_baseline_seq = seq;
+		CL_SendSnapshotAck (seq);
+	}
+	else
+	{
+		CL_SendSnapshotAck (0);
+	}
 }
 
 #define CL_SetHudStat(stat) cl.statsf[stat] = cl.stats[stat]
@@ -1386,9 +1654,16 @@ void CL_ParseServerMessage (void)
 		case svc_localsound:
 			CL_ParseLocalSound();
 			break;
+
+		case svc_snapshot_full:
+			CL_ParseSnapshotFull ();
+			break;
+
+		case svc_snapshot_delta:
+			CL_ParseSnapshotDelta ();
+			break;
 		}
 
 		lastcmd = cmd; //johnfitz
 	}
 }
-

--- a/Quake/client.h
+++ b/Quake/client.h
@@ -271,6 +271,9 @@ typedef struct
 	int			num_entities;	// held in cl_entities array
 	int			num_statics;	// held in cl_staticentities array
 	entity_t	viewent;			// the gun model
+	unsigned int snapshot_baseline_seq;
+	snapshot_state_t *snapshot_baseline;
+	byte		*snapshot_present;
 
 	int			cdtrack, looptrack;	// cd audio
 

--- a/Quake/protocol.h
+++ b/Quake/protocol.h
@@ -69,6 +69,22 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define U_EXTEND2		(1<<23) // another byte to follow, future expansion
 //johnfitz
 
+// snapshot delta field bits
+#define SNAP_ORIGIN1	(1u<<0)
+#define SNAP_ORIGIN2	(1u<<1)
+#define SNAP_ORIGIN3	(1u<<2)
+#define SNAP_ANGLE1		(1u<<3)
+#define SNAP_ANGLE2		(1u<<4)
+#define SNAP_ANGLE3		(1u<<5)
+#define SNAP_MODEL		(1u<<6)
+#define SNAP_FRAME		(1u<<7)
+#define SNAP_COLORMAP	(1u<<8)
+#define SNAP_SKIN		(1u<<9)
+#define SNAP_EFFECTS	(1u<<10)
+#define SNAP_ALPHA		(1u<<11)
+#define SNAP_SCALE		(1u<<12)
+#define SNAP_STEP		(1u<<13)
+
 //johnfitz -- PROTOCOL_NEHAHRA transparency
 #define U_TRANS			(1<<15)
 //johnfitz
@@ -223,6 +239,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define svc_levelcompleted	54
 #define svc_backtolobby		55
 #define svc_localsound		56
+#define svc_snapshot_full	57
+#define svc_snapshot_delta	58
 
 //
 // client to server
@@ -232,6 +250,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define	clc_disconnect	2
 #define	clc_move		3		// [usercmd_t]
 #define	clc_stringcmd	4		// [string] message
+#define	clc_snapshot_ack	5	// [long] seq
 
 //
 // temp entity events
@@ -266,6 +285,12 @@ typedef struct
 	unsigned char	scale;		//Quakespasm: for model scale support.
 	int		effects;
 } entity_state_t;
+
+typedef struct
+{
+	entity_state_t	state;
+	byte		step;
+} snapshot_state_t;
 
 typedef struct
 {

--- a/Quake/server.h
+++ b/Quake/server.h
@@ -161,6 +161,17 @@ typedef struct client_s
 	int				oldstats_i[MAX_CL_STATS];		//previous values of stats. if these differ from the current values, reflag resendstats.
 	float			oldstats_f[MAX_CL_STATS];		//previous values of stats. if these differ from the current values, reflag resendstats.
 	char			*oldstats_s[MAX_CL_STATS];
+
+	unsigned int	snapshot_next_seq;
+	unsigned int	snapshot_baseline_seq;
+	unsigned int	snapshot_pending_seq;
+	unsigned int	snapshot_pending_baseline_seq;
+	double			snapshot_pending_time;
+	qboolean		snapshot_pending_is_delta;
+	snapshot_state_t *snapshot_baseline;
+	byte			*snapshot_baseline_present;
+	snapshot_state_t *snapshot_pending;
+	byte			*snapshot_pending_present;
 } client_t;
 
 
@@ -307,5 +318,6 @@ void SV_CheckForNewClients (void);
 void SV_RunClients (void);
 void SV_SaveSpawnparms (void);
 void SV_SpawnServer (const char *server);
+void SV_SnapshotAck (client_t *client, unsigned int seq);
 
 #endif	/* QUAKE_SERVER_H */

--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -34,6 +34,9 @@ int		sv_protocol = PROTOCOL_RMQ; //johnfitz
 extern cvar_t nomonsters;
 
 static cvar_t sv_netsort = {"sv_netsort", "1", CVAR_NONE};
+static cvar_t sv_snapshotdelta = {"sv_snapshotdelta", "1", CVAR_NONE};
+static cvar_t sv_snapshotdebug = {"sv_snapshotdebug", "0", CVAR_NONE};
+static cvar_t sv_snapshottimeout = {"sv_snapshottimeout", "1000", CVAR_NONE};
 
 //============================================================================
 
@@ -174,6 +177,9 @@ void SV_Init (void)
 	Cvar_RegisterVariable (&sv_gameplayfix_random);
 	Cvar_RegisterVariable (&sv_gameplayfix_elevators);
 	Cvar_RegisterVariable (&sv_netsort);
+	Cvar_RegisterVariable (&sv_snapshotdelta);
+	Cvar_RegisterVariable (&sv_snapshotdebug);
+	Cvar_RegisterVariable (&sv_snapshottimeout);
 	Cvar_RegisterVariable (&sv_autoload);
 	Cvar_RegisterVariable (&sv_autosave);
 	Cvar_RegisterVariable (&sv_autosave_interval);
@@ -472,8 +478,16 @@ void SV_ConnectClient (int clientnum)
 	struct qsocket_s *netconnection;
 	int				i;
 	float			spawn_parms[NUM_SPAWN_PARMS];
+	snapshot_state_t *snapshot_baseline;
+	byte			*snapshot_baseline_present;
+	snapshot_state_t *snapshot_pending;
+	byte			*snapshot_pending_present;
 
 	client = svs.clients + clientnum;
+	snapshot_baseline = client->snapshot_baseline;
+	snapshot_baseline_present = client->snapshot_baseline_present;
+	snapshot_pending = client->snapshot_pending;
+	snapshot_pending_present = client->snapshot_pending_present;
 
 	Con_DPrintf ("Client %s connected\n", NET_QSocketGetAddressString(client->netconnection));
 
@@ -487,6 +501,13 @@ void SV_ConnectClient (int clientnum)
 	if (sv.loadgame)
 		memcpy (spawn_parms, client->spawn_parms, sizeof(spawn_parms));
 	memset (client, 0, sizeof(*client));
+	client->snapshot_baseline = snapshot_baseline;
+	client->snapshot_baseline_present = snapshot_baseline_present;
+	client->snapshot_pending = snapshot_pending;
+	client->snapshot_pending_present = snapshot_pending_present;
+	if (!client->snapshot_baseline || !client->snapshot_baseline_present || !client->snapshot_pending || !client->snapshot_pending_present)
+		SV_InitClientSnapshotData (client);
+	SV_ResetClientSnapshot (client);
 	client->netconnection = netconnection;
 
 	strcpy (client->name, "unconnected");
@@ -682,6 +703,449 @@ static uint16_t		net_edicts[MAX_NET_EDICTS];
 static byte			net_edict_dists[MAX_NET_EDICTS];
 static int			net_edict_bins[256];
 static uint16_t		net_edicts_sorted[MAX_NET_EDICTS];
+
+static void SV_InitClientSnapshotData (client_t *client)
+{
+	int max_edicts = qcvm->max_edicts;
+
+	client->snapshot_baseline = (snapshot_state_t *) Hunk_AllocName (max_edicts * sizeof(snapshot_state_t), "sv_snap_base");
+	client->snapshot_baseline_present = (byte *) Hunk_AllocName (max_edicts * sizeof(byte), "sv_snap_base_present");
+	client->snapshot_pending = (snapshot_state_t *) Hunk_AllocName (max_edicts * sizeof(snapshot_state_t), "sv_snap_pending");
+	client->snapshot_pending_present = (byte *) Hunk_AllocName (max_edicts * sizeof(byte), "sv_snap_pending_present");
+}
+
+static void SV_ResetClientSnapshot (client_t *client)
+{
+	int max_edicts = qcvm->max_edicts;
+
+	client->snapshot_next_seq = 1;
+	client->snapshot_baseline_seq = 0;
+	client->snapshot_pending_seq = 0;
+	client->snapshot_pending_baseline_seq = 0;
+	client->snapshot_pending_time = 0;
+	client->snapshot_pending_is_delta = false;
+	if (client->snapshot_baseline_present)
+		memset (client->snapshot_baseline_present, 0, max_edicts * sizeof(byte));
+	if (client->snapshot_pending_present)
+		memset (client->snapshot_pending_present, 0, max_edicts * sizeof(byte));
+}
+
+static int SV_BuildNetEdictsList (edict_t *clent)
+{
+	int		e, i, numents;
+	byte	*pvs;
+	vec3_t	org, forward, right, up;
+	float	dist, size;
+	edict_t	*ent;
+
+	VectorAdd (clent->v.origin, clent->v.view_ofs, org);
+	pvs = SV_FatPVS (org, sv.worldmodel);
+
+	AngleVectors (clent->v.v_angle, forward, right, up);
+
+	memset (net_edict_bins, 0, sizeof (net_edict_bins));
+
+	if (sv_netsort.value)
+	{
+		net_edicts[0] = NUM_FOR_EDICT (clent);
+		net_edict_dists[0] = 0;
+		net_edict_bins[0] = 1;
+	}
+	else
+		net_edicts_sorted[0] = NUM_FOR_EDICT (clent);
+	numents = 1;
+
+	ent = NEXT_EDICT(qcvm->edicts);
+	for (e=1 ; e<qcvm->num_edicts ; e++, ent = NEXT_EDICT(ent))
+	{
+		if (ent != clent)
+		{
+			if (!ent->v.modelindex || !PR_GetString(ent->v.model)[0])
+				continue;
+
+			if (sv.protocol == PROTOCOL_NETQUAKE && (int)ent->v.modelindex & 0xFF00)
+				continue;
+
+			for (i=0 ; i < ent->num_leafs ; i++)
+				if (pvs[ent->leafnums[i] >> 3] & (1 << (ent->leafnums[i]&7) ))
+					break;
+
+			if (i == ent->num_leafs && ent->num_leafs < MAX_ENT_LEAFS)
+				continue;
+
+			if (sv_netsort.value)
+			{
+				dist = size = 0.f;
+				for (i=0 ; i<3 ; i++)
+				{
+					float delta = CLAMP (ent->v.absmin[i], org[i], ent->v.absmax[i]) - org[i];
+					dist += delta * delta;
+					delta = ent->v.absmax[i] - ent->v.absmin[i];
+					size += delta * delta;
+				}
+				size = q_max (1.f, size);
+
+				dist = 8.f * sqrt (sqrt (dist/size));
+				net_edict_dists[numents] = (int) q_min (dist, 255.f);
+				net_edicts[numents] = e;
+
+				dist = 0.f;
+				for (i=0 ; i<3 ; i++)
+					dist += ((forward[i] < 0.f ? ent->v.absmin[i] : ent->v.absmax[i]) - org[i]) * forward[i];
+				if (dist < 0.f)
+					net_edict_dists[numents] |= 128;
+
+				net_edict_bins[net_edict_dists[numents]]++;
+			}
+			else
+				net_edicts_sorted[numents] = e;
+
+			if (++numents == MAX_NET_EDICTS)
+				break;
+		}
+	}
+
+	if (sv_netsort.value)
+	{
+		e = 0;
+		for (i=0 ; i<countof(net_edict_bins) ; i++)
+		{
+			int tmp = net_edict_bins[i];
+			net_edict_bins[i] = e;
+			e += tmp;
+		}
+
+		for (e=0 ; e<numents ; e++)
+			net_edicts_sorted[net_edict_bins[net_edict_dists[e]]++] = net_edicts[e];
+	}
+
+	return numents;
+}
+
+static void SV_FillSnapshotState (edict_t *ent, snapshot_state_t *out)
+{
+	int	i;
+	eval_t	*val;
+
+	for (i=0 ; i<3 ; i++)
+	{
+		out->state.origin[i] = ent->v.origin[i];
+		out->state.angles[i] = ent->v.angles[i];
+	}
+	out->state.modelindex = ent->v.modelindex;
+	out->state.frame = ent->v.frame;
+	out->state.colormap = ent->v.colormap;
+	out->state.skin = ent->v.skin;
+	out->state.effects = (int)ent->v.effects & qcvm->effects_mask;
+
+	val = GetEdictFieldValueByName(ent, "alpha");
+	if (val)
+		ent->alpha = ENTALPHA_ENCODE(val->_float);
+	out->state.alpha = ent->alpha;
+
+	val = GetEdictFieldValueByName(ent, "scale");
+	if (val)
+		ent->scale = ENTSCALE_ENCODE(val->_float);
+	else
+		ent->scale = ENTSCALE_DEFAULT;
+	out->state.scale = ent->scale;
+
+	out->step = (ent->v.movetype == MOVETYPE_STEP);
+}
+
+static int SV_BuildClientSnapshot (edict_t *clent, snapshot_state_t *states, byte *present)
+{
+	int	num, j, numents, count;
+	edict_t	*ent;
+
+	memset (present, 0, qcvm->max_edicts * sizeof(byte));
+
+	numents = SV_BuildNetEdictsList (clent);
+	count = 0;
+	for (j=0 ; j<numents ; j++)
+	{
+		num = net_edicts_sorted[j];
+		ent = EDICT_NUM (num);
+
+		SV_FillSnapshotState (ent, &states[num]);
+
+		if (states[num].state.alpha == ENTALPHA_ZERO && !((int)ent->v.effects & qcvm->effects_mask))
+			continue;
+
+		present[num] = 1;
+		count++;
+	}
+
+	return count;
+}
+
+static void SV_WriteSnapshotState (sizebuf_t *msg, const snapshot_state_t *state)
+{
+	int i;
+
+	for (i=0 ; i<3 ; i++)
+	{
+		MSG_WriteCoord (msg, state->state.origin[i], sv.protocolflags);
+		MSG_WriteAngle (msg, state->state.angles[i], sv.protocolflags);
+	}
+	MSG_WriteShort (msg, state->state.modelindex);
+	MSG_WriteShort (msg, state->state.frame);
+	MSG_WriteByte (msg, state->state.colormap);
+	MSG_WriteByte (msg, state->state.skin);
+	MSG_WriteByte (msg, state->state.effects);
+	MSG_WriteByte (msg, state->state.alpha);
+	MSG_WriteByte (msg, state->state.scale);
+	MSG_WriteByte (msg, state->step);
+}
+
+static unsigned int SV_SnapshotFieldMask (const snapshot_state_t *next, const snapshot_state_t *base)
+{
+	unsigned int mask = 0;
+
+	if (next->state.origin[0] != base->state.origin[0])
+		mask |= SNAP_ORIGIN1;
+	if (next->state.origin[1] != base->state.origin[1])
+		mask |= SNAP_ORIGIN2;
+	if (next->state.origin[2] != base->state.origin[2])
+		mask |= SNAP_ORIGIN3;
+	if (next->state.angles[0] != base->state.angles[0])
+		mask |= SNAP_ANGLE1;
+	if (next->state.angles[1] != base->state.angles[1])
+		mask |= SNAP_ANGLE2;
+	if (next->state.angles[2] != base->state.angles[2])
+		mask |= SNAP_ANGLE3;
+	if (next->state.modelindex != base->state.modelindex)
+		mask |= SNAP_MODEL;
+	if (next->state.frame != base->state.frame)
+		mask |= SNAP_FRAME;
+	if (next->state.colormap != base->state.colormap)
+		mask |= SNAP_COLORMAP;
+	if (next->state.skin != base->state.skin)
+		mask |= SNAP_SKIN;
+	if (next->state.effects != base->state.effects)
+		mask |= SNAP_EFFECTS;
+	if (next->state.alpha != base->state.alpha)
+		mask |= SNAP_ALPHA;
+	if (next->state.scale != base->state.scale)
+		mask |= SNAP_SCALE;
+	if (next->step != base->step)
+		mask |= SNAP_STEP;
+
+	return mask;
+}
+
+static void SV_WriteSnapshotFull (sizebuf_t *msg, unsigned int seq, const snapshot_state_t *states, const byte *present, int max_edicts, int *out_count)
+{
+	int count = 0;
+	int entnum;
+
+	for (entnum = 1; entnum < max_edicts; entnum++)
+	{
+		if (present[entnum])
+			count++;
+	}
+
+	MSG_WriteByte (msg, svc_snapshot_full);
+	MSG_WriteLong (msg, (int)seq);
+	MSG_WriteShort (msg, count);
+	for (entnum = 1; entnum < max_edicts; entnum++)
+	{
+		if (!present[entnum])
+			continue;
+		MSG_WriteShort (msg, entnum);
+		SV_WriteSnapshotState (msg, &states[entnum]);
+	}
+
+	if (out_count)
+		*out_count = count;
+}
+
+static void SV_WriteSnapshotDelta (sizebuf_t *msg, unsigned int seq, unsigned int baseline_seq,
+	const snapshot_state_t *states, const byte *present, const snapshot_state_t *baseline,
+	const byte *baseline_present, int max_edicts, int *out_remove, int *out_add, int *out_update)
+{
+	int entnum;
+	int remove_count = 0;
+	int add_count = 0;
+	int update_count = 0;
+
+	MSG_WriteByte (msg, svc_snapshot_delta);
+	MSG_WriteLong (msg, (int)seq);
+	MSG_WriteLong (msg, (int)baseline_seq);
+
+	for (entnum = 1; entnum < max_edicts; entnum++)
+		if (baseline_present[entnum] && !present[entnum])
+			remove_count++;
+	MSG_WriteShort (msg, remove_count);
+	for (entnum = 1; entnum < max_edicts; entnum++)
+	{
+		if (baseline_present[entnum] && !present[entnum])
+			MSG_WriteShort (msg, entnum);
+	}
+
+	for (entnum = 1; entnum < max_edicts; entnum++)
+		if (!baseline_present[entnum] && present[entnum])
+			add_count++;
+	MSG_WriteShort (msg, add_count);
+	for (entnum = 1; entnum < max_edicts; entnum++)
+	{
+		if (!baseline_present[entnum] && present[entnum])
+		{
+			MSG_WriteShort (msg, entnum);
+			SV_WriteSnapshotState (msg, &states[entnum]);
+		}
+	}
+
+	for (entnum = 1; entnum < max_edicts; entnum++)
+	{
+		unsigned int mask;
+
+		if (!baseline_present[entnum] || !present[entnum])
+			continue;
+		mask = SV_SnapshotFieldMask (&states[entnum], &baseline[entnum]);
+		if (mask)
+			update_count++;
+	}
+
+	MSG_WriteShort (msg, update_count);
+	for (entnum = 1; entnum < max_edicts; entnum++)
+	{
+		unsigned int mask;
+
+		if (!baseline_present[entnum] || !present[entnum])
+			continue;
+		mask = SV_SnapshotFieldMask (&states[entnum], &baseline[entnum]);
+		if (!mask)
+			continue;
+		MSG_WriteShort (msg, entnum);
+		MSG_WriteLong (msg, (int)mask);
+		if (mask & SNAP_ORIGIN1)
+			MSG_WriteCoord (msg, states[entnum].state.origin[0], sv.protocolflags);
+		if (mask & SNAP_ORIGIN2)
+			MSG_WriteCoord (msg, states[entnum].state.origin[1], sv.protocolflags);
+		if (mask & SNAP_ORIGIN3)
+			MSG_WriteCoord (msg, states[entnum].state.origin[2], sv.protocolflags);
+		if (mask & SNAP_ANGLE1)
+			MSG_WriteAngle (msg, states[entnum].state.angles[0], sv.protocolflags);
+		if (mask & SNAP_ANGLE2)
+			MSG_WriteAngle (msg, states[entnum].state.angles[1], sv.protocolflags);
+		if (mask & SNAP_ANGLE3)
+			MSG_WriteAngle (msg, states[entnum].state.angles[2], sv.protocolflags);
+		if (mask & SNAP_MODEL)
+			MSG_WriteShort (msg, states[entnum].state.modelindex);
+		if (mask & SNAP_FRAME)
+			MSG_WriteShort (msg, states[entnum].state.frame);
+		if (mask & SNAP_COLORMAP)
+			MSG_WriteByte (msg, states[entnum].state.colormap);
+		if (mask & SNAP_SKIN)
+			MSG_WriteByte (msg, states[entnum].state.skin);
+		if (mask & SNAP_EFFECTS)
+			MSG_WriteByte (msg, states[entnum].state.effects);
+		if (mask & SNAP_ALPHA)
+			MSG_WriteByte (msg, states[entnum].state.alpha);
+		if (mask & SNAP_SCALE)
+			MSG_WriteByte (msg, states[entnum].state.scale);
+		if (mask & SNAP_STEP)
+			MSG_WriteByte (msg, states[entnum].step);
+	}
+
+	if (out_remove)
+		*out_remove = remove_count;
+	if (out_add)
+		*out_add = add_count;
+	if (out_update)
+		*out_update = update_count;
+}
+
+static void SV_SendSnapshot (client_t *client, sizebuf_t *msg)
+{
+	int start_size = msg->cursize;
+	int add_count = 0;
+	int remove_count = 0;
+	int update_count = 0;
+	int full_count = 0;
+	double timeout_s = sv_snapshottimeout.value / 1000.0;
+	qboolean use_delta;
+
+	if (client->snapshot_pending_seq)
+	{
+		if (client->snapshot_pending_is_delta && timeout_s > 0.0 && realtime - client->snapshot_pending_time > timeout_s)
+			client->snapshot_pending_is_delta = false;
+		use_delta = client->snapshot_pending_is_delta;
+		if (use_delta)
+			SV_WriteSnapshotDelta (msg, client->snapshot_pending_seq, client->snapshot_pending_baseline_seq,
+				client->snapshot_pending, client->snapshot_pending_present,
+				client->snapshot_baseline, client->snapshot_baseline_present, qcvm->max_edicts,
+				&remove_count, &add_count, &update_count);
+		else
+			SV_WriteSnapshotFull (msg, client->snapshot_pending_seq, client->snapshot_pending,
+				client->snapshot_pending_present, qcvm->max_edicts, &full_count);
+		client->snapshot_pending_time = realtime;
+	}
+	else
+	{
+		SV_BuildClientSnapshot (client->edict, client->snapshot_pending, client->snapshot_pending_present);
+		client->snapshot_pending_seq = client->snapshot_next_seq++;
+		if (!client->snapshot_next_seq)
+			client->snapshot_next_seq = 1;
+		client->snapshot_pending_time = realtime;
+		client->snapshot_pending_baseline_seq = client->snapshot_baseline_seq;
+
+		use_delta = (sv_snapshotdelta.value && client->snapshot_baseline_seq);
+		client->snapshot_pending_is_delta = use_delta;
+		if (use_delta)
+			SV_WriteSnapshotDelta (msg, client->snapshot_pending_seq, client->snapshot_baseline_seq,
+				client->snapshot_pending, client->snapshot_pending_present,
+				client->snapshot_baseline, client->snapshot_baseline_present, qcvm->max_edicts,
+				&remove_count, &add_count, &update_count);
+		else
+			SV_WriteSnapshotFull (msg, client->snapshot_pending_seq, client->snapshot_pending,
+				client->snapshot_pending_present, qcvm->max_edicts, &full_count);
+	}
+
+	if (sv_snapshotdebug.value)
+	{
+		int size_delta = msg->cursize - start_size;
+		if (client->snapshot_pending_is_delta)
+			Con_Printf ("snapshot %s seq %u base %u size %d add %d upd %d rem %d\n",
+				client->name, client->snapshot_pending_seq, client->snapshot_pending_baseline_seq,
+				size_delta, add_count, update_count, remove_count);
+		else
+			Con_Printf ("snapshot %s seq %u full size %d ents %d\n",
+				client->name, client->snapshot_pending_seq, size_delta, full_count);
+	}
+}
+
+void SV_SnapshotAck (client_t *client, unsigned int seq)
+{
+	if (!client->snapshot_baseline_present || !client->snapshot_pending_present)
+		return;
+
+	if (seq == 0)
+	{
+		SV_ResetClientSnapshot (client);
+		if (sv_snapshotdebug.value)
+			Con_Printf ("snapshot %s baseline reset request\n", client->name);
+		return;
+	}
+
+	if (seq != client->snapshot_pending_seq)
+	{
+		if (sv_snapshotdebug.value)
+			Con_Printf ("snapshot %s ack seq %u ignored (pending %u)\n", client->name, seq, client->snapshot_pending_seq);
+		return;
+	}
+
+	memcpy (client->snapshot_baseline, client->snapshot_pending, qcvm->max_edicts * sizeof(snapshot_state_t));
+	memcpy (client->snapshot_baseline_present, client->snapshot_pending_present, qcvm->max_edicts * sizeof(byte));
+	client->snapshot_baseline_seq = seq;
+	client->snapshot_pending_seq = 0;
+	client->snapshot_pending_is_delta = false;
+	client->snapshot_pending_baseline_seq = 0;
+
+	if (sv_snapshotdebug.value)
+		Con_Printf ("snapshot %s ack seq %u\n", client->name, seq);
+}
 
 /*
 =============
@@ -1198,7 +1662,7 @@ qboolean SV_SendClientDatagram (client_t *client)
 // add the client specific data to the datagram
 	SV_WriteClientdataToMessage (client->edict, &msg);
 
-	SV_WriteEntitiesToClient (client->edict, &msg);
+	SV_SendSnapshot (client, &msg);
 
 // copy the server datagram if there is space
 	if (msg.cursize + sv.datagram.cursize < msg.maxsize)
@@ -1993,6 +2457,11 @@ void SV_SpawnServer (const char *server)
 		ent = EDICT_NUM(i+1);
 		svs.clients[i].edict = ent;
 	}
+	for (i=0 ; i<svs.maxclients ; i++)
+	{
+		SV_InitClientSnapshotData (&svs.clients[i]);
+		SV_ResetClientSnapshot (&svs.clients[i]);
+	}
 
 	sv.state = ss_loading;
 	sv.paused = false;
@@ -2079,4 +2548,3 @@ void SV_SpawnServer (const char *server)
 	if (sv.mapchecks.active)
 		SV_PrintMapChecklist ();
 }
-

--- a/Quake/sv_user.c
+++ b/Quake/sv_user.c
@@ -602,6 +602,10 @@ nextmsg:
 			case clc_move:
 				SV_ReadClientMove (&host_client->cmd);
 				break;
+
+			case clc_snapshot_ack:
+				SV_SnapshotAck (host_client, (unsigned int)MSG_ReadLong ());
+				break;
 			}
 		}
 	} while (ret == 1);
@@ -644,4 +648,3 @@ void SV_RunClients (void)
 			SV_ClientThink ();
 	}
 }
-

--- a/docs/snapshot_delta.md
+++ b/docs/snapshot_delta.md
@@ -1,0 +1,77 @@
+# Client Delta Snapshots
+
+This document describes the minimal "Client-Delta-Snapshots" system added to Ironwail. The goal is to reduce bandwidth by sending per-client delta-compressed entity snapshots instead of full entity updates every packet. Compatibility with legacy clients is **not** required.
+
+## Overview
+
+The server builds a snapshot for each client and sends either:
+
+- **FULL** snapshot (no baseline available)
+- **DELTA** snapshot (changes from the last acknowledged baseline)
+
+Clients ACK the snapshot sequence after successfully applying it. The server keeps **exactly one** baseline and uses a **stop-and-wait** approach: it will resend the pending snapshot until it receives the ACK. If the client reports a baseline mismatch, the server resets its baseline and sends a FULL snapshot.
+
+## Message types
+
+New protocol message types:
+
+- `svc_snapshot_full`
+- `svc_snapshot_delta`
+- `clc_snapshot_ack`
+
+## Snapshot data
+
+Snapshot state mirrors standard Quake entity update fields:
+
+- origin (vec3)
+- angles (vec3)
+- modelindex
+- frame
+- colormap
+- skin
+- effects
+- alpha
+- scale
+- step flag (movetype step)
+
+Entities are keyed by `entnum` and sorted by visibility (PVS) like standard entity updates.
+
+## Packet formats
+
+**FULL**
+
+```
+[svc_snapshot_full][uint32 seq][uint16 entityCount]
+  { [uint16 entnum][entityStateFull] }*
+```
+
+**DELTA**
+
+```
+[svc_snapshot_delta][uint32 seq][uint32 baseline_seq]
+  [uint16 removeCount]{ [uint16 entnum] }*
+  [uint16 addCount]{ [uint16 entnum][entityStateFull] }*
+  [uint16 updateCount]{ [uint16 entnum][uint32 fieldMask][changedFields...] }*
+```
+
+**ACK**
+
+```
+[clc_snapshot_ack][uint32 seq]
+```
+
+If the client receives a delta with a baseline mismatch, it still reads the packet but responds with `clc_snapshot_ack` **seq = 0** to force a full resend.
+
+## Stop-and-wait behavior
+
+Per client:
+
+- The server sends a snapshot with a new `seq` only when the previous one has been ACKed.
+- While awaiting ACK, the server resends the same snapshot every send tick.
+- After `sv_snapshottimeout` milliseconds, the server forces resends as FULL snapshots to recover from mismatches.
+
+## Cvars
+
+- `sv_snapshotdelta` (default `1`): enable delta snapshots; when `0`, always send FULL snapshots.
+- `sv_snapshotdebug` (default `0`): print snapshot sizes and counts.
+- `sv_snapshottimeout` (default `1000`): time (ms) before forcing FULL resend of a pending snapshot.


### PR DESCRIPTION
### Motivation

- Reduce server-to-client bandwidth by sending per-client delta-compressed entity snapshots instead of full entity updates every packet.
- Keep the design minimal: no client-side prediction changes, exactly one baseline per client, and deterministic, debuggable behavior.
- Provide a robust fallback so clients always get a full authoritative snapshot when baseline is missing or invalid.

### Description

- Add new protocol fields and messages: `svc_snapshot_full`, `svc_snapshot_delta`, and `clc_snapshot_ack`, plus `SNAP_*` field bits and a `snapshot_state_t` wrapper for entity state. (`Quake/protocol.h`)
- Implement server-side per-client snapshot storage, stop-and-wait send logic, full/delta encoding (remove/add/update ops), and ACK handling in `SV_SendSnapshot`/`SV_WriteSnapshot*`/`SV_SnapshotAck`. (`Quake/sv_main.c`, `Quake/sv_user.c`, `Quake/server.h`)
- Add client-side baseline storage and parsing/apply logic for full and delta snapshots, including ACKing behavior (`seq` or `seq=0` on mismatch), and integration into `CL_ParseServerMessage`. (`Quake/cl_parse.c`, `Quake/cl_main.c`, `Quake/client.h`)
- Expose runtime cvars for behavior and debugging: `sv_snapshotdelta`, `sv_snapshotdebug`, and `sv_snapshottimeout`, and add documentation `docs/snapshot_delta.md` describing formats and stop-and-wait semantics.

### Testing

- No automated tests were run on this change.
- Manual/acceptance scenarios suggested in docs: single client snapshot flow, large-entity maps to validate bandwidth savings, and baseline mismatch recovery were documented but not executed.
- Build and runtime validation should be performed in CI or locally before enabling on production servers.
- `sv_snapshotdebug` can be used to verify packet sizes and op counts during manual testing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e7621ba28832ebf7c4aa486b55f8e)