### PR TITLE
Fix cmd-ack validation, wrap-safe seqs, and add resync + NETDBG instrumentation

### DIFF
--- a/Quake/cl_input.c
+++ b/Quake/cl_input.c
@@ -29,6 +29,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 extern cvar_t cl_maxpitch; //johnfitz -- variable pitch clamping
 extern cvar_t cl_minpitch; //johnfitz -- variable pitch clamping
 extern cvar_t cl_mwheelpitch;
+extern cvar_t cl_netdebug_parse;
 
 /*
 ===============================================================================
@@ -442,6 +443,15 @@ void CL_SendMove (const usercmd_t *cmd)
 			MSG_WriteShort (&buf, out->upmove);
 			MSG_WriteByte (&buf, out->buttons);
 			MSG_WriteByte (&buf, out->impulse);
+		}
+
+		if (cl_netdebug_parse.value)
+		{
+			unsigned int reliable_seq = cls.netcon ? cls.netcon->sendSequence : 0u;
+			unsigned int reliable_base = cls.netcon ? cls.netcon->sendReliableBase : 0u;
+			Con_Printf ("NETDBG cmd_ack_write ack %u type long cmd_seq %u rel_seq %u rel_base %u snap_ack %u msg %d flags 0x%x\n",
+				cl.last_cmd_ack, cmd->sequence, reliable_seq, reliable_base, cl.last_snapshot_ack_sent,
+				buf.cursize, cl.protocolflags);
 		}
 	}
 

--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -884,6 +884,7 @@ static qboolean CL_SendSnapshotAck (unsigned int seq)
 	}
 	MSG_WriteByte (&cls.message, clc_snapshot_ack);
 	MSG_WriteLong (&cls.message, (int)seq);
+	cl.last_snapshot_ack_sent = seq;
 	NET_DebugLogEvent (true,
 		"NETDBG time %.3f snap_ack_send seq %u\n",
 		realtime, seq);
@@ -2581,9 +2582,9 @@ void CL_ParseClientdata (void)
 		vec3_t velocity;
 		vec3_t viewangles;
 
-		if ((int)(ack - cl.last_cmd_ack) > 0)
+		if (NETSEQ_GT (ack, cl.last_cmd_ack))
 			cl.last_cmd_ack = ack;
-		if ((int)(ack_echo - cl.last_cmd_ack_echo) > 0)
+		if (NETSEQ_GT (ack_echo, cl.last_cmd_ack_echo))
 			cl.last_cmd_ack_echo = ack_echo;
 
 		for (i = 0; i < 3; i++)

--- a/Quake/cl_predict.c
+++ b/Quake/cl_predict.c
@@ -82,7 +82,7 @@ static void CL_EnsureViewEntityOrigin (const char *reason)
 
 static qboolean CL_Predict_SeqNewer (unsigned int seq, unsigned int ref)
 {
-	return (int)(seq - ref) > 0;
+	return NETSEQ_GT (seq, ref);
 }
 
 static qboolean CL_Predict_IsEnabled (void)

--- a/Quake/client.h
+++ b/Quake/client.h
@@ -206,6 +206,7 @@ typedef struct
 	usercmd_t	pendingcmd;		// accumulated state from mice+joysticks.
 	unsigned int	last_cmd_ack;		// last command acknowledged by the server
 	unsigned int	last_cmd_ack_echo;	// last command ack echoed back by the server
+	unsigned int	last_snapshot_ack_sent;	// last snapshot ack sent to the server
 
 // information for local display
 	int			stats[MAX_CL_STATS];	// health, etc

--- a/Quake/common.h
+++ b/Quake/common.h
@@ -110,6 +110,10 @@ GENERIC_TYPES (IMPL_GENERIC_FUNCS, NO_COMMA)
 
 #define LERP(a, b, t) ((a) + ((b)-(a))*(t))
 
+// Wrap-safe sequence comparisons for 32-bit command ids (valid for < 2^31 gaps).
+#define NETSEQ_GT(a, b) ((int)((unsigned int)(a) - (unsigned int)(b)) > 0)
+#define NETSEQ_GEQ(a, b) ((int)((unsigned int)(a) - (unsigned int)(b)) >= 0)
+
 #define countof(arr) (sizeof(arr) / sizeof(arr[0]))
 
 typedef struct sizebuf_s

--- a/Quake/server.h
+++ b/Quake/server.h
@@ -271,6 +271,8 @@ typedef struct client_s
 	bot_state_t		bot;
 	unsigned int	last_cmd_seq;
 	unsigned int	last_cmd_ack;
+	int				invalid_cmd_ack_count;
+	double			invalid_cmd_ack_time;
 } client_t;
 
 

--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -45,6 +45,10 @@ static cvar_t sv_snap_full_interval = {"sv_snap_full_interval", "2.0", CVAR_NONE
 static cvar_t sv_snap_force_full_after_frames = {"sv_snap_force_full_after_frames", "3", CVAR_NONE};
 static cvar_t sv_snap_max_payload = {"sv_snap_max_payload", "1200", CVAR_NONE};
 static cvar_t sv_event_max = {"sv_event_max", "0", CVAR_NONE};
+cvar_t sv_cmd_ack_slack = {"sv_cmd_ack_slack", "64", CVAR_NONE};
+cvar_t sv_cmd_ack_bad_limit = {"sv_cmd_ack_bad_limit", "3", CVAR_NONE};
+cvar_t sv_cmd_ack_bad_window = {"sv_cmd_ack_bad_window", "2.0", CVAR_NONE};
+cvar_t sv_cmd_ack_debug = {"sv_cmd_ack_debug", "0", CVAR_NONE};
 cvar_t sv_mtu = {"sv_mtu", "1400", CVAR_NONE};
 static cvar_t sv_mtu_cap = {"sv_mtu_cap", "1400", CVAR_NONE};
 cvar_t sv_mtu_debug = {"sv_mtu_debug", "0", CVAR_NONE};
@@ -237,6 +241,10 @@ void SV_Init (void)
 	Cvar_RegisterVariable (&sv_snap_force_full_after_frames);
 	Cvar_RegisterVariable (&sv_snap_max_payload);
 	Cvar_RegisterVariable (&sv_event_max);
+	Cvar_RegisterVariable (&sv_cmd_ack_slack);
+	Cvar_RegisterVariable (&sv_cmd_ack_bad_limit);
+	Cvar_RegisterVariable (&sv_cmd_ack_bad_window);
+	Cvar_RegisterVariable (&sv_cmd_ack_debug);
 	Cvar_RegisterVariable (&sv_mtu);
 	Cvar_RegisterVariable (&sv_mtu_cap);
 	Cvar_RegisterVariable (&sv_mtu_debug);
@@ -798,7 +806,7 @@ static uint16_t		net_edicts_sorted[MAX_NET_EDICTS];
 
 static qboolean SV_SnapshotSeqNewer (unsigned int a, unsigned int b)
 {
-	return (int)(a - b) > 0;
+	return NETSEQ_GT (a, b);
 }
 
 static int SV_FindSnapshotBaselineIndex (const client_t *client, unsigned int seq)

--- a/Quake/sv_user.c
+++ b/Quake/sv_user.c
@@ -32,6 +32,10 @@ extern	cvar_t	sv_minrate;
 extern	cvar_t	sv_maxrate;
 extern	cvar_t	sv_minupdaterate;
 extern	cvar_t	sv_maxupdaterate;
+extern	cvar_t	sv_cmd_ack_slack;
+extern	cvar_t	sv_cmd_ack_bad_limit;
+extern	cvar_t	sv_cmd_ack_bad_window;
+extern	cvar_t	sv_cmd_ack_debug;
 
 static	vec3_t		forward, right, up;
 
@@ -454,7 +458,25 @@ SV_ReadClientMove
 */
 static qboolean SV_CmdSeqNewer (unsigned int seq, unsigned int last)
 {
-	return (int)(seq - last) > 0;
+	return NETSEQ_GT (seq, last);
+}
+
+static void SV_CmdAckResync (client_t *client, const char *reason)
+{
+	client->snapshot_force_full = true;
+	client->snapshot_has_valid_base = false;
+	client->snapshot_pending_seq = 0;
+	client->snapshot_pending_incomplete = false;
+	client->snapshot_pending_is_delta = false;
+	client->snapshot_unacked_frames = 0;
+	client->entstream.active = false;
+	client->entstream.next_edict = 1;
+	client->entstream.base_snapshot = 0;
+	if (sv_cmd_ack_debug.value)
+	{
+		Con_Printf ("NETDBG time %.3f cmd_ack_resync %s reason %s\n",
+			realtime, client->name, reason ? reason : "unknown");
+	}
 }
 
 void SV_ReadClientMove (usercmd_t *move)
@@ -626,24 +648,85 @@ nextmsg:
 				unsigned int cmd_seq;
 				unsigned int cmd_ack;
 				unsigned int prev_seq = 0;
+				int readcount_before_ack;
+				int readcount_after_ack;
+				const int header_bytes = 4 + 4 + 4;
+				const int cmd_bytes = 4 + (3 * 2) + (3 * 2) + 1 + 1;
 
 			// read ping time
+				if (msg_readcount + header_bytes > net_message.cursize)
+				{
+					Con_Printf ("SV_ReadClientMessage: truncated clc_move header from %s\n",
+						host_client->name);
+					return true;
+				}
 				host_client->ping_times[host_client->num_pings%NUM_PING_TIMES]
 					= qcvm->time - MSG_ReadFloat ();
 				host_client->num_pings++;
 
 				cmd_seq = (unsigned int)MSG_ReadLong ();
+				readcount_before_ack = msg_readcount;
 				cmd_ack = (unsigned int)MSG_ReadLong ();
-				if (SV_CmdSeqNewer (cmd_ack, cmd_seq))
+				readcount_after_ack = msg_readcount;
+				if (sv_cmd_ack_debug.value)
 				{
-					Con_Printf ("SV_ReadClientMessage: invalid cmd ack from %s\n",
-						host_client->name);
-					SV_DropClient (true);
-					return false;
+					int remaining = net_message.cursize - msg_readcount;
+					unsigned int window_head = cmd_seq;
+					unsigned int slack = (unsigned int)q_max(0, (int)sv_cmd_ack_slack.value);
+					unsigned int window_tail = window_head - slack;
+					Con_Printf ("NETDBG cmd_ack_read %s ack %u type long read %d->%d rem %d "
+						"cmd_seq %u last_seq %u last_ack %u win_head %u win_tail %u flags 0x%x\n",
+						host_client->name, cmd_ack, readcount_before_ack, readcount_after_ack, remaining,
+						cmd_seq, host_client->last_cmd_seq, host_client->last_cmd_ack,
+						window_head, window_tail, sv.protocolflags);
+				}
+				{
+					// Ack window: [cmd_seq - slack, cmd_seq], wrap-safe via NETSEQ_GT().
+					unsigned int slack = (unsigned int)q_max(0, (int)sv_cmd_ack_slack.value);
+					unsigned int window_head = cmd_seq;
+					unsigned int window_tail = window_head - slack;
+					qboolean ack_ahead = NETSEQ_GT (cmd_ack, window_head);
+					qboolean ack_behind = NETSEQ_GT (window_tail, cmd_ack);
+
+					if (ack_ahead || ack_behind)
+					{
+						int limit = (int)sv_cmd_ack_bad_limit.value;
+						double window_s = sv_cmd_ack_bad_window.value;
+						const char *reason = ack_ahead ? "ahead" : "behind";
+
+						if (window_s <= 0.0)
+							window_s = 1.0;
+						if (realtime - host_client->invalid_cmd_ack_time > window_s)
+						{
+							host_client->invalid_cmd_ack_time = realtime;
+							host_client->invalid_cmd_ack_count = 0;
+						}
+						host_client->invalid_cmd_ack_count++;
+						if (sv_cmd_ack_debug.value)
+						{
+							Con_Printf ("NETDBG cmd_ack_invalid %s ack %u seq %u reason %s count %d\n",
+								host_client->name, cmd_ack, cmd_seq, reason, host_client->invalid_cmd_ack_count);
+						}
+						cmd_ack = host_client->last_cmd_ack;
+						SV_CmdAckResync (host_client, reason);
+						if (limit > 0 && host_client->invalid_cmd_ack_count >= limit)
+						{
+							Con_Printf ("SV_ReadClientMessage: invalid cmd ack from %s\n",
+								host_client->name);
+							SV_DropClient (true);
+							return false;
+						}
+					}
 				}
 				if (SV_CmdSeqNewer (cmd_ack, host_client->last_cmd_ack))
 					host_client->last_cmd_ack = cmd_ack;
 
+				if (msg_readcount + 1 > net_message.cursize)
+				{
+					Con_Printf ("SV_ReadClientMessage: truncated clc_move cmdcount from %s\n",
+						host_client->name);
+					return true;
+				}
 				cmd_count = MSG_ReadByte ();
 				if (cmd_count > MAX_CMDS_PER_PACKET)
 				{
@@ -651,6 +734,12 @@ nextmsg:
 						cmd_count, host_client->name);
 					SV_DropClient (true);
 					return false;
+				}
+				if (cmd_count > 0 && msg_readcount + (cmd_count * cmd_bytes) > net_message.cursize)
+				{
+					Con_Printf ("SV_ReadClientMessage: truncated clc_move cmds from %s\n",
+						host_client->name);
+					return true;
 				}
 				for (cmd_index = 0; cmd_index < cmd_count; cmd_index++)
 				{


### PR DESCRIPTION
### Motivation
- Prevent clients being dropped due to spurious/wrapped command-ack values and avoid client/server parse desyncs caused by mismatched read/write widths or underflowed reads.

### Description
- Add wrap-safe sequence comparison macros `NETSEQ_GT`/`NETSEQ_GEQ` and replace raw signed-diff checks with them for client/server cmd/snapshot sequence logic (changes in `Quake/common.h`, `Quake/cl_parse.c`, `Quake/cl_predict.c`, `Quake/sv_main.c`, `Quake/sv_user.c`).
- Harden `clc_move` parsing on the server with pre-read size guards, per-packet readcount logging, and truncated-packet handling to avoid parse drift (`Quake/sv_user.c`).
- Validate `cmd_ack` against a configurable, wrap-safe window (`sv_cmd_ack_slack`) and implement soft-handling on invalid acks by clamping to the last good ack, incrementing an `invalid_cmd_ack_count`, triggering a resync (force full snapshot / reset cmd window) and only disconnecting after configurable repeated failures (`sv_cmd_ack_bad_limit`, `sv_cmd_ack_bad_window`, additions in `Quake/sv_main.c`, `Quake/server.h`, `Quake/sv_user.c`).
- Add `SV_CmdAckResync` to clear snapshot/entstream state and request a fresh baseline when ack validation fails, to prevent entity flicker and state corruption (`Quake/sv_user.c`).
- Add client-side instrumentation: log the written cmd-ack and related transport state when `cl_netdebug_parse` is enabled, and track `last_snapshot_ack_sent` when snapshot acks are emitted (`Quake/cl_input.c`, `Quake/cl_parse.c`, `Quake/client.h`).

### Testing
- No automated tests were executed as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69727636214c832e930ab4eb5d22af1f)