### PR TITLE
Guard snapshot size estimates to avoid snapshot buffer overflow

### DIFF
--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -1129,6 +1129,7 @@ static int SV_SnapshotEntitySizeWorst (void)
 	int angle_size;
 	int field_size = 0;
 	int extra_flags = (sv.protocolflags & PRFL_SNAPSHOT_HIRES) ? 1 : 0;
+	int entry_overhead;
 
 	if (sv.protocolflags & PRFL_FLOATCOORD)
 		coord_size = 4;
@@ -1160,18 +1161,19 @@ static int SV_SnapshotEntitySizeWorst (void)
 	field_size += 1; // scale
 	field_size += 1; // step
 
-	return 2 + extra_flags + field_size;
+	entry_overhead = q_max (extra_flags, 4); // worst-case delta includes a 32-bit mask
+	return 2 + entry_overhead + field_size;
 }
 
 static int SV_SnapshotMaxEntities (sizebuf_t *msg)
 {
-	int header_size = 1 + 4 + 2;
+	int header_size = 1 + 4 + 4 + 2 + 2 + 2;
 	int per_ent = SV_SnapshotEntitySizeWorst ();
 	int payload_cap = (int)sv_snap_max_payload.value;
 	int mtu_cap = (int)sv_mtu.value;
 
 	if (sv_snapshot2.value)
-		header_size = 1 + 4 + 4 + 1 + 2 + 2;
+		header_size = 1 + 4 + 4 + 1 + 2 + 2 + 2 + 2;
 
 	int available = msg->maxsize - msg->cursize - header_size;
 	if (mtu_cap > 0)


### PR DESCRIPTION
### Motivation
- Server logs showed `SZ_GetSpace: overflow` and illegible server messages when many bots caused large snapshots, indicating snapshot size was underestimated.
- Snapshot entries can include a 32-bit field mask and other overheads that were not accounted for in worst-case sizing.
- Underestimating per-entity or header size can cause writes beyond the `sizebuf_t` capacity and crash the server.
- The snapshot sizing logic in `sv_main.c` needed to be more conservative to avoid these overflows.

### Description
- In `SV_SnapshotEntitySizeWorst` added an `entry_overhead` and use `q_max(extra_flags, 4)` so the worst-case per-entity size accounts for a 32-bit mask.
- In `SV_SnapshotMaxEntities` increased the conservative `header_size` for both the normal and `sv_snapshot2` variants to reserve additional bytes.
- The available payload calculation now uses the updated header and per-entry estimates, reducing `SV_SnapshotMaxEntities` when appropriate.
- Changes are contained in `Quake/sv_main.c` and aim to prevent `SZ_GetSpace` overflow conditions.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696182a0b7dc832e92324c9b2e85912e)