### PR TITLE
Add r_godrayvol sources to Visual Studio project

### DIFF
--- a/Windows/VisualStudio/ironwail.vcxproj
+++ b/Windows/VisualStudio/ironwail.vcxproj
@@ -313,6 +313,7 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
     <ClCompile Include="..\..\Quake\r_brush.c" />
     <ClCompile Include="..\..\Quake\r_dlight_pool.c" />
     <ClCompile Include="..\..\Quake\r_fogvol.c" />
+    <ClCompile Include="..\..\Quake\r_godrayvol.c" />
     <ClCompile Include="..\..\Quake\r_shadow.c" />
     <ClCompile Include="..\..\Quake\r_maptex_export.c" />
     <ClCompile Include="..\..\Quake\r_postfx.c" />
@@ -422,6 +423,7 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
     <ClInclude Include="..\..\Quake\render.h" />
     <ClInclude Include="..\..\Quake\r_dlight_pool.h" />
     <ClInclude Include="..\..\Quake\r_fogvol.h" />
+    <ClInclude Include="..\..\Quake\r_godrayvol.h" />
     <ClInclude Include="..\..\Quake\resource.h" />
     <ClInclude Include="..\..\Quake\sbar.h" />
     <ClInclude Include="..\..\Quake\screen.h" />

--- a/Windows/VisualStudio/ironwail.vcxproj.filters
+++ b/Windows/VisualStudio/ironwail.vcxproj.filters
@@ -183,6 +183,9 @@
     <ClCompile Include="..\..\Quake\r_fogvol.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Quake\r_godrayvol.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\Quake\r_shadow.c">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -441,6 +444,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Quake\r_fogvol.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Quake\r_godrayvol.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Quake\resource.h">


### PR DESCRIPTION
### Motivation
- Windows build was failing with unresolved externals for `R_GodrayVolume_Init`, `R_GodrayVolume_BuildList`, and `R_GodrayVolume_Render` because the godray volume implementation was not included in the Visual Studio project.

### Description
- Add `..\..\Quake\r_godrayvol.c` to `Windows/VisualStudio/ironwail.vcxproj` and `..\..\Quake\r_godrayvol.h` to the project headers, and include both in `Windows/VisualStudio/ironwail.vcxproj.filters` for solution organization.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69696e9db6c0832eac50b464fc030549)