### PR TITLE
Fix packed entity stats declaration order

### DIFF
--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -44,6 +44,20 @@ static cvar_t net_snap_forcefull_frames = {"net_snap_forcefull_frames", "3", CVA
 static cvar_t net_snap_debug = {"net_snap_debug", "0", CVAR_NONE};
 static qboolean sv_packedents_selftest_done = false;
 
+typedef struct
+{
+	int packets;
+	int entities;
+	int bytes;
+	int mask_bits_total;
+	int mask_hist[33];
+	int clamp_origin;
+	int clamp_velocity;
+} packedent_stats_t;
+
+static packedent_stats_t sv_packedents_stats;
+static double sv_packedents_stats_next_time = 0.0;
+
 //============================================================================
 
 static void SV_InitClientSnapshotData (client_t *client);
@@ -1468,20 +1482,6 @@ typedef struct
 	byte		scale;
 	byte		lerpfinish;
 } packedent_update_t;
-
-typedef struct
-{
-	int packets;
-	int entities;
-	int bytes;
-	int mask_bits_total;
-	int mask_hist[33];
-	int clamp_origin;
-	int clamp_velocity;
-} packedent_stats_t;
-
-static packedent_stats_t sv_packedents_stats;
-static double sv_packedents_stats_next_time = 0.0;
 
 static short SV_PackedQuantizeCoord (float value, int *clamp_count)
 {


### PR DESCRIPTION
### Motivation
- The server code referenced `sv_packedents_stats` before its type and storage were declared, causing compiler errors in `sv_main.c` on some toolchains. 
- The intent is to ensure the packed-entity statistics type and globals are visible at the point of first use to avoid undeclared identifier and struct-access errors.

### Description
- Move the `packedent_stats_t` typedef and the `sv_packedents_stats` / `sv_packedents_stats_next_time` static declarations earlier in `sv_main.c` so they appear before functions that reference them.  
- Remove the duplicate definition that previously appeared later in the file to prevent redefinition and ordering problems.  
- No semantic changes to the stats structure or initialization were made, only the declaration order within `sv_main.c` was adjusted.

### Testing
- No automated tests or builds were executed as part of this change.  
- The change is limited to declaration order to resolve compile-time errors and should be validated by running a normal project build on target platforms.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696038872dbc832ea20a50001e8b0441)