### PR TITLE
Adjust client interpolation buffer timing

### DIFF
--- a/Quake/cl_main.c
+++ b/Quake/cl_main.c
@@ -36,8 +36,8 @@ cvar_t	cl_color = {"_cl_color", "0", CVAR_ARCHIVE};
 
 cvar_t	cl_shownet = {"cl_shownet","0",CVAR_NONE};	// can be 0, 1, or 2
 cvar_t	cl_nolerp = {"cl_nolerp","0",CVAR_NONE};
-cvar_t	cl_interp_delay = {"cl_interp_delay","0.05",CVAR_ARCHIVE};
-cvar_t	cl_interp_delay_max = {"cl_interp_delay_max","0.1",CVAR_ARCHIVE};
+cvar_t	cl_interp_delay = {"cl_interp_delay","0.1",CVAR_ARCHIVE};
+cvar_t	cl_interp_delay_max = {"cl_interp_delay_max","0.15",CVAR_ARCHIVE};
 cvar_t	cl_interp_extrap = {"cl_interp_extrap","0.1",CVAR_ARCHIVE};
 cvar_t	cl_interp_adapt = {"cl_interp_adapt","1",CVAR_ARCHIVE};
 
@@ -438,8 +438,14 @@ float	CL_LerpPoint (void)
 
 	if (cl_interp_adapt.value)
 	{
+		double spacing = cl.interp_last_spacing;
+		double interval = f;
+
+		if (spacing > 0.0)
+			interval = q_max(interval, spacing);
+
 		max_delay = cl_interp_delay_max.value > 0.0 ? cl_interp_delay_max.value : cl_interp_delay.value;
-		target_delay = q_min(max_delay, q_max(cl_interp_delay.value, f * 1.5));
+		target_delay = q_min(max_delay, q_max(cl_interp_delay.value, interval * 1.5));
 		cl.interp_delay_target = target_delay;
 		cl.interp_delay += (cl.interp_delay_target - cl.interp_delay) * 0.1;
 	}

--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -1633,8 +1633,14 @@ void CL_ParseServerMessage (void)
 			break;
 
 		case svc_time:
+		{
+			double newtime;
+
 			cl.mtime[1] = cl.mtime[0];
 			cl.mtime[0] = MSG_ReadFloat ();
+			newtime = cl.mtime[0];
+			if (cl.mtime[1] > 0.0)
+				cl.interp_last_spacing = q_max(0.0, newtime - cl.mtime[1]);
 			cl.fixangle = false;
 			if (cls.signon == SIGNONS - 1)
 			{	// allow map loads with no visible entity updates to finish signon
@@ -1642,6 +1648,7 @@ void CL_ParseServerMessage (void)
 				CL_SignonReply ();
 			}
 			break;
+		}
 
 		case svc_clientdata:
 			CL_ParseClientdata (); //johnfitz -- removed bits parameter, we will read this inside CL_ParseClientdata()


### PR DESCRIPTION
### Motivation
- Player movement and entity rendering appeared jittery when the server `sv_netrate` is low, indicating the client interpolation buffer may be too small or pinned to the latest snapshot.
- The client needs to render slightly in the past (a jitter buffer) so packet arrival jitter is smoothed out instead of being visible on-screen.
- Existing adaptive interpolation used only the last two snapshot timestamps and could under-estimate spacing when packets arrive irregularly.
- This change aims to make the interpolation delay more conservative and stable by accounting for observed snapshot spacing.

### Description
- Increased the default client interpolation buffer by changing `cl_interp_delay` from `0.05` to `0.1` and `cl_interp_delay_max` from `0.1` to `0.15` in `Quake/cl_main.c`.
- Track the observed spacing between `svc_time` snapshots by updating `cl.interp_last_spacing` in `Quake/cl_parse.c` when `svc_time` is received.
- When adapting `cl.interp_delay`, consider the larger of the current snapshot interval and the last observed spacing so `target_delay = max(cl_interp_delay, interval * 1.5)` where `interval = max(f, interp_last_spacing)` in `Quake/cl_main.c`.
- Preserve the existing smoothing behavior by nudging `cl.interp_delay` toward `cl.interp_delay_target` using the existing 0.1 blend factor.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696011228758832e9515eb2ef8a5c5cf)