### PR TITLE
Cast entity flag checks to int and add `MSG_WriteCoord32f` prototype

### DIFF
--- a/Quake/common.h
+++ b/Quake/common.h
@@ -224,6 +224,7 @@ void MSG_WriteLong (sizebuf_t *sb, int c);
 void MSG_WriteFloat (sizebuf_t *sb, float f);
 void MSG_WriteString (sizebuf_t *sb, const char *s);
 void MSG_WriteCoord (sizebuf_t *sb, float f, unsigned int flags);
+void MSG_WriteCoord32f (sizebuf_t *sb, float f);
 void MSG_WriteAngle (sizebuf_t *sb, float f, unsigned int flags);
 void MSG_WriteAngle16 (sizebuf_t *sb, float f, unsigned int flags); //johnfitz
 
@@ -484,4 +485,3 @@ extern qboolean		fitzmode;
 	/* if true, run in fitzquake mode disabling custom quakespasm hacks */
 
 #endif	/* _Q_COMMON_H */
-

--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -778,7 +778,7 @@ static qboolean SV_SnapshotTossMoving (const edict_t *ent)
 {
 	float tinyvel = net_snap_tinyvel.value;
 
-	if (!(ent->v.flags & FL_ONGROUND))
+	if (!((int)ent->v.flags & FL_ONGROUND))
 		return true;
 	return VectorLengthSquared (ent->v.velocity) > (tinyvel * tinyvel);
 }
@@ -807,7 +807,7 @@ static byte SV_SnapshotFlagsForEnt (const edict_t *ent)
 
 static qboolean SV_SnapshotMandatoryEnt (const edict_t *ent)
 {
-	if (ent->v.flags & FL_CLIENT)
+	if ((int)ent->v.flags & FL_CLIENT)
 		return true;
 	if (ent->v.movetype == MOVETYPE_PUSH && SV_SnapshotMoverMoving (ent))
 		return true;


### PR DESCRIPTION
### Motivation

- Resolve MSVC compile errors caused by using bitwise `&` on `ent->v.flags` when the field is treated as a floating type.  
- Ensure the codebase has a proper declaration for `MSG_WriteCoord32f` to avoid implicit declaration warnings.  
- Preserve existing snapshot behavior while making the flag checks explicit and portable.  

### Description

- Cast `ent->v.flags` to `int` before bitwise checks in `SV_SnapshotTossMoving` and `SV_SnapshotMandatoryEnt` in `Quake/sv_main.c` to avoid invalid operand errors for `&`.  
- Add the function prototype `void MSG_WriteCoord32f (sizebuf_t *sb, float f);` to `Quake/common.h` so the `MSG_WriteCoord32f` call in `sv_main.c` is declared.  
- No behavioral changes to snapshot logic beyond making flag checks explicit.  

### Testing

- No automated tests were run for this change.  
- The changes are limited to type casts and a header declaration and should build cleanly on compilers that previously errored.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fea85b154832ea3297472a1acbf30)