### PR TITLE
Declare loop index in CL_ClearState to fix MSVC build errors

### DIFF
--- a/Quake/cl_main.c
+++ b/Quake/cl_main.c
@@ -548,6 +548,8 @@ CL_ClearState
 */
 void CL_ClearState (void)
 {
+	int i;
+
 	if (cl.qcvm.extfuncs.CSQC_Shutdown)
 	{
 		PR_SwitchQCVM(&cl.qcvm);


### PR DESCRIPTION
### Motivation
- Fix MSVC compilation errors caused by an undeclared loop variable `i` in `CL_ClearState` when clearing client snapshot buffers.

### Description
- Add a declaration `int i;` at the start of `CL_ClearState` in `Quake/cl_main.c` so the snapshot-clearing loops compile correctly.

### Testing
- No automated tests or builds were run after this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697157718a80832eaad9151f039b596d)