### PR TITLE
Stabilize snapshot deltas: add `svc_snapshot2`, ACK/NAK, relevance and client hold-time

### DIFF
--- a/Quake/cl_main.c
+++ b/Quake/cl_main.c
@@ -37,6 +37,9 @@ cvar_t	cl_color = {"_cl_color", "0", CVAR_ARCHIVE};
 cvar_t	cl_shownet = {"cl_shownet","0",CVAR_NONE};	// can be 0, 1, or 2
 cvar_t	cl_nolerp = {"cl_nolerp","0",CVAR_NONE};
 cvar_t	cl_packedents = {"cl_packedents", "1", CVAR_ARCHIVE};
+cvar_t	cl_snap_debug = {"cl_snap_debug", "0", CVAR_NONE};
+cvar_t	cl_test_drop = {"cl_test_drop", "0", CVAR_NONE};
+cvar_t	cl_entity_timeout_ms = {"cl_entity_timeout_ms", "750", CVAR_NONE};
 
 cvar_t	cfg_unbindall = {"cfg_unbindall", "1", CVAR_ARCHIVE};
 
@@ -122,7 +125,15 @@ void CL_ClearState (void)
 	cl_entities = (entity_t *) Hunk_AllocName (cl_max_edicts*sizeof(entity_t), "cl_entities");
 	cl.snapshot_baseline = (snapshot_state_t *) Hunk_AllocName (cl_max_edicts*sizeof(snapshot_state_t), "cl_snap_base");
 	cl.snapshot_present = (byte *) Hunk_AllocName (cl_max_edicts*sizeof(byte), "cl_snap_present");
+	cl.snapshot_active = (byte *) Hunk_AllocName (cl_max_edicts*sizeof(byte), "cl_snap_active");
+	cl.snapshot_last_update_time = (double *) Hunk_AllocName (cl_max_edicts*sizeof(double), "cl_snap_time");
 	//johnfitz
+	if (cl.snapshot_present)
+		memset (cl.snapshot_present, 0, cl_max_edicts * sizeof(byte));
+	if (cl.snapshot_active)
+		memset (cl.snapshot_active, 0, cl_max_edicts * sizeof(byte));
+	if (cl.snapshot_last_update_time)
+		memset (cl.snapshot_last_update_time, 0, cl_max_edicts * sizeof(double));
 
 	memset (v_punchangles, 0, sizeof (v_punchangles));
 }
@@ -610,12 +621,30 @@ void CL_RelinkEntities (void)
 			continue;
 		}
 
-// if the object wasn't included in the last packet, remove it
+// if the object wasn't included in the last packet, remove it (or hold briefly)
 		if (ent->msgtime != cl.mtime[0])
 		{
-			ent->model = NULL;
-			ent->lerpflags |= LERP_RESETMOVE|LERP_RESETANIM; //johnfitz -- next time this entity slot is reused, the lerp will need to be reset
-			continue;
+			qboolean keepalive = false;
+			double timeout_s = cl_entity_timeout_ms.value / 1000.0;
+
+			if (timeout_s > 0.0 && cl.snapshot_active && cl.snapshot_active[i] && cl.snapshot_last_update_time)
+			{
+				if (cl.time - cl.snapshot_last_update_time[i] <= timeout_s)
+				{
+					ent->msgtime = cl.mtime[0];
+					ent->forcelink = true;
+					keepalive = true;
+				}
+			}
+
+			if (!keepalive)
+			{
+				ent->model = NULL;
+				ent->lerpflags |= LERP_RESETMOVE|LERP_RESETANIM; //johnfitz -- next time this entity slot is reused, the lerp will need to be reset
+				if (cl.snapshot_active)
+					cl.snapshot_active[i] = 0;
+				continue;
+			}
 		}
 
 		if (ent->forcelink)
@@ -1101,6 +1130,9 @@ void CL_Init (void)
 	Cvar_RegisterVariable (&cl_shownet);
 	Cvar_RegisterVariable (&cl_nolerp);
 	Cvar_RegisterVariable (&cl_packedents);
+	Cvar_RegisterVariable (&cl_snap_debug);
+	Cvar_RegisterVariable (&cl_test_drop);
+	Cvar_RegisterVariable (&cl_entity_timeout_ms);
 	Cvar_RegisterVariable (&freelook);
 	Cvar_RegisterVariable (&lookspring);
 	Cvar_RegisterVariable (&lookstrafe);

--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -99,7 +99,8 @@ const char *svc_strings[] =
 	"svc_localsound", // 56
 	"svc_snapshot_full", // 57
 	"svc_snapshot_delta", // 58
-	"svc_packedentities" // 59
+	"svc_packedentities", // 59
+	"svc_snapshot2" // 60
 };
 #define NUM_SVC_STRINGS Q_COUNTOF(svc_strings)
 
@@ -1019,6 +1020,15 @@ static void CL_SendSnapshotAck (unsigned int seq)
 	MSG_WriteLong (&cls.message, (int)seq);
 }
 
+static void CL_SendSnapshotNak (unsigned int expected_base, unsigned int received_base)
+{
+	if (cls.demoplayback || cls.state != ca_connected)
+		return;
+	MSG_WriteByte (&cls.message, clc_snapshot_nak);
+	MSG_WriteLong (&cls.message, (int)expected_base);
+	MSG_WriteLong (&cls.message, (int)received_base);
+}
+
 static float CL_ReadSnapshotCoord (qboolean hires)
 {
 	if (hires && (cl.protocolflags & PRFL_SNAPSHOT_HIRES))
@@ -1101,6 +1111,27 @@ static void CL_ClearSnapshotEntity (int entnum)
 	ent->model = NULL;
 	ent->effects = 0;
 	ent->forcelink = true;
+	if (cl.snapshot_active)
+		cl.snapshot_active[entnum] = 0;
+	if (cl.snapshot_last_update_time)
+		cl.snapshot_last_update_time[entnum] = 0;
+}
+
+static qboolean CL_ShouldDropSnapshot (void)
+{
+	if (cl_test_drop.value <= 0.0f)
+		return false;
+	return ((float)rand() / (float)RAND_MAX) < cl_test_drop.value;
+}
+
+static void CL_MarkSnapshotEntityUpdated (int entnum)
+{
+	if (entnum <= 0 || entnum >= cl_max_edicts)
+		return;
+	if (cl.snapshot_active)
+		cl.snapshot_active[entnum] = 1;
+	if (cl.snapshot_last_update_time)
+		cl.snapshot_last_update_time[entnum] = cl.time;
 }
 
 static void CL_ApplySnapshotState (int entnum, const snapshot_state_t *state)
@@ -1229,11 +1260,20 @@ static void CL_ParseSnapshotFull (void)
 	unsigned int seq;
 	int count;
 	int i;
+	qboolean drop;
 
 	seq = (unsigned int)MSG_ReadLong ();
 	count = (unsigned short)MSG_ReadShort ();
+	drop = CL_ShouldDropSnapshot ();
+
+	if (cl_snap_debug.value >= 1.0f)
+		Con_Printf ("cl_snap full seq %u ents %d%s\n", seq, count, drop ? " drop" : "");
 
 	memset (cl.snapshot_present, 0, cl_max_edicts * sizeof(byte));
+	if (cl.snapshot_active)
+		memset (cl.snapshot_active, 0, cl_max_edicts * sizeof(byte));
+	if (cl.snapshot_last_update_time)
+		memset (cl.snapshot_last_update_time, 0, cl_max_edicts * sizeof(double));
 
 	for (i = 0; i < count; i++)
 	{
@@ -1247,13 +1287,20 @@ static void CL_ParseSnapshotFull (void)
 		if (cl.protocolflags & PRFL_SNAPSHOT_HIRES)
 			snapflags = (unsigned int)MSG_ReadByte ();
 		CL_ReadSnapshotState (&state, snapflags);
-		cl.snapshot_baseline[entnum] = state;
-		cl.snapshot_present[entnum] = 1;
-		CL_ApplySnapshotState (entnum, &state);
+		if (!drop)
+		{
+			cl.snapshot_baseline[entnum] = state;
+			cl.snapshot_present[entnum] = 1;
+			CL_ApplySnapshotState (entnum, &state);
+			CL_MarkSnapshotEntityUpdated (entnum);
+		}
 	}
 
-	cl.snapshot_baseline_seq = seq;
-	CL_SendSnapshotAck (seq);
+	if (!drop)
+	{
+		cl.snapshot_baseline_seq = seq;
+		CL_SendSnapshotAck (seq);
+	}
 }
 
 static void CL_ParseSnapshotDelta (void)
@@ -1264,16 +1311,25 @@ static void CL_ParseSnapshotDelta (void)
 	int count;
 	int i;
 	qboolean baseline_match;
+	qboolean drop;
 
 	seq = (unsigned int)MSG_ReadLong ();
 	baseline_seq = (unsigned int)MSG_ReadLong ();
 	baseline_match = (baseline_seq != 0 && baseline_seq == cl.snapshot_baseline_seq);
+	drop = CL_ShouldDropSnapshot ();
+
+	if (cl_snap_debug.value >= 1.0f)
+		Con_Printf ("cl_snap delta seq %u base %u match %d%s\n",
+			seq, baseline_seq, baseline_match, drop ? " drop" : "");
+
+	if (!drop && baseline_match)
+		SDL_assert (baseline_seq == cl.snapshot_baseline_seq);
 
 	count = (unsigned short)MSG_ReadShort ();
 	for (i = 0; i < count; i++)
 	{
 		int entnum = (unsigned short)MSG_ReadShort ();
-		if (baseline_match && entnum > 0 && entnum < cl_max_edicts)
+		if (!drop && baseline_match && entnum > 0 && entnum < cl_max_edicts)
 		{
 			cl.snapshot_present[entnum] = 0;
 			CL_ClearSnapshotEntity (entnum);
@@ -1290,11 +1346,12 @@ static void CL_ParseSnapshotDelta (void)
 		if (cl.protocolflags & PRFL_SNAPSHOT_HIRES)
 			snapflags = (unsigned int)MSG_ReadByte ();
 		CL_ReadSnapshotState (&state, snapflags);
-		if (baseline_match && entnum > 0 && entnum < cl_max_edicts)
+		if (!drop && baseline_match && entnum > 0 && entnum < cl_max_edicts)
 		{
 			cl.snapshot_baseline[entnum] = state;
 			cl.snapshot_present[entnum] = 1;
 			CL_ApplySnapshotState (entnum, &state);
+			CL_MarkSnapshotEntityUpdated (entnum);
 		}
 	}
 
@@ -1303,12 +1360,13 @@ static void CL_ParseSnapshotDelta (void)
 	{
 		int entnum = (unsigned short)MSG_ReadShort ();
 		mask = (unsigned int)MSG_ReadLong ();
-		if (baseline_match && entnum > 0 && entnum < cl_max_edicts && cl.snapshot_present[entnum])
+		if (!drop && baseline_match && entnum > 0 && entnum < cl_max_edicts && cl.snapshot_present[entnum])
 		{
 			snapshot_state_t state = cl.snapshot_baseline[entnum];
 			CL_ReadSnapshotDeltaFields (&state, mask);
 			cl.snapshot_baseline[entnum] = state;
 			CL_ApplySnapshotState (entnum, &state);
+			CL_MarkSnapshotEntityUpdated (entnum);
 		}
 		else
 		{
@@ -1318,7 +1376,7 @@ static void CL_ParseSnapshotDelta (void)
 		}
 	}
 
-	if (baseline_match)
+	if (!drop && baseline_match)
 	{
 		for (i = 1; i < cl_max_edicts; i++)
 		{
@@ -1330,7 +1388,159 @@ static void CL_ParseSnapshotDelta (void)
 	}
 	else
 	{
-		CL_SendSnapshotAck (0);
+		if (!drop)
+			CL_SendSnapshotNak (cl.snapshot_baseline_seq, baseline_seq);
+	}
+}
+
+typedef struct
+{
+	unsigned int	seq;
+	unsigned int	base_seq;
+	unsigned int	flags;
+	unsigned short	num_entities;
+	unsigned short	num_removed;
+} snapshot_header_t;
+
+static void CL_ReadSnapshotHeader (snapshot_header_t *header)
+{
+	header->seq = (unsigned int)MSG_ReadLong ();
+	header->base_seq = (unsigned int)MSG_ReadLong ();
+	header->flags = (unsigned int)MSG_ReadByte ();
+	header->num_entities = (unsigned short)MSG_ReadShort ();
+	header->num_removed = (unsigned short)MSG_ReadShort ();
+}
+
+static void CL_ParseSnapshot2 (void)
+{
+	snapshot_header_t header;
+	qboolean baseline_match;
+	qboolean drop;
+	int i;
+
+	CL_ReadSnapshotHeader (&header);
+	drop = CL_ShouldDropSnapshot ();
+
+	if (cl_snap_debug.value >= 1.0f)
+	{
+		Con_Printf ("cl_snap2 seq %u base %u flags 0x%x ents %u rem %u%s\n",
+			header.seq, header.base_seq, header.flags,
+			header.num_entities, header.num_removed, drop ? " drop" : "");
+	}
+
+	if (header.flags & SNAPSHOT_FLAG_FULL)
+	{
+		memset (cl.snapshot_present, 0, cl_max_edicts * sizeof(byte));
+		if (cl.snapshot_active)
+			memset (cl.snapshot_active, 0, cl_max_edicts * sizeof(byte));
+		if (cl.snapshot_last_update_time)
+			memset (cl.snapshot_last_update_time, 0, cl_max_edicts * sizeof(double));
+
+		for (i = 0; i < header.num_entities; i++)
+		{
+			int entnum;
+			snapshot_state_t state;
+			unsigned int snapflags = 0;
+
+			entnum = (unsigned short)MSG_ReadShort ();
+			if (entnum <= 0 || entnum >= cl_max_edicts)
+				Host_Error ("CL_ParseSnapshot2: entnum out of range");
+			if (cl.protocolflags & PRFL_SNAPSHOT_HIRES)
+				snapflags = (unsigned int)MSG_ReadByte ();
+			CL_ReadSnapshotState (&state, snapflags);
+			if (!drop)
+			{
+				cl.snapshot_baseline[entnum] = state;
+				cl.snapshot_present[entnum] = 1;
+				CL_ApplySnapshotState (entnum, &state);
+				CL_MarkSnapshotEntityUpdated (entnum);
+			}
+		}
+
+		if (!drop)
+		{
+			cl.snapshot_baseline_seq = header.seq;
+			CL_SendSnapshotAck (header.seq);
+		}
+		return;
+	}
+
+	baseline_match = (header.base_seq != 0xFFFFFFFFu && header.base_seq == cl.snapshot_baseline_seq);
+	if (!drop && baseline_match)
+		SDL_assert (header.base_seq == cl.snapshot_baseline_seq);
+
+	if (header.flags & SNAPSHOT_FLAG_HAS_REMOVE_LIST)
+	{
+		for (i = 0; i < header.num_removed; i++)
+		{
+			int entnum = (unsigned short)MSG_ReadShort ();
+			if (!drop && baseline_match && entnum > 0 && entnum < cl_max_edicts)
+			{
+				cl.snapshot_present[entnum] = 0;
+				CL_ClearSnapshotEntity (entnum);
+			}
+		}
+	}
+
+	{
+		int add_count = (unsigned short)MSG_ReadShort ();
+		for (i = 0; i < add_count; i++)
+		{
+			int entnum = (unsigned short)MSG_ReadShort ();
+			snapshot_state_t state;
+			unsigned int snapflags = 0;
+
+			if (cl.protocolflags & PRFL_SNAPSHOT_HIRES)
+				snapflags = (unsigned int)MSG_ReadByte ();
+			CL_ReadSnapshotState (&state, snapflags);
+			if (!drop && baseline_match && entnum > 0 && entnum < cl_max_edicts)
+			{
+				cl.snapshot_baseline[entnum] = state;
+				cl.snapshot_present[entnum] = 1;
+				CL_ApplySnapshotState (entnum, &state);
+				CL_MarkSnapshotEntityUpdated (entnum);
+			}
+		}
+
+		{
+			int update_count = (unsigned short)MSG_ReadShort ();
+			for (i = 0; i < update_count; i++)
+			{
+				int entnum = (unsigned short)MSG_ReadShort ();
+				unsigned int mask = (unsigned int)MSG_ReadLong ();
+
+				if (!drop && baseline_match && entnum > 0 && entnum < cl_max_edicts && cl.snapshot_present[entnum])
+				{
+					snapshot_state_t state = cl.snapshot_baseline[entnum];
+					CL_ReadSnapshotDeltaFields (&state, mask);
+					cl.snapshot_baseline[entnum] = state;
+					CL_ApplySnapshotState (entnum, &state);
+					CL_MarkSnapshotEntityUpdated (entnum);
+				}
+				else
+				{
+					snapshot_state_t scratch;
+					memset (&scratch, 0, sizeof(scratch));
+					CL_ReadSnapshotDeltaFields (&scratch, mask);
+				}
+			}
+		}
+	}
+
+	if (!drop && baseline_match)
+	{
+		for (i = 1; i < cl_max_edicts; i++)
+		{
+			if (cl.snapshot_present[i] && cl_entities[i].msgtime != cl.mtime[0])
+				cl_entities[i].msgtime = cl.mtime[0];
+		}
+		cl.snapshot_baseline_seq = header.seq;
+		CL_SendSnapshotAck (header.seq);
+	}
+	else
+	{
+		if (!drop)
+			CL_SendSnapshotNak (cl.snapshot_baseline_seq, header.base_seq);
 	}
 }
 
@@ -2030,6 +2240,10 @@ void CL_ParseServerMessage (void)
 
 		case svc_snapshot_delta:
 			CL_ParseSnapshotDelta ();
+			break;
+
+		case svc_snapshot2:
+			CL_ParseSnapshot2 ();
 			break;
 
 		case svc_packedentities:

--- a/Quake/client.h
+++ b/Quake/client.h
@@ -274,6 +274,8 @@ typedef struct
 	unsigned int snapshot_baseline_seq;
 	snapshot_state_t *snapshot_baseline;
 	byte		*snapshot_present;
+	byte		*snapshot_active;
+	double		*snapshot_last_update_time;
 
 	int			cdtrack, looptrack;	// cd audio
 
@@ -336,6 +338,9 @@ extern	cvar_t	m_side;
 
 extern	cvar_t	cl_startdemos;
 extern	cvar_t	cl_confirmquit;
+extern	cvar_t	cl_snap_debug;
+extern	cvar_t	cl_test_drop;
+extern	cvar_t	cl_entity_timeout_ms;
 
 
 #define	MAX_TEMP_ENTITIES	256		//johnfitz -- was 64

--- a/Quake/protocol.h
+++ b/Quake/protocol.h
@@ -248,6 +248,10 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define svc_snapshot_full	57
 #define svc_snapshot_delta	58
 #define svc_packedentities	59
+#define svc_snapshot2		60
+
+#define SNAPSHOT_FLAG_FULL		(1u << 0)
+#define SNAPSHOT_FLAG_HAS_REMOVE_LIST	(1u << 1)
 
 #define PACKEDENT_MASK_EXTEND	0x8000u
 #define PACKEDENT_MASK_MODEL	(1u << 0)
@@ -288,6 +292,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define	clc_move		3		// [usercmd_t]
 #define	clc_stringcmd	4		// [string] message
 #define	clc_snapshot_ack	5	// [long] seq
+#define	clc_snapshot_nak	6	// [long] expected base [long] received base
 
 //
 // temp entity events

--- a/Quake/server.h
+++ b/Quake/server.h
@@ -167,12 +167,19 @@ typedef struct client_s
 	unsigned int	snapshot_baseline_seq;
 	unsigned int	snapshot_pending_seq;
 	unsigned int	snapshot_pending_baseline_seq;
+	unsigned int	snapshot_last_sent_seq;
+	unsigned int	snapshot_last_acked_seq;
+	unsigned int	snapshot_last_full_seq;
+	double			snapshot_last_full_time;
+	qboolean		snapshot_has_valid_base;
+	qboolean		snapshot_force_full;
 	double			snapshot_pending_time;
 	qboolean		snapshot_pending_is_delta;
 	snapshot_state_t *snapshot_baseline;
 	byte			*snapshot_baseline_present;
 	snapshot_state_t *snapshot_pending;
 	byte			*snapshot_pending_present;
+	byte			*snapshot_pending_relevant;
 	byte			*snapshot_pending_flags;
 	int				snapshot_unacked_frames;
 	int				snapshot_pending_mandatory;
@@ -330,5 +337,6 @@ void SV_RunClients (void);
 void SV_SaveSpawnparms (void);
 void SV_SpawnServer (const char *server);
 void SV_SnapshotAck (client_t *client, unsigned int seq);
+void SV_SnapshotNak (client_t *client, unsigned int expected_base, unsigned int received_base);
 
 #endif	/* QUAKE_SERVER_H */

--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -39,6 +39,12 @@ static cvar_t sv_packedents_debug = {"sv_packedents_debug", "0", CVAR_NONE};
 static cvar_t sv_snapshotdelta = {"sv_snapshotdelta", "1", CVAR_NONE};
 static cvar_t sv_snapshotdebug = {"sv_snapshotdebug", "0", CVAR_NONE};
 static cvar_t sv_snapshottimeout = {"sv_snapshottimeout", "1000", CVAR_NONE};
+static cvar_t sv_snapshot2 = {"sv_snapshot2", "1", CVAR_NONE};
+static cvar_t sv_snap_debug = {"sv_snap_debug", "0", CVAR_NONE};
+static cvar_t sv_snap_full_interval = {"sv_snap_full_interval", "2.0", CVAR_NONE};
+static cvar_t sv_snap_force_full_after_frames = {"sv_snap_force_full_after_frames", "3", CVAR_NONE};
+static cvar_t sv_snap_max_payload = {"sv_snap_max_payload", "1200", CVAR_NONE};
+static cvar_t net_test_drop = {"net_test_drop", "0", CVAR_NONE};
 static cvar_t net_snap_tinyvel = {"net_snap_tinyvel", "1", CVAR_NONE};
 static cvar_t net_snap_forcefull_frames = {"net_snap_forcefull_frames", "3", CVAR_NONE};
 static cvar_t net_snap_debug = {"net_snap_debug", "0", CVAR_NONE};
@@ -277,6 +283,12 @@ void SV_Init (void)
 	Cvar_RegisterVariable (&sv_snapshotdelta);
 	Cvar_RegisterVariable (&sv_snapshotdebug);
 	Cvar_RegisterVariable (&sv_snapshottimeout);
+	Cvar_RegisterVariable (&sv_snapshot2);
+	Cvar_RegisterVariable (&sv_snap_debug);
+	Cvar_RegisterVariable (&sv_snap_full_interval);
+	Cvar_RegisterVariable (&sv_snap_force_full_after_frames);
+	Cvar_RegisterVariable (&sv_snap_max_payload);
+	Cvar_RegisterVariable (&net_test_drop);
 	Cvar_RegisterVariable (&net_snap_tinyvel);
 	Cvar_RegisterVariable (&net_snap_forcefull_frames);
 	Cvar_RegisterVariable (&net_snap_debug);
@@ -589,6 +601,7 @@ void SV_ConnectClient (int clientnum)
 	byte			*snapshot_baseline_present;
 	snapshot_state_t *snapshot_pending;
 	byte			*snapshot_pending_present;
+	byte			*snapshot_pending_relevant;
 	byte			*snapshot_pending_flags;
 
 	client = svs.clients + clientnum;
@@ -596,6 +609,7 @@ void SV_ConnectClient (int clientnum)
 	snapshot_baseline_present = client->snapshot_baseline_present;
 	snapshot_pending = client->snapshot_pending;
 	snapshot_pending_present = client->snapshot_pending_present;
+	snapshot_pending_relevant = client->snapshot_pending_relevant;
 	snapshot_pending_flags = client->snapshot_pending_flags;
 
 	Con_DPrintf ("Client %s connected\n", NET_QSocketGetAddressString(client->netconnection));
@@ -614,10 +628,11 @@ void SV_ConnectClient (int clientnum)
 	client->snapshot_baseline_present = snapshot_baseline_present;
 	client->snapshot_pending = snapshot_pending;
 	client->snapshot_pending_present = snapshot_pending_present;
+	client->snapshot_pending_relevant = snapshot_pending_relevant;
 	client->snapshot_pending_flags = snapshot_pending_flags;
 	if (!client->snapshot_baseline || !client->snapshot_baseline_present
 		|| !client->snapshot_pending || !client->snapshot_pending_present
-		|| !client->snapshot_pending_flags)
+		|| !client->snapshot_pending_relevant || !client->snapshot_pending_flags)
 		SV_InitClientSnapshotData (client);
 	SV_ResetClientSnapshot (client);
 	client->netconnection = netconnection;
@@ -829,6 +844,7 @@ static void SV_InitClientSnapshotData (client_t *client)
 	client->snapshot_baseline_present = (byte *) Hunk_AllocName (max_edicts * sizeof(byte), "sv_snap_base_present");
 	client->snapshot_pending = (snapshot_state_t *) Hunk_AllocName (max_edicts * sizeof(snapshot_state_t), "sv_snap_pending");
 	client->snapshot_pending_present = (byte *) Hunk_AllocName (max_edicts * sizeof(byte), "sv_snap_pending_present");
+	client->snapshot_pending_relevant = (byte *) Hunk_AllocName (max_edicts * sizeof(byte), "sv_snap_pending_relevant");
 	client->snapshot_pending_flags = (byte *) Hunk_AllocName (max_edicts * sizeof(byte), "sv_snap_pending_flags");
 }
 
@@ -840,6 +856,12 @@ static void SV_ResetClientSnapshot (client_t *client)
 	client->snapshot_baseline_seq = 0;
 	client->snapshot_pending_seq = 0;
 	client->snapshot_pending_baseline_seq = 0;
+	client->snapshot_last_sent_seq = 0;
+	client->snapshot_last_acked_seq = 0;
+	client->snapshot_last_full_seq = 0;
+	client->snapshot_last_full_time = 0;
+	client->snapshot_has_valid_base = false;
+	client->snapshot_force_full = false;
 	client->snapshot_pending_time = 0;
 	client->snapshot_pending_is_delta = false;
 	client->snapshot_unacked_frames = 0;
@@ -856,6 +878,8 @@ static void SV_ResetClientSnapshot (client_t *client)
 		memset (client->snapshot_baseline_present, 0, max_edicts * sizeof(byte));
 	if (client->snapshot_pending_present)
 		memset (client->snapshot_pending_present, 0, max_edicts * sizeof(byte));
+	if (client->snapshot_pending_relevant)
+		memset (client->snapshot_pending_relevant, 0, max_edicts * sizeof(byte));
 	if (client->snapshot_pending_flags)
 		memset (client->snapshot_pending_flags, 0, max_edicts * sizeof(byte));
 }
@@ -1045,6 +1069,30 @@ static qboolean SV_SnapshotMandatoryEnt (const edict_t *ent)
 	return false;
 }
 
+static qboolean SV_SnapshotNeedsBaseline (const byte *baseline_present, int entnum)
+{
+	return baseline_present && !baseline_present[entnum];
+}
+
+static qboolean SV_SnapshotPriorityMover (const edict_t *ent)
+{
+	if ((int)ent->v.movetype == MOVETYPE_PUSH)
+		return true;
+	if ((int)ent->v.modelindex < 0)
+		return true;
+	return false;
+}
+
+static qboolean SV_SnapshotPriorityMissile (const edict_t *ent)
+{
+	if ((int)ent->v.movetype == MOVETYPE_FLYMISSILE)
+		return true;
+	if (((int)ent->v.movetype == MOVETYPE_TOSS || (int)ent->v.movetype == MOVETYPE_BOUNCE)
+		&& SV_SnapshotTossMoving (ent))
+		return true;
+	return false;
+}
+
 static int SV_SnapshotEntitySizeWorst (void)
 {
 	int coord_size;
@@ -1089,7 +1137,14 @@ static int SV_SnapshotMaxEntities (sizebuf_t *msg)
 {
 	int header_size = 1 + 4 + 2;
 	int per_ent = SV_SnapshotEntitySizeWorst ();
+	int payload_cap = (int)sv_snap_max_payload.value;
+
+	if (sv_snapshot2.value)
+		header_size = 1 + 4 + 4 + 1 + 2 + 2;
+
 	int available = msg->maxsize - msg->cursize - header_size;
+	if (payload_cap > 0)
+		available = q_min (available, payload_cap - header_size);
 
 	if (per_ent <= 0 || available <= 0)
 		return 0;
@@ -1216,7 +1271,8 @@ static void SV_FillSnapshotState (edict_t *ent, snapshot_state_t *out)
 }
 
 static int SV_BuildClientSnapshot (edict_t *clent, snapshot_state_t *states, byte *present,
-	byte *snapflags, int max_ents, int *out_mandatory, int *out_dropped, qboolean debug_frame)
+	byte *relevant, byte *snapflags, int max_ents, const byte *baseline_present,
+	int *out_mandatory, int *out_dropped, qboolean debug_frame)
 {
 	int	num, j, numents, count;
 	int mandatory_count = 0;
@@ -1224,6 +1280,8 @@ static int SV_BuildClientSnapshot (edict_t *clent, snapshot_state_t *states, byt
 	edict_t	*ent;
 
 	memset (present, 0, qcvm->max_edicts * sizeof(byte));
+	if (relevant)
+		memset (relevant, 0, qcvm->max_edicts * sizeof(byte));
 	if (snapflags)
 		memset (snapflags, 0, qcvm->max_edicts * sizeof(byte));
 
@@ -1233,9 +1291,16 @@ static int SV_BuildClientSnapshot (edict_t *clent, snapshot_state_t *states, byt
 	for (j=0 ; j<numents ; j++)
 	{
 		num = net_edicts_sorted[j];
+		if (relevant)
+			relevant[num] = 1;
+	}
+
+	for (j=0 ; j<numents ; j++)
+	{
+		num = net_edicts_sorted[j];
 		ent = EDICT_NUM (num);
 
-		if (!SV_SnapshotMandatoryEnt (ent))
+		if (!SV_SnapshotMandatoryEnt (ent) && !SV_SnapshotNeedsBaseline (baseline_present, num))
 			continue;
 
 		SV_FillSnapshotState (ent, &states[num]);
@@ -1254,6 +1319,60 @@ static int SV_BuildClientSnapshot (edict_t *clent, snapshot_state_t *states, byt
 				PR_GetString (clent->v.netname), num,
 				(snapflags[num] & SNAPFLAG_HIRES_ORIGIN) != 0,
 				(snapflags[num] & SNAPFLAG_HIRES_ANGLES) != 0);
+	}
+
+	for (j=0 ; j<numents ; j++)
+	{
+		num = net_edicts_sorted[j];
+		ent = EDICT_NUM (num);
+
+		if (present[num] || !SV_SnapshotPriorityMover (ent))
+			continue;
+
+		if (max_ents > 0 && count >= max_ents)
+		{
+			dropped_count++;
+			if (debug_frame && net_snap_debug.value)
+				Con_DPrintf ("snapdbg %s ent %d dropped budget\n", PR_GetString (clent->v.netname), num);
+			continue;
+		}
+
+		SV_FillSnapshotState (ent, &states[num]);
+
+		if (states[num].state.alpha == ENTALPHA_ZERO && !((int)ent->v.effects & qcvm->effects_mask))
+			continue;
+
+		present[num] = 1;
+		if (snapflags)
+			snapflags[num] = SV_SnapshotFlagsForEnt (ent);
+		count++;
+	}
+
+	for (j=0 ; j<numents ; j++)
+	{
+		num = net_edicts_sorted[j];
+		ent = EDICT_NUM (num);
+
+		if (present[num] || !SV_SnapshotPriorityMissile (ent))
+			continue;
+
+		if (max_ents > 0 && count >= max_ents)
+		{
+			dropped_count++;
+			if (debug_frame && net_snap_debug.value)
+				Con_DPrintf ("snapdbg %s ent %d dropped budget\n", PR_GetString (clent->v.netname), num);
+			continue;
+		}
+
+		SV_FillSnapshotState (ent, &states[num]);
+
+		if (states[num].state.alpha == ENTALPHA_ZERO && !((int)ent->v.effects & qcvm->effects_mask))
+			continue;
+
+		present[num] = 1;
+		if (snapflags)
+			snapflags[num] = SV_SnapshotFlagsForEnt (ent);
+		count++;
 	}
 
 	for (j=0 ; j<numents ; j++)
@@ -1334,6 +1453,17 @@ static void SV_WriteSnapshotState (sizebuf_t *msg, const snapshot_state_t *state
 	MSG_WriteByte (msg, state->step);
 }
 
+static void SV_WriteSnapshot2Header (sizebuf_t *msg, unsigned int seq, unsigned int base_seq,
+	unsigned int flags, unsigned short num_entities, unsigned short num_removed)
+{
+	MSG_WriteByte (msg, svc_snapshot2);
+	MSG_WriteLong (msg, (int)seq);
+	MSG_WriteLong (msg, (int)base_seq);
+	MSG_WriteByte (msg, (byte)flags);
+	MSG_WriteShort (msg, (short)num_entities);
+	MSG_WriteShort (msg, (short)num_removed);
+}
+
 static unsigned int SV_SnapshotFieldMask (const snapshot_state_t *next, const snapshot_state_t *base, byte snapflags)
 {
 	unsigned int mask = 0;
@@ -1411,10 +1541,38 @@ static void SV_WriteSnapshotFull (sizebuf_t *msg, unsigned int seq, const snapsh
 		*out_count = count;
 }
 
+static void SV_WriteSnapshot2Full (sizebuf_t *msg, unsigned int seq, const snapshot_state_t *states,
+	const byte *present, const byte *snapflags, int max_edicts, int *out_count)
+{
+	unsigned short count = 0;
+	int entnum;
+
+	for (entnum = 1; entnum < max_edicts; entnum++)
+	{
+		if (present[entnum])
+			count++;
+	}
+
+	SV_WriteSnapshot2Header (msg, seq, 0xFFFFFFFFu, SNAPSHOT_FLAG_FULL, count, 0);
+
+	for (entnum = 1; entnum < max_edicts; entnum++)
+	{
+		if (!present[entnum])
+			continue;
+		MSG_WriteShort (msg, entnum);
+		if (sv.protocolflags & PRFL_SNAPSHOT_HIRES)
+			MSG_WriteByte (msg, snapflags ? snapflags[entnum] : 0);
+		SV_WriteSnapshotState (msg, &states[entnum], snapflags ? snapflags[entnum] : 0);
+	}
+
+	if (out_count)
+		*out_count = count;
+}
+
 static void SV_WriteSnapshotDelta (sizebuf_t *msg, unsigned int seq, unsigned int baseline_seq,
-	const snapshot_state_t *states, const byte *present, const snapshot_state_t *baseline,
-	const byte *baseline_present, const byte *snapflags, int max_edicts, int *out_remove,
-	int *out_add, int *out_update)
+	const snapshot_state_t *states, const byte *present, const byte *relevant,
+	const snapshot_state_t *baseline, const byte *baseline_present, const byte *snapflags,
+	int max_edicts, int *out_remove, int *out_add, int *out_update)
 {
 	int entnum;
 	int remove_count = 0;
@@ -1426,12 +1584,12 @@ static void SV_WriteSnapshotDelta (sizebuf_t *msg, unsigned int seq, unsigned in
 	MSG_WriteLong (msg, (int)baseline_seq);
 
 	for (entnum = 1; entnum < max_edicts; entnum++)
-		if (baseline_present[entnum] && !present[entnum])
+		if (baseline_present[entnum] && relevant && !relevant[entnum])
 			remove_count++;
 	MSG_WriteShort (msg, remove_count);
 	for (entnum = 1; entnum < max_edicts; entnum++)
 	{
-		if (baseline_present[entnum] && !present[entnum])
+		if (baseline_present[entnum] && relevant && !relevant[entnum])
 			MSG_WriteShort (msg, entnum);
 	}
 
@@ -1511,6 +1669,108 @@ static void SV_WriteSnapshotDelta (sizebuf_t *msg, unsigned int seq, unsigned in
 		*out_update = update_count;
 }
 
+static void SV_WriteSnapshot2Delta (sizebuf_t *msg, unsigned int seq, unsigned int baseline_seq,
+	const snapshot_state_t *states, const byte *present, const byte *relevant,
+	const snapshot_state_t *baseline, const byte *baseline_present, const byte *snapflags,
+	int max_edicts, int *out_remove, int *out_add, int *out_update)
+{
+	int entnum;
+	unsigned short remove_count = 0;
+	unsigned short add_count = 0;
+	unsigned short update_count = 0;
+	unsigned int flags = 0;
+
+	for (entnum = 1; entnum < max_edicts; entnum++)
+		if (baseline_present[entnum] && relevant && !relevant[entnum])
+			remove_count++;
+
+	for (entnum = 1; entnum < max_edicts; entnum++)
+		if (!baseline_present[entnum] && present[entnum])
+			add_count++;
+
+	for (entnum = 1; entnum < max_edicts; entnum++)
+	{
+		unsigned int mask;
+
+		if (!baseline_present[entnum] || !present[entnum])
+			continue;
+		mask = SV_SnapshotFieldMask (&states[entnum], &baseline[entnum], snapflags ? snapflags[entnum] : 0);
+		if (mask)
+			update_count++;
+	}
+
+	if (remove_count)
+		flags |= SNAPSHOT_FLAG_HAS_REMOVE_LIST;
+	SV_WriteSnapshot2Header (msg, seq, baseline_seq, flags, add_count + update_count, remove_count);
+
+	for (entnum = 1; entnum < max_edicts; entnum++)
+	{
+		if (baseline_present[entnum] && relevant && !relevant[entnum])
+			MSG_WriteShort (msg, entnum);
+	}
+
+	MSG_WriteShort (msg, add_count);
+	for (entnum = 1; entnum < max_edicts; entnum++)
+	{
+		if (!baseline_present[entnum] && present[entnum])
+		{
+			MSG_WriteShort (msg, entnum);
+			if (sv.protocolflags & PRFL_SNAPSHOT_HIRES)
+				MSG_WriteByte (msg, snapflags ? snapflags[entnum] : 0);
+			SV_WriteSnapshotState (msg, &states[entnum], snapflags ? snapflags[entnum] : 0);
+		}
+	}
+
+	MSG_WriteShort (msg, update_count);
+	for (entnum = 1; entnum < max_edicts; entnum++)
+	{
+		unsigned int mask;
+
+		if (!baseline_present[entnum] || !present[entnum])
+			continue;
+		mask = SV_SnapshotFieldMask (&states[entnum], &baseline[entnum], snapflags ? snapflags[entnum] : 0);
+		if (!mask)
+			continue;
+		MSG_WriteShort (msg, entnum);
+		MSG_WriteLong (msg, (int)mask);
+		if (mask & SNAP_ORIGIN1)
+			SV_WriteSnapshotCoord (msg, states[entnum].state.origin[0], (mask & SNAP_HIRES_ORIGIN) != 0);
+		if (mask & SNAP_ORIGIN2)
+			SV_WriteSnapshotCoord (msg, states[entnum].state.origin[1], (mask & SNAP_HIRES_ORIGIN) != 0);
+		if (mask & SNAP_ORIGIN3)
+			SV_WriteSnapshotCoord (msg, states[entnum].state.origin[2], (mask & SNAP_HIRES_ORIGIN) != 0);
+		if (mask & SNAP_ANGLE1)
+			SV_WriteSnapshotAngle (msg, states[entnum].state.angles[0], (mask & SNAP_HIRES_ANGLES) != 0);
+		if (mask & SNAP_ANGLE2)
+			SV_WriteSnapshotAngle (msg, states[entnum].state.angles[1], (mask & SNAP_HIRES_ANGLES) != 0);
+		if (mask & SNAP_ANGLE3)
+			SV_WriteSnapshotAngle (msg, states[entnum].state.angles[2], (mask & SNAP_HIRES_ANGLES) != 0);
+		if (mask & SNAP_MODEL)
+			MSG_WriteShort (msg, states[entnum].state.modelindex);
+		if (mask & SNAP_FRAME)
+			MSG_WriteShort (msg, states[entnum].state.frame);
+		if (mask & SNAP_COLORMAP)
+			MSG_WriteByte (msg, states[entnum].state.colormap);
+		if (mask & SNAP_SKIN)
+			MSG_WriteByte (msg, states[entnum].state.skin);
+		if (mask & SNAP_EFFECTS)
+			MSG_WriteByte (msg, states[entnum].state.effects);
+		if (mask & SNAP_ALPHA)
+			MSG_WriteByte (msg, states[entnum].state.alpha);
+		if (mask & SNAP_SCALE)
+			MSG_WriteByte (msg, states[entnum].state.scale);
+		if (mask & SNAP_STEP)
+			MSG_WriteByte (msg, states[entnum].step);
+	}
+
+	if (out_remove)
+		*out_remove = remove_count;
+	if (out_add)
+		*out_add = add_count;
+	if (out_update)
+		*out_update = update_count;
+}
+
 static void SV_SendSnapshot (client_t *client, sizebuf_t *msg)
 {
 	int start_size = msg->cursize;
@@ -1519,9 +1779,24 @@ static void SV_SendSnapshot (client_t *client, sizebuf_t *msg)
 	int update_count = 0;
 	int full_count = 0;
 	double timeout_s = sv_snapshottimeout.value / 1000.0;
+	double full_interval_s = sv_snap_full_interval.value;
+	int force_full_frames = (int)sv_snap_force_full_after_frames.value;
 	qboolean use_delta;
 	qboolean forced_full = false;
+	qboolean reason_no_base = false;
+	qboolean reason_interval = false;
+	qboolean reason_force_full = false;
 
+	if (net_test_drop.value > 0.0f && ((float)rand() / (float)RAND_MAX) < net_test_drop.value)
+	{
+		if (sv_snap_debug.value >= 1.0f)
+			Con_Printf ("snapshot %s dropped by net_test_drop\n", client->name);
+		return;
+	}
+
+	// Base safety invariants:
+	// 1) Only send deltas when we know the client has the base snapshot.
+	// 2) Force a full snapshot on base uncertainty or client NAK.
 	if (client->snapshot_pending_seq)
 	{
 		client->snapshot_unacked_frames++;
@@ -1531,25 +1806,65 @@ static void SV_SendSnapshot (client_t *client, sizebuf_t *msg)
 			{
 				client->snapshot_pending_is_delta = false;
 				forced_full = true;
+				reason_force_full = true;
 			}
-			else if (net_snap_forcefull_frames.value > 0.0
-				&& client->snapshot_unacked_frames >= (int)net_snap_forcefull_frames.value)
+			else if (force_full_frames > 0 && client->snapshot_unacked_frames >= force_full_frames)
 			{
 				client->snapshot_pending_is_delta = false;
 				forced_full = true;
+				reason_force_full = true;
 			}
 		}
+		if (client->snapshot_force_full)
+		{
+			client->snapshot_pending_is_delta = false;
+			client->snapshot_force_full = false;
+			forced_full = true;
+			reason_force_full = true;
+		}
 		use_delta = client->snapshot_pending_is_delta;
+		if (use_delta && !client->snapshot_has_valid_base)
+		{
+			SDL_assert (!"snapshot delta without valid base");
+			use_delta = false;
+			forced_full = true;
+			reason_no_base = true;
+		}
+		if (use_delta && client->snapshot_pending_baseline_seq != client->snapshot_last_acked_seq)
+		{
+			SDL_assert (!"snapshot delta baseline mismatch");
+			use_delta = false;
+			forced_full = true;
+			reason_no_base = true;
+		}
 		if (use_delta)
-			SV_WriteSnapshotDelta (msg, client->snapshot_pending_seq, client->snapshot_pending_baseline_seq,
-				client->snapshot_pending, client->snapshot_pending_present,
-				client->snapshot_baseline, client->snapshot_baseline_present,
-				client->snapshot_pending_flags, qcvm->max_edicts,
-				&remove_count, &add_count, &update_count);
+		{
+			if (sv_snapshot2.value)
+				SV_WriteSnapshot2Delta (msg, client->snapshot_pending_seq, client->snapshot_pending_baseline_seq,
+					client->snapshot_pending, client->snapshot_pending_present, client->snapshot_pending_relevant,
+					client->snapshot_baseline, client->snapshot_baseline_present,
+					client->snapshot_pending_flags, qcvm->max_edicts,
+					&remove_count, &add_count, &update_count);
+			else
+				SV_WriteSnapshotDelta (msg, client->snapshot_pending_seq, client->snapshot_pending_baseline_seq,
+					client->snapshot_pending, client->snapshot_pending_present, client->snapshot_pending_relevant,
+					client->snapshot_baseline, client->snapshot_baseline_present,
+					client->snapshot_pending_flags, qcvm->max_edicts,
+					&remove_count, &add_count, &update_count);
+		}
 		else
-			SV_WriteSnapshotFull (msg, client->snapshot_pending_seq, client->snapshot_pending,
-				client->snapshot_pending_present, client->snapshot_pending_flags, qcvm->max_edicts, &full_count);
+		{
+			if (sv_snapshot2.value)
+				SV_WriteSnapshot2Full (msg, client->snapshot_pending_seq, client->snapshot_pending,
+					client->snapshot_pending_present, client->snapshot_pending_flags, qcvm->max_edicts, &full_count);
+			else
+				SV_WriteSnapshotFull (msg, client->snapshot_pending_seq, client->snapshot_pending,
+					client->snapshot_pending_present, client->snapshot_pending_flags, qcvm->max_edicts, &full_count);
+			client->snapshot_last_full_seq = client->snapshot_pending_seq;
+			client->snapshot_last_full_time = realtime;
+		}
 		client->snapshot_pending_time = realtime;
+		client->snapshot_last_sent_seq = client->snapshot_pending_seq;
 	}
 	else
 	{
@@ -1565,7 +1880,8 @@ static void SV_SendSnapshot (client_t *client, sizebuf_t *msg)
 		}
 
 		SV_BuildClientSnapshot (client->edict, client->snapshot_pending, client->snapshot_pending_present,
-			client->snapshot_pending_flags, max_ents, &mandatory_count, &dropped_count, debug_frame);
+			client->snapshot_pending_relevant, client->snapshot_pending_flags, max_ents,
+			client->snapshot_baseline_present, &mandatory_count, &dropped_count, debug_frame);
 		client->snapshot_pending_mandatory = mandatory_count;
 		client->snapshot_pending_dropped = dropped_count;
 		client->snapshot_pending_seq = client->snapshot_next_seq++;
@@ -1575,17 +1891,50 @@ static void SV_SendSnapshot (client_t *client, sizebuf_t *msg)
 		client->snapshot_unacked_frames = 0;
 		client->snapshot_pending_baseline_seq = client->snapshot_baseline_seq;
 
-		use_delta = (sv_snapshotdelta.value && client->snapshot_baseline_seq);
+		use_delta = (sv_snapshotdelta.value && client->snapshot_baseline_seq && client->snapshot_has_valid_base);
+		if (!client->snapshot_has_valid_base)
+			reason_no_base = true;
+		if (client->snapshot_force_full)
+		{
+			use_delta = false;
+			client->snapshot_force_full = false;
+			forced_full = true;
+			reason_force_full = true;
+		}
+		if (full_interval_s > 0.0 && (realtime - client->snapshot_last_full_time) > full_interval_s)
+		{
+			use_delta = false;
+			forced_full = true;
+			reason_interval = true;
+		}
 		client->snapshot_pending_is_delta = use_delta;
 		if (use_delta)
-			SV_WriteSnapshotDelta (msg, client->snapshot_pending_seq, client->snapshot_baseline_seq,
-				client->snapshot_pending, client->snapshot_pending_present,
-				client->snapshot_baseline, client->snapshot_baseline_present,
-				client->snapshot_pending_flags, qcvm->max_edicts,
-				&remove_count, &add_count, &update_count);
+		{
+			if (sv_snapshot2.value)
+				SV_WriteSnapshot2Delta (msg, client->snapshot_pending_seq, client->snapshot_baseline_seq,
+					client->snapshot_pending, client->snapshot_pending_present, client->snapshot_pending_relevant,
+					client->snapshot_baseline, client->snapshot_baseline_present,
+					client->snapshot_pending_flags, qcvm->max_edicts,
+					&remove_count, &add_count, &update_count);
+			else
+				SV_WriteSnapshotDelta (msg, client->snapshot_pending_seq, client->snapshot_baseline_seq,
+					client->snapshot_pending, client->snapshot_pending_present, client->snapshot_pending_relevant,
+					client->snapshot_baseline, client->snapshot_baseline_present,
+					client->snapshot_pending_flags, qcvm->max_edicts,
+					&remove_count, &add_count, &update_count);
+		}
 		else
-			SV_WriteSnapshotFull (msg, client->snapshot_pending_seq, client->snapshot_pending,
-				client->snapshot_pending_present, client->snapshot_pending_flags, qcvm->max_edicts, &full_count);
+		{
+			if (sv_snapshot2.value)
+				SV_WriteSnapshot2Full (msg, client->snapshot_pending_seq, client->snapshot_pending,
+					client->snapshot_pending_present, client->snapshot_pending_flags, qcvm->max_edicts, &full_count);
+			else
+				SV_WriteSnapshotFull (msg, client->snapshot_pending_seq, client->snapshot_pending,
+					client->snapshot_pending_present, client->snapshot_pending_flags, qcvm->max_edicts, &full_count);
+			client->snapshot_last_full_seq = client->snapshot_pending_seq;
+			client->snapshot_last_full_time = realtime;
+		}
+		client->snapshot_last_sent_seq = client->snapshot_pending_seq;
 	}
 
 	if (forced_full)
@@ -1623,6 +1972,33 @@ static void SV_SendSnapshot (client_t *client, sizebuf_t *msg)
 			Con_Printf ("snapshot %s seq %u full size %d ents %d\n",
 				client->name, client->snapshot_pending_seq, size_delta, full_count);
 	}
+
+	if (sv_snap_debug.value >= 1.0f)
+	{
+		unsigned int base_seq = use_delta ? client->snapshot_pending_baseline_seq : 0xFFFFFFFFu;
+		unsigned int flags = 0;
+		const char *reason = NULL;
+
+		if (!use_delta)
+			flags |= SNAPSHOT_FLAG_FULL;
+		if (remove_count)
+			flags |= SNAPSHOT_FLAG_HAS_REMOVE_LIST;
+
+		if (!use_delta && sv_snap_debug.value >= 2.0f)
+		{
+			if (reason_force_full)
+				reason = "forced_full";
+			else if (reason_interval)
+				reason = "full_interval";
+			else if (reason_no_base)
+				reason = "no_base";
+		}
+
+		Con_Printf ("snap %s seq %u base %u flags 0x%x ents %d rem %d%s%s\n",
+			client->name, client->snapshot_pending_seq, base_seq, flags,
+			use_delta ? (add_count + update_count) : full_count, remove_count,
+			reason ? " reason " : "", reason ? reason : "");
+	}
 }
 
 void SV_SnapshotAck (client_t *client, unsigned int seq)
@@ -1633,14 +2009,14 @@ void SV_SnapshotAck (client_t *client, unsigned int seq)
 	if (seq == 0)
 	{
 		SV_ResetClientSnapshot (client);
-		if (sv_snapshotdebug.value)
+		if (sv_snapshotdebug.value || sv_snap_debug.value)
 			Con_Printf ("snapshot %s baseline reset request\n", client->name);
 		return;
 	}
 
 	if (seq != client->snapshot_pending_seq)
 	{
-		if (sv_snapshotdebug.value)
+		if (sv_snapshotdebug.value || sv_snap_debug.value)
 			Con_Printf ("snapshot %s ack seq %u ignored (pending %u)\n", client->name, seq, client->snapshot_pending_seq);
 		return;
 	}
@@ -1648,13 +2024,30 @@ void SV_SnapshotAck (client_t *client, unsigned int seq)
 	memcpy (client->snapshot_baseline, client->snapshot_pending, qcvm->max_edicts * sizeof(snapshot_state_t));
 	memcpy (client->snapshot_baseline_present, client->snapshot_pending_present, qcvm->max_edicts * sizeof(byte));
 	client->snapshot_baseline_seq = seq;
+	client->snapshot_last_acked_seq = seq;
 	client->snapshot_pending_seq = 0;
+	if (!client->snapshot_pending_is_delta)
+	{
+		client->snapshot_has_valid_base = true;
+		client->snapshot_last_full_seq = seq;
+		client->snapshot_last_full_time = realtime;
+	}
 	client->snapshot_pending_is_delta = false;
 	client->snapshot_pending_baseline_seq = 0;
 	client->snapshot_unacked_frames = 0;
 
-	if (sv_snapshotdebug.value)
+	if (sv_snapshotdebug.value || sv_snap_debug.value)
 		Con_Printf ("snapshot %s ack seq %u\n", client->name, seq);
+}
+
+void SV_SnapshotNak (client_t *client, unsigned int expected_base, unsigned int received_base)
+{
+	if (sv_snap_debug.value >= 1.0f)
+		Con_Printf ("snapshot %s nak expected %u received %u\n", client->name, expected_base, received_base);
+	client->snapshot_force_full = true;
+	client->snapshot_pending_is_delta = false;
+	client->snapshot_pending_seq = 0;
+	client->snapshot_unacked_frames = 0;
 }
 
 typedef struct

--- a/Quake/sv_user.c
+++ b/Quake/sv_user.c
@@ -612,6 +612,10 @@ nextmsg:
 			case clc_snapshot_ack:
 				SV_SnapshotAck (host_client, (unsigned int)MSG_ReadLong ());
 				break;
+
+			case clc_snapshot_nak:
+				SV_SnapshotNak (host_client, (unsigned int)MSG_ReadLong (), (unsigned int)MSG_ReadLong ());
+				break;
 			}
 		}
 	} while (ret == 1);


### PR DESCRIPTION
### Motivation
- Prevent entities (players, items, MOVETYPE_PUSH bmodels) from blinking when server sends deltas against an unknown or stale base. 
- Ensure server never applies/sends unsafe deltas and force full resyncs when the base cannot be guaranteed. 
- Preserve vanilla behavior where possible while adding lightweight diagnostics and resync guarantees. 
- Make snapshot packing deterministic and prioritize movers to avoid visual jitter when bandwidth is constrained.

### Description
- Protocol and messaging: add `svc_snapshot2` header with `seq`, `base_seq`, `flags`, `num_entities`, `num_removed`, and new client message `clc_snapshot_nak` (and server handler `SV_SnapshotNak`) to request/force resyncs.  Also add flags `SNAPSHOT_FLAG_FULL` and `SNAPSHOT_FLAG_HAS_REMOVE_LIST` in `protocol.h`.
- Server-side safety & packing: track per-client snapshot state (`snapshot_last_sent_seq`, `snapshot_last_acked_seq`, `snapshot_last_full_seq`, `snapshot_has_valid_base`, `snapshot_pending_relevant`), implement `SV_WriteSnapshot2Header`/`SV_WriteSnapshot2Full`/`SV_WriteSnapshot2Delta`, compute a per-message relevant set, prioritize movers/missiles/players, and enforce base validation before sending deltas (fall back to full when uncertain or on NAK).
- Client-side validation & hold logic: add `CL_ParseSnapshot2`, send `clc_snapshot_ack`/`clc_snapshot_nak`, perform header-based base checks and never apply a delta whose `base_seq` doesn't match `cl.snapshot_baseline_seq`, and add `cl_entity_timeout_ms` with `cl.snapshot_active` / `cl.snapshot_last_update_time` to hold entities briefly instead of immediate blinking when intermittent updates are missed.
- Debug and test instrumentation: add server/client debug cvars (`sv_snap_debug`, `net_test_drop`, `sv_snapshot2`, `sv_snap_max_payload`, `cl_snap_debug`, `cl_test_drop`) and logging of per-snapshot decisions (why a full was sent, counts of add/update/remove), plus `SDL_assert` checks to catch invalid base/delta situations.

### Testing
- No automated tests were executed as part of this change.
- The patch includes `net_test_drop` / `cl_test_drop` cvars to reproduce packet loss patterns for manual verification (used for local testing, not automated).
- New debug outputs are gated behind `sv_snap_debug` / `cl_snap_debug` for reproducible inspection of snapshot selection and resync behavior.
- Assertions (`SDL_assert`) are added to fail-fast on invalid base/delta application in debug builds.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960cb644ed4832eb8028fe51987aa5c)