### PR TITLE
Gate net debug logging when debug is disabled

### DIFF
--- a/Quake/net_dgrm.c
+++ b/Quake/net_dgrm.c
@@ -98,9 +98,9 @@ static void NET_DebugLogV (qboolean force, const char *fmt, va_list argptr)
 	char text[2048];
 	int len;
 
-	if (!force && !NET_DebugEnabled ())
+	if (!NET_DebugEnabled () && (!force || !net_debug_log))
 		return;
-	if (!net_debug_log && !net_debug_log_tried)
+	if (!net_debug_log && !net_debug_log_tried && NET_DebugEnabled ())
 	{
 		char path[MAX_OSPATH];
 		net_debug_log_tried = true;


### PR DESCRIPTION
### Motivation
- Avoid automatic creation of `net_debug.log` and emission of NETDBG log entries when network debug is not enabled, preventing console/log spam when debug cvars are off.

### Description
- Tightened the early-return in `NET_DebugLogV` so it only logs when `NET_DebugEnabled()` is true or when a forced log is requested and the log is already open, and only attempts to open `net_debug.log` when `NET_DebugEnabled()` returns true.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973d69d4894832e875a8ceb77bf0521)