### PR TITLE
Remove legacy netcode and harden RMQ snapshot path

### DIFF
--- a/Quake/cl_input.c
+++ b/Quake/cl_input.c
@@ -420,7 +420,7 @@ void CL_SendMove (const usercmd_t *cmd)
 		MSG_WriteLong (&buf, (int)cl.last_cmd_ack);
 
 		cmd_count = 0;
-		for (i = CMD_BACKUP; i >= 0; i--)
+		for (i = CMD_BACKUP; i >= 0 && cmd_count < MAX_CMDS_PER_PACKET; i--)
 		{
 			unsigned int seq = cmd->sequence - (unsigned int)i;
 
@@ -435,12 +435,7 @@ void CL_SendMove (const usercmd_t *cmd)
 
 			MSG_WriteLong (&buf, (int)out->sequence);
 			for (j=0 ; j<3 ; j++)
-				//johnfitz -- 16-bit angles for PROTOCOL_FITZQUAKE
-				if (cl.protocol == PROTOCOL_NETQUAKE)
-					MSG_WriteAngle (&buf, out->viewangles[j], cl.protocolflags);
-				else
-					MSG_WriteAngle16 (&buf, out->viewangles[j], cl.protocolflags);
-				//johnfitz
+				MSG_WriteAngle16 (&buf, out->viewangles[j], cl.protocolflags);
 
 			MSG_WriteShort (&buf, out->forwardmove);
 			MSG_WriteShort (&buf, out->sidemove);

--- a/Quake/cl_main.c
+++ b/Quake/cl_main.c
@@ -42,7 +42,6 @@ cvar_t	cl_netdebug_maxdump = {"cl_netdebug_maxdump", "256", CVAR_NONE};
 cvar_t	cl_signon_chunk_debug = {"cl_signon_chunk_debug", "0", CVAR_NONE};
 cvar_t	cl_signon_debug = {"cl_signon_debug", "0", CVAR_NONE};
 cvar_t	cl_nolerp = {"cl_nolerp","0",CVAR_NONE};
-cvar_t	cl_packedents = {"cl_packedents", "1", CVAR_ARCHIVE};
 cvar_t	cl_rate = {"cl_rate", "25000", CVAR_ARCHIVE};
 cvar_t	cl_updaterate = {"cl_updaterate", "20", CVAR_ARCHIVE};
 cvar_t	cl_snap_debug = {"cl_snap_debug", "0", CVAR_NONE};
@@ -771,12 +770,6 @@ void CL_SignonReply (void)
 
 		MSG_WriteByte (&cls.message, clc_stringcmd);
 		MSG_WriteString (&cls.message, va("updaterate %d\n", (int)cl_updaterate.value));
-
-		if (cl_packedents.value)
-		{
-			MSG_WriteByte (&cls.message, clc_stringcmd);
-			MSG_WriteString (&cls.message, "packedents 1");
-		}
 
 		MSG_WriteByte (&cls.message, clc_stringcmd);
 		sprintf (str, "spawn %s", cls.spawnparms);
@@ -1732,7 +1725,6 @@ void CL_Init (void)
 	Cvar_RegisterVariable (&cl_signon_chunk_debug);
 	Cvar_RegisterVariable (&cl_signon_debug);
 	Cvar_RegisterVariable (&cl_nolerp);
-	Cvar_RegisterVariable (&cl_packedents);
 	Cvar_RegisterVariable (&cl_rate);
 	Cvar_RegisterVariable (&cl_updaterate);
 	Cvar_RegisterVariable (&cl_snap_debug);

--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -111,9 +111,8 @@ const char *svc_strings[] =
 	"svc_localsound", // 56
 	"svc_snapshot_full", // 57
 	"svc_snapshot_delta", // 58
-	"svc_packedentities", // 59
-	"svc_snapshot2", // 60
-	"svc_signon_chunk" // 61
+	"svc_snapshot2", // 59
+	"svc_signon_chunk" // 60
 };
 #define NUM_SVC_STRINGS Q_COUNTOF(svc_strings)
 
@@ -207,7 +206,6 @@ static void CL_NetDebugHeader (void)
 }
 
 static double cl_badmsg_next_warn_time = 0.0;
-static double cl_unknown_cmd_next_warn_time = 0.0;
 
 static void CL_BadServerMessage (const char *reason, int cmd, int cmd_offset,
 	int lastcmd, int lastcmd_offset, int prevcmd, int prevcmd_offset)
@@ -237,9 +235,8 @@ static void CL_BadServerMessage (const char *reason, int cmd, int cmd_offset,
 		Con_Printf ("Dropping malformed server message: %s\n", reason);
 		cl_badmsg_next_warn_time = realtime + 1.0;
 	}
+	CL_RequestFullSnapshot (reason, true);
 }
-
-qboolean warn_about_nehahra_protocol; //johnfitz
 
 static void CL_ParseSignonRecord (const byte *payload, int payload_len)
 {
@@ -427,7 +424,6 @@ void CL_ParseStartSoundPacket(void)
 	else
 		attenuation = DEFAULT_SOUND_PACKET_ATTENUATION;
 
-	//johnfitz -- PROTOCOL_FITZQUAKE
 	if (field_mask & SND_LARGEENTITY)
 	{
 		ent = (unsigned short) MSG_ReadShort ();
@@ -444,12 +440,9 @@ void CL_ParseStartSoundPacket(void)
 		sound_num = (unsigned short) MSG_ReadShort ();
 	else
 		sound_num = MSG_ReadByte ();
-	//johnfitz
 
-	//johnfitz -- check soundnum
 	if (sound_num >= MAX_SOUNDS)
 		Host_Error ("CL_ParseStartSoundPacket: %i > MAX_SOUNDS", sound_num);
-	//johnfitz
 
 	if (ent > cl_max_edicts) //johnfitz -- no more MAX_EDICTS
 		Host_Error ("CL_ParseStartSoundPacket: ent = %i", ent);
@@ -569,32 +562,17 @@ void CL_ParseServerInfo (void)
 
 // parse protocol version number
 	i = MSG_ReadLong ();
-	//johnfitz -- support multiple protocols
-	if (i != PROTOCOL_NETQUAKE && i != PROTOCOL_FITZQUAKE && i != PROTOCOL_RMQ) {
+	if (i != PROTOCOL_RMQ)
+	{
 		Con_Printf ("\n"); //because there's no newline after serverinfo print
-		Host_Error ("Server returned version %i, not %i or %i or %i", i, PROTOCOL_NETQUAKE, PROTOCOL_FITZQUAKE, PROTOCOL_RMQ);
+		Host_Error ("Server returned protocol %i, expected %i", i, PROTOCOL_RMQ);
 	}
-	cl.protocol = i;
-	//johnfitz
+	cl.protocol = PROTOCOL_RMQ;
 
-	if (cl.protocol == PROTOCOL_RMQ)
-	{
-		const unsigned int supportedflags = (PRFL_SHORTANGLE | PRFL_FLOATANGLE | PRFL_24BITCOORD | PRFL_FLOATCOORD | PRFL_EDICTSCALE | PRFL_INT32COORD | PRFL_SNAPSHOT_HIRES | PRFL_SIGNON_CHUNKS);
-		
-		// mh - read protocol flags from server so that we know what protocol features to expect
-		cl.protocolflags = (unsigned int) MSG_ReadLong ();
-		
-		if (0 != (cl.protocolflags & (~supportedflags)))
-		{
-			Con_Warning("PROTOCOL_RMQ protocolflags %i contains unsupported flags\n", cl.protocolflags);
-		}
-		cl.signon_chunking = (cl.protocolflags & PRFL_SIGNON_CHUNKS) != 0;
-	}
-	else
-	{
-		cl.protocolflags = 0;
-		cl.signon_chunking = false;
-	}
+	cl.protocolflags = (unsigned int) MSG_ReadLong ();
+	if (cl.protocolflags != PROTOCOL_RMQ_FLAGS)
+		Host_Error ("Server protocol flags 0x%x do not match required flags 0x%x", cl.protocolflags, PROTOCOL_RMQ_FLAGS);
+	cl.signon_chunking = true;
 	cl.signon_chunk_stage = SIGNON_STAGE_PRECACHES;
 	cl.signon_chunk_next_seq = 0;
 	CL_ResetSignonFragment ();
@@ -618,8 +596,7 @@ void CL_ParseServerInfo (void)
 	Con_Printf ("\n%s\n", Con_Quakebar(40)); //johnfitz
 	Con_Printf ("%c%s\n", 2, str);
 
-//johnfitz -- tell user which protocol this is
-	Con_Printf ("Using protocol %i\n", i);
+	Con_Printf ("Using protocol %i\n", cl.protocol);
 
 // first we go through and touch all of the precache data that still
 // happens to be in the cache, so precaching something else doesn't
@@ -716,264 +693,6 @@ void CL_ParseServerInfo (void)
 	memset(&dev_overflows, 0, sizeof(dev_overflows));
 }
 
-/*
-==================
-CL_ParseUpdate
-
-Parse an entity update message from the server
-If an entities model or origin changes from frame to frame, it must be
-relinked.  Other attributes can change without relinking.
-==================
-*/
-void CL_ParseUpdate (int bits)
-{
-	int		i;
-	qmodel_t	*model;
-	int		modnum;
-	qboolean	forcelink;
-	entity_t	*ent;
-	int		num;
-	int		skin;
-	int		prevframe;
-
-	if (cls.signon == SIGNONS - 1)
-	{	// first update is the final signon stage
-		cls.signon = SIGNONS;
-		CL_SignonReply ();
-	}
-
-	if (bits & U_MOREBITS)
-	{
-		i = MSG_ReadByte ();
-		bits |= (i<<8);
-	}
-
-	//johnfitz -- PROTOCOL_FITZQUAKE
-	if (cl.protocol == PROTOCOL_FITZQUAKE || cl.protocol == PROTOCOL_RMQ)
-	{
-		if (bits & U_EXTEND1)
-			bits |= MSG_ReadByte() << 16;
-		if (bits & U_EXTEND2)
-			bits |= MSG_ReadByte() << 24;
-	}
-	//johnfitz
-
-	if (bits & U_LONGENTITY)
-		num = MSG_ReadShort ();
-	else
-		num = MSG_ReadByte ();
-
-	ent = CL_EntityNum (num);
-
-	if (ent->msgtime != cl.mtime[1])
-		forcelink = true;	// no previous frame to lerp from
-	else
-		forcelink = false;
-
-	//johnfitz -- lerping
-	if (ent->msgtime + 0.2 < cl.mtime[0]) //more than 0.2 seconds since the last message (most entities think every 0.1 sec)
-		ent->lerpflags |= LERP_RESETANIM; //if we missed a think, we'd be lerping from the wrong frame
-	//johnfitz
-
-	ent->msgtime = cl.mtime[0];
-
-	if (bits & U_MODEL)
-	{
-		modnum = MSG_ReadByte ();
-		if (modnum >= MAX_MODELS)
-			Host_Error ("CL_ParseModel: bad modnum");
-	}
-	else
-		modnum = ent->baseline.modelindex;
-
-	prevframe = ent->frame;
-	if (bits & U_FRAME)
-		ent->frame = MSG_ReadByte ();
-	else
-		ent->frame = ent->baseline.frame;
-
-	if (bits & U_COLORMAP)
-		i = MSG_ReadByte();
-	else
-		i = ent->baseline.colormap;
-	if (!i)
-		ent->colormap = vid.colormap;
-	else
-	{
-		if (i > cl.maxclients)
-			Sys_Error ("i >= cl.maxclients");
-		ent->colormap = cl.scores[i-1].translations;
-	}
-	if (bits & U_SKIN)
-		skin = MSG_ReadByte();
-	else
-		skin = ent->baseline.skin;
-	if (skin != ent->skinnum)
-	{
-		ent->skinnum = skin;
-		if (num > 0 && num <= cl.maxclients)
-			R_TranslateNewPlayerSkin (num - 1); //johnfitz -- was R_TranslatePlayerSkin
-	}
-	if (bits & U_EFFECTS)
-		ent->effects = MSG_ReadByte();
-	else
-		ent->effects = ent->baseline.effects;
-
-// shift the known values for interpolation
-	VectorCopy (ent->msg_origins[0], ent->msg_origins[1]);
-	VectorCopy (ent->msg_angles[0], ent->msg_angles[1]);
-
-	if (bits & U_ORIGIN1)
-		ent->msg_origins[0][0] = MSG_ReadCoord (cl.protocolflags);
-	else
-		ent->msg_origins[0][0] = ent->baseline.origin[0];
-	if (bits & U_ANGLE1)
-		ent->msg_angles[0][0] = MSG_ReadAngle(cl.protocolflags);
-	else
-		ent->msg_angles[0][0] = ent->baseline.angles[0];
-
-	if (bits & U_ORIGIN2)
-		ent->msg_origins[0][1] = MSG_ReadCoord (cl.protocolflags);
-	else
-		ent->msg_origins[0][1] = ent->baseline.origin[1];
-	if (bits & U_ANGLE2)
-		ent->msg_angles[0][1] = MSG_ReadAngle(cl.protocolflags);
-	else
-		ent->msg_angles[0][1] = ent->baseline.angles[1];
-
-	if (bits & U_ORIGIN3)
-		ent->msg_origins[0][2] = MSG_ReadCoord (cl.protocolflags);
-	else
-		ent->msg_origins[0][2] = ent->baseline.origin[2];
-	if (bits & U_ANGLE3)
-		ent->msg_angles[0][2] = MSG_ReadAngle(cl.protocolflags);
-	else
-		ent->msg_angles[0][2] = ent->baseline.angles[2];
-
-	//johnfitz -- lerping for movetype_step entities
-	if (bits & U_STEP)
-	{
-		ent->lerpflags |= LERP_MOVESTEP;
-		ent->forcelink = true;
-	}
-	else
-		ent->lerpflags &= ~LERP_MOVESTEP;
-	//johnfitz
-
-	//johnfitz -- PROTOCOL_FITZQUAKE and PROTOCOL_NEHAHRA
-	if (cl.protocol == PROTOCOL_FITZQUAKE || cl.protocol == PROTOCOL_RMQ)
-	{
-		if (bits & U_ALPHA)
-			ent->alpha = MSG_ReadByte();
-		else
-			ent->alpha = ent->baseline.alpha;
-		if (bits & U_SCALE)
-			ent->scale = MSG_ReadByte();
-		else
-			ent->scale = ent->baseline.scale;
-		if (bits & U_FRAME2)
-			ent->frame = (ent->frame & 0x00FF) | (MSG_ReadByte() << 8);
-		if (bits & U_MODEL2)
-			modnum = (modnum & 0x00FF) | (MSG_ReadByte() << 8);
-		if (bits & U_LERPFINISH)
-		{
-			ent->lerpfinish = ent->msgtime + ((float)(MSG_ReadByte()) / 255);
-			ent->lerpflags |= LERP_FINISH;
-		}
-		else
-			ent->lerpflags &= ~LERP_FINISH;
-	}
-	else if (cl.protocol == PROTOCOL_NETQUAKE)
-	{
-		//HACK: if this bit is set, assume this is PROTOCOL_NEHAHRA
-		if (bits & U_TRANS)
-		{
-			float a, b;
-
-			if (warn_about_nehahra_protocol)
-			{
-				Con_Warning ("nonstandard update bit, assuming Nehahra protocol\n");
-				warn_about_nehahra_protocol = false;
-			}
-
-			a = MSG_ReadFloat();
-			b = MSG_ReadFloat(); //alpha
-			if (a == 2)
-				MSG_ReadFloat(); //fullbright (not using this yet)
-			ent->alpha = ENTALPHA_ENCODE(b);
-		}
-		else
-			ent->alpha = ent->baseline.alpha;
-		ent->scale = ent->baseline.scale;
-	}
-	//johnfitz
-
-	//johnfitz -- moved here from above
-	model = cl.model_precache[modnum];
-	if (model != ent->model)
-	{
-		ent->model = model;
-	// automatic animation (torches, etc) can be either all together
-	// or randomized
-		if (model)
-		{
-			if (model->synctype == ST_FRAMETIME)
-				ent->syncbase = -cl.time;
-			else if (model->synctype == ST_RAND)
-				ent->syncbase = (float)(rand()&0x7fff) / 0x7fff;
-			else
-				ent->syncbase = 0.0;
-		}
-		else
-			forcelink = true;	// hack to make null model players work
-		if (num > 0 && num <= cl.maxclients)
-			R_TranslateNewPlayerSkin (num - 1); //johnfitz -- was R_TranslatePlayerSkin
-
-		ent->lerpflags |= LERP_RESETANIM; //johnfitz -- don't lerp animation across model changes
-	}
-	//johnfitz
-	else if (model && model->synctype == ST_FRAMETIME && ent->frame != prevframe)
-		ent->syncbase = -cl.time;
-
-	if ( forcelink )
-	{	// didn't have an update last message
-		VectorCopy (ent->msg_origins[0], ent->msg_origins[1]);
-		VectorCopy (ent->msg_origins[0], ent->origin);
-		VectorCopy (ent->msg_angles[0], ent->msg_angles[1]);
-		VectorCopy (ent->msg_angles[0], ent->angles);
-		ent->forcelink = true;
-	}
-}
-
-static qboolean CL_ReadPackedByte (int *out)
-{
-	if (msg_readcount + 1 > net_message.cursize)
-		return false;
-	*out = net_message.data[msg_readcount];
-	msg_readcount++;
-	return true;
-}
-
-static qboolean CL_ReadPackedInt16 (short *out)
-{
-	if (msg_readcount + 2 > net_message.cursize)
-		return false;
-	*out = (short)(net_message.data[msg_readcount]
-		+ (net_message.data[msg_readcount+1] << 8));
-	msg_readcount += 2;
-	return true;
-}
-
-static qboolean CL_ReadPackedUInt16 (unsigned int *out)
-{
-	if (msg_readcount + 2 > net_message.cursize)
-		return false;
-	*out = (unsigned int)net_message.data[msg_readcount]
-		| ((unsigned int)net_message.data[msg_readcount+1] << 8);
-	msg_readcount += 2;
-	return true;
-}
-
 static qboolean CL_ViewEntityOriginIsBad (const vec3_t origin)
 {
 	const float max_abs = 65536.0f;
@@ -988,6 +707,31 @@ static qboolean CL_ViewEntityOriginIsBad (const vec3_t origin)
 	}
 
 	return false;
+}
+
+static qboolean CL_SnapshotOriginIsSane (const vec3_t origin)
+{
+	const float max_abs = 65536.0f;
+	int i;
+
+	for (i = 0; i < 3; i++)
+	{
+		if (!isfinite (origin[i]) || fabsf (origin[i]) > max_abs)
+			return false;
+	}
+	return true;
+}
+
+static int CL_CountMaskBits (unsigned int mask)
+{
+	int count = 0;
+
+	while (mask)
+	{
+		count += mask & 1u;
+		mask >>= 1;
+	}
+	return count;
 }
 
 static void CL_EnsureViewEntityOrigin (const char *reason)
@@ -1009,347 +753,6 @@ static void CL_EnsureViewEntityOrigin (const char *reason)
 		Con_Printf ("NETDBG: viewentity origin repaired (%s): simorg=%f %f %f\n",
 			reason ? reason : "unknown", cl.simorg[0], cl.simorg[1], cl.simorg[2]);
 	}
-}
-
-static qboolean CL_PackedOriginIsSane (const vec3_t origin)
-{
-	const float max_abs = 65536.0f;
-	int i;
-
-	for (i = 0; i < 3; i++)
-	{
-		if (!isfinite (origin[i]) || fabsf (origin[i]) > max_abs)
-			return false;
-	}
-	return true;
-}
-
-static void CL_ParsePackedEntities (void)
-{
-	unsigned int count;
-	unsigned int i;
-
-	if (cls.signon == SIGNONS - 1)
-	{	// first update is the final signon stage
-		cls.signon = SIGNONS;
-		CL_SignonReply ();
-	}
-
-	if (!CL_ReadPackedUInt16 (&count))
-	{
-		Con_DPrintf ("CL_ParsePackedEntities: short read on count\n");
-		msg_readcount = net_message.cursize;
-		return;
-	}
-
-	for (i = 0; i < count; i++)
-	{
-		entity_t *ent;
-		qmodel_t *model;
-		qboolean forcelink;
-		unsigned int entnum;
-		unsigned int lowmask;
-		unsigned int highmask = 0;
-		uint32_t mask;
-		int modnum;
-		int skin;
-		int prevframe;
-		int temp;
-		short coord;
-		qboolean origin_full;
-		vec3_t parsed_origin;
-
-		if (!CL_ReadPackedUInt16 (&entnum))
-			goto short_read;
-		if (!CL_ReadPackedUInt16 (&lowmask))
-			goto short_read;
-		if (lowmask & PACKEDENT_MASK_EXTEND)
-		{
-			if (!CL_ReadPackedUInt16 (&highmask))
-				goto short_read;
-			mask = ((uint32_t)highmask << 16) | (lowmask & ~PACKEDENT_MASK_EXTEND);
-		}
-		else
-			mask = lowmask;
-
-		if (mask & ~PACKEDENT_MASK_VALID)
-		{
-			Con_DPrintf ("CL_ParsePackedEntities: invalid mask 0x%x\n", mask);
-			msg_readcount = net_message.cursize;
-			return;
-		}
-
-		if (entnum >= (unsigned int)cl_max_edicts)
-		{
-			Con_DPrintf ("CL_ParsePackedEntities: invalid entnum %u\n", entnum);
-			msg_readcount = net_message.cursize;
-			return;
-		}
-
-		ent = CL_EntityNum ((int)entnum);
-
-		if (ent->msgtime != cl.mtime[1])
-			forcelink = true;	// no previous frame to lerp from
-		else
-			forcelink = false;
-
-		if (ent->msgtime + 0.2 < cl.mtime[0])
-			ent->lerpflags |= LERP_RESETANIM;
-
-		ent->msgtime = cl.mtime[0];
-
-		if (mask & PACKEDENT_MASK_MODEL)
-		{
-			unsigned int umod;
-			if (!CL_ReadPackedUInt16 (&umod))
-				goto short_read;
-			modnum = (int)umod;
-			if (modnum >= MAX_MODELS)
-			{
-				Con_DPrintf ("CL_ParsePackedEntities: bad modnum\n");
-				msg_readcount = net_message.cursize;
-				return;
-			}
-		}
-		else
-			modnum = ent->baseline.modelindex;
-
-		prevframe = ent->frame;
-		if (mask & PACKEDENT_MASK_FRAME)
-		{
-			unsigned int uframe;
-			if (!CL_ReadPackedUInt16 (&uframe))
-				goto short_read;
-			ent->frame = (int)uframe;
-		}
-		else
-			ent->frame = ent->baseline.frame;
-
-		if (mask & PACKEDENT_MASK_COLORMAP)
-		{
-			if (!CL_ReadPackedByte (&temp))
-				goto short_read;
-		}
-		else
-			temp = ent->baseline.colormap;
-
-		if (!temp)
-			ent->colormap = vid.colormap;
-		else
-		{
-			if (temp > cl.maxclients)
-			{
-				Con_DPrintf ("CL_ParsePackedEntities: bad colormap\n");
-				msg_readcount = net_message.cursize;
-				return;
-			}
-			ent->colormap = cl.scores[temp-1].translations;
-		}
-
-		if (mask & PACKEDENT_MASK_SKIN)
-		{
-			if (!CL_ReadPackedByte (&skin))
-				goto short_read;
-		}
-		else
-			skin = ent->baseline.skin;
-		if (skin != ent->skinnum)
-		{
-			ent->skinnum = skin;
-			if (entnum > 0 && entnum <= (unsigned int)cl.maxclients)
-				R_TranslateNewPlayerSkin ((int)entnum - 1);
-		}
-
-		if (mask & PACKEDENT_MASK_EFFECTS)
-		{
-			if (!CL_ReadPackedByte (&ent->effects))
-				goto short_read;
-		}
-		else
-			ent->effects = ent->baseline.effects;
-
-		VectorCopy (ent->msg_origins[0], ent->msg_origins[1]);
-		VectorCopy (ent->msg_angles[0], ent->msg_angles[1]);
-
-		origin_full = (mask & PACKEDENT_MASK_POS_FULL) != 0;
-		VectorCopy (ent->baseline.origin, parsed_origin);
-
-		if (mask & PACKEDENT_MASK_ORIGIN_X)
-		{
-			if (origin_full)
-				parsed_origin[0] = MSG_ReadCoord (cl.protocolflags);
-			else
-			{
-				if (!CL_ReadPackedInt16 (&coord))
-					goto short_read;
-				parsed_origin[0] = coord / PACKEDENT_POS_SCALE;
-			}
-		}
-
-		if (mask & PACKEDENT_MASK_ANGLE_PITCH)
-		{
-			unsigned int angle;
-			if (!CL_ReadPackedUInt16 (&angle))
-				goto short_read;
-			ent->msg_angles[0][0] = (float)angle * (360.0f / 65536.0f);
-		}
-		else
-			ent->msg_angles[0][0] = ent->baseline.angles[0];
-
-		if (mask & PACKEDENT_MASK_ORIGIN_Y)
-		{
-			if (origin_full)
-				parsed_origin[1] = MSG_ReadCoord (cl.protocolflags);
-			else
-			{
-				if (!CL_ReadPackedInt16 (&coord))
-					goto short_read;
-				parsed_origin[1] = coord / PACKEDENT_POS_SCALE;
-			}
-		}
-
-		if (mask & PACKEDENT_MASK_ANGLE_YAW)
-		{
-			unsigned int angle;
-			if (!CL_ReadPackedUInt16 (&angle))
-				goto short_read;
-			ent->msg_angles[0][1] = (float)angle * (360.0f / 65536.0f);
-		}
-		else
-			ent->msg_angles[0][1] = ent->baseline.angles[1];
-
-		if (mask & PACKEDENT_MASK_ORIGIN_Z)
-		{
-			if (origin_full)
-				parsed_origin[2] = MSG_ReadCoord (cl.protocolflags);
-			else
-			{
-				if (!CL_ReadPackedInt16 (&coord))
-					goto short_read;
-				parsed_origin[2] = coord / PACKEDENT_POS_SCALE;
-			}
-		}
-
-		if (mask & PACKEDENT_MASK_ANGLE_ROLL)
-		{
-			unsigned int angle;
-			if (!CL_ReadPackedUInt16 (&angle))
-				goto short_read;
-			ent->msg_angles[0][2] = (float)angle * (360.0f / 65536.0f);
-		}
-		else
-			ent->msg_angles[0][2] = ent->baseline.angles[2];
-
-		if (!CL_PackedOriginIsSane (parsed_origin))
-		{
-			CL_RequestFullSnapshot ("packedents origin guard", true);
-			msg_readcount = net_message.cursize;
-			return;
-		}
-		CL_ApplySnapshotOrigin (ent->msg_origins[0], parsed_origin);
-		CL_ApplyEntityOrigin (ent, (int)entnum);
-
-		if (mask & PACKEDENT_MASK_VEL_X)
-		{
-			if (!CL_ReadPackedInt16 (&coord))
-				goto short_read;
-			ent->packed_velocity[0] = coord / PACKEDENT_VEL_SCALE;
-		}
-		else
-			ent->packed_velocity[0] = 0.0f;
-
-		if (mask & PACKEDENT_MASK_VEL_Y)
-		{
-			if (!CL_ReadPackedInt16 (&coord))
-				goto short_read;
-			ent->packed_velocity[1] = coord / PACKEDENT_VEL_SCALE;
-		}
-		else
-			ent->packed_velocity[1] = 0.0f;
-
-		if (mask & PACKEDENT_MASK_VEL_Z)
-		{
-			if (!CL_ReadPackedInt16 (&coord))
-				goto short_read;
-			ent->packed_velocity[2] = coord / PACKEDENT_VEL_SCALE;
-		}
-		else
-			ent->packed_velocity[2] = 0.0f;
-
-		if (mask & PACKEDENT_MASK_ALPHA)
-		{
-			if (!CL_ReadPackedByte (&temp))
-				goto short_read;
-			ent->alpha = temp;
-		}
-		else
-			ent->alpha = ent->baseline.alpha;
-
-		if (mask & PACKEDENT_MASK_SCALE)
-		{
-			if (!CL_ReadPackedByte (&temp))
-				goto short_read;
-			ent->scale = temp;
-		}
-		else
-			ent->scale = ent->baseline.scale;
-
-		if (mask & PACKEDENT_MASK_LERPFINISH)
-		{
-			if (!CL_ReadPackedByte (&temp))
-				goto short_read;
-			ent->lerpfinish = ent->msgtime + ((float)temp / 255.0f);
-			ent->lerpflags |= LERP_FINISH;
-		}
-		else
-			ent->lerpflags &= ~LERP_FINISH;
-
-		if (mask & PACKEDENT_MASK_STEP)
-		{
-			ent->lerpflags |= LERP_MOVESTEP;
-			ent->forcelink = true;
-		}
-		else
-			ent->lerpflags &= ~LERP_MOVESTEP;
-
-		model = cl.model_precache[modnum];
-		if (model != ent->model)
-		{
-			ent->model = model;
-			if (model)
-			{
-				if (model->synctype == ST_FRAMETIME)
-					ent->syncbase = -cl.time;
-				else if (model->synctype == ST_RAND)
-					ent->syncbase = (float)(rand()&0x7fff) / 0x7fff;
-				else
-					ent->syncbase = 0.0;
-			}
-			else
-				forcelink = true;
-			if (entnum > 0 && entnum <= (unsigned int)cl.maxclients)
-				R_TranslateNewPlayerSkin ((int)entnum - 1);
-
-			ent->lerpflags |= LERP_RESETANIM;
-		}
-		else if (model && model->synctype == ST_FRAMETIME && ent->frame != prevframe)
-			ent->syncbase = -cl.time;
-
-		if (forcelink)
-		{
-			VectorCopy (ent->msg_origins[0], ent->msg_origins[1]);
-			VectorCopy (ent->msg_origins[0], ent->origin);
-			VectorCopy (ent->msg_angles[0], ent->msg_angles[1]);
-			VectorCopy (ent->msg_angles[0], ent->angles);
-			ent->forcelink = true;
-		}
-	}
-
-	return;
-
-short_read:
-	Con_DPrintf ("CL_ParsePackedEntities: short read\n");
-	msg_readcount = net_message.cursize;
 }
 
 // INV-2: keep control/acks from starving behind queued reliable data.
@@ -1492,7 +895,15 @@ static void CL_RequestFullSnapshot (const char *reason, qboolean count_parse_err
 	if (cls.demoplayback || cls.state != ca_connected)
 		return;
 	if (count_parse_error)
+	{
 		cl.snap_parse_errors++;
+		cl.snap_parse_consecutive++;
+		if (cl.snap_parse_consecutive >= MAX_SNAPSHOT_PARSE_ERRORS)
+		{
+			Host_EndGame ("Too many malformed packets\n");
+			return;
+		}
+	}
 	NET_DebugLogEvent (true,
 		"NETDBG time %.3f snap_abort reason %s parse_errors %d need_full %d\n",
 		realtime, reason ? reason : "unknown", cl.snap_parse_errors, cl.need_full_snapshot ? 1 : 0);
@@ -1511,6 +922,13 @@ static void CL_SendSnapshotNak (unsigned int expected_base, unsigned int receive
 	if (cls.demoplayback || cls.state != ca_connected)
 		return;
 	CL_EnsureReliableControlSpace (1 + 4 + 4, "snapshot_nak");
+	if (cls.message.maxsize - cls.message.cursize < (1 + 4 + 4))
+	{
+		NET_DebugLogEvent (true,
+			"NETDBG time %.3f snap_nak_drop expected %u received %u\n",
+			realtime, expected_base, received_base);
+		return;
+	}
 	MSG_WriteByte (&cls.message, clc_snapshot_nak);
 	MSG_WriteLong (&cls.message, (int)expected_base);
 	MSG_WriteLong (&cls.message, (int)received_base);
@@ -1644,7 +1062,7 @@ static qboolean CL_SnapshotWorldModelReady (const char *reason)
 
 static void CL_ApplySnapshotOrigin (vec3_t out, const vec3_t in)
 {
-	// Snapshot/packedent origins are model-space; offset by worldmodel origin to render in world-space.
+	// Snapshot origins are model-space; offset by worldmodel origin to render in world-space.
 	if (cl.worldmodel && cl.worldmodel->type == mod_brush
 		&& cl.worldmodel->submodels && cl.worldmodel->numsubmodels > 0)
 		VectorAdd (in, cl.worldmodel->submodels[0].origin, out);
@@ -1878,11 +1296,9 @@ void CL_ParseBaseline (entity_t *ent, int version) //johnfitz -- added argument
 	int	i;
 	int bits; //johnfitz
 
-	//johnfitz -- PROTOCOL_FITZQUAKE
 	bits = (version == 2) ? MSG_ReadByte() : 0;
 	ent->baseline.modelindex = (bits & B_LARGEMODEL) ? MSG_ReadShort() : MSG_ReadByte();
 	ent->baseline.frame = (bits & B_LARGEFRAME) ? MSG_ReadShort() : MSG_ReadByte();
-	//johnfitz
 
 	ent->baseline.colormap = MSG_ReadByte();
 	ent->baseline.skin = MSG_ReadByte();
@@ -1892,7 +1308,7 @@ void CL_ParseBaseline (entity_t *ent, int version) //johnfitz -- added argument
 		ent->baseline.angles[i] = MSG_ReadAngle (cl.protocolflags);
 	}
 
-	ent->baseline.alpha = (bits & B_ALPHA) ? MSG_ReadByte() : ENTALPHA_DEFAULT; //johnfitz -- PROTOCOL_FITZQUAKE
+	ent->baseline.alpha = (bits & B_ALPHA) ? MSG_ReadByte() : ENTALPHA_DEFAULT;
 	ent->baseline.scale = (bits & B_SCALE) ? MSG_ReadByte() : ENTSCALE_DEFAULT;
 }
 
@@ -1912,7 +1328,7 @@ static void CL_ParseSnapshotFull (void)
 	if (cl_snap_debug.value >= 1.0f)
 		Con_Printf ("cl_snap full seq %u ents %d%s\n", seq, count, drop ? " drop" : "");
 
-	if (msg_badread || count < 0 || count > cl_max_edicts)
+	if (msg_badread || count < 0 || count > cl_max_edicts || count > MAX_SNAPSHOT_ENTITIES)
 	{
 		CL_RequestFullSnapshot ("snapshot_full header", true);
 		msg_readcount = net_message.cursize;
@@ -1940,6 +1356,12 @@ static void CL_ParseSnapshotFull (void)
 		if (msg_badread)
 		{
 			CL_RequestFullSnapshot ("snapshot_full state", true);
+			msg_readcount = net_message.cursize;
+			return;
+		}
+		if (!CL_SnapshotOriginIsSane (state.state.origin))
+		{
+			CL_RequestFullSnapshot ("snapshot_full origin guard", true);
 			msg_readcount = net_message.cursize;
 			return;
 		}
@@ -1978,6 +1400,7 @@ static void CL_ParseSnapshotFull (void)
 	cl.snap_last_applied_seq = seq16;
 	cl.snap_last_complete_seq = seq16;
 	cl.snap_last_incomplete = false;
+	cl.snap_parse_consecutive = 0;
 	cl.need_full_snapshot = false;
 	cl.has_valid_worldstate = true;
 	cl.has_full_snapshot = true;
@@ -2075,7 +1498,7 @@ static void CL_ParseSnapshotDelta (void)
 
 	count = (unsigned short)MSG_ReadShort ();
 	removes_parsed = count;
-	if (msg_badread || count < 0 || count > cl_max_edicts)
+	if (msg_badread || count < 0 || count > cl_max_edicts || count > MAX_REMOVE_ENTITIES)
 	{
 		CL_RequestFullSnapshot ("snapshot_delta remove header", true);
 		msg_readcount = net_message.cursize;
@@ -2096,7 +1519,7 @@ static void CL_ParseSnapshotDelta (void)
 	}
 
 	count = (unsigned short)MSG_ReadShort ();
-	if (msg_badread || count < 0 || count > cl_max_edicts)
+	if (msg_badread || count < 0 || count > cl_max_edicts || count > MAX_SNAPSHOT_ENTITIES)
 	{
 		CL_RequestFullSnapshot ("snapshot_delta add header", true);
 		msg_readcount = net_message.cursize;
@@ -2117,6 +1540,12 @@ static void CL_ParseSnapshotDelta (void)
 			msg_readcount = net_message.cursize;
 			return;
 		}
+		if (!CL_SnapshotOriginIsSane (state.state.origin))
+		{
+			CL_RequestFullSnapshot ("snapshot_delta origin guard", true);
+			msg_readcount = net_message.cursize;
+			return;
+		}
 		if (!drop && baseline_match && entnum > 0 && entnum < cl_max_edicts)
 		{
 			cl.snapshot_stage[entnum] = state;
@@ -2125,7 +1554,7 @@ static void CL_ParseSnapshotDelta (void)
 	}
 
 	count = (unsigned short)MSG_ReadShort ();
-	if (msg_badread || count < 0 || count > cl_max_edicts)
+	if (msg_badread || count < 0 || count > cl_max_edicts || count > MAX_SNAPSHOT_ENTITIES)
 	{
 		CL_RequestFullSnapshot ("snapshot_delta update header", true);
 		msg_readcount = net_message.cursize;
@@ -2135,7 +1564,7 @@ static void CL_ParseSnapshotDelta (void)
 	{
 		int entnum = (unsigned short)MSG_ReadShort ();
 		mask = (unsigned int)MSG_ReadLong ();
-		if (msg_badread || (mask & ~SNAP_VALID_MASK))
+		if (msg_badread || (mask & ~SNAP_VALID_MASK) || CL_CountMaskBits (mask & SNAP_VALID_MASK) > MAX_PACKED_FIELDS)
 		{
 			CL_RequestFullSnapshot ("snapshot_delta update mask", true);
 			msg_readcount = net_message.cursize;
@@ -2149,6 +1578,12 @@ static void CL_ParseSnapshotDelta (void)
 			if (msg_badread)
 			{
 				CL_RequestFullSnapshot ("snapshot_delta update fields", true);
+				msg_readcount = net_message.cursize;
+				return;
+			}
+			if (!CL_SnapshotOriginIsSane (state.state.origin))
+			{
+				CL_RequestFullSnapshot ("snapshot_delta origin guard", true);
 				msg_readcount = net_message.cursize;
 				return;
 			}
@@ -2166,14 +1601,18 @@ static void CL_ParseSnapshotDelta (void)
 				msg_readcount = net_message.cursize;
 				return;
 			}
+			if (!CL_SnapshotOriginIsSane (scratch.state.origin))
+			{
+				CL_RequestFullSnapshot ("snapshot_delta origin guard", true);
+				msg_readcount = net_message.cursize;
+				return;
+			}
 		}
 	}
 
 	// INV-5: commit staged snapshot only after full parse/validation.
 	if (!drop && baseline_match)
 	{
-		byte *old_present = cl.snapshot_present;
-
 		CL_StoreSnapshotBaselineFromBase (seq, base_states, base_present);
 		if (base_is_current)
 		{
@@ -2198,10 +1637,6 @@ static void CL_ParseSnapshotDelta (void)
 					CL_MarkSnapshotEntityUpdated (i);
 					touched++;
 				}
-				else if (old_present && old_present[i])
-				{
-					CL_ClearSnapshotEntity (i);
-				}
 			}
 		}
 
@@ -2213,6 +1648,7 @@ static void CL_ParseSnapshotDelta (void)
 		cl.snap_last_applied_seq = seq16;
 		cl.snap_last_complete_seq = seq16;
 		cl.snap_last_incomplete = false;
+		cl.snap_parse_consecutive = 0;
 		cl.has_full_snapshot = true;
 		base_advanced = true;
 		(void)CL_SendSnapshotAck (CL_GetSnapshotAckSeq ());
@@ -2356,7 +1792,9 @@ static void CL_ParseSnapshot2 (void)
 			header.num_entities, header.num_removed, drop ? " drop" : "");
 	}
 
-	if (msg_badread || header.num_entities > cl_max_edicts || header.num_removed > cl_max_edicts)
+	if (msg_badread || header.num_entities > cl_max_edicts || header.num_removed > cl_max_edicts
+		|| header.num_entities > MAX_SNAPSHOT_ENTITIES || header.num_removed > MAX_REMOVE_ENTITIES
+		|| (unsigned int)header.num_entities + (unsigned int)header.num_removed > MAX_SNAPSHOT_ENTITIES)
 	{
 		CL_RequestFullSnapshot ("snapshot2 header", true);
 		msg_readcount = net_message.cursize;
@@ -2483,7 +1921,7 @@ static void CL_ParseSnapshot2 (void)
 					CL_ResetSnapshotChunk ();
 					return;
 				}
-				if (!CL_PackedOriginIsSane (state.state.origin))
+				if (!CL_SnapshotOriginIsSane (state.state.origin))
 				{
 					CL_RequestFullSnapshot ("snapshot2 origin guard", true);
 					msg_readcount = net_message.cursize;
@@ -2556,6 +1994,7 @@ static void CL_ParseSnapshot2 (void)
 				cl.snap_last_applied_seq = seq16;
 				cl.snap_last_complete_seq = seq16;
 				cl.snap_last_incomplete = false;
+				cl.snap_parse_consecutive = 0;
 				cl.need_full_snapshot = false;
 				cl.has_full_snapshot = true;
 				cl.has_valid_worldstate = true;
@@ -2576,6 +2015,7 @@ static void CL_ParseSnapshot2 (void)
 				touched = CL_ApplySnapshotOverlay (cl.snapshot_chunk, cl.snapshot_chunk_present);
 				cl.snap_last_incomplete_seq = seq16;
 				cl.snap_last_incomplete = true;
+				cl.snap_parse_consecutive = 0;
 				cl.snap_incomplete_count++;
 				NET_DebugLogEvent (true,
 					"NETDBG time %.3f snap2_partial_apply seq %u flags 0x%x incomplete %d has_full %d\n",
@@ -2590,6 +2030,7 @@ static void CL_ParseSnapshot2 (void)
 			{
 				cl.snap_last_incomplete_seq = seq16;
 				cl.snap_last_incomplete = true;
+				cl.snap_parse_consecutive = 0;
 				cl.snap_incomplete_count++;
 				NET_DebugLogEvent (true,
 					"NETDBG time %.3f snap2_buffer seq %u flags 0x%x incomplete %d has_full %d\n",
@@ -2630,7 +2071,7 @@ static void CL_ParseSnapshot2 (void)
 				msg_readcount = net_message.cursize;
 				return;
 			}
-			if (!CL_PackedOriginIsSane (state.state.origin))
+			if (!CL_SnapshotOriginIsSane (state.state.origin))
 			{
 				CL_RequestFullSnapshot ("snapshot2 origin guard", true);
 				msg_readcount = net_message.cursize;
@@ -2672,6 +2113,7 @@ static void CL_ParseSnapshot2 (void)
 				cl.snap_last_applied_seq = seq16;
 				cl.snap_last_complete_seq = seq16;
 				cl.snap_last_incomplete = false;
+				cl.snap_parse_consecutive = 0;
 				cl.need_full_snapshot = false;
 				cl.has_full_snapshot = true;
 				cl.has_valid_worldstate = true;
@@ -2692,6 +2134,7 @@ static void CL_ParseSnapshot2 (void)
 				touched = CL_ApplySnapshotOverlay (cl.snapshot_stage, cl.snapshot_stage_present);
 				cl.snap_last_incomplete_seq = seq16;
 				cl.snap_last_incomplete = true;
+				cl.snap_parse_consecutive = 0;
 				cl.snap_incomplete_count++;
 				NET_DebugLogEvent (true,
 					"NETDBG time %.3f snap2_buffer seq %u flags 0x%x incomplete %d has_full %d\n",
@@ -2776,7 +2219,7 @@ static void CL_ParseSnapshot2 (void)
 
 	{
 		int add_count = (unsigned short)MSG_ReadShort ();
-		if (msg_badread || add_count < 0 || add_count > cl_max_edicts)
+		if (msg_badread || add_count < 0 || add_count > cl_max_edicts || add_count > MAX_SNAPSHOT_ENTITIES)
 		{
 			CL_RequestFullSnapshot ("snapshot2 add header", true);
 			msg_readcount = net_message.cursize;
@@ -2799,7 +2242,7 @@ static void CL_ParseSnapshot2 (void)
 			}
 			if (!drop && baseline_match && entnum > 0 && entnum < cl_max_edicts)
 			{
-				if (!CL_PackedOriginIsSane (state.state.origin))
+				if (!CL_SnapshotOriginIsSane (state.state.origin))
 				{
 					CL_RequestFullSnapshot ("snapshot2 origin guard", true);
 					msg_readcount = net_message.cursize;
@@ -2812,7 +2255,7 @@ static void CL_ParseSnapshot2 (void)
 
 		{
 			int update_count = (unsigned short)MSG_ReadShort ();
-			if (msg_badread || update_count < 0 || update_count > cl_max_edicts)
+		if (msg_badread || update_count < 0 || update_count > cl_max_edicts || update_count > MAX_SNAPSHOT_ENTITIES)
 			{
 				CL_RequestFullSnapshot ("snapshot2 update header", true);
 				msg_readcount = net_message.cursize;
@@ -2822,7 +2265,7 @@ static void CL_ParseSnapshot2 (void)
 			{
 				int entnum = (unsigned short)MSG_ReadShort ();
 				unsigned int mask = (unsigned int)MSG_ReadLong ();
-				if (msg_badread || (mask & ~SNAP_VALID_MASK))
+				if (msg_badread || (mask & ~SNAP_VALID_MASK) || CL_CountMaskBits (mask & SNAP_VALID_MASK) > MAX_PACKED_FIELDS)
 				{
 					CL_RequestFullSnapshot ("snapshot2 update mask", true);
 					msg_readcount = net_message.cursize;
@@ -2840,7 +2283,7 @@ static void CL_ParseSnapshot2 (void)
 						msg_readcount = net_message.cursize;
 						return;
 					}
-					if (!CL_PackedOriginIsSane (state.state.origin))
+					if (!CL_SnapshotOriginIsSane (state.state.origin))
 					{
 						CL_RequestFullSnapshot ("snapshot2 origin guard", true);
 						msg_readcount = net_message.cursize;
@@ -2860,7 +2303,7 @@ static void CL_ParseSnapshot2 (void)
 						msg_readcount = net_message.cursize;
 						return;
 					}
-					if (!CL_PackedOriginIsSane (scratch.state.origin))
+					if (!CL_SnapshotOriginIsSane (scratch.state.origin))
 					{
 						CL_RequestFullSnapshot ("snapshot2 origin guard", true);
 						msg_readcount = net_message.cursize;
@@ -2875,8 +2318,6 @@ static void CL_ParseSnapshot2 (void)
 	{
 		if (!incomplete)
 		{
-			byte *old_present = cl.snapshot_present;
-
 			CL_StoreSnapshotBaselineFromBase (header.seq, base_states, base_present);
 			if (base_is_current)
 			{
@@ -2901,10 +2342,6 @@ static void CL_ParseSnapshot2 (void)
 						CL_MarkSnapshotEntityUpdated (i);
 						touched++;
 					}
-					else if (old_present && old_present[i])
-					{
-						CL_ClearSnapshotEntity (i);
-					}
 				}
 			}
 
@@ -2919,6 +2356,7 @@ static void CL_ParseSnapshot2 (void)
 			cl.snap_last_applied_seq = seq16;
 			cl.snap_last_complete_seq = seq16;
 			cl.snap_last_incomplete = false;
+			cl.snap_parse_consecutive = 0;
 			cl.snap_incomplete_count = 0;
 			cl.has_full_snapshot = true;
 			base_advanced = true;
@@ -2985,12 +2423,10 @@ void CL_ParseClientdata (void)
 
 	bits = (unsigned short)MSG_ReadShort (); //johnfitz -- read bits here isntead of in CL_ParseServerMessage()
 
-	//johnfitz -- PROTOCOL_FITZQUAKE
 	if (bits & SU_EXTEND1)
 		bits |= (MSG_ReadByte() << 16);
 	if (bits & SU_EXTEND2)
 		bits |= (MSG_ReadByte() << 24);
-	//johnfitz
 
 	if (bits & SU_VIEWHEIGHT)
 		cl.viewheight = MSG_ReadChar ();
@@ -3113,7 +2549,6 @@ void CL_ParseClientdata (void)
 		}
 	}
 
-	//johnfitz -- PROTOCOL_FITZQUAKE
 	if (bits & SU_WEAPON2)
 		cl.stats[STAT_WEAPON] |= (MSG_ReadByte() << 8);
 	if (bits & SU_ARMOR2)
@@ -3134,7 +2569,6 @@ void CL_ParseClientdata (void)
 		cl.viewent.alpha = MSG_ReadByte();
 	else
 		cl.viewent.alpha = ENTALPHA_DEFAULT;
-	//johnfitz
 
 	// svc_clientdata carries pmove-critical fields; snapshot2 owns local player position/orientation.
 	if (bits & SU_PREDICT)
@@ -3155,10 +2589,7 @@ void CL_ParseClientdata (void)
 		for (i = 0; i < 3; i++)
 			velocity[i] = MSG_ReadCoord (cl.protocolflags);
 		for (i = 0; i < 3; i++)
-			if (cl.protocol == PROTOCOL_NETQUAKE)
-				viewangles[i] = MSG_ReadAngle (cl.protocolflags);
-			else
-				viewangles[i] = MSG_ReadAngle16 (cl.protocolflags);
+			viewangles[i] = MSG_ReadAngle16 (cl.protocolflags);
 
 		CL_Predict_ServerUpdate (ack, origin, velocity, viewangles, cl.onground);
 	}
@@ -3271,12 +2702,10 @@ void CL_ParseStaticSound (int version) //johnfitz -- added argument
 	for (i = 0; i < 3; i++)
 		org[i] = MSG_ReadCoord (cl.protocolflags);
 
-	//johnfitz -- PROTOCOL_FITZQUAKE
 	if (version == 2)
 		sound_num = MSG_ReadShort ();
 	else
 		sound_num = MSG_ReadByte ();
-	//johnfitz
 
 	vol = MSG_ReadByte ();
 	atten = MSG_ReadByte ();
@@ -3325,7 +2754,6 @@ static void CL_DumpPacket (void)
 //mods and servers might not send the \n instantly.
 //some mods bug out and omit the \n entirely, this function helps prevent the damage from spreading too much.
 //some servers or mods use //prefixed commands as extensions to avoid spam about unrecognised commands.
-//proquake has its own extension coding thing.
 static void CL_ParseStuffText(const char *msg)
 {
 	const char *str;
@@ -3335,13 +2763,6 @@ static void CL_ParseStuffText(const char *msg)
 		qboolean handled = false;
 
 		str++;//skip past the \n
-
-		if (*cl.stuffcmdbuf == 0x01 && cl.protocol == PROTOCOL_NETQUAKE) //proquake message, just strip this and try again (doesn't necessarily have a trailing \n straight away)
-		{
-			for (str = cl.stuffcmdbuf+1; *str >= 0x01 && *str <= 0x1f; str++)
-				;//FIXME: parse properly
-			continue;
-		}
 
 		//handle special commands
 		if (cl.stuffcmdbuf[0] == '/' && cl.stuffcmdbuf[1] == '/')
@@ -3433,32 +2854,12 @@ void CL_ParseServerMessage (void)
 			return;
 		}
 
-	// if the high bit of the command byte is set, it is a fast update
-		if (cmd & U_SIGNAL) //johnfitz -- was 128, changed for clarity
+		// fast updates are not supported
+		if (cmd & 128)
 		{
-			SHOWNET("fast update");
-			if (cl_netdebug_parse.value)
-				Con_Printf ("NETDBG: cmd fast_update 0x%x @%d\n", cmd, cmd_offset);
-			CL_ParseUpdate (cmd&127);
-			if (msg_badread)
-			{
-				CL_BadServerMessage ("bad fast update", cmd, cmd_offset,
-					lastcmd, lastcmd_offset, prevcmd, prevcmd_offset);
-				return;
-			}
-			if (cl_netdebug_parse.value)
-			{
-				int cmd_end = CL_NetDebugReadcount ();
-				if (cmd_end < cmd_offset)
-					cmd_end = cmd_offset;
-				Con_Printf ("NETDBG: cmd fast_update end %d bytes %d\n",
-					cmd_end, cmd_end - cmd_offset);
-			}
-			prevcmd = lastcmd;
-			prevcmd_offset = lastcmd_offset;
-			lastcmd = cmd;
-			lastcmd_offset = cmd_offset;
-			continue;
+			CL_BadServerMessage ("unsupported fast update", cmd, cmd_offset,
+				lastcmd, lastcmd_offset, prevcmd, prevcmd_offset);
+			return;
 		}
 
 		if (cmd < (int)NUM_SVC_STRINGS) {
@@ -3471,14 +2872,8 @@ void CL_ParseServerMessage (void)
 		switch (cmd)
 		{
 		default:
-		//	CL_DumpPacket ();
-			if (realtime >= cl_unknown_cmd_next_warn_time)
-			{
-				Con_Printf ("Dropping server packet with unknown command %s (%d)\n",
-					CL_SvcName (cmd), cmd);
-				cl_unknown_cmd_next_warn_time = realtime + 1.0;
-			}
-			msg_readcount = net_message.cursize;
+			CL_BadServerMessage ("unknown command", cmd, cmd_offset,
+				lastcmd, lastcmd_offset, prevcmd, prevcmd_offset);
 			return;
 
 		case svc_nop:
@@ -3502,11 +2897,9 @@ void CL_ParseServerMessage (void)
 
 		case svc_version:
 			i = MSG_ReadLong ();
-			//johnfitz -- support multiple protocols
-			if (i != PROTOCOL_NETQUAKE && i != PROTOCOL_FITZQUAKE && i != PROTOCOL_RMQ)
-				Host_Error ("Server returned version %i, not %i or %i or %i", i, PROTOCOL_NETQUAKE, PROTOCOL_FITZQUAKE, PROTOCOL_RMQ);
-			cl.protocol = i;
-			//johnfitz
+			if (i != PROTOCOL_RMQ)
+				Host_Error ("Server returned protocol %i, expected %i", i, PROTOCOL_RMQ);
+			cl.protocol = PROTOCOL_RMQ;
 			break;
 
 		case svc_disconnect:
@@ -3645,6 +3038,13 @@ void CL_ParseServerMessage (void)
 			unsigned short payload_len = (unsigned short)MSG_ReadShort ();
 			const byte *payload;
 
+			if (payload_len > MAX_RELIABLE_QUEUE_BYTES)
+			{
+				CL_BadServerMessage ("signon chunk length exceeds cap", cmd, cmd_offset,
+					lastcmd, lastcmd_offset, prevcmd, prevcmd_offset);
+				return;
+			}
+
 			if (payload_len > (unsigned short)(net_message.cursize - msg_readcount))
 			{
 				CL_BadServerMessage ("signon chunk length exceeds packet", cmd, cmd_offset,
@@ -3775,17 +3175,17 @@ void CL_ParseServerMessage (void)
 			Fog_ParseServerMessage ();
 			break;
 
-		case svc_spawnbaseline2: //PROTOCOL_FITZQUAKE
+		case svc_spawnbaseline2:
 			i = MSG_ReadShort ();
 			// must use CL_EntityNum() to force cl.num_entities up
 			CL_ParseBaseline (CL_EntityNum(i), 2);
 			break;
 
-		case svc_spawnstatic2: //PROTOCOL_FITZQUAKE
+		case svc_spawnstatic2:
 			CL_ParseStatic (2);
 			break;
 
-		case svc_spawnstaticsound2: //PROTOCOL_FITZQUAKE
+		case svc_spawnstaticsound2:
 			CL_ParseStaticSound (2);
 			break;
 		//johnfitz
@@ -3814,9 +3214,6 @@ void CL_ParseServerMessage (void)
 			CL_ParseSnapshot2 ();
 			break;
 
-		case svc_packedentities:
-			CL_ParsePackedEntities ();
-			break;
 		}
 
 		if (msg_badread)

--- a/Quake/client.h
+++ b/Quake/client.h
@@ -295,6 +295,7 @@ typedef struct
 	qboolean	need_full_snapshot;
 	qboolean	has_valid_worldstate;
 	int			snap_parse_errors;
+	int			snap_parse_consecutive;
 	int			snap_delta_mismatch;
 	int			snap_incomplete_count;
 	unsigned int snap_rem0_seq;

--- a/Quake/common.c
+++ b/Quake/common.c
@@ -891,30 +891,21 @@ void MSG_WriteCoord32f (sizebuf_t *sb, float f)
 
 void MSG_WriteCoord (sizebuf_t *sb, float f, unsigned int flags)
 {
-	if (flags & PRFL_FLOATCOORD)
-		MSG_WriteFloat (sb, f);
-	else if (flags & PRFL_INT32COORD)
+	if (flags & PRFL_INT32COORD)
 		MSG_WriteLong (sb, Q_rint (f * 16));
-	else if (flags & PRFL_24BITCOORD)
-		MSG_WriteCoord24 (sb, f);
 	else MSG_WriteCoord16 (sb, f);
 }
 
 void MSG_WriteAngle (sizebuf_t *sb, float f, unsigned int flags)
 {
-	if (flags & PRFL_FLOATANGLE)
-		MSG_WriteFloat (sb, f);
-	else if (flags & PRFL_SHORTANGLE)
+	if (flags & PRFL_SHORTANGLE)
 		MSG_WriteShort (sb, Q_rint(f * 65536.0 / 360.0) & 65535);
 	else MSG_WriteByte (sb, Q_rint(f * 256.0 / 360.0) & 255); //johnfitz -- use Q_rint instead of (int)	}
 }
 
-//johnfitz -- for PROTOCOL_FITZQUAKE
 void MSG_WriteAngle16 (sizebuf_t *sb, float f, unsigned int flags)
 {
-	if (flags & PRFL_FLOATANGLE)
-		MSG_WriteFloat (sb, f);
-	else MSG_WriteShort (sb, Q_rint(f * 65536.0 / 360.0) & 65535);
+	MSG_WriteShort (sb, Q_rint(f * 65536.0 / 360.0) & 65535);
 }
 //johnfitz
 
@@ -1186,32 +1177,22 @@ float MSG_ReadCoord32f (void)
 
 float MSG_ReadCoord (unsigned int flags)
 {
-	if (flags & PRFL_FLOATCOORD)
-		return MSG_ReadFloat ();
-	else if (flags & PRFL_INT32COORD)
+	if (flags & PRFL_INT32COORD)
 		return MSG_ReadLong () * (1.0 / 16.0);
-	else if (flags & PRFL_24BITCOORD)
-		return MSG_ReadCoord24 ();
 	else return MSG_ReadCoord16 ();
 }
 
 float MSG_ReadAngle (unsigned int flags)
 {
-	if (flags & PRFL_FLOATANGLE)
-		return MSG_ReadFloat ();
-	else if (flags & PRFL_SHORTANGLE)
+	if (flags & PRFL_SHORTANGLE)
 		return MSG_ReadShort () * (360.0 / 65536);
 	else return MSG_ReadChar () * (360.0 / 256);
 }
 
-//johnfitz -- for PROTOCOL_FITZQUAKE
 float MSG_ReadAngle16 (unsigned int flags)
 {
-	if (flags & PRFL_FLOATANGLE)
-		return MSG_ReadFloat ();	// make sure
-	else return MSG_ReadShort () * (360.0 / 65536);
+	return MSG_ReadShort () * (360.0 / 65536);
 }
-//johnfitz
 
 //===========================================================================
 

--- a/Quake/net.h
+++ b/Quake/net.h
@@ -35,6 +35,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define	NET_NAMELEN		64
 
 #define NET_MAXMESSAGE		65535	/* ericw -- was 32000 */
+#define MAX_RELIABLE_QUEUE_BYTES NET_MAXMESSAGE
 
 typedef struct net_packetinfo_s
 {

--- a/Quake/net_dgrm.c
+++ b/Quake/net_dgrm.c
@@ -850,7 +850,7 @@ int	Datagram_GetMessage (qsocket_t *sock)
 				if (!entry->received || entry->sequence != sock->receiveSequence)
 					break;
 
-				if (sock->receiveMessageLength + entry->length > NET_MAXMESSAGE)
+				if (sock->receiveMessageLength + entry->length > MAX_RELIABLE_QUEUE_BYTES)
 				{
 					Con_DPrintf("NET_GetMessage: reliable message overflow (%u + %u)\n",
 						sock->receiveMessageLength, entry->length);

--- a/Quake/pr_cmds.c
+++ b/Quake/pr_cmds.c
@@ -592,7 +592,7 @@ static void PF_ambientsound (void)
 	float		*pos;
 	float		vol, attenuation;
 	int		i, soundnum;
-	int		large = false; //johnfitz -- PROTOCOL_FITZQUAKE
+	int		large = false;
 
 	pos = G_VECTOR (OFS_PARM0);
 	samp = G_STRING(OFS_PARM1);
@@ -612,21 +612,13 @@ static void PF_ambientsound (void)
 		return;
 	}
 
-	//johnfitz -- PROTOCOL_FITZQUAKE
 	if (soundnum > 255)
-	{
-		if (sv.protocol == PROTOCOL_NETQUAKE)
-			return; //don't send any info protocol can't support
-		else
-			large = true;
-	}
-	//johnfitz
+		large = true;
 
 	SV_ReserveSignonSpace (17);
 
 	// add an svc_spawnambient command to the level signon packet
 
-	//johnfitz -- PROTOCOL_FITZQUAKE
 	if (large)
 	{
 		MSG_BEGINSVC (sv.signon, svc_spawnstaticsound2);
@@ -639,17 +631,14 @@ static void PF_ambientsound (void)
 		MSG_DBGAUX (sv.signon, soundnum);
 		MSG_WriteByte (sv.signon,svc_spawnstaticsound);
 	}
-	//johnfitz
 
 	for (i = 0; i < 3; i++)
 		MSG_WriteCoord(sv.signon, pos[i], sv.protocolflags);
 
-	//johnfitz -- PROTOCOL_FITZQUAKE
 	if (large)
 		MSG_WriteShort(sv.signon, soundnum);
 	else
 		MSG_WriteByte (sv.signon, soundnum);
-	//johnfitz
 
 	MSG_WriteByte (sv.signon, vol*255);
 	MSG_WriteByte (sv.signon, attenuation*64);
@@ -1602,7 +1591,7 @@ static void PF_makestatic (void)
 {
 	edict_t	*ent;
 	int		i;
-	int	bits = 0; //johnfitz -- PROTOCOL_FITZQUAKE
+	int	bits = 0;
 
 	ent = G_EDICT(OFS_PARM0);
 
@@ -1613,37 +1602,22 @@ static void PF_makestatic (void)
 	}
 	//johnfitz
 
-	//johnfitz -- PROTOCOL_FITZQUAKE
-	if (sv.protocol == PROTOCOL_NETQUAKE)
-	{
-		if (SV_ModelIndex(PR_GetString(ent->v.model)) & 0xFF00 || (int)(ent->v.frame) & 0xFF00)
-		{
-			ED_Free (ent);
-			return; //can't display the correct model & frame, so don't show it at all
-		}
-	}
+	if (SV_ModelIndex(PR_GetString(ent->v.model)) & 0xFF00)
+		bits |= B_LARGEMODEL;
+	if ((int)(ent->v.frame) & 0xFF00)
+		bits |= B_LARGEFRAME;
+	if (ent->alpha != ENTALPHA_DEFAULT)
+		bits |= B_ALPHA;
+
+	eval_t* val;
+	val = GetEdictFieldValueByName(ent, "scale");
+	if (val)
+		ent->scale = ENTSCALE_ENCODE(val->_float);
 	else
-	{
-		if (SV_ModelIndex(PR_GetString(ent->v.model)) & 0xFF00)
-			bits |= B_LARGEMODEL;
-		if ((int)(ent->v.frame) & 0xFF00)
-			bits |= B_LARGEFRAME;
-		if (ent->alpha != ENTALPHA_DEFAULT)
-			bits |= B_ALPHA;
+		ent->scale = ENTSCALE_DEFAULT;
 
-		if (sv.protocol == PROTOCOL_RMQ)
-		{
-			eval_t* val;
-			val = GetEdictFieldValueByName(ent, "scale");
-			if (val)
-				ent->scale = ENTSCALE_ENCODE(val->_float);
-			else
-				ent->scale = ENTSCALE_DEFAULT;
-
-			if (ent->scale != ENTSCALE_DEFAULT)
-				bits |= B_SCALE;
-		}
-	}
+	if (ent->scale != ENTSCALE_DEFAULT)
+		bits |= B_SCALE;
 
 	SV_ReserveSignonSpace (34);
 
@@ -1670,8 +1644,6 @@ static void PF_makestatic (void)
 		MSG_WriteShort (sv.signon, ent->v.frame);
 	else
 		MSG_WriteByte (sv.signon, ent->v.frame);
-	//johnfitz
-
 	MSG_WriteByte (sv.signon, ent->v.colormap);
 	MSG_WriteByte (sv.signon, ent->v.skin);
 	for (i = 0; i < 3; i++)
@@ -1680,10 +1652,8 @@ static void PF_makestatic (void)
 		MSG_WriteAngle(sv.signon, ent->v.angles[i], sv.protocolflags);
 	}
 
-	//johnfitz -- PROTOCOL_FITZQUAKE
 	if (bits & B_ALPHA)
 		MSG_WriteByte (sv.signon, ent->alpha);
-	//johnfitz
 
 	if (bits & B_SCALE)
 		MSG_WriteByte (sv.signon, ent->scale);

--- a/Quake/protocol.h
+++ b/Quake/protocol.h
@@ -25,51 +25,14 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 // protocol.h -- communications protocols
 
-#define	PROTOCOL_NETQUAKE	15 //johnfitz -- standard quake protocol
-#define PROTOCOL_FITZQUAKE	666 //johnfitz -- added new protocol for fitzquake 0.85
 #define PROTOCOL_RMQ		999
 
-// PROTOCOL_RMQ protocol flags
+// protocol flags (single modern protocol)
 #define PRFL_SHORTANGLE		(1 << 1)
-#define PRFL_FLOATANGLE		(1 << 2)
-#define PRFL_24BITCOORD		(1 << 3)
-#define PRFL_FLOATCOORD		(1 << 4)
-#define PRFL_EDICTSCALE		(1 << 5)
-#define PRFL_ALPHASANITY	(1 << 6)	// cleanup insanity with alpha
 #define PRFL_INT32COORD		(1 << 7)
 #define PRFL_SNAPSHOT_HIRES	(1 << 8)
 #define PRFL_SIGNON_CHUNKS	(1 << 9)	// signon streaming via svc_signon_chunk
-#define PRFL_MOREFLAGS		(1 << 31)	// not supported
-
-// if the high bit of the servercmd is set, the low bits are fast update flags:
-#define	U_MOREBITS		(1<<0)
-#define	U_ORIGIN1		(1<<1)
-#define	U_ORIGIN2		(1<<2)
-#define	U_ORIGIN3		(1<<3)
-#define	U_ANGLE2		(1<<4)
-#define	U_STEP			(1<<5)	//johnfitz -- was U_NOLERP, renamed since it's only used for MOVETYPE_STEP
-#define	U_FRAME			(1<<6)
-#define U_SIGNAL		(1<<7)	// just differentiates from other updates
-
-// svc_update can pass all of the fast update bits, plus more
-#define	U_ANGLE1		(1<<8)
-#define	U_ANGLE3		(1<<9)
-#define	U_MODEL			(1<<10)
-#define	U_COLORMAP		(1<<11)
-#define	U_SKIN			(1<<12)
-#define	U_EFFECTS		(1<<13)
-#define	U_LONGENTITY	(1<<14)
-//johnfitz -- PROTOCOL_FITZQUAKE -- new bits
-#define U_EXTEND1		(1<<15)
-#define U_ALPHA			(1<<16) // 1 byte, uses ENTALPHA_ENCODE, not sent if equal to baseline
-#define U_FRAME2		(1<<17) // 1 byte, this is .frame & 0xFF00 (second byte)
-#define U_MODEL2		(1<<18) // 1 byte, this is .modelindex & 0xFF00 (second byte)
-#define U_LERPFINISH	(1<<19) // 1 byte, 0.0-1.0 maps to 0-255, not sent if exactly 0.1, this is ent->v.nextthink - sv.time, used for lerping
-#define U_SCALE			(1<<20) // 1 byte, for PROTOCOL_RMQ PRFL_EDICTSCALE
-#define U_UNUSED21		(1<<21)
-#define U_UNUSED22		(1<<22)
-#define U_EXTEND2		(1<<23) // another byte to follow, future expansion
-//johnfitz
+#define PROTOCOL_RMQ_FLAGS	(PRFL_INT32COORD | PRFL_SHORTANGLE | PRFL_SNAPSHOT_HIRES | PRFL_SIGNON_CHUNKS)
 
 // snapshot delta field bits
 #define SNAP_ORIGIN1	(1u<<0)
@@ -92,10 +55,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define SNAPFL_HIRES_ORIGIN	(1u<<2)
 #define SNAPFL_HIRES_ANGLES	(1u<<3)
 
-//johnfitz -- PROTOCOL_NEHAHRA transparency
-#define U_TRANS			(1<<15)
-//johnfitz
-
 #define	SU_VIEWHEIGHT	(1<<0)
 #define	SU_IDEALPITCH	(1<<1)
 #define	SU_PUNCH1		(1<<2)
@@ -111,7 +70,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define	SU_WEAPONFRAME	(1<<12)
 #define	SU_ARMOR		(1<<13)
 #define	SU_WEAPON		(1<<14)
-//johnfitz -- PROTOCOL_FITZQUAKE -- new bits
 #define SU_EXTEND1		(1<<15) // another byte to follow
 #define SU_WEAPON2		(1<<16) // 1 byte, this is .weaponmodel & 0xFF00 (second byte)
 #define SU_ARMOR2		(1<<17) // 1 byte, this is .armorvalue & 0xFF00 (second byte)
@@ -129,7 +87,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define SU_UNUSED29		(1<<29)
 #define SU_UNUSED30		(1<<30)
 #define SU_EXTEND3		(1<<31) // another byte to follow, future expansion
-//johnfitz
 
 // a sound with no channel is a local only sound
 #define	SND_VOLUME		(1<<0)	// a byte
@@ -139,19 +96,16 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define DEFAULT_SOUND_PACKET_VOLUME		255
 #define DEFAULT_SOUND_PACKET_ATTENUATION	1.0
 
-//johnfitz -- PROTOCOL_FITZQUAKE -- new bits
 #define	SND_LARGEENTITY	(1<<3)	// a short + byte (instead of just a short)
 #define	SND_LARGESOUND	(1<<4)	// a short soundindex (instead of a byte)
-//johnfitz
 
-//johnfitz -- PROTOCOL_FITZQUAKE -- flags for entity baseline messages
+// flags for entity baseline messages
 #define B_LARGEMODEL	(1<<0)	// modelindex is short instead of byte
 #define B_LARGEFRAME	(1<<1)	// frame is short instead of byte
 #define B_ALPHA			(1<<2)	// 1 byte, uses ENTALPHA_ENCODE, not sent if ENTALPHA_DEFAULT
 #define B_SCALE			(1<<3)
-//johnfitz
 
-//johnfitz -- PROTOCOL_FITZQUAKE -- alpha encoding
+// alpha encoding
 #define ENTALPHA_DEFAULT	0	//entity's alpha is "default" (i.e. water obeys r_wateralpha) -- must be zero so zeroed out memory works
 #define ENTALPHA_ZERO		1	//entity is invisible (lowest possible alpha)
 #define ENTALPHA_ONE		255 //entity is fully opaque (highest possible alpha)
@@ -221,14 +175,12 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define svc_sellscreen			33
 #define svc_cutscene			34
 
-//johnfitz -- PROTOCOL_FITZQUAKE -- new server messages
 #define	svc_skybox				37	// [string] name
 #define svc_bf					40
 #define svc_fog					41	// [byte] density [byte] red [byte] green [byte] blue [float] time
 #define svc_spawnbaseline2		42  // support for large modelindex, large framenum, alpha, using flags
 #define svc_spawnstatic2		43	// support for large modelindex, large framenum, alpha, using flags
 #define	svc_spawnstaticsound2	44	// [coord3] [short] samp [byte] vol [byte] aten
-//johnfitz
 
 // 2021 re-release server messages - see:
 // https://steamcommunity.com/sharedfiles/filedetails/?id=2679459726
@@ -248,9 +200,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define svc_localsound		56
 #define svc_snapshot_full	57
 #define svc_snapshot_delta	58
-#define svc_packedentities	59
-#define svc_snapshot2		60
-#define svc_signon_chunk	61	// [byte stage] [short seq] [byte flags] [short payload_len] [payload bytes]
+#define svc_snapshot2		59
+#define svc_signon_chunk	60	// [byte stage] [short seq] [byte flags] [short payload_len] [payload bytes]
 
 // Signon chunk format (PRFL_SIGNON_CHUNKS):
 //   svc_signon_chunk
@@ -320,6 +271,12 @@ typedef enum
 #define PACKEDENT_POS_SCALE	16.0f	// 12.4 int16 range ~+-2048; PACKEDENT_MASK_POS_FULL falls back to MSG_WriteCoord.
 #define PACKEDENT_VEL_SCALE	8.0f
 #define PACKEDENT_ANGLE_SCALE	(65536.0f / 360.0f)
+
+#define MAX_SNAPSHOT_ENTITIES	MAX_EDICTS
+#define MAX_REMOVE_ENTITIES	MAX_EDICTS
+#define MAX_PACKED_FIELDS	32
+#define MAX_CMDS_PER_PACKET	64
+#define MAX_SNAPSHOT_PARSE_ERRORS	5
 
 //
 // client to server

--- a/Quake/server.h
+++ b/Quake/server.h
@@ -181,7 +181,6 @@ typedef struct client_s
 	qboolean		active;				// false = client is free
 	qboolean		spawned;			// false = don't send datagrams
 	qboolean		dropasap;			// has been told to go to another level
-	qboolean		supports_packedents;
 	qboolean		is_bot;
 	enum sendsignon_e	sendsignon;			// only valid before spawned
 	int				signonidx;

--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -33,13 +33,9 @@ server_static_t	svs;
 
 static char	localmodels[MAX_MODELS][8];	// inline model names for precache
 
-int		sv_protocol = PROTOCOL_RMQ; //johnfitz
-
 extern cvar_t nomonsters;
 
 static cvar_t sv_netsort = {"sv_netsort", "1", CVAR_NONE};
-static cvar_t sv_packedents = {"sv_packedents", "0", CVAR_NONE};
-static cvar_t sv_packedents_debug = {"sv_packedents_debug", "0", CVAR_NONE};
 static cvar_t sv_snapshotdelta = {"sv_snapshotdelta", "1", CVAR_NONE};
 static cvar_t sv_snapshotdebug = {"sv_snapshotdebug", "0", CVAR_NONE};
 static cvar_t sv_snapshottimeout = {"sv_snapshottimeout", "1000", CVAR_NONE};
@@ -56,7 +52,6 @@ cvar_t sv_minrate = {"sv_minrate", "0", CVAR_NONE};
 cvar_t sv_maxrate = {"sv_maxrate", "0", CVAR_NONE};
 cvar_t sv_minupdaterate = {"sv_minupdaterate", "0", CVAR_NONE};
 cvar_t sv_maxupdaterate = {"sv_maxupdaterate", "0", CVAR_NONE};
-static cvar_t sv_signon_chunks = {"sv_signon_chunks", "1", CVAR_NONE};
 static cvar_t sv_signon_chunk_debug = {"sv_signon_chunk_debug", "0", CVAR_NONE};
 static cvar_t sv_signon_chunk_window = {"sv_signon_chunk_window", "3", CVAR_NONE};
 static cvar_t sv_signon_debug = {"sv_signon_debug", "0", CVAR_NONE};
@@ -69,24 +64,9 @@ static cvar_t sv_icull_radius = {"sv_icull_radius", "2048", CVAR_NONE};
 static cvar_t sv_icull_radius_players = {"sv_icull_radius_players", "0", CVAR_NONE};
 static cvar_t sv_icull_pvs = {"sv_icull_pvs", "1", CVAR_NONE};
 static cvar_t sv_icull_debug = {"sv_icull_debug", "0", CVAR_NONE};
-static qboolean sv_packedents_selftest_done = false;
 
 static qboolean SV_SignonChunksEnabled (void);
 static void SV_SignonStreamSend (client_t *client);
-
-typedef struct
-{
-	int packets;
-	int entities;
-	int bytes;
-	int mask_bits_total;
-	int mask_hist[33];
-	int clamp_origin;
-	int clamp_velocity;
-} packedent_stats_t;
-
-static packedent_stats_t sv_packedents_stats;
-static double sv_packedents_stats_next_time = 0.0;
 
 typedef struct
 {
@@ -178,57 +158,6 @@ void SV_CalcStats(client_t *client, int *statsi, float *statsf, const char **sta
 	}
 }
 
-/*
-===============
-SV_Protocol_f
-===============
-*/
-void SV_Protocol_f (void)
-{
-	int i;
-
-	switch (Cmd_Argc())
-	{
-	case 1:
-		Con_Printf ("\"sv_protocol\" is \"%i\"\n", sv_protocol);
-		break;
-	case 2:
-		i = atoi(Cmd_Argv(1));
-		if (i != PROTOCOL_NETQUAKE && i != PROTOCOL_FITZQUAKE && i != PROTOCOL_RMQ)
-			Con_Printf ("sv_protocol must be %i or %i or %i\n", PROTOCOL_NETQUAKE, PROTOCOL_FITZQUAKE, PROTOCOL_RMQ);
-		else
-		{
-			sv_protocol = i;
-			if (sv.active)
-				Con_Printf ("changes will not take effect until the next level load.\n");
-		}
-		break;
-	default:
-		Con_SafePrintf ("usage: sv_protocol <protocol>\n");
-		break;
-	}
-}
-
-static void SV_PackedEntStats_f (void)
-{
-	int i;
-	float avg_bytes = sv_packedents_stats.entities ? (float)sv_packedents_stats.bytes / sv_packedents_stats.entities : 0.0f;
-	float avg_bits = sv_packedents_stats.entities ? (float)sv_packedents_stats.mask_bits_total / sv_packedents_stats.entities : 0.0f;
-
-	Con_Printf ("packedents stats: packets %d entities %d avg_bytes %.1f avg_bits %.1f clamp_origin %d clamp_vel %d\n",
-		sv_packedents_stats.packets, sv_packedents_stats.entities, avg_bytes, avg_bits,
-		sv_packedents_stats.clamp_origin, sv_packedents_stats.clamp_velocity);
-	Con_Printf ("packedents mask hist:");
-	for (i = 0; i < (int)countof(sv_packedents_stats.mask_hist); i++)
-	{
-		if (sv_packedents_stats.mask_hist[i])
-			Con_Printf (" %d:%d", i, sv_packedents_stats.mask_hist[i]);
-	}
-	Con_Printf ("\n");
-	if (!sv_packedents_debug.value)
-		Con_Printf ("packedents stats are gathered when sv_packedents_debug is enabled.\n");
-}
-
 static void SV_IcullStats_f (void)
 {
 	int i;
@@ -299,8 +228,6 @@ void SV_Init (void)
 	Cvar_RegisterVariable (&sv_gameplayfix_random);
 	Cvar_RegisterVariable (&sv_gameplayfix_elevators);
 	Cvar_RegisterVariable (&sv_netsort);
-	Cvar_RegisterVariable (&sv_packedents);
-	Cvar_RegisterVariable (&sv_packedents_debug);
 	Cvar_RegisterVariable (&sv_snapshotdelta);
 	Cvar_RegisterVariable (&sv_snapshotdebug);
 	Cvar_RegisterVariable (&sv_snapshottimeout);
@@ -317,7 +244,6 @@ void SV_Init (void)
 	Cvar_RegisterVariable (&sv_maxrate);
 	Cvar_RegisterVariable (&sv_minupdaterate);
 	Cvar_RegisterVariable (&sv_maxupdaterate);
-	Cvar_RegisterVariable (&sv_signon_chunks);
 	Cvar_RegisterVariable (&sv_signon_chunk_debug);
 	Cvar_RegisterVariable (&sv_signon_chunk_window);
 	Cvar_RegisterVariable (&sv_signon_debug);
@@ -334,33 +260,13 @@ void SV_Init (void)
 	Cvar_RegisterVariable (&sv_autosave);
 	Cvar_RegisterVariable (&sv_autosave_interval);
 
-	Cmd_AddCommand ("sv_protocol", &SV_Protocol_f); //johnfitz
-	Cmd_AddCommand ("packedents_stats", &SV_PackedEntStats_f);
 	Cmd_AddCommand ("sv_icull_stats", &SV_IcullStats_f);
 
 	for (i=0 ; i<MAX_MODELS ; i++)
 		sprintf (localmodels[i], "*%i", i);
 
-	i = COM_CheckParm ("-protocol");
-	if (i && i < com_argc - 1)
-		sv_protocol = atoi (com_argv[i + 1]);
-	switch (sv_protocol)
-	{
-	case PROTOCOL_NETQUAKE:
-		p = "NetQuake";
-		break;
-	case PROTOCOL_FITZQUAKE:
-		p = "FitzQuake";
-		break;
-	case PROTOCOL_RMQ:
-		p = "RMQ";
-		break;
-	default:
-		Sys_Error ("Bad protocol version request %i. Accepted values: %i, %i, %i.",
-				sv_protocol, PROTOCOL_NETQUAKE, PROTOCOL_FITZQUAKE, PROTOCOL_RMQ);
-		return; /* silence compiler */
-	}
-	Sys_Printf ("Server using protocol %i (%s)\n", sv_protocol, p);
+	p = "RMQ";
+	Sys_Printf ("Server using protocol %i (%s)\n", PROTOCOL_RMQ, p);
 }
 
 /*
@@ -458,20 +364,10 @@ void SV_StartSound (edict_t *entity, int channel, const char *sample, int volume
 	if (attenuation != DEFAULT_SOUND_PACKET_ATTENUATION)
 		field_mask |= SND_ATTENUATION;
 
-	//johnfitz -- PROTOCOL_FITZQUAKE
 	if (ent >= 8192)
-	{
-		if (sv.protocol == PROTOCOL_NETQUAKE)
-			return; //don't send any info protocol can't support
 		field_mask |= SND_LARGEENTITY;
-	}
 	if (sound_num >= 256 || channel >= 8)
-	{
-		if (sv.protocol == PROTOCOL_NETQUAKE)
-			return; //don't send any info protocol can't support
 		field_mask |= SND_LARGESOUND;
-	}
-	//johnfitz
 
 	if (sv.datagram.cursize > MAX_DATAGRAM-21)
 		return;
@@ -484,7 +380,6 @@ void SV_StartSound (edict_t *entity, int channel, const char *sample, int volume
 	if (field_mask & SND_ATTENUATION)
 		MSG_WriteByte (&sv.datagram, attenuation*64);
 
-	//johnfitz -- PROTOCOL_FITZQUAKE
 	if (field_mask & SND_LARGEENTITY)
 	{
 		MSG_WriteShort (&sv.datagram, ent);
@@ -496,7 +391,6 @@ void SV_StartSound (edict_t *entity, int channel, const char *sample, int volume
 		MSG_WriteShort (&sv.datagram, sound_num);
 	else
 		MSG_WriteByte (&sv.datagram, sound_num);
-	//johnfitz
 
 	for (i = 0; i < 3; i++)
 		MSG_WriteCoord (&sv.datagram, entity->v.origin[i]+0.5*(entity->v.mins[i]+entity->v.maxs[i]), sv.protocolflags);
@@ -524,11 +418,7 @@ void SV_LocalSound (client_t *client, const char *sample)
 
 	field_mask = 0;
 	if (sound_num >= 256)
-	{
-		if (sv.protocol == PROTOCOL_NETQUAKE)
-			return;
 		field_mask = SND_LARGESOUND;
-	}
 
 	if (client->message.cursize > client->message.maxsize-4)
 		return;
@@ -599,13 +489,8 @@ void SV_SendServerinfo (client_t *client)
 
 	MSG_BEGINSVC (&client->message, svc_serverinfo);
 	MSG_WriteByte (&client->message, svc_serverinfo);
-	MSG_WriteLong (&client->message, sv.protocol); //johnfitz -- sv.protocol instead of PROTOCOL_VERSION
-	
-	if (sv.protocol == PROTOCOL_RMQ)
-	{
-		// mh - now send protocol flags so that the client knows the protocol features to expect
-		MSG_WriteLong (&client->message, sv.protocolflags);
-	}
+	MSG_WriteLong (&client->message, sv.protocol);
+	MSG_WriteLong (&client->message, sv.protocolflags);
 	
 	MSG_WriteByte (&client->message, svs.maxclients);
 
@@ -616,23 +501,19 @@ void SV_SendServerinfo (client_t *client)
 
 	MSG_WriteString (&client->message, PR_GetString(qcvm->edicts->v.message));
 
-	//johnfitz -- only send the first 256 model and sound precaches if protocol is 15
 	for (i = 1, s = sv.model_precache+1; *s; s++,i++)
-		if (sv.protocol != PROTOCOL_NETQUAKE || i < 256)
-		{
-			MSG_DBGAUX (&client->message, i);
-			MSG_WriteString (&client->message, *s);
-		}
+	{
+		MSG_DBGAUX (&client->message, i);
+		MSG_WriteString (&client->message, *s);
+	}
 	MSG_WriteByte (&client->message, 0);
 
 	for (i = 1, s = sv.sound_precache+1; *s; s++, i++)
-		if (sv.protocol != PROTOCOL_NETQUAKE || i < 256)
-		{
-			MSG_DBGAUX (&client->message, i);
-			MSG_WriteString (&client->message, *s);
-		}
+	{
+		MSG_DBGAUX (&client->message, i);
+		MSG_WriteString (&client->message, *s);
+	}
 	MSG_WriteByte (&client->message, 0);
-	//johnfitz
 
 // send music
 	MSG_BEGINSVC (&client->message, svc_cdtrack);
@@ -1139,9 +1020,6 @@ static qboolean SV_ShouldSendEntityToClient (const sv_icull_context_t *ctx, cons
 	if (!ent->v.modelindex || !PR_GetString(ent->v.model)[0])
 		return false;
 
-	if (sv.protocol == PROTOCOL_NETQUAKE && (int)ent->v.modelindex & 0xFF00)
-		return false;
-
 	if (!ctx->enabled)
 	{
 		if (ent->num_leafs < MAX_ENT_LEAFS && !SV_EdictInPVS (ent, ctx->pvs))
@@ -1304,18 +1182,12 @@ static int SV_SnapshotEntitySizeWorst (void)
 	int extra_flags = (sv.protocolflags & PRFL_SNAPSHOT_HIRES) ? 1 : 0;
 	int entry_overhead;
 
-	if (sv.protocolflags & PRFL_FLOATCOORD)
+	if (sv.protocolflags & PRFL_INT32COORD)
 		coord_size = 4;
-	else if (sv.protocolflags & PRFL_INT32COORD)
-		coord_size = 4;
-	else if (sv.protocolflags & PRFL_24BITCOORD)
-		coord_size = 3;
 	else
 		coord_size = 2;
 
-	if (sv.protocolflags & PRFL_FLOATANGLE)
-		angle_size = 4;
-	else if (sv.protocolflags & PRFL_SHORTANGLE)
+	if (sv.protocolflags & PRFL_SHORTANGLE)
 		angle_size = 2;
 	else
 		angle_size = 1;
@@ -1342,18 +1214,14 @@ static int SV_SnapshotCoordBytes (qboolean hires)
 {
 	if (hires && (sv.protocolflags & PRFL_SNAPSHOT_HIRES))
 		return 4;
-	if (sv.protocolflags & (PRFL_FLOATCOORD | PRFL_INT32COORD))
+	if (sv.protocolflags & PRFL_INT32COORD)
 		return 4;
-	if (sv.protocolflags & PRFL_24BITCOORD)
-		return 3;
 	return 2;
 }
 
 static int SV_SnapshotAngleBytes (qboolean hires)
 {
 	if (hires && (sv.protocolflags & PRFL_SNAPSHOT_HIRES))
-		return 4;
-	if (sv.protocolflags & PRFL_FLOATANGLE)
 		return 4;
 	if (sv.protocolflags & PRFL_SHORTANGLE)
 		return 2;
@@ -1581,6 +1449,7 @@ static int SV_BuildClientSnapshot (edict_t *clent, snapshot_state_t *states, byt
 	qboolean *out_continuation, qboolean *out_mandatory_oversize)
 {
 	int	num, j, numents, count;
+	int	k;
 	int mandatory_count = 0;
 	int mandatory_bytes = 0;
 	int total_bytes = 0;
@@ -1674,6 +1543,16 @@ static int SV_BuildClientSnapshot (edict_t *clent, snapshot_state_t *states, byt
 		if (remaining_budget <= 0)
 		{
 			continuation = true;
+			for (k = j; k < numents; k++)
+			{
+				int pending = net_edicts_sorted[k];
+				edict_t *pending_ent = EDICT_NUM (pending);
+				if (present[pending])
+					continue;
+				if (!SV_SnapshotTier1Ent (pending_ent))
+					continue;
+				dropped_tier1++;
+			}
 			break;
 		}
 
@@ -1688,6 +1567,16 @@ static int SV_BuildClientSnapshot (edict_t *clent, snapshot_state_t *states, byt
 			if (ent_size > remaining_budget)
 			{
 				continuation = true;
+				for (k = j; k < numents; k++)
+				{
+					int pending = net_edicts_sorted[k];
+					edict_t *pending_ent = EDICT_NUM (pending);
+					if (present[pending])
+						continue;
+					if (!SV_SnapshotTier1Ent (pending_ent))
+						continue;
+					dropped_tier1++;
+				}
 				break;
 			}
 			present[num] = 1;
@@ -1712,6 +1601,16 @@ static int SV_BuildClientSnapshot (edict_t *clent, snapshot_state_t *states, byt
 			if (remaining_budget <= 0)
 			{
 				continuation = true;
+				for (k = j; k < numents; k++)
+				{
+					int pending = net_edicts_sorted[k];
+					edict_t *pending_ent = EDICT_NUM (pending);
+					if (present[pending])
+						continue;
+					if (SV_SnapshotTier1Ent (pending_ent))
+						continue;
+					dropped_tier2++;
+				}
 				break;
 			}
 
@@ -1726,6 +1625,16 @@ static int SV_BuildClientSnapshot (edict_t *clent, snapshot_state_t *states, byt
 				if (ent_size > remaining_budget)
 				{
 					continuation = true;
+					for (k = j; k < numents; k++)
+					{
+						int pending = net_edicts_sorted[k];
+						edict_t *pending_ent = EDICT_NUM (pending);
+						if (present[pending])
+							continue;
+						if (SV_SnapshotTier1Ent (pending_ent))
+							continue;
+						dropped_tier2++;
+					}
 					break;
 				}
 				present[num] = 1;
@@ -1750,6 +1659,7 @@ static int SV_BuildClientSnapshot (edict_t *clent, snapshot_state_t *states, byt
 		*out_mandatory_bytes = mandatory_bytes;
 	if (out_total_bytes)
 		*out_total_bytes = total_bytes;
+	dropped_count = dropped_tier1 + dropped_tier2;
 	if (out_dropped)
 		*out_dropped = dropped_count;
 	if (out_dropped_tier1)
@@ -2862,628 +2772,6 @@ void SV_SnapshotNak (client_t *client, unsigned int expected_base, unsigned int 
 	client->entstream.active = false;
 }
 
-typedef struct
-{
-	uint32_t	mask;
-	unsigned short	model;
-	unsigned short	frame;
-	byte		colormap;
-	byte		skin;
-	byte		effects;
-	short		origin[3];
-	byte		origin_full_axes;
-	unsigned short	angles[3];
-	short		velocity[3];
-	byte		alpha;
-	byte		scale;
-	byte		lerpfinish;
-} packedent_update_t;
-
-static short SV_PackedQuantizeCoord (float value, int *clamp_count)
-{
-	int q = Q_rint (value * PACKEDENT_POS_SCALE);
-	int clamped = CLAMP (-32768, q, 32767);
-
-	if (clamp_count && clamped != q)
-		(*clamp_count)++;
-	return (short)clamped;
-}
-
-static short SV_PackedQuantizeVelocity (float value, int *clamp_count)
-{
-	int q = Q_rint (value * PACKEDENT_VEL_SCALE);
-	int clamped = CLAMP (-32768, q, 32767);
-
-	if (clamp_count && clamped != q)
-		(*clamp_count)++;
-	return (short)clamped;
-}
-
-static unsigned short SV_PackedQuantizeAngle (float value)
-{
-	int q = Q_rint (value * PACKEDENT_ANGLE_SCALE) & 0xFFFF;
-	return (unsigned short)q;
-}
-
-static int SV_PackedCoordSize (void)
-{
-	if (sv.protocolflags & PRFL_FLOATCOORD)
-		return 4;
-	if (sv.protocolflags & PRFL_INT32COORD)
-		return 4;
-	if (sv.protocolflags & PRFL_24BITCOORD)
-		return 3;
-	return 2;
-}
-
-static int SV_PackedMaskBits (uint32_t mask)
-{
-	int count = 0;
-
-	while (mask)
-	{
-		count += mask & 1u;
-		mask >>= 1;
-	}
-	return count;
-}
-
-static int SV_PackedEntitySize (uint32_t mask)
-{
-	int size = 0;
-	int coord_size = (mask & PACKEDENT_MASK_POS_FULL) ? SV_PackedCoordSize () : 2;
-
-	size += 2; // entnum
-	size += 2; // mask low
-	if (mask & ~0x7FFFu)
-		size += 2;
-
-	if (mask & PACKEDENT_MASK_MODEL)
-		size += 2;
-	if (mask & PACKEDENT_MASK_FRAME)
-		size += 2;
-	if (mask & PACKEDENT_MASK_COLORMAP)
-		size += 1;
-	if (mask & PACKEDENT_MASK_SKIN)
-		size += 1;
-	if (mask & PACKEDENT_MASK_EFFECTS)
-		size += 1;
-	if (mask & PACKEDENT_MASK_ORIGIN_X)
-		size += coord_size;
-	if (mask & PACKEDENT_MASK_ORIGIN_Y)
-		size += coord_size;
-	if (mask & PACKEDENT_MASK_ORIGIN_Z)
-		size += coord_size;
-	if (mask & PACKEDENT_MASK_ANGLE_PITCH)
-		size += 2;
-	if (mask & PACKEDENT_MASK_ANGLE_YAW)
-		size += 2;
-	if (mask & PACKEDENT_MASK_ANGLE_ROLL)
-		size += 2;
-	if (mask & PACKEDENT_MASK_VEL_X)
-		size += 2;
-	if (mask & PACKEDENT_MASK_VEL_Y)
-		size += 2;
-	if (mask & PACKEDENT_MASK_VEL_Z)
-		size += 2;
-	if (mask & PACKEDENT_MASK_ALPHA)
-		size += 1;
-	if (mask & PACKEDENT_MASK_SCALE)
-		size += 1;
-	if (mask & PACKEDENT_MASK_LERPFINISH)
-		size += 1;
-
-	return size;
-}
-
-static uint32_t SV_PackedReduceMaskForBudget (uint32_t mask, int available, qboolean mover)
-{
-	static const uint32_t drop_order[] =
-	{
-		PACKEDENT_MASK_LERPFINISH,
-		PACKEDENT_MASK_VEL_X,
-		PACKEDENT_MASK_VEL_Y,
-		PACKEDENT_MASK_VEL_Z,
-		PACKEDENT_MASK_SCALE,
-		PACKEDENT_MASK_ALPHA,
-		PACKEDENT_MASK_EFFECTS,
-		PACKEDENT_MASK_SKIN,
-		PACKEDENT_MASK_COLORMAP,
-		PACKEDENT_MASK_FRAME,
-		PACKEDENT_MASK_MODEL
-	};
-	uint32_t reduced = mask;
-	size_t i;
-
-	if (SV_PackedEntitySize (reduced) <= available)
-		return reduced;
-
-	for (i = 0; i < countof(drop_order); i++)
-	{
-		if (reduced & drop_order[i])
-		{
-			reduced &= ~drop_order[i];
-			if (SV_PackedEntitySize (reduced) <= available)
-				return reduced;
-		}
-	}
-
-	if (mover)
-		return 0;
-
-	if (SV_PackedEntitySize (reduced) <= available)
-		return reduced;
-
-	return 0;
-}
-
-static uint32_t SV_BuildPackedUpdate (edict_t *ent, packedent_update_t *update, int *clamp_origin, int *clamp_velocity)
-{
-	uint32_t mask = 0;
-	int model = (int)ent->v.modelindex;
-	int frame = (int)ent->v.frame;
-	int i;
-	byte origin_full_axes = 0;
-	const float packed_pos_max = 32767.0f / PACKEDENT_POS_SCALE;
-
-	if (model < 0)
-		model = 0;
-	if (model > 0xFFFF)
-		model = 0xFFFF;
-	update->model = (unsigned short)model;
-	if (ent->baseline.modelindex != update->model)
-		mask |= PACKEDENT_MASK_MODEL;
-
-	if (frame < 0)
-		frame = 0;
-	if (frame > 0xFFFF)
-		frame = 0xFFFF;
-	update->frame = (unsigned short)frame;
-	if (ent->baseline.frame != update->frame)
-		mask |= PACKEDENT_MASK_FRAME;
-
-	update->colormap = (byte)ent->v.colormap;
-	if (ent->baseline.colormap != update->colormap)
-		mask |= PACKEDENT_MASK_COLORMAP;
-
-	update->skin = (byte)ent->v.skin;
-	if (ent->baseline.skin != update->skin)
-		mask |= PACKEDENT_MASK_SKIN;
-
-	update->effects = (byte)((int)ent->v.effects & qcvm->effects_mask);
-	if (ent->baseline.effects != update->effects)
-		mask |= PACKEDENT_MASK_EFFECTS;
-
-	for (i = 0; i < 3; i++)
-	{
-		if (fabsf (ent->v.origin[i]) > packed_pos_max)
-			origin_full_axes |= (byte)(1u << i);
-	}
-	update->origin_full_axes = origin_full_axes;
-	if (origin_full_axes)
-		mask |= PACKEDENT_MASK_POS_FULL;
-
-	for (i = 0; i < 3; i++)
-	{
-		if (origin_full_axes)
-		{
-			update->origin[i] = 0;
-			mask |= PACKEDENT_MASK_ORIGIN_X << i;
-		}
-		else
-		{
-			short base = SV_PackedQuantizeCoord (ent->baseline.origin[i], NULL);
-
-			update->origin[i] = SV_PackedQuantizeCoord (ent->v.origin[i], clamp_origin);
-			if (update->origin[i] != base)
-				mask |= PACKEDENT_MASK_ORIGIN_X << i;
-		}
-
-		update->angles[i] = SV_PackedQuantizeAngle (ent->v.angles[i]);
-		if (update->angles[i] != SV_PackedQuantizeAngle (ent->baseline.angles[i]))
-			mask |= PACKEDENT_MASK_ANGLE_PITCH << i;
-
-		update->velocity[i] = SV_PackedQuantizeVelocity (ent->v.velocity[i], clamp_velocity);
-		if (update->velocity[i] != 0)
-			mask |= PACKEDENT_MASK_VEL_X << i;
-	}
-
-	update->alpha = ent->alpha;
-	if (ent->baseline.alpha != update->alpha)
-		mask |= PACKEDENT_MASK_ALPHA;
-
-	update->scale = ent->scale;
-	if (ent->baseline.scale != update->scale)
-		mask |= PACKEDENT_MASK_SCALE;
-
-	if (ent->v.movetype == MOVETYPE_STEP)
-		mask |= PACKEDENT_MASK_STEP;
-
-	if (ent->sendinterval)
-	{
-		float interval = (ent->v.nextthink - qcvm->time) * 255.0f;
-		update->lerpfinish = (byte)CLAMP (0, Q_rint (interval), 255);
-		mask |= PACKEDENT_MASK_LERPFINISH;
-	}
-	else
-		update->lerpfinish = 0;
-
-	return mask;
-}
-
-static void SV_WritePackedEntity (sizebuf_t *msg, const edict_t *ent, int entnum, uint32_t mask, const packedent_update_t *update)
-{
-	unsigned int low = (unsigned int)(mask & 0x7FFFu);
-	unsigned int high = (unsigned int)(mask >> 16);
-
-	if (high)
-		low |= PACKEDENT_MASK_EXTEND;
-
-	MSG_WriteUInt16 (msg, (unsigned int)entnum);
-	MSG_WriteUInt16 (msg, low);
-	if (high)
-		MSG_WriteUInt16 (msg, high);
-
-	if (mask & PACKEDENT_MASK_MODEL)
-		MSG_WriteUInt16 (msg, update->model);
-	if (mask & PACKEDENT_MASK_FRAME)
-		MSG_WriteUInt16 (msg, update->frame);
-	if (mask & PACKEDENT_MASK_COLORMAP)
-		MSG_WriteByte (msg, update->colormap);
-	if (mask & PACKEDENT_MASK_SKIN)
-		MSG_WriteByte (msg, update->skin);
-	if (mask & PACKEDENT_MASK_EFFECTS)
-		MSG_WriteByte (msg, update->effects);
-	if ((mask & PACKEDENT_MASK_POS_FULL) && sv_packedents_debug.value)
-	{
-		char axes[4];
-		int count = 0;
-
-		if (update->origin_full_axes & 1u)
-			axes[count++] = 'x';
-		if (update->origin_full_axes & 2u)
-			axes[count++] = 'y';
-		if (update->origin_full_axes & 4u)
-			axes[count++] = 'z';
-		axes[count] = '\0';
-		NET_DebugLogEvent (true,
-			"NETDBG time %.3f packedents_pos_full ent %d axes %s\n",
-			realtime, entnum, axes);
-	}
-	if (mask & PACKEDENT_MASK_ORIGIN_X)
-	{
-		if (mask & PACKEDENT_MASK_POS_FULL)
-			MSG_WriteCoord (msg, ent->v.origin[0], sv.protocolflags);
-		else
-			MSG_WriteInt16 (msg, update->origin[0]);
-	}
-	if (mask & PACKEDENT_MASK_ORIGIN_Y)
-	{
-		if (mask & PACKEDENT_MASK_POS_FULL)
-			MSG_WriteCoord (msg, ent->v.origin[1], sv.protocolflags);
-		else
-			MSG_WriteInt16 (msg, update->origin[1]);
-	}
-	if (mask & PACKEDENT_MASK_ORIGIN_Z)
-	{
-		if (mask & PACKEDENT_MASK_POS_FULL)
-			MSG_WriteCoord (msg, ent->v.origin[2], sv.protocolflags);
-		else
-			MSG_WriteInt16 (msg, update->origin[2]);
-	}
-	if (mask & PACKEDENT_MASK_ANGLE_PITCH)
-		MSG_WriteUInt16 (msg, update->angles[0]);
-	if (mask & PACKEDENT_MASK_ANGLE_YAW)
-		MSG_WriteUInt16 (msg, update->angles[1]);
-	if (mask & PACKEDENT_MASK_ANGLE_ROLL)
-		MSG_WriteUInt16 (msg, update->angles[2]);
-	if (mask & PACKEDENT_MASK_VEL_X)
-		MSG_WriteInt16 (msg, update->velocity[0]);
-	if (mask & PACKEDENT_MASK_VEL_Y)
-		MSG_WriteInt16 (msg, update->velocity[1]);
-	if (mask & PACKEDENT_MASK_VEL_Z)
-		MSG_WriteInt16 (msg, update->velocity[2]);
-	if (mask & PACKEDENT_MASK_ALPHA)
-		MSG_WriteByte (msg, update->alpha);
-	if (mask & PACKEDENT_MASK_SCALE)
-		MSG_WriteByte (msg, update->scale);
-	if (mask & PACKEDENT_MASK_LERPFINISH)
-		MSG_WriteByte (msg, update->lerpfinish);
-}
-
-/*
-=============
-SV_WriteEntitiesToClient
-
-=============
-*/
-void SV_WriteEntitiesToClient (edict_t	*clent, sizebuf_t *msg)
-{
-	int		e, i, j, numents;
-	int		bits;
-	float	miss;
-	eval_t	*val;
-	edict_t	*ent;
-	qboolean	use_packed = (sv_packedents.value != 0.0f && host_client && host_client->supports_packedents);
-	int		packed_start = msg->cursize;
-	int		packed_count_pos = -1;
-	int		packed_count = 0;
-	numents = SV_BuildNetEdictsList (clent);
-
-	if (use_packed)
-	{
-		if (sv_packedents_debug.value && !sv_packedents_selftest_done)
-		{
-			MSG_PackedSelfTest ();
-			sv_packedents_selftest_done = true;
-		}
-
-		if (msg->cursize + 3 > msg->maxsize)
-			goto stats;
-		MSG_BEGINSVC (msg, svc_packedentities);
-		MSG_WriteByte (msg, svc_packedentities);
-		packed_count_pos = msg->cursize;
-		MSG_WriteShort (msg, 0);
-	}
-
-// send entities (closest first)
-	for (j=0 ; j<numents ; j++)
-	{
-		e = net_edicts_sorted[j];
-		ent = EDICT_NUM (e);
-
-		if (!use_packed)
-		{
-			// johnfitz -- max size for protocol 15 is 18 bytes, not 16 as originally
-			// assumed here.  And, for protocol 85 the max size is actually 24 bytes.
-			// For float coords and angles the limit is 40.
-			// FIXME: Use tighter limit according to protocol flags and send bits.
-			if (msg->cursize + 40 > msg->maxsize)
-			{
-				//johnfitz -- less spammy overflow message
-				if (!dev_overflows.packetsize || dev_overflows.packetsize + CONSOLE_RESPAM_TIME < realtime )
-				{
-					Con_Printf ("Packet overflow!\n");
-					dev_overflows.packetsize = realtime;
-				}
-				goto stats;
-				//johnfitz
-			}
-		}
-
-// send an update
-		if (use_packed)
-		{
-			packedent_update_t update;
-			uint32_t mask;
-			int clamp_origin = 0;
-			int clamp_velocity = 0;
-			int available = msg->maxsize - msg->cursize;
-			qboolean mover = (ent->v.movetype == MOVETYPE_PUSH || ent->v.movetype == MOVETYPE_STEP);
-
-			//johnfitz -- alpha
-			val = GetEdictFieldValueByName(ent, "alpha");
-			if (val)
-				ent->alpha = ENTALPHA_ENCODE(val->_float);
-
-			//don't send invisible entities unless they have effects
-			if (ent->alpha == ENTALPHA_ZERO && !((int)ent->v.effects & qcvm->effects_mask))
-				continue;
-
-			val = GetEdictFieldValueByName(ent, "scale");
-			if (val)
-				ent->scale = ENTSCALE_ENCODE(val->_float);
-			else
-				ent->scale = ENTSCALE_DEFAULT;
-
-			mask = SV_BuildPackedUpdate (ent, &update, &clamp_origin, &clamp_velocity);
-			if (!mask)
-				continue;
-
-			mask = SV_PackedReduceMaskForBudget (mask, available, mover);
-			if (!mask)
-				goto stats;
-
-			SV_WritePackedEntity (msg, ent, e, mask, &update);
-			packed_count++;
-
-			if (sv_packedents_debug.value)
-			{
-				int size = SV_PackedEntitySize (mask);
-				int bits = SV_PackedMaskBits (mask);
-
-				sv_packedents_stats.bytes += size;
-				sv_packedents_stats.entities++;
-				sv_packedents_stats.mask_bits_total += bits;
-				if (bits >= 0 && bits < (int)countof(sv_packedents_stats.mask_hist))
-					sv_packedents_stats.mask_hist[bits]++;
-				sv_packedents_stats.clamp_origin += clamp_origin;
-				sv_packedents_stats.clamp_velocity += clamp_velocity;
-			}
-
-			continue;
-		}
-
-		bits = 0;
-
-		for (i=0 ; i<3 ; i++)
-		{
-			miss = ent->v.origin[i] - ent->baseline.origin[i];
-			if ( miss < -0.1 || miss > 0.1 )
-				bits |= U_ORIGIN1<<i;
-		}
-
-		if ( ent->v.angles[0] != ent->baseline.angles[0] )
-			bits |= U_ANGLE1;
-
-		if ( ent->v.angles[1] != ent->baseline.angles[1] )
-			bits |= U_ANGLE2;
-
-		if ( ent->v.angles[2] != ent->baseline.angles[2] )
-			bits |= U_ANGLE3;
-
-		if (ent->v.movetype == MOVETYPE_STEP)
-			bits |= U_STEP;	// don't mess up the step animation
-
-		if (ent->baseline.colormap != ent->v.colormap)
-			bits |= U_COLORMAP;
-
-		if (ent->baseline.skin != ent->v.skin)
-			bits |= U_SKIN;
-
-		if (ent->baseline.frame != ent->v.frame)
-			bits |= U_FRAME;
-
-		if ((ent->baseline.effects ^ (int)ent->v.effects) & qcvm->effects_mask)
-			bits |= U_EFFECTS;
-
-		if (ent->baseline.modelindex != ent->v.modelindex)
-			bits |= U_MODEL;
-
-		//johnfitz -- alpha
-		// TODO: find a cleaner place to put this code
-		val = GetEdictFieldValueByName(ent, "alpha");
-		if (val)
-			ent->alpha = ENTALPHA_ENCODE(val->_float);
-
-		//don't send invisible entities unless they have effects
-		if (ent->alpha == ENTALPHA_ZERO && !((int)ent->v.effects & qcvm->effects_mask))
-			continue;
-		//johnfitz
-
-		val = GetEdictFieldValueByName(ent, "scale");
-		if (val)
-			ent->scale = ENTSCALE_ENCODE(val->_float);
-		else
-			ent->scale = ENTSCALE_DEFAULT;
-
-		//johnfitz -- PROTOCOL_FITZQUAKE
-		if (sv.protocol != PROTOCOL_NETQUAKE)
-		{
-
-			if (ent->baseline.alpha != ent->alpha) bits |= U_ALPHA;
-			if (ent->baseline.scale != ent->scale) bits |= U_SCALE;
-			if (bits & U_FRAME && (int)ent->v.frame & 0xFF00) bits |= U_FRAME2;
-			if (bits & U_MODEL && (int)ent->v.modelindex & 0xFF00) bits |= U_MODEL2;
-			if (ent->sendinterval) bits |= U_LERPFINISH;
-			if (bits >= 65536) bits |= U_EXTEND1;
-			if (bits >= 16777216) bits |= U_EXTEND2;
-		}
-		//johnfitz
-
-		if (e >= 256)
-			bits |= U_LONGENTITY;
-
-		if (bits >= 256)
-			bits |= U_MOREBITS;
-
-	//
-	// write the message
-	//
-		MSG_WriteByte (msg, bits | U_SIGNAL);
-
-		if (bits & U_MOREBITS)
-			MSG_WriteByte (msg, bits>>8);
-
-		//johnfitz -- PROTOCOL_FITZQUAKE
-		if (bits & U_EXTEND1)
-			MSG_WriteByte(msg, bits>>16);
-		if (bits & U_EXTEND2)
-			MSG_WriteByte(msg, bits>>24);
-		//johnfitz
-
-		if (bits & U_LONGENTITY)
-			MSG_WriteShort (msg,e);
-		else
-			MSG_WriteByte (msg,e);
-
-		if (bits & U_MODEL)
-			MSG_WriteByte (msg,	ent->v.modelindex);
-		if (bits & U_FRAME)
-			MSG_WriteByte (msg, ent->v.frame);
-		if (bits & U_COLORMAP)
-			MSG_WriteByte (msg, ent->v.colormap);
-		if (bits & U_SKIN)
-			MSG_WriteByte (msg, ent->v.skin);
-		if (bits & U_EFFECTS)
-			MSG_WriteByte (msg, (int)ent->v.effects & qcvm->effects_mask);
-		if (bits & U_ORIGIN1)
-			MSG_WriteCoord (msg, ent->v.origin[0], sv.protocolflags);
-		if (bits & U_ANGLE1)
-			MSG_WriteAngle(msg, ent->v.angles[0], sv.protocolflags);
-		if (bits & U_ORIGIN2)
-			MSG_WriteCoord (msg, ent->v.origin[1], sv.protocolflags);
-		if (bits & U_ANGLE2)
-			MSG_WriteAngle(msg, ent->v.angles[1], sv.protocolflags);
-		if (bits & U_ORIGIN3)
-			MSG_WriteCoord (msg, ent->v.origin[2], sv.protocolflags);
-		if (bits & U_ANGLE3)
-			MSG_WriteAngle(msg, ent->v.angles[2], sv.protocolflags);
-
-		//johnfitz -- PROTOCOL_FITZQUAKE
-		if (bits & U_ALPHA)
-			MSG_WriteByte(msg, ent->alpha);
-		if (bits & U_SCALE)
-			MSG_WriteByte(msg, ent->scale);
-		if (bits & U_FRAME2)
-			MSG_WriteByte(msg, (int)ent->v.frame >> 8);
-		if (bits & U_MODEL2)
-			MSG_WriteByte(msg, (int)ent->v.modelindex >> 8);
-		if (bits & U_LERPFINISH)
-			MSG_WriteByte(msg, (byte)(Q_rint((ent->v.nextthink-qcvm->time)*255)));
-		//johnfitz
-	}
-
-	//johnfitz -- devstats
-stats:
-	if (use_packed)
-	{
-		if (packed_count == 0)
-			msg->cursize = packed_start;
-		else
-		{
-			msg->data[packed_count_pos] = packed_count & 0xff;
-			msg->data[packed_count_pos + 1] = (packed_count >> 8) & 0xff;
-		}
-
-		if (sv_packedents_debug.value)
-		{
-			sv_packedents_stats.packets++;
-			if (realtime >= sv_packedents_stats_next_time)
-			{
-				float avg_bytes = sv_packedents_stats.entities ? (float)sv_packedents_stats.bytes / sv_packedents_stats.entities : 0.0f;
-				float avg_bits = sv_packedents_stats.entities ? (float)sv_packedents_stats.mask_bits_total / sv_packedents_stats.entities : 0.0f;
-
-				char hist[256];
-				int len = 0;
-				int h;
-
-				hist[0] = '\0';
-				for (h = 0; h < (int)countof(sv_packedents_stats.mask_hist); h++)
-				{
-					if (sv_packedents_stats.mask_hist[h] == 0)
-						continue;
-					len += q_snprintf (hist + len, sizeof(hist) - len, "%d:%d ", h, sv_packedents_stats.mask_hist[h]);
-					if (len >= (int)sizeof(hist))
-						break;
-				}
-
-				Con_DPrintf ("packedents: avg_bytes %.1f avg_bits %.1f clamp_origin %d clamp_vel %d masks[%s]\n",
-					avg_bytes, avg_bits, sv_packedents_stats.clamp_origin, sv_packedents_stats.clamp_velocity,
-					hist[0] ? hist : "none");
-				sv_packedents_stats = (packedent_stats_t){0};
-				sv_packedents_stats_next_time = realtime + 1.0;
-			}
-		}
-	}
-
-	if (msg->cursize > 1024 && dev_peakstats.packetsize <= 1024)
-		Con_DWarning ("%i byte packet exceeds standard limit of 1024 (max = %d).\n", msg->cursize, msg->maxsize);
-	dev_stats.packetsize = msg->cursize;
-	dev_peakstats.packetsize = q_max(msg->cursize, dev_peakstats.packetsize);
-	//johnfitz
-}
-
 /*
 =============
 SV_CleanupEnts
@@ -3592,32 +2880,25 @@ void SV_WriteClientdataToMessage (client_t *client, edict_t *ent, sizebuf_t *msg
 
 	bits |= SU_PREDICT;
 
-	//johnfitz -- PROTOCOL_FITZQUAKE
-	if (sv.protocol != PROTOCOL_NETQUAKE)
-	{
-		if (bits & SU_WEAPON && SV_ModelIndex(PR_GetString(ent->v.weaponmodel)) & 0xFF00) bits |= SU_WEAPON2;
-		if ((int)ent->v.armorvalue & 0xFF00) bits |= SU_ARMOR2;
-		if ((int)ent->v.currentammo & 0xFF00) bits |= SU_AMMO2;
-		if ((int)ent->v.ammo_shells & 0xFF00) bits |= SU_SHELLS2;
-		if ((int)ent->v.ammo_nails & 0xFF00) bits |= SU_NAILS2;
-		if ((int)ent->v.ammo_rockets & 0xFF00) bits |= SU_ROCKETS2;
-		if ((int)ent->v.ammo_cells & 0xFF00) bits |= SU_CELLS2;
-		if (bits & SU_WEAPONFRAME && (int)ent->v.weaponframe & 0xFF00) bits |= SU_WEAPONFRAME2;
-		if (bits & SU_WEAPON && ent->alpha != ENTALPHA_DEFAULT) bits |= SU_WEAPONALPHA; //for now, weaponalpha = client entity alpha
-		if (bits >= 65536) bits |= SU_EXTEND1;
-		if (bits >= 16777216) bits |= SU_EXTEND2;
-	}
-	//johnfitz
+	if (bits & SU_WEAPON && SV_ModelIndex(PR_GetString(ent->v.weaponmodel)) & 0xFF00) bits |= SU_WEAPON2;
+	if ((int)ent->v.armorvalue & 0xFF00) bits |= SU_ARMOR2;
+	if ((int)ent->v.currentammo & 0xFF00) bits |= SU_AMMO2;
+	if ((int)ent->v.ammo_shells & 0xFF00) bits |= SU_SHELLS2;
+	if ((int)ent->v.ammo_nails & 0xFF00) bits |= SU_NAILS2;
+	if ((int)ent->v.ammo_rockets & 0xFF00) bits |= SU_ROCKETS2;
+	if ((int)ent->v.ammo_cells & 0xFF00) bits |= SU_CELLS2;
+	if (bits & SU_WEAPONFRAME && (int)ent->v.weaponframe & 0xFF00) bits |= SU_WEAPONFRAME2;
+	if (bits & SU_WEAPON && ent->alpha != ENTALPHA_DEFAULT) bits |= SU_WEAPONALPHA; //for now, weaponalpha = client entity alpha
+	if (bits >= 65536) bits |= SU_EXTEND1;
+	if (bits >= 16777216) bits |= SU_EXTEND2;
 
 // send the data
 
 	MSG_WriteByte (msg, svc_clientdata);
 	MSG_WriteShort (msg, bits);
 
-	//johnfitz -- PROTOCOL_FITZQUAKE
 	if (bits & SU_EXTEND1) MSG_WriteByte(msg, bits>>16);
 	if (bits & SU_EXTEND2) MSG_WriteByte(msg, bits>>24);
-	//johnfitz
 
 	if (bits & SU_VIEWHEIGHT)
 		MSG_WriteChar (msg, ent->v.view_ofs[2]);
@@ -3666,7 +2947,6 @@ void SV_WriteClientdataToMessage (client_t *client, edict_t *ent, sizebuf_t *msg
 		}
 	}
 
-	//johnfitz -- PROTOCOL_FITZQUAKE
 	if (bits & SU_WEAPON2)
 		MSG_WriteByte (msg, SV_ModelIndex(PR_GetString(ent->v.weaponmodel)) >> 8);
 	if (bits & SU_ARMOR2)
@@ -3694,10 +2974,7 @@ void SV_WriteClientdataToMessage (client_t *client, edict_t *ent, sizebuf_t *msg
 	for (i=0 ; i<3 ; i++)
 		MSG_WriteCoord (msg, ent->v.velocity[i], sv.protocolflags);
 	for (i=0 ; i<3 ; i++)
-		if (sv.protocol == PROTOCOL_NETQUAKE)
-			MSG_WriteAngle (msg, ent->v.v_angle[i], sv.protocolflags);
-		else
-			MSG_WriteAngle16 (msg, ent->v.v_angle[i], sv.protocolflags);
+		MSG_WriteAngle16 (msg, ent->v.v_angle[i], sv.protocolflags);
 
 	// Hack: Alkaline 1.1 uses bit flags to store the active weapon,
 	// but we only send the stat as a byte, which can lead to truncation.
@@ -4217,7 +3494,7 @@ typedef struct
 
 static qboolean SV_SignonChunksEnabled (void)
 {
-	return (sv.protocol == PROTOCOL_RMQ) && (sv.protocolflags & PRFL_SIGNON_CHUNKS) && sv_signon_chunks.value;
+	return (sv.protocolflags & PRFL_SIGNON_CHUNKS) != 0;
 }
 
 static qboolean SV_SignonReaderAtEnd (const signon_reader_t *reader)
@@ -4318,17 +3595,13 @@ static qboolean SV_SignonReadString (signon_reader_t *reader, size_t *consumed)
 
 static int SV_SignonCoordBytes (unsigned int protocolflags)
 {
-	if (protocolflags & (PRFL_FLOATCOORD | PRFL_INT32COORD))
+	if (protocolflags & PRFL_INT32COORD)
 		return 4;
-	if (protocolflags & PRFL_24BITCOORD)
-		return 3;
 	return 2;
 }
 
 static int SV_SignonAngleBytes (unsigned int protocolflags)
 {
-	if (protocolflags & PRFL_FLOATANGLE)
-		return 4;
 	if (protocolflags & PRFL_SHORTANGLE)
 		return 2;
 	return 1;
@@ -4364,7 +3637,7 @@ static int SV_SignonCommandLength (const signon_reader_t *reader, int *out_cmd, 
 	if (!SV_SignonReadByte (&temp, &cmd, &consumed))
 		return 0;
 
-	if (cmd & U_SIGNAL)
+	if (cmd & 128)
 		return -1;
 
 	if (out_cmd)
@@ -4732,7 +4005,7 @@ static client_t *SV_SignonFirewallClientForMessage (sizebuf_t *msg)
 
 void SV_SignonFirewallCheck (sizebuf_t *msg, int svc_id, const char *file, int line)
 {
-	if (!sv.active || !sv_signon_chunks.value)
+	if (!sv.active)
 		return;
 	if (svc_id == svc_signon_chunk)
 		return;
@@ -5007,7 +4280,7 @@ void SV_CreateBaseline (void)
 	int			i;
 	edict_t		*svent;
 	int			entnum;
-	int			bits; //johnfitz -- PROTOCOL_FITZQUAKE
+	int			bits;
 
 	for (entnum = 0; entnum < qcvm->num_edicts ; entnum++)
 	{
@@ -5038,38 +4311,21 @@ void SV_CreateBaseline (void)
 			svent->baseline.modelindex = SV_ModelIndex(PR_GetString(svent->v.model));
 			svent->baseline.alpha = svent->alpha; //johnfitz -- alpha support
 			svent->baseline.scale = ENTSCALE_DEFAULT;
-			if (sv.protocol == PROTOCOL_RMQ)
-			{
-				eval_t* val;
-				val = GetEdictFieldValueByName(svent, "scale");
-				if (val)
-					svent->baseline.scale = ENTSCALE_ENCODE(val->_float);
-			}
+			eval_t* val;
+			val = GetEdictFieldValueByName(svent, "scale");
+			if (val)
+				svent->baseline.scale = ENTSCALE_ENCODE(val->_float);
 		}
 
-		//johnfitz -- PROTOCOL_FITZQUAKE
 		bits = 0;
-		if (sv.protocol == PROTOCOL_NETQUAKE) //still want to send baseline in PROTOCOL_NETQUAKE, so reset these values
-		{
-			if (svent->baseline.modelindex & 0xFF00)
-				svent->baseline.modelindex = 0;
-			if (svent->baseline.frame & 0xFF00)
-				svent->baseline.frame = 0;
-			svent->baseline.alpha = ENTALPHA_DEFAULT;
-			svent->baseline.scale = ENTSCALE_DEFAULT;
-		}
-		else //decide which extra data needs to be sent
-		{
-			if (svent->baseline.modelindex & 0xFF00)
-				bits |= B_LARGEMODEL;
-			if (svent->baseline.frame & 0xFF00)
-				bits |= B_LARGEFRAME;
-			if (svent->baseline.alpha != ENTALPHA_DEFAULT)
-				bits |= B_ALPHA;
-			if (svent->baseline.scale != ENTSCALE_DEFAULT)
-				bits |= B_SCALE;
-		}
-		//johnfitz
+		if (svent->baseline.modelindex & 0xFF00)
+			bits |= B_LARGEMODEL;
+		if (svent->baseline.frame & 0xFF00)
+			bits |= B_LARGEFRAME;
+		if (svent->baseline.alpha != ENTALPHA_DEFAULT)
+			bits |= B_ALPHA;
+		if (svent->baseline.scale != ENTSCALE_DEFAULT)
+			bits |= B_SCALE;
 
 	//
 	// add to the message
@@ -5079,19 +4335,8 @@ void SV_CreateBaseline (void)
 			int angle_bytes;
 			int reserve;
 
-			if (sv.protocolflags & (PRFL_FLOATCOORD | PRFL_INT32COORD))
-				coord_bytes = 4;
-			else if (sv.protocolflags & PRFL_24BITCOORD)
-				coord_bytes = 3;
-			else
-				coord_bytes = 2;
-
-			if (sv.protocolflags & PRFL_FLOATANGLE)
-				angle_bytes = 4;
-			else if (sv.protocolflags & PRFL_SHORTANGLE)
-				angle_bytes = 2;
-			else
-				angle_bytes = 1;
+			coord_bytes = (sv.protocolflags & PRFL_INT32COORD) ? 4 : 2;
+			angle_bytes = (sv.protocolflags & PRFL_SHORTANGLE) ? 2 : 1;
 
 			reserve = 1 + 2;
 			if (bits)
@@ -5108,7 +4353,6 @@ void SV_CreateBaseline (void)
 			SV_ReserveSignonSpace (reserve);
 		}
 
-		//johnfitz -- PROTOCOL_FITZQUAKE
 		if (bits)
 		{
 			MSG_BEGINSVC (sv.signon, svc_spawnbaseline2);
@@ -5121,11 +4365,9 @@ void SV_CreateBaseline (void)
 			MSG_DBGAUX (sv.signon, entnum);
 			MSG_WriteByte (sv.signon, svc_spawnbaseline);
 		}
-		//johnfitz
 
 		MSG_WriteShort (sv.signon,entnum);
 
-		//johnfitz -- PROTOCOL_FITZQUAKE
 		if (bits)
 			MSG_WriteByte (sv.signon, bits);
 
@@ -5148,10 +4390,8 @@ void SV_CreateBaseline (void)
 			MSG_WriteAngle(sv.signon, svent->baseline.angles[i], sv.protocolflags);
 		}
 
-		//johnfitz -- PROTOCOL_FITZQUAKE
 		if (bits & B_ALPHA)
 			MSG_WriteByte (sv.signon, svent->baseline.alpha);
-		//johnfitz
 
 		if (bits & B_SCALE)
 			MSG_WriteByte (sv.signon, svent->baseline.scale);
@@ -5479,17 +4719,8 @@ void SV_SpawnServer (const char *server)
 	if (developer.value || map_checks.value)
 		sv.mapchecks.active = true;
 
-	sv.protocol = sv_protocol; // johnfitz
-	
-	if (sv.protocol == PROTOCOL_RMQ)
-	{
-		// set up the protocol flags used by this server
-		// (note - these could be cvar-ised so that server admins could choose the protocol features used by their servers)
-		sv.protocolflags = PRFL_INT32COORD | PRFL_SHORTANGLE | PRFL_SNAPSHOT_HIRES;
-		if (sv_signon_chunks.value)
-			sv.protocolflags |= PRFL_SIGNON_CHUNKS;
-	}
-	else sv.protocolflags = 0;
+	sv.protocol = PROTOCOL_RMQ;
+	sv.protocolflags = PROTOCOL_RMQ_FLAGS;
 
 	PR_SwitchQCVM(vm);
 // load progs to get entity field count

--- a/Quake/sv_phys.c
+++ b/Quake/sv_phys.c
@@ -1277,7 +1277,6 @@ void SV_Physics (void)
 		else
 			Sys_Error ("SV_Physics: bad movetype %i", (int)ent->v.movetype);
 
-	//johnfitz -- PROTOCOL_FITZQUAKE
 	//capture interval to nextthink here and send it to client for better
 	//lerp timing, but only if interval is not 0.1 (which client assumes)
 		ent->sendinterval = false;
@@ -1287,7 +1286,6 @@ void SV_Physics (void)
 			if (j >= 0 && j < 256 && j != 25 && j != 26) //25 and 26 are close enough to 0.1 to not send
 				ent->sendinterval = true;
 		}
-	//johnfitz
 	}
 
 	if (pr_global_struct->force_retouch)

--- a/Quake/sv_user.c
+++ b/Quake/sv_user.c
@@ -466,12 +466,7 @@ void SV_ReadClientMove (usercmd_t *move)
 
 // read current angles
 	for (i=0 ; i<3 ; i++)
-		//johnfitz -- 16-bit angles for PROTOCOL_FITZQUAKE
-		if (sv.protocol == PROTOCOL_NETQUAKE)
-			move->viewangles[i] = MSG_ReadAngle (sv.protocolflags);
-		else
-			move->viewangles[i] = MSG_ReadAngle16 (sv.protocolflags);
-		//johnfitz
+		move->viewangles[i] = MSG_ReadAngle16 (sv.protocolflags);
 
 // read movement
 	move->forwardmove = MSG_ReadShort ();
@@ -552,12 +547,6 @@ nextmsg:
 					host_client->updaterate = SV_ClampClientRate (updaterate, &sv_minupdaterate, &sv_maxupdaterate);
 					break;
 				}
-				if (q_strncasecmp(s, "packedents", 10) == 0)
-				{
-					int value = Q_atoi(s + 10);
-					host_client->supports_packedents = value ? true : false;
-					break;
-				}
 				if (q_strncasecmp(s, "spawn", 5) && q_strncasecmp(s, "begin", 5) && q_strncasecmp(s, "prespawn", 8) && qcvm->extfuncs.SV_ParseClientCommand)
 				{	//the spawn/begin/prespawn are because of numerous mods that disobey the rules.
 					//at a minimum, we must be able to join the server, so that we can see any sprints/bprints (because dprint sucks, yes there's proper ways to deal with this, but moders don't always know them).
@@ -636,6 +625,7 @@ nextmsg:
 				int cmd_index;
 				unsigned int cmd_seq;
 				unsigned int cmd_ack;
+				unsigned int prev_seq = 0;
 
 			// read ping time
 				host_client->ping_times[host_client->num_pings%NUM_PING_TIMES]
@@ -644,15 +634,37 @@ nextmsg:
 
 				cmd_seq = (unsigned int)MSG_ReadLong ();
 				cmd_ack = (unsigned int)MSG_ReadLong ();
+				if (SV_CmdSeqNewer (cmd_ack, cmd_seq))
+				{
+					Con_Printf ("SV_ReadClientMessage: invalid cmd ack from %s\n",
+						host_client->name);
+					SV_DropClient (true);
+					return false;
+				}
 				if (SV_CmdSeqNewer (cmd_ack, host_client->last_cmd_ack))
 					host_client->last_cmd_ack = cmd_ack;
 
 				cmd_count = MSG_ReadByte ();
+				if (cmd_count > MAX_CMDS_PER_PACKET)
+				{
+					Con_Printf ("SV_ReadClientMessage: too many cmds (%d) from %s\n",
+						cmd_count, host_client->name);
+					SV_DropClient (true);
+					return false;
+				}
 				for (cmd_index = 0; cmd_index < cmd_count; cmd_index++)
 				{
 					usercmd_t move;
 
 					SV_ReadClientMove (&move);
+					if (cmd_index > 0 && !SV_CmdSeqNewer (move.sequence, prev_seq))
+					{
+						Con_Printf ("SV_ReadClientMessage: non-increasing cmd seq from %s\n",
+							host_client->name);
+						SV_DropClient (true);
+						return false;
+					}
+					prev_seq = move.sequence;
 					if (!SV_CmdSeqNewer (move.sequence, host_client->last_cmd_seq))
 						continue;
 


### PR DESCRIPTION
### Motivation
- Enforce a single modern network protocol (RMQ) and eliminate legacy protocol branches and compatibility code to simplify runtime semantics and avoid protocol negotiation or fallbacks.
- Harden client snapshot parsing and server snapshot budgeting to make parsing fail-fast, prevent partial state application from malformed packets, and guarantee budgeted omission never implies entity removal.

### Description
- Remove legacy protocol enums/branches and lock protocol to RMQ: eliminate `PROTOCOL_NETQUAKE`/`PROTOCOL_FITZQUAKE` runtime paths and require `PROTOCOL_RMQ` with fixed `PROTOCOL_RMQ_FLAGS` in `protocol.h`, `cl_parse.c`, and `sv_main.c`.
- Simplify message encoding/decoding to the modern flag set: adjust coord/angle read/write paths in `common.c` and assume `PRFL_INT32COORD`/`PRFL_SHORTANGLE` where appropriate, and remove legacy float/24-bit branches.
- Harden snapshot parsing and add strict caps and guards: introduce `MAX_SNAPSHOT_ENTITIES`, `MAX_REMOVE_ENTITIES`, `MAX_PACKED_FIELDS`, `MAX_CMDS_PER_PACKET`, `MAX_SNAPSHOT_PARSE_ERRORS`, and use them in `cl_parse.c` to validate counts, masks (bit-count checks), origins, and chunk payload lengths; add origin sanity checks and fail-fast `CL_RequestFullSnapshot` behavior; track consecutive parse errors and disconnect after exceeding `MAX_SNAPSHOT_PARSE_ERRORS`.
- Server-side safety and budget rules: enforce single RMQ snapshot path in `sv_main.c`, compute snapshot budgets, track dropped tier1/tier2 entity counts when budget forces continuation (do not generate remove lists), send protocol flags to clients, and consolidate signon chunk behavior.
- Transport/reliable guard and limits: add `MAX_RELIABLE_QUEUE_BYTES` in `net.h`, cap reliable receive queues in `net_dgrm.c`, and guard signon/snapshot NAK writes against reliable buffer overflow in `cl_parse.c`.
- Remove optional/legacy packed-entities negotiation paths and per-client legacy flags (remove `supports_packedents` wiring and server/client toggles), folding packed-entity code paths to server-only internal usage where applicable; trim legacy fast-update handling by rejecting unsupported fast updates and unknown commands fail-fast.
- Misc cleanup/consistency changes across files to remove legacy comments/guards and align encoding/decoding to one protocol path (`Quake/*`: notable files changed include `cl_parse.c`, `sv_main.c`, `protocol.h`, `common.c`, `cl_input.c`, `cl_main.c`, `sv_user.c`, `sv_phys.c`, `pr_cmds.c`, `net.h`, `net_dgrm.c`, `server.h`, `client.h`).

### Testing
- No automated tests were run as part of this change; changes were implemented and committed locally but no build or test-suite execution was requested.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972137b925c832eae2859ee7e2c0094)