### PR TITLE
Add tcGen environment and tcMod texture matrices to renderer and shaders

### DIFF
--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -295,6 +295,7 @@ typedef struct bmodel_bindless_gpu_call_s {
 	GLfloat		polygon_offset[2];
 	GLfloat		_pad1[2];
 	GLfloat		stage_color[4];
+	GLfloat		texmatrix[8];
 	GLuint64	texture;
 	GLuint64	fullbright;
 	GLuint64	emissive;
@@ -309,6 +310,7 @@ typedef struct bmodel_bound_gpu_call_s {
 	GLfloat		polygon_offset[2];
 	GLfloat		_pad1[2];
 	GLfloat		stage_color[4];
+	GLfloat		texmatrix[8];
 	GLint		baseinstance;
 	GLint		padding[3];
 } bmodel_bound_gpu_call_t;
@@ -571,6 +573,34 @@ qboolean R_SurfaceEmitsGodrays (msurface_t *s)
 R_AddBModelCall
 =============
 */
+static void R_SetCallTexMatrix (float *dst, const mat_texmatrix_t *matrix)
+{
+	if (!dst)
+		return;
+
+	if (!matrix)
+	{
+		dst[0] = 1.f;
+		dst[1] = 0.f;
+		dst[2] = 0.f;
+		dst[3] = 0.f;
+		dst[4] = 0.f;
+		dst[5] = 1.f;
+		dst[6] = 0.f;
+		dst[7] = 0.f;
+		return;
+	}
+
+	dst[0] = matrix->m[0][0];
+	dst[1] = matrix->m[0][1];
+	dst[2] = matrix->m[0][2];
+	dst[3] = 0.f;
+	dst[4] = matrix->m[1][0];
+	dst[5] = matrix->m[1][1];
+	dst[6] = matrix->m[1][2];
+	dst[7] = 0.f;
+}
+
 static void R_AddBModelCall (int index, int first_instance, int num_instances, texture_t *t, qboolean zfix,
 	float polygon_offset_factor, float polygon_offset_units, float alpha_override, unsigned extra_flags,
 	qboolean force_fullbright)
@@ -634,6 +664,7 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
 		call->stage_color[1] = 1.f;
 		call->stage_color[2] = 1.f;
 		call->stage_color[3] = 1.f;
+		R_SetCallTexMatrix (call->texmatrix, NULL);
 		call->texture = tx ? tx->bindless_handle : greytexture->bindless_handle;
 		call->fullbright = fb ? fb->bindless_handle : blacktexture->bindless_handle;
 		call->emissive = em ? em->bindless_handle : blacktexture->bindless_handle;
@@ -655,6 +686,7 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
 		call->stage_color[1] = 1.f;
 		call->stage_color[2] = 1.f;
 		call->stage_color[3] = 1.f;
+		R_SetCallTexMatrix (call->texmatrix, NULL);
 		call->baseinstance = first_instance;
 		call->padding[0] = 0;
 		call->padding[1] = 0;
@@ -674,7 +706,7 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
 
 static void R_AddBModelCallWithTextures (int index, int first_instance, int num_instances, gltexture_t *tx, gltexture_t *fb, gltexture_t *em,
 	tcgen_mode_t tcgen, qboolean zfix, float polygon_offset_factor, float polygon_offset_units, float alpha_override, unsigned extra_flags,
-	const vec4_t stage_color)
+	const mat_texmatrix_t *texmatrix, const vec4_t stage_color)
 {
 	GLuint flags;
 	float alpha;
@@ -707,6 +739,7 @@ static void R_AddBModelCallWithTextures (int index, int first_instance, int num_
 		call->stage_color[1] = stage_color ? stage_color[1] : 1.f;
 		call->stage_color[2] = stage_color ? stage_color[2] : 1.f;
 		call->stage_color[3] = stage_color ? stage_color[3] : 1.f;
+		R_SetCallTexMatrix (call->texmatrix, texmatrix);
 		call->texture = tx ? tx->bindless_handle : greytexture->bindless_handle;
 		call->fullbright = fb ? fb->bindless_handle : blacktexture->bindless_handle;
 		call->emissive = em ? em->bindless_handle : blacktexture->bindless_handle;
@@ -728,6 +761,7 @@ static void R_AddBModelCallWithTextures (int index, int first_instance, int num_
 		call->stage_color[1] = stage_color ? stage_color[1] : 1.f;
 		call->stage_color[2] = stage_color ? stage_color[2] : 1.f;
 		call->stage_color[3] = stage_color ? stage_color[3] : 1.f;
+		R_SetCallTexMatrix (call->texmatrix, texmatrix);
 		call->baseinstance = first_instance;
 		call->padding[0] = 0;
 		call->padding[1] = 0;
@@ -944,7 +978,9 @@ static qboolean R_StageIsOpaqueBase (const shader_material_t *material)
 	return material->sort_key == MAT_SORT_OPAQUE
 		&& stage->blend_mode == MAT_BLEND_REPLACE
 		&& stage->depth_write
-		&& stage->depth_func == MAT_DEPTHFUNC_LEQUAL;
+		&& stage->depth_func == MAT_DEPTHFUNC_LEQUAL
+		&& stage->tcgen == MAT_TCGEN_BASE
+		&& stage->tcmod_count == 0;
 }
 
 /*
@@ -1190,7 +1226,8 @@ static void R_DrawBrushModels_MaterialStages (entity_t **ents, int count, brushp
 					R_GetPolygonOffsetValues (material, use_polygon_offset, &polygon_offset_factor, &polygon_offset_units);
 					R_AddBModelCallWithTextures (model->firstcmd + j, baseinst, numinst,
 						stage_tex, fb, em, R_ResolveStageTcGen (stage),
-						use_polygon_offset, polygon_offset_factor, polygon_offset_units, -1.f, extra_flags, stage_color);
+						use_polygon_offset, polygon_offset_factor, polygon_offset_units, -1.f, extra_flags,
+						MatStage_EvalTexMatrix ((mat_shader_stage_t *)stage, cl.time), stage_color);
 				}
 			}
 		}
@@ -1362,7 +1399,8 @@ static void R_DrawBrushModels_GodrayStages (entity_t **ents, int count)
 					R_GetPolygonOffsetValues (material, use_polygon_offset, &polygon_offset_factor, &polygon_offset_units);
 					R_AddBModelCallWithTextures (model->firstcmd + j, baseinst, numinst,
 						stage_tex, fb, em, R_ResolveStageTcGen (stage),
-						use_polygon_offset, polygon_offset_factor, polygon_offset_units, -1.f, extra_flags, stage_color);
+						use_polygon_offset, polygon_offset_factor, polygon_offset_units, -1.f, extra_flags,
+						MatStage_EvalTexMatrix ((mat_shader_stage_t *)stage, cl.time), stage_color);
 				}
 			}
 		}

--- a/Quake/shaders/shadow_depth.vert
+++ b/Quake/shaders/shadow_depth.vert
@@ -16,6 +16,8 @@ struct Call
 	float	_pad0;
 	vec2	polygon_offset;
 	vec4	stage_color;
+	vec4	texmatrix0;
+	vec4	texmatrix1;
 #if BINDLESS
 	uvec2	txhandle;
 	uvec2	fbhandle;

--- a/Quake/shaders/sky_cubemap.vert
+++ b/Quake/shaders/sky_cubemap.vert
@@ -23,6 +23,8 @@ struct Call
 	float	_pad0;
 	vec2	polygon_offset;
 	vec4	stage_color;
+	vec4	texmatrix0;
+	vec4	texmatrix1;
 #if BINDLESS
 	uvec2	txhandle;
 	uvec2	fbhandle;

--- a/Quake/shaders/sky_layers.vert
+++ b/Quake/shaders/sky_layers.vert
@@ -23,6 +23,8 @@ struct Call
 	float	_pad0;
 	vec2	polygon_offset;
 	vec4	stage_color;
+	vec4	texmatrix0;
+	vec4	texmatrix1;
 #if BINDLESS
 	uvec2	txhandle;
 	uvec2	fbhandle;

--- a/Quake/shaders/skystencil.vert
+++ b/Quake/shaders/skystencil.vert
@@ -23,6 +23,8 @@ struct Call
 	float	_pad0;
 	vec2	polygon_offset;
 	vec4	stage_color;
+	vec4	texmatrix0;
+	vec4	texmatrix1;
 #if BINDLESS
 	uvec2	txhandle;
 	uvec2	fbhandle;

--- a/Quake/shaders/water.vert
+++ b/Quake/shaders/water.vert
@@ -23,6 +23,8 @@ struct Call
 	float	_pad0;
 	vec2	polygon_offset;
 	vec4	stage_color;
+	vec4	texmatrix0;
+	vec4	texmatrix1;
 #if BINDLESS
 	uvec2	txhandle;
 	uvec2	fbhandle;
@@ -81,6 +83,12 @@ vec3 TransformPrev(vec3 p, Instance instance)
 	return TransformPosition(p, instance.prev_mat);
 }
 
+vec2 ApplyTexMatrix(Call call, vec2 uv)
+{
+	vec3 uvh = vec3(uv, 1.0);
+	return vec2(dot(call.texmatrix0.xyz, uvh), dot(call.texmatrix1.xyz, uvh));
+}
+
 layout(location=0) in vec3 in_pos;
 layout(location=1) in vec4 in_uv;
 layout(location=2) in float in_lmofs;
@@ -111,7 +119,7 @@ void main()
         out_curr_clip = curr_clip;
         out_prev_clip = prev_clip;
         out_flags = call.flags;
-        out_uv = in_uv.xy;
+        out_uv = ApplyTexMatrix(call, in_uv.xy);
         out_pos = world_pos;
         out_alpha = instance.alpha < 0.0 ? call.wateralpha : instance.alpha;
 #if BINDLESS

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -57,6 +57,8 @@ struct Call
 	float	_pad0;
 	vec2	polygon_offset;
 	vec4	stage_color;
+	vec4	texmatrix0;
+	vec4	texmatrix1;
 #if BINDLESS
 	uvec2	txhandle;
 	uvec2	fbhandle;

--- a/Quake/shaders/world.vert
+++ b/Quake/shaders/world.vert
@@ -52,6 +52,8 @@ struct Call
 	float	_pad0;
 	vec2	polygon_offset;
 	vec4	stage_color;
+	vec4	texmatrix0;
+	vec4	texmatrix1;
 #if BINDLESS
 	uvec2	txhandle;
 	uvec2	fbhandle;
@@ -162,6 +164,12 @@ vec2 ComputeEnvUV(vec3 world_pos, vec3 world_normal)
 	return refl_view.xy / max(m, 1e-6) + 0.5;
 }
 
+vec2 ApplyTexMatrix(Call call, vec2 uv)
+{
+	vec3 uvh = vec3(uv, 1.0);
+	return vec2(dot(call.texmatrix0.xyz, uvh), dot(call.texmatrix1.xyz, uvh));
+}
+
 void main()
 {
 	Call call = call_data[DRAW_ID];
@@ -195,6 +203,7 @@ void main()
 		uv = in_uv.zw;
 	else if (call.tcgen == TCGEN_ENVIRONMENT)
 		uv = ComputeEnvUV(world_pos, world_normal);
+	uv = ApplyTexMatrix(call, uv);
         out_uv = uv;
 	out_lmuv = in_uv.zw;
 	out_depth = gl_Position.w;

--- a/Quake/shaders/world_dlight.vert
+++ b/Quake/shaders/world_dlight.vert
@@ -39,6 +39,8 @@ struct Call
         float   _pad0;
         vec2    polygon_offset;
         vec4    stage_color;
+	vec4	texmatrix0;
+	vec4	texmatrix1;
 #if BINDLESS
         uvec2   txhandle;
         uvec2   fbhandle;
@@ -131,6 +133,12 @@ vec2 ComputeEnvUV(vec3 world_pos, vec3 world_normal)
 	return refl_view.xy / max(m, 1e-6) + 0.5;
 }
 
+vec2 ApplyTexMatrix(Call call, vec2 uv)
+{
+	vec3 uvh = vec3(uv, 1.0);
+	return vec2(dot(call.texmatrix0.xyz, uvh), dot(call.texmatrix1.xyz, uvh));
+}
+
 void main()
 {
         Call call = call_data[DRAW_ID];
@@ -158,6 +166,7 @@ void main()
 		uv = in_uv.zw;
 	else if (call.tcgen == TCGEN_ENVIRONMENT)
 		uv = ComputeEnvUV(world_pos, world_normal);
+	uv = ApplyTexMatrix(call, uv);
         out_uv = uv;
         out_depth = gl_Position.w;
         out_coord = (gl_Position.xy / gl_Position.w * 0.5 + 0.5) * vec2(LIGHT_TILES_X, LIGHT_TILES_Y);


### PR DESCRIPTION
### Motivation
- The material parser already recognizes `tcGen`/`tcMod` but the renderer did not forward or apply those transforms to GPU draws, preventing environment-mapped and transformed stage UVs from rendering correctly.
- Pass per-stage texture matrices into draw call buffers so vertex shaders can apply `tcMod` transforms and environment `tcGen` consistently on the GPU.

### Description
- Add `texmatrix[8]` to the bmodel GPU call structures and a helper `R_SetCallTexMatrix` to initialize or copy a `mat_texmatrix_t` into call data.
- Extend `R_AddBModelCallWithTextures` to accept a `const mat_texmatrix_t *texmatrix` and write the evaluated matrix from `MatStage_EvalTexMatrix` into the call; when none is present identity is stored.
- Update `R_StageIsOpaqueBase` to treat stages with non-base `tcgen` or any `tcmod` as non-opaque so environment-mapped / transformed stages are not skipped by opaque optimizations.
- Add `texmatrix0`/`texmatrix1` to the `Call` struct in multiple shaders and implement `ApplyTexMatrix` to transform UVs in `world.vert`, `world_dlight.vert`, `water.vert` (and related vertex/fragment shaders), applying the per-draw matrix to stage UVs.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696264ceb048832eb0ec39864016a8f7)