### PR TITLE
Include cl_predict.c in Visual Studio project to fix missing prediction symbols

### DIFF
--- a/Windows/VisualStudio/ironwail.vcxproj
+++ b/Windows/VisualStudio/ironwail.vcxproj
@@ -241,6 +241,7 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
     <ClCompile Include="..\..\Quake\cl_input.c" />
     <ClCompile Include="..\..\Quake\cl_main.c" />
     <ClCompile Include="..\..\Quake\cl_parse.c" />
+    <ClCompile Include="..\..\Quake\cl_predict.c" />
     <ClCompile Include="..\..\Quake\cl_postfx.c" />
     <ClCompile Include="..\..\Quake\cl_tent.c" />
     <ClCompile Include="..\..\Quake\cmd.c" />

--- a/Windows/VisualStudio/ironwail.vcxproj.filters
+++ b/Windows/VisualStudio/ironwail.vcxproj.filters
@@ -39,6 +39,9 @@
     <ClCompile Include="..\..\Quake\cl_parse.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Quake\cl_predict.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\Quake\cl_tent.c">
       <Filter>Source Files</Filter>
     </ClCompile>


### PR DESCRIPTION
### Motivation
- Resolve LNK2001 unresolved externals for `CL_Predict_*` by ensuring the client prediction implementation is compiled and linked into the Windows build.

### Description
- Add `..\..\Quake\cl_predict.c` to the Visual Studio project `Windows/VisualStudio/ironwail.vcxproj` and include the corresponding entry in `Windows/VisualStudio/ironwail.vcxproj.filters` so `cl_predict.c` is compiled with the project.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ec6e2773c832e8b8525c3cfd53407)