### PR TITLE
Add sv_coalesce.c to Visual Studio project build and filters

### DIFF
--- a/Windows/VisualStudio/ironwail.vcxproj
+++ b/Windows/VisualStudio/ironwail.vcxproj
@@ -355,6 +355,7 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="..\..\Quake\sv_main.c" />
+    <ClCompile Include="..\..\Quake\sv_coalesce.c" />
     <ClCompile Include="..\..\Quake\sv_move.c" />
     <ClCompile Include="..\..\Quake\sv_phys.c" />
     <ClCompile Include="..\..\Quake\sv_user.c" />

--- a/Windows/VisualStudio/ironwail.vcxproj.filters
+++ b/Windows/VisualStudio/ironwail.vcxproj.filters
@@ -249,6 +249,9 @@
     <ClCompile Include="..\..\Quake\sv_main.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Quake\sv_coalesce.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\Quake\sv_move.c">
       <Filter>Source Files</Filter>
     </ClCompile>


### PR DESCRIPTION
### Motivation
- The Visual Studio project omitted `sv_coalesce.c`, which can cause missing-symbol or build inconsistencies on Windows.
- Including the file ensures the Windows IDE build matches other build systems and includes server coalescing logic.

### Description
- Add ` <ClCompile Include="..\..\Quake\sv_coalesce.c" />` to `Windows/VisualStudio/ironwail.vcxproj` to include the source in the build.
- Add the matching `<ClCompile>` entry with `<Filter>Source Files</Filter>` to `Windows/VisualStudio/ironwail.vcxproj.filters` so the file appears in the project tree.
- Only project metadata files were modified; no source code changes were made.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695feb11a9d0832e9ffc3e4fd7933722)