### PR TITLE
Fix black lift strength falloff

### DIFF
--- a/Quake/shaders/postprocess.frag
+++ b/Quake/shaders/postprocess.frag
@@ -783,8 +783,9 @@ void main()
                 float blackLiftStrength = max(TonemapBlackLiftParams.y, 0.0);
                 if (blackLift > 0.0 && blackLiftStrength > 0.0)
                 {
+                        float liftFalloff = max(blackLiftStrength, 1e-4);
                         mapped = mix(mapped, vec3(blackLift),
-                                exp(-mapped * blackLiftStrength));
+                                exp(-mapped / liftFalloff));
                         mapped = clamp(mapped, 0.0, 1.0);
                 }
         }


### PR DESCRIPTION
### Motivation
- Correct the black lift blending math so the falloff scales with the configured strength and avoid divide-by-zero when strength is zero.

### Description
- In `Quake/shaders/postprocess.frag` replace `exp(-mapped * blackLiftStrength)` with `exp(-mapped / liftFalloff)` and add `float liftFalloff = max(blackLiftStrength, 1e-4);` to clamp the divisor.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e6fc6fad4832eb70e6d52f682f8d5)