### PR TITLE
Chunk snapshot2 full updates for MTU-capped datagrams

### DIFF
--- a/Quake/cl_input.c
+++ b/Quake/cl_input.c
@@ -393,6 +393,7 @@ void CL_SendMove (const usercmd_t *cmd)
 	buf.overflowed = false;
 	buf.overflowed_once = false;
 	buf.write_blocked = false;
+	buf.write_locked = false;
 	buf.blocked_file = NULL;
 	buf.blocked_line = 0;
 	buf.dbg_name = "cl_move";

--- a/Quake/cl_main.c
+++ b/Quake/cl_main.c
@@ -320,6 +320,8 @@ void CL_ClearState (void)
 	cl.snapshot_present = (byte *) Hunk_AllocName (cl_max_edicts*sizeof(byte), "cl_snap_present");
 	cl.snapshot_active = (byte *) Hunk_AllocName (cl_max_edicts*sizeof(byte), "cl_snap_active");
 	cl.snapshot_last_update_time = (double *) Hunk_AllocName (cl_max_edicts*sizeof(double), "cl_snap_time");
+	cl.snapshot_chunk = (snapshot_state_t *) Hunk_AllocName (cl_max_edicts*sizeof(snapshot_state_t), "cl_snap_chunk");
+	cl.snapshot_chunk_present = (byte *) Hunk_AllocName (cl_max_edicts*sizeof(byte), "cl_snap_chunk_present");
 	//johnfitz
 	if (cl.snapshot_present)
 		memset (cl.snapshot_present, 0, cl_max_edicts * sizeof(byte));
@@ -327,6 +329,10 @@ void CL_ClearState (void)
 		memset (cl.snapshot_active, 0, cl_max_edicts * sizeof(byte));
 	if (cl.snapshot_last_update_time)
 		memset (cl.snapshot_last_update_time, 0, cl_max_edicts * sizeof(double));
+	if (cl.snapshot_chunk_present)
+		memset (cl.snapshot_chunk_present, 0, cl_max_edicts * sizeof(byte));
+	cl.snapshot_chunk_active = false;
+	cl.snapshot_chunk_seq = 0;
 
 	memset (v_punchangles, 0, sizeof (v_punchangles));
 }

--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -1661,6 +1661,14 @@ static void CL_ReadSnapshotHeader (snapshot_header_t *header)
 	header->num_removed = (unsigned short)MSG_ReadShort ();
 }
 
+static void CL_ResetSnapshotChunk (void)
+{
+	if (cl.snapshot_chunk_present)
+		memset (cl.snapshot_chunk_present, 0, cl_max_edicts * sizeof(byte));
+	cl.snapshot_chunk_active = false;
+	cl.snapshot_chunk_seq = 0;
+}
+
 static void CL_ParseSnapshot2 (void)
 {
 	snapshot_header_t header;
@@ -1680,6 +1688,68 @@ static void CL_ParseSnapshot2 (void)
 
 	if (header.flags & SNAPSHOT_FLAG_FULL)
 	{
+		qboolean continuation = (header.flags & SNAPSHOT_FLAG_CONTINUE) != 0;
+
+		if (continuation || cl.snapshot_chunk_active)
+		{
+			if (!cl.snapshot_chunk_active || cl.snapshot_chunk_seq != header.seq)
+			{
+				CL_ResetSnapshotChunk ();
+				cl.snapshot_chunk_active = true;
+				cl.snapshot_chunk_seq = header.seq;
+			}
+
+			for (i = 0; i < header.num_entities; i++)
+			{
+				int entnum;
+				snapshot_state_t state;
+				unsigned int snapflags = 0;
+
+				entnum = (unsigned short)MSG_ReadShort ();
+				if (entnum <= 0 || entnum >= cl_max_edicts)
+					Host_Error ("CL_ParseSnapshot2: entnum out of range");
+				if (cl.protocolflags & PRFL_SNAPSHOT_HIRES)
+					snapflags = (unsigned int)MSG_ReadByte ();
+				CL_ReadSnapshotState (&state, snapflags);
+				if (!drop)
+				{
+					cl.snapshot_chunk[entnum] = state;
+					cl.snapshot_chunk_present[entnum] = 1;
+				}
+			}
+
+			if (drop)
+			{
+				CL_ResetSnapshotChunk ();
+				return;
+			}
+
+			if (continuation)
+				return;
+
+			memset (cl.snapshot_present, 0, cl_max_edicts * sizeof(byte));
+			if (cl.snapshot_active)
+				memset (cl.snapshot_active, 0, cl_max_edicts * sizeof(byte));
+			if (cl.snapshot_last_update_time)
+				memset (cl.snapshot_last_update_time, 0, cl_max_edicts * sizeof(double));
+
+			for (i = 1; i < cl_max_edicts; i++)
+			{
+				if (!cl.snapshot_chunk_present[i])
+					continue;
+				cl.snapshot_baseline[i] = cl.snapshot_chunk[i];
+				cl.snapshot_present[i] = 1;
+				CL_ApplySnapshotState (i, &cl.snapshot_baseline[i]);
+				CL_MarkSnapshotEntityUpdated (i);
+			}
+
+			cl.snapshot_baseline_seq = header.seq;
+			CL_SendSnapshotAck (header.seq);
+			CL_RecordPlayerSnap ();
+			CL_ResetSnapshotChunk ();
+			return;
+		}
+
 		memset (cl.snapshot_present, 0, cl_max_edicts * sizeof(byte));
 		if (cl.snapshot_active)
 			memset (cl.snapshot_active, 0, cl_max_edicts * sizeof(byte));

--- a/Quake/client.h
+++ b/Quake/client.h
@@ -276,6 +276,10 @@ typedef struct
 	byte		*snapshot_present;
 	byte		*snapshot_active;
 	double		*snapshot_last_update_time;
+	qboolean	snapshot_chunk_active;
+	unsigned int snapshot_chunk_seq;
+	snapshot_state_t *snapshot_chunk;
+	byte		*snapshot_chunk_present;
 
 	int			cdtrack, looptrack;	// cd audio
 

--- a/Quake/common.c
+++ b/Quake/common.c
@@ -693,7 +693,7 @@ static const char *SZ_DebugName (const sizebuf_t *buf);
 
 static qboolean MSG_EnsureSpace (sizebuf_t *sb, int length)
 {
-	if (sb->overflowed || sb->write_blocked)
+	if (sb->overflowed || sb->write_blocked || sb->write_locked)
 	{
 #if !defined(NDEBUG)
 		SDL_assert (!"MSG write after overflow");
@@ -727,6 +727,7 @@ static qboolean MSG_EnsureSpace (sizebuf_t *sb, int length)
 		sb->overflowed = true;
 		sb->overflowed_once = true;
 		sb->write_blocked = true;
+		sb->write_locked = true;
 		sb->blocked_file = __FILE__;
 		sb->blocked_line = __LINE__;
 		SZ_PrintOverflowDiagnostics (sb, length);
@@ -1052,6 +1053,7 @@ qboolean MSG_PackedSelfTest (void)
 	buf.overflowed = false;
 	buf.overflowed_once = false;
 	buf.write_blocked = false;
+	buf.write_locked = false;
 	buf.blocked_file = NULL;
 	buf.blocked_line = 0;
 	buf.dbg_name = "packed_selftest";
@@ -1299,6 +1301,7 @@ static const char *SZ_DebugName (const sizebuf_t *buf)
 void SZ_BlockWrites (sizebuf_t *buf, const char *file, int line)
 {
 	buf->write_blocked = true;
+	buf->write_locked = true;
 	buf->blocked_file = file;
 	buf->blocked_line = line;
 }
@@ -1306,6 +1309,7 @@ void SZ_BlockWrites (sizebuf_t *buf, const char *file, int line)
 void SZ_UnblockWrites (sizebuf_t *buf)
 {
 	buf->write_blocked = false;
+	buf->write_locked = false;
 	buf->blocked_file = NULL;
 	buf->blocked_line = 0;
 }
@@ -1321,6 +1325,7 @@ void SZ_Alloc (sizebuf_t *buf, int startsize)
 	buf->overflowed = false;
 	buf->overflowed_once = false;
 	buf->write_blocked = false;
+	buf->write_locked = false;
 	buf->blocked_file = NULL;
 	buf->blocked_line = 0;
 	buf->dbg_name = NULL;
@@ -1346,13 +1351,14 @@ void SZ_Clear (sizebuf_t *buf)
 	buf->bitpos = 0;
 	buf->overflowed = false;
 	buf->overflowed_once = false;
+	buf->write_locked = false;
 }
 
 void *SZ_GetSpace (sizebuf_t *buf, int length)
 {
 	void	*data;
 
-	if (buf->write_blocked)
+	if (buf->write_blocked || buf->write_locked)
 	{
 		const char *name = SZ_DebugName (buf);
 		Sys_Error ("SZ_GetSpace: write blocked on '%s' (blocked at %s:%d, last write %s:%d msgkind=%d id=%d aux=%d)",

--- a/Quake/common.h
+++ b/Quake/common.h
@@ -118,6 +118,7 @@ typedef struct sizebuf_s
 	qboolean	overflowed;		// set to true if the buffer size failed
 	qboolean	overflowed_once;	// set on first overflow until explicit clear/init
 	qboolean	write_blocked;		// set when writes are not allowed
+	qboolean	write_locked;		// set when no more writes should occur
 	const char	*blocked_file;
 	int		blocked_line;
 	const char	*dbg_name;
@@ -154,6 +155,10 @@ typedef struct sizebuf_s
 } while (0)
 
 #define MSG_CAN_FIT(msg, bytes) ((msg)->cursize + (bytes) <= (msg)->maxsize)
+static inline qboolean MSG_CanFit (sizebuf_t *msg, int bytes)
+{
+	return MSG_CAN_FIT (msg, bytes);
+}
 
 void SV_SignonFirewallCheck (sizebuf_t *msg, int svc_id, const char *file, int line);
 

--- a/Quake/host.c
+++ b/Quake/host.c
@@ -749,6 +749,7 @@ void Host_ShutdownServer(qboolean crash)
 	buf.overflowed = false;
 	buf.overflowed_once = false;
 	buf.write_blocked = false;
+	buf.write_locked = false;
 	buf.blocked_file = NULL;
 	buf.blocked_line = 0;
 	buf.dbg_name = "shutdown_disconnect";

--- a/Quake/protocol.h
+++ b/Quake/protocol.h
@@ -262,6 +262,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #define SNAPSHOT_FLAG_FULL		(1u << 0)
 #define SNAPSHOT_FLAG_HAS_REMOVE_LIST	(1u << 1)
+#define SNAPSHOT_FLAG_CONTINUE		(1u << 2)
 
 // signon chunk protocol extension
 #define SIGNON_CHUNK_FLAG_STAGE_END	(1u << 0)

--- a/Quake/server.h
+++ b/Quake/server.h
@@ -160,6 +160,18 @@ typedef struct signon_stream_s
 	size_t		stage_max_record[SIGNON_STAGE_COUNT];
 } signon_stream_t;
 
+typedef struct sv_entity_stream_s
+{
+	qboolean	active;
+	int			signon_stage;
+	int			next_edict;
+	int			total_edicts;
+	int			base_snapshot;
+	int			total_entities;
+	int			sent_entities;
+	double		next_log_time;
+} sv_entity_stream_t;
+
 typedef struct client_s
 {
 	qboolean		active;				// false = client is free
@@ -170,6 +182,7 @@ typedef struct client_s
 	enum sendsignon_e	sendsignon;			// only valid before spawned
 	int				signonidx;
 	signon_stream_t	signon_stream;
+	sv_entity_stream_t entstream;
 
 	double			last_message;		// reliable messages must be sent
 										// periodically
@@ -232,6 +245,7 @@ typedef struct client_s
 	int				mtu_dropped_tier2;
 	double			mtu_debug_next_time;
 	int				datagram_overflow_count;
+	double			datagram_overflow_next_time;
 	bot_state_t		bot;
 } client_t;
 

--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -923,6 +923,15 @@ static void SV_ResetClientSnapshot (client_t *client)
 	client->mtu_dropped_tier1 = 0;
 	client->mtu_dropped_tier2 = 0;
 	client->mtu_debug_next_time = 0;
+	client->datagram_overflow_next_time = 0;
+	client->entstream.active = false;
+	client->entstream.signon_stage = 0;
+	client->entstream.next_edict = 1;
+	client->entstream.total_edicts = 0;
+	client->entstream.base_snapshot = 0;
+	client->entstream.total_entities = 0;
+	client->entstream.sent_entities = 0;
+	client->entstream.next_log_time = 0;
 	if (client->snapshot_baseline_present)
 		memset (client->snapshot_baseline_present, 0, max_edicts * sizeof(byte));
 	if (client->snapshot_pending_present)
@@ -931,6 +940,18 @@ static void SV_ResetClientSnapshot (client_t *client)
 		memset (client->snapshot_pending_relevant, 0, max_edicts * sizeof(byte));
 	if (client->snapshot_pending_flags)
 		memset (client->snapshot_pending_flags, 0, max_edicts * sizeof(byte));
+}
+
+static void SV_InitEntityStream (client_t *client, int total_entities, unsigned int seq)
+{
+	client->entstream.active = true;
+	client->entstream.signon_stage = client->sendsignon;
+	client->entstream.next_edict = 1;
+	client->entstream.total_edicts = qcvm->max_edicts;
+	client->entstream.base_snapshot = (int)seq;
+	client->entstream.total_entities = total_entities;
+	client->entstream.sent_entities = 0;
+	client->entstream.next_log_time = 0;
 }
 
 static qboolean SV_SnapshotMoverMoving (const edict_t *ent)
@@ -1199,6 +1220,58 @@ static int SV_SnapshotEntitySizeWorst (void)
 
 	entry_overhead = q_max (extra_flags, 4); // worst-case delta includes a 32-bit mask
 	return 2 + entry_overhead + field_size;
+}
+
+static int SV_SnapshotCoordBytes (qboolean hires)
+{
+	if (hires && (sv.protocolflags & PRFL_SNAPSHOT_HIRES))
+		return 4;
+	if (sv.protocolflags & (PRFL_FLOATCOORD | PRFL_INT32COORD))
+		return 4;
+	if (sv.protocolflags & PRFL_24BITCOORD)
+		return 3;
+	return 2;
+}
+
+static int SV_SnapshotAngleBytes (qboolean hires)
+{
+	if (hires && (sv.protocolflags & PRFL_SNAPSHOT_HIRES))
+		return 4;
+	if (sv.protocolflags & PRFL_FLOATANGLE)
+		return 4;
+	if (sv.protocolflags & PRFL_SHORTANGLE)
+		return 2;
+	return 1;
+}
+
+static int SV_Snapshot2EntitySizeForFlags (byte snapflags)
+{
+	int coord_size = SV_SnapshotCoordBytes ((snapflags & SNAPFLAG_HIRES_ORIGIN) != 0);
+	int angle_size = SV_SnapshotAngleBytes ((snapflags & SNAPFLAG_HIRES_ANGLES) != 0);
+	int state_size = 3 * coord_size + 3 * angle_size + 2 + 2 + 1 + 1 + 1 + 1 + 1 + 1;
+	int extra_flags = (sv.protocolflags & PRFL_SNAPSHOT_HIRES) ? 1 : 0;
+
+	return 2 + extra_flags + state_size;
+}
+
+static int SV_Snapshot2FullSize (const byte *present, const byte *snapflags, int max_edicts, int *out_count)
+{
+	int entnum;
+	int count = 0;
+	int size = 1 + 4 + 4 + 1 + 2 + 2;
+
+	for (entnum = 1; entnum < max_edicts; entnum++)
+	{
+		if (!present[entnum])
+			continue;
+		count++;
+		size += SV_Snapshot2EntitySizeForFlags (snapflags ? snapflags[entnum] : 0);
+	}
+
+	if (out_count)
+		*out_count = count;
+
+	return size;
 }
 
 static int SV_SnapshotMaxEntities (sizebuf_t *msg)
@@ -1516,6 +1589,105 @@ static void SV_WriteSnapshot2Header (sizebuf_t *msg, unsigned int seq, unsigned 
 	MSG_WriteByte (msg, (byte)flags);
 	MSG_WriteShort (msg, (short)num_entities);
 	MSG_WriteShort (msg, (short)num_removed);
+}
+
+static qboolean SV_WriteSnapshot2FullChunked (client_t *client, sizebuf_t *msg,
+	const byte *present, const byte *snapflags)
+{
+	int header_size = 1 + 4 + 4 + 1 + 2 + 2;
+	int available = msg->maxsize - msg->cursize;
+	int entnum;
+	int chunk_count = 0;
+	int chunk_size = header_size;
+	int last_sent = 0;
+	qboolean more = false;
+	unsigned int flags = SNAPSHOT_FLAG_FULL;
+
+	if (available < header_size)
+		return false;
+
+	for (entnum = client->entstream.next_edict; entnum < qcvm->max_edicts; entnum++)
+	{
+		int ent_size;
+
+		if (!present[entnum])
+			continue;
+
+		ent_size = SV_Snapshot2EntitySizeForFlags (snapflags ? snapflags[entnum] : 0);
+		if (chunk_size + ent_size > available)
+		{
+			more = true;
+			break;
+		}
+
+		chunk_size += ent_size;
+		chunk_count++;
+		last_sent = entnum;
+	}
+
+	if (chunk_count == 0 && more)
+		return false;
+
+	if (more)
+		flags |= SNAPSHOT_FLAG_CONTINUE;
+
+	if (!MSG_CanFit (msg, chunk_size))
+		return false;
+
+	SV_WriteSnapshot2Header (msg, client->snapshot_pending_seq,
+		0xFFFFFFFFu, flags, (unsigned short)chunk_count, 0);
+
+	if (chunk_count)
+	{
+		int remaining = chunk_count;
+
+		for (entnum = client->entstream.next_edict; entnum < qcvm->max_edicts; entnum++)
+		{
+			snapshot_state_t state;
+			byte snapflag = 0;
+
+			if (!present[entnum])
+				continue;
+
+			if (snapflags)
+				snapflag = snapflags[entnum];
+
+			state = client->snapshot_pending[entnum];
+			MSG_WriteShort (msg, entnum);
+			if (sv.protocolflags & PRFL_SNAPSHOT_HIRES)
+				MSG_WriteByte (msg, snapflag);
+			SV_WriteSnapshotState (msg, &state, snapflag);
+
+			remaining--;
+			if (remaining == 0)
+				break;
+		}
+	}
+
+	client->entstream.sent_entities += chunk_count;
+
+	if (more)
+	{
+		client->entstream.next_edict = last_sent + 1;
+		msg->write_locked = true;
+		if (realtime >= client->entstream.next_log_time)
+		{
+			Con_Printf ("snapshot %s seq %u: sent %d/%d entities, continuing\n",
+				client->name,
+				client->snapshot_pending_seq,
+				client->entstream.sent_entities,
+				client->entstream.total_entities);
+			client->entstream.next_log_time = realtime + 1.0;
+		}
+	}
+	else
+	{
+		client->entstream.active = false;
+		client->entstream.next_edict = 1;
+		client->entstream.base_snapshot = 0;
+	}
+
+	return true;
 }
 
 static unsigned int SV_SnapshotFieldMask (const snapshot_state_t *next, const snapshot_state_t *base, byte snapflags)
@@ -1851,6 +2023,9 @@ static void SV_SendSnapshot (client_t *client, sizebuf_t *msg)
 	qboolean reason_interval = false;
 	qboolean reason_force_full = false;
 
+	if (client->entstream.active && client->entstream.base_snapshot != (int)client->snapshot_pending_seq)
+		client->entstream.active = false;
+
 	if (net_test_drop.value > 0.0f && ((float)rand() / (float)RAND_MAX) < net_test_drop.value)
 	{
 		if (sv_snap_debug.value >= 1.0f)
@@ -1919,11 +2094,44 @@ static void SV_SendSnapshot (client_t *client, sizebuf_t *msg)
 		else
 		{
 			if (sv_snapshot2.value)
-				SV_WriteSnapshot2Full (msg, client->snapshot_pending_seq, client->snapshot_pending,
-					client->snapshot_pending_present, client->snapshot_pending_flags, qcvm->max_edicts, &full_count);
+			{
+				int total_count = 0;
+				int total_size = SV_Snapshot2FullSize (client->snapshot_pending_present,
+					client->snapshot_pending_flags, qcvm->max_edicts, &total_count);
+
+				full_count = total_count;
+				if (client->entstream.active)
+				{
+					if (!SV_WriteSnapshot2FullChunked (client, msg,
+						client->snapshot_pending_present, client->snapshot_pending_flags))
+					{
+						msg->overflowed = true;
+						msg->write_locked = true;
+						return;
+					}
+				}
+				else if (total_size > (msg->maxsize - msg->cursize))
+				{
+					SV_InitEntityStream (client, total_count, client->snapshot_pending_seq);
+					if (!SV_WriteSnapshot2FullChunked (client, msg,
+						client->snapshot_pending_present, client->snapshot_pending_flags))
+					{
+						msg->overflowed = true;
+						msg->write_locked = true;
+						return;
+					}
+				}
+				else
+				{
+					SV_WriteSnapshot2Full (msg, client->snapshot_pending_seq, client->snapshot_pending,
+						client->snapshot_pending_present, client->snapshot_pending_flags, qcvm->max_edicts, &full_count);
+				}
+			}
 			else
+			{
 				SV_WriteSnapshotFull (msg, client->snapshot_pending_seq, client->snapshot_pending,
 					client->snapshot_pending_present, client->snapshot_pending_flags, qcvm->max_edicts, &full_count);
+			}
 			client->snapshot_last_full_seq = client->snapshot_pending_seq;
 			client->snapshot_last_full_time = realtime;
 		}
@@ -1998,11 +2206,34 @@ static void SV_SendSnapshot (client_t *client, sizebuf_t *msg)
 		else
 		{
 			if (sv_snapshot2.value)
-				SV_WriteSnapshot2Full (msg, client->snapshot_pending_seq, client->snapshot_pending,
-					client->snapshot_pending_present, client->snapshot_pending_flags, qcvm->max_edicts, &full_count);
+			{
+				int total_count = 0;
+				int total_size = SV_Snapshot2FullSize (client->snapshot_pending_present,
+					client->snapshot_pending_flags, qcvm->max_edicts, &total_count);
+
+				full_count = total_count;
+				if (total_size > (msg->maxsize - msg->cursize))
+				{
+					SV_InitEntityStream (client, total_count, client->snapshot_pending_seq);
+					if (!SV_WriteSnapshot2FullChunked (client, msg,
+						client->snapshot_pending_present, client->snapshot_pending_flags))
+					{
+						msg->overflowed = true;
+						msg->write_locked = true;
+						return;
+					}
+				}
+				else
+				{
+					SV_WriteSnapshot2Full (msg, client->snapshot_pending_seq, client->snapshot_pending,
+						client->snapshot_pending_present, client->snapshot_pending_flags, qcvm->max_edicts, &full_count);
+				}
+			}
 			else
+			{
 				SV_WriteSnapshotFull (msg, client->snapshot_pending_seq, client->snapshot_pending,
 					client->snapshot_pending_present, client->snapshot_pending_flags, qcvm->max_edicts, &full_count);
+			}
 			client->snapshot_last_full_seq = client->snapshot_pending_seq;
 			client->snapshot_last_full_time = realtime;
 		}
@@ -2083,6 +2314,7 @@ void SV_SnapshotAck (client_t *client, unsigned int seq)
 	if (seq == 0)
 	{
 		SV_ResetClientSnapshot (client);
+		client->entstream.active = false;
 		if (sv_snapshotdebug.value || sv_snap_debug.value)
 			Con_Printf ("snapshot %s baseline reset request\n", client->name);
 		return;
@@ -2109,6 +2341,7 @@ void SV_SnapshotAck (client_t *client, unsigned int seq)
 	client->snapshot_pending_is_delta = false;
 	client->snapshot_pending_baseline_seq = 0;
 	client->snapshot_unacked_frames = 0;
+	client->entstream.active = false;
 
 	if (sv_snapshotdebug.value || sv_snap_debug.value)
 		Con_Printf ("snapshot %s ack seq %u\n", client->name, seq);
@@ -2122,6 +2355,7 @@ void SV_SnapshotNak (client_t *client, unsigned int expected_base, unsigned int 
 	client->snapshot_pending_is_delta = false;
 	client->snapshot_pending_seq = 0;
 	client->snapshot_unacked_frames = 0;
+	client->entstream.active = false;
 }
 
 typedef struct
@@ -2914,6 +3148,7 @@ qboolean SV_SendClientDatagram (client_t *client)
 	msg.overflowed = false;
 	msg.overflowed_once = false;
 	msg.write_blocked = false;
+	msg.write_locked = false;
 	msg.blocked_file = NULL;
 	msg.blocked_line = 0;
 	msg.dbg_name = "sv_client_datagram";
@@ -2943,8 +3178,10 @@ qboolean SV_SendClientDatagram (client_t *client)
 	SV_WriteClientdataToMessage (client->edict, &msg);
 	if (msg.overflowed)
 	{
-		packet_too_large = true;
-		goto datagram_too_large;
+		Con_Printf ("sv_mtu_cap %d too small for mandatory clientdata for %s\n",
+			msg.maxsize, client->name);
+		SV_DropClient (true);
+		return false;
 	}
 
 	SV_SendSnapshot (client, &msg);
@@ -2957,7 +3194,7 @@ qboolean SV_SendClientDatagram (client_t *client)
 	client->datagram_overflow_count = 0;
 
 // copy the server datagram if there is space
-	if (msg.cursize + sv.datagram.cursize < msg.maxsize)
+	if (!msg.write_locked && msg.cursize + sv.datagram.cursize < msg.maxsize)
 		SZ_Write (&msg, sv.datagram.data, sv.datagram.cursize);
 
 	if (sv_mtu_debug.value > 0 && realtime >= client->mtu_debug_next_time)
@@ -2995,13 +3232,26 @@ datagram_too_large:
 			}
 			client->datagram_overflow_count = 1;
 		}
-		Con_Printf ("Datagram too large for MTU cap %d for %s (size %d, stage %d, mandatory %d dropped %d)\n",
-			msg.maxsize,
-			client->name,
-			msg.cursize,
-			client->sendsignon,
-			client->snapshot_pending_mandatory,
-			client->snapshot_pending_dropped);
+		if (realtime >= client->datagram_overflow_next_time)
+		{
+			if (client->entstream.active)
+				Con_Printf ("Datagram too large for MTU cap %d for %s (size %d, stage %d, entities %d/%d)\n",
+					msg.maxsize,
+					client->name,
+					msg.cursize,
+					client->sendsignon,
+					client->entstream.sent_entities,
+					client->entstream.total_entities);
+			else
+				Con_Printf ("Datagram too large for MTU cap %d for %s (size %d, stage %d, mandatory %d dropped %d)\n",
+					msg.maxsize,
+					client->name,
+					msg.cursize,
+					client->sendsignon,
+					client->snapshot_pending_mandatory,
+					client->snapshot_pending_dropped);
+			client->datagram_overflow_next_time = realtime + 1.0;
+		}
 		return false;
 	}
 
@@ -3152,6 +3402,7 @@ void SV_SendNop (client_t *client)
 	msg.overflowed = false;
 	msg.overflowed_once = false;
 	msg.write_blocked = false;
+	msg.write_locked = false;
 	msg.blocked_file = NULL;
 	msg.blocked_line = 0;
 	msg.dbg_name = "sv_nop";
@@ -4275,6 +4526,7 @@ void SV_SendReconnect (void)
 	msg.overflowed = false;
 	msg.overflowed_once = false;
 	msg.write_blocked = false;
+	msg.write_locked = false;
 	msg.blocked_file = NULL;
 	msg.blocked_line = 0;
 	msg.dbg_name = "sv_reconnect";


### PR DESCRIPTION
### Motivation

- Prevent server-side sizebuf overflows and repeated "DATAGRAM TOO LARGE" spam when `sv_mtu_cap` forces small datagrams. 
- Ensure mandatory data is always sent (or trigger a clear failure), and stream large `snapshot2` full updates in MTU-sized chunks. 
- Allow the server to stop appending entities once the packet budget is exhausted and continue the entity stream in later datagrams. 
- Provide safety/hardening so no further writes happen on a message after a "no space" condition is detected.

### Description

- Added `write_locked` to `sizebuf_t` and a small helper `MSG_CanFit()` in `Quake/common.h`, plus guards in `MSG_EnsureSpace`/`SZ_GetSpace` to prevent further writes after a detected overflow. 
- Introduced per-client entity streaming state `sv_entity_stream_t` and embedded `entstream` in `client_t` to remember `next_edict`, `base_snapshot`, totals and progress for chunked sends (changes in `Quake/server.h` and `Quake/sv_main.c`). 
- Implemented chunked `snapshot2` full sending with `SV_WriteSnapshot2FullChunked`, `SV_Snapshot2FullSize`, `SV_InitEntityStream`, and logic in `SV_SendSnapshot` to start/continue chunked sends when a full snapshot won’t fit in the current MTU (all in `Quake/sv_main.c`). 
- Client-side support for snapshot2 continuation was added (continuation flag `SNAPSHOT_FLAG_CONTINUE` in `Quake/protocol.h` and chunk-assemble logic in `Quake/cl_parse.c` / allocations in `Quake/cl_main.c` / `Quake/client.h`). 
- Hardening and behavior changes: mandatory `clientdata` that cannot fit now triggers a clear log + disconnect rather than producing malformed packets; when a chunk is cut, `msg.write_locked` is set to prevent further appends to the same message; server datagram copying is skipped if `msg.write_locked` is set; overflow log printing is rate-limited and shows entity-stream progress. 

### Testing

- No automated tests were executed as part of this change. 
- Functional testing has not been performed in CI (manual runtime validation recommended: exercise signon and normal runtime with `sv_mtu_cap` set low and observe no `SZ_GetSpace` overflows). 
- Static compile was not run here (build/test recommended before merging). 
- Logging and behavior around `DATAGRAM TOO LARGE` were adjusted to be rate-limited and informative; please validate on a running server in a controlled environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963c464b9e0832e847c0e33a27d01cc)