### PR TITLE
Apply emissiveScale and bloomScale to stage color evaluation

### DIFF
--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -814,6 +814,7 @@ static void R_EvalStageColorAlpha (const mat_shader_stage_t *stage, float time, 
 {
 	static qboolean warned_vertex_color = false;
 	float wave_value;
+	float output_scale = 1.f;
 
 	out[0] = 1.f;
 	out[1] = 1.f;
@@ -867,6 +868,15 @@ static void R_EvalStageColorAlpha (const mat_shader_stage_t *stage, float time, 
 	default:
 		break;
 	}
+
+	if (stage->outputs & MAT_STAGE_OUT_EMISSIVE)
+		output_scale *= stage->emissive_scale;
+	if (stage->outputs & MAT_STAGE_OUT_BLOOM)
+		output_scale *= stage->bloom_scale;
+
+	out[0] *= output_scale;
+	out[1] *= output_scale;
+	out[2] *= output_scale;
 }
 
 static unsigned R_MapBlendMode (const mat_shader_stage_t *stage)


### PR DESCRIPTION
### Motivation
- Stage-level `emissiveScale` and `bloomScale` were parsed and stored but not applied to the rendered stage color, making those directives effectively no-ops.
- The color evaluation path (`R_EvalStageColorAlpha`) is the canonical place to modify per-stage output color before it's passed to shader calls.

### Description
- Add a local `output_scale` in `R_EvalStageColorAlpha` and multiply it by `stage->emissive_scale` when `MAT_STAGE_OUT_EMISSIVE` is set. 
- Multiply `output_scale` by `stage->bloom_scale` when `MAT_STAGE_OUT_BLOOM` is set and apply the combined scale to `out[0..2]` (RGB).
- Changes are contained in `Quake/r_world.c` inside the `R_EvalStageColorAlpha` function and do not alter alpha handling.

### Testing
- No automated tests were executed for this change.
- A single file `Quake/r_world.c` was modified and committed, and the change compiles in the repository build (manual build/test not recorded here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69655525ffd0832ea24bbca59248e60a)