### PR TITLE
Avoid crashing on repeated datagram overflow

### DIFF
--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -360,6 +360,7 @@ extern devstats_t dev_stats, dev_peakstats;
 //ohnfitz -- reduce overflow warning spam
 typedef struct {
 	double	packetsize;
+	double	datagram;
 	double	efrags;
 	double	beams;
 	double	varstring;

--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -2947,13 +2947,20 @@ qboolean SV_SendClientDatagram (client_t *client)
 	{
 		client->datagram_overflow_count++;
 		if (client->datagram_overflow_count > 1)
-			Sys_Error ("Repeated datagram overflow for %s (last write %s:%d msgkind=%d id=%d aux=%d)",
-				client->name,
-				msg.dbg_file ? msg.dbg_file : "unknown",
-				msg.dbg_line,
-				msg.dbg_msgkind,
-				msg.dbg_id,
-				msg.dbg_aux);
+		{
+			if (!dev_overflows.datagram || dev_overflows.datagram + CONSOLE_RESPAM_TIME < realtime )
+			{
+				Con_Printf ("Datagram overflow for %s (last write %s:%d msgkind=%d id=%d aux=%d)\n",
+					client->name,
+					msg.dbg_file ? msg.dbg_file : "unknown",
+					msg.dbg_line,
+					msg.dbg_msgkind,
+					msg.dbg_id,
+					msg.dbg_aux);
+				dev_overflows.datagram = realtime;
+			}
+			client->datagram_overflow_count = 1;
+		}
 		Con_Printf ("Datagram too large for MTU cap %d for %s (size %d, stage %d, mandatory %d dropped %d)\n",
 			msg.maxsize,
 			client->name,


### PR DESCRIPTION
### Motivation
- Certain maps could trigger `msg.overflowed` repeatedly and cause a `Sys_Error` crash due to repeated datagram overflows. 
- The change prevents the server from aborting on these repeated overflows and reduces console spam by rate-limiting warnings.

### Description
- Add a `datagram` timestamp field to `overflowtimes_t` in `Quake/glquake.h` to track datagram warning cooldowns.  
- Replace the fatal `Sys_Error` path in `SV_SendClientDatagram` with a rate-limited `Con_Printf` and clamp `client->datagram_overflow_count` to `1` in `Quake/sv_main.c`.  
- Use `dev_overflows.datagram` together with `CONSOLE_RESPAM_TIME` to suppress repeated datagram overflow messages.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963b9159ee4832e840aec49d4c7b16b)