### PR TITLE
Ensure serverinfo uses active qcvm during SV_SendServerinfo

### DIFF
--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -446,9 +446,12 @@ This will be sent on the initial connection and upon each server load.
 */
 void SV_SendServerinfo (client_t *client)
 {
+	qcvm_t			*oldvm;
 	const char		**s;
 	char			message[2048];
 	int				i; //johnfitz
+
+	PR_PushQCVM (&sv.qcvm, &oldvm);
 
 	MSG_WriteByte (&client->message, svc_print);
 	sprintf (message, "%c\nFITZQUAKE %1.2f SERVER (%i CRC)\n", 2, FITZQUAKE_VERSION, qcvm->crc); //johnfitz -- include fitzquake version
@@ -498,6 +501,8 @@ void SV_SendServerinfo (client_t *client)
 
 	client->sendsignon = PRESPAWN_FLUSH;
 	client->spawned = false;		// need prespawn, spawn, etc
+
+	PR_PopQCVM (oldvm);
 }
 
 /*


### PR DESCRIPTION
### Motivation

- Prevent a `NULL` qcvm when composing the serverinfo message which could cause `PR_GetString`/other qcvm accesses to `Host_Error` during map start or client connects.
- `SV_SendServerinfo` reads `qcvm->edicts->v.message` and other qcvm-backed data, so it must run with the server `qcvm` active.
- Avoid crashes or failed map starts that occur when server info is serialized without a valid qcvm context.

### Description

- Wrap `SV_SendServerinfo` with `PR_PushQCVM(&sv.qcvm, &oldvm)` at the start and `PR_PopQCVM(oldvm)` at the end to ensure a valid qcvm context.
- Add a local `qcvm_t *oldvm` variable and perform the push/pop calls around the existing message serialization logic.
- Modified file: `Quake/sv_main.c` (changes confined to `SV_SendServerinfo`).

### Testing

- No automated tests were executed for this change.
- The change is restricted to a small, deterministic scope and only adjusts qcvm context handling for `SV_SendServerinfo`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696026889cf0832e976c4a28ebd1fac0)