### PR TITLE
Prevent loopback signon message overflow

### DIFF
--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -98,6 +98,7 @@ static double sv_icull_debug_next_time = 0.0;
 
 static void SV_InitClientSnapshotData (client_t *client);
 static void SV_ResetClientSnapshot (client_t *client);
+static qboolean SV_IsLocalClient (client_t *client);
 
 void SV_CalcStats(client_t *client, int *statsi, float *statsf, const char **statss)
 {
@@ -652,6 +653,8 @@ void SV_ConnectClient (int clientnum)
 	client->message.data = client->msgbuf;
 	client->message.maxsize = sizeof(client->msgbuf);
 	client->message.allowoverflow = true;		// we can catch it
+	if (SV_IsLocalClient (client))
+		client->message.maxsize = NET_MAXMESSAGE - 4;
 
 	if (sv.loadgame)
 		memcpy (client->spawn_parms, spawn_parms, sizeof(spawn_parms));


### PR DESCRIPTION
### Motivation
- Prevent disconnects at map startup caused by message buffer overflow during initial signon.
- Loopback/local clients use the internal message path which can exceed the per-client `msgbuf` size when signon data is large.
- Reserve headroom for the loopback header/alignment to avoid overflow of `client->message` on connect.

### Description
- Add a forward declaration for `SV_IsLocalClient` and use it from `SV_ConnectClient` in `Quake/sv_main.c`.
- When a client is detected as local, cap `client->message.maxsize` to `NET_MAXMESSAGE - 4` to leave space for the loopback header/alignment.
- The change is localized to `SV_ConnectClient` initialization of `client->message` to avoid altering other network paths.

### Testing
- No automated tests were run for this change.
- Compilation or runtime smoke tests were not executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69626c419bec832e8ec007a72ff280c3)