### PR TITLE
Add player-centric fields to snapshot state and delta serialization

### DIFF
--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -1040,6 +1040,30 @@ static void CL_ReadSnapshotState (snapshot_state_t *state, unsigned int snapflag
 	state->state.alpha = (unsigned char)MSG_ReadByte ();
 	state->state.scale = (unsigned char)MSG_ReadByte ();
 	state->step = (byte)MSG_ReadByte ();
+	state->health = (short)MSG_ReadShort ();
+	state->armor = (short)MSG_ReadShort ();
+	state->ammo = (short)MSG_ReadShort ();
+	state->weaponmodel = (unsigned short)MSG_ReadShort ();
+	state->weaponframe = (unsigned short)MSG_ReadShort ();
+	state->items = (unsigned int)MSG_ReadLong ();
+	state->activeweapon = (unsigned int)MSG_ReadLong ();
+	state->ammo_shells = (byte)MSG_ReadByte ();
+	state->ammo_nails = (byte)MSG_ReadByte ();
+	state->ammo_rockets = (byte)MSG_ReadByte ();
+	state->ammo_cells = (byte)MSG_ReadByte ();
+	state->viewheight = (char)MSG_ReadChar ();
+	state->idealpitch = (char)MSG_ReadChar ();
+	for (i = 0; i < 3; i++)
+		state->punchangle[i] = (char)MSG_ReadChar ();
+	for (i = 0; i < 3; i++)
+		state->velocity[i] = (char)MSG_ReadChar ();
+	state->movetype = (byte)MSG_ReadByte ();
+	state->pm_flags = (byte)MSG_ReadByte ();
+	state->waterlevel = (byte)MSG_ReadByte ();
+	state->watertype = (byte)MSG_ReadByte ();
+	state->event = (byte)MSG_ReadByte ();
+	state->event_param = (byte)MSG_ReadByte ();
+	state->event_seq = (unsigned short)MSG_ReadShort ();
 }
 
 static void CL_ReadSnapshotDeltaFields (snapshot_state_t *state, unsigned int mask)
@@ -1076,6 +1100,41 @@ static void CL_ReadSnapshotDeltaFields (snapshot_state_t *state, unsigned int ma
 		state->state.scale = (unsigned char)MSG_ReadByte ();
 	if (mask & SNAP_STEP)
 		state->step = (byte)MSG_ReadByte ();
+	if (mask & SNAP_PLAYERSTATS)
+	{
+		state->health = (short)MSG_ReadShort ();
+		state->armor = (short)MSG_ReadShort ();
+		state->ammo = (short)MSG_ReadShort ();
+		state->weaponmodel = (unsigned short)MSG_ReadShort ();
+		state->weaponframe = (unsigned short)MSG_ReadShort ();
+		state->items = (unsigned int)MSG_ReadLong ();
+		state->activeweapon = (unsigned int)MSG_ReadLong ();
+		state->ammo_shells = (byte)MSG_ReadByte ();
+		state->ammo_nails = (byte)MSG_ReadByte ();
+		state->ammo_rockets = (byte)MSG_ReadByte ();
+		state->ammo_cells = (byte)MSG_ReadByte ();
+	}
+	if (mask & SNAP_PLAYERMOVE)
+	{
+		int i;
+
+		state->viewheight = (char)MSG_ReadChar ();
+		state->idealpitch = (char)MSG_ReadChar ();
+		for (i = 0; i < 3; i++)
+			state->punchangle[i] = (char)MSG_ReadChar ();
+		for (i = 0; i < 3; i++)
+			state->velocity[i] = (char)MSG_ReadChar ();
+		state->movetype = (byte)MSG_ReadByte ();
+		state->pm_flags = (byte)MSG_ReadByte ();
+		state->waterlevel = (byte)MSG_ReadByte ();
+		state->watertype = (byte)MSG_ReadByte ();
+	}
+	if (mask & SNAP_PLAYEREVENTS)
+	{
+		state->event = (byte)MSG_ReadByte ();
+		state->event_param = (byte)MSG_ReadByte ();
+		state->event_seq = (unsigned short)MSG_ReadShort ();
+	}
 }
 
 static void CL_ClearSnapshotStage (void);

--- a/Quake/protocol.h
+++ b/Quake/protocol.h
@@ -51,6 +51,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define SNAP_STEP		(1u<<13)
 #define SNAP_HIRES_ORIGIN	(1u<<14)
 #define SNAP_HIRES_ANGLES	(1u<<15)
+#define SNAP_PLAYERSTATS	(1u<<16)
+#define SNAP_PLAYERMOVE		(1u<<17)
+#define SNAP_PLAYEREVENTS	(1u<<18)
 
 #define SNAPFL_HIRES_ORIGIN	(1u<<2)
 #define SNAPFL_HIRES_ANGLES	(1u<<3)
@@ -221,7 +224,11 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define SNAP_VALID_MASK		(SNAP_ORIGIN1 | SNAP_ORIGIN2 | SNAP_ORIGIN3 | SNAP_ANGLE1 | \
 				 SNAP_ANGLE2 | SNAP_ANGLE3 | SNAP_MODEL | SNAP_FRAME | SNAP_COLORMAP | \
 				 SNAP_SKIN | SNAP_EFFECTS | SNAP_ALPHA | SNAP_SCALE | SNAP_STEP | \
-				 SNAP_HIRES_ORIGIN | SNAP_HIRES_ANGLES)
+				 SNAP_HIRES_ORIGIN | SNAP_HIRES_ANGLES | SNAP_PLAYERSTATS | SNAP_PLAYERMOVE | \
+				 SNAP_PLAYEREVENTS)
+
+#define SNAP_PM_ONGROUND	(1u<<0)
+#define SNAP_PM_INWATER		(1u<<1)
 
 // signon chunk protocol extension
 #define SIGNON_CHUNK_FLAG_STAGE_END	(1u << 0)
@@ -330,6 +337,28 @@ typedef struct
 {
 	entity_state_t	state;
 	byte		step;
+	short		health;
+	short		armor;
+	short		ammo;
+	unsigned short	weaponmodel;
+	unsigned short	weaponframe;
+	unsigned int	items;
+	unsigned int	activeweapon;
+	byte		ammo_shells;
+	byte		ammo_nails;
+	byte		ammo_rockets;
+	byte		ammo_cells;
+	char		viewheight;
+	char		idealpitch;
+	char		punchangle[3];
+	char		velocity[3];
+	byte		movetype;
+	byte		pm_flags;
+	byte		waterlevel;
+	byte		watertype;
+	byte		event;
+	byte		event_param;
+	unsigned short	event_seq;
 } snapshot_state_t;
 
 typedef struct

--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -1384,6 +1384,9 @@ static int SV_SnapshotEntitySizeWorst (void)
 	field_size += 1; // alpha
 	field_size += 1; // scale
 	field_size += 1; // step
+	field_size += 22; // player stats
+	field_size += 12; // player movement
+	field_size += 4; // player events
 
 	entry_overhead = q_max (extra_flags, 4); // worst-case delta includes a 32-bit mask
 	return 2 + entry_overhead + field_size;
@@ -1411,7 +1414,7 @@ static int SV_Snapshot2EntitySizeForFlags (byte snapflags)
 {
 	int coord_size = SV_SnapshotCoordBytes ((snapflags & SNAPFLAG_HIRES_ORIGIN) != 0);
 	int angle_size = SV_SnapshotAngleBytes ((snapflags & SNAPFLAG_HIRES_ANGLES) != 0);
-	int state_size = 3 * coord_size + 3 * angle_size + 2 + 2 + 1 + 1 + 1 + 1 + 1 + 1;
+	int state_size = 3 * coord_size + 3 * angle_size + 2 + 2 + 1 + 1 + 1 + 1 + 1 + 1 + 22 + 12 + 4;
 	int extra_flags = (sv.protocolflags & PRFL_SNAPSHOT_HIRES) ? 1 : 0;
 
 	return 2 + extra_flags + state_size;
@@ -1729,6 +1732,7 @@ static void SV_FillSnapshotState (edict_t *ent, snapshot_state_t *out)
 {
 	int	i;
 	eval_t	*val;
+	int	items;
 
 	for (i=0 ; i<3 ; i++)
 	{
@@ -1754,6 +1758,82 @@ static void SV_FillSnapshotState (edict_t *ent, snapshot_state_t *out)
 	out->state.scale = ent->scale;
 
 	out->step = (ent->v.movetype == MOVETYPE_STEP);
+
+	out->health = 0;
+	out->armor = 0;
+	out->ammo = 0;
+	out->weaponmodel = 0;
+	out->weaponframe = 0;
+	out->items = 0;
+	out->activeweapon = 0;
+	out->ammo_shells = 0;
+	out->ammo_nails = 0;
+	out->ammo_rockets = 0;
+	out->ammo_cells = 0;
+	out->viewheight = 0;
+	out->idealpitch = 0;
+	out->punchangle[0] = 0;
+	out->punchangle[1] = 0;
+	out->punchangle[2] = 0;
+	out->velocity[0] = 0;
+	out->velocity[1] = 0;
+	out->velocity[2] = 0;
+	out->movetype = 0;
+	out->pm_flags = 0;
+	out->waterlevel = 0;
+	out->watertype = 0;
+	out->event = 0;
+	out->event_param = 0;
+	out->event_seq = 0;
+
+	if ((int)ent->v.flags & FL_CLIENT)
+	{
+		out->health = (short)ent->v.health;
+		out->armor = (short)ent->v.armorvalue;
+		out->ammo = (short)ent->v.currentammo;
+		out->weaponmodel = (unsigned short)SV_ModelIndex (PR_GetString (ent->v.weaponmodel));
+		out->weaponframe = (unsigned short)ent->v.weaponframe;
+		out->activeweapon = (unsigned int)ent->v.weapon;
+		out->ammo_shells = (byte)ent->v.ammo_shells;
+		out->ammo_nails = (byte)ent->v.ammo_nails;
+		out->ammo_rockets = (byte)ent->v.ammo_rockets;
+		out->ammo_cells = (byte)ent->v.ammo_cells;
+
+		val = GetEdictFieldValueByName(ent, "items2");
+		if (val)
+			items = (int)ent->v.items | ((int)val->_float << 23);
+		else
+			items = (int)ent->v.items | ((int)pr_global_struct->serverflags << 28);
+		out->items = (unsigned int)items;
+
+		out->viewheight = (char)ent->v.view_ofs[2];
+		out->idealpitch = (char)ent->v.idealpitch;
+		for (i = 0; i < 3; i++)
+		{
+			int vel = Q_rint (ent->v.velocity[i] / 16.0f);
+			vel = CLAMP (-128, vel, 127);
+			out->punchangle[i] = (char)ent->v.punchangle[i];
+			out->velocity[i] = (char)vel;
+		}
+
+		out->movetype = (byte)ent->v.movetype;
+		if ((int)ent->v.flags & FL_ONGROUND)
+			out->pm_flags |= SNAP_PM_ONGROUND;
+		if (ent->v.waterlevel >= 2)
+			out->pm_flags |= SNAP_PM_INWATER;
+		out->waterlevel = (byte)ent->v.waterlevel;
+		out->watertype = (byte)ent->v.watertype;
+
+		val = GetEdictFieldValueByName(ent, "event");
+		if (val)
+			out->event = (byte)val->_float;
+		val = GetEdictFieldValueByName(ent, "event_param");
+		if (val)
+			out->event_param = (byte)val->_float;
+		val = GetEdictFieldValueByName(ent, "event_seq");
+		if (val)
+			out->event_seq = (unsigned short)val->_float;
+	}
 }
 
 static int SV_BuildClientSnapshot (client_t *client, snapshot_state_t *states, byte *present,
@@ -2164,6 +2244,30 @@ static void SV_WriteSnapshotState (sizebuf_t *msg, const snapshot_state_t *state
 	MSG_WriteByte (msg, state->state.alpha);
 	MSG_WriteByte (msg, state->state.scale);
 	MSG_WriteByte (msg, state->step);
+	MSG_WriteShort (msg, state->health);
+	MSG_WriteShort (msg, state->armor);
+	MSG_WriteShort (msg, state->ammo);
+	MSG_WriteShort (msg, state->weaponmodel);
+	MSG_WriteShort (msg, state->weaponframe);
+	MSG_WriteLong (msg, (int)state->items);
+	MSG_WriteLong (msg, (int)state->activeweapon);
+	MSG_WriteByte (msg, state->ammo_shells);
+	MSG_WriteByte (msg, state->ammo_nails);
+	MSG_WriteByte (msg, state->ammo_rockets);
+	MSG_WriteByte (msg, state->ammo_cells);
+	MSG_WriteChar (msg, state->viewheight);
+	MSG_WriteChar (msg, state->idealpitch);
+	for (i = 0; i < 3; i++)
+		MSG_WriteChar (msg, state->punchangle[i]);
+	for (i = 0; i < 3; i++)
+		MSG_WriteChar (msg, state->velocity[i]);
+	MSG_WriteByte (msg, state->movetype);
+	MSG_WriteByte (msg, state->pm_flags);
+	MSG_WriteByte (msg, state->waterlevel);
+	MSG_WriteByte (msg, state->watertype);
+	MSG_WriteByte (msg, state->event);
+	MSG_WriteByte (msg, state->event_param);
+	MSG_WriteShort (msg, state->event_seq);
 }
 
 static void SV_WriteSnapshot2Header (sizebuf_t *msg, unsigned int seq, unsigned int base_seq,
@@ -2379,6 +2483,27 @@ static unsigned int SV_SnapshotFieldMask (const snapshot_state_t *next, const sn
 		mask |= SNAP_SCALE;
 	if (next->step != base->step)
 		mask |= SNAP_STEP;
+	if (next->health != base->health || next->armor != base->armor || next->ammo != base->ammo
+		|| next->weaponmodel != base->weaponmodel || next->weaponframe != base->weaponframe
+		|| next->items != base->items || next->activeweapon != base->activeweapon
+		|| next->ammo_shells != base->ammo_shells || next->ammo_nails != base->ammo_nails
+		|| next->ammo_rockets != base->ammo_rockets || next->ammo_cells != base->ammo_cells)
+		mask |= SNAP_PLAYERSTATS;
+	if (next->viewheight != base->viewheight || next->idealpitch != base->idealpitch
+		|| next->punchangle[0] != base->punchangle[0]
+		|| next->punchangle[1] != base->punchangle[1]
+		|| next->punchangle[2] != base->punchangle[2]
+		|| next->velocity[0] != base->velocity[0]
+		|| next->velocity[1] != base->velocity[1]
+		|| next->velocity[2] != base->velocity[2]
+		|| next->movetype != base->movetype
+		|| next->pm_flags != base->pm_flags
+		|| next->waterlevel != base->waterlevel
+		|| next->watertype != base->watertype)
+		mask |= SNAP_PLAYERMOVE;
+	if (next->event != base->event || next->event_param != base->event_param
+		|| next->event_seq != base->event_seq)
+		mask |= SNAP_PLAYEREVENTS;
 
 	if (snapflags & SNAPFLAG_FORCE_ORIGIN)
 		mask |= SNAP_ORIGIN1 | SNAP_ORIGIN2 | SNAP_ORIGIN3;
@@ -2449,6 +2574,12 @@ static int SV_SnapshotDeltaFieldSize (unsigned int mask)
 		size += 1;
 	if (mask & SNAP_STEP)
 		size += 1;
+	if (mask & SNAP_PLAYERSTATS)
+		size += 22;
+	if (mask & SNAP_PLAYERMOVE)
+		size += 12;
+	if (mask & SNAP_PLAYEREVENTS)
+		size += 4;
 
 	return size;
 }
@@ -2606,6 +2737,41 @@ static void SV_WriteSnapshotDelta (sizebuf_t *msg, unsigned int seq, unsigned in
 			MSG_WriteByte (msg, states[entnum].state.scale);
 		if (mask & SNAP_STEP)
 			MSG_WriteByte (msg, states[entnum].step);
+		if (mask & SNAP_PLAYERSTATS)
+		{
+			MSG_WriteShort (msg, states[entnum].health);
+			MSG_WriteShort (msg, states[entnum].armor);
+			MSG_WriteShort (msg, states[entnum].ammo);
+			MSG_WriteShort (msg, states[entnum].weaponmodel);
+			MSG_WriteShort (msg, states[entnum].weaponframe);
+			MSG_WriteLong (msg, (int)states[entnum].items);
+			MSG_WriteLong (msg, (int)states[entnum].activeweapon);
+			MSG_WriteByte (msg, states[entnum].ammo_shells);
+			MSG_WriteByte (msg, states[entnum].ammo_nails);
+			MSG_WriteByte (msg, states[entnum].ammo_rockets);
+			MSG_WriteByte (msg, states[entnum].ammo_cells);
+		}
+		if (mask & SNAP_PLAYERMOVE)
+		{
+			int i;
+
+			MSG_WriteChar (msg, states[entnum].viewheight);
+			MSG_WriteChar (msg, states[entnum].idealpitch);
+			for (i = 0; i < 3; i++)
+				MSG_WriteChar (msg, states[entnum].punchangle[i]);
+			for (i = 0; i < 3; i++)
+				MSG_WriteChar (msg, states[entnum].velocity[i]);
+			MSG_WriteByte (msg, states[entnum].movetype);
+			MSG_WriteByte (msg, states[entnum].pm_flags);
+			MSG_WriteByte (msg, states[entnum].waterlevel);
+			MSG_WriteByte (msg, states[entnum].watertype);
+		}
+		if (mask & SNAP_PLAYEREVENTS)
+		{
+			MSG_WriteByte (msg, states[entnum].event);
+			MSG_WriteByte (msg, states[entnum].event_param);
+			MSG_WriteShort (msg, states[entnum].event_seq);
+		}
 	}
 
 	if (out_remove)
@@ -2742,6 +2908,41 @@ static void SV_WriteSnapshot2Delta (sizebuf_t *msg, unsigned int seq, unsigned i
 			MSG_WriteByte (msg, states[entnum].state.scale);
 		if (mask & SNAP_STEP)
 			MSG_WriteByte (msg, states[entnum].step);
+		if (mask & SNAP_PLAYERSTATS)
+		{
+			MSG_WriteShort (msg, states[entnum].health);
+			MSG_WriteShort (msg, states[entnum].armor);
+			MSG_WriteShort (msg, states[entnum].ammo);
+			MSG_WriteShort (msg, states[entnum].weaponmodel);
+			MSG_WriteShort (msg, states[entnum].weaponframe);
+			MSG_WriteLong (msg, (int)states[entnum].items);
+			MSG_WriteLong (msg, (int)states[entnum].activeweapon);
+			MSG_WriteByte (msg, states[entnum].ammo_shells);
+			MSG_WriteByte (msg, states[entnum].ammo_nails);
+			MSG_WriteByte (msg, states[entnum].ammo_rockets);
+			MSG_WriteByte (msg, states[entnum].ammo_cells);
+		}
+		if (mask & SNAP_PLAYERMOVE)
+		{
+			int i;
+
+			MSG_WriteChar (msg, states[entnum].viewheight);
+			MSG_WriteChar (msg, states[entnum].idealpitch);
+			for (i = 0; i < 3; i++)
+				MSG_WriteChar (msg, states[entnum].punchangle[i]);
+			for (i = 0; i < 3; i++)
+				MSG_WriteChar (msg, states[entnum].velocity[i]);
+			MSG_WriteByte (msg, states[entnum].movetype);
+			MSG_WriteByte (msg, states[entnum].pm_flags);
+			MSG_WriteByte (msg, states[entnum].waterlevel);
+			MSG_WriteByte (msg, states[entnum].watertype);
+		}
+		if (mask & SNAP_PLAYEREVENTS)
+		{
+			MSG_WriteByte (msg, states[entnum].event);
+			MSG_WriteByte (msg, states[entnum].event_param);
+			MSG_WriteShort (msg, states[entnum].event_seq);
+		}
 		update_count--;
 		update_written++;
 	}

--- a/docs/snapshot_delta.md
+++ b/docs/snapshot_delta.md
@@ -33,6 +33,9 @@ Snapshot state mirrors standard Quake entity update fields:
 - alpha
 - scale
 - step flag (movetype step)
+- player stats block (health, armor, ammo, weaponmodel, weaponframe, items, activeweapon, ammo counts)
+- player movement block (viewheight, idealpitch, punch angles, velocity, movetype, flags, waterlevel, watertype)
+- player events block (event, event_param, event_seq)
 
 Entities are keyed by `entnum` and sorted by visibility (PVS) like standard entity updates.
 
@@ -61,6 +64,51 @@ Entities are keyed by `entnum` and sorted by visibility (PVS) like standard enti
 ```
 
 If the client receives a delta with a baseline mismatch, it still reads the packet but responds with `clc_snapshot_ack` **seq = 0** to force a full resend.
+
+## Player state extensions
+
+Snapshots now include additional player-centric fields modeled after Quake 3's `playerState`. These are always present in FULL snapshots and are grouped into three delta blocks. Each block has a single field mask bit so any change inside a block sends the full block payload.
+
+### Delta mask bits
+
+- `SNAP_PLAYERSTATS` (block of stats)
+- `SNAP_PLAYERMOVE` (movement state)
+- `SNAP_PLAYEREVENTS` (event state)
+
+### Block payloads
+
+All numeric values are little-endian and use the standard message types (`short`, `long`, `byte`, `char`) already used in clientdata.
+
+**Player stats (`SNAP_PLAYERSTATS`, 22 bytes)**
+
+- `short health`
+- `short armor`
+- `short ammo`
+- `short weaponmodel`
+- `short weaponframe`
+- `long items` (combined with `items2`/serverflags like `svc_clientdata`)
+- `long activeweapon`
+- `byte ammo_shells`
+- `byte ammo_nails`
+- `byte ammo_rockets`
+- `byte ammo_cells`
+
+**Player movement (`SNAP_PLAYERMOVE`, 12 bytes)**
+
+- `char viewheight`
+- `char idealpitch`
+- `char punchangle[3]`
+- `char velocity[3]` (velocity scaled by 1/16, matching `svc_clientdata`)
+- `byte movetype`
+- `byte pm_flags` (`SNAP_PM_ONGROUND`, `SNAP_PM_INWATER`)
+- `byte waterlevel`
+- `byte watertype`
+
+**Player events (`SNAP_PLAYEREVENTS`, 4 bytes)**
+
+- `byte event`
+- `byte event_param`
+- `short event_seq`
 
 ## Baseline window + ACK behavior
 


### PR DESCRIPTION
### Motivation
- Extend entity snapshots to carry player-centric data (stats, movement, events) so client/server can sync player state in snapshots similar to Quake 3 `playerState` semantics.
- Ensure baseline/delta machinery, sizing, and masks account for the new fields so snapshot budgeting, delta encoding and chunking remain correct.

### Description
- Added delta mask bits `SNAP_PLAYERSTATS`, `SNAP_PLAYERMOVE`, and `SNAP_PLAYEREVENTS` and PM flags `SNAP_PM_ONGROUND` / `SNAP_PM_INWATER` in `Quake/protocol.h`, and expanded `snapshot_state_t` with health, armor, ammo, weapon fields, items/activeweapon, per-ammo bytes, movement fields, and event fields.
- Updated server side snapshot construction/serialization in `Quake/sv_main.c`, including `SV_FillSnapshotState`, `SV_WriteSnapshotState`, `SV_WriteSnapshotDelta`/`SV_WriteSnapshot2Delta`, `SV_SnapshotFieldMask`, `SV_SnapshotDeltaFieldSize`, `SV_Snapshot2EntitySizeForFlags`, and worst-case sizing (`SV_SnapshotEntitySizeWorst`) to include the new blocks and to account for their sizes in budgeting and debug output.
- Updated client parsing in `Quake/cl_parse.c` by extending `CL_ReadSnapshotState` and `CL_ReadSnapshotDeltaFields` to read the new player stats, movement and event blocks from full and delta snapshots.
- Extended `docs/snapshot_delta.md` with the new block descriptions, delta mask bits, and exact block payload encodings so client and server remain aligned.

### Testing
- No automated tests were run as part of this change.  Manual compile/run verification was not executed in this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973a66c90d4832e9c4eab631a5d1130)