### PR TITLE
Ignore MTU caps for local singleplayer packets

### DIFF
--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -535,8 +535,10 @@ static qboolean SV_IsLocalClient (client_t *client)
 	return Q_strcmp (NET_QSocketGetAddressString (client->netconnection), "LOCAL") == 0;
 }
 
-static int SV_MTUCap (void)
+static int SV_MTUCap (client_t *client)
 {
+	if (client && SV_IsLocalClient (client))
+		return 0;
 	int cap = (int)sv_mtu_cap.value;
 	if (cap <= 0)
 		cap = (int)sv_mtu.value;
@@ -1274,12 +1276,12 @@ static int SV_Snapshot2FullSize (const byte *present, const byte *snapflags, int
 	return size;
 }
 
-static int SV_SnapshotMaxEntities (sizebuf_t *msg)
+static int SV_SnapshotMaxEntities (client_t *client, sizebuf_t *msg)
 {
 	int header_size = 1 + 4 + 4 + 2 + 2 + 2;
 	int per_ent = SV_SnapshotEntitySizeWorst ();
 	int payload_cap = (int)sv_snap_max_payload.value;
-	int mtu_cap = SV_MTUCap ();
+	int mtu_cap = SV_MTUCap (client);
 
 	if (sv_snapshot2.value)
 		header_size = 1 + 4 + 4 + 1 + 2 + 2 + 2 + 2;
@@ -2144,7 +2146,7 @@ static void SV_SendSnapshot (client_t *client, sizebuf_t *msg)
 		int dropped_count = 0;
 		int dropped_tier1 = 0;
 		int dropped_tier2 = 0;
-		int max_ents = SV_SnapshotMaxEntities (msg);
+		int max_ents = SV_SnapshotMaxEntities (client, msg);
 		qboolean debug_frame = false;
 
 		if (net_snap_debug.value && realtime >= client->snapshot_debug_next_time)
@@ -3163,7 +3165,7 @@ qboolean SV_SendClientDatagram (client_t *client)
 	if (Q_strcmp(NET_QSocketGetAddressString(client->netconnection), "LOCAL") != 0)
 		msg.maxsize = DATAGRAM_MTU;
 	//johnfitz
-	mtu_cap = SV_MTUCap ();
+	mtu_cap = SV_MTUCap (client);
 	if (mtu_cap > 0)
 		msg.maxsize = q_min (msg.maxsize, mtu_cap);
 
@@ -4140,7 +4142,7 @@ static void SV_SignonStreamSend (client_t *client)
 {
 	signon_stream_t *stream = &client->signon_stream;
 	int window = (int)sv_signon_chunk_window.value;
-	int mtu_cap = SV_MTUCap ();
+	int mtu_cap = SV_MTUCap (client);
 	int payload_cap = SIGNON_CHUNK_MAX_PAYLOAD;
 
 	if (!stream->active)


### PR DESCRIPTION
### Motivation

- Avoid constraining singleplayer signon/datagram sizes by the network MTU cap when client is local, while preserving MTU enforcement for remote/multiplayer clients. 
- Prevent unnecessary entity/signon truncation and improve singleplayer load stability caused by per-packet MTU limits.

### Description

- Changed `SV_MTUCap` signature to `SV_MTUCap(client_t *client)` and return `0` (no cap) when `SV_IsLocalClient(client)` is true. 
- Threaded per-client MTU checks into snapshot and signon sizing by updating `SV_SnapshotMaxEntities` signature to `SV_SnapshotMaxEntities(client_t *client, sizebuf_t *msg)` and passing `client` to `SV_MTUCap` where appropriate. 
- Updated all call sites in `Quake/sv_main.c` to pass the `client` argument (datagram sizing, snapshot calculation, and signon chunking) so remote clients still obey MTU limits.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963f48dc31c832eb21510236bfb4690)