### PR TITLE
Per-client send rate budgeting (per-interval rate limit)

### DIFF
--- a/Quake/net_defs.h
+++ b/Quake/net_defs.h
@@ -156,6 +156,8 @@ typedef struct qsocket_s
 	double		connecttime;
 	double		lastMessageTime;
 	double		lastSendTime;
+	double		rate_next_time;
+	int		rate_budget;
 
 	qboolean	disconnected;
 	qboolean	canSend;

--- a/Quake/net_dgrm.c
+++ b/Quake/net_dgrm.c
@@ -186,6 +186,44 @@ static int NET_GetPacketDataLimit (const qsocket_t *sock)
 	return q_min (data_limit, MAX_DATAGRAM);
 }
 
+static unsigned int NET_GetRateBudgetLimit (const qsocket_t *sock)
+{
+	unsigned int payload = (unsigned int)NET_GetPacketPayloadLimit (sock);
+	unsigned int budget = payload * 4u;
+
+	if (budget < (unsigned int)(NET_HEADERSIZE + 1))
+		budget = (unsigned int)(NET_HEADERSIZE + 1);
+	return budget;
+}
+
+static void NET_UpdateRateBudget (qsocket_t *sock)
+{
+	if (IS_LOOP_DRIVER(sock->driver))
+		return;
+	if (sock->rate_next_time == 0.0 || net_time >= sock->rate_next_time)
+	{
+		sock->rate_budget = (int)NET_GetRateBudgetLimit (sock);
+		sock->rate_next_time = net_time + 0.1;
+	}
+}
+
+static qboolean NET_HasRateBudget (qsocket_t *sock, unsigned int packet_len)
+{
+	if (IS_LOOP_DRIVER(sock->driver))
+		return true;
+	NET_UpdateRateBudget(sock);
+	return sock->rate_budget >= (int)packet_len;
+}
+
+static qboolean NET_ConsumeRateBudget (qsocket_t *sock, unsigned int packet_len)
+{
+	if (!NET_HasRateBudget(sock, packet_len))
+		return false;
+	if (!IS_LOOP_DRIVER(sock->driver))
+		sock->rate_budget -= (int)packet_len;
+	return true;
+}
+
 static void NET_LogOversizedSend (const qsocket_t *sock, unsigned int packet_len)
 {
 	static double next_log_time = 0.0;
@@ -283,6 +321,9 @@ static int NET_SendReliablePacket (qsocket_t *sock, net_reliable_send_t *packet,
 		return -1;
 	}
 
+	if (!NET_ConsumeRateBudget(sock, packet_len))
+		return 0;
+
 	NET_SetPacketHeader(sock, packet_len, flags, packet->sequence);
 	Q_memcpy (packetBuffer.data, sock->sendMessage + packet->offset, packet->length);
 
@@ -328,6 +369,8 @@ static int NET_SendPendingReliable (qsocket_t *sock)
 		if (data_len > (int)max_data)
 			data_len = (int)max_data;
 		eom = (sock->sendMessageOffset + data_len) >= sock->sendMessageLength;
+		if (!NET_HasRateBudget(sock, (unsigned int)(NET_HEADERSIZE + data_len)))
+			break;
 
 		sequence = sock->sendSequence++;
 		packet = &sock->reliableSend[sequence % NET_RELIABLE_WINDOW];
@@ -338,8 +381,13 @@ static int NET_SendPendingReliable (qsocket_t *sock)
 		packet->acked = false;
 		packet->lastSendTime = 0.0;
 
-		if (NET_SendReliablePacket (sock, packet, "window", false) == -1)
-			return -1;
+		{
+			int ret = NET_SendReliablePacket (sock, packet, "window", false);
+			if (ret == -1)
+				return -1;
+			if (ret == 0)
+				break;
+		}
 
 		sock->sendMessageOffset += data_len;
 	}
@@ -416,7 +464,8 @@ static void NET_ResendReliablePackets (qsocket_t *sock)
 			continue;
 		if ((net_time - packet->lastSendTime) <= 1.0)
 			continue;
-		NET_SendReliablePacket (sock, packet, "resend", true);
+		if (NET_SendReliablePacket (sock, packet, "resend", true) == 0)
+			break;
 	}
 }
 
@@ -575,6 +624,9 @@ int Datagram_SendUnreliableMessage (qsocket_t *sock, sizebuf_t *data)
 		NET_DebugMaybeLogSummary ();
 		return 0;
 	}
+
+	if (!NET_ConsumeRateBudget(sock, (unsigned int)packetLen))
+		return 0;
 
 	NET_SetPacketHeader(sock, (unsigned int)packetLen, NETFLAG_UNRELIABLE, sock->unreliableSendSequence++);
 	Q_memcpy (packetBuffer.data, data->data, data->cursize);

--- a/Quake/net_main.c
+++ b/Quake/net_main.c
@@ -119,6 +119,8 @@ qsocket_t *NET_NewQSocket (void)
 	sock->driverdata = NULL;
 	sock->canSend = true;
 	sock->lastMessageTime = net_time;
+	sock->rate_next_time = 0.0;
+	sock->rate_budget = 0;
 	sock->sendSequence = 1;
 	sock->unreliableSendSequence = 0;
 	sock->sendMessageLength = 0;


### PR DESCRIPTION
### Motivation
- Add per-client send budgeting to throttle outgoing network traffic at the point messages are queued/sent to avoid bursts and excessive per-client bandwidth usage.
- Apply the budget to both reliable and unreliable sends and make it reset on a fixed short interval to allow smoothing over time.

### Description
- Added per-socket bookkeeping fields `rate_next_time` and `rate_budget` to `qsocket_t` in `Quake/net_defs.h` and initialized them in `NET_NewQSocket` in `Quake/net_main.c`.
- Implemented budget helpers in `Quake/net_dgrm.c`: `NET_GetRateBudgetLimit`, `NET_UpdateRateBudget`, `NET_HasRateBudget`, and `NET_ConsumeRateBudget`, with a fixed interval of 0.1s (100ms) and a budget of `payload * 4` bytes per interval.
- Enforced budget checks/consumption for reliable packets inside `NET_SendReliablePacket` and when assembling windowed sends in `NET_SendPendingReliable`, and for unreliable datagrams in `Datagram_SendUnreliableMessage` so sends are deferred/fragmented when the budget is exhausted.
- Updated resend logic so resends stop when budget is exhausted and preserved loop-driver bypasses for local loopback sockets.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697146894058832e80bb56fc71256478)