### PR TITLE
Handle coalesced framing before protocol flags

### DIFF
--- a/Quake/cl_main.c
+++ b/Quake/cl_main.c
@@ -796,6 +796,7 @@ int CL_ReadFromServer (void)
 	int			num_dlights = 0; //johnfitz
 	beam_t		*b; //johnfitz
 	int			i; //johnfitz
+	qboolean	coalesced_message;
 
 	CL_AdvanceTime ();
 
@@ -808,7 +809,27 @@ int CL_ReadFromServer (void)
 			break;
 
 		cl.last_received_message = realtime;
-		if (cl.protocolflags & PRFL_NET_COALESCE)
+		coalesced_message = (cl.protocolflags & PRFL_NET_COALESCE);
+		if (!coalesced_message && cl.protocol == 0 && cls.state == ca_connected && net_message.cursize >= 2)
+		{
+			int pos = 0;
+			coalesced_message = true;
+			while (pos + 2 <= net_message.cursize)
+			{
+				int len = net_message.data[pos] | (net_message.data[pos + 1] << 8);
+				pos += 2;
+				if (len <= 0 || pos + len > net_message.cursize)
+				{
+					coalesced_message = false;
+					break;
+				}
+				pos += len;
+			}
+			if (pos != net_message.cursize)
+				coalesced_message = false;
+		}
+
+		if (coalesced_message)
 		{
 			sizebuf_t old = net_message;
 			int pos = 0;


### PR DESCRIPTION
### Motivation

- Fix a server message parsing bug that caused errors like `SVC_Updatecolors > MAX_SCOREBOARD` during map load after enabling packet coalescing and tickrate decoupling.
- The root cause was assuming `cl.protocolflags` indicates coalesced framing only after the serverinfo packet, while initial messages (pre-serverinfo) can already be coalesced-framed.
- Detecting coalesced framing earlier avoids misparsing of early scoreboard/name/color updates before protocol flags are known.
- Limit the heuristic to the initial connection phase to avoid changing behavior for established connections.

### Description

- Add a `qboolean coalesced_message` and a small heuristic that inspects `net_message` framing when `cl.protocol == 0` to detect coalesced-framed datagrams.
- When the heuristic detects framed coalescing, reuse the existing framed parsing loop (2-byte length prefix per submessage) to call `CL_ParseServerMessage` for each contained message.
- Preserve the original code path when `cl.protocolflags & PRFL_NET_COALESCE` is already set, so behavior is unchanged after serverinfo is parsed.
- Change localized to `Quake/cl_main.c` (added ~22 lines) and keeps parsing logic identical for each submessage once framing is detected.

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ff3cd7920832e9068704a0e9b836a)