### PR TITLE
Fix const qualifiers for R_EntityMatrix parameters

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -2569,7 +2569,7 @@ R_EntityMatrix
 PERF OPT: Calculate sin/cos only once, reuse for both branches
 ===============
 */
-void R_EntityMatrix (float matrix[16], vec3_t origin, vec3_t angles, unsigned char scale)
+void R_EntityMatrix (float matrix[16], const vec3_t origin, const vec3_t angles, unsigned char scale)
 {
 	float scalefactor = ENTSCALE_DECODE (scale);
 	float yaw = DEG2RAD (angles[YAW]);

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -475,7 +475,7 @@ void R_MarkSurfaces (void);
 qboolean R_CullBox (vec3_t emins, vec3_t emaxs);
 qboolean R_CullModelForEntity (entity_t *e);
 void R_GetEntityBounds (const entity_t *e, vec3_t mins, vec3_t maxs);
-void R_EntityMatrix (float matrix[16], vec3_t origin, vec3_t angles, unsigned char scale);
+void R_EntityMatrix (float matrix[16], const vec3_t origin, const vec3_t angles, unsigned char scale);
 
 void R_InitParticles (void);
 void R_DrawParticles (qboolean alpha);


### PR DESCRIPTION
### Motivation
- Silence a MSVC const-qualification warning (C4090 treated as error C2220) by making the `R_EntityMatrix` parameters match call sites that pass `const vec3_t` values.

### Description
- Change the `R_EntityMatrix` declaration in `Quake/glquake.h` and its definition in `Quake/gl_rmain.c` to use `const vec3_t origin` and `const vec3_t angles` so the prototype and implementation accept const inputs.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69693ac52130832e9cef296902d181a3)