### PR TITLE
Gate client prediction until world ready

### DIFF
--- a/Quake/cl_main.c
+++ b/Quake/cl_main.c
@@ -179,6 +179,26 @@ void CL_RecordPlayerSnap (void)
 	cl_psnap_count = q_min (cl_psnap_count + 1, CL_PLAYER_SNAP_HISTORY);
 }
 
+qboolean CL_WorldReady (void)
+{
+	entity_t *view;
+
+	// Strict mapload gating: only allow prediction/input when the viewentity has a model.
+	if (cls.signon != SIGNONS)
+		return false;
+	if (!cl.worldmodel)
+		return false;
+	if (cl.viewentity <= 0 || cl.viewentity >= cl_max_edicts)
+		return false;
+	if (!cl_entities)
+		return false;
+	view = &cl_entities[cl.viewentity];
+	if (!view->model)
+		return false;
+
+	return true;
+}
+
 static float CL_LerpAngle (float a, float b, float f)
 {
 	float d = b - a;
@@ -498,7 +518,7 @@ void CL_ClearState (void)
 	cl.snap_last_complete_seq = 0;
 	cl.snap_last_incomplete_seq = 0;
 	cl.snap_last_incomplete = false;
-	cl.need_full_snapshot = false;
+	cl.need_full_snapshot = true;
 	cl.has_valid_worldstate = false;
 	cl.snap_parse_errors = 0;
 	cl.snap_delta_mismatch = 0;
@@ -1370,11 +1390,21 @@ void CL_SendCmd (void)
 		in_attack.state &= ~2;
 
 		if (in_jump.state & 3)
-			cmd.buttons |= 2;
+		cmd.buttons |= 2;
 		in_jump.state &= ~2;
 
 		cmd.impulse = in_impulse;
 		in_impulse = 0;
+
+		// Freeze local movement until we have a ready viewentity to avoid void spawns.
+		if (!CL_WorldReady ())
+		{
+			cmd.forwardmove = 0;
+			cmd.sidemove = 0;
+			cmd.upmove = 0;
+			cmd.buttons = 0;
+			cmd.impulse = 0;
+		}
 
 		CL_Predict_SetupCmd (&cmd);
 

--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -2652,6 +2652,7 @@ void CL_ParseClientdata (void)
 		cl.viewent.alpha = ENTALPHA_DEFAULT;
 	//johnfitz
 
+	// svc_clientdata carries pmove-critical fields; snapshot2 owns local player position/orientation.
 	if (bits & SU_PREDICT)
 	{
 		unsigned int ack = (unsigned int)MSG_ReadLong ();
@@ -3053,6 +3054,7 @@ void CL_ParseServerMessage (void)
 			break;
 
 		case svc_setview:
+			// Viewentity is per-client and must be set immediately for snapshot2/clientdata merge.
 			cl.viewentity = MSG_ReadShort ();
 			break;
 

--- a/Quake/cl_predict.c
+++ b/Quake/cl_predict.c
@@ -39,15 +39,13 @@ static qboolean CL_Predict_IsEnabled (void)
 {
 	if (cls.state != ca_connected)
 		return false;
-	if (cls.signon != SIGNONS)
-		return false;
 	if (cls.demoplayback)
 		return false;
 	if (cl.intermission)
 		return false;
 	if (!cl.has_valid_worldstate)
 		return false;
-	if (cl.viewentity <= 0)
+	if (!CL_WorldReady ())
 		return false;
 	return true;
 }

--- a/Quake/client.h
+++ b/Quake/client.h
@@ -496,6 +496,7 @@ void CL_TimeDemo_f (void);
 void CL_ParseServerMessage (void);
 void CL_NewTranslation (int slot);
 void CL_RecordPlayerSnap (void);
+qboolean CL_WorldReady (void);
 
 //
 // view

--- a/Quake/net_loop.c
+++ b/Quake/net_loop.c
@@ -29,6 +29,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 static qboolean	localconnectpending = false;
 static qsocket_t	*loop_client = NULL;
 static qsocket_t	*loop_server = NULL;
+static unsigned int	loop_sequence = 0;
 
 int Loop_Init (void)
 {
@@ -142,6 +143,13 @@ int Loop_GetMessage (qsocket_t *sock)
 	SZ_Clear (&net_message);
 	SZ_Write (&net_message, &sock->receiveMessage[4], length);
 
+	net_last_incoming.sequence = ++loop_sequence;
+	net_last_incoming.flags = 0;
+	net_last_incoming.packet_length = (unsigned int)(length + 4);
+	net_last_incoming.payload_length = (unsigned int)length;
+	net_last_incoming.unreliable = (ret == 2);
+	net_last_incoming.valid = true;
+
 	length = IntAlign(length + 4);
 	sock->receiveMessageLength -= length;
 
@@ -247,4 +255,3 @@ void Loop_Close (qsocket_t *sock)
 	else
 		loop_server = NULL;
 }
-


### PR DESCRIPTION
### Motivation

- Prevent local player from spawning into the void and seeing invisible entities by making map load/signon processing robust and by preventing premature application of prediction/pmove state.
- Ensure `svc_setview` is applied immediately and `svc_clientdata` (pmove-critical fields) and `svc_snapshot2` (pos/orient) do not corrupt local player origin during signon/map start.

### Description

- Added `CL_WorldReady()` which implements the strict mapload gating condition (`cls.signon == SIGNONS`, `cl.worldmodel != NULL`, `cl.viewentity` valid and `cl_entities[cl.viewentity].model != NULL`). (added in `Quake/cl_main.c`, exposed in `Quake/client.h`)
- Freeze local input/movement while world is not ready by zeroing movement/buttons/impulse in `CL_SendCmd` to avoid falling into void before a valid player entity exists (`Quake/cl_main.c`).
- Gate client prediction on the world-ready check by using `CL_WorldReady()` inside `CL_Predict_IsEnabled()` so prediction and pmove are not applied until the viewentity/model are present (`Quake/cl_predict.c`).
- Force clients to request/apply a full snapshot at map start by initializing `cl.need_full_snapshot = true` in `CL_ClearState()` so the first complete baseline is required before treating deltas as authoritative (`Quake/cl_main.c`).
- Clarified handling of `svc_setview` and `svc_clientdata` with small comments to ensure `cl.viewentity` is set immediately and to document that `svc_clientdata` carries pmove-critical fields while `snapshot2` supplies position/orientation (`Quake/cl_parse.c`).
- Added a monotonically increasing internal `loop_sequence` for loopback transport and stamp `net_last_incoming` so local transport does not reuse network sequence semantics and reassembly/diagnostics behave consistently (`Quake/net_loop.c`).

Files changed: `Quake/cl_main.c`, `Quake/cl_predict.c`, `Quake/cl_parse.c`, `Quake/client.h`, `Quake/net_loop.c`.

### Testing

- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fe904e0f4832ebcc5fdb80a28fa5c)