### PR TITLE
Fix world model snapshot origin offset

### DIFF
--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -1521,8 +1521,9 @@ static qboolean CL_SnapshotWorldModelReady (const char *reason)
 static void CL_ApplySnapshotOrigin (vec3_t out, const vec3_t in)
 {
 	// Snapshot/packedent origins are model-space; offset by worldmodel origin to render in world-space.
-	if (cl.worldmodel && cl.worldmodel->type == mod_brush)
-		VectorAdd (in, cl.worldmodel->origin, out);
+	if (cl.worldmodel && cl.worldmodel->type == mod_brush
+		&& cl.worldmodel->submodels && cl.worldmodel->numsubmodels > 0)
+		VectorAdd (in, cl.worldmodel->submodels[0].origin, out);
 	else
 		VectorCopy (in, out);
 }


### PR DESCRIPTION
### Motivation
- `CL_ApplySnapshotOrigin` previously used `cl.worldmodel->origin`, which is not a member of `qmodel_t` and caused an incorrect reference/compile issue; the intent is to offset model-space snapshot origins into world-space using the brush model's actual origin stored in its first submodel.

### Description
- Change `CL_ApplySnapshotOrigin` to add `in` to `cl.worldmodel->submodels[0].origin` when `cl.worldmodel->type == mod_brush`, and add guards checking `submodels` and `numsubmodels > 0` before accessing it; otherwise fall back to `VectorCopy`.

### Testing
- No automated tests were run as part of this change (no build or test commands executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697000c35f88832e8875fa8f1c2b749c)