### PR TITLE
Fix AngleVectors const correctness

### DIFF
--- a/Quake/mathlib.c
+++ b/Quake/mathlib.c
@@ -236,7 +236,7 @@ void VectorAngles (const vec3_t forward, vec3_t angles)
 	angles[ROLL] = 0;
 }
 
-void AngleVectors (vec3_t angles, vec3_t forward, vec3_t right, vec3_t up)
+void AngleVectors (const vec3_t angles, vec3_t forward, vec3_t right, vec3_t up)
 {
 	float		angle;
 	float		sr, sp, sy, cr, cp, cy;

--- a/Quake/mathlib.h
+++ b/Quake/mathlib.h
@@ -126,7 +126,7 @@ void FloorDivMod (double numer, double denom, int *quotient,
 fixed16_t Invert24To16(fixed16_t val);
 int GreatestCommonDivisor (int i1, int i2);
 
-void AngleVectors (vec3_t angles, vec3_t forward, vec3_t right, vec3_t up);
+void AngleVectors (const vec3_t angles, vec3_t forward, vec3_t right, vec3_t up);
 int BoxOnPlaneSide (vec3_t emins, vec3_t emaxs, struct mplane_s *plane);
 float	anglemod(float a);
 


### PR DESCRIPTION
### Motivation
- Resolve const-qualifier mismatch for `AngleVectors` to eliminate compiler warning/error (e.g. MSVC C4090 treated as error) when callers pass const `viewangles`.

### Description
- Change the `AngleVectors` declaration in `Quake/mathlib.h` to accept `const vec3_t angles`.
- Update the `AngleVectors` definition in `Quake/mathlib.c` to match the const-correct signature.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ec769a2fc832e819b657c8e9e22d3)