### PR TITLE
Fix signon reserve sizing for baselines

### DIFF
--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -3304,7 +3304,39 @@ void SV_CreateBaseline (void)
 	//
 	// add to the message
 	//
-		SV_ReserveSignonSpace (35);
+		{
+			int coord_bytes;
+			int angle_bytes;
+			int reserve;
+
+			if (sv.protocolflags & (PRFL_FLOATCOORD | PRFL_INT32COORD))
+				coord_bytes = 4;
+			else if (sv.protocolflags & PRFL_24BITCOORD)
+				coord_bytes = 3;
+			else
+				coord_bytes = 2;
+
+			if (sv.protocolflags & PRFL_FLOATANGLE)
+				angle_bytes = 4;
+			else if (sv.protocolflags & PRFL_SHORTANGLE)
+				angle_bytes = 2;
+			else
+				angle_bytes = 1;
+
+			reserve = 1 + 2;
+			if (bits)
+				reserve += 1;
+			reserve += (bits & B_LARGEMODEL) ? 2 : 1;
+			reserve += (bits & B_LARGEFRAME) ? 2 : 1;
+			reserve += 1 + 1;
+			reserve += 3 * (coord_bytes + angle_bytes);
+			if (bits & B_ALPHA)
+				reserve += 1;
+			if (bits & B_SCALE)
+				reserve += 1;
+
+			SV_ReserveSignonSpace (reserve);
+		}
 
 		//johnfitz -- PROTOCOL_FITZQUAKE
 		if (bits)


### PR DESCRIPTION
### Motivation

- Prevent `SZ_GetSpace`/signon buffer overflows that can occur when loading maps with large baseline data by avoiding a fixed reserve size.
- Ensure the server reserves enough bytes for baseline messages according to the active networking protocol flags and baseline `bits`.

### Description

- Replace the fixed `SV_ReserveSignonSpace(35)` call with computed `reserve` bytes based on `sv.protocolflags` and baseline `bits`.
- Compute `coord_bytes` and `angle_bytes` from `sv.protocolflags` (handling `PRFL_FLOATCOORD`, `PRFL_INT32COORD`, `PRFL_24BITCOORD`, `PRFL_FLOATANGLE`, and `PRFL_SHORTANGLE`).
- Add contributions to `reserve` for header bytes, model/frame sizes depending on `B_LARGEMODEL`/`B_LARGEFRAME`, per-axis coords/angles, and optional `B_ALPHA`/`B_SCALE` fields.
- Change applied in `Quake/sv_main.c` to call `SV_ReserveSignonSpace(reserve)` before writing the baseline message.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69626277acd0832eac52b021adb781d5)