### PR TITLE
Harden sizebuf overflow diagnostics

### DIFF
--- a/Quake/common.c
+++ b/Quake/common.c
@@ -1157,13 +1157,43 @@ static void SZ_DumpBufferTail (const sizebuf_t *buf)
 
 static void SZ_PrintOverflowDiagnostics (const sizebuf_t *buf, int length)
 {
-	const char *name = buf->dbg_name ? buf->dbg_name : "unnamed";
-	const char *file = buf->dbg_file ? buf->dbg_file : "unknown";
+	const char *name = "unnamed";
+	const char *file = "unknown";
+	qboolean name_valid = false;
+	qboolean file_valid = false;
+
+	if (buf->dbg_name)
+	{
+#if UINTPTR_MAX > 0xFFFFFFFFu
+		uintptr_t dbg_name_ptr = (uintptr_t)buf->dbg_name;
+		name_valid = ((dbg_name_ptr >> 48) == 0u) || ((dbg_name_ptr >> 48) == 0xFFFFu);
+#else
+		name_valid = true;
+#endif
+	}
+	if (buf->dbg_file)
+	{
+#if UINTPTR_MAX > 0xFFFFFFFFu
+		uintptr_t dbg_file_ptr = (uintptr_t)buf->dbg_file;
+		file_valid = ((dbg_file_ptr >> 48) == 0u) || ((dbg_file_ptr >> 48) == 0xFFFFu);
+#else
+		file_valid = true;
+#endif
+	}
+
+	if (name_valid)
+		name = buf->dbg_name;
+	if (file_valid)
+		file = buf->dbg_file;
 
 	Con_Printf ("SZ_GetSpace overflow on '%s': max=%d cursize=%d request=%d\n",
 		name, buf->maxsize, buf->cursize, length);
+	if (buf->dbg_name && !name_valid)
+		Con_Printf ("  dbg_name pointer looks invalid: %p\n", (void *)buf->dbg_name);
 	Con_Printf ("  last write at %s:%d msgkind=%d id=%d aux=%d\n",
 		file, buf->dbg_line, buf->dbg_msgkind, buf->dbg_id, buf->dbg_aux);
+	if (buf->dbg_file && !file_valid)
+		Con_Printf ("  dbg_file pointer looks invalid: %p\n", (void *)buf->dbg_file);
 	if (sz_debug_hexdump.value)
 		SZ_DumpBufferTail (buf);
 }


### PR DESCRIPTION
### Motivation
- Crash observed when `SZ_PrintOverflowDiagnostics` dereferenced a corrupted `dbg_name`/`dbg_file` pointer during an overflow diagnostic, causing `vsnprintf` to hit an invalid `%s` argument.
- Corruption appears to come from memory/formatting errors elsewhere (e.g. UTF-16 bytes written into `char*`), so the diagnostics path must avoid exacerbating crashes.
- Provide safer diagnostic output that avoids dereferencing obviously-invalid pointers and gives pointer addresses to aid debugging.
- Keep the change minimal and local to the diagnostic helper rather than masking the underlying corruption permanently.

### Description
- Update `SZ_PrintOverflowDiagnostics` in `Quake/common.c` to use safe defaults `"unnamed"` and `"unknown"` for `name`/`file` instead of unconditionally dereferencing `buf->dbg_name`/`buf->dbg_file`.
- Add `name_valid`/`file_valid` boolean checks and on 64-bit targets validate pointer canonicality by inspecting high bits using `UINTPTR_MAX` and pointer casts.
- Only use `buf->dbg_name`/`buf->dbg_file` when the checks pass, and print the raw pointer address when a pointer looks invalid to help locate the corruption.
- Preserve existing hexdump behavior (`sz_debug_hexdump`) and otherwise leave overflow reporting semantics unchanged.

### Testing
- No automated tests were run for this change.
- Please run a full build and runtime checks (e.g. ASAN/MSAN/Valgrind) and reproduce overflow scenarios to validate behavior in your environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962d3292824832e8f9656a946b93ec8)