### PR TITLE
Never gate CL_SendCmd on snapshot readiness; complete-first-full-snapshot handling

### DIFF
--- a/Quake/cl_main.c
+++ b/Quake/cl_main.c
@@ -1501,15 +1501,8 @@ void CL_SendCmd (void)
 		cmd.impulse = in_impulse;
 		in_impulse = 0;
 
-		// Freeze local movement until we have a ready viewentity to avoid void spawns.
-		if (!CL_WorldReady ())
-		{
-			cmd.forwardmove = 0;
-			cmd.sidemove = 0;
-			cmd.upmove = 0;
-			cmd.buttons = 0;
-			cmd.impulse = 0;
-		}
+		// NOTE: Never gate command generation/sending on snapshot readiness.
+		// Prediction handles world-ready checks; the server still needs cmds every frame.
 
 		CL_Predict_SetupCmd (&cmd);
 

--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -2211,6 +2211,7 @@ static void CL_ParseSnapshot2 (void)
 	qboolean need_full;
 	qboolean is_full;
 	qboolean is_delta;
+	qboolean continuation;
 	const int incomplete_limit = 3;
 	qboolean base_advanced = false;
 
@@ -2222,6 +2223,10 @@ static void CL_ParseSnapshot2 (void)
 	need_full = (cl.need_full_snapshot || !cl.has_full_snapshot);
 	is_full = (header.flags & SNAPSHOT_FLAG_FULL) != 0;
 	is_delta = (header.flags & SNAPSHOT_FLAG_DELTA) != 0;
+	continuation = (header.flags & SNAPSHOT_FLAG_CONTINUE) != 0;
+
+	if (is_full && !cl.has_full_snapshot && !continuation)
+		incomplete = false;
 
 	if (!CL_SnapshotWorldModelReady ("snapshot2 worldmodel"))
 		drop = true;
@@ -2292,7 +2297,6 @@ static void CL_ParseSnapshot2 (void)
 
 	if (is_full)
 	{
-		qboolean continuation = (header.flags & SNAPSHOT_FLAG_CONTINUE) != 0;
 		qboolean rem_zero = (header.num_removed == 0);
 		qboolean final_chunk = (!continuation || rem_zero);
 		qboolean finalize_invalid = (!continuation && !rem_zero);

--- a/Quake/cl_predict.c
+++ b/Quake/cl_predict.c
@@ -81,6 +81,7 @@ static qboolean CL_Predict_SeqNewer (unsigned int seq, unsigned int ref)
 
 static qboolean CL_Predict_IsEnabled (void)
 {
+	// Prediction may be gated on world readiness, but command sending must not be.
 	if (cls.state != ca_connected)
 		return false;
 	if (cls.demoplayback)


### PR DESCRIPTION
### Motivation

- Restore player movement (including noclip) in maps where snapshot/world gating prevented `CL_SendCmd` from sending input while preserving the viewentity origin spawn fix. 
- Separate prediction gating from command generation/sending so prediction may wait for a ready world while the server still receives usercmds each frame. 
- Prevent permanent waiting on a first full snapshot by treating it as complete unless a continuation flag is present.

### Description

- Removed snapshot/world-ready gating from `CL_SendCmd` in `Quake/cl_main.c` and added a short comment explaining that command generation/sending must not be gated by snapshot readiness so the server receives commands every frame. (`CL_SendCmd`, `CL_Predict_SetupCmd`).
- In `Quake/cl_parse.c` `CL_ParseSnapshot2` added a `continuation` local and logic to treat a received `FULL` snapshot as complete when the client does not yet have a full snapshot and the packet is not marked as a continuation, preventing permanent full-snapshot waiting states. (`SNAPSHOT_FLAG_FULL`, `SNAPSHOT_FLAG_CONTINUE`, `incomplete` adjustment).
- Clarified prediction-only gating in `Quake/cl_predict.c` by adding a comment to `CL_Predict_IsEnabled` to note that prediction may be gated by world readiness but command sending must not be.
- Changes are minimal, local to the three files requested, and introduce no new cvars or behavioral changes to server-side logic.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69713905e7f4832e802b1c5b2bcee81c)