### PR TITLE
Reapply client prediction after snapshot2 apply and clamp NETDBG offsets

### DIFF
--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -160,6 +160,18 @@ static int CL_NetDebugDumpLength (void)
 	return maxdump;
 }
 
+static int CL_NetDebugReadcount (void)
+{
+	int readcount = msg_readcount;
+
+	if (readcount < 0)
+		readcount = 0;
+	if (readcount > net_message.cursize)
+		readcount = net_message.cursize;
+
+	return readcount;
+}
+
 static void CL_NetDebugHeader (void)
 {
 	if (!cl_netdebug_parse.value && !cl_netdebug_hexdump.value)
@@ -2120,6 +2132,8 @@ static void CL_ParseSnapshot2 (void)
 				CL_MarkSnapshotEntityUpdated (i);
 			}
 
+			CL_Predict_Reapply ();
+
 			if (apply_complete)
 			{
 				cl.snapshot_baseline_seq = header.seq;
@@ -2190,6 +2204,8 @@ static void CL_ParseSnapshot2 (void)
 					CL_MarkSnapshotEntityUpdated (i);
 				}
 
+				CL_Predict_Reapply ();
+
 				cl.snapshot_baseline_seq = header.seq;
 				cl.snap_last_applied_seq = seq16;
 				cl.snap_last_complete_seq = seq16;
@@ -2210,6 +2226,7 @@ static void CL_ParseSnapshot2 (void)
 					CL_ApplySnapshotState (i, &cl.snapshot_stage[i]);
 					CL_MarkSnapshotEntityUpdated (i);
 				}
+				CL_Predict_Reapply ();
 				cl.snap_last_incomplete_seq = seq16;
 				cl.snap_last_incomplete = true;
 				cl.snap_incomplete_count++;
@@ -2374,6 +2391,8 @@ static void CL_ParseSnapshot2 (void)
 			CL_ApplySnapshotState (i, &cl.snapshot_stage[i]);
 			CL_MarkSnapshotEntityUpdated (i);
 		}
+
+		CL_Predict_Reapply ();
 
 		for (i = 1; i < cl_max_edicts; i++)
 		{
@@ -2877,8 +2896,13 @@ void CL_ParseServerMessage (void)
 				return;
 			}
 			if (cl_netdebug_parse.value)
+			{
+				int cmd_end = CL_NetDebugReadcount ();
+				if (cmd_end < cmd_offset)
+					cmd_end = cmd_offset;
 				Con_Printf ("NETDBG: cmd fast_update end %d bytes %d\n",
-					msg_readcount, msg_readcount - cmd_offset);
+					cmd_end, cmd_end - cmd_offset);
+			}
 			prevcmd = lastcmd;
 			prevcmd_offset = lastcmd_offset;
 			lastcmd = cmd;
@@ -3250,8 +3274,13 @@ void CL_ParseServerMessage (void)
 			return;
 		}
 		if (cl_netdebug_parse.value)
+		{
+			int cmd_end = CL_NetDebugReadcount ();
+			if (cmd_end < cmd_offset)
+				cmd_end = cmd_offset;
 			Con_Printf ("NETDBG: cmd %s end %d bytes %d\n",
-				CL_SvcName (cmd), msg_readcount, msg_readcount - cmd_offset);
+				CL_SvcName (cmd), cmd_end, cmd_end - cmd_offset);
+		}
 
 		prevcmd = lastcmd;
 		prevcmd_offset = lastcmd_offset;

--- a/Quake/cl_predict.c
+++ b/Quake/cl_predict.c
@@ -312,3 +312,11 @@ void CL_Predict_ServerUpdate (unsigned int ack, const vec3_t origin, const vec3_
 
 	CL_Predict_ApplyToClient ();
 }
+
+void CL_Predict_Reapply (void)
+{
+	if (!CL_Predict_IsEnabled () || !cl_pred.has_base)
+		return;
+
+	CL_Predict_ApplyToClient ();
+}

--- a/Quake/client.h
+++ b/Quake/client.h
@@ -456,6 +456,7 @@ void CL_SendMove (const usercmd_t *cmd);
 void CL_Predict_Clear (void);
 void CL_Predict_SetupCmd (usercmd_t *cmd);
 void CL_Predict_ServerUpdate (unsigned int ack, const vec3_t origin, const vec3_t velocity, const vec3_t viewangles, qboolean onground);
+void CL_Predict_Reapply (void);
 qboolean CL_Predict_GetCmd (unsigned int seq, usercmd_t *out);
 int  CL_ReadFromServer (void);
 void CL_AdjustAngles (void);


### PR DESCRIPTION
### Motivation
- Snapshot2 application could overwrite local-player state used by PMOVE (origin/velocity/angles/onground) and cause the local player to fall through the floor, so prediction must be re-applied after snapshot handling to restore correct pmove-relevant state.
- NETDBG instrumentation printed command end offsets that could diverge from the message buffer cursor, producing impossible values and confusing debugging output, so NETDBG must use a single clamped cursor for all prints.

### Description
- Added `CL_Predict_Reapply()` in `Quake/cl_predict.c` and exported it from `Quake/client.h` as `void CL_Predict_Reapply (void);` to re-apply the client's predicted result to the local player without re-running pmove.
- Called `CL_Predict_Reapply()` at the completion points in `CL_ParseSnapshot2()` (reassembled chunks, staged commit, staged-apply branch and baseline-apply branch) in `Quake/cl_parse.c` so the predicted `origin`, `velocity`, `viewangles` and `onground` are applied after snapshot entity state updates.
- Kept server clientdata/snapshot2 behavior intact (no change to `CL_ParseClientdata`); the fix merges by reapplying the client's prediction after snapshot application rather than changing snapshot sequencing or requiring netchan sequencing for loopback/local transport.
- Fixed NETDBG cursor/length consistency by adding `CL_NetDebugReadcount()` in `Quake/cl_parse.c` which returns a clamped `msg_readcount` (0..`net_message.cursize`) and using that value for all `cmd end` prints, ensuring `cmd end` never exceeds `msg len` and is always >= the saved `cmd_offset`.

### Testing
- No automated tests were run as part of this change (no CI/unit tests executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fdcc7e9d4832eaf04dd99ca607b5d)