### PR TITLE
Declare `msg_readbitpos` extern in common.h

### DIFF
--- a/Quake/common.h
+++ b/Quake/common.h
@@ -234,6 +234,7 @@ void MSG_WriteAngle (sizebuf_t *sb, float f, unsigned int flags);
 void MSG_WriteAngle16 (sizebuf_t *sb, float f, unsigned int flags); //johnfitz
 
 extern	int			msg_readcount;
+extern	int			msg_readbitpos;
 extern	qboolean	msg_badread;		// set if a read goes beyond end of message
 
 void MSG_BeginReading (void);


### PR DESCRIPTION
### Motivation

- A compilation error occurred when `cl_parse.c` referenced `msg_readbitpos` without a visible declaration, causing undefined identifier errors. 
- `msg_readbitpos` is defined and used by the message-reading logic in `Quake/common.c`, so it needs to be exported for other translation units. 
- The change aims to restore correct compilation of message parsing code that depends on the read-bit position state.

### Description

- Add an `extern int msg_readbitpos;` declaration to `Quake/common.h` next to the other message-read state externs. 
- The declaration is placed alongside `msg_readcount` and `msg_badread` so parsing modules can access the shared state. 

### Testing

- No automated tests were run as part of this change. 
- A build was not executed in this rollout, so compilation success is unverified by CI here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962799e600c832e855ca2d683c349b8)