### PR TITLE
Fix godray volume build by including mat_shader.h

### DIFF
--- a/Quake/r_godrayvol.c
+++ b/Quake/r_godrayvol.c
@@ -20,6 +20,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 */
 
 #include "quakedef.h"
+#include "mat_shader.h"
 #include "r_godrayvol.h"
 
 #define MAX_GODRAY_VOLUMES 256


### PR DESCRIPTION
### Motivation
- Resolve Windows build errors in `Quake/r_godrayvol.c` where `shader_material_t`, shader-related symbols and the `r_shaders` cvar were undefined.

### Description
- Add `#include "mat_shader.h"` to `Quake/r_godrayvol.c` to provide shader material type declarations and the `r_shaders` cvar.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969708df9b0832eb42becbbe3209569)