### PR TITLE
Map server snapshot hires flags to protocol bits to fix client read overflow

### DIFF
--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -1112,6 +1112,18 @@ static void SV_WriteSnapshotState (sizebuf_t *msg, const snapshot_state_t *state
 	MSG_WriteByte (msg, state->step);
 }
 
+static byte SV_SnapshotNetFlags (byte flags)
+{
+	byte net_flags = 0;
+
+	if (flags & SNAPFLAG_HIRES_ORIGIN)
+		net_flags |= SNAPFL_HIRES_ORIGIN;
+	if (flags & SNAPFLAG_HIRES_ANGLES)
+		net_flags |= SNAPFL_HIRES_ANGLES;
+
+	return net_flags;
+}
+
 static void SV_WriteShortAt (sizebuf_t *msg, int offset, unsigned short value)
 {
 	msg->data[offset] = value & 0xff;
@@ -1220,7 +1232,7 @@ static void SV_WriteSnapshotFull (sizebuf_t *msg, unsigned int seq, const snapsh
 			continue;
 		MSG_WriteShort (msg, entnum);
 		if (sv.protocolflags & PRFL_SNAPSHOT_HIRES)
-			MSG_WriteByte (msg, snapflags ? snapflags[entnum] : 0);
+			MSG_WriteByte (msg, snapflags ? SV_SnapshotNetFlags (snapflags[entnum]) : 0);
 		SV_WriteSnapshotState (msg, &states[entnum], snapflags ? snapflags[entnum] : 0);
 	}
 
@@ -1279,7 +1291,7 @@ static void SV_WriteSnapshotDelta (sizebuf_t *msg, unsigned int seq, unsigned in
 		{
 			MSG_WriteShort (msg, entnum);
 			if (sv.protocolflags & PRFL_SNAPSHOT_HIRES)
-				MSG_WriteByte (msg, snapflags ? snapflags[entnum] : 0);
+				MSG_WriteByte (msg, snapflags ? SV_SnapshotNetFlags (snapflags[entnum]) : 0);
 			SV_WriteSnapshotState (msg, &states[entnum], snapflags ? snapflags[entnum] : 0);
 		}
 	}


### PR DESCRIPTION
### Motivation
- The server was writing internal snapshot hires flag bits directly into network messages instead of using protocol flag bits, which can cause the client to misinterpret payloads and trigger "Bad server message (read overflow)" errors.
- Ensure snapshot entries in full/add delta messages encode hires precision flags using the protocol-defined bits so clients parse snapshots correctly.

### Description
- Added `SV_SnapshotNetFlags` to translate internal `SNAPFLAG_*` flags to protocol `SNAPFL_*` bits. 
- Updated `SV_WriteSnapshotFull` and the add-path of `SV_WriteSnapshotDelta` to call `SV_SnapshotNetFlags` when writing the snapshot flag byte. 
- Kept `SV_WriteSnapshotState` unchanged so server-side packing still uses internal flags to choose write precision. 
- Change applied to `Quake/sv_main.c`.

### Testing
- No automated tests were executed for this change.
- A source commit was created containing the modification and compilation was not performed as part of automated CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696002745f1c832e91ef297e1dea1834)