### PR TITLE
Fix snapshot model typing and bindless padding fields

### DIFF
--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -755,7 +755,7 @@ static void CL_ApplySnapshotState (int entnum, const snapshot_state_t *state)
 	double		oldtime;
 	int			i;
 	int			skin;
-	model_t		*model;
+	qmodel_t	*model;
 
 	ent = CL_EntityNum (entnum);
 	forcelink = (ent->msgtime != cl.mtime[1]);

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -298,7 +298,7 @@ typedef struct bmodel_bindless_gpu_call_s {
 	GLuint64	texture;
 	GLuint64	fullbright;
 	GLuint64	emissive;
-	GLuint64	_pad1;
+	GLuint64	_pad1_handle;
 } bmodel_bindless_gpu_call_t;
 
 typedef struct bmodel_bound_gpu_call_s {
@@ -637,7 +637,7 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
 		call->texture = tx ? tx->bindless_handle : greytexture->bindless_handle;
 		call->fullbright = fb ? fb->bindless_handle : blacktexture->bindless_handle;
 		call->emissive = em ? em->bindless_handle : blacktexture->bindless_handle;
-		call->_pad1 = 0;
+		call->_pad1_handle = 0;
 	}
 	else
 	{
@@ -710,7 +710,7 @@ static void R_AddBModelCallWithTextures (int index, int first_instance, int num_
 		call->texture = tx ? tx->bindless_handle : greytexture->bindless_handle;
 		call->fullbright = fb ? fb->bindless_handle : blacktexture->bindless_handle;
 		call->emissive = em ? em->bindless_handle : blacktexture->bindless_handle;
-		call->_pad1 = 0;
+		call->_pad1_handle = 0;
 	}
 	else
 	{

--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -40,6 +40,9 @@ static cvar_t sv_snapshottimeout = {"sv_snapshottimeout", "1000", CVAR_NONE};
 
 //============================================================================
 
+static void SV_InitClientSnapshotData (client_t *client);
+static void SV_ResetClientSnapshot (client_t *client);
+
 void SV_CalcStats(client_t *client, int *statsi, float *statsf, const char **statss)
 {
 	size_t i;


### PR DESCRIPTION
### Motivation

- Fix compiler errors caused by an incorrect model pointer type in snapshot application code.
- Avoid a duplicate/ambiguous member name in the bindless GPU call struct that prevented assigning the 64-bit handle.
- Silence implicit-declaration warnings treated as errors by explicitly declaring snapshot helper functions used earlier in `sv_main.c`.

### Description

- Change the snapshot model variable in `CL_ApplySnapshotState` from `model_t *` to `qmodel_t *` in `Quake/cl_parse.c` to match project model types.
- Rename the bindless padding field ` _pad1` to `_pad1_handle` in `bmodel_bindless_gpu_call_t` and update all assignments to `call->_pad1_handle` in `Quake/r_world.c` to make the 64-bit handle an l-value.
- Add forward declarations for `SV_InitClientSnapshotData` and `SV_ResetClientSnapshot` at the top of `Quake/sv_main.c` to prevent implicit declaration warnings.

### Testing

- No automated tests were run for this change.
- The changes were committed after local edits and compilation issues were investigated and fixed in the source files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e99906700832eb344e1bdf90a9aff)