### PR TITLE
Add `.jpeg` extension to image loader

### DIFF
--- a/Quake/image.c
+++ b/Quake/image.c
@@ -105,7 +105,7 @@ returns a pointer to hunk allocated RGBA data
 */
 byte *Image_LoadImage (const char *name, int *width, int *height, enum srcformat *fmt)
 {
-	static const char *const stbi_formats[] = {"png", "tga", "jpg", NULL};
+	static const char *const stbi_formats[] = {"png", "tga", "jpg", "jpeg", NULL};
 	FILE	*f;
 	int		i;
 


### PR DESCRIPTION
### Motivation
- Allow the engine to load textures whose files use the `.jpeg` extension in addition to `.jpg`.
- `stb_image` already supports JPEG data, so adding the extension improves compatibility with existing assets.
- Reduce false "not supported" warnings for non-TGA JPEG files when loading external images.

### Description
- Added `"jpeg"` to the `stbi_formats` array used by `Image_LoadImage` in `Quake/image.c` so the loader will probe `name.jpeg` files.
- The change is limited to `Quake/image.c` and affects the `Image_LoadImage` probing loop that calls `stbi_load_from_file`.
- No decoding or runtime behavior of `stbi_load_from_file` was changed; images are still loaded into `SRC_RGBA` data.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961ac1a5dcc832ead33afe4e2a5dc3e)