### PR TITLE
Fix CL_ApplyEntityOrigin prototype

### DIFF
--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -118,6 +118,7 @@ const char *svc_strings[] =
 
 static void CL_RequestFullSnapshot (const char *reason, qboolean count_parse_error);
 static void CL_ApplySnapshotOrigin (vec3_t out, const vec3_t in);
+static void CL_ApplyEntityOrigin (entity_t *ent, int entnum);
 
 static const char *CL_SvcName (int cmd)
 {


### PR DESCRIPTION
### Motivation
- Add a forward declaration for `CL_ApplyEntityOrigin` to prevent implicit-int warnings and mismatched redefinition errors during compilation.

### Description
- Inserted the `static` prototype `static void CL_ApplyEntityOrigin (entity_t *ent, int entnum);` alongside other forward declarations in `Quake/cl_parse.c`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69701186b2cc832ebced06327aabc763)