### PR TITLE
Include network headers in sv_main.c to fix qsocket ackSequence build error

### DIFF
--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -25,6 +25,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "quakedef.h"
 #include "sv_coalesce.h"
 #include "crc.h"
+#include "arch_def.h"
+#include "net_sys.h"
+#include "net_defs.h"
 
 server_t	sv;
 server_static_t	svs;


### PR DESCRIPTION
### Motivation
- Fix a compile-time error when accessing `qsocket_t` fields (e.g. `ackSequence`) from server snapshot debug logging due to an incomplete `qsocket_s` type on some toolchains. 
- Ensure `sv_main.c` has the necessary network internals available so snapshot debugging prints can reference connection state safely.

### Description
- Added `#include "arch_def.h"`, `#include "net_sys.h"`, and `#include "net_defs.h"` to `Quake/sv_main.c` so the `qsocket_t` definition is visible. 
- No other functional logic was changed in `sv_main.c`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fff8998cc832ebae4d1357621f8a3)