### PR TITLE
Fix missing return in SV_SendClientDatagram

### DIFF
--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -3004,6 +3004,8 @@ datagram_too_large:
 			client->snapshot_pending_dropped);
 		return false;
 	}
+
+	return false;
 }
 
 /*


### PR DESCRIPTION
### Motivation

- MSVC reported `warning C4715` for `SV_SendClientDatagram` because not all control paths returned a value, causing the build to fail when warnings are treated as errors.
- Ensure the function has a defined fallback return value to make control flow explicit and avoid platform-specific compiler errors.

### Description

- Added an explicit `return false;` at the end of `SV_SendClientDatagram` in `Quake/sv_main.c` to cover the missing code path.
- The change is a single-line addition and does not modify other logic or behavior in the function.

### Testing

- No automated tests were run for this change.
- No CI/build was executed as part of this patch submission.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963c26a8ea0832e8f1ec157c53de2ae)