### PR TITLE
Enforce sv_mtu in snapshot MTU budgeting and add continuation / oversize guards

### DIFF
--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -550,10 +550,13 @@ static int SV_MTUCap (client_t *client)
 {
 	(void)client;
 	int cap = (int)sv_mtu_cap.value;
+	int mtu = (int)sv_mtu.value;
 	int payload;
 
 	if (cap <= 0)
-		cap = (int)sv_mtu.value;
+		cap = mtu;
+	else if (mtu > 0)
+		cap = q_min (cap, mtu);
 	if (cap <= 0)
 		return 0;
 
@@ -1478,9 +1481,11 @@ static void SV_FillSnapshotState (edict_t *ent, snapshot_state_t *out)
 }
 
 static int SV_BuildClientSnapshot (edict_t *clent, snapshot_state_t *states, byte *present,
-	byte *relevant, byte *snapflags, int budget_bytes, int header_bytes, const byte *baseline_present,
+	byte *relevant, byte *snapflags, int budget_bytes, int optional_budget_bytes, int header_bytes,
+	const byte *baseline_present,
 	int *out_mandatory, int *out_mandatory_bytes, int *out_total_bytes, int *out_dropped,
-	int *out_dropped_tier1, int *out_dropped_tier2, qboolean debug_frame)
+	int *out_dropped_tier1, int *out_dropped_tier2, qboolean debug_frame,
+	qboolean *out_continuation, qboolean *out_mandatory_oversize)
 {
 	int	num, j, numents, count;
 	int mandatory_count = 0;
@@ -1490,10 +1495,19 @@ static int SV_BuildClientSnapshot (edict_t *clent, snapshot_state_t *states, byt
 	int dropped_tier1 = 0;
 	int dropped_tier2 = 0;
 	int entity_budget = budget_bytes - header_bytes;
+	int optional_entity_budget = optional_budget_bytes - header_bytes;
+	int remaining_budget;
+	qboolean continuation = false;
 	edict_t	*ent;
 
 	if (entity_budget < 0)
 		entity_budget = 0;
+	if (optional_entity_budget < 0)
+		optional_entity_budget = 0;
+	remaining_budget = entity_budget;
+
+	if (out_mandatory_oversize)
+		*out_mandatory_oversize = false;
 
 	memset (present, 0, qcvm->max_edicts * sizeof(byte));
 	if (relevant)
@@ -1542,6 +1556,20 @@ static int SV_BuildClientSnapshot (edict_t *clent, snapshot_state_t *states, byt
 				(snapflags[num] & SNAPFLAG_HIRES_ANGLES) != 0);
 	}
 
+	remaining_budget = entity_budget - mandatory_bytes;
+	if (remaining_budget < 0)
+	{
+		if (out_mandatory_oversize)
+			*out_mandatory_oversize = true;
+		remaining_budget = 0;
+	}
+	if (optional_entity_budget - mandatory_bytes < remaining_budget)
+	{
+		remaining_budget = optional_entity_budget - mandatory_bytes;
+		if (remaining_budget < 0)
+			remaining_budget = 0;
+	}
+
 	for (j=0 ; j<numents ; j++)
 	{
 		num = net_edicts_sorted[j];
@@ -1550,6 +1578,12 @@ static int SV_BuildClientSnapshot (edict_t *clent, snapshot_state_t *states, byt
 		if (present[num] || !SV_SnapshotTier1Ent (ent))
 			continue;
 
+		if (remaining_budget <= 0)
+		{
+			continuation = true;
+			break;
+		}
+
 		SV_FillSnapshotState (ent, &states[num]);
 
 		if (states[num].state.alpha == ENTALPHA_ZERO && !((int)ent->v.effects & qcvm->effects_mask))
@@ -1558,58 +1592,63 @@ static int SV_BuildClientSnapshot (edict_t *clent, snapshot_state_t *states, byt
 		{
 			byte snapflag = snapflags ? SV_SnapshotFlagsForEnt (ent) : 0;
 			int ent_size = SV_SnapshotEntityBudgetBytes (snapflag);
-			if (total_bytes + ent_size > entity_budget)
+			if (ent_size > remaining_budget)
 			{
-				dropped_count++;
-				dropped_tier1++;
-				if (debug_frame && net_snap_debug.value)
-					Con_DPrintf ("snapdbg %s ent %d dropped budget\n", PR_GetString (clent->v.netname), num);
-				continue;
+				continuation = true;
+				break;
 			}
 			present[num] = 1;
 			if (snapflags)
 				snapflags[num] = snapflag;
 			total_bytes += ent_size;
+			remaining_budget -= ent_size;
 		}
 		count++;
 	}
 
-	for (j=0 ; j<numents ; j++)
+	if (!continuation)
 	{
-		num = net_edicts_sorted[j];
-		ent = EDICT_NUM (num);
-
-		if (present[num])
-			continue;
-
-		SV_FillSnapshotState (ent, &states[num]);
-
-		if (states[num].state.alpha == ENTALPHA_ZERO && !((int)ent->v.effects & qcvm->effects_mask))
-			continue;
-
+		for (j=0 ; j<numents ; j++)
 		{
-			byte snapflag = snapflags ? SV_SnapshotFlagsForEnt (ent) : 0;
-			int ent_size = SV_SnapshotEntityBudgetBytes (snapflag);
-			if (total_bytes + ent_size > entity_budget)
-			{
-				dropped_count++;
-				dropped_tier2++;
-				if (debug_frame && net_snap_debug.value)
-					Con_DPrintf ("snapdbg %s ent %d dropped budget\n", PR_GetString (clent->v.netname), num);
-				continue;
-			}
-			present[num] = 1;
-			if (snapflags)
-				snapflags[num] = snapflag;
-			total_bytes += ent_size;
-		}
-		count++;
+			num = net_edicts_sorted[j];
+			ent = EDICT_NUM (num);
 
-		if (debug_frame && net_snap_debug.value)
-			Con_DPrintf ("snapdbg %s ent %d included hires_o %d hires_a %d\n",
-				PR_GetString (clent->v.netname), num,
-				(snapflags[num] & SNAPFLAG_HIRES_ORIGIN) != 0,
-				(snapflags[num] & SNAPFLAG_HIRES_ANGLES) != 0);
+			if (present[num])
+				continue;
+
+			if (remaining_budget <= 0)
+			{
+				continuation = true;
+				break;
+			}
+
+			SV_FillSnapshotState (ent, &states[num]);
+
+			if (states[num].state.alpha == ENTALPHA_ZERO && !((int)ent->v.effects & qcvm->effects_mask))
+				continue;
+
+			{
+				byte snapflag = snapflags ? SV_SnapshotFlagsForEnt (ent) : 0;
+				int ent_size = SV_SnapshotEntityBudgetBytes (snapflag);
+				if (ent_size > remaining_budget)
+				{
+					continuation = true;
+					break;
+				}
+				present[num] = 1;
+				if (snapflags)
+					snapflags[num] = snapflag;
+				total_bytes += ent_size;
+				remaining_budget -= ent_size;
+			}
+			count++;
+
+			if (debug_frame && net_snap_debug.value)
+				Con_DPrintf ("snapdbg %s ent %d included hires_o %d hires_a %d\n",
+					PR_GetString (clent->v.netname), num,
+					(snapflags[num] & SNAPFLAG_HIRES_ORIGIN) != 0,
+					(snapflags[num] & SNAPFLAG_HIRES_ANGLES) != 0);
+		}
 	}
 
 	if (out_mandatory)
@@ -1624,6 +1663,8 @@ static int SV_BuildClientSnapshot (edict_t *clent, snapshot_state_t *states, byt
 		*out_dropped_tier1 = dropped_tier1;
 	if (out_dropped_tier2)
 		*out_dropped_tier2 = dropped_tier2;
+	if (out_continuation)
+		*out_continuation = continuation;
 
 	return count;
 }
@@ -2345,7 +2386,6 @@ static void SV_SendSnapshot (client_t *client, sizebuf_t *msg)
 	{
 		int mandatory_count = 0;
 		int mandatory_bytes = 0;
-		int total_bytes = 0;
 		int dropped_count = 0;
 		int dropped_tier1 = 0;
 		int dropped_tier2 = 0;
@@ -2356,10 +2396,9 @@ static void SV_SendSnapshot (client_t *client, sizebuf_t *msg)
 		int snapshot_budget_bytes = SV_SnapshotBudgetBytes (client, msg,
 			&mtu_payload_bytes, &current_bytes, &remaining_bytes, &header_bytes);
 		int mandatory_total_bytes = 0;
-		const int tier0_slack_bytes = 8;
+		qboolean budget_continuation = false;
+		qboolean mandatory_oversize = false;
 		qboolean debug_frame = false;
-		qboolean tier0_only = false;
-		const char *tier0_reason = NULL;
 
 		if (net_snap_debug.value && realtime >= client->snapshot_debug_next_time)
 		{
@@ -2368,39 +2407,37 @@ static void SV_SendSnapshot (client_t *client, sizebuf_t *msg)
 		}
 
 		SV_BuildClientSnapshot (client->edict, client->snapshot_pending, client->snapshot_pending_present,
-			client->snapshot_pending_relevant, client->snapshot_pending_flags, snapshot_budget_bytes, header_bytes,
-			client->snapshot_baseline_present, &mandatory_count, &mandatory_bytes, &total_bytes, &dropped_count,
-			&dropped_tier1, &dropped_tier2, debug_frame);
+			client->snapshot_pending_relevant, client->snapshot_pending_flags, remaining_bytes, snapshot_budget_bytes,
+			header_bytes, client->snapshot_baseline_present, &mandatory_count, &mandatory_bytes, NULL,
+			&dropped_count, &dropped_tier1, &dropped_tier2, debug_frame, &budget_continuation,
+			&mandatory_oversize);
 		mandatory_total_bytes = header_bytes + mandatory_bytes;
-		if (remaining_bytes <= mandatory_total_bytes + tier0_slack_bytes)
+		if (mtu_payload_bytes > 0 && current_bytes + mandatory_total_bytes > mtu_payload_bytes)
 		{
-			tier0_only = true;
-			tier0_reason = "mandatory_bytes";
+			client->snapshot_pending_incomplete = true;
+			client->snapshot_pending_mandatory = mandatory_count;
+			client->snapshot_pending_dropped = 0;
+			client->mtu_dropped_tier1 = 0;
+			client->mtu_dropped_tier2 = 0;
+			return;
+		}
+		if (mandatory_oversize)
+		{
+			client->snapshot_pending_incomplete = true;
+			client->snapshot_pending_mandatory = mandatory_count;
+			client->snapshot_pending_dropped = 0;
+			client->mtu_dropped_tier1 = 0;
+			client->mtu_dropped_tier2 = 0;
+			return;
 		}
 		client->snapshot_pending_mandatory = mandatory_count;
 		client->snapshot_pending_dropped = dropped_count;
 		client->mtu_dropped_tier1 = dropped_tier1;
 		client->mtu_dropped_tier2 = dropped_tier2;
-		if (client->snapshot_pending_dropped > 0)
+		if (budget_continuation && sv_snapshot2.value)
+			extra_flags |= SNAPSHOT_FLAG_CONTINUE;
+		if (client->snapshot_pending_dropped > 0 || budget_continuation)
 			extra_flags |= SNAPSHOT_FLAG_INCOMPLETE;
-		if (sv_mtu_debug.value > 0 && (tier0_only || dropped_tier1 > 0 || dropped_tier2 > 0))
-		{
-			const char *reason = tier0_reason ? tier0_reason : "budget_drop";
-			if (tier0_only)
-				Con_Printf ("mtu %s forcing tier0 only (mtu_payload %d current %d remaining %d budget %d header %d mandatory %d reason %s)\n",
-					client->name, mtu_payload_bytes, current_bytes, remaining_bytes, snapshot_budget_bytes,
-					header_bytes, mandatory_total_bytes, reason);
-			else
-				Con_Printf ("mtu %s budget drop (mtu_payload %d current %d remaining %d budget %d header %d mandatory %d reason %s)\n",
-					client->name, mtu_payload_bytes, current_bytes, remaining_bytes, snapshot_budget_bytes,
-					header_bytes, mandatory_total_bytes, reason);
-		}
-		if (tier0_only || dropped_tier1 > 0 || dropped_tier2 > 0)
-			NET_DebugLogEvent (true,
-				"NETDBG time %.3f snap_budget %s mtu_payload %d current %d remaining %d budget %d header %d mandatory %d total %d drop1 %d drop2 %d reason %s\n",
-				realtime, client->name, mtu_payload_bytes, current_bytes, remaining_bytes,
-				snapshot_budget_bytes, header_bytes, mandatory_total_bytes, total_bytes,
-				dropped_tier1, dropped_tier2, tier0_reason ? tier0_reason : "budget_drop");
 		client->snapshot_pending_seq = client->snapshot_next_seq++;
 		if (!client->snapshot_next_seq)
 			client->snapshot_next_seq = 1;
@@ -2481,6 +2518,8 @@ static void SV_SendSnapshot (client_t *client, sizebuf_t *msg)
 
 	client->mtu_last_snapshot_size = msg->cursize - start_size;
 	continuation = msg->write_locked && client->entstream.active;
+	if (extra_flags & SNAPSHOT_FLAG_CONTINUE)
+		continuation = true;
 
 	if (forced_full)
 		client->snapshot_stats_forced_full++;
@@ -2573,6 +2612,8 @@ static void SV_SendSnapshot (client_t *client, sizebuf_t *msg)
 			const char *reason = NULL;
 			if (client->snapshot_pending_dropped > 0)
 				reason = "budget_drop";
+			else if (extra_flags & SNAPSHOT_FLAG_CONTINUE)
+				reason = "continuation";
 			else if (delta_incomplete)
 				reason = "delta_budget";
 			else
@@ -3512,6 +3553,19 @@ qboolean SV_SendClientDatagram (client_t *client)
 			realtime, client->name, msg.cursize, msg.maxsize, client->message.cursize,
 			client->mtu_last_snapshot_size, sv.datagram.cursize);
 		goto datagram_too_large;
+	}
+
+	if (sv_mtu.value > 0)
+	{
+		int packet_bytes = msg.cursize + NET_HEADERSIZE + NET_UDPIP_HEADER_BYTES;
+		if (packet_bytes > (int)sv_mtu.value)
+		{
+			packet_too_large = true;
+			NET_DebugLogEvent (true,
+				"NETDBG time %.3f PREVENTED_OVERSHOOT %s total %d mtu %d snapshot %d\n",
+				realtime, client->name, packet_bytes, (int)sv_mtu.value, client->mtu_last_snapshot_size);
+			goto datagram_too_large;
+		}
 	}
 
 	if (sv_mtu_debug.value > 0 && realtime >= client->mtu_debug_next_time)


### PR DESCRIPTION
### Motivation
- Prevent packets from ever exceeding `sv_mtu` and ensure mandatory snapshot data always fits a single packet or is retried next frame. 
- Stop partial/fragmented snapshot behavior that caused flickering or stuck temporary effects by making continuation explicit and never sending partial mandatory data. 
- Keep existing snapshot/MTU code paths and avoid new cvars while removing ambiguous "budget_drop" behavior.

### Description
- Cap MTU payload calculations to `sv_mtu` in `SV_MTUCap` so the server-side payload cap never exceeds the configured MTU. 
- Change `SV_BuildClientSnapshot` signature to accept an optional budget (`optional_budget_bytes`) and two out-parameters: `out_continuation` and `out_mandatory_oversize`, and update its logic to: pre-reserve mandatory bytes, compute remaining budget after reserving mandatory bytes, stop adding entities as soon as the remaining budget is insufficient, and set the continuation flag rather than dropping tiers or sending partial mandatory data. 
- In `SV_SendSnapshot` stop the entire snapshot send for the frame and mark it incomplete when mandatory bytes would exceed the MTU payload, or when `out_mandatory_oversize` is set; otherwise set `SNAPSHOT_FLAG_CONTINUE` only for snapshot2 chunking. 
- Add a hard final-packet guard in `SV_SendClientDatagram` to check `packet_bytes` against `sv_mtu` and abort sending (with debug log) if the assembled datagram would exceed `sv_mtu`. 
- Preserve existing snapshot continuation and entity-stream chunking behavior (`SV_WriteSnapshot2FullChunked` / entity stream) while making continuation decisions deterministic from the budget calculation. 
- Update debug/reason strings so incomplete snapshots caused by continuation are reported as `continuation` instead of ambiguous budget-drop messages.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e81bc6f84832e978399337623d4c8)