### PR TITLE
Fix snapshot stage forward declaration and include order for net headers

### DIFF
--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -1364,6 +1364,8 @@ static void CL_ReadSnapshotDeltaFields (snapshot_state_t *state, unsigned int ma
 		state->step = (byte)MSG_ReadByte ();
 }
 
+static void CL_ClearSnapshotStage (void);
+
 static void CL_ClearSnapshotEntity (int entnum)
 {
 	entity_t *ent;

--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -23,6 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // sv_main.c -- server main program
 
 #include "quakedef.h"
+#include "net_sys.h"
 #include "net_defs.h"
 
 server_t	sv;


### PR DESCRIPTION
### Motivation

- Resolve compiler errors caused by an implicit declaration of `CL_ClearSnapshotStage` when parsing snapshots in `cl_parse.c`.
- Ensure `sys_socket_t` and other network types are defined by including `net_sys.h` before `net_defs.h` in `sv_main.c` to avoid syntax/type errors.

### Description

- Added a forward declaration `static void CL_ClearSnapshotStage (void);` in `Quake/cl_parse.c` before functions that reference it.
- Kept the actual `CL_ClearSnapshotStage` definition in `Quake/cl_parse.c` where it clears `snapshot_stage_present` and `snapshot_stage_remove` arrays.
- Inserted `#include "net_sys.h"` before `#include "net_defs.h"` in `Quake/sv_main.c` so `net_defs.h` has the required network type definitions available.

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d72250228832e9f2a687b7864ee2d)