### PR TITLE
Fix MSVC bitwise operand errors and add MSG_WriteCoord32f prototype

### DIFF
--- a/Quake/common.h
+++ b/Quake/common.h
@@ -223,6 +223,7 @@ void MSG_WriteShort (sizebuf_t *sb, int c);
 void MSG_WriteLong (sizebuf_t *sb, int c);
 void MSG_WriteFloat (sizebuf_t *sb, float f);
 void MSG_WriteString (sizebuf_t *sb, const char *s);
+void MSG_WriteCoord32f (sizebuf_t *sb, float f);
 void MSG_WriteCoord (sizebuf_t *sb, float f, unsigned int flags);
 void MSG_WriteAngle (sizebuf_t *sb, float f, unsigned int flags);
 void MSG_WriteAngle16 (sizebuf_t *sb, float f, unsigned int flags); //johnfitz
@@ -484,4 +485,3 @@ extern qboolean		fitzmode;
 	/* if true, run in fitzquake mode disabling custom quakespasm hacks */
 
 #endif	/* _Q_COMMON_H */
-

--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -775,7 +775,7 @@ static qboolean SV_SnapshotTossMoving (const edict_t *ent)
 {
 	float tinyvel = net_snap_tinyvel.value;
 
-	if (!(ent->v.flags & FL_ONGROUND))
+	if (!((int)ent->v.flags & FL_ONGROUND))
 		return true;
 	return VectorLengthSquared (ent->v.velocity) > (tinyvel * tinyvel);
 }
@@ -804,9 +804,9 @@ static byte SV_SnapshotFlagsForEnt (const edict_t *ent)
 
 static qboolean SV_SnapshotMandatoryEnt (const edict_t *ent)
 {
-	if (ent->v.flags & FL_CLIENT)
+	if ((int)ent->v.flags & FL_CLIENT)
 		return true;
-	if (ent->v.movetype == MOVETYPE_PUSH && SV_SnapshotMoverMoving (ent))
+	if ((int)ent->v.movetype == MOVETYPE_PUSH && SV_SnapshotMoverMoving (ent))
 		return true;
 	return false;
 }


### PR DESCRIPTION
### Motivation
- MSVC reported invalid bitwise operand errors when checking entity flags/movetype, indicating a need to ensure integer operands for `&`/bit checks.
- A warning about `MSG_WriteCoord32f` being undefined indicated the prototype was missing from the common header.

### Description
- Cast `ent->v.flags` and `ent->v.movetype` to `int` before performing bitwise checks to avoid MSVC operand type errors in `Quake/sv_main.c`.
- Add the declaration `void MSG_WriteCoord32f(sizebuf_t *sb, float f);` to `Quake/common.h` to provide the missing prototype.
- Changes touch `Quake/sv_main.c` (snapshot helper checks) and `Quake/common.h` (function prototype).

### Testing
- No automated build or unit tests were run as part of this change.
- Basic repository file checks (file listings and greps) were used to locate affected call sites and confirm the prototype placement.
- The change is intended to resolve MSVC compiler errors `C2296` and the implicit declaration warning `C4013` reported earlier.
- Further verification should be performed by running a full build on MSVC and other supported toolchains.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69602e9f176c832e9d76af1e526081dd)