### PR TITLE
Implement chunked, flow-controlled signon streaming (svc_signon_chunk)

### DIFF
--- a/Quake/cl_main.c
+++ b/Quake/cl_main.c
@@ -39,6 +39,7 @@ cvar_t	cl_netdebug_parse = {"cl_netdebug_parse", "0", CVAR_NONE};
 cvar_t	cl_netdebug_hexdump = {"cl_netdebug_hexdump", "0", CVAR_NONE};
 cvar_t	cl_netdebug_dropbad = {"cl_netdebug_dropbad", "1", CVAR_NONE};
 cvar_t	cl_netdebug_maxdump = {"cl_netdebug_maxdump", "256", CVAR_NONE};
+cvar_t	cl_signon_chunk_debug = {"cl_signon_chunk_debug", "0", CVAR_NONE};
 cvar_t	cl_nolerp = {"cl_nolerp","0",CVAR_NONE};
 cvar_t	cl_packedents = {"cl_packedents", "1", CVAR_ARCHIVE};
 cvar_t	cl_snap_debug = {"cl_snap_debug", "0", CVAR_NONE};
@@ -1349,6 +1350,7 @@ void CL_Init (void)
 	Cvar_RegisterVariable (&cl_netdebug_hexdump);
 	Cvar_RegisterVariable (&cl_netdebug_dropbad);
 	Cvar_RegisterVariable (&cl_netdebug_maxdump);
+	Cvar_RegisterVariable (&cl_signon_chunk_debug);
 	Cvar_RegisterVariable (&cl_nolerp);
 	Cvar_RegisterVariable (&cl_packedents);
 	Cvar_RegisterVariable (&cl_snap_debug);

--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -34,6 +34,7 @@ extern cvar_t cl_netdebug_parse;
 extern cvar_t cl_netdebug_hexdump;
 extern cvar_t cl_netdebug_dropbad;
 extern cvar_t cl_netdebug_maxdump;
+extern cvar_t cl_signon_chunk_debug;
 
 const char *svc_strings[] =
 {
@@ -108,7 +109,8 @@ const char *svc_strings[] =
 	"svc_snapshot_full", // 57
 	"svc_snapshot_delta", // 58
 	"svc_packedentities", // 59
-	"svc_snapshot2" // 60
+	"svc_snapshot2", // 60
+	"svc_signon_chunk" // 61
 };
 #define NUM_SVC_STRINGS Q_COUNTOF(svc_strings)
 
@@ -218,6 +220,30 @@ static void CL_BadServerMessage (const char *reason, int cmd, int cmd_offset,
 }
 
 qboolean warn_about_nehahra_protocol; //johnfitz
+
+static void CL_ParseSignonChunkPayload (const byte *payload, int payload_len)
+{
+	sizebuf_t saved_message = net_message;
+	int saved_readcount = msg_readcount;
+	qboolean saved_badread = msg_badread;
+	int saved_readbitpos = msg_readbitpos;
+	sizebuf_t chunk_message;
+
+	chunk_message.data = (byte *)payload;
+	chunk_message.cursize = payload_len;
+	chunk_message.maxsize = payload_len;
+	chunk_message.allowoverflow = false;
+	chunk_message.overflowed = false;
+	chunk_message.bitpos = 0;
+
+	net_message = chunk_message;
+	CL_ParseServerMessage ();
+
+	net_message = saved_message;
+	msg_readcount = saved_readcount;
+	msg_badread = saved_badread;
+	msg_readbitpos = saved_readbitpos;
+}
 
 extern vec3_t	v_punchangles[2]; //johnfitz
 
@@ -433,7 +459,7 @@ void CL_ParseServerInfo (void)
 
 	if (cl.protocol == PROTOCOL_RMQ)
 	{
-		const unsigned int supportedflags = (PRFL_SHORTANGLE | PRFL_FLOATANGLE | PRFL_24BITCOORD | PRFL_FLOATCOORD | PRFL_EDICTSCALE | PRFL_INT32COORD | PRFL_SNAPSHOT_HIRES);
+		const unsigned int supportedflags = (PRFL_SHORTANGLE | PRFL_FLOATANGLE | PRFL_24BITCOORD | PRFL_FLOATCOORD | PRFL_EDICTSCALE | PRFL_INT32COORD | PRFL_SNAPSHOT_HIRES | PRFL_SIGNON_CHUNKS);
 		
 		// mh - read protocol flags from server so that we know what protocol features to expect
 		cl.protocolflags = (unsigned int) MSG_ReadLong ();
@@ -442,8 +468,15 @@ void CL_ParseServerInfo (void)
 		{
 			Con_Warning("PROTOCOL_RMQ protocolflags %i contains unsupported flags\n", cl.protocolflags);
 		}
+		cl.signon_chunking = (cl.protocolflags & PRFL_SIGNON_CHUNKS) != 0;
 	}
-	else cl.protocolflags = 0;
+	else
+	{
+		cl.protocolflags = 0;
+		cl.signon_chunking = false;
+	}
+	cl.signon_chunk_stage = SIGNON_STAGE_PRECACHES;
+	cl.signon_chunk_next_seq = 0;
 
 // parse maxclients
 	cl.maxclients = MSG_ReadByte ();
@@ -2290,6 +2323,59 @@ void CL_ParseServerMessage (void)
 			//johnfitz
 			CL_SignonReply ();
 			break;
+
+		case svc_signon_chunk:
+		{
+			byte stage = (byte)MSG_ReadByte ();
+			unsigned short seq = (unsigned short)MSG_ReadShort ();
+			byte flags = (byte)MSG_ReadByte ();
+			unsigned short payload_len = (unsigned short)MSG_ReadShort ();
+			const byte *payload;
+
+			if (payload_len > (unsigned short)(net_message.cursize - msg_readcount))
+			{
+				CL_BadServerMessage ("signon chunk length exceeds packet", cmd, cmd_offset,
+					lastcmd, lastcmd_offset, prevcmd, prevcmd_offset);
+				return;
+			}
+
+			payload = net_message.data + msg_readcount;
+			msg_readcount += payload_len;
+
+			if (cl_signon_chunk_debug.value)
+				Con_Printf ("SIGNONCHUNK: stage %u seq %u len %u flags 0x%x\n",
+					stage, seq, payload_len, flags);
+
+			if (!cl.signon_chunking)
+			{
+				Con_Warning ("Received signon chunk without negotiation\n");
+				break;
+			}
+
+			if (stage != cl.signon_chunk_stage && cl.signon_chunk_next_seq == 0)
+				cl.signon_chunk_stage = stage;
+
+			if (seq != cl.signon_chunk_next_seq)
+			{
+				if (cl_signon_chunk_debug.value)
+					Con_Printf ("SIGNONCHUNK: expected seq %u, got %u (stage %u)\n",
+						cl.signon_chunk_next_seq, seq, stage);
+				MSG_WriteByte (&cls.message, clc_signon_ack);
+				MSG_WriteByte (&cls.message, cl.signon_chunk_stage);
+				MSG_WriteShort (&cls.message, cl.signon_chunk_next_seq);
+				break;
+			}
+
+			CL_ParseSignonChunkPayload (payload, payload_len);
+			cl.signon_chunk_next_seq++;
+			if (flags & SIGNON_CHUNK_FLAG_STAGE_END)
+				cl.signon_chunk_stage = stage + 1;
+
+			MSG_WriteByte (&cls.message, clc_signon_ack);
+			MSG_WriteByte (&cls.message, stage);
+			MSG_WriteShort (&cls.message, cl.signon_chunk_next_seq);
+			break;
+		}
 
 		case svc_killedmonster:
 			cl.stats[STAT_MONSTERS]++;

--- a/Quake/client.h
+++ b/Quake/client.h
@@ -284,6 +284,9 @@ typedef struct
 
 	unsigned	protocol; //johnfitz
 	unsigned	protocolflags;
+	qboolean	signon_chunking;
+	byte		signon_chunk_stage;
+	unsigned short	signon_chunk_next_seq;
 
 	qboolean	sendprespawn;
 

--- a/Quake/host_cmd.c
+++ b/Quake/host_cmd.c
@@ -3069,6 +3069,7 @@ static void Host_PreSpawn_f (void)
 
 	host_client->sendsignon = PRESPAWN_SIGNONBUFS;
 	host_client->signonidx = 0;
+	memset (&host_client->signon_stream, 0, sizeof(host_client->signon_stream));
 }
 
 /*

--- a/Quake/protocol.h
+++ b/Quake/protocol.h
@@ -38,6 +38,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define PRFL_ALPHASANITY	(1 << 6)	// cleanup insanity with alpha
 #define PRFL_INT32COORD		(1 << 7)
 #define PRFL_SNAPSHOT_HIRES	(1 << 8)
+#define PRFL_SIGNON_CHUNKS	(1 << 9)	// signon streaming via svc_signon_chunk
 #define PRFL_MOREFLAGS		(1 << 31)	// not supported
 
 // if the high bit of the servercmd is set, the low bits are fast update flags:
@@ -249,9 +250,32 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define svc_snapshot_delta	58
 #define svc_packedentities	59
 #define svc_snapshot2		60
+#define svc_signon_chunk	61	// [byte stage] [short seq] [byte flags] [short payload_len] [payload bytes]
+
+// Signon chunk format (PRFL_SIGNON_CHUNKS):
+//   svc_signon_chunk
+//     stage: signon_stage_t
+//     seq:   monotonically increasing sequence number
+//     flags: SIGNON_CHUNK_FLAG_* (stage end, etc.)
+//     payload_len: size of payload bytes that follow
+//     payload: one or more complete svc_* commands
 
 #define SNAPSHOT_FLAG_FULL		(1u << 0)
 #define SNAPSHOT_FLAG_HAS_REMOVE_LIST	(1u << 1)
+
+// signon chunk protocol extension
+#define SIGNON_CHUNK_FLAG_STAGE_END	(1u << 0)
+
+typedef enum
+{
+	SIGNON_STAGE_PRECACHES = 0,
+	SIGNON_STAGE_BASELINES,
+	SIGNON_STAGE_STATIC_ENTS,
+	SIGNON_STAGE_LIGHTSTYLES,
+	SIGNON_STAGE_CUSTOM_EXT,
+	SIGNON_STAGE_FINAL,
+	SIGNON_STAGE_COUNT
+} signon_stage_t;
 
 #define PACKEDENT_MASK_EXTEND	0x8000u
 #define PACKEDENT_MASK_MODEL	(1u << 0)
@@ -293,6 +317,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define	clc_stringcmd	4		// [string] message
 #define	clc_snapshot_ack	5	// [long] seq
 #define	clc_snapshot_nak	6	// [long] expected base [long] received base
+#define	clc_signon_ack	7	// [byte stage] [short next_seq_expected]
 
 //
 // temp entity events

--- a/Quake/server.h
+++ b/Quake/server.h
@@ -139,6 +139,21 @@ typedef struct bot_state_s
 	vec3_t		last_origin;
 } bot_state_t;
 
+typedef struct signon_stream_s
+{
+	qboolean	active;
+	qboolean	complete;
+	byte		stage;
+	unsigned short	next_seq;
+	unsigned short	acked_seq;
+	int			buffer_index;
+	int			buffer_offset;
+	double		start_time;
+	size_t		stage_bytes[SIGNON_STAGE_COUNT];
+	size_t		stage_records[SIGNON_STAGE_COUNT];
+	size_t		stage_max_record[SIGNON_STAGE_COUNT];
+} signon_stream_t;
+
 typedef struct client_s
 {
 	qboolean		active;				// false = client is free
@@ -148,6 +163,7 @@ typedef struct client_s
 	qboolean		is_bot;
 	enum sendsignon_e	sendsignon;			// only valid before spawned
 	int				signonidx;
+	signon_stream_t	signon_stream;
 
 	double			last_message;		// reliable messages must be sent
 										// periodically

--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -46,6 +46,9 @@ static cvar_t sv_snap_force_full_after_frames = {"sv_snap_force_full_after_frame
 static cvar_t sv_snap_max_payload = {"sv_snap_max_payload", "1200", CVAR_NONE};
 static cvar_t sv_mtu = {"sv_mtu", "1200", CVAR_NONE};
 static cvar_t sv_mtu_debug = {"sv_mtu_debug", "0", CVAR_NONE};
+static cvar_t sv_signon_chunks = {"sv_signon_chunks", "1", CVAR_NONE};
+static cvar_t sv_signon_chunk_debug = {"sv_signon_chunk_debug", "0", CVAR_NONE};
+static cvar_t sv_signon_chunk_window = {"sv_signon_chunk_window", "3", CVAR_NONE};
 static cvar_t net_test_drop = {"net_test_drop", "0", CVAR_NONE};
 static cvar_t net_snap_tinyvel = {"net_snap_tinyvel", "1", CVAR_NONE};
 static cvar_t net_snap_forcefull_frames = {"net_snap_forcefull_frames", "3", CVAR_NONE};
@@ -293,6 +296,9 @@ void SV_Init (void)
 	Cvar_RegisterVariable (&sv_snap_max_payload);
 	Cvar_RegisterVariable (&sv_mtu);
 	Cvar_RegisterVariable (&sv_mtu_debug);
+	Cvar_RegisterVariable (&sv_signon_chunks);
+	Cvar_RegisterVariable (&sv_signon_chunk_debug);
+	Cvar_RegisterVariable (&sv_signon_chunk_window);
 	Cvar_RegisterVariable (&net_test_drop);
 	Cvar_RegisterVariable (&net_snap_tinyvel);
 	Cvar_RegisterVariable (&net_snap_forcefull_frames);
@@ -3103,22 +3109,29 @@ void SV_SendClientMessages (void)
 			}
 			if (host_client->sendsignon == PRESPAWN_SIGNONBUFS)
 			{
-				qboolean local = SV_IsLocalClient (host_client);
-				while (host_client->signonidx < sv.num_signon_buffers)
+				if (SV_SignonChunksEnabled ())
 				{
-					sizebuf_t *signon = sv.signon_buffers[host_client->signonidx];
-					if (host_client->message.cursize + signon->cursize > host_client->message.maxsize)
-						break;
-					SZ_Write (&host_client->message, signon->data, signon->cursize);
-					host_client->signonidx++;
-					// only send multiple buffers at once when playing locally,
-					// otherwise we send one signon at a time to avoid overflowing
-					// the datagram buffer for clients using a lower limit (e.g. 32000 in QS)
-					if (!local)
-						break;
+					SV_SignonStreamSend (host_client);
 				}
-				if (host_client->signonidx == sv.num_signon_buffers)
-					host_client->sendsignon = PRESPAWN_SIGNONMSG;
+				else
+				{
+					qboolean local = SV_IsLocalClient (host_client);
+					while (host_client->signonidx < sv.num_signon_buffers)
+					{
+						sizebuf_t *signon = sv.signon_buffers[host_client->signonidx];
+						if (host_client->message.cursize + signon->cursize > host_client->message.maxsize)
+							break;
+						SZ_Write (&host_client->message, signon->data, signon->cursize);
+						host_client->signonidx++;
+						// only send multiple buffers at once when playing locally,
+						// otherwise we send one signon at a time to avoid overflowing
+						// the datagram buffer for clients using a lower limit (e.g. 32000 in QS)
+						if (!local)
+							break;
+					}
+					if (host_client->signonidx == sv.num_signon_buffers)
+						host_client->sendsignon = PRESPAWN_SIGNONMSG;
+				}
 			}
 			if (host_client->sendsignon == PRESPAWN_SIGNONMSG)
 			{
@@ -3179,6 +3192,612 @@ SERVER SPAWNING
 */
 
 #define SIGNON_SIZE		(MAX_MSGLEN - 1024) // allow larger signon buffers for busy startups while leaving headroom
+#define SIGNON_CHUNK_MAX_PAYLOAD	1024
+#define SIGNON_CHUNK_HEADER_BYTES	7
+
+typedef struct
+{
+	int	buffer_index;
+	int	buffer_offset;
+} signon_reader_t;
+
+static qboolean SV_SignonChunksEnabled (void)
+{
+	return (sv.protocol == PROTOCOL_RMQ) && (sv.protocolflags & PRFL_SIGNON_CHUNKS) && sv_signon_chunks.value;
+}
+
+static qboolean SV_SignonReaderAtEnd (const signon_reader_t *reader)
+{
+	int index = reader->buffer_index;
+	int offset = reader->buffer_offset;
+
+	while (index < sv.num_signon_buffers)
+	{
+		sizebuf_t *sb = sv.signon_buffers[index];
+		if (offset < sb->cursize)
+			return false;
+		index++;
+		offset = 0;
+	}
+	return true;
+}
+
+static qboolean SV_SignonReaderRead (signon_reader_t *reader, void *out, int count)
+{
+	byte *outbytes = (byte *)out;
+	int remaining = count;
+
+	while (remaining > 0)
+	{
+		sizebuf_t *sb;
+		int available;
+		int take;
+
+		while (reader->buffer_index < sv.num_signon_buffers)
+		{
+			sb = sv.signon_buffers[reader->buffer_index];
+			if (reader->buffer_offset < sb->cursize)
+				break;
+			reader->buffer_index++;
+			reader->buffer_offset = 0;
+		}
+
+		if (reader->buffer_index >= sv.num_signon_buffers)
+			return false;
+
+		sb = sv.signon_buffers[reader->buffer_index];
+		available = sb->cursize - reader->buffer_offset;
+		take = q_min(available, remaining);
+		if (outbytes)
+		{
+			memcpy (outbytes, sb->data + reader->buffer_offset, take);
+			outbytes += take;
+		}
+		reader->buffer_offset += take;
+		remaining -= take;
+	}
+
+	return true;
+}
+
+static qboolean SV_SignonReadBytes (signon_reader_t *reader, int count, size_t *consumed)
+{
+	if (!SV_SignonReaderRead (reader, NULL, count))
+		return false;
+	if (consumed)
+		*consumed += (size_t)count;
+	return true;
+}
+
+static qboolean SV_SignonReadByte (signon_reader_t *reader, int *out, size_t *consumed)
+{
+	byte value;
+	if (!SV_SignonReaderRead (reader, &value, 1))
+		return false;
+	if (out)
+		*out = value;
+	if (consumed)
+		*consumed += 1;
+	return true;
+}
+
+static qboolean SV_SignonReadShort (signon_reader_t *reader, size_t *consumed)
+{
+	return SV_SignonReadBytes (reader, 2, consumed);
+}
+
+static qboolean SV_SignonReadLong (signon_reader_t *reader, size_t *consumed)
+{
+	return SV_SignonReadBytes (reader, 4, consumed);
+}
+
+static qboolean SV_SignonReadString (signon_reader_t *reader, size_t *consumed)
+{
+	int c;
+	do
+	{
+		if (!SV_SignonReadByte (reader, &c, consumed))
+			return false;
+	} while (c != 0);
+	return true;
+}
+
+static int SV_SignonCoordBytes (unsigned int protocolflags)
+{
+	if (protocolflags & (PRFL_FLOATCOORD | PRFL_INT32COORD))
+		return 4;
+	if (protocolflags & PRFL_24BITCOORD)
+		return 3;
+	return 2;
+}
+
+static int SV_SignonAngleBytes (unsigned int protocolflags)
+{
+	if (protocolflags & PRFL_FLOATANGLE)
+		return 4;
+	if (protocolflags & PRFL_SHORTANGLE)
+		return 2;
+	return 1;
+}
+
+static signon_stage_t SV_SignonStageForCommand (int cmd)
+{
+	switch (cmd)
+	{
+	case svc_spawnbaseline:
+	case svc_spawnbaseline2:
+		return SIGNON_STAGE_BASELINES;
+	case svc_spawnstatic:
+	case svc_spawnstatic2:
+	case svc_spawnstaticsound:
+	case svc_spawnstaticsound2:
+		return SIGNON_STAGE_STATIC_ENTS;
+	case svc_lightstyle:
+		return SIGNON_STAGE_LIGHTSTYLES;
+	default:
+		return SIGNON_STAGE_CUSTOM_EXT;
+	}
+}
+
+static int SV_SignonCommandLength (const signon_reader_t *reader, int *out_cmd, signon_stage_t *out_stage)
+{
+	signon_reader_t temp = *reader;
+	size_t consumed = 0;
+	int cmd;
+	int coord_bytes = SV_SignonCoordBytes (sv.protocolflags);
+	int angle_bytes = SV_SignonAngleBytes (sv.protocolflags);
+
+	if (!SV_SignonReadByte (&temp, &cmd, &consumed))
+		return 0;
+
+	if (cmd & U_SIGNAL)
+		return -1;
+
+	if (out_cmd)
+		*out_cmd = cmd;
+	if (out_stage)
+		*out_stage = SV_SignonStageForCommand (cmd);
+
+	switch (cmd)
+	{
+	case svc_nop:
+	case svc_disconnect:
+	case svc_bf:
+	case svc_sellscreen:
+		break;
+
+	case svc_time:
+		if (!SV_SignonReadLong (&temp, &consumed))
+			return 0;
+		break;
+
+	case svc_clientdata:
+		if (!SV_SignonReadShort (&temp, &consumed))
+			return 0;
+		// variable length based on bits - skip worst case by reading all bits
+		// clientdata does not appear during signon, so reject to avoid mis-splitting
+		return -1;
+
+	case svc_version:
+		if (!SV_SignonReadLong (&temp, &consumed))
+			return 0;
+		break;
+
+	case svc_print:
+	case svc_stufftext:
+	case svc_centerprint:
+	case svc_finale:
+	case svc_cutscene:
+	case svc_skybox:
+	case svc_rawprint:
+	case svc_servervars:
+	case svc_chat:
+	case svc_achievement:
+		if (!SV_SignonReadString (&temp, &consumed))
+			return 0;
+		if (cmd == svc_finale)
+		{
+			if (!SV_SignonReadString (&temp, &consumed))
+				return 0;
+		}
+		break;
+
+	case svc_serverinfo:
+		return -1;
+
+	case svc_lightstyle:
+		if (!SV_SignonReadByte (&temp, NULL, &consumed))
+			return 0;
+		if (!SV_SignonReadString (&temp, &consumed))
+			return 0;
+		break;
+
+	case svc_setangle:
+		if (!SV_SignonReadBytes (&temp, angle_bytes * 3, &consumed))
+			return 0;
+		break;
+
+	case svc_setview:
+		if (!SV_SignonReadShort (&temp, &consumed))
+			return 0;
+		break;
+
+	case svc_sound:
+	{
+		int field_mask;
+		if (!SV_SignonReadByte (&temp, &field_mask, &consumed))
+			return 0;
+		if (field_mask & SND_VOLUME)
+		{
+			if (!SV_SignonReadByte (&temp, NULL, &consumed))
+				return 0;
+		}
+		if (field_mask & SND_ATTENUATION)
+		{
+			if (!SV_SignonReadByte (&temp, NULL, &consumed))
+				return 0;
+		}
+		if (field_mask & SND_LARGEENTITY)
+		{
+			if (!SV_SignonReadShort (&temp, &consumed))
+				return 0;
+			if (!SV_SignonReadByte (&temp, NULL, &consumed))
+				return 0;
+		}
+		else
+		{
+			if (!SV_SignonReadShort (&temp, &consumed))
+				return 0;
+		}
+		if (field_mask & SND_LARGESOUND)
+		{
+			if (!SV_SignonReadShort (&temp, &consumed))
+				return 0;
+		}
+		else
+		{
+			if (!SV_SignonReadByte (&temp, NULL, &consumed))
+				return 0;
+		}
+		if (!SV_SignonReadBytes (&temp, coord_bytes * 3, &consumed))
+			return 0;
+		break;
+	}
+
+	case svc_stopsound:
+		if (!SV_SignonReadShort (&temp, &consumed))
+			return 0;
+		break;
+
+	case svc_updatename:
+		if (!SV_SignonReadByte (&temp, NULL, &consumed))
+			return 0;
+		if (!SV_SignonReadString (&temp, &consumed))
+			return 0;
+		break;
+
+	case svc_updatecolors:
+		if (!SV_SignonReadBytes (&temp, 2, &consumed))
+			return 0;
+		break;
+
+	case svc_updatestat:
+		if (!SV_SignonReadByte (&temp, NULL, &consumed))
+			return 0;
+		if (!SV_SignonReadLong (&temp, &consumed))
+			return 0;
+		break;
+
+	case svc_updatefrags:
+		if (!SV_SignonReadByte (&temp, NULL, &consumed))
+			return 0;
+		if (!SV_SignonReadShort (&temp, &consumed))
+			return 0;
+		break;
+
+	case svc_particle:
+		if (!SV_SignonReadBytes (&temp, coord_bytes * 3, &consumed))
+			return 0;
+		if (!SV_SignonReadBytes (&temp, 3, &consumed))
+			return 0;
+		if (!SV_SignonReadByte (&temp, NULL, &consumed))
+			return 0;
+		if (!SV_SignonReadByte (&temp, NULL, &consumed))
+			return 0;
+		break;
+
+	case svc_damage:
+		if (!SV_SignonReadBytes (&temp, 2, &consumed))
+			return 0;
+		if (!SV_SignonReadBytes (&temp, coord_bytes * 3, &consumed))
+			return 0;
+		break;
+
+	case svc_spawnstatic:
+		if (!SV_SignonReadBytes (&temp, 1 + 1 + 1 + 1, &consumed))
+			return 0;
+		if (!SV_SignonReadBytes (&temp, coord_bytes * 3, &consumed))
+			return 0;
+		if (!SV_SignonReadBytes (&temp, angle_bytes * 3, &consumed))
+			return 0;
+		break;
+
+	case svc_spawnbaseline:
+		if (!SV_SignonReadShort (&temp, &consumed))
+			return 0;
+		if (!SV_SignonReadBytes (&temp, 1 + 1 + 1 + 1, &consumed))
+			return 0;
+		if (!SV_SignonReadBytes (&temp, coord_bytes * 3, &consumed))
+			return 0;
+		if (!SV_SignonReadBytes (&temp, angle_bytes * 3, &consumed))
+			return 0;
+		break;
+
+	case svc_temp_entity:
+		return -1;
+
+	case svc_spawnstaticsound:
+		if (!SV_SignonReadBytes (&temp, coord_bytes * 3, &consumed))
+			return 0;
+		if (!SV_SignonReadBytes (&temp, 1 + 1 + 1, &consumed))
+			return 0;
+		break;
+
+	case svc_intermission:
+		break;
+
+	case svc_cdtrack:
+		if (!SV_SignonReadBytes (&temp, 2, &consumed))
+			return 0;
+		break;
+
+	case svc_fog:
+		if (!SV_SignonReadBytes (&temp, 4, &consumed))
+			return 0;
+		if (!SV_SignonReadShort (&temp, &consumed))
+			return 0;
+		break;
+
+	case svc_spawnbaseline2:
+	{
+		int bits;
+		if (!SV_SignonReadShort (&temp, &consumed))
+			return 0;
+		if (!SV_SignonReadByte (&temp, &bits, &consumed))
+			return 0;
+		if (!SV_SignonReadBytes (&temp, (bits & B_LARGEMODEL) ? 2 : 1, &consumed))
+			return 0;
+		if (!SV_SignonReadBytes (&temp, (bits & B_LARGEFRAME) ? 2 : 1, &consumed))
+			return 0;
+		if (!SV_SignonReadBytes (&temp, 1 + 1, &consumed))
+			return 0;
+		if (!SV_SignonReadBytes (&temp, coord_bytes * 3, &consumed))
+			return 0;
+		if (!SV_SignonReadBytes (&temp, angle_bytes * 3, &consumed))
+			return 0;
+		if (bits & B_ALPHA)
+		{
+			if (!SV_SignonReadByte (&temp, NULL, &consumed))
+				return 0;
+		}
+		if (bits & B_SCALE)
+		{
+			if (!SV_SignonReadByte (&temp, NULL, &consumed))
+				return 0;
+		}
+		break;
+	}
+
+	case svc_spawnstatic2:
+	{
+		int bits;
+		if (!SV_SignonReadByte (&temp, &bits, &consumed))
+			return 0;
+		if (!SV_SignonReadBytes (&temp, (bits & B_LARGEMODEL) ? 2 : 1, &consumed))
+			return 0;
+		if (!SV_SignonReadBytes (&temp, (bits & B_LARGEFRAME) ? 2 : 1, &consumed))
+			return 0;
+		if (!SV_SignonReadBytes (&temp, 1 + 1, &consumed))
+			return 0;
+		if (!SV_SignonReadBytes (&temp, coord_bytes * 3, &consumed))
+			return 0;
+		if (!SV_SignonReadBytes (&temp, angle_bytes * 3, &consumed))
+			return 0;
+		if (bits & B_ALPHA)
+		{
+			if (!SV_SignonReadByte (&temp, NULL, &consumed))
+				return 0;
+		}
+		if (bits & B_SCALE)
+		{
+			if (!SV_SignonReadByte (&temp, NULL, &consumed))
+				return 0;
+		}
+		break;
+	}
+
+	case svc_spawnstaticsound2:
+		if (!SV_SignonReadBytes (&temp, coord_bytes * 3, &consumed))
+			return 0;
+		if (!SV_SignonReadShort (&temp, &consumed))
+			return 0;
+		if (!SV_SignonReadBytes (&temp, 2, &consumed))
+			return 0;
+		break;
+
+	case svc_localsound:
+	{
+		int field_mask;
+		if (!SV_SignonReadByte (&temp, &field_mask, &consumed))
+			return 0;
+		if (field_mask & SND_LARGESOUND)
+		{
+			if (!SV_SignonReadShort (&temp, &consumed))
+				return 0;
+		}
+		else
+		{
+			if (!SV_SignonReadByte (&temp, NULL, &consumed))
+				return 0;
+		}
+		break;
+	}
+
+	default:
+		return -1;
+	}
+
+	return (int)consumed;
+}
+
+static void SV_SignonStreamInit (client_t *client)
+{
+	signon_stream_t *stream = &client->signon_stream;
+
+	memset (stream, 0, sizeof(*stream));
+	stream->active = true;
+	stream->stage = SIGNON_STAGE_PRECACHES;
+	stream->next_seq = 0;
+	stream->acked_seq = 0;
+	stream->buffer_index = 0;
+	stream->buffer_offset = 0;
+	stream->start_time = realtime;
+}
+
+static void SV_SignonStreamFinish (client_t *client)
+{
+	signon_stream_t *stream = &client->signon_stream;
+	double elapsed = realtime - stream->start_time;
+	int stage;
+
+	if (sv_signon_chunk_debug.value || developer.value)
+	{
+		Con_Printf ("Signon chunks complete in %.3fs\n", elapsed);
+		for (stage = 0; stage < SIGNON_STAGE_COUNT; stage++)
+		{
+			if (!stream->stage_records[stage])
+				continue;
+			Con_Printf ("  stage %d: bytes %u records %u max_record %u\n",
+				stage,
+				(unsigned)stream->stage_bytes[stage],
+				(unsigned)stream->stage_records[stage],
+				(unsigned)stream->stage_max_record[stage]);
+		}
+	}
+	stream->active = false;
+}
+
+static void SV_SignonStreamSend (client_t *client)
+{
+	signon_stream_t *stream = &client->signon_stream;
+	int window = (int)sv_signon_chunk_window.value;
+
+	if (!stream->active)
+		SV_SignonStreamInit (client);
+
+	if (window < 1)
+		window = 1;
+	if (window > 4)
+		window = 4;
+
+	while ((unsigned short)(stream->next_seq - stream->acked_seq) < window)
+	{
+		signon_reader_t reader = { stream->buffer_index, stream->buffer_offset };
+		byte payload[SIGNON_CHUNK_MAX_PAYLOAD];
+		int payload_len = 0;
+		int cmd_len;
+		int cmd;
+		signon_stage_t stage;
+		byte flags = 0;
+
+		cmd_len = SV_SignonCommandLength (&reader, &cmd, &stage);
+		if (cmd_len == 0)
+			stream->complete = true;
+		if (cmd_len < 0)
+			Host_Error ("Unsupported signon command %d in stream", cmd);
+		if (cmd_len <= 0)
+			break;
+
+		if (cmd_len > SIGNON_CHUNK_MAX_PAYLOAD)
+			Host_Error ("Signon command %d exceeds chunk payload (%d bytes)", cmd, cmd_len);
+
+		reader = (signon_reader_t){ stream->buffer_index, stream->buffer_offset };
+		stage = SV_SignonStageForCommand (cmd);
+
+		while (cmd_len > 0)
+		{
+			signon_stage_t cmd_stage;
+			signon_reader_t temp = reader;
+
+			cmd_len = SV_SignonCommandLength (&temp, &cmd, &cmd_stage);
+			if (cmd_len < 0)
+				Host_Error ("Unsupported signon command %d in stream", cmd);
+			if (cmd_len <= 0)
+			{
+				stream->complete = true;
+				flags |= SIGNON_CHUNK_FLAG_STAGE_END;
+				break;
+			}
+
+			if (cmd_stage != stage)
+			{
+				flags |= SIGNON_CHUNK_FLAG_STAGE_END;
+				break;
+			}
+
+			if (payload_len + cmd_len > SIGNON_CHUNK_MAX_PAYLOAD)
+				break;
+
+			if (!SV_SignonReaderRead (&reader, payload + payload_len, cmd_len))
+			{
+				Host_Error ("Signon stream read failed");
+				break;
+			}
+
+			payload_len += cmd_len;
+			stream->stage_bytes[stage] += (size_t)cmd_len;
+			stream->stage_records[stage] += 1;
+			if ((size_t)cmd_len > stream->stage_max_record[stage])
+				stream->stage_max_record[stage] = (size_t)cmd_len;
+		}
+
+		if (payload_len == 0)
+			break;
+
+		if (SV_SignonReaderAtEnd (&reader))
+			flags |= SIGNON_CHUNK_FLAG_STAGE_END;
+
+		if (client->message.maxsize - client->message.cursize < SIGNON_CHUNK_HEADER_BYTES + payload_len)
+			break;
+
+		MSG_WriteByte (&client->message, svc_signon_chunk);
+		MSG_WriteByte (&client->message, stage);
+		MSG_WriteShort (&client->message, stream->next_seq);
+		MSG_WriteByte (&client->message, flags);
+		MSG_WriteShort (&client->message, payload_len);
+		SZ_Write (&client->message, payload, payload_len);
+
+		if (sv_signon_chunk_debug.value)
+			Con_Printf ("SIGNONCHUNK: client %s stage %d seq %u len %d flags 0x%x\n",
+				client->name, stage, stream->next_seq, payload_len, flags);
+
+		stream->stage = stage;
+		stream->next_seq++;
+		stream->buffer_index = reader.buffer_index;
+		stream->buffer_offset = reader.buffer_offset;
+
+		if (SV_SignonReaderAtEnd (&reader))
+			stream->complete = true;
+	}
+
+	if (stream->complete && stream->acked_seq == stream->next_seq)
+	{
+		if (client->sendsignon == PRESPAWN_SIGNONBUFS)
+			client->sendsignon = PRESPAWN_SIGNONMSG;
+		if (stream->active)
+			SV_SignonStreamFinish (client);
+	}
+}
 
 /*
 ================
@@ -3696,6 +4315,8 @@ void SV_SpawnServer (const char *server)
 		// set up the protocol flags used by this server
 		// (note - these could be cvar-ised so that server admins could choose the protocol features used by their servers)
 		sv.protocolflags = PRFL_INT32COORD | PRFL_SHORTANGLE | PRFL_SNAPSHOT_HIRES;
+		if (sv_signon_chunks.value)
+			sv.protocolflags |= PRFL_SIGNON_CHUNKS;
 	}
 	else sv.protocolflags = 0;
 
@@ -3820,3 +4441,12 @@ void SV_SpawnServer (const char *server)
 	if (sv.mapchecks.active)
 		SV_PrintMapChecklist ();
 }
+	case svc_setpause:
+		if (!SV_SignonReadByte (&temp, NULL, &consumed))
+			return 0;
+		break;
+
+	case svc_signonnum:
+		if (!SV_SignonReadByte (&temp, NULL, &consumed))
+			return 0;
+		break;

--- a/Quake/sv_user.c
+++ b/Quake/sv_user.c
@@ -616,6 +616,18 @@ nextmsg:
 			case clc_snapshot_nak:
 				SV_SnapshotNak (host_client, (unsigned int)MSG_ReadLong (), (unsigned int)MSG_ReadLong ());
 				break;
+
+			case clc_signon_ack:
+			{
+				MSG_ReadByte ();
+				{
+					unsigned short next_seq = (unsigned short)MSG_ReadShort ();
+					signon_stream_t *stream = &host_client->signon_stream;
+					if (stream->active && next_seq > stream->acked_seq)
+						stream->acked_seq = next_seq;
+				}
+				break;
+			}
 			}
 		}
 	} while (ret == 1);


### PR DESCRIPTION
### Motivation
- Fix intermittent `SZ_GetSpace`/signon overflows by eliminating the “build one huge signon buffer” pattern and streaming signon data in safe-sized chunks. 
- Avoid relying on raising `MAX_MSGLEN`; instead make signon robust to arbitrary map/mod content via flow-controlled chunks. 
- Keep compatibility optional via a negotiated protocol flag so older clients remain supported when desired. 
- Provide clear runtime diagnostics for bytes/records per stage and largest record sizes to aid debugging.

### Description
- Added protocol extension: `PRFL_SIGNON_CHUNKS`, message `svc_signon_chunk` and client ack `clc_signon_ack`, plus documented chunk format and stages in `protocol.h` and `clc_*`/`svc_*` enums. 
- Implemented server-side signon streamer in `sv_main.c` that reads signon records from existing signon buffers via a `signon_reader_t`, packs complete `svc_*` commands into chunks <= `SIGNON_CHUNK_MAX_PAYLOAD` (1024 bytes), enforces a small in-flight window (`sv_signon_chunk_window`), and sends `svc_signon_chunk` with stage/seq/flags/payload. 
- Implemented client support in `cl_parse.c` including `CL_ParseSignonChunkPayload` to treat a chunk payload as a self-contained message stream, chunk reassembly/ordering checks, and sending `clc_signon_ack` replies; client state fields added in `client.h` to track chunking. 
- Added flow-control, safety and diagnostics: `sv_signon_chunks`, `sv_signon_chunk_debug`, `cl_signon_chunk_debug`, per-stage counters (`stage_bytes`, `stage_records`, `stage_max_record`), and explicit `Host_Error` on unsupported/oversized records so signon never overruns `sizebuf_t` buffers.

### Testing
- No automated tests were run as part of this change. 
- The implementation includes runtime debug `cvar`s (`sv_signon_chunk_debug` and `cl_signon_chunk_debug`) to assist manual verification of chunk sizes, counts, and largest record during signon. 
- The chunk payload cap is set to `SIGNON_CHUNK_MAX_PAYLOAD` (1024) to keep datagrams below typical MTU and avoid fragmentation. 
- Compatibility is gated by `PRFL_SIGNON_CHUNKS` so servers can opt-in and clients will only use chunking when negotiated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69626ee76440832e9e3fa838c2928623)