### PR TITLE
Remove bloodhound gametype

### DIFF
--- a/Quake/host.c
+++ b/Quake/host.c
@@ -82,7 +82,6 @@ cvar_t	noexit = {"noexit","0",CVAR_NOTIFY|CVAR_SERVERINFO};
 cvar_t	skill = {"skill","1",CVAR_NONE};			// 0 - 3
 cvar_t	deathmatch = {"deathmatch","0",CVAR_NONE};	// 0, 1, or 2
 cvar_t	coop = {"coop","0",CVAR_NONE};			// 0 or 1
-cvar_t	bloodhound = {"bloodhound","0",CVAR_NONE};
 
 cvar_t	pausable = {"pausable","1",CVAR_NONE};
 
@@ -453,7 +452,6 @@ void Host_InitLocal (void)
 	Cvar_SetCallback (&map_checks, Map_Checks_f);
 	Cvar_RegisterVariable (&coop);
 	Cvar_RegisterVariable (&deathmatch);
-	Cvar_RegisterVariable (&bloodhound);
 
 	Cvar_RegisterVariable (&campaign);
 	Cvar_RegisterVariable (&horde);

--- a/Quake/menu.c
+++ b/Quake/menu.c
@@ -1411,7 +1411,6 @@ void M_SinglePlayer_Key (int key)
 			Cbuf_AddText ("maxplayers 1\n");
 			Cbuf_AddText ("deathmatch 0\n"); //johnfitz
 			Cbuf_AddText ("coop 0\n"); //johnfitz
-			Cbuf_AddText ("bloodhound 0\n");
 			Cbuf_AddText ("campaign 1\n");
 			Cbuf_AddText ("map start\n");
 			break;
@@ -2204,7 +2203,6 @@ void M_Skill_Key (int key)
 			Cbuf_AddText ("maxplayers 1\n");
 			Cbuf_AddText ("deathmatch 0\n"); //johnfitz
 			Cbuf_AddText ("coop 0\n"); //johnfitz
-			Cbuf_AddText ("bloodhound 0\n");
 			Cbuf_AddText ("campaign 0\n");
 			Cbuf_AddText (va ("map \"%s\"\n", m_skill_mapname));
 		}
@@ -5912,14 +5910,11 @@ void M_Menu_GameOptions_f (void)
 typedef enum
 {
 	GAMETYPE_DEATHMATCH,
-	GAMETYPE_COOPERATIVE,
-	GAMETYPE_BLOODHOUND
+	GAMETYPE_COOPERATIVE
 } gametype_t;
 
 static gametype_t M_GameOptions_CurrentGametype (void)
 {
-	if (bloodhound.value)
-		return GAMETYPE_BLOODHOUND;
 	if (coop.value)
 		return GAMETYPE_COOPERATIVE;
 
@@ -5933,20 +5928,12 @@ static void M_GameOptions_SetGametype (gametype_t type)
 	case GAMETYPE_COOPERATIVE:
 		Cvar_Set ("coop", "1");
 		Cvar_Set ("deathmatch", "0");
-		Cvar_Set ("bloodhound", "0");
-		break;
-
-	case GAMETYPE_BLOODHOUND:
-		Cvar_Set ("coop", "0");
-		Cvar_Set ("deathmatch", "1");
-		Cvar_Set ("bloodhound", "1");
 		break;
 
 	case GAMETYPE_DEATHMATCH:
 	default:
 		Cvar_Set ("coop", "0");
 		Cvar_Set ("deathmatch", "1");
-		Cvar_Set ("bloodhound", "0");
 		break;
 	}
 }
@@ -5976,9 +5963,6 @@ void M_GameOptions_Draw (void)
 	{
 	case GAMETYPE_COOPERATIVE:
 		M_Print (160, 64, "Cooperative");
-		break;
-	case GAMETYPE_BLOODHOUND:
-		M_Print (160, 64, "Bloodhound");
 		break;
 	case GAMETYPE_DEATHMATCH:
 	default:
@@ -6112,10 +6096,10 @@ void M_NetStart_Change (int dir)
 	case 2:
 	{
 		int type = M_GameOptions_CurrentGametype () + dir;
-		if (type > GAMETYPE_BLOODHOUND)
+		if (type > GAMETYPE_COOPERATIVE)
 			type = GAMETYPE_DEATHMATCH;
 		else if (type < GAMETYPE_DEATHMATCH)
-			type = GAMETYPE_BLOODHOUND;
+			type = GAMETYPE_COOPERATIVE;
 	
 		M_GameOptions_SetGametype ((gametype_t) type);
 	}
@@ -7626,4 +7610,3 @@ void M_CheckMods (void)
 	m_skill_usecustomtitle = M_CheckCustomGfx ("gfx/p_skill.lmp",
 		"gfx/ttl_sgl.lmp", 6728, sgl_hashes, countof (sgl_hashes));
 }
-

--- a/Quake/server.h
+++ b/Quake/server.h
@@ -279,7 +279,6 @@ extern	cvar_t	teamplay;
 extern	cvar_t	skill;
 extern	cvar_t	deathmatch;
 extern	cvar_t	coop;
-extern	cvar_t	bloodhound;
 extern	cvar_t	fraglimit;
 extern	cvar_t	timelimit;
 


### PR DESCRIPTION
### Motivation
- Remove the legacy `bloodhound` gametype and its associated cvar from the engine to simplify game-type handling.
- Clean up menu and single-player flows that referenced or reset the `bloodhound` mode.
- Reduce unused server-facing configuration surface by removing the `bloodhound` cvar export.

### Description
- Removed the `cvar_t bloodhound` declaration from `Quake/host.c` and its registration call (`Cvar_RegisterVariable (&bloodhound)`).
- Removed the `extern cvar_t bloodhound;` declaration from `Quake/server.h`.
- Updated `Quake/menu.c` to delete `bloodhound` resets in single-player and skill paths and removed the `GAMETYPE_BLOODHOUND` enum and associated branches, adjusting the game-type cycling logic to use `GAMETYPE_COOPERATIVE` as the upper bound.
- Adjusted `M_GameOptions_CurrentGametype` and `M_GameOptions_SetGametype` to no longer reference `bloodhound` and simplified displayed game-type text.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960c2b51860832ea1d89e0260e5209c)