### PR TITLE
Add per-emitter godray direction MRT and emitter-center projection

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -819,12 +819,16 @@ void GL_CreateFrameBuffers (void)
 	framebufs.godrays.width = q_max (1, vid.width / 2);
 	framebufs.godrays.height = q_max (1, vid.height / 2);
 	framebufs.godrays.source_tex = GL_CreateTexture2D (GL_RGBA16F, vid.width, vid.height, GL_LINEAR, "godrays source");
+	framebufs.godrays.dir_tex = GL_CreateTexture2D (GL_RG16F, vid.width, vid.height, GL_LINEAR, "godrays dir");
 	framebufs.godrays.mask_tex = GL_CreateTexture2D (GL_RGBA16F, framebufs.godrays.width, framebufs.godrays.height, GL_LINEAR, "godrays mask");
 	framebufs.godrays.shafts_tex = GL_CreateTexture2D (GL_RGBA16F, framebufs.godrays.width, framebufs.godrays.height, GL_LINEAR, "godrays shafts");
-	framebufs.godrays.source_fbo = GL_CreateSimpleFBO (GL_TEXTURE_2D, framebufs.godrays.source_tex,
-		framebufs.composite.depth_stencil_tex,
-		framebufs.composite.depth_stencil_tex,
-		"godrays source fbo");
+	{
+		GLuint colors[2] = { framebufs.godrays.source_tex, framebufs.godrays.dir_tex };
+		framebufs.godrays.source_fbo = GL_CreateFBO (GL_TEXTURE_2D, colors, 2,
+			framebufs.composite.depth_stencil_tex,
+			framebufs.composite.depth_stencil_tex,
+			"godrays source fbo");
+	}
 	framebufs.godrays.mask_fbo = GL_CreateSimpleFBO (GL_TEXTURE_2D, framebufs.godrays.mask_tex, 0, 0, "godrays mask fbo");
 	framebufs.godrays.shafts_fbo = GL_CreateSimpleFBO (GL_TEXTURE_2D, framebufs.godrays.shafts_tex, 0, 0, "godrays shafts fbo");
 
@@ -965,6 +969,7 @@ void GL_DeleteFrameBuffers (void)
 	GL_DeleteNativeTexture (framebufs.bloom.pingpong_tex[1]);
 	GL_DeleteNativeTexture (framebufs.bloom.extract_tex);
 	GL_DeleteNativeTexture (framebufs.godrays.source_tex);
+	GL_DeleteNativeTexture (framebufs.godrays.dir_tex);
 	GL_DeleteNativeTexture (framebufs.godrays.mask_tex);
 	GL_DeleteNativeTexture (framebufs.godrays.shafts_tex);
 	GL_DeleteNativeTexture (framebufs.ssao.noise_tex);
@@ -1584,7 +1589,7 @@ static void GL_GenerateGodraysSource (qboolean draw_sky, qboolean draw_brush)
 {
 	int width = vid.width;
 	int height = vid.height;
-	if (framebufs.godrays.source_fbo == 0 || framebufs.godrays.source_tex == 0)
+	if (framebufs.godrays.source_fbo == 0 || framebufs.godrays.source_tex == 0 || framebufs.godrays.dir_tex == 0)
 		return;
 	if (!draw_sky && !draw_brush)
 		return;
@@ -1595,7 +1600,9 @@ static void GL_GenerateGodraysSource (qboolean draw_sky, qboolean draw_brush)
 	glViewport (0, 0, width, height);
 	{
 		const float zero[4] = { 0.f, 0.f, 0.f, 0.f };
+		const float clear_dir[4] = { 0.5f, 0.5f, 0.f, 1.f };
 		GL_ClearBufferfvFunc (GL_COLOR, 0, zero);
+		GL_ClearBufferfvFunc (GL_COLOR, 1, clear_dir);
 	}
 
 	if (draw_sky && glprogs.godrays_source_sky)
@@ -1632,6 +1639,7 @@ static void GL_GenerateGodraysSource (qboolean draw_sky, qboolean draw_brush)
 				q_max (0.f, r_godrays_emissive_threshold.value),
 				q_max (0.f, r_godrays_light_threshold.value));
 			GL_Uniform4fFunc (1, mask_knee, 0.f, 0.f, 0.f);
+			GL_Uniform2fFunc (2, (float)width, (float)height);
 			R_DrawBrushModels_Godrays (ents, count);
 		}
 	}
@@ -1652,7 +1660,7 @@ static GLuint GL_GenerateGodraysTexture (GLuint *out_mask)
 		return fallback;
 	if (framebufs.godrays.mask_fbo == 0 || framebufs.godrays.shafts_fbo == 0)
 		return fallback;
-	if (framebufs.godrays.source_fbo == 0 || framebufs.godrays.source_tex == 0)
+	if (framebufs.godrays.source_fbo == 0 || framebufs.godrays.source_tex == 0 || framebufs.godrays.dir_tex == 0)
 		return fallback;
 	if (!R_GodraysReady ())
 		return fallback;
@@ -1723,6 +1731,7 @@ static GLuint GL_GenerateGodraysTexture (GLuint *out_mask)
 			GL_UseProgram (glprogs.godrays);
 			GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
 			GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, framebufs.godrays.mask_tex);
+			GL_BindNative (GL_TEXTURE1, GL_TEXTURE_2D, framebufs.godrays.dir_tex);
 			GL_Uniform4fFunc (0, stabilized_x, stabilized_y, density, weight);
 			GL_Uniform4fFunc (1, decay, exposure, max_radius, (float)samples);
 			glDrawArrays (GL_TRIANGLES, 0, 3);
@@ -1757,6 +1766,7 @@ static GLuint GL_GenerateGodraysTexture (GLuint *out_mask)
 			GL_UseProgram (glprogs.godrays);
 			GL_SetState ((first_pass ? GLS_BLEND_OPAQUE : GLS_BLEND_ADD) | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
 			GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, framebufs.godrays.mask_tex);
+			GL_BindNative (GL_TEXTURE1, GL_TEXTURE_2D, framebufs.godrays.dir_tex);
 			GL_Uniform4fFunc (0, stabilized_x, stabilized_y, density, weight);
 			GL_Uniform4fFunc (1, decay, exposure, max_radius, (float)samples);
 			glDrawArrays (GL_TRIANGLES, 0, 3);

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -682,6 +682,7 @@ typedef struct glframebufs_s {
 
 	struct {
 		GLuint		source_tex;
+		GLuint		dir_tex;
 		GLuint		mask_tex;
 		GLuint		shafts_tex;
 		GLuint		source_fbo;

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -296,6 +296,7 @@ typedef struct bmodel_bindless_gpu_call_s {
 	GLfloat		_pad1[2];
 	GLfloat		stage_color[4];
 	GLfloat		texmatrix[8];
+	GLfloat		emitter_center[4];
 	GLuint64	texture;
 	GLuint64	fullbright;
 	GLuint64	emissive;
@@ -311,6 +312,7 @@ typedef struct bmodel_bound_gpu_call_s {
 	GLfloat		_pad1[2];
 	GLfloat		stage_color[4];
 	GLfloat		texmatrix[8];
+	GLfloat		emitter_center[4];
 	GLint		baseinstance;
 	GLint		padding[3];
 } bmodel_bound_gpu_call_t;
@@ -601,9 +603,110 @@ static void R_SetCallTexMatrix (float *dst, const mat_texmatrix_t *matrix)
 	dst[7] = 0.f;
 }
 
+static void R_SetCallEmitterCenter (float *dst, const vec2_t emitter_center_ss)
+{
+	if (!dst)
+		return;
+
+	if (emitter_center_ss)
+	{
+		dst[0] = emitter_center_ss[0];
+		dst[1] = emitter_center_ss[1];
+	}
+	else
+	{
+		dst[0] = 0.5f;
+		dst[1] = 0.5f;
+	}
+	dst[2] = 0.f;
+	dst[3] = 0.f;
+}
+
+static void R_TransformPoint (const float matrix[16], const vec3_t in, vec3_t out)
+{
+	out[0] = in[0] * matrix[0] + in[1] * matrix[4] + in[2] * matrix[8] + matrix[12];
+	out[1] = in[0] * matrix[1] + in[1] * matrix[5] + in[2] * matrix[9] + matrix[13];
+	out[2] = in[0] * matrix[2] + in[1] * matrix[6] + in[2] * matrix[10] + matrix[14];
+}
+
+static qboolean R_GetModelTextureBounds (const qmodel_t *model, int texnum, vec3_t out_mins, vec3_t out_maxs)
+{
+	qboolean found = false;
+
+	if (!model || !model->surfaces || model->nummodelsurfaces <= 0)
+		return false;
+
+	int start = model->firstmodelsurface;
+	int end = start + model->nummodelsurfaces;
+	for (int i = start; i < end; i++)
+	{
+		msurface_t *surf = &model->surfaces[i];
+		if (!surf->texinfo || surf->texinfo->texnum != texnum)
+			continue;
+
+		if (!found)
+		{
+			VectorCopy (surf->mins, out_mins);
+			VectorCopy (surf->maxs, out_maxs);
+			found = true;
+		}
+		else
+		{
+			out_mins[0] = q_min (out_mins[0], surf->mins[0]);
+			out_mins[1] = q_min (out_mins[1], surf->mins[1]);
+			out_mins[2] = q_min (out_mins[2], surf->mins[2]);
+			out_maxs[0] = q_max (out_maxs[0], surf->maxs[0]);
+			out_maxs[1] = q_max (out_maxs[1], surf->maxs[1]);
+			out_maxs[2] = q_max (out_maxs[2], surf->maxs[2]);
+		}
+	}
+
+	return found;
+}
+
+static void R_ComputeGodraysEmitterCenterSS (const entity_t *ent, const qmodel_t *model, int texnum, vec2_t out_center_ss)
+{
+	vec3_t mins;
+	vec3_t maxs;
+	vec3_t center_local;
+	vec3_t center_world;
+	vec3_t proj;
+
+	if (!out_center_ss)
+		return;
+
+	out_center_ss[0] = 0.5f;
+	out_center_ss[1] = 0.5f;
+
+	if (!R_GetModelTextureBounds (model, texnum, mins, maxs))
+		return;
+
+	center_local[0] = (mins[0] + maxs[0]) * 0.5f;
+	center_local[1] = (mins[1] + maxs[1]) * 0.5f;
+	center_local[2] = (mins[2] + maxs[2]) * 0.5f;
+
+	if (ent && ent != &cl_entities[0])
+	{
+		vec3_t matrix_angles;
+		float matrix[16];
+		VectorCopy (ent->angles, matrix_angles);
+		matrix_angles[0] = -matrix_angles[0];
+		R_EntityMatrix (matrix, ent->origin, matrix_angles, ent->scale);
+		R_TransformPoint (matrix, center_local, center_world);
+	}
+	else
+	{
+		VectorCopy (center_local, center_world);
+	}
+
+	ProjectVector (center_world, r_matviewproj, proj);
+	out_center_ss[0] = CLAMP (0.f, proj[0] * 0.5f + 0.5f, 1.f);
+	out_center_ss[1] = CLAMP (0.f, proj[1] * 0.5f + 0.5f, 1.f);
+}
+
 static void R_AddBModelCall (int index, int first_instance, int num_instances, texture_t *t, qboolean zfix,
 	float polygon_offset_factor, float polygon_offset_units, float alpha_override, unsigned extra_flags,
-	qboolean force_fullbright)
+	qboolean force_fullbright, const vec2_t emitter_center_ss)
 {
 	GLuint		flags;
 	float		alpha;
@@ -665,6 +768,7 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
 		call->stage_color[2] = 1.f;
 		call->stage_color[3] = 1.f;
 		R_SetCallTexMatrix (call->texmatrix, NULL);
+		R_SetCallEmitterCenter (call->emitter_center, emitter_center_ss);
 		call->texture = tx ? tx->bindless_handle : greytexture->bindless_handle;
 		call->fullbright = fb ? fb->bindless_handle : blacktexture->bindless_handle;
 		call->emissive = em ? em->bindless_handle : blacktexture->bindless_handle;
@@ -687,6 +791,7 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
 		call->stage_color[2] = 1.f;
 		call->stage_color[3] = 1.f;
 		R_SetCallTexMatrix (call->texmatrix, NULL);
+		R_SetCallEmitterCenter (call->emitter_center, emitter_center_ss);
 		call->baseinstance = first_instance;
 		call->padding[0] = 0;
 		call->padding[1] = 0;
@@ -706,7 +811,7 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
 
 static void R_AddBModelCallWithTextures (int index, int first_instance, int num_instances, gltexture_t *tx, gltexture_t *fb, gltexture_t *em,
 	tcgen_mode_t tcgen, qboolean zfix, float polygon_offset_factor, float polygon_offset_units, float alpha_override, unsigned extra_flags,
-	const mat_texmatrix_t *texmatrix, const vec4_t stage_color)
+	const mat_texmatrix_t *texmatrix, const vec4_t stage_color, const vec2_t emitter_center_ss)
 {
 	GLuint flags;
 	float alpha;
@@ -740,6 +845,7 @@ static void R_AddBModelCallWithTextures (int index, int first_instance, int num_
 		call->stage_color[2] = stage_color ? stage_color[2] : 1.f;
 		call->stage_color[3] = stage_color ? stage_color[3] : 1.f;
 		R_SetCallTexMatrix (call->texmatrix, texmatrix);
+		R_SetCallEmitterCenter (call->emitter_center, emitter_center_ss);
 		call->texture = tx ? tx->bindless_handle : greytexture->bindless_handle;
 		call->fullbright = fb ? fb->bindless_handle : blacktexture->bindless_handle;
 		call->emissive = em ? em->bindless_handle : blacktexture->bindless_handle;
@@ -762,6 +868,7 @@ static void R_AddBModelCallWithTextures (int index, int first_instance, int num_
 		call->stage_color[2] = stage_color ? stage_color[2] : 1.f;
 		call->stage_color[3] = stage_color ? stage_color[3] : 1.f;
 		R_SetCallTexMatrix (call->texmatrix, texmatrix);
+		R_SetCallEmitterCenter (call->emitter_center, emitter_center_ss);
 		call->baseinstance = first_instance;
 		call->padding[0] = 0;
 		call->padding[1] = 0;
@@ -1237,7 +1344,7 @@ static void R_DrawBrushModels_MaterialStages (entity_t **ents, int count, brushp
 					R_AddBModelCallWithTextures (model->firstcmd + j, baseinst, numinst,
 						stage_tex, fb, em, R_ResolveStageTcGen (stage),
 						use_polygon_offset, polygon_offset_factor, polygon_offset_units, -1.f, extra_flags,
-						MatStage_EvalTexMatrix ((mat_shader_stage_t *)stage, cl.time), stage_color);
+						MatStage_EvalTexMatrix ((mat_shader_stage_t *)stage, cl.time), stage_color, NULL);
 				}
 			}
 		}
@@ -1334,6 +1441,8 @@ static void R_DrawBrushModels_GodrayStages (entity_t **ents, int count)
 			const shader_material_t *material;
 			unsigned mat_flags = 0u;
 			size_t stage_count;
+			qboolean emitter_center_valid = false;
+			vec2_t emitter_center_ss = { 0.5f, 0.5f };
 
 			if (!t || !R_ValidPtr (t))
 				continue;
@@ -1401,6 +1510,12 @@ static void R_DrawBrushModels_GodrayStages (entity_t **ents, int count)
 				if (t->type == TEXTYPE_CUTOUT)
 					extra_flags |= CALLFLAG_ALPHA_TEST;
 
+				if (!emitter_center_valid)
+				{
+					R_ComputeGodraysEmitterCenterSS (e, model, j, emitter_center_ss);
+					emitter_center_valid = true;
+				}
+
 				{
 					float polygon_offset_factor;
 					float polygon_offset_units;
@@ -1410,7 +1525,7 @@ static void R_DrawBrushModels_GodrayStages (entity_t **ents, int count)
 					R_AddBModelCallWithTextures (model->firstcmd + j, baseinst, numinst,
 						stage_tex, fb, em, R_ResolveStageTcGen (stage),
 						use_polygon_offset, polygon_offset_factor, polygon_offset_units, -1.f, extra_flags,
-						MatStage_EvalTexMatrix ((mat_shader_stage_t *)stage, cl.time), stage_color);
+						MatStage_EvalTexMatrix ((mat_shader_stage_t *)stage, cl.time), stage_color, emitter_center_ss);
 				}
 			}
 		}
@@ -1643,7 +1758,7 @@ GL_Bind (GL_TEXTURE2, skybox->cubemap);
 				R_GetPolygonOffsetValues (material, zfix, &polygon_offset_factor, &polygon_offset_units);
 				R_AddBModelCall (model->firstcmd + j, baseinst, numinst,
 					pass != BP_SHOWTRIS ? R_TextureAnimation (t, frame) : 0,
-					zfix, polygon_offset_factor, polygon_offset_units, -1, extra_flags, force_fullbright);
+					zfix, polygon_offset_factor, polygon_offset_units, -1, extra_flags, force_fullbright, NULL);
 			}
 		}
 		
@@ -1796,7 +1911,7 @@ GL_Upload (GL_SHADER_STORAGE_BUFFER, bmodel_instances, sizeof(bmodel_instances[0
 				R_GetPolygonOffsetValues (material, zfix, &polygon_offset_factor, &polygon_offset_units);
 				R_AddBModelCall (model->firstcmd + j, baseinst, numinst,
 					R_TextureAnimation (t, frame),
-					zfix, polygon_offset_factor, polygon_offset_units, alpha, extra_flags, false);
+					zfix, polygon_offset_factor, polygon_offset_units, alpha, extra_flags, false, NULL);
 			}
 		}
 

--- a/Quake/shaders/godrays.frag
+++ b/Quake/shaders/godrays.frag
@@ -1,4 +1,5 @@
 layout(binding=0) uniform sampler2D MaskTexture;
+layout(binding=1) uniform sampler2D DirTexture;
 
 layout(location=0) uniform vec4 LightParams; // xy: light position, z: density, w: weight
 layout(location=1) uniform vec4 ScatterParams; // x: decay, y: exposure, z: max radius, w: samples
@@ -18,11 +19,16 @@ void main()
         int samples = int(ScatterParams.w + 0.5);
         samples = clamp(samples, 1, 128);
 
-        vec2 delta = uv - lightPos;
-        float dist = length(delta);
-        if (maxRadius > 0.0 && dist > maxRadius)
-                delta *= maxRadius / max(dist, 1e-4);
-        vec2 step = delta * (density / float(samples));
+        vec2 dir = texture(DirTexture, uv).rg * 2.0 - 1.0;
+        float l2 = dot(dir, dir);
+        if (l2 < 1e-4)
+                dir = normalize(uv - lightPos);
+        else
+                dir *= inversesqrt(l2);
+        float step_scale = density / float(samples);
+        if (maxRadius > 0.0)
+                step_scale = min(step_scale, maxRadius / float(samples));
+        vec2 step = dir * step_scale;
 
         vec2 coord = uv;
         vec3 accum = vec3(0.0);
@@ -32,7 +38,8 @@ void main()
                 if (i >= samples)
                         break;
                 coord -= step;
-                coord = clamp(coord, vec2(0.0), vec2(1.0));
+                if (coord.x < 0.0 || coord.x > 1.0 || coord.y < 0.0 || coord.y > 1.0)
+                        break;
                 vec4 sampleColor = texture(MaskTexture, coord);
                 accum += sampleColor.rgb * sampleColor.a * illuminationDecay * weight;
                 illuminationDecay *= decay;

--- a/Quake/shaders/godrays_source.frag
+++ b/Quake/shaders/godrays_source.frag
@@ -8,6 +8,7 @@
 
 layout(location=0) uniform vec4 GodraysSourceParams0; // x: emissive intensity, y: light intensity, z: emissive threshold, w: light threshold
 layout(location=1) uniform vec4 GodraysSourceParams1; // x: mask knee, yzw: unused
+layout(location=2) uniform vec2 GodraysViewportSize; // viewport size in pixels
 
 const uint
 	CF_USE_FULLBRIGHT = 2u,
@@ -19,12 +20,14 @@ const uint
 layout(location=0) flat in uint in_flags;
 layout(location=3) in vec2 in_uv;
 layout(location=15) flat in vec4 in_stage_color;
+layout(location=17) flat in vec2 in_emitter_center_ss;
 #if BINDLESS
 	layout(location=9) flat in uvec4 in_samplers0;
 	layout(location=10) flat in uvec2 in_samplers1;
 #endif
 
-layout(location=0) out vec4 outColor;
+layout(location=0) out vec4 outMask;
+layout(location=1) out vec4 outDir;
 
 float BrightPartMask(vec3 color, float threshold, float knee)
 {
@@ -95,5 +98,12 @@ void main()
 	if (emissive_strength > 0.0)
 		color += emissive_color * emissive_strength * emissive_mask;
 
-	outColor = vec4(color, mask);
+	outMask = vec4(color, mask);
+
+	vec2 uv = (gl_FragCoord.xy + vec2(0.5)) / max(GodraysViewportSize, vec2(1.0));
+	vec2 dir = uv - in_emitter_center_ss;
+	dir.y *= 0.7;
+	float len2 = dot(dir, dir);
+	dir = (len2 > 1e-6) ? dir * inversesqrt(len2) : vec2(1.0, 0.0);
+	outDir = vec4(dir * 0.5 + 0.5, 0.0, 1.0);
 }

--- a/Quake/shaders/godrays_source_sky.frag
+++ b/Quake/shaders/godrays_source_sky.frag
@@ -4,6 +4,7 @@ layout(location=1) uniform vec4 SkyTint; // rgb: sky tint
 layout(location=2) uniform vec4 SkyMaskParams; // x: mask knee, yzw: unused
 
 layout(location=0) out vec4 outColor;
+layout(location=1) out vec4 outDir;
 
 float BrightPartMask(vec3 color, float threshold, float knee)
 {
@@ -23,4 +24,5 @@ void main()
 		mask = BrightPartMask(SkyTint.rgb, SkyParams.w, SkyMaskParams.x);
 	vec3 color = SkyTint.rgb * SkyParams.y * mask;
 	outColor = vec4(color, mask);
+	outDir = vec4(0.5, 0.5, 0.0, 1.0);
 }

--- a/Quake/shaders/shadow_depth.vert
+++ b/Quake/shaders/shadow_depth.vert
@@ -18,6 +18,7 @@ struct Call
 	vec4	stage_color;
 	vec4	texmatrix0;
 	vec4	texmatrix1;
+	vec4	emitter_center;
 #if BINDLESS
 	uvec2	txhandle;
 	uvec2	fbhandle;

--- a/Quake/shaders/sky_cubemap.vert
+++ b/Quake/shaders/sky_cubemap.vert
@@ -25,6 +25,7 @@ struct Call
 	vec4	stage_color;
 	vec4	texmatrix0;
 	vec4	texmatrix1;
+	vec4	emitter_center;
 #if BINDLESS
 	uvec2	txhandle;
 	uvec2	fbhandle;

--- a/Quake/shaders/sky_layers.vert
+++ b/Quake/shaders/sky_layers.vert
@@ -25,6 +25,7 @@ struct Call
 	vec4	stage_color;
 	vec4	texmatrix0;
 	vec4	texmatrix1;
+	vec4	emitter_center;
 #if BINDLESS
 	uvec2	txhandle;
 	uvec2	fbhandle;

--- a/Quake/shaders/skystencil.vert
+++ b/Quake/shaders/skystencil.vert
@@ -25,6 +25,7 @@ struct Call
 	vec4	stage_color;
 	vec4	texmatrix0;
 	vec4	texmatrix1;
+	vec4	emitter_center;
 #if BINDLESS
 	uvec2	txhandle;
 	uvec2	fbhandle;

--- a/Quake/shaders/water.vert
+++ b/Quake/shaders/water.vert
@@ -25,6 +25,7 @@ struct Call
 	vec4	stage_color;
 	vec4	texmatrix0;
 	vec4	texmatrix1;
+	vec4	emitter_center;
 #if BINDLESS
 	uvec2	txhandle;
 	uvec2	fbhandle;

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -60,6 +60,7 @@ struct Call
 	vec4	stage_color;
 	vec4	texmatrix0;
 	vec4	texmatrix1;
+	vec4	emitter_center;
 #if BINDLESS
 	uvec2	txhandle;
 	uvec2	fbhandle;

--- a/Quake/shaders/world.vert
+++ b/Quake/shaders/world.vert
@@ -55,6 +55,7 @@ struct Call
 	vec4	stage_color;
 	vec4	texmatrix0;
 	vec4	texmatrix1;
+	vec4	emitter_center;
 #if BINDLESS
 	uvec2	txhandle;
 	uvec2	fbhandle;
@@ -155,6 +156,7 @@ layout(location=13) out vec3 out_normal;
 layout(location=14) out vec3 out_lightgrid;
 layout(location=15) flat out vec4 out_stage_color;
 layout(location=16) flat out uint out_tcgen;
+layout(location=17) flat out vec2 out_emitter_center_ss;
 
 vec2 ComputeEnvUV(vec3 world_pos, vec3 world_normal)
 {
@@ -232,6 +234,7 @@ void main()
 	out_lmofs = in_lmofs;
 	out_stage_color = call.stage_color;
 	out_tcgen = call.tcgen;
+	out_emitter_center_ss = call.emitter_center.xy;
 #if BINDLESS
 	out_samplers0.xy = call.txhandle;
 	if ((call.flags & CF_USE_FULLBRIGHT) != 0u)

--- a/Quake/shaders/world_dlight.vert
+++ b/Quake/shaders/world_dlight.vert
@@ -41,6 +41,7 @@ struct Call
         vec4    stage_color;
 	vec4	texmatrix0;
 	vec4	texmatrix1;
+	vec4	emitter_center;
 #if BINDLESS
         uvec2   txhandle;
         uvec2   fbhandle;


### PR DESCRIPTION
### Motivation
- Reduce visible godray skew by anchoring ray direction to the emitting surface instead of using a global radial vector.

### Description
- Add a secondary per-framebuffer render target `dir_tex` and build the godrays source FBO as an MRT with `source_tex` and `dir_tex`, plus clear and delete handling for the new target (`GL_CreateTexture2D`, `GL_CreateFBO`, cleanup).  
- Compute per-drawcall emitter center in world space and project to screen-space with `R_ComputeGodraysEmitterCenterSS`, propagate it into the GPU call buffers by adding `emitter_center` to the `bmodel_*_gpu_call_t` structs and writing it out from `world.vert` as `out_emitter_center_ss`.  
- Update the source shaders to emit two outputs: `outMask` (mask/source) and `outDir` (packed normalized screen-space direction), and add `GodraysViewportSize` / emitter-center inputs to compute per-pixel directions in `godrays_source.frag` and a default for sky in `godrays_source_sky.frag`.  
- Update the scatter/postpass `godrays.frag` to sample `DirTexture` (binding=1), use the stored per-pixel direction for stepping, normalize/fallback to the light position when needed, and break the sample loop when the coordinate leaves the screen.  

### Testing
- No automated tests were executed as part of this change (no build/run/test performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969356b0a4c832e8710f066d96cf244)