### PR TITLE
Guard AngleVectors against NULL right/up

### DIFF
--- a/Quake/mathlib.c
+++ b/Quake/mathlib.c
@@ -254,12 +254,18 @@ void AngleVectors (vec3_t angles, vec3_t forward, vec3_t right, vec3_t up)
 	forward[0] = cp*cy;
 	forward[1] = cp*sy;
 	forward[2] = -sp;
-	right[0] = (-1*sr*sp*cy+-1*cr*-sy);
-	right[1] = (-1*sr*sp*sy+-1*cr*cy);
-	right[2] = -1*sr*cp;
-	up[0] = (cr*sp*cy+-sr*-sy);
-	up[1] = (cr*sp*sy+-sr*cy);
-	up[2] = cr*cp;
+	if (right)
+	{
+		right[0] = (-1*sr*sp*cy+-1*cr*-sy);
+		right[1] = (-1*sr*sp*sy+-1*cr*cy);
+		right[2] = -1*sr*cp;
+	}
+	if (up)
+	{
+		up[0] = (cr*sp*cy+-sr*-sy);
+		up[1] = (cr*sp*sy+-sr*cy);
+		up[2] = cr*cp;
+	}
 }
 
 int VectorCompare (const vec3_t v1, const vec3_t v2)


### PR DESCRIPTION
### Motivation
- Prevent a null-pointer dereference crash when `AngleVectors` is called with `right` or `up` equal to `NULL`, as observed in bot code (`SV_BotFrame`) that only needs the `forward` vector.
- Fix an API/contract mismatch where callers pass `NULL` for unused outputs but the function unconditionally wrote to those pointers.
- Improve robustness and maintain compatibility with existing call sites that intentionally omit `right`/`up`.

### Description
- Updated `AngleVectors` in `Quake/mathlib.c` to check `right` and `up` for non-NULL before writing to them.
- Kept `forward` population unchanged so callers that request it still receive the computed vector.
- The change is localized to guarding the assignments to `right` and `up` with `if (right)` and `if (up)`.

### Testing
- No automated tests were run on the modified code.
- Local static inspection and code navigation commands were used to verify the modified function and call sites compiled conceptually without further changes.
- The patch was committed with the message `Handle null right/up in AngleVectors`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69617187ac74832ea0e2dc11823c6632)