### PR TITLE
Reset per-client message buffer in `SV_SendServerinfo` to prevent signon overflow

### DIFF
--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -535,6 +535,10 @@ void SV_SendServerinfo (client_t *client)
 	char			message[2048];
 	int				i; //johnfitz
 
+	SZ_Clear (&client->message);
+	client->message.allowoverflow = true;
+	client->message.overflowed = false;
+
 	MSG_WriteByte (&client->message, svc_print);
 	sprintf (message, "%c\nFITZQUAKE %1.2f SERVER (%i CRC)\n", 2, FITZQUAKE_VERSION, qcvm->crc); //johnfitz -- include fitzquake version
 	MSG_WriteString (&client->message,message);


### PR DESCRIPTION
### Motivation
- Clients were being disconnected during level transitions with messages like `Host_Error: Illegible server message` and `SZ_GetSpace: overflow` indicating a message buffer overflow.
- The server writes `serverinfo`/signon data to the per-client `message` buffer during `SV_SendServerinfo`, and leftover data from previous state could cause the buffer to overflow.
- Clearing and resetting the per-client message state before composing the serverinfo prevents sending malformed/overflowed messages to clients.

### Description
- In `Quake/sv_main.c` inside `SV_SendServerinfo`, added `SZ_Clear(&client->message);` to reset the buffer before use.
- Also set `client->message.allowoverflow = true;` and `client->message.overflowed = false;` to ensure overflows are handled as intended for this write.
- This ensures the `serverinfo` and subsequent signon bytes are written into a fresh message buffer for each client.

### Testing
- No automated tests were run for this change.
- The change is a defensive fix limiting the risk of `SZ_GetSpace` overflow when composing signon messages.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696169215ea8832e8b77c8b3bb341c35)