### PR TITLE
Include net_defs.h in cl_input.c to resolve qsocket_s references

### DIFF
--- a/Quake/cl_input.c
+++ b/Quake/cl_input.c
@@ -25,6 +25,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // rights reserved.
 
 #include "quakedef.h"
+#include "net_defs.h"
 
 extern cvar_t cl_maxpitch; //johnfitz -- variable pitch clamping
 extern cvar_t cl_minpitch; //johnfitz -- variable pitch clamping


### PR DESCRIPTION
### Motivation
- Fix compilation errors where `cl_input.c` accesses `qsocket_s` fields (`sendSequence`, `sendReliableBase`) while the type is incomplete by making the definition available.

### Description
- Add `#include "net_defs.h"` to `Quake/cl_input.c` so `qsocket_s` and its fields are visible to the file.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69727b07d110832ea6f32e50e84bb164)