### PR TITLE
Enforce MTU budgeting on outgoing UDP packets (prevent oversized sends)

### DIFF
--- a/Quake/net.h
+++ b/Quake/net.h
@@ -124,5 +124,6 @@ extern	char		my_ipx_address[NET_NAMELEN];
 extern	char		my_tcpip_address[NET_NAMELEN];
 
 extern cvar_t		net_maxpacket;
+extern cvar_t		net_mtu;
 
 #endif	/* _QUAKE_NET_H */

--- a/Quake/net_defs.h
+++ b/Quake/net_defs.h
@@ -36,6 +36,7 @@ struct qsockaddr
 };
 
 #define NET_HEADERSIZE		(2 * sizeof(unsigned int))
+#define NET_UDPIP_HEADER_BYTES	28
 #define NET_DATAGRAMSIZE	(MAX_DATAGRAM + NET_HEADERSIZE)
 
 // NetHeader flags
@@ -147,6 +148,7 @@ typedef struct qsocket_s
 	unsigned int	sendSequence;
 	unsigned int	unreliableSendSequence;
 	int		sendMessageLength;
+	int		sendMessageSize;
 	byte		sendMessage [NET_MAXMESSAGE];
 
 	unsigned int	receiveSequence;
@@ -257,4 +259,3 @@ typedef struct _PollProcedure
 void SchedulePollProcedure(PollProcedure *pp, double timeOffset);
 
 #endif	/* __NET_DEFS_H */
-

--- a/Quake/net_dgrm.c
+++ b/Quake/net_dgrm.c
@@ -55,6 +55,53 @@ static int myDriverLevel;
 extern qboolean m_return_onerror;
 extern char m_return_reason[32];
 
+static int NET_GetConfiguredMTU (const qsocket_t *sock)
+{
+	(void)sock;
+	if (sv.active)
+		return (int)sv_mtu.value;
+	return (int)net_mtu.value;
+}
+
+static int NET_GetPacketPayloadLimit (const qsocket_t *sock)
+{
+	int mtu = NET_GetConfiguredMTU (sock);
+	int payload;
+
+	if (mtu <= 0)
+		return NET_DATAGRAMSIZE;
+	payload = mtu - NET_UDPIP_HEADER_BYTES;
+	if (payload < NET_HEADERSIZE + 1)
+		payload = NET_HEADERSIZE + 1;
+	return q_min (payload, NET_DATAGRAMSIZE);
+}
+
+static int NET_GetPacketDataLimit (const qsocket_t *sock)
+{
+	int payload = NET_GetPacketPayloadLimit (sock);
+	int data_limit = payload - NET_HEADERSIZE;
+
+	if (data_limit < 1)
+		data_limit = 1;
+	return q_min (data_limit, MAX_DATAGRAM);
+}
+
+static void NET_LogOversizedSend (const qsocket_t *sock, unsigned int packet_len)
+{
+	static double next_log_time = 0.0;
+
+	if (!sv.active || sv_mtu_debug.value <= 0)
+		return;
+	if (net_time < next_log_time)
+		return;
+
+	Con_Printf ("sv_mtu %d oversize send blocked (%s size %u)\n",
+		(int)sv_mtu.value,
+		NET_QSocketGetAddressString (sock),
+		packet_len);
+	next_log_time = net_time + 1.0;
+}
+
 
 static char *StrAddr (struct qsockaddr *addr)
 {
@@ -134,6 +181,8 @@ int Datagram_SendMessage (qsocket_t *sock, sizebuf_t *data)
 	unsigned int	packetLen;
 	unsigned int	dataLen;
 	unsigned int	eom;
+	unsigned int	payload_limit = (unsigned int)NET_GetPacketPayloadLimit (sock);
+	unsigned int	max_data = (unsigned int)NET_GetPacketDataLimit (sock);
 
 #ifdef DEBUG
 	if (data->cursize == 0)
@@ -149,23 +198,30 @@ int Datagram_SendMessage (qsocket_t *sock, sizebuf_t *data)
 	Q_memcpy(sock->sendMessage, data->data, data->cursize);
 	sock->sendMessageLength = data->cursize;
 
-	if (data->cursize <= MAX_DATAGRAM)
+	if (data->cursize <= (int)max_data)
 	{
 		dataLen = data->cursize;
 		eom = NETFLAG_EOM;
 	}
 	else
 	{
-		dataLen = MAX_DATAGRAM;
+		dataLen = max_data;
 		eom = 0;
 	}
 	packetLen = NET_HEADERSIZE + dataLen;
+
+	if (packetLen > payload_limit)
+	{
+		NET_LogOversizedSend (sock, packetLen);
+		return -1;
+	}
 
 	packetBuffer.length = BigLong(packetLen | (NETFLAG_DATA | eom));
 	packetBuffer.sequence = BigLong(sock->sendSequence++);
 	Q_memcpy (packetBuffer.data, sock->sendMessage, dataLen);
 
 	sock->canSend = false;
+	sock->sendMessageSize = (int)dataLen;
 
 	if (sfunc.Write (sock->socket, (byte *)&packetBuffer, packetLen, &sock->addr) == -1)
 		return -1;
@@ -181,24 +237,33 @@ static int SendMessageNext (qsocket_t *sock)
 	unsigned int	packetLen;
 	unsigned int	dataLen;
 	unsigned int	eom;
+	unsigned int	payload_limit = (unsigned int)NET_GetPacketPayloadLimit (sock);
+	unsigned int	max_data = (unsigned int)NET_GetPacketDataLimit (sock);
 
-	if (sock->sendMessageLength <= MAX_DATAGRAM)
+	if (sock->sendMessageLength <= (int)max_data)
 	{
 		dataLen = sock->sendMessageLength;
 		eom = NETFLAG_EOM;
 	}
 	else
 	{
-		dataLen = MAX_DATAGRAM;
+		dataLen = max_data;
 		eom = 0;
 	}
 	packetLen = NET_HEADERSIZE + dataLen;
+
+	if (packetLen > payload_limit)
+	{
+		NET_LogOversizedSend (sock, packetLen);
+		return -1;
+	}
 
 	packetBuffer.length = BigLong(packetLen | (NETFLAG_DATA | eom));
 	packetBuffer.sequence = BigLong(sock->sendSequence++);
 	Q_memcpy (packetBuffer.data, sock->sendMessage, dataLen);
 
 	sock->sendNext = false;
+	sock->sendMessageSize = (int)dataLen;
 
 	if (sfunc.Write (sock->socket, (byte *)&packetBuffer, packetLen, &sock->addr) == -1)
 		return -1;
@@ -214,24 +279,33 @@ static int ReSendMessage (qsocket_t *sock)
 	unsigned int	packetLen;
 	unsigned int	dataLen;
 	unsigned int	eom;
+	unsigned int	payload_limit = (unsigned int)NET_GetPacketPayloadLimit (sock);
+	unsigned int	max_data = (unsigned int)NET_GetPacketDataLimit (sock);
 
-	if (sock->sendMessageLength <= MAX_DATAGRAM)
+	if (sock->sendMessageLength <= (int)max_data)
 	{
 		dataLen = sock->sendMessageLength;
 		eom = NETFLAG_EOM;
 	}
 	else
 	{
-		dataLen = MAX_DATAGRAM;
+		dataLen = max_data;
 		eom = 0;
 	}
 	packetLen = NET_HEADERSIZE + dataLen;
+
+	if (packetLen > payload_limit)
+	{
+		NET_LogOversizedSend (sock, packetLen);
+		return -1;
+	}
 
 	packetBuffer.length = BigLong(packetLen | (NETFLAG_DATA | eom));
 	packetBuffer.sequence = BigLong(sock->sendSequence - 1);
 	Q_memcpy (packetBuffer.data, sock->sendMessage, dataLen);
 
 	sock->sendNext = false;
+	sock->sendMessageSize = (int)dataLen;
 
 	if (sfunc.Write (sock->socket, (byte *)&packetBuffer, packetLen, &sock->addr) == -1)
 		return -1;
@@ -260,6 +334,8 @@ qboolean Datagram_CanSendUnreliableMessage (qsocket_t *sock)
 int Datagram_SendUnreliableMessage (qsocket_t *sock, sizebuf_t *data)
 {
 	int	packetLen;
+	int	payload_limit = NET_GetPacketPayloadLimit (sock);
+	int	max_data = NET_GetPacketDataLimit (sock);
 
 #ifdef DEBUG
 	if (data->cursize == 0)
@@ -269,7 +345,18 @@ int Datagram_SendUnreliableMessage (qsocket_t *sock, sizebuf_t *data)
 		Sys_Error("Datagram_SendUnreliableMessage: message too big: %u", data->cursize);
 #endif
 
+	if (data->cursize > max_data)
+	{
+		NET_LogOversizedSend (sock, (unsigned int)(NET_HEADERSIZE + data->cursize));
+		return 0;
+	}
+
 	packetLen = NET_HEADERSIZE + data->cursize;
+	if (packetLen > payload_limit)
+	{
+		NET_LogOversizedSend (sock, (unsigned int)packetLen);
+		return 0;
+	}
 
 	packetBuffer.length = BigLong(packetLen | NETFLAG_UNRELIABLE);
 	packetBuffer.sequence = BigLong(sock->unreliableSendSequence++);
@@ -421,16 +508,20 @@ int	Datagram_GetMessage (qsocket_t *sock)
 				Con_DPrintf("Duplicate ACK received\n");
 				continue;
 			}
-			sock->sendMessageLength -= MAX_DATAGRAM;
-			if (sock->sendMessageLength > 0)
 			{
-				memmove (sock->sendMessage, sock->sendMessage + MAX_DATAGRAM, sock->sendMessageLength);
-				sock->sendNext = true;
-			}
-			else
-			{
-				sock->sendMessageLength = 0;
-				sock->canSend = true;
+				int chunk = sock->sendMessageSize > 0 ? sock->sendMessageSize : MAX_DATAGRAM;
+				sock->sendMessageLength -= chunk;
+				if (sock->sendMessageLength > 0)
+				{
+					memmove (sock->sendMessage, sock->sendMessage + chunk, sock->sendMessageLength);
+					sock->sendNext = true;
+				}
+				else
+				{
+					sock->sendMessageLength = 0;
+					sock->canSend = true;
+				}
+				sock->sendMessageSize = 0;
 			}
 			continue;
 		}

--- a/Quake/net_main.c
+++ b/Quake/net_main.c
@@ -67,6 +67,7 @@ int		unreliableMessagesReceived	= 0;
 static	cvar_t	net_messagetimeout = {"net_messagetimeout","300",CVAR_NONE};
 cvar_t	hostname = {"hostname", "UNNAMED", CVAR_NONE};
 cvar_t	net_maxpacket = {"net_maxpacket", "1400", CVAR_NONE};
+cvar_t	net_mtu = {"net_mtu", "1400", CVAR_NONE};
 
 // these two macros are to make the code more readable
 #define sfunc	net_drivers[sock->driver]
@@ -123,6 +124,7 @@ qsocket_t *NET_NewQSocket (void)
 	sock->sendSequence = 0;
 	sock->unreliableSendSequence = 0;
 	sock->sendMessageLength = 0;
+	sock->sendMessageSize = 0;
 	sock->receiveSequence = 0;
 	sock->unreliableReceiveSequence = 0;
 	sock->receiveMessageLength = 0;
@@ -820,6 +822,7 @@ void NET_Init (void)
 	Cvar_RegisterVariable (&net_messagetimeout);
 	Cvar_RegisterVariable (&hostname);
 	Cvar_RegisterVariable (&net_maxpacket);
+	Cvar_RegisterVariable (&net_mtu);
 
 	Cmd_AddCommand ("slist", NET_Slist_f);
 	Cmd_AddCommand ("listen", NET_Listen_f);

--- a/Quake/server.h
+++ b/Quake/server.h
@@ -34,6 +34,9 @@ typedef struct
 	qboolean	changelevel_issued;	// cleared when at SV_SpawnServer
 } server_static_t;
 
+extern cvar_t sv_mtu;
+extern cvar_t sv_mtu_debug;
+
 //=============================================================================
 
 #define MAX_SIGNON_BUFFERS 256

--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -23,6 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // sv_main.c -- server main program
 
 #include "quakedef.h"
+#include "net_defs.h"
 
 server_t	sv;
 server_static_t	svs;
@@ -45,9 +46,9 @@ static cvar_t sv_snap_full_interval = {"sv_snap_full_interval", "2.0", CVAR_NONE
 static cvar_t sv_snap_force_full_after_frames = {"sv_snap_force_full_after_frames", "3", CVAR_NONE};
 static cvar_t sv_snap_max_payload = {"sv_snap_max_payload", "1200", CVAR_NONE};
 static cvar_t sv_event_max = {"sv_event_max", "0", CVAR_NONE};
-static cvar_t sv_mtu = {"sv_mtu", "1200", CVAR_NONE};
-static cvar_t sv_mtu_cap = {"sv_mtu_cap", "1200", CVAR_NONE};
-static cvar_t sv_mtu_debug = {"sv_mtu_debug", "0", CVAR_NONE};
+cvar_t sv_mtu = {"sv_mtu", "1400", CVAR_NONE};
+static cvar_t sv_mtu_cap = {"sv_mtu_cap", "1400", CVAR_NONE};
+cvar_t sv_mtu_debug = {"sv_mtu_debug", "0", CVAR_NONE};
 static cvar_t sv_signon_chunks = {"sv_signon_chunks", "1", CVAR_NONE};
 static cvar_t sv_signon_chunk_debug = {"sv_signon_chunk_debug", "0", CVAR_NONE};
 static cvar_t sv_signon_chunk_window = {"sv_signon_chunk_window", "3", CVAR_NONE};
@@ -547,9 +548,17 @@ static int SV_MTUCap (client_t *client)
 	if (client && SV_IsLocalClient (client))
 		return 0;
 	int cap = (int)sv_mtu_cap.value;
+	int payload;
+
 	if (cap <= 0)
 		cap = (int)sv_mtu.value;
-	return cap;
+	if (cap <= 0)
+		return 0;
+
+	payload = cap - NET_UDPIP_HEADER_BYTES - NET_HEADERSIZE;
+	if (payload < 1)
+		payload = 1;
+	return payload;
 }
 
 /*
@@ -3312,10 +3321,6 @@ qboolean SV_SendClientDatagram (client_t *client)
 	msg.dbg_aux = 0;
 	msg.bitpos = 0;
 
-	//johnfitz -- if client is nonlocal, use smaller max size so packets aren't fragmented
-	if (Q_strcmp(NET_QSocketGetAddressString(client->netconnection), "LOCAL") != 0)
-		msg.maxsize = DATAGRAM_MTU;
-	//johnfitz
 	mtu_cap = SV_MTUCap (client);
 	if (mtu_cap > 0)
 		msg.maxsize = q_min (msg.maxsize, mtu_cap);
@@ -3352,8 +3357,17 @@ qboolean SV_SendClientDatagram (client_t *client)
 
 	if (sv_mtu_debug.value > 0 && realtime >= client->mtu_debug_next_time)
 	{
-		Con_Printf ("mtu %s bytes %d dropped tier1 %d tier2 %d\n",
-			client->name, msg.cursize, client->mtu_dropped_tier1, client->mtu_dropped_tier2);
+		int packet_bytes = msg.cursize + NET_HEADERSIZE + NET_UDPIP_HEADER_BYTES;
+		Con_Printf ("mtu %s sv_mtu %d packet %d reliable %d snapshot %d dropped tier1 %d tier2 %d\n",
+			client->name,
+			(int)sv_mtu.value,
+			packet_bytes,
+			client->message.cursize,
+			client->mtu_last_snapshot_size,
+			client->mtu_dropped_tier1,
+			client->mtu_dropped_tier2);
+		if (mtu_cap > 0 && sv_mtu.value > 0)
+			SDL_assert (packet_bytes <= (int)sv_mtu.value);
 		client->mtu_debug_next_time = realtime + 1.0;
 	}
 


### PR DESCRIPTION
### Motivation
- Clients were dropping oversized UDP datagrams ("NET_GetMessage: OVERSIZED PACKET"), causing connect failures; the server must never emit UDP packets larger than the configured MTU. 
- The goal is a single MTU budget applied at final send time and to force proper chunking/continuation (snapshot2/signon chunks) instead of truncating or sending oversized packets. 

### Description
- Add a configurable client-side `net_mtu` and server `sv_mtu` defaults set to `1400`, and expose `sv_mtu`/`sv_mtu_debug` via `server.h`. 
- Introduce `NET_UDPIP_HEADER_BYTES` in `net_defs.h` and central helpers in `Quake/net_dgrm.c`: `NET_GetConfiguredMTU`, `NET_GetPacketPayloadLimit`, `NET_GetPacketDataLimit`, and `NET_LogOversizedSend` to compute and enforce per-packet payload budgets (accounting for UDP/IP + internal headers). 
- Enforce the MTU budget at send points by changing `Datagram_SendMessage`, `SendMessageNext`, `ReSendMessage`, and `Datagram_SendUnreliableMessage` to cap data to `NET_GetPacketDataLimit`, block/log any attempt to send packets that would exceed the payload limit, and track `sock->sendMessageSize` for correct ACK/fragment bookkeeping. 
- Make server snapshot/signon paths use the computed budget: change `SV_MTUCap` (server) to return payload budget derived from `sv_mtu` minus header overhead and replace prior DATAGRAM_MTU heuristics; add richer `sv_mtu_debug` output (prints `sv_mtu`, built packet bytes, reliable bytes, snapshot bytes and `SDL_assert` to validate no send exceeds `sv_mtu` when enabled). 
- Minimal, rate-limited debug logging added via `NET_LogOversizedSend` and enhanced `sv_mtu_debug` messages to prove outgoing packets respect `sv_mtu` without altering protocol semantics (uses existing snapshot2 continuation and signon chunking already present). 
- Modified files: `Quake/net_defs.h`, `Quake/net.h`, `Quake/net_main.c`, `Quake/net_dgrm.c`, `Quake/server.h`, `Quake/sv_main.c` (see diffs for exact edits). 

### Testing
- No automated tests were executed as part of this change; manual runtime verification is intended (enable `sv_mtu_debug` to assert and log packet sizes and confirm clients no longer report "OVERSIZED PACKET").

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d69414f2c832e872dbdfb34bf5bc5)