### PR TITLE
Increase signon buffer size to reduce startup network overflows

### DIFF
--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -3175,7 +3175,7 @@ SERVER SPAWNING
 ==============================================================================
 */
 
-#define SIGNON_SIZE		31500 // QS has a MAX_DATAGRAM of 32000, try to play nice
+#define SIGNON_SIZE		(MAX_MSGLEN - 1024) // allow larger signon buffers for busy startups while leaving headroom
 
 /*
 ================


### PR DESCRIPTION
### Motivation

- The engine was hitting `SZ_GetSpace: overflow without allowoverflow set` during busy startups due to signon/protocol payloads exceeding the fixed buffer.
- The previous `SIGNON_SIZE` was a hard-coded `31500` which is small compared to the configured `MAX_MSGLEN` used for messages.
- Increasing the signon buffer to scale with `MAX_MSGLEN` reduces the likelihood of early startup message overflows while still leaving room for headers.

### Description

- Replaced the fixed `#define SIGNON_SIZE 31500` with `#define SIGNON_SIZE (MAX_MSGLEN - 1024)` in `Quake/sv_main.c` to size signon buffers relative to `MAX_MSGLEN`.
- This change affects signon buffer allocation in `SV_AddSignonBuffer`, which uses `Hunk_AllocName` and sets `sb->maxsize = SIGNON_SIZE`.
- The new value preserves headroom (`- 1024`) for protocol headers and avoids pushing signon buffers all the way to `MAX_MSGLEN`.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69626847071c832eac3df5d39154e8b8)