### PR TITLE
Fix snapshot helper prototypes in sv_main.c

### DIFF
--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -73,6 +73,11 @@ static cvar_t sv_icull_debug = {"sv_icull_debug", "0", CVAR_NONE};
 
 static qboolean SV_SignonChunksEnabled (void);
 static void SV_SignonStreamSend (client_t *client);
+static qboolean SV_Snapshot2RecoveryEnabled (void);
+static int SV_Snapshot2EstimateDeltaBytes (const snapshot_state_t *next, const snapshot_state_t *base,
+	byte snapflags, unsigned int *out_mask);
+static unsigned int SV_SnapshotFieldMask (const snapshot_state_t *next, const snapshot_state_t *base, byte snapflags);
+static int SV_SnapshotDeltaFieldSize (unsigned int mask);
 
 typedef struct
 {


### PR DESCRIPTION
### Motivation
- Resolve compiler implicit-declaration warnings (e.g. C4013/C2220) by providing prototypes for snapshot helper functions that are called before their definitions in `Quake/sv_main.c`.

### Description
- Add forward declarations for `SV_Snapshot2RecoveryEnabled`, `SV_Snapshot2EstimateDeltaBytes`, `SV_SnapshotFieldMask`, and `SV_SnapshotDeltaFieldSize` adjacent to the other static prototypes in `Quake/sv_main.c`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972bcd913bc832e9129db9a513fd4b4)