### PR TITLE
Handle RMQ protocol extra flags in serverinfo parsing

### DIFF
--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -337,10 +337,22 @@ void CL_ParseServerInfo (void)
 	if (cl.protocol == PROTOCOL_RMQ)
 	{
 		const unsigned int supportedflags = (PRFL_SHORTANGLE | PRFL_FLOATANGLE | PRFL_24BITCOORD | PRFL_FLOATCOORD | PRFL_EDICTSCALE | PRFL_INT32COORD | PRFL_SNAPSHOT_HIRES | PRFL_NET_COALESCE);
-		
+
 		// mh - read protocol flags from server so that we know what protocol features to expect
 		cl.protocolflags = (unsigned int) MSG_ReadLong ();
-		
+
+		if (cl.protocolflags & PRFL_MOREFLAGS)
+		{
+			unsigned int extra_flags = cl.protocolflags;
+			Con_Warning ("PROTOCOL_RMQ protocolflags %i contains PRFL_MOREFLAGS; ignoring additional flags\n", cl.protocolflags);
+			while (extra_flags & PRFL_MOREFLAGS)
+			{
+				extra_flags = (unsigned int) MSG_ReadLong ();
+				Con_DWarning ("PROTOCOL_RMQ extra protocolflags %i ignored\n", extra_flags);
+			}
+		}
+
+		cl.protocolflags &= ~PRFL_MOREFLAGS;
 		if (0 != (cl.protocolflags & (~supportedflags)))
 		{
 			Con_Warning("PROTOCOL_RMQ protocolflags %i contains unsupported flags\n", cl.protocolflags);


### PR DESCRIPTION
### Motivation

- Map-change/client parsing errors and "Bad server message" logs were caused by RMQ servers setting `PRFL_MOREFLAGS`, which indicates there are additional protocol-flag words to read. 
- If those extra words are not consumed, subsequent `MSG_Read*` calls become misaligned and lead to illegible server messages during map changes.

### Description

- In `CL_ParseServerInfo` for `PROTOCOL_RMQ`, read `cl.protocolflags` and, when `PRFL_MOREFLAGS` is set, loop calling `MSG_ReadLong()` to consume additional flag words until no `PRFL_MOREFLAGS` remain. 
- Emit a `Con_Warning` when `PRFL_MOREFLAGS` is present and a `Con_DWarning` for each extra flags word read, then clear the `PRFL_MOREFLAGS` bit and validate remaining flags against the supported set. 
- Change made in `Quake/cl_parse.c` to prevent misaligned serverinfo parsing.

### Testing

- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69600ee2f484832ea1ba0006012f171c)