### PR TITLE
Implement fixed server tick, decoupled net send, and snapshot hardening

### DIFF
--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -920,13 +920,14 @@ ent->baseline.scale = (bits & B_SCALE) ? MSG_ReadByte() : ENTSCALE_DEFAULT;
 }
 
 static qboolean CL_ReadSnapshotHeader (unsigned int *out_seq, unsigned int *out_delta_from,
-	unsigned int *out_payload_len, unsigned int *out_entity_count, unsigned int *out_crc,
-	int *out_payload_start, int *out_payload_end)
+	unsigned int *out_server_tick, unsigned int *out_payload_len, unsigned int *out_entity_count,
+	unsigned int *out_crc, int *out_payload_start, int *out_payload_end)
 {
 	int limit = MSG_GetReadLimit();
 
 	*out_seq = (unsigned short)MSG_ReadShort ();
 	*out_delta_from = (unsigned short)MSG_ReadShort ();
+	*out_server_tick = (unsigned int)MSG_ReadLong ();
 	*out_payload_len = (unsigned short)MSG_ReadShort ();
 	*out_entity_count = (unsigned short)MSG_ReadShort ();
 	*out_crc = (unsigned short)MSG_ReadShort ();
@@ -960,6 +961,7 @@ static void CL_ParseSnapshotFull (void)
 {
 	unsigned int seq;
 	unsigned int delta_from;
+	unsigned int server_tick;
 	unsigned int payload_len;
 	unsigned int entity_count;
 	unsigned int crc;
@@ -970,12 +972,24 @@ static void CL_ParseSnapshotFull (void)
 	int i;
 
 	old_limit = MSG_GetReadLimit();
-	if (!CL_ReadSnapshotHeader (&seq, &delta_from, &payload_len, &entity_count, &crc, &payload_start, &payload_end))
+	if (!CL_ReadSnapshotHeader (&seq, &delta_from, &server_tick, &payload_len, &entity_count, &crc,
+		&payload_start, &payload_end))
 		return;
 	MSG_SetReadLimit (payload_end);
 
 	cl.last_snapshot_seq = seq;
 	cl.last_snapshot_delta_from = delta_from;
+	if (server_tick < cl.last_snapshot_server_tick)
+	{
+		if (net_debug_snap.value)
+			Con_Printf ("snapdbg client full server_tick regressed %u -> %u\n",
+				cl.last_snapshot_server_tick, server_tick);
+		cl.need_fullsnap = true;
+	}
+	else
+	{
+		cl.last_snapshot_server_tick = server_tick;
+	}
 
 	if (net_debug_snap.value)
 	{
@@ -1042,6 +1056,7 @@ static void CL_ParseSnapshotDelta (void)
 	unsigned int seq;
 	unsigned int baseline_seq;
 	unsigned int mask;
+	unsigned int server_tick;
 	unsigned int payload_len;
 	unsigned int entity_count;
 	unsigned int crc;
@@ -1053,12 +1068,24 @@ static void CL_ParseSnapshotDelta (void)
 	qboolean baseline_match;
 
 	old_limit = MSG_GetReadLimit();
-	if (!CL_ReadSnapshotHeader (&seq, &baseline_seq, &payload_len, &entity_count, &crc, &payload_start, &payload_end))
+	if (!CL_ReadSnapshotHeader (&seq, &baseline_seq, &server_tick, &payload_len, &entity_count, &crc,
+		&payload_start, &payload_end))
 		return;
 	MSG_SetReadLimit (payload_end);
 
 	cl.last_snapshot_seq = seq;
 	cl.last_snapshot_delta_from = baseline_seq;
+	if (server_tick < cl.last_snapshot_server_tick)
+	{
+		if (net_debug_snap.value)
+			Con_Printf ("snapdbg client delta server_tick regressed %u -> %u\n",
+				cl.last_snapshot_server_tick, server_tick);
+		cl.need_fullsnap = true;
+	}
+	else
+	{
+		cl.last_snapshot_server_tick = server_tick;
+	}
 
 	if (net_debug_snap.value)
 	{

--- a/Quake/client.h
+++ b/Quake/client.h
@@ -274,6 +274,7 @@ typedef struct
 	unsigned int snapshot_baseline_seq;
 	unsigned int last_snapshot_seq;
 	unsigned int last_snapshot_delta_from;
+	unsigned int last_snapshot_server_tick;
 	snapshot_state_t *snapshot_baseline;
 	byte		*snapshot_present;
 	qboolean	need_fullsnap;

--- a/Quake/common.c
+++ b/Quake/common.c
@@ -692,6 +692,17 @@ Handles byte ordering and avoids alignment errors
 // writing functions
 //
 
+static qboolean MSG_TryGetSpace (sizebuf_t *sb, int length, byte **out)
+{
+	if (length < 0)
+		return false;
+	if (sb->cursize + length > sb->maxsize)
+		return false;
+	*out = sb->data + sb->cursize;
+	sb->cursize += length;
+	return true;
+}
+
 void MSG_WriteChar (sizebuf_t *sb, int c)
 {
 	byte	*buf;
@@ -705,6 +716,21 @@ void MSG_WriteChar (sizebuf_t *sb, int c)
 	buf[0] = c;
 }
 
+qboolean MSG_TryWriteChar (sizebuf_t *sb, int c)
+{
+	byte *buf;
+
+#ifdef PARANOID
+	if (c < -128 || c > 127)
+		Sys_Error ("MSG_TryWriteChar: range error");
+#endif
+
+	if (!MSG_TryGetSpace (sb, 1, &buf))
+		return false;
+	buf[0] = c;
+	return true;
+}
+
 void MSG_WriteByte (sizebuf_t *sb, int c)
 {
 	byte	*buf;
@@ -716,6 +742,21 @@ void MSG_WriteByte (sizebuf_t *sb, int c)
 
 	buf = (byte *) SZ_GetSpace (sb, 1);
 	buf[0] = c;
+}
+
+qboolean MSG_TryWriteByte (sizebuf_t *sb, int c)
+{
+	byte *buf;
+
+#ifdef PARANOID
+	if (c < 0 || c > 255)
+		Sys_Error ("MSG_TryWriteByte: range error");
+#endif
+
+	if (!MSG_TryGetSpace (sb, 1, &buf))
+		return false;
+	buf[0] = c;
+	return true;
 }
 
 void MSG_WriteShort (sizebuf_t *sb, int c)
@@ -732,6 +773,22 @@ void MSG_WriteShort (sizebuf_t *sb, int c)
 	buf[1] = c>>8;
 }
 
+qboolean MSG_TryWriteShort (sizebuf_t *sb, int c)
+{
+	byte *buf;
+
+#ifdef PARANOID
+	if (c < ((short)0x8000) || c > (short)0x7fff)
+		Sys_Error ("MSG_TryWriteShort: range error");
+#endif
+
+	if (!MSG_TryGetSpace (sb, 2, &buf))
+		return false;
+	buf[0] = c&0xff;
+	buf[1] = c>>8;
+	return true;
+}
+
 void MSG_WriteLong (sizebuf_t *sb, int c)
 {
 	byte	*buf;
@@ -741,6 +798,19 @@ void MSG_WriteLong (sizebuf_t *sb, int c)
 	buf[1] = (c>>8)&0xff;
 	buf[2] = (c>>16)&0xff;
 	buf[3] = c>>24;
+}
+
+qboolean MSG_TryWriteLong (sizebuf_t *sb, int c)
+{
+	byte *buf;
+
+	if (!MSG_TryGetSpace (sb, 4, &buf))
+		return false;
+	buf[0] = c&0xff;
+	buf[1] = (c>>8)&0xff;
+	buf[2] = (c>>16)&0xff;
+	buf[3] = c>>24;
+	return true;
 }
 
 void MSG_WriteFloat (sizebuf_t *sb, float f)
@@ -757,12 +827,41 @@ void MSG_WriteFloat (sizebuf_t *sb, float f)
 	SZ_Write (sb, &dat.l, 4);
 }
 
+qboolean MSG_TryWriteFloat (sizebuf_t *sb, float f)
+{
+	union
+	{
+		float	f;
+		int	l;
+	} dat;
+
+	dat.f = f;
+	dat.l = LittleLong (dat.l);
+
+	return MSG_TryWriteLong (sb, dat.l);
+}
+
 void MSG_WriteString (sizebuf_t *sb, const char *s)
 {
 	if (!s)
 		SZ_Write (sb, "", 1);
 	else
 		SZ_Write (sb, s, Q_strlen(s)+1);
+}
+
+qboolean MSG_TryWriteString (sizebuf_t *sb, const char *s)
+{
+	int len;
+	byte *buf;
+
+	if (!s)
+		s = "";
+
+	len = Q_strlen (s) + 1;
+	if (!MSG_TryGetSpace (sb, len, &buf))
+		return false;
+	Q_memcpy (buf, s, len);
+	return true;
 }
 
 //johnfitz -- original behavior, 13.3 fixed point coords, max range +-4096
@@ -784,6 +883,11 @@ void MSG_WriteCoord32f (sizebuf_t *sb, float f)
 	MSG_WriteFloat (sb, f);
 }
 
+qboolean MSG_TryWriteCoord32f (sizebuf_t *sb, float f)
+{
+	return MSG_TryWriteFloat (sb, f);
+}
+
 void MSG_WriteCoord (sizebuf_t *sb, float f, unsigned int flags)
 {
 	if (flags & PRFL_FLOATCOORD)
@@ -795,6 +899,22 @@ void MSG_WriteCoord (sizebuf_t *sb, float f, unsigned int flags)
 	else MSG_WriteCoord16 (sb, f);
 }
 
+qboolean MSG_TryWriteCoord (sizebuf_t *sb, float f, unsigned int flags)
+{
+	if (flags & PRFL_FLOATCOORD)
+		return MSG_TryWriteFloat (sb, f);
+	if (flags & PRFL_INT32COORD)
+		return MSG_TryWriteLong (sb, Q_rint (f * 16));
+	if (flags & PRFL_24BITCOORD)
+	{
+		int whole = (int)f;
+		if (!MSG_TryWriteShort (sb, whole))
+			return false;
+		return MSG_TryWriteByte (sb, (int)(f*255) % 255);
+	}
+	return MSG_TryWriteShort (sb, Q_rint (f * 8));
+}
+
 void MSG_WriteAngle (sizebuf_t *sb, float f, unsigned int flags)
 {
 	if (flags & PRFL_FLOATANGLE)
@@ -802,6 +922,15 @@ void MSG_WriteAngle (sizebuf_t *sb, float f, unsigned int flags)
 	else if (flags & PRFL_SHORTANGLE)
 		MSG_WriteShort (sb, Q_rint(f * 65536.0 / 360.0) & 65535);
 	else MSG_WriteByte (sb, Q_rint(f * 256.0 / 360.0) & 255); //johnfitz -- use Q_rint instead of (int)	}
+}
+
+qboolean MSG_TryWriteAngle (sizebuf_t *sb, float f, unsigned int flags)
+{
+	if (flags & PRFL_FLOATANGLE)
+		return MSG_TryWriteFloat (sb, f);
+	if (flags & PRFL_SHORTANGLE)
+		return MSG_TryWriteShort (sb, Q_rint(f * 65536.0 / 360.0) & 65535);
+	return MSG_TryWriteByte (sb, Q_rint(f * 256.0 / 360.0) & 255);
 }
 
 //johnfitz -- for PROTOCOL_FITZQUAKE
@@ -812,6 +941,13 @@ void MSG_WriteAngle16 (sizebuf_t *sb, float f, unsigned int flags)
 	else MSG_WriteShort (sb, Q_rint(f * 65536.0 / 360.0) & 65535);
 }
 //johnfitz
+
+qboolean MSG_TryWriteAngle16 (sizebuf_t *sb, float f, unsigned int flags)
+{
+	if (flags & PRFL_FLOATANGLE)
+		return MSG_TryWriteFloat (sb, f);
+	return MSG_TryWriteShort (sb, Q_rint(f * 65536.0 / 360.0) & 65535);
+}
 
 //
 // reading functions

--- a/Quake/common.h
+++ b/Quake/common.h
@@ -227,6 +227,16 @@ void MSG_WriteCoord (sizebuf_t *sb, float f, unsigned int flags);
 void MSG_WriteCoord32f (sizebuf_t *sb, float f);
 void MSG_WriteAngle (sizebuf_t *sb, float f, unsigned int flags);
 void MSG_WriteAngle16 (sizebuf_t *sb, float f, unsigned int flags); //johnfitz
+qboolean MSG_TryWriteChar (sizebuf_t *sb, int c);
+qboolean MSG_TryWriteByte (sizebuf_t *sb, int c);
+qboolean MSG_TryWriteShort (sizebuf_t *sb, int c);
+qboolean MSG_TryWriteLong (sizebuf_t *sb, int c);
+qboolean MSG_TryWriteFloat (sizebuf_t *sb, float f);
+qboolean MSG_TryWriteString (sizebuf_t *sb, const char *s);
+qboolean MSG_TryWriteCoord (sizebuf_t *sb, float f, unsigned int flags);
+qboolean MSG_TryWriteCoord32f (sizebuf_t *sb, float f);
+qboolean MSG_TryWriteAngle (sizebuf_t *sb, float f, unsigned int flags);
+qboolean MSG_TryWriteAngle16 (sizebuf_t *sb, float f, unsigned int flags);
 
 extern	int			msg_readcount;
 extern	qboolean	msg_badread;		// set if a read goes beyond end of message

--- a/Quake/host.c
+++ b/Quake/host.c
@@ -23,6 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // host.c -- coordinates spawning and killing of local servers
 
 #include "quakedef.h"
+#include "sv_coalesce.h"
 #include "bgmusic.h"
 #include "steam.h"
 #include <setjmp.h>
@@ -100,9 +101,16 @@ cvar_t	sv_cheats = {"sv_cheats","0",CVAR_NONE}; // for the 2021 rerelease
 
 cvar_t	sv_autosave = {"sv_autosave", "1", CVAR_ARCHIVE};
 cvar_t	sv_autosave_interval = {"sv_autosave_interval", "30", CVAR_ARCHIVE};
+cvar_t	sv_maxtickcatchup = {"sv_maxtickcatchup", "8", CVAR_NONE};
+cvar_t	sv_tickdebug = {"sv_tickdebug", "0", CVAR_NONE};
+cvar_t	sv_clock_log = {"sv_clock_log", "0", CVAR_NONE};
 
 devstats_t dev_stats, dev_peakstats;
 overflowtimes_t dev_overflows; //this stores the last time overflow messages were displayed, not the last time overflows occured
+
+sv_clock_t sv_clock;
+
+static void Host_ClockStats_f (void);
 
 
 /*
@@ -418,6 +426,7 @@ void Host_InitLocal (void)
 {
 	Cmd_AddCommand ("version", Host_Version_f);
         Cmd_AddCommand ("writeconfig", Host_WriteConfig_f);
+	Cmd_AddCommand ("sv_clock_stats", Host_ClockStats_f);
 
         Host_InitCommands ();
 
@@ -462,6 +471,9 @@ void Host_InitLocal (void)
 	Cvar_RegisterVariable (&pausable);
 
 	Cvar_RegisterVariable (&temp1);
+	Cvar_RegisterVariable (&sv_maxtickcatchup);
+	Cvar_RegisterVariable (&sv_tickdebug);
+	Cvar_RegisterVariable (&sv_clock_log);
 
 	Host_FindMaxClients ();
 }
@@ -995,6 +1007,191 @@ static void Host_CheckAutosave (void)
 	Cbuf_AddText (va ("save \"autosave/%s\" 0\n", sv.name));
 }
 
+static void Host_UpdateServerDevStats (void)
+{
+	int i, active;
+	edict_t *ent;
+
+	if (cls.signon != SIGNONS)
+		return;
+
+	for (i = 0, active = 0; i < qcvm->num_edicts; i++)
+	{
+		ent = EDICT_NUM (i);
+		if (!ent->free)
+			active++;
+	}
+	if (active > 600 && dev_peakstats.edicts <= 600)
+		Con_DWarning ("%i edicts exceeds standard limit of 600 (max = %d).\n", active, qcvm->max_edicts);
+	dev_stats.edicts = active;
+	dev_peakstats.edicts = q_max (active, dev_peakstats.edicts);
+}
+
+void Host_ResetServerClock (void)
+{
+	memset (&sv_clock, 0, sizeof (sv_clock));
+	sv_clock.last_realtime = realtime;
+}
+
+static void Host_RunServerSimTicks (double real_dt)
+{
+	int max_steps;
+	int steps = 0;
+	double rate;
+
+	if (!sv.active)
+		return;
+
+	rate = sv_tickrate.value;
+	if (rate < 10.0)
+		rate = 10.0;
+
+	sv_clock.tick_dt = 1.0 / rate;
+	sv_clock.sim_accum += real_dt;
+
+	max_steps = (sv_maxtickcatchup.value > 0.0) ? (int)sv_maxtickcatchup.value : 1;
+
+	while (sv_clock.sim_accum >= sv_clock.tick_dt && steps < max_steps)
+	{
+		double old_frametime = host_frametime;
+		double old_rawframetime = host_rawframetime;
+
+		host_frametime = sv_clock.tick_dt;
+		host_rawframetime = sv_clock.tick_dt;
+
+		PR_SwitchQCVM(&sv.qcvm);
+		SV_RunTick (sv_clock.tick_dt);
+		Host_UpdateServerDevStats ();
+		Host_CheckAutosave ();
+		PR_SwitchQCVM(NULL);
+
+		host_frametime = old_frametime;
+		host_rawframetime = old_rawframetime;
+
+		sv_clock.sim_accum -= sv_clock.tick_dt;
+		sv_clock.server_tick++;
+		steps++;
+	}
+
+	if (steps >= max_steps && sv_clock.sim_accum >= sv_clock.tick_dt)
+	{
+		sv_clock.sim_accum = q_min (sv_clock.sim_accum, sv_clock.tick_dt);
+		sv_clock.stats_hitch_clamps++;
+		if (sv_tickdebug.value)
+			Con_DWarning ("sv_clock: catchup clamp (accum %.4f)\n", sv_clock.sim_accum);
+	}
+
+	sv_clock.frame_sim_steps += steps;
+	sv_clock.stats_sim_ticks += steps;
+	sv_clock.stats_catchup_steps += steps;
+}
+
+static void Host_RunServerNetSends (double real_dt)
+{
+	int send_steps = 0;
+	double rate;
+
+	if (!sv.active)
+		return;
+
+	rate = sv_netrate.value;
+	if (rate <= 0.0)
+		return;
+
+	rate = CLAMP (1.0, rate, 200.0);
+	sv_clock.send_dt = 1.0 / rate;
+	sv_clock.send_accum += real_dt;
+
+	while (sv_clock.send_accum >= sv_clock.send_dt)
+	{
+		SV_SendClientMessages ();
+		sv_clock.send_accum -= sv_clock.send_dt;
+		send_steps++;
+	}
+
+	sv_clock.frame_send_steps += send_steps;
+	sv_clock.stats_send_ticks += send_steps;
+}
+
+static void Host_ClockStats_f (void)
+{
+	double sim_rate = 0.0;
+	double send_rate = 0.0;
+	double avg_steps = 0.0;
+
+	if (sv_clock.stats_time > 0.0)
+	{
+		sim_rate = sv_clock.stats_sim_ticks / sv_clock.stats_time;
+		send_rate = sv_clock.stats_send_ticks / sv_clock.stats_time;
+	}
+	if (sv_clock.stats_frames > 0)
+		avg_steps = (double)sv_clock.stats_catchup_steps / (double)sv_clock.stats_frames;
+
+	Con_Printf ("sv_clock: tickrate %.2f tick_dt %.4f sim %.2f/s net %.2f/s avg_steps %.2f clamps %u tick %llu\n",
+		sv_tickrate.value, sv_clock.tick_dt, sim_rate, send_rate, avg_steps,
+		sv_clock.stats_hitch_clamps, (unsigned long long)sv_clock.server_tick);
+
+	sv_clock.stats_frames = 0;
+	sv_clock.stats_sim_ticks = 0;
+	sv_clock.stats_send_ticks = 0;
+	sv_clock.stats_catchup_steps = 0;
+	sv_clock.stats_hitch_clamps = 0;
+	sv_clock.stats_time = 0.0;
+}
+
+static void Host_UpdateClockLog (void)
+{
+	static FILE *clock_log = NULL;
+	static qboolean log_active = false;
+	char path[MAX_OSPATH];
+
+	if (!sv.active)
+	{
+		if (sv_clock_log.value <= 0 && log_active)
+		{
+			fclose (clock_log);
+			clock_log = NULL;
+			log_active = false;
+		}
+		return;
+	}
+
+	if (sv_clock_log.value <= 0)
+	{
+		if (log_active)
+		{
+			fclose (clock_log);
+			clock_log = NULL;
+			log_active = false;
+		}
+		return;
+	}
+
+	if (!log_active)
+	{
+		q_snprintf (path, sizeof (path), "%s/logs/sv_clock.csv", com_gamedir);
+		COM_CreatePath (path);
+		clock_log = Sys_fopen (path, "w");
+		if (!clock_log)
+			return;
+		fprintf (clock_log, "realtime_ms,sim_steps,server_tick,send_steps,mtu_drops,ents_sent,bytes_sent\n");
+		log_active = true;
+	}
+
+	if (clock_log)
+	{
+		fprintf (clock_log, "%.0f,%u,%llu,%u,%u,%u,%u\n",
+			realtime * 1000.0,
+			sv_clock.frame_sim_steps,
+			(unsigned long long)sv_clock.server_tick,
+			sv_clock.frame_send_steps,
+			sv_clock.frame_mtu_drops,
+			sv_clock.frame_ents_sent,
+			sv_clock.frame_bytes_sent);
+		fflush (clock_log);
+	}
+}
+
 /*
 ==================
 Host_ServerFrame
@@ -1002,43 +1199,8 @@ Host_ServerFrame
 */
 void Host_ServerFrame (void)
 {
-	int		i, active; //johnfitz
-	edict_t	*ent; //johnfitz
-
-// run the world state
-	pr_global_struct->frametime = host_frametime;
-
-// set the time and clear the general datagram
-	SV_ClearDatagram ();
-
-// check for new clients
-	SV_CheckForNewClients ();
-
-// read client messages
-	SV_RunClients ();
-
-// move things around and think
-// always pause in single player if in console or menus
-	if (!sv.paused && (svs.maxclients > 1 || key_dest == key_game) )
-		SV_Physics ();
-
-//johnfitz -- devstats
-	if (cls.signon == SIGNONS)
-	{
-		for (i=0, active=0; i<qcvm->num_edicts; i++)
-		{
-			ent = EDICT_NUM(i);
-			if (!ent->free)
-				active++;
-		}
-		if (active > 600 && dev_peakstats.edicts <= 600)
-			Con_DWarning ("%i edicts exceeds standard limit of 600 (max = %d).\n", active, qcvm->max_edicts);
-		dev_stats.edicts = active;
-		dev_peakstats.edicts = q_max(active, dev_peakstats.edicts);
-	}
-//johnfitz
-
-// send all messages to the clients
+	SV_RunTick (host_frametime);
+	Host_UpdateServerDevStats ();
 	SV_SendClientMessages ();
 
 	Host_CheckAutosave ();
@@ -1260,6 +1422,7 @@ void _Host_Frame (double time)
 {
 	static double	accumtime = 0;
 	double time1, time2, time3;
+	double real_dt;
 	qboolean ranserver = false;
 
 	time1 = Sys_DoubleTime ();
@@ -1271,8 +1434,15 @@ void _Host_Frame (double time)
 	rand ();
 
 // decide the simulation time
-	accumtime += host_netinterval?CLAMP(0.0, time, 0.2):0.0;	//for renderer/server isolation
-	Host_AdvanceTime (time);
+	real_dt = CLAMP (0.0, time, 0.25);
+	accumtime += host_netinterval ? CLAMP(0.0, real_dt, 0.2) : 0.0;	//for renderer/server isolation
+	Host_AdvanceTime (real_dt);
+
+	sv_clock.frame_sim_steps = 0;
+	sv_clock.frame_send_steps = 0;
+	sv_clock.frame_mtu_drops = 0;
+	sv_clock.frame_ents_sent = 0;
+	sv_clock.frame_bytes_sent = 0;
 
 // run async procs
 	AsyncQueue_Drain (&async_queue);
@@ -1304,33 +1474,25 @@ void _Host_Frame (double time)
 	}
 
 	CL_AccumulateCmd ();
-
-	//Run the server+networking (client->server->client), at a different rate from everyt
-	if (accumtime >= host_netinterval)
+	if (!host_netinterval || accumtime >= host_netinterval)
 	{
-		float realframetime = host_frametime;
-		if (host_netinterval)
-		{
-			host_frametime = q_max(accumtime, (double)host_netinterval);
-			accumtime -= host_frametime;
-			if (host_timescale.value > 0)
-				host_frametime *= host_timescale.value;
-			else if (host_framerate.value)
-				host_frametime = host_framerate.value;
-		}
-		else
-			accumtime -= host_netinterval;
 		CL_SendCmd ();
-		if (sv.active)
-		{
-			PR_SwitchQCVM(&sv.qcvm);
-			Host_ServerFrame ();
-			PR_SwitchQCVM(NULL);
-		}
-		host_frametime = realframetime;
+		if (host_netinterval)
+			accumtime -= host_netinterval;
 		Cbuf_Waited();
-		ranserver = true;
 	}
+
+	if (sv.active)
+	{
+		sv_clock.stats_time += real_dt;
+		sv_clock.stats_frames++;
+		Host_RunServerSimTicks (real_dt);
+		Host_RunServerNetSends (real_dt);
+	}
+
+	Host_UpdateClockLog ();
+
+	ranserver = (sv_clock.frame_sim_steps > 0);
 
 // fetch results from server
 	if (cls.state == ca_connected)

--- a/Quake/server.h
+++ b/Quake/server.h
@@ -115,6 +115,35 @@ typedef struct
 	}			mapchecks;				// additional map checks (for level designers)
 } server_t;
 
+typedef struct
+{
+	double		tick_dt;
+	double		send_dt;
+	double		sim_accum;
+	double		send_accum;
+	double		last_realtime;
+	uint64_t	server_tick;
+	unsigned int	frame_sim_steps;
+	unsigned int	frame_send_steps;
+	unsigned int	frame_mtu_drops;
+	unsigned int	frame_ents_sent;
+	unsigned int	frame_bytes_sent;
+	unsigned int	stats_frames;
+	unsigned int	stats_sim_ticks;
+	unsigned int	stats_send_ticks;
+	unsigned int	stats_catchup_steps;
+	unsigned int	stats_hitch_clamps;
+	double		stats_time;
+} sv_clock_t;
+
+extern sv_clock_t sv_clock;
+
+extern cvar_t sv_tickdebug;
+extern cvar_t sv_maxtickcatchup;
+extern cvar_t sv_clock_log;
+
+void SV_RunTick (double tick_dt);
+void Host_ResetServerClock (void);
 
 #define	NUM_PING_TIMES		16
 #define COALESCE_BUFSIZE	16384
@@ -175,6 +204,7 @@ typedef struct client_s
 	unsigned int	snapshot_pending_baseline_seq;
 	double			snapshot_pending_time;
 	qboolean		snapshot_pending_is_delta;
+	unsigned int	snapshot_last_server_tick;
 	snapshot_state_t *snapshot_baseline;
 	byte			*snapshot_baseline_present;
 	snapshot_state_t *snapshot_pending;

--- a/Quake/sv_coalesce.c
+++ b/Quake/sv_coalesce.c
@@ -7,6 +7,7 @@
 cvar_t sv_tickrate = {"sv_tickrate", "60", CVAR_NONE};
 cvar_t sv_netrate = {"sv_netrate", "30", CVAR_NONE};
 cvar_t sv_netburst = {"sv_netburst", "1", CVAR_NONE};
+cvar_t sv_net_mtu = {"sv_net_mtu", "1200", CVAR_NONE};
 cvar_t sv_pktmax = {"sv_pktmax", "1200", CVAR_NONE};
 cvar_t sv_netcoalesce = {"sv_netcoalesce", "1", CVAR_NONE};
 cvar_t sv_net_debug = {"sv_net_debug", "0", CVAR_NONE};
@@ -62,6 +63,8 @@ static int SV_Coalesce_PacketCap(client_t *client)
 	if (Q_strcmp(NET_QSocketGetAddressString(client->netconnection), "LOCAL") != 0)
 		cap = DATAGRAM_MTU;
 
+	if (sv_net_mtu.value > 0)
+		cap = q_min(cap, (int)sv_net_mtu.value);
 	if (sv_pktmax.value > 0)
 		cap = q_min(cap, (int)sv_pktmax.value);
 
@@ -107,6 +110,7 @@ void SV_Coalesce_RegisterCvars(void)
 	Cvar_RegisterVariable(&sv_tickrate);
 	Cvar_RegisterVariable(&sv_netrate);
 	Cvar_RegisterVariable(&sv_netburst);
+	Cvar_RegisterVariable(&sv_net_mtu);
 	Cvar_RegisterVariable(&sv_pktmax);
 	Cvar_RegisterVariable(&sv_netcoalesce);
 	Cvar_RegisterVariable(&sv_net_debug);

--- a/Quake/sv_coalesce.h
+++ b/Quake/sv_coalesce.h
@@ -6,6 +6,7 @@
 extern cvar_t sv_tickrate;
 extern cvar_t sv_netrate;
 extern cvar_t sv_netburst;
+extern cvar_t sv_net_mtu;
 extern cvar_t sv_pktmax;
 extern cvar_t sv_netcoalesce;
 extern cvar_t sv_net_debug;

--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -42,6 +42,8 @@ static cvar_t sv_netsort = {"sv_netsort", "1", CVAR_NONE};
 static cvar_t sv_snapshotdelta = {"sv_snapshotdelta", "1", CVAR_NONE};
 static cvar_t sv_snapshotdebug = {"sv_snapshotdebug", "0", CVAR_NONE};
 static cvar_t sv_snapshottimeout = {"sv_snapshottimeout", "1000", CVAR_NONE};
+static cvar_t sv_snapshot_maxents = {"sv_snapshot_maxents", "768", CVAR_NONE};
+static cvar_t sv_snapshot_full_on_ackstall = {"sv_snapshot_full_on_ackstall", "3", CVAR_NONE};
 static cvar_t net_snap_tinyvel = {"net_snap_tinyvel", "1", CVAR_NONE};
 static cvar_t net_snap_forcefull_frames = {"net_snap_forcefull_frames", "3", CVAR_NONE};
 static cvar_t net_snap_debug = {"net_snap_debug", "0", CVAR_NONE};
@@ -109,6 +111,25 @@ void SV_CalcStats(client_t *client, int *statsi, float *statsf, const char **sta
 			break;
 		}
 	}
+}
+
+void SV_RunTick (double tick_dt)
+{
+	pr_global_struct->frametime = tick_dt;
+
+// set the time and clear the general datagram
+	SV_ClearDatagram ();
+
+// check for new clients
+	SV_CheckForNewClients ();
+
+// read client messages
+	SV_RunClients ();
+
+// move things around and think
+// always pause in single player if in console or menus
+	if (!sv.paused && (svs.maxclients > 1 || key_dest == key_game) )
+		SV_Physics ();
 }
 
 /*
@@ -191,6 +212,8 @@ void SV_Init (void)
 	Cvar_RegisterVariable (&sv_snapshotdelta);
 	Cvar_RegisterVariable (&sv_snapshotdebug);
 	Cvar_RegisterVariable (&sv_snapshottimeout);
+	Cvar_RegisterVariable (&sv_snapshot_maxents);
+	Cvar_RegisterVariable (&sv_snapshot_full_on_ackstall);
 	Cvar_RegisterVariable (&net_snap_tinyvel);
 	Cvar_RegisterVariable (&net_snap_forcefull_frames);
 	Cvar_RegisterVariable (&net_snap_debug);
@@ -751,6 +774,7 @@ static void SV_ResetClientSnapshot (client_t *client)
 	client->snapshot_pending_baseline_seq = 0;
 	client->snapshot_pending_time = 0;
 	client->snapshot_pending_is_delta = false;
+	client->snapshot_last_server_tick = 0;
 	client->snapshot_unacked_frames = 0;
 	client->snapshot_pending_mandatory = 0;
 	client->snapshot_pending_dropped = 0;
@@ -815,6 +839,9 @@ static qboolean SV_SnapshotMandatoryEnt (const edict_t *ent)
 		return true;
 	if (ent->v.movetype == MOVETYPE_PUSH && SV_SnapshotMoverMoving (ent))
 		return true;
+	if ((ent->v.movetype == MOVETYPE_TOSS || ent->v.movetype == MOVETYPE_BOUNCE)
+		&& SV_SnapshotTossMoving (ent))
+		return true;
 	return false;
 }
 
@@ -860,7 +887,7 @@ static int SV_SnapshotEntitySizeWorst (void)
 
 static int SV_SnapshotMaxEntities (sizebuf_t *msg)
 {
-	int header_size = 1 + 2 + 2 + 2 + 2 + 2;
+	int header_size = 1 + 2 + 2 + 4 + 2 + 2 + 2;
 	int delta_counts_size = 3 * 2;
 	int per_ent = SV_SnapshotEntitySizeWorst ();
 	int available = msg->maxsize - msg->cursize - header_size - delta_counts_size;
@@ -1075,23 +1102,21 @@ static int SV_BuildClientSnapshot (edict_t *clent, snapshot_state_t *states, byt
 	return count;
 }
 
-static void SV_WriteSnapshotCoord (sizebuf_t *msg, float value, qboolean hires)
+static qboolean SV_WriteSnapshotCoord (sizebuf_t *msg, float value, qboolean hires)
 {
 	if (hires && (sv.protocolflags & PRFL_SNAPSHOT_HIRES))
-		MSG_WriteCoord32f (msg, value);
-	else
-		MSG_WriteCoord (msg, value, sv.protocolflags);
+		return MSG_TryWriteCoord32f (msg, value);
+	return MSG_TryWriteCoord (msg, value, sv.protocolflags);
 }
 
-static void SV_WriteSnapshotAngle (sizebuf_t *msg, float value, qboolean hires)
+static qboolean SV_WriteSnapshotAngle (sizebuf_t *msg, float value, qboolean hires)
 {
 	if (hires && (sv.protocolflags & PRFL_SNAPSHOT_HIRES))
-		MSG_WriteFloat (msg, value);
-	else
-		MSG_WriteAngle (msg, value, sv.protocolflags);
+		return MSG_TryWriteFloat (msg, value);
+	return MSG_TryWriteAngle (msg, value, sv.protocolflags);
 }
 
-static void SV_WriteSnapshotState (sizebuf_t *msg, const snapshot_state_t *state, byte snapflags)
+static qboolean SV_WriteSnapshotState (sizebuf_t *msg, const snapshot_state_t *state, byte snapflags)
 {
 	int i;
 	qboolean hires_origin = (snapflags & SNAPFLAG_HIRES_ORIGIN) != 0;
@@ -1099,17 +1124,28 @@ static void SV_WriteSnapshotState (sizebuf_t *msg, const snapshot_state_t *state
 
 	for (i=0 ; i<3 ; i++)
 	{
-		SV_WriteSnapshotCoord (msg, state->state.origin[i], hires_origin);
-		SV_WriteSnapshotAngle (msg, state->state.angles[i], hires_angles);
+		if (!SV_WriteSnapshotCoord (msg, state->state.origin[i], hires_origin))
+			return false;
+		if (!SV_WriteSnapshotAngle (msg, state->state.angles[i], hires_angles))
+			return false;
 	}
-	MSG_WriteShort (msg, state->state.modelindex);
-	MSG_WriteShort (msg, state->state.frame);
-	MSG_WriteByte (msg, state->state.colormap);
-	MSG_WriteByte (msg, state->state.skin);
-	MSG_WriteByte (msg, state->state.effects);
-	MSG_WriteByte (msg, state->state.alpha);
-	MSG_WriteByte (msg, state->state.scale);
-	MSG_WriteByte (msg, state->step);
+	if (!MSG_TryWriteShort (msg, state->state.modelindex))
+		return false;
+	if (!MSG_TryWriteShort (msg, state->state.frame))
+		return false;
+	if (!MSG_TryWriteByte (msg, state->state.colormap))
+		return false;
+	if (!MSG_TryWriteByte (msg, state->state.skin))
+		return false;
+	if (!MSG_TryWriteByte (msg, state->state.effects))
+		return false;
+	if (!MSG_TryWriteByte (msg, state->state.alpha))
+		return false;
+	if (!MSG_TryWriteByte (msg, state->state.scale))
+		return false;
+	if (!MSG_TryWriteByte (msg, state->step))
+		return false;
+	return true;
 }
 
 static byte SV_SnapshotNetFlags (byte flags)
@@ -1130,22 +1166,30 @@ static void SV_WriteShortAt (sizebuf_t *msg, int offset, unsigned short value)
 	msg->data[offset + 1] = (value >> 8) & 0xff;
 }
 
-static int SV_WriteSnapshotHeader (sizebuf_t *msg, qboolean is_delta, unsigned int seq,
-	unsigned int baseline_seq, unsigned short entity_count, int *out_payload_offset,
-	int *out_len_offset, int *out_crc_offset)
+static qboolean SV_WriteSnapshotHeader (sizebuf_t *msg, qboolean is_delta, unsigned int seq,
+	unsigned int baseline_seq, unsigned int server_tick, unsigned short entity_count,
+	int *out_payload_offset, int *out_len_offset, int *out_crc_offset)
 {
-	MSG_WriteByte (msg, is_delta ? svc_snapshot_delta : svc_snapshot_full);
-	MSG_WriteShort (msg, (int)seq);
-	MSG_WriteShort (msg, is_delta ? (int)baseline_seq : 0xFFFF);
+	if (!MSG_TryWriteByte (msg, is_delta ? svc_snapshot_delta : svc_snapshot_full))
+		return false;
+	if (!MSG_TryWriteShort (msg, (int)seq))
+		return false;
+	if (!MSG_TryWriteShort (msg, is_delta ? (int)baseline_seq : 0xFFFF))
+		return false;
+	if (!MSG_TryWriteLong (msg, (int)server_tick))
+		return false;
 
 	*out_len_offset = msg->cursize;
-	MSG_WriteShort (msg, 0);
-	MSG_WriteShort (msg, entity_count);
+	if (!MSG_TryWriteShort (msg, 0))
+		return false;
+	if (!MSG_TryWriteShort (msg, entity_count))
+		return false;
 	*out_crc_offset = msg->cursize;
-	MSG_WriteShort (msg, 0);
+	if (!MSG_TryWriteShort (msg, 0))
+		return false;
 
 	*out_payload_offset = msg->cursize;
-	return msg->cursize;
+	return true;
 }
 
 static void SV_FinalizeSnapshotHeader (sizebuf_t *msg, int payload_offset, int len_offset, int crc_offset)
@@ -1208,8 +1252,9 @@ static unsigned int SV_SnapshotFieldMask (const snapshot_state_t *next, const sn
 	return mask;
 }
 
-static void SV_WriteSnapshotFull (sizebuf_t *msg, unsigned int seq, const snapshot_state_t *states,
-	const byte *present, const byte *snapflags, int max_edicts, int *out_count)
+static qboolean SV_WriteSnapshotFull (sizebuf_t *msg, unsigned int seq, unsigned int server_tick,
+	const snapshot_state_t *states, const byte *present, const byte *snapflags, int max_edicts,
+	int *out_count)
 {
 	int count = 0;
 	int entnum;
@@ -1223,29 +1268,37 @@ static void SV_WriteSnapshotFull (sizebuf_t *msg, unsigned int seq, const snapsh
 			count++;
 	}
 
-	SV_WriteSnapshotHeader (msg, false, seq, 0, (unsigned short)count,
-		&payload_offset, &len_offset, &crc_offset);
-	MSG_WriteShort (msg, count);
+	if (!SV_WriteSnapshotHeader (msg, false, seq, 0, server_tick, (unsigned short)count,
+		&payload_offset, &len_offset, &crc_offset))
+		return false;
+	if (!MSG_TryWriteShort (msg, count))
+		return false;
 	for (entnum = 1; entnum < max_edicts; entnum++)
 	{
 		if (!present[entnum])
 			continue;
-		MSG_WriteShort (msg, entnum);
+		if (!MSG_TryWriteShort (msg, entnum))
+			return false;
 		if (sv.protocolflags & PRFL_SNAPSHOT_HIRES)
-			MSG_WriteByte (msg, snapflags ? SV_SnapshotNetFlags (snapflags[entnum]) : 0);
-		SV_WriteSnapshotState (msg, &states[entnum], snapflags ? snapflags[entnum] : 0);
+		{
+			if (!MSG_TryWriteByte (msg, snapflags ? SV_SnapshotNetFlags (snapflags[entnum]) : 0))
+				return false;
+		}
+		if (!SV_WriteSnapshotState (msg, &states[entnum], snapflags ? snapflags[entnum] : 0))
+			return false;
 	}
 
 	SV_FinalizeSnapshotHeader (msg, payload_offset, len_offset, crc_offset);
 
 	if (out_count)
 		*out_count = count;
+	return true;
 }
 
-static void SV_WriteSnapshotDelta (sizebuf_t *msg, unsigned int seq, unsigned int baseline_seq,
-	const snapshot_state_t *states, const byte *present, const snapshot_state_t *baseline,
-	const byte *baseline_present, const byte *snapflags, int max_edicts, int *out_remove,
-	int *out_add, int *out_update)
+static qboolean SV_WriteSnapshotDelta (sizebuf_t *msg, unsigned int seq, unsigned int baseline_seq,
+	unsigned int server_tick, const snapshot_state_t *states, const byte *present,
+	const snapshot_state_t *baseline, const byte *baseline_present, const byte *snapflags,
+	int max_edicts, int *out_remove, int *out_add, int *out_update)
 {
 	int entnum;
 	int remove_count = 0;
@@ -1274,29 +1327,41 @@ static void SV_WriteSnapshotDelta (sizebuf_t *msg, unsigned int seq, unsigned in
 			update_count++;
 	}
 
-	SV_WriteSnapshotHeader (msg, true, seq, baseline_seq, (unsigned short)(add_count + update_count),
-		&payload_offset, &len_offset, &crc_offset);
+	if (!SV_WriteSnapshotHeader (msg, true, seq, baseline_seq, server_tick,
+		(unsigned short)(add_count + update_count), &payload_offset, &len_offset, &crc_offset))
+		return false;
 
-	MSG_WriteShort (msg, remove_count);
+	if (!MSG_TryWriteShort (msg, remove_count))
+		return false;
 	for (entnum = 1; entnum < max_edicts; entnum++)
 	{
 		if (baseline_present[entnum] && !present[entnum])
-			MSG_WriteShort (msg, entnum);
+		{
+			if (!MSG_TryWriteShort (msg, entnum))
+				return false;
+		}
 	}
 
-	MSG_WriteShort (msg, add_count);
+	if (!MSG_TryWriteShort (msg, add_count))
+		return false;
 	for (entnum = 1; entnum < max_edicts; entnum++)
 	{
 		if (!baseline_present[entnum] && present[entnum])
 		{
-			MSG_WriteShort (msg, entnum);
+			if (!MSG_TryWriteShort (msg, entnum))
+				return false;
 			if (sv.protocolflags & PRFL_SNAPSHOT_HIRES)
-				MSG_WriteByte (msg, snapflags ? SV_SnapshotNetFlags (snapflags[entnum]) : 0);
-			SV_WriteSnapshotState (msg, &states[entnum], snapflags ? snapflags[entnum] : 0);
+			{
+				if (!MSG_TryWriteByte (msg, snapflags ? SV_SnapshotNetFlags (snapflags[entnum]) : 0))
+					return false;
+			}
+			if (!SV_WriteSnapshotState (msg, &states[entnum], snapflags ? snapflags[entnum] : 0))
+				return false;
 		}
 	}
 
-	MSG_WriteShort (msg, update_count);
+	if (!MSG_TryWriteShort (msg, update_count))
+		return false;
 	for (entnum = 1; entnum < max_edicts; entnum++)
 	{
 		unsigned int mask;
@@ -1306,36 +1371,80 @@ static void SV_WriteSnapshotDelta (sizebuf_t *msg, unsigned int seq, unsigned in
 		mask = SV_SnapshotFieldMask (&states[entnum], &baseline[entnum], snapflags ? snapflags[entnum] : 0);
 		if (!mask)
 			continue;
-		MSG_WriteShort (msg, entnum);
-		MSG_WriteLong (msg, (int)mask);
+		if (!MSG_TryWriteShort (msg, entnum))
+			return false;
+		if (!MSG_TryWriteLong (msg, (int)mask))
+			return false;
 		if (mask & SNAP_ORIGIN1)
-			SV_WriteSnapshotCoord (msg, states[entnum].state.origin[0], (mask & SNAP_HIRES_ORIGIN) != 0);
+		{
+			if (!SV_WriteSnapshotCoord (msg, states[entnum].state.origin[0], (mask & SNAP_HIRES_ORIGIN) != 0))
+				return false;
+		}
 		if (mask & SNAP_ORIGIN2)
-			SV_WriteSnapshotCoord (msg, states[entnum].state.origin[1], (mask & SNAP_HIRES_ORIGIN) != 0);
+		{
+			if (!SV_WriteSnapshotCoord (msg, states[entnum].state.origin[1], (mask & SNAP_HIRES_ORIGIN) != 0))
+				return false;
+		}
 		if (mask & SNAP_ORIGIN3)
-			SV_WriteSnapshotCoord (msg, states[entnum].state.origin[2], (mask & SNAP_HIRES_ORIGIN) != 0);
+		{
+			if (!SV_WriteSnapshotCoord (msg, states[entnum].state.origin[2], (mask & SNAP_HIRES_ORIGIN) != 0))
+				return false;
+		}
 		if (mask & SNAP_ANGLE1)
-			SV_WriteSnapshotAngle (msg, states[entnum].state.angles[0], (mask & SNAP_HIRES_ANGLES) != 0);
+		{
+			if (!SV_WriteSnapshotAngle (msg, states[entnum].state.angles[0], (mask & SNAP_HIRES_ANGLES) != 0))
+				return false;
+		}
 		if (mask & SNAP_ANGLE2)
-			SV_WriteSnapshotAngle (msg, states[entnum].state.angles[1], (mask & SNAP_HIRES_ANGLES) != 0);
+		{
+			if (!SV_WriteSnapshotAngle (msg, states[entnum].state.angles[1], (mask & SNAP_HIRES_ANGLES) != 0))
+				return false;
+		}
 		if (mask & SNAP_ANGLE3)
-			SV_WriteSnapshotAngle (msg, states[entnum].state.angles[2], (mask & SNAP_HIRES_ANGLES) != 0);
+		{
+			if (!SV_WriteSnapshotAngle (msg, states[entnum].state.angles[2], (mask & SNAP_HIRES_ANGLES) != 0))
+				return false;
+		}
 		if (mask & SNAP_MODEL)
-			MSG_WriteShort (msg, states[entnum].state.modelindex);
+		{
+			if (!MSG_TryWriteShort (msg, states[entnum].state.modelindex))
+				return false;
+		}
 		if (mask & SNAP_FRAME)
-			MSG_WriteShort (msg, states[entnum].state.frame);
+		{
+			if (!MSG_TryWriteShort (msg, states[entnum].state.frame))
+				return false;
+		}
 		if (mask & SNAP_COLORMAP)
-			MSG_WriteByte (msg, states[entnum].state.colormap);
+		{
+			if (!MSG_TryWriteByte (msg, states[entnum].state.colormap))
+				return false;
+		}
 		if (mask & SNAP_SKIN)
-			MSG_WriteByte (msg, states[entnum].state.skin);
+		{
+			if (!MSG_TryWriteByte (msg, states[entnum].state.skin))
+				return false;
+		}
 		if (mask & SNAP_EFFECTS)
-			MSG_WriteByte (msg, states[entnum].state.effects);
+		{
+			if (!MSG_TryWriteByte (msg, states[entnum].state.effects))
+				return false;
+		}
 		if (mask & SNAP_ALPHA)
-			MSG_WriteByte (msg, states[entnum].state.alpha);
+		{
+			if (!MSG_TryWriteByte (msg, states[entnum].state.alpha))
+				return false;
+		}
 		if (mask & SNAP_SCALE)
-			MSG_WriteByte (msg, states[entnum].state.scale);
+		{
+			if (!MSG_TryWriteByte (msg, states[entnum].state.scale))
+				return false;
+		}
 		if (mask & SNAP_STEP)
-			MSG_WriteByte (msg, states[entnum].step);
+		{
+			if (!MSG_TryWriteByte (msg, states[entnum].step))
+				return false;
+		}
 	}
 
 	SV_FinalizeSnapshotHeader (msg, payload_offset, len_offset, crc_offset);
@@ -1346,6 +1455,7 @@ static void SV_WriteSnapshotDelta (sizebuf_t *msg, unsigned int seq, unsigned in
 		*out_add = add_count;
 	if (out_update)
 		*out_update = update_count;
+	return true;
 }
 
 static void SV_SendSnapshot (client_t *client, sizebuf_t *msg)
@@ -1358,14 +1468,22 @@ static void SV_SendSnapshot (client_t *client, sizebuf_t *msg)
 	int entity_count = 0;
 	int snap_flags = 0;
 	int drop_pct = 0;
+	unsigned int server_tick = (unsigned int)sv_clock.server_tick;
 	double timeout_s = sv_snapshottimeout.value / 1000.0;
 	qboolean use_delta;
 	qboolean forced_full = false;
+	qboolean wrote_snapshot = false;
 
 	drop_pct = CLAMP (0, (int)net_drop_delta_pct.value, 100);
 
+	if (server_tick < client->snapshot_last_server_tick)
+		server_tick = client->snapshot_last_server_tick;
+	client->snapshot_last_server_tick = server_tick;
+
 	if (client->snapshot_pending_seq)
 	{
+		int ackstall = (int)sv_snapshot_full_on_ackstall.value;
+
 		client->snapshot_unacked_frames++;
 		if (client->snapshot_pending_is_delta)
 		{
@@ -1374,11 +1492,15 @@ static void SV_SendSnapshot (client_t *client, sizebuf_t *msg)
 				client->snapshot_pending_is_delta = false;
 				forced_full = true;
 			}
-			else if (net_snap_forcefull_frames.value > 0.0
-				&& client->snapshot_unacked_frames >= (int)net_snap_forcefull_frames.value)
+			else
 			{
-				client->snapshot_pending_is_delta = false;
-				forced_full = true;
+				if (ackstall <= 0)
+					ackstall = (int)net_snap_forcefull_frames.value;
+				if (ackstall > 0 && client->snapshot_unacked_frames >= ackstall)
+				{
+					client->snapshot_pending_is_delta = false;
+					forced_full = true;
+				}
 			}
 		}
 		use_delta = client->snapshot_pending_is_delta;
@@ -1395,14 +1517,16 @@ static void SV_SendSnapshot (client_t *client, sizebuf_t *msg)
 		}
 		client->snapshot_pending_is_delta = use_delta;
 		if (use_delta)
-			SV_WriteSnapshotDelta (msg, client->snapshot_pending_seq, client->snapshot_pending_baseline_seq,
-				client->snapshot_pending, client->snapshot_pending_present,
+			wrote_snapshot = SV_WriteSnapshotDelta (msg, client->snapshot_pending_seq,
+				client->snapshot_pending_baseline_seq, server_tick, client->snapshot_pending,
+				client->snapshot_pending_present,
 				client->snapshot_baseline, client->snapshot_baseline_present,
 				client->snapshot_pending_flags, qcvm->max_edicts,
 				&remove_count, &add_count, &update_count);
 		else
-			SV_WriteSnapshotFull (msg, client->snapshot_pending_seq, client->snapshot_pending,
-				client->snapshot_pending_present, client->snapshot_pending_flags, qcvm->max_edicts, &full_count);
+			wrote_snapshot = SV_WriteSnapshotFull (msg, client->snapshot_pending_seq, server_tick,
+				client->snapshot_pending, client->snapshot_pending_present, client->snapshot_pending_flags,
+				qcvm->max_edicts, &full_count);
 		client->snapshot_pending_time = realtime;
 	}
 	else
@@ -1411,6 +1535,9 @@ static void SV_SendSnapshot (client_t *client, sizebuf_t *msg)
 		int dropped_count = 0;
 		int max_ents = SV_SnapshotMaxEntities (msg);
 		qboolean debug_frame = false;
+
+		if (sv_snapshot_maxents.value > 0)
+			max_ents = q_min (max_ents, (int)sv_snapshot_maxents.value);
 
 		if (net_snap_debug.value && realtime >= client->snapshot_debug_next_time)
 		{
@@ -1422,6 +1549,8 @@ static void SV_SendSnapshot (client_t *client, sizebuf_t *msg)
 			client->snapshot_pending_flags, max_ents, &mandatory_count, &dropped_count, debug_frame);
 		client->snapshot_pending_mandatory = mandatory_count;
 		client->snapshot_pending_dropped = dropped_count;
+		if (sv_tickdebug.value && dropped_count > 0)
+			Con_DWarning ("snapshot %s dropped %d ents (budget)\n", client->name, dropped_count);
 		client->snapshot_pending_seq = client->snapshot_next_seq++;
 		if (client->snapshot_next_seq > 0xFFFF)
 			client->snapshot_next_seq = 1;
@@ -1443,14 +1572,25 @@ static void SV_SendSnapshot (client_t *client, sizebuf_t *msg)
 		}
 		client->snapshot_pending_is_delta = use_delta;
 		if (use_delta)
-			SV_WriteSnapshotDelta (msg, client->snapshot_pending_seq, client->snapshot_baseline_seq,
-				client->snapshot_pending, client->snapshot_pending_present,
+			wrote_snapshot = SV_WriteSnapshotDelta (msg, client->snapshot_pending_seq,
+				client->snapshot_baseline_seq, server_tick, client->snapshot_pending,
+				client->snapshot_pending_present,
 				client->snapshot_baseline, client->snapshot_baseline_present,
 				client->snapshot_pending_flags, qcvm->max_edicts,
 				&remove_count, &add_count, &update_count);
 		else
-			SV_WriteSnapshotFull (msg, client->snapshot_pending_seq, client->snapshot_pending,
-				client->snapshot_pending_present, client->snapshot_pending_flags, qcvm->max_edicts, &full_count);
+			wrote_snapshot = SV_WriteSnapshotFull (msg, client->snapshot_pending_seq, server_tick,
+				client->snapshot_pending, client->snapshot_pending_present, client->snapshot_pending_flags,
+				qcvm->max_edicts, &full_count);
+	}
+
+	if (!wrote_snapshot)
+	{
+		msg->cursize = start_size;
+		sv_clock.frame_mtu_drops++;
+		if (sv_tickdebug.value)
+			Con_DWarning ("snapshot %s dropped (mtu cap)\n", client->name);
+		return;
 	}
 
 	if (forced_full)
@@ -1489,9 +1629,12 @@ static void SV_SendSnapshot (client_t *client, sizebuf_t *msg)
 				client->name, client->snapshot_pending_seq, size_delta, full_count);
 	}
 
+	entity_count = client->snapshot_pending_is_delta ? (add_count + update_count) : full_count;
+	sv_clock.frame_ents_sent += entity_count;
+	sv_clock.frame_bytes_sent += (msg->cursize - start_size);
+
 	if (net_debug_snap.value)
 	{
-		entity_count = client->snapshot_pending_is_delta ? (add_count + update_count) : full_count;
 		snap_flags = client->snapshot_pending_is_delta ? 1 : 0;
 		if (forced_full)
 			snap_flags |= 2;
@@ -2050,6 +2193,21 @@ static void SV_BuildClientDatagram (client_t *client, sizebuf_t *msg)
 		SZ_Write (msg, sv.datagram.data, sv.datagram.cursize);
 }
 
+static int SV_ClientPacketCap (client_t *client)
+{
+	int cap = MAX_DATAGRAM;
+
+	if (Q_strcmp(NET_QSocketGetAddressString(client->netconnection), "LOCAL") != 0)
+		cap = DATAGRAM_MTU;
+
+	if (sv_net_mtu.value > 0)
+		cap = q_min (cap, (int)sv_net_mtu.value);
+	if (sv_pktmax.value > 0)
+		cap = q_min (cap, (int)sv_pktmax.value);
+
+	return cap;
+}
+
 qboolean SV_SendClientDatagram (client_t *client)
 {
 	byte		buf[MAX_DATAGRAM];
@@ -2059,10 +2217,7 @@ qboolean SV_SendClientDatagram (client_t *client)
 	msg.maxsize = sizeof(buf);
 	msg.cursize = 0;
 
-	//johnfitz -- if client is nonlocal, use smaller max size so packets aren't fragmented
-	if (Q_strcmp(NET_QSocketGetAddressString(client->netconnection), "LOCAL") != 0)
-		msg.maxsize = DATAGRAM_MTU;
-	//johnfitz
+	msg.maxsize = q_min (msg.maxsize, SV_ClientPacketCap (client));
 
 	SV_BuildClientDatagram (client, &msg);
 
@@ -2254,10 +2409,7 @@ void SV_SendClientMessages (void)
 			msg.maxsize = sizeof(buf);
 			msg.cursize = 0;
 
-			//johnfitz -- if client is nonlocal, use smaller max size so packets aren't fragmented
-			if (Q_strcmp(NET_QSocketGetAddressString(host_client->netconnection), "LOCAL") != 0)
-				msg.maxsize = DATAGRAM_MTU;
-			//johnfitz
+			msg.maxsize = q_min (msg.maxsize, SV_ClientPacketCap (host_client));
 
 			SV_BuildClientDatagram (host_client, &msg);
 			SV_Coalesce_Enqueue (host_client, msg.data, msg.cursize);
@@ -2972,6 +3124,7 @@ void SV_SpawnServer (const char *server)
 	ED_LoadFromFile (sv.worldmodel->entities);
 
 	sv.active = true;
+	Host_ResetServerClock ();
 
 // all setup is completed, any further precache statements are errors
 	sv.state = ss_active;


### PR DESCRIPTION
### Motivation

- Provide a deterministic fixed-timestep server simulation driven by `sv_tickrate` to eliminate sim jitter and uneven interpolation points.  
- Decouple network sends from simulation with a separate `sv_netrate` scheduler so snapshot production and transmission cadence are independent.  
- Harden snapshot generation and message building to avoid `SZ_GetSpace` overflows, enforce MTU/budgets, and recover from ack stalls.  
- Add instrumentation and optional CSV logging to prove stable tick/send rates and observe snapshot health metrics.

### Description

- Introduced `sv_clock_t sv_clock` and related cvars (`sv_maxtickcatchup`, `sv_tickdebug`, `sv_clock_log`, `sv_net_mtu`, `sv_snapshot_maxents`, `sv_snapshot_full_on_ackstall`) and added `Host_RunServerSimTicks` / `Host_RunServerNetSends` driven from `_Host_Frame` to implement fixed sim ticks and decoupled sends.  
- Added `SV_RunTick(double)` as the single-tick server simulation entry called at fixed `tick_dt`, and updated `Host_ServerFrame`/`_Host_Frame` to use the new scheduling, clamping catch-up to avoid spiral-of-death.  
- Hardened message writes with overflow-safe try-write helpers (`MSG_TryWrite*`) and replaced snapshot write paths to use those functions, plus extended snapshot header to include `server_tick` and made snapshot builders return success/failure for MTU-safe behavior.  
- Snapshot budget/MTU logic: added `SV_SnapshotMaxEntities` limit, per-client packet cap via `SV_ClientPacketCap`, `sv_net_mtu` integration into coalescing, mandatory-entity rules (movers/toss/bounce), and ack-stall fallback to force full snapshots after configurable threshold.  
- Instrumentation and logging: `sv_clock` accumulators, `sv_clock_stats` console command, and optional CSV logging to `logs/sv_clock.csv` for realtime_ms, sim/send steps, mtu drops, ents/bytes sent.  

### Testing

- No automated tests were executed for these changes.  
- The patch adds defensive write paths and budgets to prevent runtime buffer overflows, and includes debug/logging hooks to observe behavior under runtime testing.  
- Manual QA recommendations (not executed here): hitch injection, dedicated-server `sys_ticrate` variations, high-entity maps, and packet-loss simulation to validate fallback behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69601a66ecc0832ea22b3c3256ffcfc1)