### PR TITLE
Fix snapshot2 chunk finalization and continuation/no-progress handling

### DIFF
--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -1981,10 +1981,22 @@ static void CL_ParseSnapshot2 (void)
 	if (header.flags & SNAPSHOT_FLAG_FULL)
 	{
 		qboolean continuation = (header.flags & SNAPSHOT_FLAG_CONTINUE) != 0;
-		qboolean final_chunk = (!continuation || header.num_removed == 0);
+		qboolean rem_zero = (header.num_removed == 0);
+		qboolean final_chunk = (!continuation || rem_zero);
+		qboolean finalize_invalid = (!continuation && !rem_zero);
+
+		if (finalize_invalid)
+		{
+			NET_DebugLogEvent (true,
+				"NETDBG time %.3f snap_finalize_skip seq %u base %u flags 0x%x reason flag_mismatch\n",
+				realtime, header.seq, header.base_seq, header.flags);
+			CL_RequestFullSnapshot ("snapshot2 flag mismatch", false);
+			drop = true;
+		}
 
 		if (continuation || cl.snapshot_chunk_active)
 		{
+			qboolean apply_complete;
 			if (!cl.snapshot_chunk_active || cl.snapshot_chunk_seq != header.seq)
 			{
 				CL_ResetSnapshotChunk ();
@@ -2039,7 +2051,11 @@ static void CL_ParseSnapshot2 (void)
 			if (!final_chunk)
 				return;
 
-			if (!incomplete)
+			apply_complete = !drop && final_chunk && !finalize_invalid;
+			if (apply_complete && rem_zero)
+				incomplete = false;
+
+			if (apply_complete)
 			{
 				memset (cl.snapshot_present, 0, cl_max_edicts * sizeof(byte));
 				if (cl.snapshot_active)
@@ -2062,7 +2078,7 @@ static void CL_ParseSnapshot2 (void)
 				CL_MarkSnapshotEntityUpdated (i);
 			}
 
-			if (!incomplete)
+			if (apply_complete)
 			{
 				cl.snapshot_baseline_seq = header.seq;
 				cl.snap_last_applied_seq = seq16;
@@ -2074,7 +2090,7 @@ static void CL_ParseSnapshot2 (void)
 					"NETDBG time %.3f snap_complete_apply seq %u\n",
 					realtime, header.seq);
 			}
-			else
+			else if (!drop)
 			{
 				cl.snap_last_incomplete_seq = seq16;
 				cl.snap_last_incomplete = true;

--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -1736,7 +1736,7 @@ static qboolean SV_WriteSnapshot2FullChunked (client_t *client, sizebuf_t *msg,
 	int chunk_size = header_size;
 	int last_sent = 0;
 	qboolean more = false;
-	unsigned int flags = SNAPSHOT_FLAG_FULL | extra_flags;
+	unsigned int flags = SNAPSHOT_FLAG_FULL | (extra_flags & ~SNAPSHOT_FLAG_INCOMPLETE);
 	int remaining_entities = 0;
 
 	if (available < header_size)
@@ -1769,14 +1769,9 @@ static qboolean SV_WriteSnapshot2FullChunked (client_t *client, sizebuf_t *msg,
 		remaining_entities = 0;
 
 	if (remaining_entities > 0)
-	{
-		flags |= SNAPSHOT_FLAG_CONTINUE;
-		flags |= SNAPSHOT_FLAG_INCOMPLETE;
-	}
+		flags |= SNAPSHOT_FLAG_CONTINUE | SNAPSHOT_FLAG_INCOMPLETE;
 	else
-	{
 		flags &= ~(SNAPSHOT_FLAG_CONTINUE | SNAPSHOT_FLAG_INCOMPLETE);
-	}
 
 	if (!MSG_CanWrite (msg, chunk_size))
 		return false;
@@ -1838,6 +1833,9 @@ static qboolean SV_WriteSnapshot2FullChunked (client_t *client, sizebuf_t *msg,
 		*out_remaining = remaining_entities;
 	if (out_flags)
 		*out_flags = flags;
+	NET_DebugLogEvent (true,
+		"NETDBG time %.3f snap_chunk_flags %s seq %u rem %d flags 0x%x\n",
+		realtime, client->name, client->snapshot_pending_seq, remaining_entities, flags);
 	if (net_snap_debug.value)
 		NET_DebugLogEvent (true,
 			"NETDBG time %.3f snap_chunk_rem %s seq %u rem %d flags 0x%x\n",
@@ -2586,14 +2584,19 @@ static void SV_SendSnapshot (client_t *client, sizebuf_t *msg)
 	}
 
 	client->mtu_last_snapshot_size = msg->cursize - start_size;
-	continuation = msg->write_locked && client->entstream.active;
-	if (chunked_snapshot && (chunk_flags & SNAPSHOT_FLAG_CONTINUE))
-		continuation = true;
-	else if (!chunked_snapshot && (extra_flags & SNAPSHOT_FLAG_CONTINUE))
+	if (chunked_snapshot)
+		continuation = (chunk_remaining > 0);
+	else
+		continuation = msg->write_locked && client->entstream.active;
+	if (!chunked_snapshot && (extra_flags & SNAPSHOT_FLAG_CONTINUE))
 		continuation = true;
 	if (invalid_base)
 	{
 		client->snapshot_has_valid_base = false;
+		client->snapshot_force_full = true;
+		client->entstream.active = false;
+		client->entstream.next_edict = 1;
+		client->entstream.base_snapshot = 0;
 		NET_DebugLogEvent (true,
 			"NETDBG time %.3f snap_invalid_base %s seq %u base %u\n",
 			realtime, client->name, client->snapshot_pending_seq,
@@ -2720,11 +2723,9 @@ static void SV_SendSnapshot (client_t *client, sizebuf_t *msg)
 			qboolean same_seq = (client->snapshot_pending_seq == client->snapshot_no_progress_seq);
 			qboolean same_base = (base_seq == client->snapshot_no_progress_base);
 			qboolean same_cursor = (cursor == client->snapshot_no_progress_next_edict);
-			qboolean same_size = (size_delta == client->snapshot_no_progress_bytes);
-			qboolean same_remaining = (remaining == client->snapshot_no_progress_remaining);
-			qboolean continuation_stall = continuation && (same_cursor || (remaining == 0 && same_remaining));
+			qboolean continuation_stall = continuation && (remaining == 0 || same_cursor);
 
-			if (same_seq && same_base && (same_cursor || same_size || continuation_stall))
+			if (same_seq && same_base && continuation_stall)
 				client->snapshot_no_progress_count++;
 			else
 				client->snapshot_no_progress_count = 0;


### PR DESCRIPTION
### Motivation
- Prevent cases where `snap_incomplete` loops forever when `rem==0` by making remaining/cursor state and continuation/incomplete flags consistent between sender and receiver. 
- Ensure the client finalizes and `snap_complete_apply`/`snap_ack_send` on truly final chunks, and trigger safe recovery when validation blocks finalization. 
- Harden server continuation state so it does not keep emitting `snap_incomplete` for invalid or stalled progress (including `base==0xFFFFFFFF`).

### Description
- Server: align chunk header flags with the computed remaining count by masking out `SNAPSHOT_FLAG_INCOMPLETE` from `extra_flags` and only set `SNAPSHOT_FLAG_CONTINUE`/`SNAPSHOT_FLAG_INCOMPLETE` when `remaining_entities > 0`, and emit a `NETDBG` log `snap_chunk_flags` with the decision (`SV_WriteSnapshot2FullChunked`).
- Server: compute `continuation` from the actual `chunk_remaining` when chunked, reset per-client `entstream` state and force a full snapshot on `invalid_base`, and clear `entstream` when forcing full to avoid repeated continuation emits (`SV_SendSnapshot`).
- Server: simplify the no-progress guard to detect stalls when the continuation is active but the cursor is not advancing or `remaining==0`, and force a full snapshot/reset (`snapshot_no_progress_count` logic in `SV_SendSnapshot`).
- Client: when parsing `svc_snapshot2` chunks, compute `rem_zero` and a `final_chunk` decision from the same remaining value used to set/clear continuation, log and request a full snapshot if flags are inconsistent (`snap_finalize_skip`), and ensure final chunk assembly triggers `snap_complete_apply` and an ack when valid (`CL_ParseSnapshot2`).
- Logging: add minimal `NETDBG` entries to show the computed remaining + flag decision (`snap_chunk_flags`) and to explain why finalization/apply was skipped (`snap_finalize_skip`); preserve existing debug behavior for `snap_incomplete` and `snap_invalid_base`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696eb564c274832e8e098ca554dab45f)