### PR TITLE
Apply min scene luma during auto-exposure sampling

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -1966,7 +1966,10 @@ static qboolean GL_SampleAutoExposureLuminance (float *out_luminance)
 		const float g = pixels[i * 4 + 1];
 		const float b = pixels[i * 4 + 2];
 		float lum = 0.2126f * r + 0.7152f * g + 0.0722f * b;
+		const float min_scene_luma = q_max (0.f, r_ae_min_scene_luma.value);
 		lum = q_max (lum, 0.0001f);
+		if (min_scene_luma > 0.f)
+			lum = q_max (lum, min_scene_luma);
 		luminance_samples[i] = lum;
 	}
 


### PR DESCRIPTION
### Motivation
- `r_ae_min_scene_luma` was being applied only after computing the scene luminance, so very dark pixels could be discarded by percentile trimming and not influence exposure, leaving dark corners unaffected.

### Description
- In `GL_SampleAutoExposureLuminance` compute `min_scene_luma = q_max(0.f, r_ae_min_scene_luma.value)` and apply it to each per-pixel `lum` sample before sorting.
- The per-sample clamp is performed in addition to the existing clamp applied to the final `scene_luminance`, ensuring dark pixels influence percentile trimming/log averaging.
- Change is localized to `Quake/gl_rmain.c` inside the auto-exposure luminance sampling loop.

### Testing
- No automated tests were run for this change.
- Manual runtime verification is recommended to confirm dark corners now affect auto-exposure as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ed285bb00832e963ca4ea90edac40)