### PR TITLE
Client: per-entity snapshot history, safer delta guards and interpolation

### DIFF
--- a/Quake/cl_main.c
+++ b/Quake/cl_main.c
@@ -272,6 +272,146 @@ static qboolean CL_GetInterpolatedPlayer (int player, vec3_t out_org, vec3_t out
 	return false;
 }
 
+static qboolean CL_GetInterpolatedEntity (int entnum, vec3_t out_org, vec3_t out_ang)
+{
+	double render_t;
+	double max_gap_s;
+	double max_extrap_s;
+	cl_entity_snap_t *snaps;
+	cl_entity_snap_t *newest;
+	cl_entity_snap_t *oldest = NULL;
+	cl_entity_snap_t *snap;
+	cl_entity_snap_t *prev;
+	int snap_count;
+	int head;
+	int idx;
+	int axis;
+
+	if (cl_lerp_ms.value <= 0.0f)
+		return false;
+	if (!cl.entity_snapshots || !cl.entity_snap_head || !cl.entity_snap_count)
+		return false;
+	if (entnum <= 0 || entnum >= cl_max_edicts)
+		return false;
+
+	snap_count = cl.entity_snap_count[entnum];
+	if (snap_count <= 0)
+		return false;
+
+	render_t = cl.time - (cl_lerp_ms.value * 0.001);
+	max_gap_s = cl_lerp_max_gap_ms.value * 0.001;
+	max_extrap_s = 0.05;
+	if (max_gap_s > 0.0 && max_gap_s < max_extrap_s)
+		max_extrap_s = max_gap_s;
+
+	snaps = &cl.entity_snapshots[entnum * CL_ENTITY_SNAP_HISTORY];
+	head = cl.entity_snap_head[entnum];
+	newest = &snaps[head];
+
+	if (snap_count == 1)
+	{
+		VectorCopy (newest->origin, out_org);
+		VectorCopy (newest->angles, out_ang);
+		return true;
+	}
+
+	if (render_t >= newest->servertime)
+	{
+		int prev_idx = (head - 1 + CL_ENTITY_SNAP_HISTORY) % CL_ENTITY_SNAP_HISTORY;
+		prev = &snaps[prev_idx];
+		if (prev->servertime > 0.0 && newest->servertime > prev->servertime)
+		{
+			double dt = newest->servertime - prev->servertime;
+			double extrap_t = render_t - newest->servertime;
+
+			if ((max_gap_s <= 0.0 || dt <= max_gap_s) && dt > 0.0)
+			{
+				float f;
+
+				if (extrap_t < 0.0)
+					extrap_t = 0.0;
+				if (extrap_t > max_extrap_s)
+					extrap_t = max_extrap_s;
+
+				for (axis = 0; axis < 3; axis++)
+				{
+					float delta = newest->origin[axis] - prev->origin[axis];
+					if (delta > 100.0f || delta < -100.0f)
+					{
+						VectorCopy (newest->origin, out_org);
+						VectorCopy (newest->angles, out_ang);
+						return true;
+					}
+				}
+
+				f = (float)((dt + extrap_t) / dt);
+				for (axis = 0; axis < 3; axis++)
+				{
+					out_org[axis] = prev->origin[axis] + f * (newest->origin[axis] - prev->origin[axis]);
+					out_ang[axis] = CL_LerpAngle (prev->angles[axis], newest->angles[axis], f);
+				}
+				return true;
+			}
+		}
+		VectorCopy (newest->origin, out_org);
+		VectorCopy (newest->angles, out_ang);
+		return true;
+	}
+
+	prev = newest;
+	idx = head;
+	for (idx = 0; idx < snap_count; idx++)
+	{
+		snap = &snaps[head];
+		oldest = snap;
+		if (snap->servertime <= render_t)
+		{
+			double span = prev->servertime - snap->servertime;
+			float f;
+
+			if (span <= 0.0)
+				break;
+			if (max_gap_s > 0.0 && span > max_gap_s)
+			{
+				VectorCopy (snap->origin, out_org);
+				VectorCopy (snap->angles, out_ang);
+				return true;
+			}
+
+			for (axis = 0; axis < 3; axis++)
+			{
+				float delta = prev->origin[axis] - snap->origin[axis];
+				if (delta > 100.0f || delta < -100.0f)
+				{
+					VectorCopy (prev->origin, out_org);
+					VectorCopy (prev->angles, out_ang);
+					return true;
+				}
+			}
+
+			f = (float)((render_t - snap->servertime) / span);
+			f = CLAMP (0.0f, f, 1.0f);
+			for (axis = 0; axis < 3; axis++)
+			{
+				out_org[axis] = snap->origin[axis] + f * (prev->origin[axis] - snap->origin[axis]);
+				out_ang[axis] = CL_LerpAngle (snap->angles[axis], prev->angles[axis], f);
+			}
+			return true;
+		}
+		prev = snap;
+		head = (head - 1 + CL_ENTITY_SNAP_HISTORY) % CL_ENTITY_SNAP_HISTORY;
+	}
+
+	if (oldest && render_t < oldest->servertime)
+	{
+		VectorCopy (oldest->origin, out_org);
+		VectorCopy (oldest->angles, out_ang);
+		return true;
+	}
+
+	return false;
+}
+
 void CL_FreeState(void)
 {
         int i;
@@ -328,6 +468,9 @@ void CL_ClearState (void)
 	cl.snapshot_stage = (snapshot_state_t *) Hunk_AllocName (cl_max_edicts*sizeof(snapshot_state_t), "cl_snap_stage");
 	cl.snapshot_stage_present = (byte *) Hunk_AllocName (cl_max_edicts*sizeof(byte), "cl_snap_stage_present");
 	cl.snapshot_stage_remove = (byte *) Hunk_AllocName (cl_max_edicts*sizeof(byte), "cl_snap_stage_remove");
+	cl.entity_snapshots = (cl_entity_snap_t *) Hunk_AllocName (cl_max_edicts * CL_ENTITY_SNAP_HISTORY * sizeof(cl_entity_snap_t), "cl_ent_snaps");
+	cl.entity_snap_head = (byte *) Hunk_AllocName (cl_max_edicts * sizeof(byte), "cl_ent_snap_head");
+	cl.entity_snap_count = (byte *) Hunk_AllocName (cl_max_edicts * sizeof(byte), "cl_ent_snap_count");
 	//johnfitz
 	if (cl.snapshot_present)
 		memset (cl.snapshot_present, 0, cl_max_edicts * sizeof(byte));
@@ -341,6 +484,12 @@ void CL_ClearState (void)
 		memset (cl.snapshot_stage_present, 0, cl_max_edicts * sizeof(byte));
 	if (cl.snapshot_stage_remove)
 		memset (cl.snapshot_stage_remove, 0, cl_max_edicts * sizeof(byte));
+	if (cl.entity_snapshots)
+		memset (cl.entity_snapshots, 0, cl_max_edicts * CL_ENTITY_SNAP_HISTORY * sizeof(cl_entity_snap_t));
+	if (cl.entity_snap_head)
+		memset (cl.entity_snap_head, 0, cl_max_edicts * sizeof(byte));
+	if (cl.entity_snap_count)
+		memset (cl.entity_snap_count, 0, cl_max_edicts * sizeof(byte));
 	cl.snapshot_chunk_active = false;
 	cl.snapshot_chunk_seq = 0;
 	cl.snapshot_chunk_start_time = 0;
@@ -851,8 +1000,6 @@ void CL_RelinkEntities (void)
 
 			if (cl.snap_last_incomplete)
 			{
-				ent->msgtime = cl.mtime[0];
-				ent->forcelink = true;
 				keepalive = true;
 			}
 
@@ -860,13 +1007,19 @@ void CL_RelinkEntities (void)
 			{
 				if (cl.time - cl.snapshot_last_update_time[i] <= timeout_s)
 				{
-					ent->msgtime = cl.mtime[0];
-					ent->forcelink = true;
 					keepalive = true;
 				}
 			}
+			else
+			{
+				keepalive = true;
+			}
 
-			if (!keepalive)
+			if (keepalive)
+			{
+				ent->msgtime = cl.mtime[0];
+			}
+			else
 			{
 				ent->model = NULL;
 				ent->lerpflags |= LERP_RESETMOVE|LERP_RESETANIM; //johnfitz -- next time this entity slot is reused, the lerp will need to be reset
@@ -921,6 +1074,17 @@ void CL_RelinkEntities (void)
 			vec3_t lerp_ang;
 
 			if (CL_GetInterpolatedPlayer (i - 1, lerp_org, lerp_ang))
+			{
+				VectorCopy (lerp_org, ent->origin);
+				VectorCopy (lerp_ang, ent->angles);
+			}
+		}
+		else if (i > cl.maxclients)
+		{
+			vec3_t lerp_org;
+			vec3_t lerp_ang;
+
+			if (CL_GetInterpolatedEntity (i, lerp_org, lerp_ang))
 			{
 				VectorCopy (lerp_org, ent->origin);
 				VectorCopy (lerp_ang, ent->angles);

--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -1410,6 +1410,18 @@ static void CL_ReadSnapshotDeltaFields (snapshot_state_t *state, unsigned int ma
 
 static void CL_ClearSnapshotStage (void);
 
+static void CL_ClearEntitySnapHistory (int entnum)
+{
+	if (entnum <= 0 || entnum >= cl_max_edicts)
+		return;
+	if (!cl.entity_snapshots || !cl.entity_snap_head || !cl.entity_snap_count)
+		return;
+	cl.entity_snap_head[entnum] = 0;
+	cl.entity_snap_count[entnum] = 0;
+	memset (&cl.entity_snapshots[entnum * CL_ENTITY_SNAP_HISTORY], 0,
+		sizeof(cl_entity_snap_t) * CL_ENTITY_SNAP_HISTORY);
+}
+
 static void CL_ClearSnapshotEntity (int entnum)
 {
 	entity_t *ent;
@@ -1425,6 +1437,7 @@ static void CL_ClearSnapshotEntity (int entnum)
 		cl.snapshot_active[entnum] = 0;
 	if (cl.snapshot_last_update_time)
 		cl.snapshot_last_update_time[entnum] = 0;
+	CL_ClearEntitySnapHistory (entnum);
 }
 
 static qboolean CL_ShouldDropSnapshot (void)
@@ -1463,6 +1476,40 @@ static void CL_MarkSnapshotEntityUpdated (int entnum)
 		cl.snapshot_active[entnum] = 1;
 	if (cl.snapshot_last_update_time)
 		cl.snapshot_last_update_time[entnum] = cl.time;
+}
+
+static void CL_RecordEntitySnap (int entnum, const snapshot_state_t *state)
+{
+	int base;
+	byte head;
+	cl_entity_snap_t *snap;
+
+	if (entnum <= 0 || entnum >= cl_max_edicts)
+		return;
+	if (!cl.entity_snapshots || !cl.entity_snap_head || !cl.entity_snap_count)
+		return;
+
+	base = entnum * CL_ENTITY_SNAP_HISTORY;
+	head = cl.entity_snap_head[entnum];
+	if (cl.entity_snap_count[entnum] == 0)
+		head = 0;
+	else
+		head = (byte)((head + 1) % CL_ENTITY_SNAP_HISTORY);
+	cl.entity_snap_head[entnum] = head;
+	if (cl.entity_snap_count[entnum] < CL_ENTITY_SNAP_HISTORY)
+		cl.entity_snap_count[entnum]++;
+
+	snap = &cl.entity_snapshots[base + head];
+	snap->servertime = cl.mtime[0];
+	VectorCopy (state->state.origin, snap->origin);
+	VectorCopy (state->state.angles, snap->angles);
+}
+
+static qboolean CL_IsSnapshotSeqStale (unsigned short seq)
+{
+	if (cl.snap_last_applied_seq == 0)
+		return false;
+	return (short)(seq - cl.snap_last_applied_seq) <= 0;
 }
 
 static void CL_ApplySnapshotState (int entnum, const snapshot_state_t *state)
@@ -1556,6 +1603,8 @@ static void CL_ApplySnapshotState (int entnum, const snapshot_state_t *state)
 		VectorCopy (ent->msg_angles[0], ent->angles);
 		ent->forcelink = true;
 	}
+
+	CL_RecordEntitySnap (entnum, state);
 }
 
 /*
@@ -1643,12 +1692,6 @@ static void CL_ParseSnapshotFull (void)
 	if (drop)
 		return;
 
-	memset (cl.snapshot_present, 0, cl_max_edicts * sizeof(byte));
-	if (cl.snapshot_active)
-		memset (cl.snapshot_active, 0, cl_max_edicts * sizeof(byte));
-	if (cl.snapshot_last_update_time)
-		memset (cl.snapshot_last_update_time, 0, cl_max_edicts * sizeof(double));
-
 	// INV-5: commit staged snapshot only after full parse.
 	for (i = 1; i < cl_max_edicts; i++)
 	{
@@ -1735,6 +1778,14 @@ static void CL_ParseSnapshotDelta (void)
 			CL_LogDeltaReject ("need_full", seq, baseline_seq);
 		cl.snap_delta_mismatch++;
 		CL_RequestFullSnapshot ("snapshot_delta base mismatch", false);
+		drop = true;
+	}
+
+	if (!drop && CL_IsSnapshotSeqStale (seq16))
+	{
+		CL_LogDeltaReject ("seq_stale", seq, baseline_seq);
+		cl.snap_delta_mismatch++;
+		CL_RequestFullSnapshot ("snapshot_delta seq stale", false);
 		drop = true;
 	}
 
@@ -2055,15 +2106,6 @@ static void CL_ParseSnapshot2 (void)
 			if (apply_complete && rem_zero)
 				incomplete = false;
 
-			if (apply_complete)
-			{
-				memset (cl.snapshot_present, 0, cl_max_edicts * sizeof(byte));
-				if (cl.snapshot_active)
-					memset (cl.snapshot_active, 0, cl_max_edicts * sizeof(byte));
-				if (cl.snapshot_last_update_time)
-					memset (cl.snapshot_last_update_time, 0, cl_max_edicts * sizeof(double));
-			}
-
 			// INV-5: commit reassembled snapshot only after full chunk parse.
 			for (i = 1; i < cl_max_edicts; i++)
 			{
@@ -2137,12 +2179,6 @@ static void CL_ParseSnapshot2 (void)
 		{
 			if (!incomplete)
 			{
-				memset (cl.snapshot_present, 0, cl_max_edicts * sizeof(byte));
-				if (cl.snapshot_active)
-					memset (cl.snapshot_active, 0, cl_max_edicts * sizeof(byte));
-				if (cl.snapshot_last_update_time)
-					memset (cl.snapshot_last_update_time, 0, cl_max_edicts * sizeof(double));
-
 				// INV-5: commit staged snapshot only after full parse.
 				for (i = 1; i < cl_max_edicts; i++)
 				{
@@ -2212,6 +2248,14 @@ static void CL_ParseSnapshot2 (void)
 			CL_LogDeltaReject ("need_full", header.seq, header.base_seq);
 		cl.snap_delta_mismatch++;
 		CL_RequestFullSnapshot ("snapshot2 base mismatch", false);
+		drop = true;
+	}
+
+	if (!drop && CL_IsSnapshotSeqStale (seq16))
+	{
+		CL_LogDeltaReject ("seq_stale", header.seq, header.base_seq);
+		cl.snap_delta_mismatch++;
+		CL_RequestFullSnapshot ("snapshot2 seq stale", false);
 		drop = true;
 	}
 

--- a/Quake/client.h
+++ b/Quake/client.h
@@ -69,6 +69,15 @@ extern cshift_t		cshift_empty;
 
 #define	SIGNONS		4			// signon messages to receive before connected
 
+#define CL_ENTITY_SNAP_HISTORY 3
+
+typedef struct cl_entity_snap_s
+{
+	double		servertime;
+	vec3_t		origin;
+	vec3_t		angles;
+} cl_entity_snap_t;
+
 typedef enum
 {
 	DLIGHT_DEFAULT = 0,
@@ -296,6 +305,9 @@ typedef struct
 	snapshot_state_t *snapshot_stage;
 	byte		*snapshot_stage_present;
 	byte		*snapshot_stage_remove;
+	cl_entity_snap_t *entity_snapshots;
+	byte		*entity_snap_head;
+	byte		*entity_snap_count;
 
 	int			cdtrack, looptrack;	// cd audio
 


### PR DESCRIPTION
### Motivation
- Reduce non-local entity stutter/flicker by keeping omitted updates from implying immediate removal and by smoothing rendering with a tiny history buffer and interpolation window.
- Strengthen delta robustness so clients only apply deltas when the base snapshot is actually compatible and avoid partial/incorrect delta application.
- Reuse existing timeout and debug/logging facilities (no new cvars) to implement a small TTL/grace period for transient entities (explosions/projectiles) and to log delta rejects.

### Description
- Add a small per-entity history buffer and types in `Quake/client.h` (`CL_ENTITY_SNAP_HISTORY`, `cl_entity_snap_t`) and wire new storage into client state (`cl.entity_snapshots`, `cl.entity_snap_head`, `cl.entity_snap_count`).
- Record and clear per-entity snapshots from the snapshot apply path by adding `CL_RecordEntitySnap` and `CL_ClearEntitySnapHistory`, and call `CL_RecordEntitySnap` from `CL_ApplySnapshotState` in `Quake/cl_parse.c` to keep the last 2–3 states for each entity.
- Implement `CL_GetInterpolatedEntity` in `Quake/cl_main.c` to render non-player entities by interpolating between the last snapshots at `render_time = cl.time - cl_lerp_ms`, with a small clamped extrapolation window and teleport/large-delta guards to avoid bad interpolation.
- Change relink/removal handling in `Quake/cl_main.c` so that "missing in snapshot" does NOT imply immediate deletion: entities are retained while `cl.snap_last_incomplete` is set or while `cl.snapshot_last_update_time` is within `cl_entity_timeout_ms`, providing a TTL/grace period for transient effects; entity history is cleared only on explicit removal via the snapshot remove-list or `CL_ClearSnapshotEntity`.
- Add delta-sequence sanity checks in `Quake/cl_parse.c` (`CL_IsSnapshotSeqStale`) and reject/stall deltas that are stale relative to `cl.snap_last_applied_seq`, triggering the existing full-snapshot recovery path and logging via existing `NETDBG` hooks (no new cvars).
- Kept existing packed/`snapshotdelta`/`snapshot2`/MTU logic intact and only augmented snapshot handling and rendering paths; reused existing `CL_RequestFullSnapshot`, `CL_SendSnapshotNak`, and debug logging for recovery and diagnostics.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696eba2211a0832ead93d51f3b60f8f1)