### PR TITLE
Fix filmgrain shader seed/frame usage

### DIFF
--- a/Quake/shaders/filmgrain.frag
+++ b/Quake/shaders/filmgrain.frag
@@ -79,6 +79,8 @@ void main()
 	float grainDebug = FilmGrainParams1.z;
 	if (grainAmount > 0.0 || grainDebug > 0.5)
 	{
+		float seed = FilmGrainParams1.w;
+		float frame = FilmGrainParams2.x;
 		float grainSize = max(FilmGrainParams0.y, 0.01);
 		// Subtle size wobble for analog feel (keep tiny to avoid shimmer)
 		grainSize *= mix(0.97, 1.03, U01(Hash32(floatBitsToUint(seed) ^ uint(frame) * 0x51ed2705u)));
@@ -86,8 +88,6 @@ void main()
 		float lumaWeight = clamp(FilmGrainParams0.w, 0.0, 1.0);
 		float blend = clamp(FilmGrainParams1.x, 0.0, 1.0);
 		float colored = clamp(FilmGrainParams1.y, 0.0, 1.0);
-		float seed = FilmGrainParams1.w;
-		float frame = FilmGrainParams2.x;
 		float time = frame * grainSpeed;
 		uvec2 pix = uvec2(pixel);
 		uint jseed = floatBitsToUint(seed) ^ uint(frame) * 0x9e3779b9u;


### PR DESCRIPTION
### Motivation
- GLSL compilation failed with undefined `seed` and `frame` variables in the film grain fragment shader, causing OpenGL initialization errors on startup.

### Description
- Initialize `seed` and `frame` earlier in `Quake/shaders/filmgrain.frag` (use `FilmGrainParams1.w` and `FilmGrainParams2.x`) so they are defined before being referenced in the grain size wobble and subsequent calculations.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d403eb85c832e984a0b4a137108f2)