### PR TITLE
Instrument and harden cmd_ack handling for RMQ (protocol 999)

### DIFF
--- a/Quake/cl_input.c
+++ b/Quake/cl_input.c
@@ -420,6 +420,7 @@ void CL_SendMove (const usercmd_t *cmd)
 		MSG_WriteByte (&buf, clc_move);
 
 		MSG_WriteFloat (&buf, cl.mtime[0]);	// so server can get ping times
+		// RMQ wire format: cmd_seq/cmd_ack are 32-bit unsigned (wrap-safe via NETSEQ_GT).
 		MSG_WriteLong (&buf, (int)cmd->sequence);
 		MSG_WriteLong (&buf, (int)cl.last_cmd_ack);
 
@@ -452,9 +453,11 @@ void CL_SendMove (const usercmd_t *cmd)
 		{
 			unsigned int reliable_seq = cls.netcon ? cls.netcon->sendSequence : 0u;
 			unsigned int reliable_base = cls.netcon ? cls.netcon->sendReliableBase : 0u;
-			Con_Printf ("NETDBG cmd_ack_write ack %u type long cmd_seq %u rel_seq %u rel_base %u snap_ack %u msg %d flags 0x%x\n",
-				cl.last_cmd_ack, cmd->sequence, reliable_seq, reliable_base, cl.last_snapshot_ack_sent,
-				buf.cursize, cl.protocolflags);
+			Con_Printf ("NETDBG time %.3f cmd_move_write msg %d type %d flags 0x%x cmd_seq %u "
+				"cmd_ack %u snap_ack %u rel_seq %u rel_base %u widths[mtime=float cmd_seq=long "
+				"cmd_ack=long cmd_count=byte ucmd_seq=long angles=short moves=short buttons=byte impulse=byte]\n",
+				realtime, buf.cursize, clc_move, cl.protocolflags, cmd->sequence,
+				cl.last_cmd_ack, cl.last_snapshot_ack_sent, reliable_seq, reliable_base);
 		}
 	}
 

--- a/Quake/protocol.h
+++ b/Quake/protocol.h
@@ -285,6 +285,7 @@ typedef enum
 #define	clc_nop 		1
 #define	clc_disconnect	2
 #define	clc_move		3		// [float mtime] [long cmd_seq] [long cmd_ack] [byte count] [usercmd_t]
+						// RMQ: cmd_seq/cmd_ack are uint32 on wire; compare with NETSEQ_GT for wrap safety.
 #define	clc_stringcmd	4		// [string] message
 #define	clc_snapshot_ack	5	// [long] seq
 #define	clc_snapshot_nak	6	// [long] expected base [long] received base

--- a/Quake/sv_user.c
+++ b/Quake/sv_user.c
@@ -479,6 +479,17 @@ static void SV_CmdAckResync (client_t *client, const char *reason)
 	}
 }
 
+static void SV_NetHexDump (const byte *data, int len, int max)
+{
+	int dump_len = q_min(len, max);
+	int i;
+
+	Con_Printf ("NETDBG cmd_ack_hexdump %d bytes (cursize %d):", dump_len, len);
+	for (i = 0; i < dump_len; i++)
+		Con_Printf (" %02x", data[i]);
+	Con_Printf ("\n");
+}
+
 void SV_ReadClientMove (usercmd_t *move)
 {
 	int		i;
@@ -648,10 +659,15 @@ nextmsg:
 				unsigned int cmd_seq;
 				unsigned int cmd_ack;
 				unsigned int prev_seq = 0;
+				int readcount_before_time;
+				int readcount_after_time;
+				int readcount_before_seq;
+				int readcount_after_seq;
 				int readcount_before_ack;
 				int readcount_after_ack;
 				const int header_bytes = 4 + 4 + 4;
 				const int cmd_bytes = 4 + (3 * 2) + (3 * 2) + 1 + 1;
+				float mtime;
 
 			// read ping time
 				if (msg_readcount + header_bytes > net_message.cursize)
@@ -660,33 +676,51 @@ nextmsg:
 						host_client->name);
 					return true;
 				}
+				readcount_before_time = msg_readcount;
+				mtime = MSG_ReadFloat ();
+				readcount_after_time = msg_readcount;
 				host_client->ping_times[host_client->num_pings%NUM_PING_TIMES]
-					= qcvm->time - MSG_ReadFloat ();
+					= qcvm->time - mtime;
 				host_client->num_pings++;
 
+				readcount_before_seq = msg_readcount;
 				cmd_seq = (unsigned int)MSG_ReadLong ();
+				readcount_after_seq = msg_readcount;
 				readcount_before_ack = msg_readcount;
 				cmd_ack = (unsigned int)MSG_ReadLong ();
 				readcount_after_ack = msg_readcount;
 				if (sv_cmd_ack_debug.value)
 				{
 					int remaining = net_message.cursize - msg_readcount;
-					unsigned int window_head = cmd_seq;
+					unsigned int newest_cmd_seq = cmd_seq;
+					unsigned int last_cmd_received = host_client->last_cmd_seq;
+					unsigned int last_cmd_acked = host_client->last_cmd_ack;
 					unsigned int slack = (unsigned int)q_max(0, (int)sv_cmd_ack_slack.value);
-					unsigned int window_tail = window_head - slack;
-					Con_Printf ("NETDBG cmd_ack_read %s ack %u type long read %d->%d rem %d "
-						"cmd_seq %u last_seq %u last_ack %u win_head %u win_tail %u flags 0x%x\n",
-						host_client->name, cmd_ack, readcount_before_ack, readcount_after_ack, remaining,
-						cmd_seq, host_client->last_cmd_seq, host_client->last_cmd_ack,
-						window_head, window_tail, sv.protocolflags);
+					unsigned int window_tail = last_cmd_acked - slack;
+					Con_Printf ("NETDBG time %.3f cmd_ack_read %s cmd %d flags 0x%x "
+						"mtime %d->%d seq %d->%d ack %d->%d rem %d cmd_ack %u "
+						"newest_cmd %u last_recv %u last_ack %u win_tail %u slack %u\n",
+						realtime, host_client->name, clc_move, sv.protocolflags,
+						readcount_before_time, readcount_after_time,
+						readcount_before_seq, readcount_after_seq,
+						readcount_before_ack, readcount_after_ack,
+						remaining, cmd_ack, newest_cmd_seq,
+						last_cmd_received, last_cmd_acked, window_tail, slack);
 				}
 				{
-					// Ack window: [cmd_seq - slack, cmd_seq], wrap-safe via NETSEQ_GT().
+					// Ack window: not ahead of newest, not too far behind last ack (wrap-safe via NETSEQ_GT).
 					unsigned int slack = (unsigned int)q_max(0, (int)sv_cmd_ack_slack.value);
-					unsigned int window_head = cmd_seq;
-					unsigned int window_tail = window_head - slack;
-					qboolean ack_ahead = NETSEQ_GT (cmd_ack, window_head);
-					qboolean ack_behind = NETSEQ_GT (window_tail, cmd_ack);
+					unsigned int newest_cmd_seq = cmd_seq;
+					unsigned int last_cmd_acked = host_client->last_cmd_ack;
+					qboolean ack_ahead = NETSEQ_GT (cmd_ack, newest_cmd_seq);
+					qboolean ack_behind = false;
+					unsigned int ack_behind_delta = 0;
+
+					if (NETSEQ_GT (last_cmd_acked, cmd_ack))
+					{
+						ack_behind_delta = last_cmd_acked - cmd_ack;
+						ack_behind = ack_behind_delta > slack;
+					}
 
 					if (ack_ahead || ack_behind)
 					{
@@ -694,6 +728,8 @@ nextmsg:
 						double window_s = sv_cmd_ack_bad_window.value;
 						const char *reason = ack_ahead ? "ahead" : "behind";
 
+						if (limit < 2)
+							limit = 2;
 						if (window_s <= 0.0)
 							window_s = 1.0;
 						if (realtime - host_client->invalid_cmd_ack_time > window_s)
@@ -704,8 +740,11 @@ nextmsg:
 						host_client->invalid_cmd_ack_count++;
 						if (sv_cmd_ack_debug.value)
 						{
-							Con_Printf ("NETDBG cmd_ack_invalid %s ack %u seq %u reason %s count %d\n",
-								host_client->name, cmd_ack, cmd_seq, reason, host_client->invalid_cmd_ack_count);
+							Con_Printf ("NETDBG cmd_ack_invalid %s ack %u newest %u last_ack %u "
+								"behind_delta %u slack %u reason %s count %d\n",
+								host_client->name, cmd_ack, newest_cmd_seq, last_cmd_acked,
+								ack_behind_delta, slack, reason, host_client->invalid_cmd_ack_count);
+							SV_NetHexDump (net_message.data, net_message.cursize, 48);
 						}
 						cmd_ack = host_client->last_cmd_ack;
 						SV_CmdAckResync (host_client, reason);


### PR DESCRIPTION
### Motivation
- Clients were being dropped with "invalid cmd ack" while snapshots appeared healthy, suggesting cmd_ack mis-parsing, width/sign mismatch, or wrap-unsafe comparisons for protocol 999 (RMQ).
- Add targeted instrumentation to confirm exact wire layout and read/write sizes and to aid reproducing the problem in the field.
- Improve robustness: make ack validation wrap-safe, clamp on first error and request resync instead of immediate disconnect, and provide hexdumps for invalid acks to diagnose layout drift.

### Description
- Documented RMQ wire format in `Quake/protocol.h` noting that `cmd_seq`/`cmd_ack` are uint32 on the wire and should be compared via `NETSEQ_GT` for wrap-safety.
- Added client-side instrumentation in `Quake/cl_input.c` (inside `CL_SendMove`) that logs time, message size, message type, flags, `cmd_seq`, `cmd_ack`, `snap_ack`, reliable seq/base and an explicit list of the wire widths used when `cl_netdebug_parse` is enabled.
- Added server-side diagnostics in `Quake/sv_user.c` including read-count snapshots around `mtime`, `cmd_seq`, and `cmd_ack`, expanded `cmd_ack` logging when `sv_cmd_ack_debug` is enabled, and a small `SV_NetHexDump` hexdump of the first bytes on invalid ack conditions.
- Hardened ack window validation to be wrap-safe and less fatal: compute newest/last sequences, detect `ack_ahead` and `ack_behind` using `NETSEQ_GT`, clamp the ack to `last_cmd_ack` and call `SV_CmdAckResync` on the first invalid occurrence, and only disconnect after repeated invalid acks (honoring `sv_cmd_ack_bad_limit` and `sv_cmd_ack_bad_window`).
- Minor parsing symmetry fixes: capture and log `msg_readcount` before/after reads for `mtime`, `cmd_seq`, and `cmd_ack` to make it easier to spot layout drift and width mismatches.

### Testing
- No automated tests were run for this change (manual/runtime verification not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69729ebf1cdc832e8315dcc59bc7cfa0)