### PR TITLE
Load BSPX `RGBLIGHTING` even when classic lightmaps are present

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -1611,6 +1611,8 @@ static void Mod_LoadLighting (lump_t *l)
 	qboolean bspx_dlit;
 	qboolean has_classic_lighting;
 	qboolean allow_bspx_lighting;
+	byte *bspx_rgb = NULL;
+	int bspx_rgb_size = 0;
 	qboolean loaded_bspx_rgb = false;
 	qboolean loaded_bspx_dir = false;
 	const char *lighting_mode = "none";
@@ -1628,6 +1630,10 @@ static void Mod_LoadLighting (lump_t *l)
 	bspx_dlit = Q1BSPX_IsProcessed("DLIT");
 	has_classic_lighting = (l->filelen > 0);
 	allow_bspx_lighting = (gl_loadlitfiles.value > 0) || !has_classic_lighting;
+	if (!allow_bspx_lighting)
+	{
+		bspx_rgb = Q1BSPX_FindLump("RGBLIGHTING", &bspx_rgb_size);
+	}
 	// LordHavoc: check for a .lit file
 	q_strlcpy(litfilename, loadmodel->name, sizeof(litfilename));
 	COM_StripExtension(litfilename, litfilename, sizeof(litfilename));
@@ -1791,6 +1797,29 @@ static void Mod_LoadLighting (lump_t *l)
                         Con_DWarning("RGBLIGHTING lump size %d is not a multiple of 3 bytes\n", bspxsize);
                 }
 
+        }
+        else if (bspx_rgb)
+        {
+                if (bspx_rgb_size % 3 == 0)
+                {
+                        int samples = bspx_rgb_size / 3;
+
+                        loadmodel->lightdata = (byte*)Hunk_AllocName(bspx_rgb_size, litfilename);
+                        loadmodel->lightdatasamples = samples;
+                        loadmodel->litfile = true;
+                        loadmodel->lightdatasize = samples;
+
+                        memcpy(loadmodel->lightdata, bspx_rgb, bspx_rgb_size);
+                        Q1BSPX_MarkUsed("RGBLIGHTING");
+
+                        Con_DPrintf("loaded BSPX lighting (%d samples)\n", samples);
+                        lighting_mode = "bspx_rgb";
+                        loaded_bspx_rgb = true;
+                        goto loadlightdir;
+                }
+
+                Q1BSPX_MarkUnsupported("RGBLIGHTING");
+                Con_DWarning("RGBLIGHTING lump size %d is not a multiple of 3 bytes\n", bspx_rgb_size);
         }
         else if (gl_loadlitfiles.value <= 0)
         {


### PR DESCRIPTION
### Motivation
- Ensure BSPX-provided RGB lightmaps are used when present even if classic LUMP_LIGHTING exists or BSPX lighting is normally disabled.
- Preserve existing behavior for HDR/DELUXE lighting while allowing `RGBLIGHTING` to be reused when `gl_loadlitfiles` is turned off.

### Description
- Add local variables `bspx_rgb` and `bspx_rgb_size` and call `Q1BSPX_FindLump("RGBLIGHTING", &bspx_rgb_size)` when `allow_bspx_lighting` is false.
- Add a new branch that, if `bspx_rgb` exists and its size is a multiple of 3, allocates `loadmodel->lightdata`, copies the BMPX RGB data, sets `loadmodel->lightdatasamples`/`lightdatasize`/`litfile`, and calls `Q1BSPX_MarkUsed("RGBLIGHTING")` then jumps to `loadlightdir`.
- Keep existing size checks/warnings and existing BSPX HDR (`LIGHTING_E5BGR9`) and `DLIT` handling unchanged.
- Change implemented in `Mod_LoadLighting` in `Quake/gl_model.c`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960bf27ff08832e9d36d7bfd075f5a7)