### PR TITLE
Add minimal server-side bots (sv_addbot / sv_kickbots)

### DIFF
--- a/Quake/host.c
+++ b/Quake/host.c
@@ -559,11 +559,13 @@ void SV_DropClient (qboolean crash)
 	int		saveSelf;
 	int		i;
 	client_t *client;
+	qboolean is_bot;
 
+	is_bot = host_client->is_bot;
 	if (!crash)
 	{
 		// send any final messages (don't check for errors)
-		if (NET_CanSendMessage (host_client->netconnection))
+		if (!is_bot && host_client->netconnection && NET_CanSendMessage (host_client->netconnection))
 		{
 			MSG_WriteByte (&host_client->message, svc_disconnect);
 			NET_SendMessage (host_client->netconnection, &host_client->message);
@@ -588,14 +590,19 @@ void SV_DropClient (qboolean crash)
 	}
 
 // break the net connection
-	NET_Close (host_client->netconnection);
-	host_client->netconnection = NULL;
+	if (!is_bot && host_client->netconnection)
+	{
+		NET_Close (host_client->netconnection);
+		host_client->netconnection = NULL;
+	}
 
 // free the client (the body stays around)
 	host_client->active = false;
+	host_client->is_bot = false;
 	host_client->name[0] = 0;
 	host_client->old_frags = -999999;
-	net_activeconnections--;
+	if (!is_bot)
+		net_activeconnections--;
 
 // send notification to all clients
 	for (i = 0, client = svs.clients; i < svs.maxclients; i++, client++)
@@ -645,7 +652,7 @@ void Host_ShutdownServer(qboolean crash)
 		count = 0;
 		for (i=0, host_client = svs.clients ; i<svs.maxclients ; i++, host_client++)
 		{
-			if (host_client->active && host_client->message.cursize)
+			if (host_client->active && host_client->message.cursize && !host_client->is_bot)
 			{
 				if (NET_CanSendMessage (host_client->netconnection))
 				{

--- a/Quake/host_cmd.c
+++ b/Quake/host_cmd.c
@@ -3209,6 +3209,41 @@ static void Host_Begin_f (void)
 	host_client->spawned = true;
 }
 
+/*
+==================
+Host_AddBot_f
+==================
+*/
+static void Host_AddBot_f (void)
+{
+	const char *name;
+
+	if (cmd_source != src_command)
+	{
+		Con_Printf ("sv_addbot is not valid from the client\n");
+		return;
+	}
+
+	name = (Cmd_Argc () > 1) ? Cmd_Args () : NULL;
+	SV_AddBot (name);
+}
+
+/*
+==================
+Host_KickBots_f
+==================
+*/
+static void Host_KickBots_f (void)
+{
+	if (cmd_source != src_command)
+	{
+		Con_Printf ("sv_kickbots is not valid from the client\n");
+		return;
+	}
+
+	SV_KickBots ();
+}
+
 //===========================================================================
 
 /*
@@ -3804,6 +3839,8 @@ void Host_InitCommands (void)
 	Cmd_AddCommand_ClientCommand ("prespawn", Host_PreSpawn_f);
 	Cmd_AddCommand_ClientCommand ("kick", Host_Kick_f);
 	Cmd_AddCommand_ClientCommand ("ping", Host_Ping_f);
+	Cmd_AddCommand_Console ("sv_addbot", Host_AddBot_f);
+	Cmd_AddCommand_Console ("sv_kickbots", Host_KickBots_f);
 	Cmd_AddCommand ("load", Host_Loadgame_f);
 	Cmd_AddCommand ("save", Host_Savegame_f);
 	Cmd_AddCommand_ClientCommand ("give", Host_Give_f);
@@ -3817,4 +3854,3 @@ void Host_InitCommands (void)
 	Cmd_AddCommand ("viewnext", Host_Viewnext_f);
 	Cmd_AddCommand ("viewprev", Host_Viewprev_f);
 }
-

--- a/Quake/server.h
+++ b/Quake/server.h
@@ -126,12 +126,26 @@ enum sendsignon_e
 	PRESPAWN_SIGNONMSG,
 };
 
+typedef struct bot_state_s
+{
+	int			enemy;
+	double		next_target_scan;
+	double		next_fire_time;
+	double		next_wander_time;
+	double		next_strafe_time;
+	double		last_progress_time;
+	float		wander_yaw;
+	int			strafe_dir;
+	vec3_t		last_origin;
+} bot_state_t;
+
 typedef struct client_s
 {
 	qboolean		active;				// false = client is free
 	qboolean		spawned;			// false = don't send datagrams
 	qboolean		dropasap;			// has been told to go to another level
 	qboolean		supports_packedents;
+	qboolean		is_bot;
 	enum sendsignon_e	sendsignon;			// only valid before spawned
 	int				signonidx;
 
@@ -195,6 +209,7 @@ typedef struct client_s
 	int				mtu_dropped_tier1;
 	int				mtu_dropped_tier2;
 	double			mtu_debug_next_time;
+	bot_state_t		bot;
 } client_t;
 
 
@@ -338,6 +353,9 @@ void SV_MoveToGoal (void);
 
 void SV_CheckForNewClients (void);
 void SV_RunClients (void);
+qboolean SV_AddBot (const char *name);
+void SV_KickBots (void);
+void SV_BotFrame (client_t *client, double now);
 void SV_SaveSpawnparms (void);
 void SV_SpawnServer (const char *server);
 void SV_SnapshotAck (client_t *client, unsigned int seq);

--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -3001,7 +3001,7 @@ void SV_UpdateToReliableMessages (void)
 		{
 			for (j=0, client = svs.clients ; j<svs.maxclients ; j++, client++)
 			{
-				if (!client->active)
+				if (!client->active || client->is_bot)
 					continue;
 				MSG_WriteByte (&client->message, svc_updatefrags);
 				MSG_WriteByte (&client->message, i);
@@ -3014,7 +3014,7 @@ void SV_UpdateToReliableMessages (void)
 
 	for (j=0, client = svs.clients ; j<svs.maxclients ; j++, client++)
 	{
-		if (!client->active)
+		if (!client->active || client->is_bot)
 			continue;
 		SV_WriteStats (client);
 		SV_WriteUnderwaterOverride (client);
@@ -3065,6 +3065,8 @@ void SV_SendClientMessages (void)
 	for (i=0, host_client = svs.clients ; i<svs.maxclients ; i++, host_client++)
 	{
 		if (!host_client->active)
+			continue;
+		if (host_client->is_bot)
 			continue;
 
 		if (host_client->spawned)
@@ -3614,6 +3616,7 @@ void SV_SpawnServer (const char *server)
 //
 	if (sv.active)
 	{
+		SV_KickBots ();
 		SV_SendReconnect ();
 	}
 

--- a/Quake/sv_user.c
+++ b/Quake/sv_user.c
@@ -623,6 +623,286 @@ nextmsg:
 	return true;
 }
 
+static float SV_BotRandom (void)
+{
+	return (float)(rand() & 0x7fff) / 32767.0f;
+}
+
+static void SV_BotReset (client_t *client, double now)
+{
+	client->bot.enemy = -1;
+	client->bot.next_target_scan = 0;
+	client->bot.next_fire_time = 0;
+	client->bot.next_wander_time = now;
+	client->bot.next_strafe_time = now;
+	client->bot.last_progress_time = now;
+	client->bot.wander_yaw = client->edict->v.angles[YAW];
+	client->bot.strafe_dir = 1;
+	VectorCopy (client->edict->v.origin, client->bot.last_origin);
+}
+
+static qboolean SV_BotCanSee (edict_t *self, edict_t *other)
+{
+	vec3_t start;
+	vec3_t end;
+	trace_t trace;
+
+	VectorAdd (self->v.origin, self->v.view_ofs, start);
+	VectorAdd (other->v.origin, other->v.view_ofs, end);
+	trace = SV_Move (start, vec3_origin, vec3_origin, end, MOVE_NOMONSTERS, self);
+	return (trace.fraction >= 1.0f);
+}
+
+static void SV_BotSelectEnemy (client_t *client, double now)
+{
+	int i;
+	float best_dist = 0;
+	int best_index = -1;
+	vec3_t delta;
+
+	if (now < client->bot.next_target_scan)
+		return;
+
+	client->bot.next_target_scan = now + 0.3 + SV_BotRandom() * 0.2;
+
+	for (i = 0; i < svs.maxclients; i++)
+	{
+		client_t *other = &svs.clients[i];
+		float dist;
+
+		if (!other->active || !other->spawned || other == client)
+			continue;
+		if (other->edict->v.health <= 0)
+			continue;
+		if (!SV_BotCanSee (client->edict, other->edict))
+			continue;
+
+		VectorSubtract (other->edict->v.origin, client->edict->v.origin, delta);
+		dist = VectorLength (delta);
+		if (best_index == -1 || dist < best_dist)
+		{
+			best_index = i;
+			best_dist = dist;
+		}
+	}
+
+	client->bot.enemy = best_index;
+}
+
+void SV_BotFrame (client_t *client, double now)
+{
+	usercmd_t cmd;
+	vec3_t target_dir;
+	vec3_t angles;
+	vec3_t forward;
+	float dot;
+	vec3_t delta;
+
+	if (!client->spawned)
+		return;
+
+	if (client->bot.last_progress_time == 0)
+		SV_BotReset (client, now);
+
+	SV_BotSelectEnemy (client, now);
+
+	memset (&cmd, 0, sizeof(cmd));
+	client->edict->v.button0 = 0;
+	client->edict->v.button2 = 0;
+	client->edict->v.impulse = 0;
+
+	if (client->bot.enemy >= 0 && client->bot.enemy < svs.maxclients)
+	{
+		client_t *enemy = &svs.clients[client->bot.enemy];
+		if (!enemy->active || !enemy->spawned || enemy->edict->v.health <= 0
+			|| !SV_BotCanSee (client->edict, enemy->edict))
+			client->bot.enemy = -1;
+	}
+
+	if (client->bot.enemy >= 0)
+	{
+		client_t *enemy = &svs.clients[client->bot.enemy];
+
+		VectorSubtract (enemy->edict->v.origin, client->edict->v.origin, target_dir);
+		VectorNormalize (target_dir);
+		VectorAngles (target_dir, angles);
+		angles[ROLL] = 0;
+		if (angles[PITCH] > 80)
+			angles[PITCH] = 80;
+		if (angles[PITCH] < -80)
+			angles[PITCH] = -80;
+
+		VectorCopy (angles, client->edict->v.v_angle);
+		client->edict->v.fixangle = 0;
+
+		cmd.forwardmove = 400;
+		if (now >= client->bot.next_strafe_time)
+		{
+			client->bot.strafe_dir = (SV_BotRandom() > 0.5f) ? 1 : -1;
+			client->bot.next_strafe_time = now + 0.8 + SV_BotRandom() * 0.6;
+		}
+		cmd.sidemove = client->bot.strafe_dir * 200;
+
+		AngleVectors (angles, forward, NULL, NULL);
+		dot = DotProduct (forward, target_dir);
+		if (dot > 0.9f && now >= client->bot.next_fire_time)
+		{
+			client->edict->v.button0 = 1;
+			client->bot.next_fire_time = now + 0.2 + SV_BotRandom() * 0.4;
+		}
+	}
+	else
+	{
+		if (now >= client->bot.next_wander_time)
+		{
+			client->bot.wander_yaw += (SV_BotRandom() - 0.5f) * 120.0f;
+			client->bot.next_wander_time = now + 1.0 + SV_BotRandom() * 1.5;
+		}
+
+		angles[PITCH] = 0;
+		angles[YAW] = client->bot.wander_yaw;
+		angles[ROLL] = 0;
+		VectorCopy (angles, client->edict->v.v_angle);
+		client->edict->v.fixangle = 0;
+
+		cmd.forwardmove = 200;
+		if (now >= client->bot.next_strafe_time)
+		{
+			client->bot.strafe_dir = (SV_BotRandom() > 0.5f) ? 1 : -1;
+			client->bot.next_strafe_time = now + 1.0 + SV_BotRandom() * 1.0;
+		}
+		cmd.sidemove = client->bot.strafe_dir * 120;
+	}
+
+	VectorSubtract (client->edict->v.origin, client->bot.last_origin, delta);
+	if (VectorLength (delta) > 8.0f)
+	{
+		VectorCopy (client->edict->v.origin, client->bot.last_origin);
+		client->bot.last_progress_time = now;
+	}
+	else if (now - client->bot.last_progress_time > 1.0)
+	{
+		client->bot.wander_yaw += 120.0f;
+		cmd.sidemove = client->bot.strafe_dir * 300;
+		cmd.upmove = 200;
+		VectorCopy (client->edict->v.origin, client->bot.last_origin);
+		client->bot.last_progress_time = now;
+	}
+
+	client->cmd = cmd;
+}
+
+qboolean SV_AddBot (const char *name)
+{
+	int i;
+	client_t *client = NULL;
+	edict_t *ent;
+	const char *bot_name = name;
+	qcvm_t *oldvm;
+
+	if (!sv.active)
+	{
+		Con_Printf ("No active server.\n");
+		return false;
+	}
+
+	for (i = 0; i < svs.maxclients; i++)
+	{
+		if (!svs.clients[i].active)
+		{
+			client = &svs.clients[i];
+			break;
+		}
+	}
+
+	if (!client)
+	{
+		Con_Printf ("No free client slots.\n");
+		return false;
+	}
+
+	ent = client->edict ? client->edict : EDICT_NUM(i + 1);
+	memset (client, 0, sizeof(*client));
+	client->edict = ent;
+	client->message.data = client->msgbuf;
+	client->message.maxsize = sizeof(client->msgbuf);
+	client->message.allowoverflow = true;
+	client->active = true;
+	client->spawned = true;
+	client->is_bot = true;
+	client->old_frags = 0;
+	client->colors = 0;
+
+	if (!bot_name || !bot_name[0])
+	{
+		static char default_name[32];
+		q_snprintf (default_name, sizeof(default_name), "bot%i", i + 1);
+		bot_name = default_name;
+	}
+	q_strlcpy (client->name, bot_name, sizeof(client->name));
+
+	oldvm = qcvm;
+	PR_SwitchQCVM(NULL);
+	PR_SwitchQCVM(&sv.qcvm);
+
+	if (sv.loadgame)
+		memset (client->spawn_parms, 0, sizeof(client->spawn_parms));
+	else
+	{
+		PR_ExecuteProgram (pr_global_struct->SetNewParms);
+		for (i = 0; i < NUM_SPAWN_PARMS; i++)
+			client->spawn_parms[i] = (&pr_global_struct->parm1)[i];
+	}
+
+	host_client = client;
+	sv_player = ent;
+
+	memset (&ent->v, 0, qcvm->progs->entityfields * 4);
+	ent->v.colormap = NUM_FOR_EDICT(ent);
+	ent->v.team = (client->colors & 15) + 1;
+	ent->v.netname = PR_SetEngineString(client->name);
+
+	for (i = 0; i < NUM_SPAWN_PARMS; i++)
+		(&pr_global_struct->parm1)[i] = client->spawn_parms[i];
+
+	pr_global_struct->time = qcvm->time;
+	pr_global_struct->self = EDICT_TO_PROG(sv_player);
+	PR_ExecuteProgram (pr_global_struct->ClientConnect);
+	PR_ExecuteProgram (pr_global_struct->PutClientInServer);
+
+	PR_SwitchQCVM(NULL);
+	PR_SwitchQCVM(oldvm);
+
+	SV_BotReset (client, qcvm->time);
+
+	MSG_WriteByte (&sv.reliable_datagram, svc_updatename);
+	MSG_WriteByte (&sv.reliable_datagram, client - svs.clients);
+	MSG_WriteString (&sv.reliable_datagram, client->name);
+	MSG_WriteByte (&sv.reliable_datagram, svc_updatefrags);
+	MSG_WriteByte (&sv.reliable_datagram, client - svs.clients);
+	MSG_WriteShort (&sv.reliable_datagram, client->edict->v.frags);
+	MSG_WriteByte (&sv.reliable_datagram, svc_updatecolors);
+	MSG_WriteByte (&sv.reliable_datagram, client - svs.clients);
+	MSG_WriteByte (&sv.reliable_datagram, client->colors);
+
+	Con_Printf ("Added bot %s\n", client->name);
+	return true;
+}
+
+void SV_KickBots (void)
+{
+	int i;
+	client_t *client;
+
+	for (i = 0, client = svs.clients; i < svs.maxclients; i++, client++)
+	{
+		if (!client->active || !client->is_bot)
+			continue;
+		host_client = client;
+		sv_player = client->edict;
+		SV_DropClient (false);
+	}
+}
 
 /*
 ==================
@@ -640,10 +920,17 @@ void SV_RunClients (void)
 
 		sv_player = host_client->edict;
 
-		if (!SV_ReadClientMessage ())
+		if (host_client->is_bot)
 		{
-			SV_DropClient (false);	// client misbehaved...
-			continue;
+			SV_BotFrame (host_client, qcvm->time);
+		}
+		else
+		{
+			if (!SV_ReadClientMessage ())
+			{
+				SV_DropClient (false);	// client misbehaved...
+				continue;
+			}
 		}
 
 		if (!host_client->spawned)


### PR DESCRIPTION
### Motivation
- Provide a very small, server-side bot implementation so listen/dedicated servers can spawn simple AI players without client changes or protocol modifications. 
- Keep the change minimal and isolated while reusing existing server movement and physics where possible. 
- Ensure bots appear as regular clients (scoreboard/name) and are cleaned up safely on map changes or disconnects. 

### Description
- Add a compact `bot_state_t` and a `is_bot` flag to `client_t`, and expose `SV_AddBot`, `SV_KickBots`, and `SV_BotFrame` in `server.h` to manage bot lifecycle. 
- Implement simple bot logic in `sv_user.c` that picks the nearest visible enemy, aims (sets `v_angle`), moves (`cmd.forwardmove`/`cmd.sidemove`), fires occasionally, roams when idle, and performs a basic anti-stuck tweak. 
- Hook bots into the server frame by calling `SV_BotFrame` from `SV_RunClients`, and avoid network send/receive paths for bot clients by guarding message and connection code in `host.c` and `sv_main.c`. 
- Add console commands `sv_addbot [name]` and `sv_kickbots` in `host_cmd.c`, and ensure `SV_KickBots` is invoked on level spawn to clean up bots across map changes. 

### Testing
- No automated tests were run as part of this change. 
- The patch compiles and was committed locally (manual build/run verification not performed as part of this PR).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69616b28d0c0832ea9f8f1a7f0284b9e)