### PR TITLE
Increase multiplayer player cap to 32

### DIFF
--- a/Quake/host.c
+++ b/Quake/host.c
@@ -320,8 +320,8 @@ void	Host_FindMaxClients (void)
 		svs.maxclients = MAX_SCOREBOARD;
 
 	svs.maxclientslimit = svs.maxclients;
-	if (svs.maxclientslimit < 4)
-		svs.maxclientslimit = 4;
+	if (svs.maxclientslimit < 32)
+		svs.maxclientslimit = 32;
 	svs.clients = (struct client_s *) Hunk_AllocName (svs.maxclientslimit*sizeof(client_t), "clients");
 
 	if (svs.maxclients > 1)

--- a/Quake/menu.c
+++ b/Quake/menu.c
@@ -6061,7 +6061,7 @@ void M_GameOptions_Draw (void)
 			x = (320-26*8)/2;
 			M_DrawTextBox (x, 138, 24, 4);
 			x += 8;
-			M_Print (x, 146, "  More than 4 players   ");
+			M_Print (x, 146, "  More than 32 players  ");
 			M_Print (x, 154, " requires using command ");
 			M_Print (x, 162, "line parameters; please ");
 			M_Print (x, 170, "   see techinfo.txt.    ");

--- a/Quake/quakedef.h
+++ b/Quake/quakedef.h
@@ -220,7 +220,7 @@ typedef enum
 
 //===========================================
 
-#define	MAX_SCOREBOARD		16
+#define	MAX_SCOREBOARD		32
 #define	MAX_SCOREBOARDNAME	32
 
 #define	SOUND_CHANNELS		8


### PR DESCRIPTION
### Motivation
- Allow larger multiplayer sessions by raising the scoreboard and client limits from 16/4 to 32.
- Ensure the server allocates enough client slots when larger matches are requested via command line.
- Keep the in-game UI message consistent with the new player cap.

### Description
- Bumped `MAX_SCOREBOARD` from `16` to `32` in `Quake/quakedef.h` to raise the global scoreboard/player cap.
- Changed the server-side minimum `svs.maxclientslimit` floor from `4` to `32` in `Quake/host.c` so the server allocates at least 32 client slots.
- Updated the multiplayer menu notice text in `Quake/menu.c` from "More than 4 players" to "More than 32 players" to match the new limit.

### Testing
- No automated tests were executed for this change.
- A commit including the three modified files was created successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696180dcb348832e9adea4cdf927567a)