### PR TITLE
Fix compute shader view uniform conflict

### DIFF
--- a/Quake/shaders/cluster_lights.comp
+++ b/Quake/shaders/cluster_lights.comp
@@ -38,7 +38,7 @@ layout(rg32ui, binding=0) uniform writeonly uimage3D LightClusters;
 layout(std140, binding=1) uniform InputUBO
 {
 	mat4	TransposedProj;
-	mat4	View;
+	mat4	ViewMatrix;
 };
 
 shared vec4 local_lights[MAX_LIGHTS]; // xyz = view space pos; w = radius
@@ -131,7 +131,7 @@ void main()
 		{
 			Light l = Lights[lightIdx];
 			// Transformiere ins View Space und speichere in shared memory
-			local_lights[lightIdx] = vec4((View * vec4(l.origin, 1.0)).xyz, l.radius);
+			local_lights[lightIdx] = vec4((ViewMatrix * vec4(l.origin, 1.0)).xyz, l.radius);
 		}
 	}
 	


### PR DESCRIPTION
### Motivation
- Resolve a GLSL compile error caused by a `View` uniform name clashing with the frame uniforms block during compute shader compilation.
- Prevent OpenGL initialization failures on systems where the shader compiler reports conflicting declarations.
- Keep the compute shader's uniform block unambiguous so it can be bound without affecting other shader UBOs.

### Description
- Rename the uniform `mat4 View` to `mat4 ViewMatrix` in `Quake/shaders/cluster_lights.comp`.
- Update the light transform usage to use `ViewMatrix` in the shared light upload: `local_lights[lightIdx] = vec4((ViewMatrix * vec4(l.origin, 1.0)).xyz, l.radius);`.
- No other shader files or runtime code were modified.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e9c7f06bc832e948b21a7508fe94b)