### PR TITLE
Preserve bot time before QCVM restore to avoid null-deref in SV_AddBot

### DIFF
--- a/Quake/sv_user.c
+++ b/Quake/sv_user.c
@@ -799,6 +799,7 @@ qboolean SV_AddBot (const char *name)
 	edict_t *ent;
 	const char *bot_name = name;
 	qcvm_t *oldvm;
+	double bot_time;
 
 	if (!sv.active)
 	{
@@ -870,10 +871,12 @@ qboolean SV_AddBot (const char *name)
 	PR_ExecuteProgram (pr_global_struct->ClientConnect);
 	PR_ExecuteProgram (pr_global_struct->PutClientInServer);
 
+	bot_time = qcvm->time;
+
 	PR_SwitchQCVM(NULL);
 	PR_SwitchQCVM(oldvm);
 
-	SV_BotReset (client, qcvm->time);
+	SV_BotReset (client, bot_time);
 
 	MSG_WriteByte (&sv.reliable_datagram, svc_updatename);
 	MSG_WriteByte (&sv.reliable_datagram, client - svs.clients);


### PR DESCRIPTION
### Motivation
- Spawning a bot could crash because `SV_BotReset` was called with `qcvm->time` after `qcvm` had been set back to `NULL`, causing a read access violation. 
- The code saved `oldvm` but it could already be `NULL`, so restoring it before finishing bot setup made `qcvm` invalid for subsequent use. 
- The intent is to ensure the time value needed by bot initialization is captured while `qcvm` points to the bot QCVM. 
- This prevents dereferencing a potentially NULL `qcvm` when resetting the bot.

### Description
- Added a local `double bot_time` in `SV_AddBot` in `Quake/sv_user.c` to capture `qcvm->time` while the server QCVM is active. 
- Captures `bot_time = qcvm->time` immediately after running the client connect/put-in-server programs. 
- Restores the previous QCVM with `PR_SwitchQCVM(oldvm)` and then calls `SV_BotReset(client, bot_time)` instead of using `qcvm->time`. 
- This change isolates the required time value from QCVM switching to avoid null dereference.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69616edff4ec832eb9dd21ffc10956f9)