### PR TITLE
Fix snapshot hires flag decoding

### DIFF
--- a/Quake/protocol.h
+++ b/Quake/protocol.h
@@ -88,8 +88,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define SNAP_HIRES_ORIGIN	(1u<<14)
 #define SNAP_HIRES_ANGLES	(1u<<15)
 
-#define SNAPFL_HIRES_ORIGIN	(1u<<0)
-#define SNAPFL_HIRES_ANGLES	(1u<<1)
+#define SNAPFL_HIRES_ORIGIN	(1u<<2)
+#define SNAPFL_HIRES_ANGLES	(1u<<3)
 
 //johnfitz -- PROTOCOL_NEHAHRA transparency
 #define U_TRANS			(1<<15)


### PR DESCRIPTION
### Motivation

- Clients were mis-parsing snapshot messages which could lead to errors like `Host_Error: Illegible server message 0 (previous was svc_snapshot_delta)` and `CL_ParseSnapshotFull: entnum out of range` during map load or entering teleporters.
- The root cause was a client/server mismatch in which bits indicate high-resolution snapshot fields, causing the client to read the wrong field types (`float` vs packed coord/angle) and desynchronize the message stream.

### Description

- Adjust the client-side snapshot hires flag bit positions to match the server encoding by updating `Quake/protocol.h`.
- Change `SNAPFL_HIRES_ORIGIN` from `(1u<<0)` to `(1u<<2)` and `SNAPFL_HIRES_ANGLES` from `(1u<<1)` to `(1u<<3)` to align with the server `SNAPFLAG_*` definitions.
- This keeps the `SNAPFL_*` (client-side flag mask) bit indices consistent with the `SNAPFLAG_*` (server-side) values used when writing snapshot packets.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69602fb8b248832eae9d3fe46aa34d2d)