### PR TITLE
Introduce command sequencing and ack fields for client-side prediction and server reconciliation

### DIFF
--- a/Quake/cl_input.c
+++ b/Quake/cl_input.c
@@ -416,6 +416,8 @@ void CL_SendMove (const usercmd_t *cmd)
 		MSG_WriteByte (&buf, clc_move);
 
 		MSG_WriteFloat (&buf, cl.mtime[0]);	// so server can get ping times
+		MSG_WriteLong (&buf, (int)cmd->sequence);
+		MSG_WriteLong (&buf, (int)cl.last_cmd_ack);
 
 		cmd_count = 0;
 		for (i = CMD_BACKUP; i >= 0; i--)

--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -3002,9 +3002,15 @@ void CL_ParseClientdata (void)
 	if (bits & SU_PREDICT)
 	{
 		unsigned int ack = (unsigned int)MSG_ReadLong ();
+		unsigned int ack_echo = (unsigned int)MSG_ReadLong ();
 		vec3_t origin;
 		vec3_t velocity;
 		vec3_t viewangles;
+
+		if ((int)(ack - cl.last_cmd_ack) > 0)
+			cl.last_cmd_ack = ack;
+		if ((int)(ack_echo - cl.last_cmd_ack_echo) > 0)
+			cl.last_cmd_ack_echo = ack_echo;
 
 		for (i = 0; i < 3; i++)
 			origin[i] = MSG_ReadCoord (cl.protocolflags);

--- a/Quake/client.h
+++ b/Quake/client.h
@@ -201,6 +201,8 @@ typedef struct
 								// first frame
 	usercmd_t	cmd;			// last command sent to the server
 	usercmd_t	pendingcmd;		// accumulated state from mice+joysticks.
+	unsigned int	last_cmd_ack;		// last command acknowledged by the server
+	unsigned int	last_cmd_ack_echo;	// last command ack echoed back by the server
 
 // information for local display
 	int			stats[MAX_CL_STATS];	// health, etc

--- a/Quake/protocol.h
+++ b/Quake/protocol.h
@@ -327,7 +327,7 @@ typedef enum
 #define	clc_bad			0
 #define	clc_nop 		1
 #define	clc_disconnect	2
-#define	clc_move		3		// [usercmd_t]
+#define	clc_move		3		// [float mtime] [long cmd_seq] [long cmd_ack] [byte count] [usercmd_t]
 #define	clc_stringcmd	4		// [string] message
 #define	clc_snapshot_ack	5	// [long] seq
 #define	clc_snapshot_nak	6	// [long] expected base [long] received base

--- a/Quake/server.h
+++ b/Quake/server.h
@@ -264,6 +264,7 @@ typedef struct client_s
 	double			datagram_overflow_next_time;
 	bot_state_t		bot;
 	unsigned int	last_cmd_seq;
+	unsigned int	last_cmd_ack;
 } client_t;
 
 

--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -3660,6 +3660,7 @@ void SV_WriteClientdataToMessage (client_t *client, edict_t *ent, sizebuf_t *msg
 	//johnfitz
 
 	MSG_WriteLong (msg, (int)client->last_cmd_seq);
+	MSG_WriteLong (msg, (int)client->last_cmd_ack);
 	for (i=0 ; i<3 ; i++)
 		MSG_WriteCoord (msg, ent->v.origin[i], sv.protocolflags);
 	for (i=0 ; i<3 ; i++)

--- a/Quake/sv_user.c
+++ b/Quake/sv_user.c
@@ -605,11 +605,18 @@ nextmsg:
 			{
 				int cmd_count;
 				int cmd_index;
+				unsigned int cmd_seq;
+				unsigned int cmd_ack;
 
 			// read ping time
 				host_client->ping_times[host_client->num_pings%NUM_PING_TIMES]
 					= qcvm->time - MSG_ReadFloat ();
 				host_client->num_pings++;
+
+				cmd_seq = (unsigned int)MSG_ReadLong ();
+				cmd_ack = (unsigned int)MSG_ReadLong ();
+				if (SV_CmdSeqNewer (cmd_ack, host_client->last_cmd_ack))
+					host_client->last_cmd_ack = cmd_ack;
 
 				cmd_count = MSG_ReadByte ();
 				for (cmd_index = 0; cmd_index < cmd_count; cmd_index++)
@@ -629,6 +636,8 @@ nextmsg:
 					if (move.impulse)
 						host_client->edict->v.impulse = move.impulse;
 				}
+				if (cmd_count == 0 && SV_CmdSeqNewer (cmd_seq, host_client->last_cmd_seq))
+					host_client->last_cmd_seq = cmd_seq;
 				break;
 			}
 


### PR DESCRIPTION
### Motivation
- Add explicit command sequence metadata to client move messages so the server can correlate and acknowledge inputs for reconciliation. 
- Maintain last-acknowledged command state on both client and server to support client-side prediction and authoritative reconciliation. 
- Echo the server ack back to the client in `svc_clientdata` so the client can advance its prediction base and drop already-acked commands.

### Description
- Extend the `clc_move` message description in `Quake/protocol.h` to include `[float mtime] [long cmd_seq] [long cmd_ack]` before the command list. 
- Write the current command sequence and the client-side `last_cmd_ack` into the move packet in `Quake/cl_input.c` (`MSG_WriteLong` for `cmd->sequence` and `cl.last_cmd_ack`). 
- Add `last_cmd_ack` and `last_cmd_ack_echo` fields to the client state in `Quake/client.h` to track acked commands from the server. 
- Read `cmd_seq` and `cmd_ack` in `Quake/sv_user.c`, update `host_client->last_cmd_ack` when newer, and handle the zero-`cmd_count` case by advancing `last_cmd_seq` from `cmd_seq` if appropriate. 
- Write `client->last_cmd_ack` alongside `client->last_cmd_seq` in server clientdata (`Quake/sv_main.c`) so the client receives the server-ack echo. 
- Parse the ack and ack-echo in `Quake/cl_parse.c`, updating `cl.last_cmd_ack` and `cl.last_cmd_ack_echo`, and pass the ack into the existing prediction reconciliation call `CL_Predict_ServerUpdate`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971483d31d0832e94f17a08ebbfe640)