### PR TITLE
Prevent datagram buffer reuse/overflow; add MTU cap and SZ hardening

### DIFF
--- a/Quake/cl_input.c
+++ b/Quake/cl_input.c
@@ -389,6 +389,19 @@ void CL_SendMove (const usercmd_t *cmd)
 	buf.maxsize = 128;
 	buf.cursize = 0;
 	buf.data = data;
+	buf.allowoverflow = false;
+	buf.overflowed = false;
+	buf.overflowed_once = false;
+	buf.write_blocked = false;
+	buf.blocked_file = NULL;
+	buf.blocked_line = 0;
+	buf.dbg_name = "cl_move";
+	buf.dbg_file = NULL;
+	buf.dbg_line = 0;
+	buf.dbg_msgkind = 0;
+	buf.dbg_id = 0;
+	buf.dbg_aux = 0;
+	buf.bitpos = 0;
 
 	if (cmd) 
 	{
@@ -496,4 +509,3 @@ void CL_InitInput (void)
 	Cmd_AddCommand ("-mlook", IN_MLookUp);
 
 }
-

--- a/Quake/common.c
+++ b/Quake/common.c
@@ -983,6 +983,16 @@ qboolean MSG_PackedSelfTest (void)
 	buf.cursize = 0;
 	buf.allowoverflow = false;
 	buf.overflowed = false;
+	buf.overflowed_once = false;
+	buf.write_blocked = false;
+	buf.blocked_file = NULL;
+	buf.blocked_line = 0;
+	buf.dbg_name = "packed_selftest";
+	buf.dbg_file = NULL;
+	buf.dbg_line = 0;
+	buf.dbg_msgkind = 0;
+	buf.dbg_id = 0;
+	buf.dbg_aux = 0;
 	buf.bitpos = 0;
 
 	MSG_WriteBits (&buf, 0x3, 2);
@@ -1198,6 +1208,41 @@ static void SZ_PrintOverflowDiagnostics (const sizebuf_t *buf, int length)
 		SZ_DumpBufferTail (buf);
 }
 
+static const char *SZ_DebugName (const sizebuf_t *buf)
+{
+	const char *name = "unnamed";
+	qboolean name_valid = false;
+
+	if (buf->dbg_name)
+	{
+#if UINTPTR_MAX > 0xFFFFFFFFu
+		uintptr_t dbg_name_ptr = (uintptr_t)buf->dbg_name;
+		name_valid = ((dbg_name_ptr >> 48) == 0u) || ((dbg_name_ptr >> 48) == 0xFFFFu);
+#else
+		name_valid = true;
+#endif
+	}
+
+	if (name_valid)
+		name = buf->dbg_name;
+
+	return name;
+}
+
+void SZ_BlockWrites (sizebuf_t *buf, const char *file, int line)
+{
+	buf->write_blocked = true;
+	buf->blocked_file = file;
+	buf->blocked_line = line;
+}
+
+void SZ_UnblockWrites (sizebuf_t *buf)
+{
+	buf->write_blocked = false;
+	buf->blocked_file = NULL;
+	buf->blocked_line = 0;
+}
+
 void SZ_Alloc (sizebuf_t *buf, int startsize)
 {
 	if (startsize < 256)
@@ -1206,6 +1251,11 @@ void SZ_Alloc (sizebuf_t *buf, int startsize)
 	buf->maxsize = startsize;
 	buf->cursize = 0;
 	buf->bitpos = 0;
+	buf->overflowed = false;
+	buf->overflowed_once = false;
+	buf->write_blocked = false;
+	buf->blocked_file = NULL;
+	buf->blocked_line = 0;
 	buf->dbg_name = NULL;
 	buf->dbg_file = NULL;
 	buf->dbg_line = 0;
@@ -1227,11 +1277,27 @@ void SZ_Clear (sizebuf_t *buf)
 {
 	buf->cursize = 0;
 	buf->bitpos = 0;
+	buf->overflowed = false;
+	buf->overflowed_once = false;
 }
 
 void *SZ_GetSpace (sizebuf_t *buf, int length)
 {
 	void	*data;
+
+	if (buf->write_blocked)
+	{
+		const char *name = SZ_DebugName (buf);
+		Sys_Error ("SZ_GetSpace: write blocked on '%s' (blocked at %s:%d, last write %s:%d msgkind=%d id=%d aux=%d)",
+			name,
+			buf->blocked_file ? buf->blocked_file : "unknown",
+			buf->blocked_line,
+			buf->dbg_file ? buf->dbg_file : "unknown",
+			buf->dbg_line,
+			buf->dbg_msgkind,
+			buf->dbg_id,
+			buf->dbg_aux);
+	}
 
 	if (buf->cursize + length > buf->maxsize)
 	{
@@ -1244,9 +1310,23 @@ void *SZ_GetSpace (sizebuf_t *buf, int length)
 		if (length > buf->maxsize)
 			Sys_Error ("SZ_GetSpace: %i is > full buffer size", length);
 
+		if (buf->overflowed_once)
+		{
+			const char *name = SZ_DebugName (buf);
+			Sys_Error ("Repeated SZ overflow on '%s': indicates buffer reuse / reentrant append bug (last write %s:%d msgkind=%d id=%d aux=%d)",
+				name,
+				buf->dbg_file ? buf->dbg_file : "unknown",
+				buf->dbg_line,
+				buf->dbg_msgkind,
+				buf->dbg_id,
+				buf->dbg_aux);
+		}
+
 		buf->overflowed = true;
+		buf->overflowed_once = true;
 		SZ_PrintOverflowDiagnostics (buf, length);
-		SZ_Clear (buf);
+		buf->cursize = 0;
+		buf->bitpos = 0;
 	}
 
 	data = buf->data + buf->cursize;

--- a/Quake/common.h
+++ b/Quake/common.h
@@ -116,6 +116,10 @@ typedef struct sizebuf_s
 {
 	qboolean	allowoverflow;	// if false, do a Sys_Error
 	qboolean	overflowed;		// set to true if the buffer size failed
+	qboolean	overflowed_once;	// set on first overflow until explicit clear/init
+	qboolean	write_blocked;		// set when writes are not allowed
+	const char	*blocked_file;
+	int		blocked_line;
 	const char	*dbg_name;
 	const char	*dbg_file;
 	int		dbg_line;
@@ -128,19 +132,21 @@ typedef struct sizebuf_s
 	int		bitpos;
 } sizebuf_t;
 
-#define MSG_BEGINSVC(msg, svc_id) do { \
-	SV_SignonFirewallCheck((msg), (svc_id), __FILE__, __LINE__); \
-	(msg)->dbg_msgkind = 1; \
-	(msg)->dbg_id = (svc_id); \
+#define MSG_DBG_SET(msg, kind, id, aux) do { \
+	(msg)->dbg_msgkind = (kind); \
+	(msg)->dbg_id = (id); \
+	(msg)->dbg_aux = (aux); \
 	(msg)->dbg_file = __FILE__; \
 	(msg)->dbg_line = __LINE__; \
 } while (0)
 
+#define MSG_BEGINSVC(msg, svc_id) do { \
+	SV_SignonFirewallCheck((msg), (svc_id), __FILE__, __LINE__); \
+	MSG_DBG_SET((msg), 1, (svc_id), (msg)->dbg_aux); \
+} while (0)
+
 #define MSG_BEGINCLC(msg, clc_id) do { \
-	(msg)->dbg_msgkind = 2; \
-	(msg)->dbg_id = (clc_id); \
-	(msg)->dbg_file = __FILE__; \
-	(msg)->dbg_line = __LINE__; \
+	MSG_DBG_SET((msg), 2, (clc_id), (msg)->dbg_aux); \
 } while (0)
 
 #define MSG_DBGAUX(msg, aux) do { \
@@ -155,6 +161,11 @@ void SZ_Clear (sizebuf_t *buf);
 void *SZ_GetSpace (sizebuf_t *buf, int length);
 void SZ_Write (sizebuf_t *buf, const void *data, int length);
 void SZ_Print (sizebuf_t *buf, const char *data);	// strcats onto the sizebuf
+void SZ_BlockWrites (sizebuf_t *buf, const char *file, int line);
+void SZ_UnblockWrites (sizebuf_t *buf);
+
+#define SZ_BLOCK_WRITES(buf) SZ_BlockWrites((buf), __FILE__, __LINE__)
+#define SZ_UNBLOCK_WRITES(buf) SZ_UnblockWrites((buf))
 
 //============================================================================
 

--- a/Quake/host.c
+++ b/Quake/host.c
@@ -745,6 +745,19 @@ void Host_ShutdownServer(qboolean crash)
 	buf.data = message;
 	buf.maxsize = 4;
 	buf.cursize = 0;
+	buf.allowoverflow = false;
+	buf.overflowed = false;
+	buf.overflowed_once = false;
+	buf.write_blocked = false;
+	buf.blocked_file = NULL;
+	buf.blocked_line = 0;
+	buf.dbg_name = "shutdown_disconnect";
+	buf.dbg_file = NULL;
+	buf.dbg_line = 0;
+	buf.dbg_msgkind = 0;
+	buf.dbg_id = 0;
+	buf.dbg_aux = 0;
+	buf.bitpos = 0;
 	MSG_WriteByte(&buf, svc_disconnect);
 	count = NET_SendToAll(&buf, 5.0);
 	if (count)

--- a/Quake/net.h
+++ b/Quake/net.h
@@ -72,6 +72,7 @@ const char *NET_QSocketGetAddressString (const struct qsocket_s *sock);
 qboolean NET_CanSendMessage (struct qsocket_s *sock);
 // Returns true or false if the given qsocket can currently accept a
 // message to be transmitted.
+qboolean NET_CanSendUnreliableMessage (struct qsocket_s *sock);
 
 int	NET_GetMessage (struct qsocket_s *sock);
 // returns data in net_message sizebuf

--- a/Quake/net_main.c
+++ b/Quake/net_main.c
@@ -677,6 +677,19 @@ qboolean NET_CanSendMessage (qsocket_t *sock)
 	return sfunc.CanSendMessage(sock);
 }
 
+qboolean NET_CanSendUnreliableMessage (qsocket_t *sock)
+{
+	if (!sock)
+		return false;
+
+	if (sock->disconnected)
+		return false;
+
+	SetNetTime();
+
+	return sfunc.CanSendUnreliableMessage(sock);
+}
+
 
 int NET_SendToAll (sizebuf_t *data, double blocktime)
 {

--- a/Quake/server.h
+++ b/Quake/server.h
@@ -231,6 +231,7 @@ typedef struct client_s
 	int				mtu_dropped_tier1;
 	int				mtu_dropped_tier2;
 	double			mtu_debug_next_time;
+	int				datagram_overflow_count;
 	bot_state_t		bot;
 } client_t;
 

--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -45,6 +45,7 @@ static cvar_t sv_snap_full_interval = {"sv_snap_full_interval", "2.0", CVAR_NONE
 static cvar_t sv_snap_force_full_after_frames = {"sv_snap_force_full_after_frames", "3", CVAR_NONE};
 static cvar_t sv_snap_max_payload = {"sv_snap_max_payload", "1200", CVAR_NONE};
 static cvar_t sv_mtu = {"sv_mtu", "1200", CVAR_NONE};
+static cvar_t sv_mtu_cap = {"sv_mtu_cap", "1200", CVAR_NONE};
 static cvar_t sv_mtu_debug = {"sv_mtu_debug", "0", CVAR_NONE};
 static cvar_t sv_signon_chunks = {"sv_signon_chunks", "1", CVAR_NONE};
 static cvar_t sv_signon_chunk_debug = {"sv_signon_chunk_debug", "0", CVAR_NONE};
@@ -299,6 +300,7 @@ void SV_Init (void)
 	Cvar_RegisterVariable (&sv_snap_force_full_after_frames);
 	Cvar_RegisterVariable (&sv_snap_max_payload);
 	Cvar_RegisterVariable (&sv_mtu);
+	Cvar_RegisterVariable (&sv_mtu_cap);
 	Cvar_RegisterVariable (&sv_mtu_debug);
 	Cvar_RegisterVariable (&sv_signon_chunks);
 	Cvar_RegisterVariable (&sv_signon_chunk_debug);
@@ -531,6 +533,14 @@ CLIENT SPAWNING
 static qboolean SV_IsLocalClient (client_t *client)
 {
 	return Q_strcmp (NET_QSocketGetAddressString (client->netconnection), "LOCAL") == 0;
+}
+
+static int SV_MTUCap (void)
+{
+	int cap = (int)sv_mtu_cap.value;
+	if (cap <= 0)
+		cap = (int)sv_mtu.value;
+	return cap;
 }
 
 /*
@@ -1196,7 +1206,7 @@ static int SV_SnapshotMaxEntities (sizebuf_t *msg)
 	int header_size = 1 + 4 + 4 + 2 + 2 + 2;
 	int per_ent = SV_SnapshotEntitySizeWorst ();
 	int payload_cap = (int)sv_snap_max_payload.value;
-	int mtu_cap = (int)sv_mtu.value;
+	int mtu_cap = SV_MTUCap ();
 
 	if (sv_snapshot2.value)
 		header_size = 1 + 4 + 4 + 1 + 2 + 2 + 2 + 2;
@@ -1499,6 +1509,7 @@ static void SV_WriteSnapshotState (sizebuf_t *msg, const snapshot_state_t *state
 static void SV_WriteSnapshot2Header (sizebuf_t *msg, unsigned int seq, unsigned int base_seq,
 	unsigned int flags, unsigned short num_entities, unsigned short num_removed)
 {
+	MSG_BEGINSVC (msg, svc_snapshot2);
 	MSG_WriteByte (msg, svc_snapshot2);
 	MSG_WriteLong (msg, (int)seq);
 	MSG_WriteLong (msg, (int)base_seq);
@@ -1567,6 +1578,7 @@ static void SV_WriteSnapshotFull (sizebuf_t *msg, unsigned int seq, const snapsh
 			count++;
 	}
 
+	MSG_BEGINSVC (msg, svc_snapshot_full);
 	MSG_WriteByte (msg, svc_snapshot_full);
 	MSG_WriteLong (msg, (int)seq);
 	MSG_WriteShort (msg, count);
@@ -1622,6 +1634,7 @@ static void SV_WriteSnapshotDelta (sizebuf_t *msg, unsigned int seq, unsigned in
 	int add_count = 0;
 	int update_count = 0;
 
+	MSG_BEGINSVC (msg, svc_snapshot_delta);
 	MSG_WriteByte (msg, svc_snapshot_delta);
 	MSG_WriteLong (msg, (int)seq);
 	MSG_WriteLong (msg, (int)baseline_seq);
@@ -2406,6 +2419,7 @@ void SV_WriteEntitiesToClient (edict_t	*clent, sizebuf_t *msg)
 
 		if (msg->cursize + 3 > msg->maxsize)
 			goto stats;
+		MSG_BEGINSVC (msg, svc_packedentities);
 		MSG_WriteByte (msg, svc_packedentities);
 		packed_count_pos = msg->cursize;
 		MSG_WriteShort (msg, 0);
@@ -2707,6 +2721,7 @@ void SV_WriteClientdataToMessage (edict_t *ent, sizebuf_t *msg)
 	if (ent->v.dmg_take || ent->v.dmg_save)
 	{
 		other = PROG_TO_EDICT(ent->v.dmg_inflictor);
+		MSG_BEGINSVC (msg, svc_damage);
 		MSG_WriteByte (msg, svc_damage);
 		MSG_WriteByte (msg, ent->v.dmg_save);
 		MSG_WriteByte (msg, ent->v.dmg_take);
@@ -2725,6 +2740,7 @@ void SV_WriteClientdataToMessage (edict_t *ent, sizebuf_t *msg)
 // a fixangle might get lost in a dropped packet.  Oh well.
 	if ( ent->v.fixangle )
 	{
+		MSG_BEGINSVC (msg, svc_setangle);
 		MSG_WriteByte (msg, svc_setangle);
 		for (i=0 ; i < 3 ; i++)
 			MSG_WriteAngle (msg, ent->v.angles[i], sv.protocolflags );
@@ -2888,21 +2904,37 @@ qboolean SV_SendClientDatagram (client_t *client)
 {
 	byte		buf[MAX_DATAGRAM];
 	sizebuf_t	msg;
+	int		mtu_cap;
 
 	msg.data = buf;
 	msg.maxsize = sizeof(buf);
 	msg.cursize = 0;
 	msg.allowoverflow = true;
 	msg.overflowed = false;
+	msg.overflowed_once = false;
+	msg.write_blocked = false;
+	msg.blocked_file = NULL;
+	msg.blocked_line = 0;
+	msg.dbg_name = "sv_client_datagram";
+	msg.dbg_file = NULL;
+	msg.dbg_line = 0;
+	msg.dbg_msgkind = 0;
+	msg.dbg_id = 0;
+	msg.dbg_aux = 0;
 	msg.bitpos = 0;
 
 	//johnfitz -- if client is nonlocal, use smaller max size so packets aren't fragmented
 	if (Q_strcmp(NET_QSocketGetAddressString(client->netconnection), "LOCAL") != 0)
 		msg.maxsize = DATAGRAM_MTU;
 	//johnfitz
-	if (sv_mtu.value > 0)
-		msg.maxsize = q_min (msg.maxsize, (int)sv_mtu.value);
+	mtu_cap = SV_MTUCap ();
+	if (mtu_cap > 0)
+		msg.maxsize = q_min (msg.maxsize, mtu_cap);
 
+	if (!NET_CanSendUnreliableMessage (client->netconnection))
+		return false;
+
+	MSG_BEGINSVC (&msg, svc_time);
 	MSG_WriteByte (&msg, svc_time);
 	MSG_WriteFloat (&msg, qcvm->time);
 
@@ -2913,9 +2945,25 @@ qboolean SV_SendClientDatagram (client_t *client)
 
 	if (msg.overflowed)
 	{
-		Con_DPrintf ("SV_SendClientDatagram: overflow for %s, dropping packet\n", client->name);
-		return true;
+		client->datagram_overflow_count++;
+		if (client->datagram_overflow_count > 1)
+			Sys_Error ("Repeated datagram overflow for %s (last write %s:%d msgkind=%d id=%d aux=%d)",
+				client->name,
+				msg.dbg_file ? msg.dbg_file : "unknown",
+				msg.dbg_line,
+				msg.dbg_msgkind,
+				msg.dbg_id,
+				msg.dbg_aux);
+		Con_Printf ("Datagram too large for MTU cap %d for %s (size %d, stage %d, mandatory %d dropped %d)\n",
+			msg.maxsize,
+			client->name,
+			msg.cursize,
+			client->sendsignon,
+			client->snapshot_pending_mandatory,
+			client->snapshot_pending_dropped);
+		return false;
 	}
+	client->datagram_overflow_count = 0;
 
 // copy the server datagram if there is space
 	if (msg.cursize + sv.datagram.cursize < msg.maxsize)
@@ -3078,7 +3126,21 @@ void SV_SendNop (client_t *client)
 	msg.data = buf;
 	msg.maxsize = sizeof(buf);
 	msg.cursize = 0;
+	msg.allowoverflow = false;
+	msg.overflowed = false;
+	msg.overflowed_once = false;
+	msg.write_blocked = false;
+	msg.blocked_file = NULL;
+	msg.blocked_line = 0;
+	msg.dbg_name = "sv_nop";
+	msg.dbg_file = NULL;
+	msg.dbg_line = 0;
+	msg.dbg_msgkind = 0;
+	msg.dbg_id = 0;
+	msg.dbg_aux = 0;
+	msg.bitpos = 0;
 
+	MSG_BEGINSVC (&msg, svc_nop);
 	MSG_WriteChar (&msg, svc_nop);
 
 	if (NET_SendUnreliableMessage (client->netconnection, &msg) == -1)
@@ -3105,6 +3167,7 @@ void SV_SendClientMessages (void)
 			continue;
 		if (host_client->is_bot)
 			continue;
+		SZ_UNBLOCK_WRITES (&host_client->message);
 
 		if (host_client->spawned)
 		{
@@ -3118,6 +3181,11 @@ void SV_SendClientMessages (void)
 		// send a full message when the next signon stage has been requested
 		// some other message data (name changes, etc) may accumulate
 		// between signon stages
+			if (!NET_CanSendMessage (host_client->netconnection))
+			{
+				SZ_BLOCK_WRITES (&host_client->message);
+				continue;
+			}
 			if (!host_client->sendsignon)
 			{
 				if (realtime - host_client->last_message > 5)
@@ -3178,6 +3246,7 @@ void SV_SendClientMessages (void)
 			if (!NET_CanSendMessage (host_client->netconnection))
 			{
 //				I_Printf ("can't write\n");
+				SZ_BLOCK_WRITES (&host_client->message);
 				continue;
 			}
 
@@ -3798,6 +3867,8 @@ static void SV_SignonStreamSend (client_t *client)
 {
 	signon_stream_t *stream = &client->signon_stream;
 	int window = (int)sv_signon_chunk_window.value;
+	int mtu_cap = SV_MTUCap ();
+	int payload_cap = SIGNON_CHUNK_MAX_PAYLOAD;
 
 	if (!stream->active)
 		SV_SignonStreamInit (client);
@@ -3806,6 +3877,10 @@ static void SV_SignonStreamSend (client_t *client)
 		window = 1;
 	if (window > 4)
 		window = 4;
+	if (mtu_cap > 0)
+		payload_cap = q_min (payload_cap, mtu_cap - SIGNON_CHUNK_HEADER_BYTES);
+	if (payload_cap < 1)
+		return;
 
 	while ((unsigned short)(stream->next_seq - stream->acked_seq) < window)
 	{
@@ -3820,9 +3895,9 @@ static void SV_SignonStreamSend (client_t *client)
 		byte flags = 0;
 		int records_in_chunk = 0;
 
-		while (payload_len < SIGNON_CHUNK_MAX_PAYLOAD)
+		while (payload_len < payload_cap)
 		{
-			int remaining = SIGNON_CHUNK_MAX_PAYLOAD - payload_len;
+			int remaining = payload_cap - payload_len;
 			int header_len;
 			int take;
 
@@ -4174,6 +4249,19 @@ void SV_SendReconnect (void)
 	msg.data = data;
 	msg.cursize = 0;
 	msg.maxsize = sizeof(data);
+	msg.allowoverflow = false;
+	msg.overflowed = false;
+	msg.overflowed_once = false;
+	msg.write_blocked = false;
+	msg.blocked_file = NULL;
+	msg.blocked_line = 0;
+	msg.dbg_name = "sv_reconnect";
+	msg.dbg_file = NULL;
+	msg.dbg_line = 0;
+	msg.dbg_msgkind = 0;
+	msg.dbg_id = 0;
+	msg.dbg_aux = 0;
+	msg.bitpos = 0;
 
 	MSG_BEGINSVC (&msg, svc_stufftext);
 	MSG_WriteChar (&msg, svc_stufftext);


### PR DESCRIPTION
### Motivation

- Fix repeated "SZ_GetSpace OVERFLOW" spam caused by appending to a near-full datagram/sizebuf across frames or after send failures. 
- Ensure outgoing datagrams and signon chunk payloads are built atomically and discarded on failed send attempts instead of being re-used. 
- Add diagnostics to detect re-entrant/cross-frame buffer reuse and provide actionable context for fatal errors. 
- Keep MTU policy (1200) but make it configurable and applied consistently to datagrams and signon chunks.

### Description

- Add write-blocking and debug metadata to `sizebuf_t` and implement `SZ_BlockWrites`/`SZ_UnblockWrites`, plus `MSG_DBG_SET`/improved `MSG_BEGINSVC` tagging to track last-write callsite and message context. 
- Harden `SZ_GetSpace` so the first overflow prints diagnostics and resets the buffer, while a second overflow without an intervening `SZ_Clear`/`SZ_Init` triggers a fatal `Sys_Error` with file/line and last-write tags. 
- Make server datagram/signon building ephemeral: `SV_SendClientDatagram` builds into a local stack buffer, enforces `NET_CanSendUnreliableMessage` before building, and applies `sv_mtu_cap` (falls back to `sv_mtu`) as the MTU cap; signon chunk payloads also respect the MTU cap. 
- Prevent appends while a connection cannot send by blocking writes to per-client `message` buffers when `NET_CanSendMessage` is false, and add a per-client `datagram_overflow_count` to hard-fail on repeated datagram oversize conditions instead of spamming the console.

### Testing

- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963311650b4832eb1bcab8fd8372f0f)