### PR TITLE
Include arch_def.h before net_sys.h in sv_main to fix build

### DIFF
--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -23,6 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // sv_main.c -- server main program
 
 #include "quakedef.h"
+#include "arch_def.h"
 #include "net_sys.h"
 #include "net_defs.h"
 


### PR DESCRIPTION
### Motivation
- Ensure platform macros and typedefs like `sys_socket_t` are available before including `net_sys.h`/`net_defs.h`, fixing compiler syntax errors when building the server.

### Description
- Add `#include "arch_def.h"` before `#include "net_sys.h"` in `Quake/sv_main.c`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d7739cff0832eb530931b0f794b0f)