### PR TITLE
Abort oversized client datagrams and harden message writes

### DIFF
--- a/Quake/common.c
+++ b/Quake/common.c
@@ -688,6 +688,54 @@ Handles byte ordering and avoids alignment errors
 ==============================================================================
 */
 
+static void SZ_PrintOverflowDiagnostics (const sizebuf_t *buf, int length);
+static const char *SZ_DebugName (const sizebuf_t *buf);
+
+static qboolean MSG_EnsureSpace (sizebuf_t *sb, int length)
+{
+	if (sb->overflowed || sb->write_blocked)
+	{
+#if !defined(NDEBUG)
+		SDL_assert (!"MSG write after overflow");
+#endif
+		return false;
+	}
+
+	if (!MSG_CAN_FIT(sb, length))
+	{
+		if (!sb->allowoverflow)
+		{
+			SZ_PrintOverflowDiagnostics (sb, length);
+			Host_Error ("SZ_GetSpace: overflow without allowoverflow set"); // ericw -- made Host_Error to be less annoying
+		}
+
+		if (length > sb->maxsize)
+			Sys_Error ("SZ_GetSpace: %i is > full buffer size", length);
+
+		if (sb->overflowed_once)
+		{
+			const char *name = SZ_DebugName (sb);
+			Sys_Error ("Repeated SZ overflow on '%s': indicates buffer reuse / reentrant append bug (last write %s:%d msgkind=%d id=%d aux=%d)",
+				name,
+				sb->dbg_file ? sb->dbg_file : "unknown",
+				sb->dbg_line,
+				sb->dbg_msgkind,
+				sb->dbg_id,
+				sb->dbg_aux);
+		}
+
+		sb->overflowed = true;
+		sb->overflowed_once = true;
+		sb->write_blocked = true;
+		sb->blocked_file = __FILE__;
+		sb->blocked_line = __LINE__;
+		SZ_PrintOverflowDiagnostics (sb, length);
+		return false;
+	}
+
+	return true;
+}
+
 //
 // writing functions
 //
@@ -701,6 +749,8 @@ void MSG_WriteChar (sizebuf_t *sb, int c)
 		Sys_Error ("MSG_WriteChar: range error");
 #endif
 
+	if (!MSG_EnsureSpace (sb, 1))
+		return;
 	buf = (byte *) SZ_GetSpace (sb, 1);
 	buf[0] = c;
 }
@@ -714,6 +764,8 @@ void MSG_WriteByte (sizebuf_t *sb, int c)
 		Sys_Error ("MSG_WriteByte: range error");
 #endif
 
+	if (!MSG_EnsureSpace (sb, 1))
+		return;
 	buf = (byte *) SZ_GetSpace (sb, 1);
 	buf[0] = c;
 }
@@ -727,6 +779,8 @@ void MSG_WriteShort (sizebuf_t *sb, int c)
 		Sys_Error ("MSG_WriteShort: range error");
 #endif
 
+	if (!MSG_EnsureSpace (sb, 2))
+		return;
 	buf = (byte *) SZ_GetSpace (sb, 2);
 	buf[0] = c&0xff;
 	buf[1] = c>>8;
@@ -736,6 +790,8 @@ void MSG_WriteLong (sizebuf_t *sb, int c)
 {
 	byte	*buf;
 
+	if (!MSG_EnsureSpace (sb, 4))
+		return;
 	buf = (byte *) SZ_GetSpace (sb, 4);
 	buf[0] = c&0xff;
 	buf[1] = (c>>8)&0xff;
@@ -767,7 +823,14 @@ void MSG_WriteString (sizebuf_t *sb, const char *s)
 
 void MSG_WriteBits (sizebuf_t *sb, unsigned int value, int bits)
 {
+	int bytes_needed;
 	int i;
+
+	bytes_needed = (sb->bitpos + bits + 7) / 8;
+	if (sb->bitpos != 0)
+		bytes_needed--;
+	if (bytes_needed > 0 && !MSG_EnsureSpace (sb, bytes_needed))
+		return;
 
 	for (i = 0; i < bits; i++)
 	{
@@ -797,7 +860,11 @@ void MSG_WriteInt16 (sizebuf_t *sb, int c)
 
 void MSG_WriteUInt16 (sizebuf_t *sb, unsigned int c)
 {
-	byte *buf = (byte *) SZ_GetSpace (sb, 2);
+	byte *buf;
+
+	if (!MSG_EnsureSpace (sb, 2))
+		return;
+	buf = (byte *) SZ_GetSpace (sb, 2);
 	buf[0] = c & 0xff;
 	buf[1] = (c >> 8) & 0xff;
 }
@@ -1337,6 +1404,8 @@ void *SZ_GetSpace (sizebuf_t *buf, int length)
 
 void SZ_Write (sizebuf_t *buf, const void *data, int length)
 {
+	if (!MSG_EnsureSpace (buf, length))
+		return;
 	Q_memcpy (SZ_GetSpace(buf,length),data,length);
 }
 
@@ -1346,10 +1415,14 @@ void SZ_Print (sizebuf_t *buf, const char *data)
 
 	if (buf->data[buf->cursize-1])
 	{	/* no trailing 0 */
+		if (!MSG_EnsureSpace (buf, len))
+			return;
 		Q_memcpy ((byte *)SZ_GetSpace(buf, len  )  , data, len);
 	}
 	else
 	{	/* write over trailing 0 */
+		if (!MSG_EnsureSpace (buf, len - 1))
+			return;
 		Q_memcpy ((byte *)SZ_GetSpace(buf, len-1)-1, data, len);
 	}
 }

--- a/Quake/common.h
+++ b/Quake/common.h
@@ -153,6 +153,8 @@ typedef struct sizebuf_s
 	(msg)->dbg_aux = (aux); \
 } while (0)
 
+#define MSG_CAN_FIT(msg, bytes) ((msg)->cursize + (bytes) <= (msg)->maxsize)
+
 void SV_SignonFirewallCheck (sizebuf_t *msg, int svc_id, const char *file, int line);
 
 void SZ_Alloc (sizebuf_t *buf, int startsize);

--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -2905,6 +2905,7 @@ qboolean SV_SendClientDatagram (client_t *client)
 	byte		buf[MAX_DATAGRAM];
 	sizebuf_t	msg;
 	int		mtu_cap;
+	qboolean	packet_too_large = false;
 
 	msg.data = buf;
 	msg.maxsize = sizeof(buf);
@@ -2940,10 +2941,43 @@ qboolean SV_SendClientDatagram (client_t *client)
 
 // add the client specific data to the datagram
 	SV_WriteClientdataToMessage (client->edict, &msg);
+	if (msg.overflowed)
+	{
+		packet_too_large = true;
+		goto datagram_too_large;
+	}
 
 	SV_SendSnapshot (client, &msg);
 
 	if (msg.overflowed)
+	{
+		packet_too_large = true;
+		goto datagram_too_large;
+	}
+	client->datagram_overflow_count = 0;
+
+// copy the server datagram if there is space
+	if (msg.cursize + sv.datagram.cursize < msg.maxsize)
+		SZ_Write (&msg, sv.datagram.data, sv.datagram.cursize);
+
+	if (sv_mtu_debug.value > 0 && realtime >= client->mtu_debug_next_time)
+	{
+		Con_Printf ("mtu %s bytes %d dropped tier1 %d tier2 %d\n",
+			client->name, msg.cursize, client->mtu_dropped_tier1, client->mtu_dropped_tier2);
+		client->mtu_debug_next_time = realtime + 1.0;
+	}
+
+// send the datagram
+	if (NET_SendUnreliableMessage (client->netconnection, &msg) == -1)
+	{
+		SV_DropClient (true);// if the message couldn't send, kick off
+		return false;
+	}
+
+	return true;
+
+datagram_too_large:
+	if (packet_too_large)
 	{
 		client->datagram_overflow_count++;
 		if (client->datagram_overflow_count > 1)
@@ -2970,27 +3004,6 @@ qboolean SV_SendClientDatagram (client_t *client)
 			client->snapshot_pending_dropped);
 		return false;
 	}
-	client->datagram_overflow_count = 0;
-
-// copy the server datagram if there is space
-	if (msg.cursize + sv.datagram.cursize < msg.maxsize)
-		SZ_Write (&msg, sv.datagram.data, sv.datagram.cursize);
-
-	if (sv_mtu_debug.value > 0 && realtime >= client->mtu_debug_next_time)
-	{
-		Con_Printf ("mtu %s bytes %d dropped tier1 %d tier2 %d\n",
-			client->name, msg.cursize, client->mtu_dropped_tier1, client->mtu_dropped_tier2);
-		client->mtu_debug_next_time = realtime + 1.0;
-	}
-
-// send the datagram
-	if (NET_SendUnreliableMessage (client->netconnection, &msg) == -1)
-	{
-		SV_DropClient (true);// if the message couldn't send, kick off
-		return false;
-	}
-
-	return true;
 }
 
 /*


### PR DESCRIPTION
### Motivation
- Fix a logic bug where an MTU overflow was detected but packet construction continued, causing `SZ_GetSpace` overflow and repeated "DATAGRAM TOO LARGE" spam.
- Ensure MTU overflow causes an immediate abort of the current datagram so no footer/mandatory svc bytes are written after detection.
- Harden the `sizebuf_t`/message write path to detect reuse or further writes after overflow and prevent this class of control-flow bugs.
- Preserve expected behavior by dropping the oversized datagram and allowing the datagram to be rebuilt next frame.

### Description
- Add `MSG_CAN_FIT` macro in `Quake/common.h` for simple preflight checks of space before writes.
- Introduce `MSG_EnsureSpace` in `Quake/common.c` which preflights writes, asserts on writes after overflow (in dev builds), sets `overflowed`/`overflowed_once`/`write_blocked` and records blocking location, and returns false to stop writes.
- Update all `MSG_Write*` helpers, `SZ_Write` and `SZ_Print` to call `MSG_EnsureSpace` and bail out early if space is not available, preventing calls to `SZ_GetSpace` after overflow.
- Change `SV_SendClientDatagram` in `Quake/sv_main.c` to use a local `packet_too_large` flag and immediately abort via a `datagram_too_large` path when overflow is detected after client data or snapshot construction, ensuring no footer/mandatory svc bytes are appended and the current `sizebuf_t` is not reused.

### Testing
- No automated tests were executed for this change.
- The change is limited to message building and server datagram logic and includes defensive guards to surface repeated overflows as a fatal error in non-development builds.
- Manual runtime validation is recommended: reproduce the previously observed MTU overflow scenario and verify no `SZ_GetSpace` overflow spam and that packets are retried next frame.
- Building the tree is recommended to verify compile-time integration (`make` / project build).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963bb732398832e8dd4a1fabdeba834)