### PR TITLE
Reset client interpolation on full snapshots

### DIFF
--- a/Quake/cl_main.c
+++ b/Quake/cl_main.c
@@ -145,6 +145,13 @@ static void CL_ClearPlayerSnaps (void)
 	cl_lerp_debug_next_time = 0.0;
 }
 
+void CL_ResetPlayerSnaps (void)
+{
+	CL_ClearPlayerSnaps ();
+}
+
+float cl_lerpfrac = 1.0f;
+
 void CL_RecordPlayerSnap (void)
 {
 	cl_player_snap_t *snap;
@@ -365,6 +372,8 @@ static qboolean CL_GetInterpolatedEntity (int entnum, vec3_t out_org, vec3_t out
 				}
 
 				f = (float)((dt + extrap_t) / dt);
+				if (f < 0.0f || f > 1.0f)
+					f = 1.0f;
 				for (axis = 0; axis < 3; axis++)
 				{
 					out_org[axis] = prev->origin[axis] + f * (newest->origin[axis] - prev->origin[axis]);
@@ -390,7 +399,11 @@ static qboolean CL_GetInterpolatedEntity (int entnum, vec3_t out_org, vec3_t out
 			float f;
 
 			if (span <= 0.0)
-				break;
+			{
+				VectorCopy (prev->origin, out_org);
+				VectorCopy (prev->angles, out_ang);
+				return true;
+			}
 			if (max_gap_s > 0.0 && span > max_gap_s)
 			{
 				VectorCopy (snap->origin, out_org);
@@ -492,6 +505,8 @@ void CL_ClearState (void)
 	cl.entity_snap_head = (byte *) Hunk_AllocName (cl_max_edicts * sizeof(byte), "cl_ent_snap_head");
 	cl.entity_snap_count = (byte *) Hunk_AllocName (cl_max_edicts * sizeof(byte), "cl_ent_snap_count");
 	//johnfitz
+	if (cl_entities)
+		memset (cl_entities, 0, cl_max_edicts * sizeof(entity_t));
 	if (cl.snapshot_present)
 		memset (cl.snapshot_present, 0, cl_max_edicts * sizeof(byte));
 	if (cl.snapshot_active)
@@ -510,6 +525,11 @@ void CL_ClearState (void)
 		memset (cl.entity_snap_head, 0, cl_max_edicts * sizeof(byte));
 	if (cl.entity_snap_count)
 		memset (cl.entity_snap_count, 0, cl_max_edicts * sizeof(byte));
+	cl.mtime[0] = 0.0;
+	cl.mtime[1] = 0.0;
+	cl.time = 0.0;
+	cl.oldtime = 0.0;
+	cl_lerpfrac = 1.0f;
 	cl.snapshot_chunk_active = false;
 	cl.snapshot_chunk_seq = 0;
 	cl.snapshot_chunk_start_time = 0;
@@ -830,9 +850,10 @@ float	CL_LerpPoint (void)
 
 	f = cl.mtime[0] - cl.mtime[1];
 
-	if (!f || cls.timedemo || (sv.active && !host_netinterval))
+	if (f <= 0.0f || cls.timedemo || (sv.active && !host_netinterval))
 	{
 		cl.time = cl.mtime[0];
+		cl.mtime[1] = cl.mtime[0];
 		return 1;
 	}
 
@@ -844,17 +865,11 @@ float	CL_LerpPoint (void)
 
 	frac = (cl.time - cl.mtime[1]) / f;
 
-	if (frac < 0)
+	if (frac < 0.0f || frac > 1.0f)
 	{
-		if (frac < -0.01)
-			cl.time = cl.mtime[1];
-		frac = 0;
-	}
-	else if (frac > 1)
-	{
-		if (frac > 1.01)
-			cl.time = cl.mtime[0];
-		frac = 1;
+		cl.time = cl.mtime[0];
+		cl.mtime[1] = cl.mtime[0];
+		frac = 1.0f;
 	}
 
 	//johnfitz -- better nolerp behavior
@@ -976,6 +991,7 @@ void CL_RelinkEntities (void)
 
 // determine partial update time
 	frac = CL_LerpPoint ();
+	cl_lerpfrac = frac;
 
 	cl_numvisedicts = 0;
 

--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -1469,6 +1469,8 @@ static void CL_ReadSnapshotDeltaFields (snapshot_state_t *state, unsigned int ma
 }
 
 static void CL_ClearSnapshotStage (void);
+static void CL_PrepareFullSnapshotInterpReset (void);
+static void CL_FinalizeFullSnapshotInterpReset (void);
 
 static void CL_ClearEntitySnapHistory (int entnum)
 {
@@ -1768,6 +1770,12 @@ static void CL_ParseSnapshotFull (void)
 	if (drop)
 		return;
 
+	{
+		qboolean reset_interp = (!cl.has_full_snapshot || cl.need_full_snapshot);
+
+		if (reset_interp)
+			CL_PrepareFullSnapshotInterpReset ();
+
 	// INV-5: commit staged snapshot only after full parse.
 	for (i = 1; i < cl_max_edicts; i++)
 	{
@@ -1777,6 +1785,10 @@ static void CL_ParseSnapshotFull (void)
 		cl.snapshot_present[i] = 1;
 		CL_ApplySnapshotState (i, &cl.snapshot_baseline[i]);
 		CL_MarkSnapshotEntityUpdated (i);
+	}
+
+		if (reset_interp)
+			CL_FinalizeFullSnapshotInterpReset ();
 	}
 
 	cl.snapshot_baseline_seq = seq;
@@ -2028,6 +2040,39 @@ static void CL_ClearSnapshotStage (void)
 		memset (cl.snapshot_stage_remove, 0, cl_max_edicts * sizeof(byte));
 }
 
+static void CL_PrepareFullSnapshotInterpReset (void)
+{
+	int i;
+
+	cl.mtime[1] = cl.mtime[0];
+	cl.time = cl.mtime[0];
+	cl.oldtime = cl.mtime[0];
+	CL_ResetPlayerSnaps ();
+
+	for (i = 1; i < cl_max_edicts; i++)
+		CL_ClearEntitySnapHistory (i);
+}
+
+static void CL_FinalizeFullSnapshotInterpReset (void)
+{
+	int i;
+
+	for (i = 1; i < cl_max_edicts; i++)
+	{
+		entity_t *ent;
+
+		if (!cl.snapshot_present || !cl.snapshot_present[i])
+			continue;
+		ent = &cl_entities[i];
+		VectorCopy (ent->msg_origins[0], ent->msg_origins[1]);
+		VectorCopy (ent->msg_angles[0], ent->msg_angles[1]);
+		VectorCopy (ent->msg_origins[0], ent->origin);
+		VectorCopy (ent->msg_angles[0], ent->angles);
+		ent->forcelink = true;
+		ent->lerpflags |= LERP_RESETMOVE|LERP_RESETANIM;
+	}
+}
+
 static void CL_ResetSnapshotChunk (void)
 {
 	if (cl.snapshot_chunk_present)
@@ -2253,6 +2298,11 @@ static void CL_ParseSnapshot2 (void)
 
 			if (apply_complete)
 			{
+				qboolean reset_interp = (!cl.has_full_snapshot || cl.need_full_snapshot);
+
+				if (reset_interp)
+					CL_PrepareFullSnapshotInterpReset ();
+
 				// INV-5: commit reassembled snapshot only after full chunk parse.
 				for (i = 1; i < cl_max_edicts; i++)
 				{
@@ -2263,6 +2313,9 @@ static void CL_ParseSnapshot2 (void)
 					CL_ApplySnapshotState (i, &cl.snapshot_chunk[i]);
 					CL_MarkSnapshotEntityUpdated (i);
 				}
+
+				if (reset_interp)
+					CL_FinalizeFullSnapshotInterpReset ();
 
 				CL_Predict_Reapply ();
 
@@ -2333,6 +2386,11 @@ static void CL_ParseSnapshot2 (void)
 		{
 			if (!incomplete)
 			{
+				qboolean reset_interp = (!cl.has_full_snapshot || cl.need_full_snapshot);
+
+				if (reset_interp)
+					CL_PrepareFullSnapshotInterpReset ();
+
 				// INV-5: commit staged snapshot only after full parse.
 				for (i = 1; i < cl_max_edicts; i++)
 				{
@@ -2343,6 +2401,9 @@ static void CL_ParseSnapshot2 (void)
 					CL_ApplySnapshotState (i, &cl.snapshot_baseline[i]);
 					CL_MarkSnapshotEntityUpdated (i);
 				}
+
+				if (reset_interp)
+					CL_FinalizeFullSnapshotInterpReset ();
 
 				CL_Predict_Reapply ();
 

--- a/Quake/client.h
+++ b/Quake/client.h
@@ -391,6 +391,7 @@ extern	cvar_t	cl_entity_timeout_ms;
 extern	cvar_t	cl_lerp_ms;
 extern	cvar_t	cl_lerp_max_gap_ms;
 extern	cvar_t	cl_lerp_debug;
+extern	float	cl_lerpfrac;
 
 
 #define	MAX_TEMP_ENTITIES	256		//johnfitz -- was 64
@@ -472,6 +473,7 @@ qboolean CL_IsPlayerEnt (const entity_t *ent);
 
 void CL_ParseTEnt (void);
 void CL_UpdateTEnts (void);
+void CL_ResetPlayerSnaps (void);
 
 void CL_FreeState(void);
 void CL_ClearState (void);

--- a/Quake/view.c
+++ b/Quake/view.c
@@ -76,6 +76,8 @@ cvar_t	r_viewmodel_quake = {"r_viewmodel_quake", "0", CVAR_ARCHIVE};
 
 vec3_t	v_punchangles[2]; //johnfitz -- copied from cl.punchangle.  0 is current, 1 is previous value. never the same unless map just loaded
 
+extern cvar_t cl_netdebug_parse;
+
 /*
 ===============
 V_CalcRoll
@@ -1059,6 +1061,16 @@ void V_CalcRefdef (void)
 	}
 	else
 		oldz = ent->origin[2];
+
+	if (cl_netdebug_parse.value)
+	{
+		Con_Printf ("NETDBG vieworg ent %d cur %.2f %.2f %.2f prev %.2f %.2f %.2f lerp %.3f view %.2f %.2f %.2f\n",
+			cl.viewentity,
+			ent->msg_origins[0][0], ent->msg_origins[0][1], ent->msg_origins[0][2],
+			ent->msg_origins[1][0], ent->msg_origins[1][1], ent->msg_origins[1][2],
+			cl_lerpfrac,
+			r_refdef.vieworg[0], r_refdef.vieworg[1], r_refdef.vieworg[2]);
+	}
 
 	if (chase_active.value)
 		Chase_UpdateForDrawing (); //johnfitz


### PR DESCRIPTION
### Motivation

- Fix reproducible cases where the rendered camera spawns in the void due to interpolation using stale previous-map frame history and mismatched player state.
- Ensure the authoritative player origin from snapshots/prediction is reflected immediately in the rendered view (`r_refdef.vieworg`) at map start and after full snapshot resyncs.
- Prevent extrapolation/overshoot from producing out-of-range lerp fractions and stop using stale `previous` frame data across map boundaries.

### Description

- Reset interpolation and snapshot timing/state on map change and when applying a complete full snapshot by initializing `cl.mtime[]`, `cl.time`, `cl.oldtime`, clearing player snap history, and invalidating per-entity interpolation history via new helpers `CL_PrepareFullSnapshotInterpReset` and `CL_FinalizeFullSnapshotInterpReset` called during full snapshot apply paths in `CL_ParseSnapshotFull` and `CL_ParseSnapshot2`.
- Ensure `cl_entities` and entity snapshot buffers are zeroed on `CL_ClearState` and reset lerp timings to prevent any previous-map frames from being used by setting `cl.mtime[0/1]=0`, `cl.time=0`, `cl.oldtime=0` and `cl_lerpfrac=1.0f` in `CL_ClearState`.
- Harden interpolation: clamp and repair lerp fractions by changing `CL_LerpPoint` so if the denominator/timing yields `f <= 0` or the computed fraction is out-of-range the code snaps `cl.time`/`mtime[1]` to the current message and returns `1.0f`; and in entity interpolation (`CL_GetInterpolatedEntity`) clamp extrapolation factor `f` to `[0..1]` and handle zero/negative span by returning the newest frame to avoid invalid blends.
- Track the computed lerp fraction in a new global `cl_lerpfrac` and add a single-line NETDBG trace (reusing existing `cl_netdebug_parse`) in the view code to print `cl.viewentity`, raw current origin, prev origin, `lerpfrac`, and resulting `r_refdef.vieworg` to help confirm whether bad view origins were caused by interpolation.
- API/headers: expose `CL_ResetPlayerSnaps` and `cl_lerpfrac` in `client.h` for unit consistency with the new helpers and logging usage.

### Testing

- No automated tests were run for this change; manual verification was not recorded in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697002ef1bd0832eabeecff9ebac9d7e)