### PR TITLE
Fix snapshot size budgeting to prevent read overflows

### DIFF
--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -860,9 +860,10 @@ static int SV_SnapshotEntitySizeWorst (void)
 
 static int SV_SnapshotMaxEntities (sizebuf_t *msg)
 {
-	int header_size = 1 + 4 + 2;
+	int header_size = 1 + 2 + 2 + 2 + 2 + 2;
+	int delta_counts_size = 3 * 2;
 	int per_ent = SV_SnapshotEntitySizeWorst ();
-	int available = msg->maxsize - msg->cursize - header_size;
+	int available = msg->maxsize - msg->cursize - header_size - delta_counts_size;
 
 	if (per_ent <= 0 || available <= 0)
 		return 0;


### PR DESCRIPTION
### Motivation
- Underestimated snapshot payload budget could let snapshot messages exceed read limits and trigger "Bad server message (read overflow)" logs leading to visible entity jitter.
- The prior max-entity calculation did not account for the full snapshot header and the delta-count fields, so reported available payload space was optimistic.
- Fixing the budgeting prevents oversized snapshot payloads that can cause truncated reads and interpolation resets.

### Description
- Update `SV_SnapshotMaxEntities` to account for the full snapshot header by changing `header_size` to `1 + 2 + 2 + 2 + 2 + 2`.
- Subtract an additional `delta_counts_size = 3 * 2` (three 2-byte counts) from the available payload when computing max entities.
- This aligns the computed capacity with the actual layout produced by `SV_WriteSnapshotHeader`/`SV_FinalizeSnapshotHeader` and `SV_WriteSnapshot*` flows.

### Testing
- No automated tests were run for this change.
- No CI/build verification was executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960011d01f0832eb226007b72e6fb58)