### PR TITLE
Flush coalesced buffers to avoid drops at low `sv_netrate`

### DIFF
--- a/Quake/sv_coalesce.c
+++ b/Quake/sv_coalesce.c
@@ -18,6 +18,8 @@ static unsigned int sv_net_split_packets;
 static unsigned int sv_net_dropped_msgs;
 static double sv_net_debug_next_time;
 
+void SV_Coalesce_FlushClient(client_t *client);
+
 static double SV_Coalesce_Interval(void)
 {
 	double rate = sv_netrate.value;
@@ -141,9 +143,22 @@ void SV_Coalesce_Enqueue(client_t *client, const byte *data, int len)
 
 	if (buf->cursize + len + 2 > buf->maxsize)
 	{
-		if (buf->cursize)
-			sv_net_dropped_msgs++;
-		buf->cursize = 0;
+		while (buf->cursize && buf->cursize + len + 2 > buf->maxsize)
+		{
+			int before = buf->cursize;
+
+			SV_Coalesce_FlushClient(client);
+
+			if (buf->cursize >= before)
+				break;
+		}
+
+		if (buf->cursize + len + 2 > buf->maxsize)
+		{
+			if (buf->cursize)
+				sv_net_dropped_msgs++;
+			buf->cursize = 0;
+		}
 	}
 
 	buf->data[buf->cursize] = len & 0xff;


### PR DESCRIPTION
### Motivation
- Coalesced outgoing messages were being dropped when `sv_netrate` is low, causing jitter and flicker. 
- The change aims to reduce dropped updates by attempting to flush existing coalesced data before discarding it. 

### Description
- Added a forward declaration for `SV_Coalesce_FlushClient` to allow calling the flush helper from `SV_Coalesce_Enqueue`.
- Modified `SV_Coalesce_Enqueue` to call `SV_Coalesce_FlushClient` in a loop while there is data and the new message would overflow the coalesce buffer, trying to free space for the incoming message.
- Kept the original fallback behavior of incrementing `sv_net_dropped_msgs` and clearing the buffer if flushing did not create enough room.

### Testing
- No automated tests were executed as part of this change.
- Manual runtime validation was not recorded in automated test logs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960142b1638832eb6526c646a955329)