### PR TITLE
Fix snapshot entity interpolation

### DIFF
--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -879,8 +879,6 @@ static void CL_ParseSnapshotFull (void)
 	count = (unsigned short)MSG_ReadShort ();
 
 	memset (cl.snapshot_present, 0, cl_max_edicts * sizeof(byte));
-	for (i = 1; i < cl_max_edicts; i++)
-		CL_ClearSnapshotEntity (i);
 
 	for (i = 0; i < count; i++)
 	{
@@ -961,6 +959,11 @@ static void CL_ParseSnapshotDelta (void)
 
 	if (baseline_match)
 	{
+		for (i = 1; i < cl_max_edicts; i++)
+		{
+			if (cl.snapshot_present[i] && cl_entities[i].msgtime != cl.mtime[0])
+				cl_entities[i].msgtime = cl.mtime[0];
+		}
 		cl.snapshot_baseline_seq = seq;
 		CL_SendSnapshotAck (seq);
 	}


### PR DESCRIPTION
### Motivation

- sv_snapshotdelta-based delta snapshots caused model interpolation to break, producing flickering models and invisible movable brushes.
- Clearing all snapshot entities on full snapshots discarded previous state needed for interpolation across frames.
- Delta snapshot handling could leave entities with stale timing information, breaking lerp logic.
- The change aims to preserve per-entity timing/state so model/frame interpolation and movable brush visibility are stable.

### Description

- Removed the loop that called `CL_ClearSnapshotEntity` for every edict during `CL_ParseSnapshotFull` to avoid wiping entity slots needed for interpolation.
- Added a loop in `CL_ParseSnapshotDelta` that sets `cl_entities[i].msgtime = cl.mtime[0]` for entities marked in `cl.snapshot_present` so unchanged-but-present entities keep up-to-date timing for lerping.
- All edits are localized to `Quake/cl_parse.c` around the `CL_ParseSnapshotFull` and `CL_ParseSnapshotDelta` functions to preserve snapshot baseline behavior.
- Commit message: `Fix snapshot entity interpolation`.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695eaf320494832eba156a1b9ce5ea16)