### PR TITLE
Fix snapshot function forward declaration

### DIFF
--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -83,6 +83,7 @@ static void SV_SignonStreamSend (client_t *client);
 static qboolean SV_Snapshot2RecoveryEnabled (void);
 static int SV_Snapshot2EstimateDeltaBytes (const snapshot_state_t *next, const snapshot_state_t *base,
 	byte snapflags, unsigned int *out_mask);
+static int SV_Snapshot2CountFullChunks (const byte *present, const byte *snapflags, int max_edicts, int available);
 static unsigned int SV_SnapshotFieldMask (const snapshot_state_t *next, const snapshot_state_t *base, byte snapflags);
 static int SV_SnapshotDeltaFieldSize (unsigned int mask);
 


### PR DESCRIPTION
### Motivation
- Prevent implicit-declaration warnings/errors during compilation by declaring `SV_Snapshot2CountFullChunks` before it is used.

### Description
- Add a forward declaration `static int SV_Snapshot2CountFullChunks(const byte *present, const byte *snapflags, int max_edicts, int available);` to `Quake/sv_main.c` above its usage.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973b14a391c832e9ac8e81645335d42)