### PR TITLE
Add forward declaration for CL_RequestFullSnapshot to fix build warnings

### DIFF
--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -116,6 +116,8 @@ const char *svc_strings[] =
 };
 #define NUM_SVC_STRINGS Q_COUNTOF(svc_strings)
 
+static void CL_RequestFullSnapshot (const char *reason, qboolean count_parse_error);
+
 static const char *CL_SvcName (int cmd)
 {
 	if (cmd >= 0 && cmd < (int)NUM_SVC_STRINGS)


### PR DESCRIPTION
### Motivation
- Prevent implicit declaration and type mismatch of `CL_RequestFullSnapshot` that produced MSVC warnings/errors during compilation.

### Description
- Add a forward declaration `static void CL_RequestFullSnapshot (const char *reason, qboolean count_parse_error);` to `Quake/cl_parse.c` immediately after `NUM_SVC_STRINGS`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ff681ce0c832ebe4bbd17dfc2d8ca)