### PR TITLE
LAN discovery: per-interface broadcasts, socket options, and status responses

### DIFF
--- a/Quake/net_dgrm.c
+++ b/Quake/net_dgrm.c
@@ -883,7 +883,28 @@ static qsocket_t *_Datagram_CheckNewConnections (void)
 	control = BigLong(*((int *)net_message.data));
 	MSG_ReadLong();
 	if (control == -1)
+	{
+		const char *request = MSG_ReadString();
+
+		if (!q_strncasecmp(request, "status", 6) ||
+			!q_strncasecmp(request, "info", 4) ||
+			!q_strncasecmp(request, "A2A_INFO", 8))
+		{
+			char reply[MAX_MSGLEN];
+
+			q_snprintf (reply, sizeof (reply),
+					"\\hostname\\%s\\map\\%s\\players\\%d\\max\\%d",
+					hostname.string, sv.name, net_activeconnections, svs.maxclients);
+
+			SZ_Clear(&net_message);
+			MSG_WriteLong(&net_message, -1);
+			MSG_WriteString(&net_message, "statusResponse");
+			MSG_WriteString(&net_message, reply);
+			dfunc.Write (acceptsock, net_message.data, net_message.cursize, &clientaddr);
+			SZ_Clear(&net_message);
+		}
 		return NULL;
+	}
 	if ((control & (~NETFLAG_LENGTH_MASK)) != (int)NETFLAG_CTL)
 		return NULL;
 	if ((control & NETFLAG_LENGTH_MASK) != len)
@@ -1418,4 +1439,3 @@ qsocket_t *Datagram_Connect (const char *host)
 	}
 	return ret;
 }
-

--- a/Quake/net_udp.c
+++ b/Quake/net_udp.c
@@ -25,6 +25,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "net_sys.h"
 #include "quakedef.h"
 #include "net_defs.h"
+#include <ifaddrs.h>
+#include <net/if.h>
 
 static sys_socket_t net_acceptsocket = INVALID_SOCKET;	// socket for fielding new connections
 static sys_socket_t net_controlsocket;
@@ -168,6 +170,9 @@ sys_socket_t UDP_OpenSocket (int port)
 		Con_SafePrintf("UDP_OpenSocket: %s\n", socketerror(err));
 		return INVALID_SOCKET;
 	}
+
+	setsockopt (newsocket, SOL_SOCKET, SO_BROADCAST, (char *)&_true, sizeof(_true));
+	setsockopt (newsocket, SOL_SOCKET, SO_REUSEADDR, (char *)&_true, sizeof(_true));
 
 	if (ioctlsocket (newsocket, FIONBIO, &_true) == SOCKET_ERROR)
 		goto ErrorReturn;
@@ -321,9 +326,51 @@ static int UDP_MakeSocketBroadcastCapable (sys_socket_t socketid)
 
 //=============================================================================
 
+static int UDP_BroadcastOnInterfaces (sys_socket_t socketid, byte *buf, int len)
+{
+	struct ifaddrs *ifaddr = NULL;
+	struct ifaddrs *ifa;
+	int sent = 0;
+
+	if (getifaddrs (&ifaddr) != 0)
+		return 0;
+
+	for (ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next)
+	{
+		struct sockaddr_in addr;
+		in_addr_t ip;
+		in_addr_t mask;
+		in_addr_t broadcast;
+
+		if (!ifa->ifa_addr || !ifa->ifa_netmask)
+			continue;
+		if (!(ifa->ifa_flags & IFF_UP))
+			continue;
+		if (ifa->ifa_flags & IFF_LOOPBACK)
+			continue;
+		if (ifa->ifa_addr->sa_family != AF_INET)
+			continue;
+
+		ip = ((struct sockaddr_in *)ifa->ifa_addr)->sin_addr.s_addr;
+		mask = ((struct sockaddr_in *)ifa->ifa_netmask)->sin_addr.s_addr;
+		broadcast = htonl((ntohl(ip) & ntohl(mask)) | ~ntohl(mask));
+
+		memset(&addr, 0, sizeof(addr));
+		addr.sin_family = AF_INET;
+		addr.sin_addr.s_addr = broadcast;
+		addr.sin_port = htons((unsigned short)net_hostport);
+		if (UDP_Write (socketid, buf, len, (struct qsockaddr *)&addr) >= 0)
+			sent++;
+	}
+
+	freeifaddrs (ifaddr);
+	return sent;
+}
+
 int UDP_Broadcast (sys_socket_t socketid, byte *buf, int len)
 {
 	int	ret;
+	int sent;
 
 	if (socketid != net_broadcastsocket)
 	{
@@ -336,6 +383,10 @@ int UDP_Broadcast (sys_socket_t socketid, byte *buf, int len)
 			return ret;
 		}
 	}
+
+	sent = UDP_BroadcastOnInterfaces (socketid, buf, len);
+	if (sent > 0)
+		return len;
 
 	return UDP_Write (socketid, buf, len, (struct qsockaddr *)&broadcastaddr);
 }
@@ -477,4 +528,3 @@ int UDP_SetSocketPort (struct qsockaddr *addr, int port)
 }
 
 //=============================================================================
-

--- a/Quake/net_wins.c
+++ b/Quake/net_wins.c
@@ -23,6 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "arch_def.h"
 #include "net_sys.h"
 #include "net_defs.h"
+#include <iphlpapi.h>
 
 static sys_socket_t net_acceptsocket = INVALID_SOCKET;	// socket for fielding new connections
 static sys_socket_t net_controlsocket;
@@ -230,6 +231,9 @@ sys_socket_t WINS_OpenSocket (int port)
 		return INVALID_SOCKET;
 	}
 
+	setsockopt (newsocket, SOL_SOCKET, SO_BROADCAST, (char *)&_true, sizeof(_true));
+	setsockopt (newsocket, SOL_SOCKET, SO_REUSEADDR, (char *)&_true, sizeof(_true));
+
 	if (ioctlsocket (newsocket, FIONBIO, &_true) == SOCKET_ERROR)
 		goto ErrorReturn;
 
@@ -385,9 +389,83 @@ static int WINS_MakeSocketBroadcastCapable (sys_socket_t socketid)
 
 //=============================================================================
 
+static int WINS_BroadcastOnInterfaces (sys_socket_t socketid, byte *buf, int len)
+{
+	IP_ADAPTER_ADDRESSES *addrs = NULL;
+	IP_ADAPTER_ADDRESSES *adapter;
+	IP_ADAPTER_UNICAST_ADDRESS *unicast;
+	ULONG flags = GAA_FLAG_SKIP_ANYCAST | GAA_FLAG_SKIP_MULTICAST | GAA_FLAG_SKIP_DNS_SERVER;
+	ULONG size = 15000;
+	DWORD status;
+	int sent = 0;
+
+	addrs = (IP_ADAPTER_ADDRESSES *)malloc(size);
+	if (!addrs)
+		return 0;
+
+	status = GetAdaptersAddresses(AF_INET, flags, NULL, addrs, &size);
+	if (status == ERROR_BUFFER_OVERFLOW)
+	{
+		free(addrs);
+		addrs = (IP_ADAPTER_ADDRESSES *)malloc(size);
+		if (!addrs)
+			return 0;
+		status = GetAdaptersAddresses(AF_INET, flags, NULL, addrs, &size);
+	}
+
+	if (status != NO_ERROR)
+	{
+		free(addrs);
+		return 0;
+	}
+
+	for (adapter = addrs; adapter; adapter = adapter->Next)
+	{
+		if (adapter->OperStatus != IfOperStatusUp)
+			continue;
+		if (adapter->IfType == IF_TYPE_SOFTWARE_LOOPBACK)
+			continue;
+
+		for (unicast = adapter->FirstUnicastAddress; unicast; unicast = unicast->Next)
+		{
+			struct sockaddr_in *addr;
+			struct sockaddr_in dest;
+			ULONG prefix;
+			uint32_t mask;
+			uint32_t host_addr;
+			uint32_t broadcast_host;
+
+			if (!unicast->Address.lpSockaddr)
+				continue;
+			if (unicast->Address.lpSockaddr->sa_family != AF_INET)
+				continue;
+
+			addr = (struct sockaddr_in *)unicast->Address.lpSockaddr;
+			prefix = unicast->OnLinkPrefixLength;
+			if (prefix > 32)
+				continue;
+
+			mask = (prefix == 0) ? 0 : (0xffffffffu << (32 - prefix));
+			host_addr = ntohl(addr->sin_addr.s_addr);
+			broadcast_host = (host_addr & mask) | (~mask);
+
+			memset(&dest, 0, sizeof(dest));
+			dest.sin_family = AF_INET;
+			dest.sin_addr.s_addr = htonl(broadcast_host);
+			dest.sin_port = htons((unsigned short)net_hostport);
+			if (WINS_Write (socketid, buf, len, (struct qsockaddr *)&dest) >= 0)
+				sent++;
+		}
+	}
+
+	free(addrs);
+	return sent;
+}
+
 int WINS_Broadcast (sys_socket_t socketid, byte *buf, int len)
 {
 	int	ret;
+	int sent;
 
 	if (socketid != net_broadcastsocket)
 	{
@@ -401,6 +479,10 @@ int WINS_Broadcast (sys_socket_t socketid, byte *buf, int len)
 			return ret;
 		}
 	}
+
+	sent = WINS_BroadcastOnInterfaces (socketid, buf, len);
+	if (sent > 0)
+		return len;
 
 	return WINS_Write (socketid, buf, len, (struct qsockaddr *)&broadcastaddr);
 }
@@ -541,4 +623,3 @@ int WINS_SetSocketPort (struct qsockaddr *addr, int port)
 }
 
 //=============================================================================
-


### PR DESCRIPTION
### Motivation
- Ensure LAN discovery works reliably across multi-homed hosts and platforms by sending broadcasts on each active IPv4 interface and by enabling appropriate socket options. 
- Allow the server to answer simple connectionless discovery queries (status/info/A2A_INFO) directly back to the requestor. 
- Provide fallbacks to the old INADDR_BROADCAST behavior if per-interface enumeration fails. 
- Improve both Unix and Windows network drivers to compute and use interface subnets rather than relying solely on a single broadcast address. 

### Description
- Enable `SO_BROADCAST` and `SO_REUSEADDR` on new UDP sockets in `UDP_OpenSocket` and `WINS_OpenSocket`. 
- Add `UDP_BroadcastOnInterfaces` (Unix, using `getifaddrs` + `IFF_UP`/`IFF_LOOPBACK`) to compute per-interface IPv4 broadcast addresses and send the discovery packet to each broadcast. 
- Add `WINS_BroadcastOnInterfaces` (Windows, using `GetAdaptersAddresses`) that enumerates adapters and per-unicast prefixes to compute and send per-interface broadcasts. 
- Add handling in `_Datagram_CheckNewConnections` (`net_dgrm.c`) to respond to connectionless `control == -1` queries like `status`, `info`, or `A2A_INFO` by sending a small server status reply back to the requestor. 

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e7c15d134832eb54ec9f2d5798368)