### PR TITLE
Fix signon stream compile issues

### DIFF
--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -60,6 +60,9 @@ static cvar_t sv_icull_pvs = {"sv_icull_pvs", "1", CVAR_NONE};
 static cvar_t sv_icull_debug = {"sv_icull_debug", "0", CVAR_NONE};
 static qboolean sv_packedents_selftest_done = false;
 
+static qboolean SV_SignonChunksEnabled (void);
+static void SV_SignonStreamSend (client_t *client);
+
 typedef struct
 {
 	int packets;
@@ -3643,6 +3646,16 @@ static int SV_SignonCommandLength (const signon_reader_t *reader, int *out_cmd, 
 		break;
 	}
 
+	case svc_setpause:
+		if (!SV_SignonReadByte (&temp, NULL, &consumed))
+			return 0;
+		break;
+
+	case svc_signonnum:
+		if (!SV_SignonReadByte (&temp, NULL, &consumed))
+			return 0;
+		break;
+
 	default:
 		return -1;
 	}
@@ -4441,12 +4454,3 @@ void SV_SpawnServer (const char *server)
 	if (sv.mapchecks.active)
 		SV_PrintMapChecklist ();
 }
-	case svc_setpause:
-		if (!SV_SignonReadByte (&temp, NULL, &consumed))
-			return 0;
-		break;
-
-	case svc_signonnum:
-		if (!SV_SignonReadByte (&temp, NULL, &consumed))
-			return 0;
-		break;


### PR DESCRIPTION
### Motivation
- Resolve compiler errors caused by implicit/undefined references to signon-chunk helpers used before their definitions.
- Fix syntax errors generated by stray `case` labels that were placed after the end of `SV_SpawnServer`.
- Restore signon command parsing for `svc_setpause` and `svc_signonnum` to avoid mis-parsing signon streams.

### Description
- Added forward declarations for `SV_SignonChunksEnabled` and `SV_SignonStreamSend` near the top of `Quake/sv_main.c` so they can be referenced before their definitions.
- Reintroduced handling for `svc_setpause` and `svc_signonnum` in the `SV_SignonCommandLength` switch to correctly measure their command lengths.
- Removed duplicate/stray `case` labels that appeared after the `SV_SpawnServer` function to eliminate syntax errors.
- The changes modify only `Quake/sv_main.c` and adjust the signon-stream-related parsing and declarations.

### Testing
- No automated tests were run.
- A commit was created with the changes, but no build or CI run was executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69627747e874832e8abb4426375bc09f)