### PR TITLE
Fix tonemap black lift weighting

### DIFF
--- a/Quake/shaders/postprocess.frag
+++ b/Quake/shaders/postprocess.frag
@@ -784,7 +784,7 @@ void main()
                 if (blackLift > 0.0 && blackLiftStrength > 0.0)
                 {
                         mapped = mix(mapped, vec3(blackLift),
-                                1.0 - exp(-mapped * blackLiftStrength));
+                                exp(-mapped * blackLiftStrength));
                         mapped = clamp(mapped, 0.0, 1.0);
                 }
         }


### PR DESCRIPTION
### Motivation
- The black lift tonemapping control was applying its effect more strongly to brighter colors, which washed out lighter tones and made high `r_tonemap_black_lift_strength` values produce an almost black-and-white image.
- The intent is for black lift to raise/darken the darker parts of the image (i.e. target low luminance), not to desaturate highlights.

### Description
- Adjusted the blending weight in the tonemapping shader to invert the attenuation curve so darker `mapped` values receive more lift. 
- Modified `Quake/shaders/postprocess.frag` to replace `1.0 - exp(-mapped * blackLiftStrength)` with `exp(-mapped * blackLiftStrength)` in the black lift `mix` call.
- The change is a single-line fix that preserves clamping and existing parameter handling (`TonemapBlackLiftParams`).

### Testing
- No automated tests were run for this change (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696444bdde94832e9c525480e6ddb603)