### PR TITLE
Make godrays camera-invariant via world-space ray reconstruction

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -1686,8 +1686,18 @@ static GLuint GL_GenerateGodraysTexture (GLuint *out_mask)
 	float light_y = R_SanitizeGodraysValue (r_godrays_light_y.value, 0.5f, 0.f, 1.f);
 	float stabilized_x = light_x;
 	float stabilized_y = light_y;
+	float inv_viewproj[16];
+	vec3_t light_dir;
+	vec3_t emitter_normal;
+	GLuint depth_tex = framebufs.composite.depth_stencil_tex;
 
 	GL_GetGodraysLightPos (width, height, light_x, light_y, &stabilized_x, &stabilized_y);
+	if (!MatrixInverse4x4 (r_matviewproj, inv_viewproj))
+		memcpy (inv_viewproj, r_identity_mat4, sizeof (inv_viewproj));
+	VectorCopy (r_framedata.shadow_sun_dir, light_dir);
+	if (VectorNormalize (light_dir) <= 0.f)
+		VectorSet (light_dir, 0.f, 0.f, -1.f);
+	VectorSet (emitter_normal, 0.f, 0.f, 1.f);
 
 	GL_BeginGroup ("Godrays scatter");
 	GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.godrays.shafts_fbo);
@@ -1731,9 +1741,14 @@ static GLuint GL_GenerateGodraysTexture (GLuint *out_mask)
 			GL_UseProgram (glprogs.godrays);
 			GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
 			GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, framebufs.godrays.mask_tex);
-			GL_BindNative (GL_TEXTURE1, GL_TEXTURE_2D, framebufs.godrays.dir_tex);
+			GL_BindNative (GL_TEXTURE1, GL_TEXTURE_2D, depth_tex);
+			GL_BindNative (GL_TEXTURE2, GL_TEXTURE_2D, framebufs.godrays.dir_tex);
 			GL_Uniform4fFunc (0, stabilized_x, stabilized_y, density, weight);
 			GL_Uniform4fFunc (1, decay, exposure, max_radius, (float)samples);
+			GL_UniformMatrix4fvFunc (2, 1, GL_FALSE, inv_viewproj);
+			GL_UniformMatrix4fvFunc (6, 1, GL_FALSE, r_matviewproj);
+			GL_Uniform3fFunc (10, light_dir[0], light_dir[1], light_dir[2]);
+			GL_Uniform3fFunc (11, emitter_normal[0], emitter_normal[1], emitter_normal[2]);
 			glDrawArrays (GL_TRIANGLES, 0, 3);
 			GL_EndGroup ();
 			first_pass = false;
@@ -1766,9 +1781,14 @@ static GLuint GL_GenerateGodraysTexture (GLuint *out_mask)
 			GL_UseProgram (glprogs.godrays);
 			GL_SetState ((first_pass ? GLS_BLEND_OPAQUE : GLS_BLEND_ADD) | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
 			GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, framebufs.godrays.mask_tex);
-			GL_BindNative (GL_TEXTURE1, GL_TEXTURE_2D, framebufs.godrays.dir_tex);
+			GL_BindNative (GL_TEXTURE1, GL_TEXTURE_2D, depth_tex);
+			GL_BindNative (GL_TEXTURE2, GL_TEXTURE_2D, framebufs.godrays.dir_tex);
 			GL_Uniform4fFunc (0, stabilized_x, stabilized_y, density, weight);
 			GL_Uniform4fFunc (1, decay, exposure, max_radius, (float)samples);
+			GL_UniformMatrix4fvFunc (2, 1, GL_FALSE, inv_viewproj);
+			GL_UniformMatrix4fvFunc (6, 1, GL_FALSE, r_matviewproj);
+			GL_Uniform3fFunc (10, light_dir[0], light_dir[1], light_dir[2]);
+			GL_Uniform3fFunc (11, emitter_normal[0], emitter_normal[1], emitter_normal[2]);
 			glDrawArrays (GL_TRIANGLES, 0, 3);
 			GL_EndGroup ();
 		}

--- a/Quake/shaders/godrays.frag
+++ b/Quake/shaders/godrays.frag
@@ -1,34 +1,78 @@
 layout(binding=0) uniform sampler2D MaskTexture;
-layout(binding=1) uniform sampler2D DirTexture;
+layout(binding=1) uniform sampler2D DepthTexture;
+layout(binding=2) uniform sampler2D DirTexture;
 
 layout(location=0) uniform vec4 LightParams; // xy: light position, z: density, w: weight
 layout(location=1) uniform vec4 ScatterParams; // x: decay, y: exposure, z: max radius, w: samples
+layout(location=2) uniform mat4 uInvViewProj;
+layout(location=6) uniform mat4 uViewProj;
+layout(location=10) uniform vec3 uLightDirWS;
+layout(location=11) uniform vec3 uEmitterNormalWS;
 
 layout(location=0) out vec4 outColor;
 
+vec3 ReconstructWS(vec2 uv, float depth)
+{
+	vec4 ndc = vec4(uv * 2.0 - 1.0, depth * 2.0 - 1.0, 1.0);
+	vec4 ws = uInvViewProj * ndc;
+	float w = max(abs(ws.w), 1e-6);
+	return ws.xyz / w;
+}
+
+vec3 ProjectOnPlane(vec3 v, vec3 n)
+{
+	return v - n * dot(v, n);
+}
+
+vec2 ProjectUV(vec3 ws)
+{
+	vec4 clip = uViewProj * vec4(ws, 1.0);
+	float w = max(abs(clip.w), 1e-6);
+	vec2 ndc = clip.xy / w;
+	return ndc * 0.5 + 0.5;
+}
+
 void main()
 {
-        vec2 texSize = vec2(textureSize(MaskTexture, 0));
-        vec2 uv = (gl_FragCoord.xy + 0.5) / max(texSize, vec2(1.0));
-        vec2 lightPos = clamp(LightParams.xy, vec2(0.0), vec2(1.0));
+	vec2 texSize = vec2(textureSize(MaskTexture, 0));
+	vec2 uv = (gl_FragCoord.xy + 0.5) / max(texSize, vec2(1.0));
+	vec2 lightPos = clamp(LightParams.xy, vec2(0.0), vec2(1.0));
         float density = max(LightParams.z, 0.0);
         float weight = max(LightParams.w, 0.0);
         float decay = max(ScatterParams.x, 0.0);
-        float exposure = max(ScatterParams.y, 0.0);
-        float maxRadius = max(ScatterParams.z, 0.0);
-        int samples = int(ScatterParams.w + 0.5);
-        samples = clamp(samples, 1, 128);
+	float exposure = max(ScatterParams.y, 0.0);
+	float maxRadius = max(ScatterParams.z, 0.0);
+	int samples = int(ScatterParams.w + 0.5);
+	samples = clamp(samples, 1, 128);
 
-        vec2 dir = texture(DirTexture, uv).rg * 2.0 - 1.0;
-        float l2 = dot(dir, dir);
-        if (l2 < 1e-4)
-                dir = normalize(uv - lightPos);
-        else
-                dir *= inversesqrt(l2);
-        float step_scale = density / float(samples);
-        if (maxRadius > 0.0)
-                step_scale = min(step_scale, maxRadius / float(samples));
-        vec2 step = dir * step_scale;
+	vec3 lightDir = normalize(uLightDirWS);
+	vec3 emitterNormal = normalize(uEmitterNormalWS);
+	vec3 rayWS = ProjectOnPlane(lightDir, emitterNormal);
+	float rayLen2 = dot(rayWS, rayWS);
+	vec2 dir = vec2(0.0);
+	if (rayLen2 > 1e-6)
+	{
+		vec3 posWS = ReconstructWS(uv, texture(DepthTexture, uv).r);
+		vec2 uv2 = ProjectUV(posWS + rayWS * 1.0);
+		dir = uv2 - uv;
+	}
+
+	vec2 fallback = texture(DirTexture, uv).rg * 2.0 - 1.0;
+	float fallbackLen2 = dot(fallback, fallback);
+	if (fallbackLen2 < 1e-4)
+		fallback = uv - lightPos;
+	else
+		fallback *= inversesqrt(fallbackLen2);
+
+	float dirLen2 = dot(dir, dir);
+	if (dirLen2 < 1e-6)
+		dir = fallback;
+	else
+		dir *= inversesqrt(dirLen2);
+	float step_scale = density / float(samples);
+	if (maxRadius > 0.0)
+		step_scale = min(step_scale, maxRadius / float(samples));
+	vec2 step = dir * step_scale;
 
         vec2 coord = uv;
         vec3 accum = vec3(0.0);


### PR DESCRIPTION
### Motivation
- The existing godrays scatter pass used a fullscreen radial / precomputed `DirTexture` which can produce camera-dependent/stable artifacts when the camera moves.  The goal is to derive a stable per-pixel ray in world/view space using depth reprojection and emitter/light world data.  
- Use the reconstructed world position at each pixel and emitter/light geometry to compute a camera-invariant screen-space direction while keeping the current fullscreen scatter pass and falling back to the previous direction texture when needed.

### Description
- Added depth + matrix + light/emitter uniforms to the godrays scatter shader: `DepthTexture`, `uInvViewProj`, `uViewProj`, `uLightDirWS`, and `uEmitterNormalWS`, and implemented `ReconstructWS`, `ProjectOnPlane`, and `ProjectUV` helpers in `Quake/shaders/godrays.frag` to reconstruct world position and project world-space rays back to UV.  
- Compute the world-space ray as the `uLightDirWS` projected onto the `uEmitterNormalWS` plane and convert it into a per-pixel screen UV direction by projecting `posWS` and `posWS + rayWS*eps` into clip/UV space; normalize and use that as the scatter `dir`.  
- Preserve the existing `DirTexture` as a fallback: sample the old direction texture when the world-space method produces degenerate results.  
- Bind the composite depth texture and upload the inverse view-projection matrix, current view-projection, and light/emitter vectors for the scatter shader in `Quake/gl_rmain.c`, using `MatrixInverse4x4` with a safe identity fallback and default emitter normal when needed.  

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69693ee0ed34832e8330669a596ffcc9)