### PR TITLE
Fix signon completion when no entity updates arrive

### DIFF
--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -1407,6 +1407,11 @@ void CL_ParseServerMessage (void)
 			cl.mtime[1] = cl.mtime[0];
 			cl.mtime[0] = MSG_ReadFloat ();
 			cl.fixangle = false;
+			if (cls.signon == SIGNONS - 1)
+			{	// allow map loads with no visible entity updates to finish signon
+				cls.signon = SIGNONS;
+				CL_SignonReply ();
+			}
 			break;
 
 		case svc_clientdata:


### PR DESCRIPTION
### Motivation
- When loading a new map that sends no visible entity updates the client could remain stuck showing only the console and no game graphics. 
- The client previously only completed signon in entity update handling, so maps that only sent a server time message could fail to finish signon. 
- Ensure the client transitions to fully connected state even if the first non-signon server message is just `svc_time`.

### Description
- Add handling in `CL_ParseServerMessage` for `svc_time` to complete the final signon stage when `cls.signon == SIGNONS - 1`.
- The added code sets `cls.signon = SIGNONS` and calls `CL_SignonReply()` so the client will run the remaining signon-stage logic.
- Change was made in `Quake/cl_parse.c` inside the `case svc_time:` branch.

### Testing
- No automated tests were run on this change.
- Manual validation (not automated) is recommended: load a map that previously produced only console output and verify the in-game view appears after the server time message.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ea8aa8ce4832e87f82b63293c97be)