### PR TITLE
Add client-side player interpolation buffer and server MTU-capped snapshots

### DIFF
--- a/Quake/cl_main.c
+++ b/Quake/cl_main.c
@@ -40,6 +40,9 @@ cvar_t	cl_packedents = {"cl_packedents", "1", CVAR_ARCHIVE};
 cvar_t	cl_snap_debug = {"cl_snap_debug", "0", CVAR_NONE};
 cvar_t	cl_test_drop = {"cl_test_drop", "0", CVAR_NONE};
 cvar_t	cl_entity_timeout_ms = {"cl_entity_timeout_ms", "750", CVAR_NONE};
+cvar_t	cl_lerp_ms = {"cl_lerp_ms", "120", CVAR_NONE};
+cvar_t	cl_lerp_max_gap_ms = {"cl_lerp_max_gap_ms", "250", CVAR_NONE};
+cvar_t	cl_lerp_debug = {"cl_lerp_debug", "0", CVAR_NONE};
 
 cvar_t	cfg_unbindall = {"cfg_unbindall", "1", CVAR_ARCHIVE};
 
@@ -79,6 +82,187 @@ extern float	host_netinterval;	//Spike
 
 extern vec3_t	v_punchangles[2];
 
+#define CL_PLAYER_SNAP_HISTORY 64
+#define CL_PLAYER_SNAP_MASK_WORDS ((MAX_SCOREBOARD + 31) / 32)
+
+typedef struct cl_player_snap_s
+{
+	double		t;
+	int			servertime;
+	vec3_t		org[MAX_SCOREBOARD];
+	vec3_t		ang[MAX_SCOREBOARD];
+	uint32_t	valid_mask_words[CL_PLAYER_SNAP_MASK_WORDS];
+} cl_player_snap_t;
+
+static cl_player_snap_t	cl_psnaps[CL_PLAYER_SNAP_HISTORY];
+static int				cl_psnap_head = 0;
+static int				cl_psnap_count = 0;
+
+static int				cl_lerp_miss_pairs = 0;
+static int				cl_lerp_hold_newest = 0;
+static int				cl_lerp_hold_oldest = 0;
+static int				cl_lerp_gap_holds = 0;
+static double			cl_lerp_debug_next_time = 0.0;
+
+static inline void CL_SetValidBit (cl_player_snap_t *snap, int idx)
+{
+	int word = idx >> 5;
+	int bit = idx & 31;
+
+	if (word < 0 || word >= CL_PLAYER_SNAP_MASK_WORDS)
+		return;
+	snap->valid_mask_words[word] |= (1u << bit);
+}
+
+static inline qboolean CL_IsValidBit (const cl_player_snap_t *snap, int idx)
+{
+	int word = idx >> 5;
+	int bit = idx & 31;
+
+	if (word < 0 || word >= CL_PLAYER_SNAP_MASK_WORDS)
+		return false;
+	return (snap->valid_mask_words[word] & (1u << bit)) != 0;
+}
+
+static void CL_ClearPlayerSnaps (void)
+{
+	memset (cl_psnaps, 0, sizeof(cl_psnaps));
+	cl_psnap_head = 0;
+	cl_psnap_count = 0;
+	cl_lerp_miss_pairs = 0;
+	cl_lerp_hold_newest = 0;
+	cl_lerp_hold_oldest = 0;
+	cl_lerp_gap_holds = 0;
+	cl_lerp_debug_next_time = 0.0;
+}
+
+void CL_RecordPlayerSnap (void)
+{
+	cl_player_snap_t *snap;
+	int i;
+
+	if (cl.maxclients <= 0)
+		return;
+
+	snap = &cl_psnaps[cl_psnap_head];
+	memset (snap, 0, sizeof(*snap));
+	snap->t = Sys_DoubleTime ();
+	snap->servertime = 0;
+
+	for (i = 0; i < cl.maxclients && i < MAX_SCOREBOARD; i++)
+	{
+		int entnum = i + 1;
+		entity_t *ent;
+
+		if (entnum == cl.viewentity)
+			continue;
+		if (!cl.snapshot_present || !cl.snapshot_present[entnum])
+			continue;
+		ent = &cl_entities[entnum];
+		if (!ent->model)
+			continue;
+		VectorCopy (ent->msg_origins[0], snap->org[i]);
+		VectorCopy (ent->msg_angles[0], snap->ang[i]);
+		CL_SetValidBit (snap, i);
+	}
+
+	cl_psnap_head = (cl_psnap_head + 1) % CL_PLAYER_SNAP_HISTORY;
+	cl_psnap_count = q_min (cl_psnap_count + 1, CL_PLAYER_SNAP_HISTORY);
+}
+
+static float CL_LerpAngle (float a, float b, float f)
+{
+	float d = b - a;
+
+	while (d > 180.0f)
+		d -= 360.0f;
+	while (d < -180.0f)
+		d += 360.0f;
+	return a + f * d;
+}
+
+static qboolean CL_GetInterpolatedPlayer (int player, vec3_t out_org, vec3_t out_ang)
+{
+	double now;
+	double render_t;
+	double max_gap_s;
+	cl_player_snap_t *newest;
+	cl_player_snap_t *oldest = NULL;
+	cl_player_snap_t *snap;
+	cl_player_snap_t *prev;
+	int idx;
+	int count;
+
+	if (cl_lerp_ms.value <= 0.0f)
+		return false;
+	if (player < 0 || player >= MAX_SCOREBOARD)
+		return false;
+	if (cl_psnap_count <= 0)
+		return false;
+
+	now = Sys_DoubleTime ();
+	render_t = now - (cl_lerp_ms.value * 0.001);
+	max_gap_s = cl_lerp_max_gap_ms.value * 0.001;
+
+	idx = (cl_psnap_head - 1 + CL_PLAYER_SNAP_HISTORY) % CL_PLAYER_SNAP_HISTORY;
+	newest = &cl_psnaps[idx];
+
+	if (render_t >= newest->t)
+	{
+		if (!CL_IsValidBit (newest, player))
+			return false;
+		VectorCopy (newest->org[player], out_org);
+		VectorCopy (newest->ang[player], out_ang);
+		cl_lerp_hold_newest++;
+		return true;
+	}
+
+	prev = newest;
+	for (count = 0; count < cl_psnap_count; count++)
+	{
+		snap = &cl_psnaps[idx];
+		oldest = snap;
+		if (snap->t <= render_t)
+		{
+			if (!CL_IsValidBit (snap, player) || !CL_IsValidBit (prev, player))
+				break;
+			if (prev->t - snap->t > max_gap_s)
+			{
+				VectorCopy (snap->org[player], out_org);
+				VectorCopy (snap->ang[player], out_ang);
+				cl_lerp_gap_holds++;
+				return true;
+			}
+			if (prev->t <= snap->t)
+				break;
+			{
+				float f = (float)((render_t - snap->t) / (prev->t - snap->t));
+				int axis;
+				f = CLAMP (0.0f, f, 1.0f);
+				for (axis = 0; axis < 3; axis++)
+				{
+					out_org[axis] = snap->org[player][axis] + f * (prev->org[player][axis] - snap->org[player][axis]);
+					out_ang[axis] = CL_LerpAngle (snap->ang[player][axis], prev->ang[player][axis], f);
+				}
+				return true;
+			}
+		}
+		prev = snap;
+		idx = (idx - 1 + CL_PLAYER_SNAP_HISTORY) % CL_PLAYER_SNAP_HISTORY;
+	}
+
+	if (oldest && render_t < oldest->t && CL_IsValidBit (oldest, player))
+	{
+		VectorCopy (oldest->org[player], out_org);
+		VectorCopy (oldest->ang[player], out_ang);
+		cl_lerp_hold_oldest++;
+		return true;
+	}
+
+	cl_lerp_miss_pairs++;
+	return false;
+}
+
 void CL_FreeState(void)
 {
         int i;
@@ -110,6 +294,7 @@ void CL_ClearState (void)
 
 // wipe the entire cl structure
 	CL_FreeState ();
+	CL_ClearPlayerSnaps ();
 
 	SZ_Clear (&cls.message);
 
@@ -686,6 +871,18 @@ void CL_RelinkEntities (void)
 			}
 		}
 
+		if (i <= cl.maxclients && i != cl.viewentity)
+		{
+			vec3_t lerp_org;
+			vec3_t lerp_ang;
+
+			if (CL_GetInterpolatedPlayer (i - 1, lerp_org, lerp_ang))
+			{
+				VectorCopy (lerp_org, ent->origin);
+				VectorCopy (lerp_ang, ent->angles);
+			}
+		}
+
 		if (ent->forcelink || ent->lerpflags & LERP_RESETMOVE)
 			CL_ResetTrail (ent);
 
@@ -814,6 +1011,22 @@ void CL_RelinkEntities (void)
 
 	if (viewentity_teleported)
 		cl.teleport_fx_time = cl.time;
+
+	if (cl_lerp_debug.value > 0.0f)
+	{
+		double now = Sys_DoubleTime ();
+
+		if (now >= cl_lerp_debug_next_time)
+		{
+			Con_Printf ("lerp: miss_pairs %d hold_newest %d hold_oldest %d gap_holds %d\n",
+				cl_lerp_miss_pairs, cl_lerp_hold_newest, cl_lerp_hold_oldest, cl_lerp_gap_holds);
+			cl_lerp_miss_pairs = 0;
+			cl_lerp_hold_newest = 0;
+			cl_lerp_hold_oldest = 0;
+			cl_lerp_gap_holds = 0;
+			cl_lerp_debug_next_time = now + 1.0;
+		}
+	}
 }
 
 
@@ -1133,6 +1346,9 @@ void CL_Init (void)
 	Cvar_RegisterVariable (&cl_snap_debug);
 	Cvar_RegisterVariable (&cl_test_drop);
 	Cvar_RegisterVariable (&cl_entity_timeout_ms);
+	Cvar_RegisterVariable (&cl_lerp_ms);
+	Cvar_RegisterVariable (&cl_lerp_max_gap_ms);
+	Cvar_RegisterVariable (&cl_lerp_debug);
 	Cvar_RegisterVariable (&freelook);
 	Cvar_RegisterVariable (&lookspring);
 	Cvar_RegisterVariable (&lookstrafe);

--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -1300,6 +1300,7 @@ static void CL_ParseSnapshotFull (void)
 	{
 		cl.snapshot_baseline_seq = seq;
 		CL_SendSnapshotAck (seq);
+		CL_RecordPlayerSnap ();
 	}
 }
 
@@ -1385,6 +1386,7 @@ static void CL_ParseSnapshotDelta (void)
 		}
 		cl.snapshot_baseline_seq = seq;
 		CL_SendSnapshotAck (seq);
+		CL_RecordPlayerSnap ();
 	}
 	else
 	{
@@ -1461,6 +1463,7 @@ static void CL_ParseSnapshot2 (void)
 		{
 			cl.snapshot_baseline_seq = header.seq;
 			CL_SendSnapshotAck (header.seq);
+			CL_RecordPlayerSnap ();
 		}
 		return;
 	}
@@ -1536,6 +1539,7 @@ static void CL_ParseSnapshot2 (void)
 		}
 		cl.snapshot_baseline_seq = header.seq;
 		CL_SendSnapshotAck (header.seq);
+		CL_RecordPlayerSnap ();
 	}
 	else
 	{

--- a/Quake/client.h
+++ b/Quake/client.h
@@ -341,6 +341,9 @@ extern	cvar_t	cl_confirmquit;
 extern	cvar_t	cl_snap_debug;
 extern	cvar_t	cl_test_drop;
 extern	cvar_t	cl_entity_timeout_ms;
+extern	cvar_t	cl_lerp_ms;
+extern	cvar_t	cl_lerp_max_gap_ms;
+extern	cvar_t	cl_lerp_debug;
 
 
 #define	MAX_TEMP_ENTITIES	256		//johnfitz -- was 64
@@ -439,6 +442,7 @@ void CL_TimeDemo_f (void);
 //
 void CL_ParseServerMessage (void);
 void CL_NewTranslation (int slot);
+void CL_RecordPlayerSnap (void);
 
 //
 // view

--- a/Quake/server.h
+++ b/Quake/server.h
@@ -191,6 +191,10 @@ typedef struct client_s
 	int				snapshot_stats_dropped;
 	double			snapshot_stats_next_time;
 	double			snapshot_debug_next_time;
+	int				mtu_last_snapshot_size;
+	int				mtu_dropped_tier1;
+	int				mtu_dropped_tier2;
+	double			mtu_debug_next_time;
 } client_t;
 
 

--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -44,6 +44,8 @@ static cvar_t sv_snap_debug = {"sv_snap_debug", "0", CVAR_NONE};
 static cvar_t sv_snap_full_interval = {"sv_snap_full_interval", "2.0", CVAR_NONE};
 static cvar_t sv_snap_force_full_after_frames = {"sv_snap_force_full_after_frames", "3", CVAR_NONE};
 static cvar_t sv_snap_max_payload = {"sv_snap_max_payload", "1200", CVAR_NONE};
+static cvar_t sv_mtu = {"sv_mtu", "1200", CVAR_NONE};
+static cvar_t sv_mtu_debug = {"sv_mtu_debug", "0", CVAR_NONE};
 static cvar_t net_test_drop = {"net_test_drop", "0", CVAR_NONE};
 static cvar_t net_snap_tinyvel = {"net_snap_tinyvel", "1", CVAR_NONE};
 static cvar_t net_snap_forcefull_frames = {"net_snap_forcefull_frames", "3", CVAR_NONE};
@@ -288,6 +290,8 @@ void SV_Init (void)
 	Cvar_RegisterVariable (&sv_snap_full_interval);
 	Cvar_RegisterVariable (&sv_snap_force_full_after_frames);
 	Cvar_RegisterVariable (&sv_snap_max_payload);
+	Cvar_RegisterVariable (&sv_mtu);
+	Cvar_RegisterVariable (&sv_mtu_debug);
 	Cvar_RegisterVariable (&net_test_drop);
 	Cvar_RegisterVariable (&net_snap_tinyvel);
 	Cvar_RegisterVariable (&net_snap_forcefull_frames);
@@ -874,6 +878,10 @@ static void SV_ResetClientSnapshot (client_t *client)
 	client->snapshot_stats_dropped = 0;
 	client->snapshot_stats_next_time = 0;
 	client->snapshot_debug_next_time = 0;
+	client->mtu_last_snapshot_size = 0;
+	client->mtu_dropped_tier1 = 0;
+	client->mtu_dropped_tier2 = 0;
+	client->mtu_debug_next_time = 0;
 	if (client->snapshot_baseline_present)
 		memset (client->snapshot_baseline_present, 0, max_edicts * sizeof(byte));
 	if (client->snapshot_pending_present)
@@ -1064,8 +1072,6 @@ static qboolean SV_SnapshotMandatoryEnt (const edict_t *ent)
 {
 	if ((int)ent->v.flags & FL_CLIENT)
 		return true;
-	if ((int)ent->v.movetype == MOVETYPE_PUSH && SV_SnapshotMoverMoving (ent))
-		return true;
 	return false;
 }
 
@@ -1089,6 +1095,19 @@ static qboolean SV_SnapshotPriorityMissile (const edict_t *ent)
 		return true;
 	if (((int)ent->v.movetype == MOVETYPE_TOSS || (int)ent->v.movetype == MOVETYPE_BOUNCE)
 		&& SV_SnapshotTossMoving (ent))
+		return true;
+	return false;
+}
+
+static qboolean SV_SnapshotTier1Ent (const edict_t *ent)
+{
+	if (SV_SnapshotPriorityMover (ent))
+		return true;
+	if (SV_SnapshotPriorityMissile (ent))
+		return true;
+	if ((int)ent->v.solid == SOLID_BSP)
+		return true;
+	if (ent->v.velocity[0] || ent->v.velocity[1] || ent->v.velocity[2])
 		return true;
 	return false;
 }
@@ -1138,11 +1157,14 @@ static int SV_SnapshotMaxEntities (sizebuf_t *msg)
 	int header_size = 1 + 4 + 2;
 	int per_ent = SV_SnapshotEntitySizeWorst ();
 	int payload_cap = (int)sv_snap_max_payload.value;
+	int mtu_cap = (int)sv_mtu.value;
 
 	if (sv_snapshot2.value)
 		header_size = 1 + 4 + 4 + 1 + 2 + 2;
 
 	int available = msg->maxsize - msg->cursize - header_size;
+	if (mtu_cap > 0)
+		payload_cap = payload_cap > 0 ? q_min (payload_cap, mtu_cap) : mtu_cap;
 	if (payload_cap > 0)
 		available = q_min (available, payload_cap - header_size);
 
@@ -1272,11 +1294,14 @@ static void SV_FillSnapshotState (edict_t *ent, snapshot_state_t *out)
 
 static int SV_BuildClientSnapshot (edict_t *clent, snapshot_state_t *states, byte *present,
 	byte *relevant, byte *snapflags, int max_ents, const byte *baseline_present,
-	int *out_mandatory, int *out_dropped, qboolean debug_frame)
+	int *out_mandatory, int *out_dropped, int *out_dropped_tier1, int *out_dropped_tier2,
+	qboolean debug_frame)
 {
 	int	num, j, numents, count;
 	int mandatory_count = 0;
 	int dropped_count = 0;
+	int dropped_tier1 = 0;
+	int dropped_tier2 = 0;
 	edict_t	*ent;
 
 	memset (present, 0, qcvm->max_edicts * sizeof(byte));
@@ -1326,39 +1351,13 @@ static int SV_BuildClientSnapshot (edict_t *clent, snapshot_state_t *states, byt
 		num = net_edicts_sorted[j];
 		ent = EDICT_NUM (num);
 
-		if (present[num] || !SV_SnapshotPriorityMover (ent))
+		if (present[num] || !SV_SnapshotTier1Ent (ent))
 			continue;
 
 		if (max_ents > 0 && count >= max_ents)
 		{
 			dropped_count++;
-			if (debug_frame && net_snap_debug.value)
-				Con_DPrintf ("snapdbg %s ent %d dropped budget\n", PR_GetString (clent->v.netname), num);
-			continue;
-		}
-
-		SV_FillSnapshotState (ent, &states[num]);
-
-		if (states[num].state.alpha == ENTALPHA_ZERO && !((int)ent->v.effects & qcvm->effects_mask))
-			continue;
-
-		present[num] = 1;
-		if (snapflags)
-			snapflags[num] = SV_SnapshotFlagsForEnt (ent);
-		count++;
-	}
-
-	for (j=0 ; j<numents ; j++)
-	{
-		num = net_edicts_sorted[j];
-		ent = EDICT_NUM (num);
-
-		if (present[num] || !SV_SnapshotPriorityMissile (ent))
-			continue;
-
-		if (max_ents > 0 && count >= max_ents)
-		{
-			dropped_count++;
+			dropped_tier1++;
 			if (debug_frame && net_snap_debug.value)
 				Con_DPrintf ("snapdbg %s ent %d dropped budget\n", PR_GetString (clent->v.netname), num);
 			continue;
@@ -1386,6 +1385,7 @@ static int SV_BuildClientSnapshot (edict_t *clent, snapshot_state_t *states, byt
 		if (max_ents > 0 && count >= max_ents)
 		{
 			dropped_count++;
+			dropped_tier2++;
 			if (debug_frame && net_snap_debug.value)
 				Con_DPrintf ("snapdbg %s ent %d dropped budget\n", PR_GetString (clent->v.netname), num);
 			continue;
@@ -1412,6 +1412,10 @@ static int SV_BuildClientSnapshot (edict_t *clent, snapshot_state_t *states, byt
 		*out_mandatory = mandatory_count;
 	if (out_dropped)
 		*out_dropped = dropped_count;
+	if (out_dropped_tier1)
+		*out_dropped_tier1 = dropped_tier1;
+	if (out_dropped_tier2)
+		*out_dropped_tier2 = dropped_tier2;
 
 	return count;
 }
@@ -1870,6 +1874,8 @@ static void SV_SendSnapshot (client_t *client, sizebuf_t *msg)
 	{
 		int mandatory_count = 0;
 		int dropped_count = 0;
+		int dropped_tier1 = 0;
+		int dropped_tier2 = 0;
 		int max_ents = SV_SnapshotMaxEntities (msg);
 		qboolean debug_frame = false;
 
@@ -1881,9 +1887,15 @@ static void SV_SendSnapshot (client_t *client, sizebuf_t *msg)
 
 		SV_BuildClientSnapshot (client->edict, client->snapshot_pending, client->snapshot_pending_present,
 			client->snapshot_pending_relevant, client->snapshot_pending_flags, max_ents,
-			client->snapshot_baseline_present, &mandatory_count, &dropped_count, debug_frame);
+			client->snapshot_baseline_present, &mandatory_count, &dropped_count,
+			&dropped_tier1, &dropped_tier2, debug_frame);
 		client->snapshot_pending_mandatory = mandatory_count;
 		client->snapshot_pending_dropped = dropped_count;
+		client->mtu_dropped_tier1 = dropped_tier1;
+		client->mtu_dropped_tier2 = dropped_tier2;
+		if (sv_mtu_debug.value > 0 && max_ents > 0 && dropped_tier1 > 0 && mandatory_count >= max_ents)
+			Con_Printf ("mtu %s forcing tier0 only (budget %d mandatory %d)\n",
+				client->name, max_ents, mandatory_count);
 		client->snapshot_pending_seq = client->snapshot_next_seq++;
 		if (!client->snapshot_next_seq)
 			client->snapshot_next_seq = 1;
@@ -1936,6 +1948,8 @@ static void SV_SendSnapshot (client_t *client, sizebuf_t *msg)
 		}
 		client->snapshot_last_sent_seq = client->snapshot_pending_seq;
 	}
+
+	client->mtu_last_snapshot_size = msg->cursize - start_size;
 
 	if (forced_full)
 		client->snapshot_stats_forced_full++;
@@ -2836,6 +2850,8 @@ qboolean SV_SendClientDatagram (client_t *client)
 	if (Q_strcmp(NET_QSocketGetAddressString(client->netconnection), "LOCAL") != 0)
 		msg.maxsize = DATAGRAM_MTU;
 	//johnfitz
+	if (sv_mtu.value > 0)
+		msg.maxsize = q_min (msg.maxsize, (int)sv_mtu.value);
 
 	MSG_WriteByte (&msg, svc_time);
 	MSG_WriteFloat (&msg, qcvm->time);
@@ -2848,6 +2864,13 @@ qboolean SV_SendClientDatagram (client_t *client)
 // copy the server datagram if there is space
 	if (msg.cursize + sv.datagram.cursize < msg.maxsize)
 		SZ_Write (&msg, sv.datagram.data, sv.datagram.cursize);
+
+	if (sv_mtu_debug.value > 0 && realtime >= client->mtu_debug_next_time)
+	{
+		Con_Printf ("mtu %s bytes %d dropped tier1 %d tier2 %d\n",
+			client->name, msg.cursize, client->mtu_dropped_tier1, client->mtu_dropped_tier2);
+		client->mtu_debug_next_time = realtime + 1.0;
+	}
 
 // send the datagram
 	if (NET_SendUnreliableMessage (client->netconnection, &msg) == -1)


### PR DESCRIPTION
### Motivation

- Reduce visible jitter of remote players by rendering slightly in the past and interpolating only remote player transforms. 
- Prevent large UDP datagrams from fragmenting by capping snapshot payloads and preferring high-priority entities so snapshots arrive regularly. 
- Make minimal, localized changes: do not alter snapshot protocol IDs or local player prediction, and keep entity history tiny and client-only. 
- Provide opt-in debug controls to observe interpolation and MTU behavior.

### Description

- Client: added lerp cvars `cl_lerp_ms`, `cl_lerp_max_gap_ms`, and `cl_lerp_debug`, a compact ring buffer and helpers (`CL_RecordPlayerSnap`, `CL_GetInterpolatedPlayer`, `CL_ClearPlayerSnaps`) to store recent remote-player transforms, and angle lerp helpers; recorded snapshots at the end of snapshot parsing and applied interpolated `origin`/`angles` for remote players during `CL_RelinkEntities` so renderer sees smoothed transforms only (no game-state feedback). (Files: `Quake/cl_main.c`, `Quake/cl_parse.c`, `Quake/client.h`.)
- Client: added lightweight debug counters (`cl_lerp_miss_pairs`, `cl_lerp_hold_newest`, `cl_lerp_hold_oldest`, `cl_lerp_gap_holds`) printed once per second when `cl_lerp_debug` is enabled. (File: `Quake/cl_main.c`.)
- Server: added `sv_mtu` and `sv_mtu_debug` cvars, limited per-datagram `msg.maxsize` to the MTU when set, and incorporated the MTU into `SV_SnapshotMaxEntities` calculation to cap snapshot payload. (File: `Quake/sv_main.c`.)
- Server: introduced a minimal tiered prioritization for snapshot inclusion — Tier0 (clients/must), Tier1 (movers/missiles/moving/solid BSP), Tier2 (others) — implemented by grouping passes in `SV_BuildClientSnapshot`, tracking dropped counts per tier, storing per-client MTU stats, and emitting debug prints when `sv_mtu_debug` is enabled; added per-client MTU fields to `client_t`. (Files: `Quake/sv_main.c`, `Quake/server.h`.)
- Registration: new cvars are registered where other cvars are registered so they are available at init. (Files: `Quake/cl_main.c`, `Quake/sv_main.c`.)

### Testing

- No automated tests were run on the modified code as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696130693d74832e83dd4a28508586a5)