### PR TITLE
Increase `MAX_MSGLEN` to protocol maximum (65535)

### DIFF
--- a/Quake/quakedef.h
+++ b/Quake/quakedef.h
@@ -98,7 +98,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #define	DIST_EPSILON	(0.03125)	// 1/32 epsilon to keep floating point happy (moved from world.c)
 
-#define	MAX_MSGLEN	64000		// max length of a reliable message //ericw -- was 32000
+#define	MAX_MSGLEN	65535		// max length of a reliable message //ericw -- was 32000
 #define	MAX_DATAGRAM	64000		// max length of unreliable message //johnfitz -- was 1024
 
 #define	DATAGRAM_MTU	1400		// johnfitz -- actual limit for unreliable messages to nonlocal clients


### PR DESCRIPTION
### Motivation
- Large reliable messages (e.g. signon data) could overflow the server/client reliable buffer and trigger `SZ_GetSpace: overflow` disconnects.
- The protocol supports up to 65535 bytes for reliable messages (`NET_MAXMESSAGE`), but `MAX_MSGLEN` was smaller, creating a mismatch.
- Aligning the reliable message buffer with the protocol maximum prevents fragmentation/overflow during heavy signon or large server messages.

### Description
- Increased `MAX_MSGLEN` from `64000` to `65535` in `Quake/quakedef.h` to match the full protocol size.
- This change raises the maximum allowed reliable message size to the same value as `NET_MAXMESSAGE`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69615bbec134832ebf26a7b7fdca5c62)