### PR TITLE
Fix viewentity origin after snapshot2

### DIFF
--- a/Quake/cl_main.c
+++ b/Quake/cl_main.c
@@ -151,6 +151,44 @@ void CL_ResetPlayerSnaps (void)
 }
 
 float cl_lerpfrac = 1.0f;
+qboolean cl_viewent_needs_init = true;
+
+static qboolean CL_ViewEntityOriginIsBad (const vec3_t origin)
+{
+	const float max_abs = 65536.0f;
+	int i;
+
+	if (VectorCompare (origin, vec3_origin))
+		return true;
+	for (i = 0; i < 3; i++)
+	{
+		if (!isfinite (origin[i]) || fabsf (origin[i]) > max_abs)
+			return true;
+	}
+
+	return false;
+}
+
+static void CL_EnsureViewEntityOrigin (const char *reason)
+{
+	entity_t *ent;
+
+	if (!cl_entities || cl.viewentity <= 0 || cl.viewentity >= cl_max_edicts)
+		return;
+	ent = &cl_entities[cl.viewentity];
+	if (!CL_ViewEntityOriginIsBad (ent->origin))
+		return;
+
+	// The renderer/camera rely on the viewentity origin; repair it using simorg.
+	VectorCopy (cl.simorg, ent->origin);
+	VectorCopy (cl.simorg, ent->msg_origins[0]);
+	VectorCopy (cl.simorg, ent->msg_origins[1]);
+	if (cl_netdebug_parse.value)
+	{
+		Con_Printf ("NETDBG: viewentity origin repaired (%s): simorg=%f %f %f\n",
+			reason ? reason : "unknown", cl.simorg[0], cl.simorg[1], cl.simorg[2]);
+	}
+}
 
 void CL_RecordPlayerSnap (void)
 {
@@ -530,6 +568,7 @@ void CL_ClearState (void)
 	cl.time = 0.0;
 	cl.oldtime = 0.0;
 	cl_lerpfrac = 1.0f;
+	cl_viewent_needs_init = true;
 	cl.snapshot_chunk_active = false;
 	cl.snapshot_chunk_seq = 0;
 	cl.snapshot_chunk_start_time = 0;
@@ -1081,6 +1120,11 @@ void CL_RelinkEntities (void)
 		else
 		{	// if the delta is large, assume a teleport and don't lerp
 			f = frac;
+			if (ent == &cl_entities[cl.viewentity] && cl_viewent_needs_init)
+			{
+				f = 1.0f;
+				ent->lerpflags |= LERP_RESETMOVE;
+			}
 			for (j=0 ; j<3 ; j++)
 			{
 				delta[j] = ent->msg_origins[0][j] - ent->msg_origins[1][j];
@@ -1314,6 +1358,7 @@ int CL_ReadFromServer (void)
 	if (cl_shownet.value)
 		Con_Printf ("\n");
 
+	CL_EnsureViewEntityOrigin ("render");
 	CL_RelinkEntities ();
 	CL_UpdateTEnts ();
 

--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -37,6 +37,7 @@ extern cvar_t cl_netdebug_dropbad;
 extern cvar_t cl_netdebug_maxdump;
 extern cvar_t cl_signon_chunk_debug;
 extern cvar_t cl_signon_debug;
+extern qboolean cl_viewent_needs_init;
 
 const char *svc_strings[] =
 {
@@ -973,6 +974,43 @@ static qboolean CL_ReadPackedUInt16 (unsigned int *out)
 	return true;
 }
 
+static qboolean CL_ViewEntityOriginIsBad (const vec3_t origin)
+{
+	const float max_abs = 65536.0f;
+	int i;
+
+	if (VectorCompare (origin, vec3_origin))
+		return true;
+	for (i = 0; i < 3; i++)
+	{
+		if (!isfinite (origin[i]) || fabsf (origin[i]) > max_abs)
+			return true;
+	}
+
+	return false;
+}
+
+static void CL_EnsureViewEntityOrigin (const char *reason)
+{
+	entity_t *ent;
+
+	if (!cl_entities || cl.viewentity <= 0 || cl.viewentity >= cl_max_edicts)
+		return;
+	ent = &cl_entities[cl.viewentity];
+	if (!CL_ViewEntityOriginIsBad (ent->origin))
+		return;
+
+	// The renderer/camera rely on the viewentity origin; repair it using simorg.
+	VectorCopy (cl.simorg, ent->origin);
+	VectorCopy (cl.simorg, ent->msg_origins[0]);
+	VectorCopy (cl.simorg, ent->msg_origins[1]);
+	if (cl_netdebug_parse.value)
+	{
+		Con_Printf ("NETDBG: viewentity origin repaired (%s): simorg=%f %f %f\n",
+			reason ? reason : "unknown", cl.simorg[0], cl.simorg[1], cl.simorg[2]);
+	}
+}
+
 static qboolean CL_PackedOriginIsSane (const vec3_t origin)
 {
 	const float max_abs = 65536.0f;
@@ -1532,6 +1570,22 @@ static void CL_ApplySnapshotOrigin (vec3_t out, const vec3_t in)
 		VectorCopy (in, out);
 }
 
+static void CL_InitViewEntityFromSim (void)
+{
+	entity_t *ent;
+
+	if (!cl_viewent_needs_init)
+		return;
+	if (!cl_entities || cl.viewentity <= 0 || cl.viewentity >= cl_max_edicts)
+		return;
+
+	ent = &cl_entities[cl.viewentity];
+	VectorCopy (cl.simorg, ent->origin);
+	VectorCopy (cl.simorg, ent->msg_origins[0]);
+	VectorCopy (cl.simorg, ent->msg_origins[1]);
+	cl_viewent_needs_init = false;
+}
+
 static void CL_ApplyEntityOrigin (entity_t *ent, int entnum)
 {
 	VectorCopy (ent->msg_origins[0], ent->origin);
@@ -1805,6 +1859,8 @@ static void CL_ParseSnapshotFull (void)
 
 		if (reset_interp)
 			CL_FinalizeFullSnapshotInterpReset ();
+
+		CL_InitViewEntityFromSim ();
 	}
 
 	cl.snapshot_baseline_seq = seq;
@@ -2274,6 +2330,13 @@ static void CL_ParseSnapshot2 (void)
 					CL_ResetSnapshotChunk ();
 					return;
 				}
+				if (!CL_PackedOriginIsSane (state.state.origin))
+				{
+					CL_RequestFullSnapshot ("snapshot2 origin guard", true);
+					msg_readcount = net_message.cursize;
+					CL_ResetSnapshotChunk ();
+					return;
+				}
 				if (!drop)
 				{
 					cl.snapshot_chunk[entnum] = state;
@@ -2333,6 +2396,7 @@ static void CL_ParseSnapshot2 (void)
 				if (reset_interp)
 					CL_FinalizeFullSnapshotInterpReset ();
 
+				CL_InitViewEntityFromSim ();
 				CL_Predict_Reapply ();
 
 				cl.snapshot_baseline_seq = header.seq;
@@ -2344,6 +2408,7 @@ static void CL_ParseSnapshot2 (void)
 				cl.has_valid_worldstate = true;
 				cl.snap_incomplete_count = 0;
 				CL_RecordPlayerSnap ();
+				CL_EnsureViewEntityOrigin ("snapshot2");
 				NET_DebugLogEvent (true,
 					"NETDBG time %.3f snap2_apply seq %u flags 0x%x full %d delta %d has_full %d\n",
 					realtime, header.seq, header.flags, is_full ? 1 : 0, is_delta ? 1 : 0,
@@ -2391,6 +2456,12 @@ static void CL_ParseSnapshot2 (void)
 				msg_readcount = net_message.cursize;
 				return;
 			}
+			if (!CL_PackedOriginIsSane (state.state.origin))
+			{
+				CL_RequestFullSnapshot ("snapshot2 origin guard", true);
+				msg_readcount = net_message.cursize;
+				return;
+			}
 			if (!drop)
 			{
 				cl.snapshot_stage[entnum] = state;
@@ -2421,6 +2492,7 @@ static void CL_ParseSnapshot2 (void)
 				if (reset_interp)
 					CL_FinalizeFullSnapshotInterpReset ();
 
+				CL_InitViewEntityFromSim ();
 				CL_Predict_Reapply ();
 
 				cl.snapshot_baseline_seq = header.seq;
@@ -2432,6 +2504,7 @@ static void CL_ParseSnapshot2 (void)
 				cl.has_valid_worldstate = true;
 				cl.snap_incomplete_count = 0;
 				CL_RecordPlayerSnap ();
+				CL_EnsureViewEntityOrigin ("snapshot2");
 				NET_DebugLogEvent (true,
 					"NETDBG time %.3f snap2_apply seq %u flags 0x%x full %d delta %d has_full %d\n",
 					realtime, header.seq, header.flags, is_full ? 1 : 0, is_delta ? 1 : 0,
@@ -2537,6 +2610,12 @@ static void CL_ParseSnapshot2 (void)
 			}
 			if (!drop && baseline_match && entnum > 0 && entnum < cl_max_edicts)
 			{
+				if (!CL_PackedOriginIsSane (state.state.origin))
+				{
+					CL_RequestFullSnapshot ("snapshot2 origin guard", true);
+					msg_readcount = net_message.cursize;
+					return;
+				}
 				cl.snapshot_stage[entnum] = state;
 				cl.snapshot_stage_present[entnum] = 1;
 			}
@@ -2571,6 +2650,12 @@ static void CL_ParseSnapshot2 (void)
 						msg_readcount = net_message.cursize;
 						return;
 					}
+					if (!CL_PackedOriginIsSane (state.state.origin))
+					{
+						CL_RequestFullSnapshot ("snapshot2 origin guard", true);
+						msg_readcount = net_message.cursize;
+						return;
+					}
 					cl.snapshot_stage[entnum] = state;
 					cl.snapshot_stage_present[entnum] = 1;
 				}
@@ -2582,6 +2667,12 @@ static void CL_ParseSnapshot2 (void)
 					if (msg_badread)
 					{
 						CL_RequestFullSnapshot ("snapshot2 update skip", true);
+						msg_readcount = net_message.cursize;
+						return;
+					}
+					if (!CL_PackedOriginIsSane (scratch.state.origin))
+					{
+						CL_RequestFullSnapshot ("snapshot2 origin guard", true);
 						msg_readcount = net_message.cursize;
 						return;
 					}
@@ -2623,6 +2714,7 @@ static void CL_ParseSnapshot2 (void)
 			cl.snap_incomplete_count = 0;
 			cl.has_full_snapshot = true;
 			CL_RecordPlayerSnap ();
+			CL_EnsureViewEntityOrigin ("snapshot2");
 			NET_DebugLogEvent (true,
 				"NETDBG time %.3f snap2_apply seq %u flags 0x%x full %d delta %d has_full %d\n",
 				realtime, header.seq, header.flags, is_full ? 1 : 0, is_delta ? 1 : 0,

--- a/Quake/cl_predict.c
+++ b/Quake/cl_predict.c
@@ -9,6 +9,7 @@ extern cvar_t sv_accelerate;
 extern cvar_t sv_friction;
 extern cvar_t sv_stopspeed;
 extern cvar_t sv_gravity;
+extern cvar_t cl_netdebug_parse;
 
 typedef struct
 {
@@ -29,6 +30,43 @@ typedef struct
 } cl_pred_t;
 
 static cl_pred_t cl_pred;
+
+static qboolean CL_ViewEntityOriginIsBad (const vec3_t origin)
+{
+	const float max_abs = 65536.0f;
+	int i;
+
+	if (VectorCompare (origin, vec3_origin))
+		return true;
+	for (i = 0; i < 3; i++)
+	{
+		if (!isfinite (origin[i]) || fabsf (origin[i]) > max_abs)
+			return true;
+	}
+
+	return false;
+}
+
+static void CL_EnsureViewEntityOrigin (const char *reason)
+{
+	entity_t *ent;
+
+	if (!cl_entities || cl.viewentity <= 0 || cl.viewentity >= cl_max_edicts)
+		return;
+	ent = &cl_entities[cl.viewentity];
+	if (!CL_ViewEntityOriginIsBad (ent->origin))
+		return;
+
+	// The renderer/camera rely on the viewentity origin; repair it using simorg.
+	VectorCopy (cl.simorg, ent->origin);
+	VectorCopy (cl.simorg, ent->msg_origins[0]);
+	VectorCopy (cl.simorg, ent->msg_origins[1]);
+	if (cl_netdebug_parse.value)
+	{
+		Con_Printf ("NETDBG: viewentity origin repaired (%s): simorg=%f %f %f\n",
+			reason ? reason : "unknown", cl.simorg[0], cl.simorg[1], cl.simorg[2]);
+	}
+}
 
 static qboolean CL_Predict_SeqNewer (unsigned int seq, unsigned int ref)
 {
@@ -62,6 +100,8 @@ static void CL_Predict_ApplyToClient (void)
 	VectorCopy (cl_pred.predicted.velocity, cl.mvelocity[0]);
 	VectorCopy (cl_pred.predicted.velocity, cl.mvelocity[1]);
 	cl.onground = cl_pred.predicted.onground;
+
+	CL_EnsureViewEntityOrigin ("predict");
 }
 
 static void CL_Predict_Friction (vec3_t velocity)


### PR DESCRIPTION
### Motivation

- Prevent cases where `cl.entities[cl.viewentity].origin` is left at `(0,0,0)`/NaN/huge values after map load or snapshot2 apply, which caused the camera to render the player in the void. 
- Harden snapshot2 parsing, interpolation and prediction so an invalid viewentity origin cannot reach rendering or cause regressions. 

### Description

- Add a small helper `CL_EnsureViewEntityOrigin(const char *reason)` and a predicate `CL_ViewEntityOriginIsBad` to detect zero/NaN/inf/absurd origins and repair them from `cl.simorg`, with an optional `NETDBG` log message. 
- Call `CL_EnsureViewEntityOrigin` at the end of snapshot2 full apply paths, at the end of prediction (`CL_Predict_ApplyToClient`) and just before relinking/render (`CL_ReadFromServer` / render path) to guarantee the renderer never sees a bad viewentity origin. 
- Introduce `cl_viewent_needs_init` set in `CL_ClearState` and cleared when the first complete FULL snapshot is applied; initialize the viewentity origin from `cl.simorg` on the first full snapshot via `CL_InitViewEntityFromSim`, and force the viewentity to skip lerp for the first frame to avoid void spawns. 
- Harden snapshot2 and packed-entities parsing by validating decoded origins via `CL_PackedOriginIsSane` and rejecting snapshots (requesting a full snapshot) if origins contain NaN/Inf or are absurdly large; avoid committing staged snapshot state until the snapshot is complete. 
- Minimal, local changes only to `Quake/cl_main.c`, `Quake/cl_parse.c`, and `Quake/cl_predict.c`, no protocol changes or new cvars; added short comments and a guarded `NETDBG` repair log. 

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69712ac8add4832eb993b01ae0203da5)