### PR TITLE
Prevent toggling sv_netcoalesce during RMQ sessions

### DIFF
--- a/Quake/sv_coalesce.c
+++ b/Quake/sv_coalesce.c
@@ -17,6 +17,28 @@ static unsigned int sv_net_coalesced_msgs;
 static unsigned int sv_net_split_packets;
 static unsigned int sv_net_dropped_msgs;
 static double sv_net_debug_next_time;
+static float sv_netcoalesce_prev;
+static qboolean sv_netcoalesce_updating;
+
+static void SV_NetCoalesce_Changed(cvar_t *var)
+{
+	if (sv_netcoalesce_updating)
+		return;
+
+	if (sv.active && sv.protocol == PROTOCOL_RMQ)
+	{
+		if (var->value != sv_netcoalesce_prev)
+		{
+			Con_Printf("sv_netcoalesce cannot be changed while a RMQ server is running; restart to apply.\n");
+			sv_netcoalesce_updating = true;
+			Cvar_SetValueQuick(var, sv_netcoalesce_prev);
+			sv_netcoalesce_updating = false;
+		}
+		return;
+	}
+
+	sv_netcoalesce_prev = var->value;
+}
 
 void SV_Coalesce_FlushClient(client_t *client);
 
@@ -88,6 +110,8 @@ void SV_Coalesce_RegisterCvars(void)
 	Cvar_RegisterVariable(&sv_pktmax);
 	Cvar_RegisterVariable(&sv_netcoalesce);
 	Cvar_RegisterVariable(&sv_net_debug);
+	Cvar_SetCallback(&sv_netcoalesce, SV_NetCoalesce_Changed);
+	sv_netcoalesce_prev = sv_netcoalesce.value;
 }
 
 void SV_Coalesce_UpdateProtocolFlags(void)


### PR DESCRIPTION
### Motivation
- Prevent client/server framing mismatches caused by changing `sv_netcoalesce` while an RMQ server is running.
- Ensure `sv_netcoalesce` runtime changes are only applied when the server is inactive or not using the RMQ protocol.
- Remember the previously-applied `sv_netcoalesce` setting so disallowed changes can be safely rolled back.

### Description
- Add static variables `sv_netcoalesce_prev` and `sv_netcoalesce_updating` to track the last value and suppress recursive updates.
- Implement `SV_NetCoalesce_Changed(cvar_t *var)` to reject changes when `sv.active && sv.protocol == PROTOCOL_RMQ` and restore the previous value via `Cvar_SetValueQuick` while printing a warning.
- Register the callback with `Cvar_SetCallback(&sv_netcoalesce, SV_NetCoalesce_Changed)` in `SV_Coalesce_RegisterCvars` and initialize `sv_netcoalesce_prev` from `sv_netcoalesce.value`.

### Testing
- No automated tests were executed for this change.
- A code commit was created after the modification and the build context was updated, but CI/tests were not run as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960162d47d8832eb65b450031bf2ec8)