### PR TITLE
Add `PerpendicularVector` declaration to mathlib.h

### DIFF
--- a/Quake/mathlib.h
+++ b/Quake/mathlib.h
@@ -97,6 +97,7 @@ float DistanceSquared (const vec3_t a, const vec3_t b);
 float Distance (const vec3_t a, const vec3_t b);
 void VectorInverse (vec3_t v);
 void VectorScale (const vec3_t in, vec_t scale, vec3_t out);
+void PerpendicularVector (vec3_t dst, const vec3_t src);
 int Q_log2(int val);
 int Q_nextPow2(int val);
 
@@ -173,4 +174,3 @@ qboolean RayVsBox (const vec3_t org, const vec3_t rcpdelta, const vec3_t mins, c
 /*==========================================================================*/
 
 #endif	/* __MATHLIB_H */
-


### PR DESCRIPTION
### Motivation
- Add missing declaration of `PerpendicularVector` to `Quake/mathlib.h` to prevent implicit-declaration warnings (MSVC C4013) that are treated as errors during Windows builds.

### Description
- Declare `void PerpendicularVector (vec3_t dst, const vec3_t src);` in `Quake/mathlib.h` so callers in `r_godrayvol.c` have a proper prototype.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969894972cc832ebad0d4b41899e456)