### PR TITLE
Per-client `rate`/`updaterate` cvars, server clamps, and budget enforcement

### DIFF
--- a/Quake/cl_main.c
+++ b/Quake/cl_main.c
@@ -43,6 +43,8 @@ cvar_t	cl_signon_chunk_debug = {"cl_signon_chunk_debug", "0", CVAR_NONE};
 cvar_t	cl_signon_debug = {"cl_signon_debug", "0", CVAR_NONE};
 cvar_t	cl_nolerp = {"cl_nolerp","0",CVAR_NONE};
 cvar_t	cl_packedents = {"cl_packedents", "1", CVAR_ARCHIVE};
+cvar_t	cl_rate = {"cl_rate", "25000", CVAR_ARCHIVE};
+cvar_t	cl_updaterate = {"cl_updaterate", "20", CVAR_ARCHIVE};
 cvar_t	cl_snap_debug = {"cl_snap_debug", "0", CVAR_NONE};
 cvar_t	cl_snapshot_debug = {"cl_snapshot_debug", "0", CVAR_NONE};
 cvar_t	cl_delta_reject_debug = {"cl_delta_reject_debug", "0", CVAR_NONE};
@@ -748,6 +750,12 @@ void CL_SignonReply (void)
 
 		MSG_WriteByte (&cls.message, clc_stringcmd);
 		MSG_WriteString (&cls.message, va("color %i %i\n", ((int)cl_color.value)>>4, ((int)cl_color.value)&15));
+
+		MSG_WriteByte (&cls.message, clc_stringcmd);
+		MSG_WriteString (&cls.message, va("rate %d\n", (int)cl_rate.value));
+
+		MSG_WriteByte (&cls.message, clc_stringcmd);
+		MSG_WriteString (&cls.message, va("updaterate %d\n", (int)cl_updaterate.value));
 
 		if (cl_packedents.value)
 		{
@@ -1710,6 +1718,8 @@ void CL_Init (void)
 	Cvar_RegisterVariable (&cl_signon_debug);
 	Cvar_RegisterVariable (&cl_nolerp);
 	Cvar_RegisterVariable (&cl_packedents);
+	Cvar_RegisterVariable (&cl_rate);
+	Cvar_RegisterVariable (&cl_updaterate);
 	Cvar_RegisterVariable (&cl_snap_debug);
 	Cvar_RegisterVariable (&cl_snapshot_debug);
 	Cvar_RegisterVariable (&cl_delta_reject_debug);

--- a/Quake/net_dgrm.c
+++ b/Quake/net_dgrm.c
@@ -186,11 +186,32 @@ static int NET_GetPacketDataLimit (const qsocket_t *sock)
 	return q_min (data_limit, MAX_DATAGRAM);
 }
 
+static const client_t *NET_GetClientForSocket (const qsocket_t *sock)
+{
+	int i;
+
+	if (!sv.active || !svs.clients)
+		return NULL;
+	for (i = 0; i < svs.maxclients; i++)
+	{
+		client_t *client = &svs.clients[i];
+
+		if (!client->active)
+			continue;
+		if (client->netconnection == sock)
+			return client;
+	}
+	return NULL;
+}
+
 static unsigned int NET_GetRateBudgetLimit (const qsocket_t *sock)
 {
 	unsigned int payload = (unsigned int)NET_GetPacketPayloadLimit (sock);
 	unsigned int budget = payload * 4u;
+	const client_t *client = NET_GetClientForSocket (sock);
 
+	if (client && client->rate > 0)
+		budget = (unsigned int)client->rate / 10u;
 	if (budget < (unsigned int)(NET_HEADERSIZE + 1))
 		budget = (unsigned int)(NET_HEADERSIZE + 1);
 	return budget;

--- a/Quake/server.h
+++ b/Quake/server.h
@@ -191,6 +191,8 @@ typedef struct client_s
 										// periodically
 
 	struct qsocket_s *netconnection;	// communications handle
+	int				rate;				// bytes per second
+	int				updaterate;			// snapshots per second
 
 	usercmd_t		cmd;				// movement
 	vec3_t			wishdir;			// intended motion calced from cmd

--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -52,6 +52,10 @@ static cvar_t sv_event_max = {"sv_event_max", "0", CVAR_NONE};
 cvar_t sv_mtu = {"sv_mtu", "1400", CVAR_NONE};
 static cvar_t sv_mtu_cap = {"sv_mtu_cap", "1400", CVAR_NONE};
 cvar_t sv_mtu_debug = {"sv_mtu_debug", "0", CVAR_NONE};
+cvar_t sv_minrate = {"sv_minrate", "0", CVAR_NONE};
+cvar_t sv_maxrate = {"sv_maxrate", "0", CVAR_NONE};
+cvar_t sv_minupdaterate = {"sv_minupdaterate", "0", CVAR_NONE};
+cvar_t sv_maxupdaterate = {"sv_maxupdaterate", "0", CVAR_NONE};
 static cvar_t sv_signon_chunks = {"sv_signon_chunks", "1", CVAR_NONE};
 static cvar_t sv_signon_chunk_debug = {"sv_signon_chunk_debug", "0", CVAR_NONE};
 static cvar_t sv_signon_chunk_window = {"sv_signon_chunk_window", "3", CVAR_NONE};
@@ -309,6 +313,10 @@ void SV_Init (void)
 	Cvar_RegisterVariable (&sv_mtu);
 	Cvar_RegisterVariable (&sv_mtu_cap);
 	Cvar_RegisterVariable (&sv_mtu_debug);
+	Cvar_RegisterVariable (&sv_minrate);
+	Cvar_RegisterVariable (&sv_maxrate);
+	Cvar_RegisterVariable (&sv_minupdaterate);
+	Cvar_RegisterVariable (&sv_maxupdaterate);
 	Cvar_RegisterVariable (&sv_signon_chunks);
 	Cvar_RegisterVariable (&sv_signon_chunk_debug);
 	Cvar_RegisterVariable (&sv_signon_chunk_window);
@@ -700,6 +708,8 @@ void SV_ConnectClient (int clientnum)
 		SV_InitClientSnapshotData (client);
 	SV_ResetClientSnapshot (client);
 	client->netconnection = netconnection;
+	client->rate = sv_minrate.value > 0.0f ? (int)sv_minrate.value : 0;
+	client->updaterate = sv_minupdaterate.value > 0.0f ? (int)sv_minupdaterate.value : 0;
 
 	strcpy (client->name, "unconnected");
 	client->active = true;
@@ -1354,6 +1364,14 @@ static int SV_SnapshotBudgetBytes (client_t *client, sizebuf_t *msg,
 			cap = 1;
 		if (budget > cap)
 			budget = cap;
+	}
+	if (client->rate > 0 && client->updaterate > 0)
+	{
+		int per_snapshot = client->rate / client->updaterate;
+		if (per_snapshot < header_size + 1)
+			per_snapshot = header_size + 1;
+		if (budget > per_snapshot)
+			budget = per_snapshot;
 	}
 
 	if (out_mtu_payload)

--- a/Quake/sv_user.c
+++ b/Quake/sv_user.c
@@ -28,6 +28,10 @@ edict_t	*sv_player;
 extern	cvar_t	sv_friction;
 cvar_t	sv_edgefriction = {"edgefriction", "2", CVAR_NONE};
 extern	cvar_t	sv_stopspeed;
+extern	cvar_t	sv_minrate;
+extern	cvar_t	sv_maxrate;
+extern	cvar_t	sv_minupdaterate;
+extern	cvar_t	sv_maxupdaterate;
 
 static	vec3_t		forward, right, up;
 
@@ -37,6 +41,19 @@ float	*origin;
 float	*velocity;
 
 qboolean	onground;
+
+static int SV_ClampClientRate (int value, const cvar_t *min_rate, const cvar_t *max_rate)
+{
+	int clamped = value;
+
+	if (clamped < 0)
+		clamped = 0;
+	if (min_rate->value > 0.0f && clamped < (int)min_rate->value)
+		clamped = (int)min_rate->value;
+	if (max_rate->value > 0.0f && clamped > (int)max_rate->value)
+		clamped = (int)max_rate->value;
+	return clamped;
+}
 
 usercmd_t	cmd;
 
@@ -523,6 +540,18 @@ nextmsg:
 
 			case clc_stringcmd:
 				s = MSG_ReadString ();
+				if (q_strncasecmp(s, "rate", 4) == 0)
+				{
+					int rate = Q_atoi(s + 4);
+					host_client->rate = SV_ClampClientRate (rate, &sv_minrate, &sv_maxrate);
+					break;
+				}
+				if (q_strncasecmp(s, "updaterate", 10) == 0)
+				{
+					int updaterate = Q_atoi(s + 10);
+					host_client->updaterate = SV_ClampClientRate (updaterate, &sv_minupdaterate, &sv_maxupdaterate);
+					break;
+				}
 				if (q_strncasecmp(s, "packedents", 10) == 0)
 				{
 					int value = Q_atoi(s + 10);


### PR DESCRIPTION
### Motivation
- Allow clients to advertise desired bandwidth (`rate`) and snapshot frequency (`updaterate`) and let the server clamp and honor those preferences when sending snapshots and datagrams.

### Description
- Added client cvars `cl_rate` and `cl_updaterate`, register them and advertise their values during signon using `clc_stringcmd` in `Quake/cl_main.c`.
- Added per-client fields `rate` and `updaterate` to `client_t` in `Quake/server.h` and initialize them from server minimums in `SV_ConnectClient` (`Quake/sv_main.c`).
- Added server clamp cvars `sv_minrate`, `sv_maxrate`, `sv_minupdaterate`, and `sv_maxupdaterate` and registered them in `Quake/sv_main.c`.
- Parse incoming `rate` and `updaterate` `clc_stringcmd` messages, clamp with `SV_ClampClientRate`, and store in the `host_client` record in `Quake/sv_user.c`.
- Apply per-client limits when computing budgets: cap per-snapshot bytes in `SV_SnapshotBudgetBytes` (using `client->rate` / `client->updaterate`) and use per-client `rate` to influence `NET_GetRateBudgetLimit` (via a `NET_GetClientForSocket` helper) in `Quake/net_dgrm.c`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69714d621dac832e947ace331b662eff)