### PR TITLE
Fix net header include order in cl_input

### DIFF
--- a/Quake/cl_input.c
+++ b/Quake/cl_input.c
@@ -25,6 +25,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // rights reserved.
 
 #include "quakedef.h"
+#include "arch_def.h"
+#include "net_sys.h"
 #include "net_defs.h"
 
 extern cvar_t cl_maxpitch; //johnfitz -- variable pitch clamping


### PR DESCRIPTION
### Motivation
- Resolve Windows compilation errors caused by undefined network types like `sys_socket_t` by ensuring network system headers are included before `net_defs.h`.

### Description
- Add `#include "arch_def.h"` and `#include "net_sys.h"` before `#include "net_defs.h"` in `Quake/cl_input.c` so required typedefs and macros are available.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69728185696c832eb1e32acd023af6f6)