### PR TITLE
Fix godray volume vector negation build warning

### DIFF
--- a/Quake/r_godrayvol.c
+++ b/Quake/r_godrayvol.c
@@ -194,7 +194,7 @@ static qboolean R_GodrayVolume_AddSurface (const qmodel_t *model, const msurface
 	dist = surf->plane->dist;
 	if (surf->flags & SURF_PLANEBACK)
 	{
-		VectorNegate (normal, normal);
+		VectorScale (normal, -1.f, normal);
 		dist = -dist;
 	}
 
@@ -221,7 +221,7 @@ static qboolean R_GodrayVolume_AddSurface (const qmodel_t *model, const msurface
 	if (fabsf (DotProduct (axis_r, normal)) < 0.1f)
 		VectorCopy (normal, axis_r);
 	if (DotProduct (axis_r, normal) < 0.f)
-		VectorNegate (axis_r, axis_r);
+		VectorScale (axis_r, -1.f, axis_r);
 
 	if (fabsf (normal[2]) < 0.95f)
 	{


### PR DESCRIPTION
### Motivation
- Avoid MSVC implicit-declaration warning `C4013` (treated as error `C2220`) caused by calls to `VectorNegate` in `Quake/r_godrayvol.c` by using the existing `VectorScale` function instead.

### Description
- Replace `VectorNegate(normal, normal)` with `VectorScale(normal, -1.f, normal)` and `VectorNegate(axis_r, axis_r)` with `VectorScale(axis_r, -1.f, axis_r)` in `Quake/r_godrayvol.c` to remove undefined-symbol usage.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69697104b2dc832ea380ea5b52c9f876)