### PR TITLE
Declare warn_about_nehahra_protocol in cl_parse.c

### DIFF
--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -39,6 +39,8 @@ extern cvar_t cl_signon_chunk_debug;
 extern cvar_t cl_signon_debug;
 extern qboolean cl_viewent_needs_init;
 
+static qboolean warn_about_nehahra_protocol;
+
 const char *svc_strings[] =
 {
 	"svc_bad",


### PR DESCRIPTION
### Motivation
- Fix a compilation error where `warn_about_nehahra_protocol` was assigned but not declared, causing an undeclared identifier during build.

### Description
- Add `static qboolean warn_about_nehahra_protocol;` to `Quake/cl_parse.c` alongside the other declarations to define the missing flag.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697271200554832e949a79c3018b146b)