### PR TITLE
Reset per-client command ack tracking when spawning server

### DIFF
--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -4766,6 +4766,10 @@ void SV_SpawnServer (const char *server)
 	{
 		SV_InitClientSnapshotData (&svs.clients[i]);
 		SV_ResetClientSnapshot (&svs.clients[i]);
+		svs.clients[i].last_cmd_seq = 0;
+		svs.clients[i].last_cmd_ack = 0;
+		svs.clients[i].invalid_cmd_ack_count = 0;
+		svs.clients[i].invalid_cmd_ack_time = 0.0;
 	}
 
 	sv.state = ss_loading;


### PR DESCRIPTION
### Motivation
- Prevent stale command ack/sequence state from persisting across level changes so reconnecting clients or local reconnects won't trigger `SV_ReadClientMessage` invalid-ack handling due to leftover values.

### Description
- In `SV_SpawnServer`, after calling `SV_InitClientSnapshotData` and `SV_ResetClientSnapshot` for each client, explicitly set `last_cmd_seq`, `last_cmd_ack`, `invalid_cmd_ack_count` and `invalid_cmd_ack_time` to zero (`0` / `0.0`).

### Testing
- No automated tests were run for this change (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697282b2a03c832ebeb0580f5ec10219)