### PR TITLE
snapshot2: enforce complete baselines, fix ack semantics, and add incomplete timeout

### DIFF
--- a/Quake/cl_demo.c
+++ b/Quake/cl_demo.c
@@ -98,6 +98,7 @@ void CL_ClearSignons (void)
 	cl.snap_last_complete_seq = 0;
 	cl.snap_last_incomplete_seq = 0;
 	cl.snap_last_incomplete = false;
+	cl.snap_incomplete_start_time = 0;
 	cl.snapshot_baseline_seq = 0;
 	cl.snapshot_baseline_head = 0;
 	cl.snapshot_baseline_index = -1;

--- a/Quake/cl_main.c
+++ b/Quake/cl_main.c
@@ -49,6 +49,7 @@ cvar_t	cl_snapshot_debug = {"cl_snapshot_debug", "0", CVAR_NONE};
 cvar_t	cl_delta_reject_debug = {"cl_delta_reject_debug", "0", CVAR_NONE};
 cvar_t	cl_full_reasm_debug = {"cl_full_reasm_debug", "0", CVAR_NONE};
 cvar_t	cl_full_reasm_timeout_ms = {"cl_full_reasm_timeout_ms", "1000", CVAR_NONE};
+cvar_t	cl_snap_incomplete_timeout_ms = {"cl_snap_incomplete_timeout_ms", "1500", CVAR_NONE};
 cvar_t	cl_test_drop = {"cl_test_drop", "0", CVAR_NONE};
 cvar_t	cl_entity_timeout_ms = {"cl_entity_timeout_ms", "750", CVAR_NONE};
 cvar_t	cl_lerp_ms = {"cl_lerp_ms", "120", CVAR_NONE};
@@ -636,6 +637,7 @@ void CL_ClearState (void)
 	cl.snap_last_complete_seq = 0;
 	cl.snap_last_incomplete_seq = 0;
 	cl.snap_last_incomplete = false;
+	cl.snap_incomplete_start_time = 0;
 	cl.has_full_snapshot = false;
 	cl.need_full_snapshot = true;
 	cl.has_valid_worldstate = false;
@@ -1732,6 +1734,7 @@ void CL_Init (void)
 	Cvar_RegisterVariable (&cl_delta_reject_debug);
 	Cvar_RegisterVariable (&cl_full_reasm_debug);
 	Cvar_RegisterVariable (&cl_full_reasm_timeout_ms);
+	Cvar_RegisterVariable (&cl_snap_incomplete_timeout_ms);
 	Cvar_RegisterVariable (&cl_test_drop);
 	Cvar_RegisterVariable (&cl_entity_timeout_ms);
 	Cvar_RegisterVariable (&cl_lerp_ms);

--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -785,6 +785,7 @@ static unsigned int CL_GetSnapshotAckSeq (void)
 {
 	if (!cl.has_full_snapshot)
 		return 0;
+	// Ack the last applied COMPLETE snapshot baseline (never incomplete/buffered).
 	return cl.snapshot_baseline_seq;
 }
 
@@ -888,6 +889,12 @@ static qboolean CL_SendSnapshotAck (unsigned int seq)
 	NET_DebugLogEvent (true,
 		"NETDBG time %.3f snap_ack_send seq %u\n",
 		realtime, seq);
+	if (cl_snap_debug.value >= 1.0f)
+	{
+		NET_DebugLogEvent (false,
+			"NETDBG time %.3f snap_ack_status seq %u last_complete %u\n",
+			realtime, seq, cl.snapshot_baseline_seq);
+	}
 	return true;
 }
 
@@ -1121,6 +1128,33 @@ static qboolean CL_SnapshotChunkTimedOut (void)
 	if (timeout_s <= 0.0)
 		return false;
 	return (realtime - cl.snapshot_chunk_start_time) > timeout_s;
+}
+
+static void CL_TrackSnapshotIncomplete (unsigned short seq16, const char *reason)
+{
+	double timeout_s = cl_snap_incomplete_timeout_ms.value * 0.001;
+
+	if (!cl.snap_last_incomplete || cl.snap_last_incomplete_seq != seq16)
+		cl.snap_incomplete_start_time = realtime;
+
+	cl.snap_last_incomplete = true;
+	cl.snap_last_incomplete_seq = seq16;
+	cl.snap_incomplete_count++;
+
+	if (timeout_s <= 0.0)
+		return;
+	if ((realtime - cl.snap_incomplete_start_time) <= timeout_s)
+		return;
+
+	if (cl_snap_debug.value >= 1.0f)
+	{
+		NET_DebugLogEvent (false,
+			"NETDBG time %.3f snap2_incomplete_timeout seq %u reason %s\n",
+			realtime, (unsigned int)seq16, reason ? reason : "unknown");
+	}
+	CL_RequestFullSnapshot ("snapshot2 incomplete timeout", false);
+	cl.snap_incomplete_start_time = realtime;
+	cl.snap_incomplete_count = 0;
 }
 
 static void CL_MarkSnapshotEntityUpdated (int entnum)
@@ -1403,6 +1437,7 @@ static void CL_ParseSnapshotFull (void)
 	cl.snap_last_applied_seq = seq16;
 	cl.snap_last_complete_seq = seq16;
 	cl.snap_last_incomplete = false;
+	cl.snap_incomplete_start_time = 0;
 	cl.snap_parse_consecutive = 0;
 	cl.need_full_snapshot = false;
 	cl.has_valid_worldstate = true;
@@ -1651,6 +1686,7 @@ static void CL_ParseSnapshotDelta (void)
 		cl.snap_last_applied_seq = seq16;
 		cl.snap_last_complete_seq = seq16;
 		cl.snap_last_incomplete = false;
+		cl.snap_incomplete_start_time = 0;
 		cl.snap_parse_consecutive = 0;
 		cl.has_full_snapshot = true;
 		base_advanced = true;
@@ -1757,7 +1793,6 @@ static void CL_ParseSnapshot2 (void)
 	qboolean is_full;
 	qboolean is_delta;
 	qboolean continuation;
-	const int incomplete_limit = 3;
 	qboolean base_advanced = false;
 
 	CL_ReadSnapshotHeader (&header);
@@ -1997,6 +2032,7 @@ static void CL_ParseSnapshot2 (void)
 				cl.snap_last_applied_seq = seq16;
 				cl.snap_last_complete_seq = seq16;
 				cl.snap_last_incomplete = false;
+				cl.snap_incomplete_start_time = 0;
 				cl.snap_parse_consecutive = 0;
 				cl.need_full_snapshot = false;
 				cl.has_full_snapshot = true;
@@ -2016,31 +2052,23 @@ static void CL_ParseSnapshot2 (void)
 			{
 				// INCOMPLETE snapshots: keep existing entities, overlay only touched updates.
 				touched = CL_ApplySnapshotOverlay (cl.snapshot_chunk, cl.snapshot_chunk_present);
-				cl.snap_last_incomplete_seq = seq16;
-				cl.snap_last_incomplete = true;
 				cl.snap_parse_consecutive = 0;
-				cl.snap_incomplete_count++;
+				CL_TrackSnapshotIncomplete (seq16, "chunk_full");
 				NET_DebugLogEvent (true,
 					"NETDBG time %.3f snap2_partial_apply seq %u flags 0x%x incomplete %d has_full %d\n",
 					realtime, header.seq, header.flags, cl.snap_incomplete_count,
 					cl.has_full_snapshot ? 1 : 0);
-				if (cl.snap_incomplete_count >= incomplete_limit)
-					CL_RequestFullSnapshot ("snapshot2 incomplete", false);
 				CL_LogSnapshotDebug ("snap2_full", header.seq, header.flags, false,
 					0, touched, base_advanced);
 			}
 			else if (!drop)
 			{
-				cl.snap_last_incomplete_seq = seq16;
-				cl.snap_last_incomplete = true;
 				cl.snap_parse_consecutive = 0;
-				cl.snap_incomplete_count++;
+				CL_TrackSnapshotIncomplete (seq16, "chunk_full_buffer");
 				NET_DebugLogEvent (true,
 					"NETDBG time %.3f snap2_buffer seq %u flags 0x%x incomplete %d has_full %d\n",
 					realtime, header.seq, header.flags, cl.snap_incomplete_count,
 					cl.has_full_snapshot ? 1 : 0);
-				if (cl.snap_incomplete_count >= incomplete_limit)
-					CL_RequestFullSnapshot ("snapshot2 incomplete", false);
 				CL_LogSnapshotDebug ("snap2_full", header.seq, header.flags, false,
 					0, touched, base_advanced);
 			}
@@ -2116,6 +2144,7 @@ static void CL_ParseSnapshot2 (void)
 				cl.snap_last_applied_seq = seq16;
 				cl.snap_last_complete_seq = seq16;
 				cl.snap_last_incomplete = false;
+				cl.snap_incomplete_start_time = 0;
 				cl.snap_parse_consecutive = 0;
 				cl.need_full_snapshot = false;
 				cl.has_full_snapshot = true;
@@ -2135,16 +2164,12 @@ static void CL_ParseSnapshot2 (void)
 			{
 				// INCOMPLETE snapshots: keep existing entities, overlay only touched updates.
 				touched = CL_ApplySnapshotOverlay (cl.snapshot_stage, cl.snapshot_stage_present);
-				cl.snap_last_incomplete_seq = seq16;
-				cl.snap_last_incomplete = true;
 				cl.snap_parse_consecutive = 0;
-				cl.snap_incomplete_count++;
+				CL_TrackSnapshotIncomplete (seq16, "full");
 				NET_DebugLogEvent (true,
 					"NETDBG time %.3f snap2_buffer seq %u flags 0x%x incomplete %d has_full %d\n",
 					realtime, header.seq, header.flags, cl.snap_incomplete_count,
 					cl.has_full_snapshot ? 1 : 0);
-				if (cl.snap_incomplete_count >= incomplete_limit)
-					CL_RequestFullSnapshot ("snapshot2 incomplete", false);
 				CL_LogSnapshotDebug ("snap2_full", header.seq, header.flags, false,
 					0, touched, base_advanced);
 			}
@@ -2172,6 +2197,13 @@ static void CL_ParseSnapshot2 (void)
 			base_states = cl.snapshot_baselines[base_index];
 			base_present = cl.snapshot_baseline_present[base_index];
 		}
+	}
+	if (cl_snap_debug.value >= 1.0f)
+	{
+		NET_DebugLogEvent (false,
+			"NETDBG time %.3f snap2_base seq %u base %u flags 0x%x baseline %d base_current %d need_full %d\n",
+			realtime, header.seq, header.base_seq, header.flags,
+			baseline_match ? 1 : 0, base_is_current ? 1 : 0, need_full ? 1 : 0);
 	}
 	if (!drop && base_is_current)
 		SDL_assert (header.base_seq == cl.snapshot_baseline_seq);
@@ -2359,6 +2391,7 @@ static void CL_ParseSnapshot2 (void)
 			cl.snap_last_applied_seq = seq16;
 			cl.snap_last_complete_seq = seq16;
 			cl.snap_last_incomplete = false;
+			cl.snap_incomplete_start_time = 0;
 			cl.snap_parse_consecutive = 0;
 			cl.snap_incomplete_count = 0;
 			cl.has_full_snapshot = true;
@@ -2383,15 +2416,11 @@ static void CL_ParseSnapshot2 (void)
 			{
 				// INCOMPLETE snapshots: keep existing entities, overlay only touched updates.
 				touched = CL_ApplySnapshotOverlay (cl.snapshot_stage, cl.snapshot_stage_present);
-				cl.snap_last_incomplete_seq = seq16;
-				cl.snap_last_incomplete = true;
-				cl.snap_incomplete_count++;
+				CL_TrackSnapshotIncomplete (seq16, "delta");
 				NET_DebugLogEvent (true,
 					"NETDBG time %.3f snap2_buffer seq %u flags 0x%x incomplete %d has_full %d\n",
 					realtime, header.seq, header.flags, cl.snap_incomplete_count,
 					cl.has_full_snapshot ? 1 : 0);
-				if (cl.snap_incomplete_count >= incomplete_limit)
-					CL_RequestFullSnapshot ("snapshot2 incomplete", false);
 				CL_LogSnapshotDebug ("snap2_delta", header.seq, header.flags, false,
 					removes_parsed, touched, base_advanced);
 			}

--- a/Quake/client.h
+++ b/Quake/client.h
@@ -292,6 +292,7 @@ typedef struct
 	unsigned short snap_last_complete_seq;
 	unsigned short snap_last_incomplete_seq;
 	qboolean	snap_last_incomplete;
+	double		snap_incomplete_start_time;
 	qboolean	has_full_snapshot;
 	qboolean	need_full_snapshot;
 	qboolean	has_valid_worldstate;
@@ -401,6 +402,7 @@ extern	cvar_t	cl_snapshot_debug;
 extern	cvar_t	cl_delta_reject_debug;
 extern	cvar_t	cl_full_reasm_debug;
 extern	cvar_t	cl_full_reasm_timeout_ms;
+extern	cvar_t	cl_snap_incomplete_timeout_ms;
 extern	cvar_t	cl_test_drop;
 extern	cvar_t	cl_entity_timeout_ms;
 extern	cvar_t	cl_lerp_ms;

--- a/Quake/server.h
+++ b/Quake/server.h
@@ -228,6 +228,7 @@ typedef struct client_s
 	unsigned int	snapshot_pending_baseline_seq;
 	unsigned int	snapshot_last_sent_seq;
 	unsigned int	snapshot_last_acked_seq;
+	unsigned int	snapshot_last_acked_complete_seq;
 	unsigned int	snapshot_last_full_seq;
 	double			snapshot_last_full_time;
 	double			snapshot_last_acked_time;

--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -830,15 +830,19 @@ static int SV_FindSnapshotBaselineIndex (const client_t *client, unsigned int se
 static qboolean SV_SelectSnapshotBaseline (const client_t *client, unsigned int *out_seq,
 	const snapshot_state_t **out_states, const byte **out_present)
 {
-	int index = client->snapshot_baseline_index;
+	// Snapshot2 deltas must reference the last ACKED COMPLETE snapshot.
+	unsigned int seq = client->snapshot_last_acked_complete_seq;
+	int index = SV_FindSnapshotBaselineIndex (client, seq);
 
-	if (index < 0 || index >= SV_SNAPSHOT_BASELINE_HISTORY)
+	if (!client->snapshot_has_valid_base)
 		return false;
-	if (!client->snapshot_baseline_valid[index])
+	if (!seq)
+		return false;
+	if (index < 0 || index >= SV_SNAPSHOT_BASELINE_HISTORY)
 		return false;
 
 	if (out_seq)
-		*out_seq = client->snapshot_baseline_seqs[index];
+		*out_seq = seq;
 	if (out_states)
 		*out_states = client->snapshot_baselines[index];
 	if (out_present)
@@ -887,6 +891,7 @@ static void SV_ResetClientSnapshot (client_t *client)
 	client->snapshot_pending_baseline_seq = 0;
 	client->snapshot_last_sent_seq = 0;
 	client->snapshot_last_acked_seq = 0;
+	client->snapshot_last_acked_complete_seq = 0;
 	client->snapshot_last_full_seq = 0;
 	client->snapshot_last_full_time = 0;
 	client->snapshot_last_acked_time = 0;
@@ -2317,6 +2322,9 @@ static void SV_SendSnapshot (client_t *client, sizebuf_t *msg)
 		const byte *baseline_present = NULL;
 		unsigned int baseline_seq = 0;
 		qboolean have_baseline = SV_SelectSnapshotBaseline (client, &baseline_seq, &baseline_states, &baseline_present);
+		qboolean need_full = (client->snapshot_force_full
+			|| !client->snapshot_has_valid_base
+			|| client->snapshot_last_acked_complete_seq == 0);
 
 		if (!have_baseline && client->snapshot_baseline_present[0])
 			baseline_present = client->snapshot_baseline_present[0];
@@ -2405,10 +2413,13 @@ static void SV_SendSnapshot (client_t *client, sizebuf_t *msg)
 			int header_bytes = 0;
 			int snapshot_budget_bytes = SV_SnapshotBudgetBytes (client, msg,
 				&mtu_payload_bytes, &current_bytes, &remaining_bytes, &header_bytes);
+			int build_budget_bytes = remaining_bytes;
+			int build_optional_budget_bytes = snapshot_budget_bytes;
 			int mandatory_total_bytes = 0;
 			qboolean budget_continuation = false;
 			qboolean mandatory_oversize = false;
 			qboolean debug_frame = false;
+			qboolean force_complete_full = need_full;
 
 			if (net_snap_debug.value && realtime >= client->snapshot_debug_next_time)
 			{
@@ -2416,13 +2427,20 @@ static void SV_SendSnapshot (client_t *client, sizebuf_t *msg)
 				client->snapshot_debug_next_time = realtime + 1.0;
 			}
 
+			if (force_complete_full)
+			{
+				build_budget_bytes = 1 << 30;
+				build_optional_budget_bytes = 1 << 30;
+			}
+
 			SV_BuildClientSnapshot (client->edict, client->snapshot_pending, client->snapshot_pending_present,
-				client->snapshot_pending_relevant, client->snapshot_pending_flags, remaining_bytes, snapshot_budget_bytes,
+				client->snapshot_pending_relevant, client->snapshot_pending_flags, build_budget_bytes,
+				build_optional_budget_bytes,
 				header_bytes, baseline_present, &mandatory_count, &mandatory_bytes, NULL,
 				&dropped_count, &dropped_tier1, &dropped_tier2, debug_frame, &budget_continuation,
 				&mandatory_oversize);
 			mandatory_total_bytes = header_bytes + mandatory_bytes;
-			if (mtu_payload_bytes > 0 && current_bytes + mandatory_total_bytes > mtu_payload_bytes)
+			if (!force_complete_full && mtu_payload_bytes > 0 && current_bytes + mandatory_total_bytes > mtu_payload_bytes)
 			{
 				client->snapshot_pending_incomplete = true;
 				client->snapshot_pending_mandatory = mandatory_count;
@@ -2431,7 +2449,7 @@ static void SV_SendSnapshot (client_t *client, sizebuf_t *msg)
 				client->mtu_dropped_tier2 = 0;
 				return;
 			}
-			if (mandatory_oversize)
+			if (!force_complete_full && mandatory_oversize)
 			{
 				client->snapshot_pending_incomplete = true;
 				client->snapshot_pending_mandatory = mandatory_count;
@@ -2656,6 +2674,17 @@ static void SV_SendSnapshot (client_t *client, sizebuf_t *msg)
 		client->snapshot_debug_remove = remove_count;
 		client->snapshot_debug_full_count = full_count;
 
+		if (sv_snap_debug.value >= 1.0f && sv_snapshot2.value)
+		{
+			int size_delta = msg->cursize - start_size;
+			qboolean complete = (!client->snapshot_pending_incomplete && !continuation);
+
+			NET_DebugLogEvent (false,
+				"NETDBG time %.3f snap2_build %s seq %u base %u flags 0x%x complete %d bytes %d need_full %d\n",
+				realtime, client->name, client->snapshot_pending_seq, base_seq, debug_flags,
+				complete ? 1 : 0, size_delta, need_full ? 1 : 0);
+		}
+
 		if (client->snapshot_pending_incomplete)
 		{
 			const char *reason = NULL;
@@ -2756,6 +2785,8 @@ void SV_SnapshotAck (client_t *client, unsigned int seq)
 	{
 		if (SV_SnapshotSeqNewer (seq, client->snapshot_last_acked_seq))
 			client->snapshot_last_acked_seq = seq;
+		if (SV_SnapshotSeqNewer (seq, client->snapshot_last_acked_complete_seq))
+			client->snapshot_last_acked_complete_seq = seq;
 		client->snapshot_last_acked_time = realtime;
 		client->snapshot_unacked_frames = 0;
 		client->snapshot_has_valid_base = true;


### PR DESCRIPTION
### Motivation
- Break deadlocks where the client continually requests a FULL but never applies one because the server sent incomplete/chunked or delta snapshots based on an ACK that did not represent a complete baseline.  
- Make `snap_ack` semantics unambiguous: clients must only ack the last APPLIED COMPLETE baseline so the server can safely use that as a delta base.  
- Harden client recovery for buffered/incomplete full snapshots by adding timeout-driven retry behavior instead of immediate abort/spam requests.

### Description
- Client-side: change ack semantics and buffering logic so `CL_GetSnapshotAckSeq()` returns the last applied COMPLETE baseline (`cl.snapshot_baseline_seq`) and `CL_SendSnapshotAck()` logs ack+complete state; incomplete full reassembly is tracked by `CL_TrackSnapshotIncomplete()` using a new cvar `cl_snap_incomplete_timeout_ms`, and timeouts call `CL_RequestFullSnapshot()` to recover; reset of `snap_incomplete` timestamps happens when a COMPLETE snapshot is applied.  
- Server-side: add per-client `snapshot_last_acked_complete_seq` and update `SV_SnapshotAck()` to advance it when a COMPLETE ack arrives, and make `SV_SelectSnapshotBaseline()` choose the baseline using that COMPLETE ack only.  
- Server snapshot build: when a client needs a FULL baseline (no valid complete base or `snapshot_force_full`), the server forces full snapshot construction to be complete by using a very large build budget (so the FULL is constructed rather than truncated) and logs `snap2_build` debug events showing `seq/base/flags/complete/bytes/need_full`.  
- Misc: added NETDBG logging for base lookup (`snap2_base`), expanded client `snap_ack` NETDBG output, declared/registered the new cvar `cl_snap_incomplete_timeout_ms`, and added a `snap_incomplete_start_time` field to client state to enable timeout tracking.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972941b8d70832ea993b4fe05b0436e)