### PR TITLE
Fix snapshot entity origin updates for viewentity

### DIFF
--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -1208,6 +1208,7 @@ static void CL_ParsePackedEntities (void)
 			return;
 		}
 		CL_ApplySnapshotOrigin (ent->msg_origins[0], parsed_origin);
+		CL_ApplyEntityOrigin (ent, (int)entnum);
 
 		if (mask & PACKEDENT_MASK_VEL_X)
 		{
@@ -1530,6 +1531,19 @@ static void CL_ApplySnapshotOrigin (vec3_t out, const vec3_t in)
 		VectorCopy (in, out);
 }
 
+static void CL_ApplyEntityOrigin (entity_t *ent, int entnum)
+{
+	VectorCopy (ent->msg_origins[0], ent->origin);
+
+	if (entnum == cl.viewentity)
+	{
+		if (!VectorCompare (ent->msg_origins[0], vec3_origin))
+			VectorCopy (ent->msg_origins[0], cl.simorg);
+		if (VectorCompare (ent->origin, vec3_origin))
+			VectorCopy (cl.simorg, ent->origin);
+	}
+}
+
 static void CL_LogDeltaReject (const char *reason, unsigned int seq, unsigned int base_seq)
 {
 	NET_DebugLogEvent (true,
@@ -1641,6 +1655,7 @@ static void CL_ApplySnapshotState (int entnum, const snapshot_state_t *state)
 
 	CL_ApplySnapshotOrigin (ent->msg_origins[0], state->state.origin);
 	VectorCopy (state->state.angles, ent->msg_angles[0]);
+	CL_ApplyEntityOrigin (ent, entnum);
 
 	if (state->step)
 	{

--- a/Quake/cl_predict.c
+++ b/Quake/cl_predict.c
@@ -55,6 +55,7 @@ static void CL_Predict_ApplyToClient (void)
 	if (!CL_Predict_IsEnabled () || !cl_pred.has_base)
 		return;
 
+	VectorCopy (cl_pred.predicted.origin, cl.simorg);
 	VectorCopy (cl_pred.predicted.origin, cl_entities[cl.viewentity].origin);
 	VectorCopy (cl_pred.predicted.origin, cl_entities[cl.viewentity].msg_origins[0]);
 	VectorCopy (cl_pred.predicted.origin, cl_entities[cl.viewentity].msg_origins[1]);
@@ -292,6 +293,7 @@ void CL_Predict_ServerUpdate (unsigned int ack, const vec3_t origin, const vec3_
 
 	cl_pred.seq_acked = ack;
 	VectorCopy (origin, cl_pred.base.origin);
+	VectorCopy (origin, cl.simorg);
 	VectorCopy (velocity, cl_pred.base.velocity);
 	VectorCopy (viewangles, cl_pred.base.viewangles);
 	cl_pred.base.onground = onground;

--- a/Quake/client.h
+++ b/Quake/client.h
@@ -220,6 +220,7 @@ typedef struct
 	vec3_t		mviewangles[2];	// during demo playback viewangles is lerped
 								// between these
 	vec3_t		viewangles;
+	vec3_t		simorg;			// last simulated origin for viewentity
 
 	vec3_t		mvelocity[2];	// update by server, used for lean+bob
 								// (0 is newest)


### PR DESCRIPTION
### Motivation

- Players could spawn looking into the void because the local player entity (`cl_entities[cl.viewentity].origin`) was left as (0,0,0) when snapshot/packed-entity apply paths did not ensure the viewentity origin was written.
- The goal is to ensure snapshot2/packedents always set the entity origin for all entities including the viewentity and to provide a safety fallback from the last predicted origin when the server-supplied origin is zero.

### Description

- Added a new client state field `cl.simorg` in `Quake/client.h` to track the last simulated/predicted viewentity origin used for a safety fallback.
- Updated prediction code in `Quake/cl_predict.c` to set `cl.simorg` from the prediction base and when applying predictions in `CL_Predict_ApplyToClient` and `CL_Predict_ServerUpdate`.
- Introduced `CL_ApplyEntityOrigin(entity_t *ent, int entnum)` in `Quake/cl_parse.c` which copies the staged `msg_origins[0]` into `ent->origin` and, for the viewentity, records non-zero origins into `cl.simorg` and uses `cl.simorg` as a fallback when the resolved `ent->origin` is `(0,0,0)`.
- Invoked `CL_ApplyEntityOrigin` immediately after snapshot/packed entity origin conversion in `CL_ParsePackedEntities` and in `CL_ApplySnapshotState` to ensure every entity (including `cl.viewentity`) gets its origin written during snapshot apply.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69700eb691e8832e83461233bf6cdfef)