### PR TITLE
Gate NETDBG tick logs behind sv_tick_debug

### DIFF
--- a/Quake/host.c
+++ b/Quake/host.c
@@ -1165,7 +1165,7 @@ void Host_ServerFrame (void)
 		if (svs.clients[i].active)
 			active_clients++;
 	}
-	if (realtime >= next_sv_report_time)
+	if (sv_tick_debug.value && realtime >= next_sv_report_time)
 	{
 		Con_Printf ("NETDBG sv.time %.3f sv.frametime %.6f edicts %d active_clients %d\n",
 			qcvm->time, clamped_frametime, qcvm->num_edicts, active_clients);
@@ -1204,7 +1204,7 @@ void Host_ServerFrame (void)
 			sv_accum = 0.0;
 			sv_next_snapshot_time = qcvm->time;
 		}
-		else if (qcvm->time <= last_sv_time && realtime >= next_sv_stall_log)
+		else if (sv_tick_debug.value && qcvm->time <= last_sv_time && realtime >= next_sv_stall_log)
 		{
 			Con_Printf ("NETDBG sv.time stalled at %.3f (frametime %.6f)\n",
 				qcvm->time, clamped_frametime);


### PR DESCRIPTION
### Motivation
- Prevent periodic server NETDBG spam on startup by only emitting the tick and stall messages when the `sv_tick_debug` CVAR is enabled.

### Description
- Guarded the periodic `NETDBG sv.time` report and the `NETDBG sv.time stalled` message in `Quake/host.c` with `sv_tick_debug.value` checks so they only print when `sv_tick_debug` is enabled.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973d7f599a8832e862cf5b6a366fe68)