### PR TITLE
Fix snapshot chunk assembly forward declarations

### DIFF
--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -121,6 +121,8 @@ const char *svc_strings[] =
 static void CL_RequestFullSnapshot (const char *reason, qboolean count_parse_error);
 static void CL_ApplySnapshotOrigin (vec3_t out, const vec3_t in);
 static void CL_ApplyEntityOrigin (entity_t *ent, int entnum);
+static void CL_ResetSnapshotChunkAssembly (cl_snapshot_chunk_asm_t *chunk);
+static qboolean CL_HasActiveSnapshotChunks (void);
 
 static const char *CL_SvcName (int cmd)
 {


### PR DESCRIPTION
### Motivation
- Prevent MSVC implicit-declaration and redefinition errors for snapshot chunk helpers by providing explicit forward declarations for the functions referenced earlier in the file.

### Description
- Add forward declarations for `CL_ResetSnapshotChunkAssembly` and `CL_HasActiveSnapshotChunks` in `Quake/cl_parse.c` alongside the other static function prototypes.

### Testing
- No automated tests were run; this is a compile-time declaration fix to address build warnings/errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973bb1ef58c832e90e2825bcdf192c8)