### PR TITLE
Use server QCVM when spawning server

### DIFF
--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -2980,7 +2980,7 @@ void SV_SpawnServer (const char *server)
 	static char	dummy[8] = { 0,0,0,0,0,0,0,0 };
 	edict_t		*ent;
 	int			i, signonsize;
-	qcvm_t		*vm = qcvm;
+	qcvm_t		*vm = &sv.qcvm;
 
 	// let's not have any servers with no name
 	if (hostname.string[0] == 0)


### PR DESCRIPTION
### Motivation
- `SV_SpawnServer` previously used the global `qcvm` pointer which can be `NULL`, causing `PR_GetString: qcvm == NULL` host errors during startup.
- Defaulting to the server's QCVM prevents null dereferences when loading progs and initializing entities.
- This improves robustness of server spawn and map loading during startup.

### Description
- Replace `qcvm_t *vm = qcvm;` with `qcvm_t *vm = &sv.qcvm;` in `Quake/sv_main.c` so the server QCVM is used by default.
- The change ensures subsequent calls like `PR_LoadProgs` and entity setup operate on the server VM instead of a potentially null global.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696025743cec832ebed4501616572cc6)