### PR TITLE
Fix QCVM context for prediction SV_Move

### DIFF
--- a/Quake/cl_predict.c
+++ b/Quake/cl_predict.c
@@ -206,6 +206,7 @@ static trace_t CL_Predict_TraceBox (const vec3_t start, const vec3_t end, const 
 	vec3_t mins_copy;
 	vec3_t maxs_copy;
 	qmodel_t *saved;
+	qcvm_t *oldvm;
 
 	memset (&trace, 0, sizeof(trace));
 	trace.fraction = 1.0f;
@@ -221,7 +222,9 @@ static trace_t CL_Predict_TraceBox (const vec3_t start, const vec3_t end, const 
 
 	saved = sv.worldmodel;
 	sv.worldmodel = cl.worldmodel;
+	PR_PushQCVM(&sv.qcvm, &oldvm);
 	trace = SV_Move (start_copy, mins_copy, maxs_copy, end_copy, typeflags, NULL);
+	PR_PopQCVM(oldvm);
 	sv.worldmodel = saved;
 
 	return trace;


### PR DESCRIPTION
### Motivation
- Ensure `SV_Move` invoked during client-side prediction has a valid server QCVM context to avoid null QCVM access and use the correct world model.

### Description
- In `Quake/cl_predict.c` added a `qcvm_t *oldvm` and wrapped the `SV_Move` call inside `CL_Predict_TraceBox` with `PR_PushQCVM(&sv.qcvm, &oldvm)` before the call and `PR_PopQCVM(oldvm)` after, while temporarily setting `sv.worldmodel = cl.worldmodel`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971649af200832e85c495fe58a4cf14)