### PR TITLE
PR_GetString: add sanity checks for `qcvm` and `stringssize`

### DIFF
--- a/Quake/pr_edict.c
+++ b/Quake/pr_edict.c
@@ -2375,6 +2375,10 @@ static qboolean PR_IsValidString (const char *p)
 
 const char *PR_GetString (int num)
 {
+	if (!qcvm)
+		Host_Error ("PR_GetString: qcvm == NULL\n");
+	if (qcvm->stringssize < 0 || qcvm->stringssize > (1 << 28))
+		Host_Error ("PR_GetString: qcvm->stringssize out of range %d\n", qcvm->stringssize);
 	if (num >= 0 && num < qcvm->stringssize)
 		return qcvm->strings + num;
 	else if (num < 0 && num >= -qcvm->numknownstrings)


### PR DESCRIPTION
### Motivation
- Prevent crashes caused by dereferencing a NULL or corrupted VM state when calling `PR_GetString`.
- The code previously accessed `qcvm->stringssize` and `qcvm->strings` without verifying `qcvm` or validating `stringssize`, leading to potential access violations.
- Provide earlier, clearer failure diagnostics via `Host_Error` instead of allowing a silent memory read fault.

### Description
- Added a NULL check for `qcvm` at the start of `PR_GetString` and call `Host_Error` if it is NULL.
- Added a sanity-range check for `qcvm->stringssize` and call `Host_Error` if the value is negative or exceeds `1 << 28`.
- Changes applied in `Quake/pr_edict.c` inside the `PR_GetString` function to perform the new guard checks before using `qcvm`.

### Testing
- No automated tests were run for this change.
- The change is limited to adding guard clauses and does not alter the existing return paths for valid inputs.
- Manual runtime validation is recommended (debug build / ASan / watchpoints) to verify crash repro and guard behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69602472b298832ebd0e79448a3fc7ac)