### PR TITLE
Fix icull stats declaration order

### DIFF
--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -63,6 +63,29 @@ typedef struct
 static packedent_stats_t sv_packedents_stats;
 static double sv_packedents_stats_next_time = 0.0;
 
+typedef struct
+{
+	int considered;
+	int sent;
+	int culled_distance;
+	int culled_pvs;
+	int forced_sent;
+} sv_icull_stats_t;
+
+typedef struct
+{
+	vec3_t	vieworg;
+	float	radius2;
+	byte	*pvs;
+	qboolean	enabled;
+	qboolean	radius_enabled;
+	qboolean	pvs_enabled;
+	qboolean	cull_players;
+} sv_icull_context_t;
+
+static sv_icull_stats_t sv_icull_last_stats[MAX_SCOREBOARD];
+static double sv_icull_debug_next_time = 0.0;
+
 //============================================================================
 
 static void SV_InitClientSnapshotData (client_t *client);
@@ -785,29 +808,6 @@ qboolean SV_VisibleToClient (edict_t *client, edict_t *test, qmodel_t *worldmode
 }
 
 //=============================================================================
-
-typedef struct
-{
-	int considered;
-	int sent;
-	int culled_distance;
-	int culled_pvs;
-	int forced_sent;
-} sv_icull_stats_t;
-
-typedef struct
-{
-	vec3_t	vieworg;
-	float	radius2;
-	byte	*pvs;
-	qboolean	enabled;
-	qboolean	radius_enabled;
-	qboolean	pvs_enabled;
-	qboolean	cull_players;
-} sv_icull_context_t;
-
-static sv_icull_stats_t sv_icull_last_stats[MAX_SCOREBOARD];
-static double sv_icull_debug_next_time = 0.0;
 
 #define MAX_NET_EDICTS 65536
 


### PR DESCRIPTION
### Motivation
- The compiler reported undeclared identifier and indexing errors for `sv_icull_last_stats` because the interest-culling types/variables were defined after their first use. 
- Moving the declarations earlier prevents out-of-order usage in `sv_main.c` and resolves the compile-time errors. 

### Description
- Move `sv_icull_stats_t` and `sv_icull_context_t` typedefs and the `sv_icull_last_stats`/`sv_icull_debug_next_time` static variables to a location above the first use. 
- Remove the later duplicate declarations so the types/variables are declared only once. 
- Changes are confined to `Quake/sv_main.c` and preserve existing logic and naming. 

### Testing
- No automated tests were run after this change. 
- The change was implemented to address the compilation errors reported prior to the patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960407f2380832eae310984a96810cc)