### PR TITLE
Harden snapshot timing, interpolation, and prediction smoothing

### DIFF
--- a/Quake/cl_main.c
+++ b/Quake/cl_main.c
@@ -58,9 +58,15 @@ cvar_t	cl_snap_incomplete_timeout_ms = {"cl_snap_incomplete_timeout_ms", "1500",
 cvar_t	cl_snap_chunk_drop = {"cl_snap_chunk_drop", "0", CVAR_NONE};
 cvar_t	cl_test_drop = {"cl_test_drop", "0", CVAR_NONE};
 cvar_t	cl_entity_timeout_ms = {"cl_entity_timeout_ms", "750", CVAR_NONE};
+cvar_t	cl_entity_dormant_ms = {"cl_entity_dormant_ms", "400", CVAR_NONE};
 cvar_t	cl_lerp_ms = {"cl_lerp_ms", "120", CVAR_NONE};
 cvar_t	cl_lerp_max_gap_ms = {"cl_lerp_max_gap_ms", "250", CVAR_NONE};
 cvar_t	cl_lerp_debug = {"cl_lerp_debug", "0", CVAR_NONE};
+cvar_t	cl_netdbg_interp = {"cl_netdbg_interp", "0", CVAR_NONE};
+cvar_t	cl_netdbg_watch_ent = {"cl_netdbg_watch_ent", "0", CVAR_NONE};
+cvar_t	cl_netdbg_pred = {"cl_netdbg_pred", "0", CVAR_NONE};
+cvar_t	cl_pred_smooth_ms = {"cl_pred_smooth_ms", "120", CVAR_NONE};
+cvar_t	cl_pred_teleport_dist = {"cl_pred_teleport_dist", "128", CVAR_NONE};
 
 cvar_t	cfg_unbindall = {"cfg_unbindall", "1", CVAR_ARCHIVE};
 
@@ -174,6 +180,53 @@ void CL_ResetPlayerSnaps (void)
 float cl_lerpfrac = 1.0f;
 qboolean cl_viewent_needs_init = true;
 
+void CL_GetPlayerSnapRange (double *out_oldest, double *out_newest, int *out_count)
+{
+	double oldest = 0.0;
+	double newest = 0.0;
+	int count = cl_psnap_count;
+	int idx;
+	int i;
+
+	if (count <= 0)
+	{
+		if (out_oldest)
+			*out_oldest = 0.0;
+		if (out_newest)
+			*out_newest = 0.0;
+		if (out_count)
+			*out_count = 0;
+		return;
+	}
+
+	idx = (cl_psnap_head - 1 + CL_PLAYER_SNAP_HISTORY) % CL_PLAYER_SNAP_HISTORY;
+	for (i = 0; i < count; i++)
+	{
+		const cl_player_snap_t *snap = &cl_psnaps[idx];
+		double t = (snap->servertime > 0 ? snap->servertime : snap->t);
+		if (i == 0)
+		{
+			oldest = t;
+			newest = t;
+		}
+		else
+		{
+			if (t < oldest)
+				oldest = t;
+			if (t > newest)
+				newest = t;
+		}
+		idx = (idx - 1 + CL_PLAYER_SNAP_HISTORY) % CL_PLAYER_SNAP_HISTORY;
+	}
+
+	if (out_oldest)
+		*out_oldest = oldest;
+	if (out_newest)
+		*out_newest = newest;
+	if (out_count)
+		*out_count = count;
+}
+
 static qboolean CL_ViewEntityOriginIsBad (const vec3_t origin)
 {
 	const float max_abs = 65536.0f;
@@ -222,7 +275,7 @@ void CL_RecordPlayerSnap (void)
 	snap = &cl_psnaps[cl_psnap_head];
 	memset (snap, 0, sizeof(*snap));
 	snap->t = Sys_DoubleTime ();
-	snap->servertime = cl.mtime[0];
+	snap->servertime = cl.snapshot_time > 0.0 ? cl.snapshot_time : cl.mtime[0];
 
 	for (i = 0; i < cl.maxclients && i < MAX_SCOREBOARD; i++)
 	{
@@ -336,10 +389,14 @@ static double CL_GetInterpDelaySeconds (void)
 static double CL_GetInterpTargetTime (void)
 {
 	double delay = CL_GetInterpDelaySeconds ();
-	double server_time = cl.latest_server_time > 0.0 ? cl.latest_server_time : cl.mtime[0];
+	double server_time = 0.0;
 
-	if (server_time > 0.0 && cl.clock_offset != 0.0)
+	if (cl.server_time_base > 0.0 && cl.server_time_skew > 0.0)
+		server_time = cl.server_time_base + (realtime - cl.server_time_skew);
+	else if (cl.clock_offset != 0.0)
 		server_time = realtime + cl.clock_offset;
+	else
+		server_time = cl.latest_server_time > 0.0 ? cl.latest_server_time : cl.mtime[0];
 
 	if (server_time > 0.0)
 		return server_time - delay;
@@ -374,6 +431,52 @@ static qboolean CL_GetInterpolatedPlayer (int player, vec3_t out_org, vec3_t out
 
 	if (render_t >= (newest->servertime > 0 ? newest->servertime : newest->t))
 	{
+		int prev_idx = (idx - 1 + CL_PLAYER_SNAP_HISTORY) % CL_PLAYER_SNAP_HISTORY;
+		cl_player_snap_t *prev_snap = &cl_psnaps[prev_idx];
+		double newest_time = (newest->servertime > 0 ? newest->servertime : newest->t);
+		double prev_time = (prev_snap->servertime > 0 ? prev_snap->servertime : prev_snap->t);
+
+		if (cl_psnap_count > 1 && CL_IsValidBit (newest, player) && CL_IsValidBit (prev_snap, player)
+			&& prev_time > 0.0 && newest_time > prev_time)
+		{
+			double dt = newest_time - prev_time;
+			double extrap_t = render_t - newest_time;
+			double max_extrap_s = 0.1;
+			int axis;
+
+			if (max_gap_s > 0.0 && max_gap_s < max_extrap_s)
+				max_extrap_s = max_gap_s;
+			if ((max_gap_s <= 0.0 || dt <= max_gap_s) && dt > 0.0)
+			{
+				float f;
+
+				if (extrap_t < 0.0)
+					extrap_t = 0.0;
+				if (extrap_t > max_extrap_s)
+					extrap_t = max_extrap_s;
+
+				for (axis = 0; axis < 3; axis++)
+				{
+					float delta = newest->org[player][axis] - prev_snap->org[player][axis];
+					if (delta > 100.0f || delta < -100.0f)
+					{
+						VectorCopy (newest->org[player], out_org);
+						VectorCopy (newest->ang[player], out_ang);
+						return true;
+					}
+				}
+
+				f = (float)((dt + extrap_t) / dt);
+				f = CLAMP (0.0f, f, 1.0f);
+				for (axis = 0; axis < 3; axis++)
+				{
+					out_org[axis] = prev_snap->org[player][axis] + f * (newest->org[player][axis] - prev_snap->org[player][axis]);
+					out_ang[axis] = CL_LerpAngle (prev_snap->ang[player][axis], newest->ang[player][axis], f);
+				}
+				return true;
+			}
+		}
+
 		if (!CL_IsValidBit (newest, player))
 			return false;
 		VectorCopy (newest->org[player], out_org);
@@ -1201,15 +1304,21 @@ void CL_RelinkEntities (void)
 		{
 			qboolean keepalive = false;
 			double timeout_s = cl_entity_timeout_ms.value / 1000.0;
+			double dormant_s = cl_entity_dormant_ms.value / 1000.0;
+			double grace_s = 0.0;
 
 			if (cl.snap_last_incomplete)
 			{
 				keepalive = true;
 			}
 
-			if (timeout_s > 0.0 && cl.snapshot_active && cl.snapshot_active[i] && cl.snapshot_last_update_time)
+			if (dormant_s > 0.0)
+				grace_s = dormant_s;
+			if (timeout_s > 0.0 && timeout_s > grace_s)
+				grace_s = timeout_s;
+			if (grace_s > 0.0 && cl.snapshot_active && cl.snapshot_active[i] && cl.snapshot_last_update_time)
 			{
-				if (cl.time - cl.snapshot_last_update_time[i] <= timeout_s)
+				if (grace_s > 0.0 && cl.time - cl.snapshot_last_update_time[i] <= grace_s)
 				{
 					keepalive = true;
 				}
@@ -1877,9 +1986,15 @@ void CL_Init (void)
 	Cvar_RegisterVariable (&cl_snap_chunk_drop);
 	Cvar_RegisterVariable (&cl_test_drop);
 	Cvar_RegisterVariable (&cl_entity_timeout_ms);
+	Cvar_RegisterVariable (&cl_entity_dormant_ms);
 	Cvar_RegisterVariable (&cl_lerp_ms);
 	Cvar_RegisterVariable (&cl_lerp_max_gap_ms);
 	Cvar_RegisterVariable (&cl_lerp_debug);
+	Cvar_RegisterVariable (&cl_netdbg_interp);
+	Cvar_RegisterVariable (&cl_netdbg_watch_ent);
+	Cvar_RegisterVariable (&cl_netdbg_pred);
+	Cvar_RegisterVariable (&cl_pred_smooth_ms);
+	Cvar_RegisterVariable (&cl_pred_teleport_dist);
 	Cvar_RegisterVariable (&freelook);
 	Cvar_RegisterVariable (&lookspring);
 	Cvar_RegisterVariable (&lookstrafe);

--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -1143,6 +1143,64 @@ static void CL_ClearSnapshotStage (void);
 static void CL_PrepareFullSnapshotInterpReset (void);
 static void CL_FinalizeFullSnapshotInterpReset (void);
 
+static void CL_UpdateServerTimeEstimate (double server_time, const char *source)
+{
+	double offset;
+	double delta;
+	double max_step = 0.05;
+
+	if (server_time <= 0.0)
+		return;
+
+	if (cl.latest_server_time > 0.0 && server_time + 0.001 < cl.latest_server_time)
+	{
+		if (cl_netdbg_interp.value > 0.0f)
+		{
+			Con_Printf ("NETDBG: server_time non-monotonic %.3f < %.3f (%s)\n",
+				server_time, cl.latest_server_time, source ? source : "unknown");
+		}
+		server_time = cl.latest_server_time;
+	}
+
+	cl.latest_server_time = server_time;
+	cl.server_time_base = server_time;
+	cl.server_time_skew = realtime;
+
+	offset = server_time - realtime;
+	if (cl.clock_offset == 0.0)
+	{
+		cl.clock_offset = offset;
+		return;
+	}
+
+	delta = offset - cl.clock_offset;
+	if (delta > max_step)
+		delta = max_step;
+	else if (delta < -max_step)
+		delta = -max_step;
+
+	cl.clock_offset += delta * 0.25;
+}
+
+static double CL_ClampSnapshotServerTime (double snap_time, unsigned int seq)
+{
+	if (snap_time <= 0.0)
+		return 0.0;
+
+	if (cl.snap_last_server_time > 0.0 && snap_time + 0.001 < cl.snap_last_server_time)
+	{
+		if (cl_netdbg_interp.value > 0.0f)
+		{
+			Con_Printf ("NETDBG: snap_time non-monotonic %.3f < %.3f seq %u\n",
+				snap_time, cl.snap_last_server_time, seq);
+		}
+		snap_time = cl.snap_last_server_time;
+	}
+
+	cl.snap_last_server_time = snap_time;
+	return snap_time;
+}
+
 static void CL_ClearEntitySnapHistory (int entnum)
 {
 	if (entnum <= 0 || entnum >= cl_max_edicts)
@@ -1292,12 +1350,14 @@ static void CL_TrackSnapshotIncomplete (unsigned short seq16, const char *reason
 
 static void CL_MarkSnapshotEntityUpdated (int entnum)
 {
+	double stamp = cl.snapshot_time > 0.0 ? cl.snapshot_time : cl.mtime[0];
+
 	if (entnum <= 0 || entnum >= cl_max_edicts)
 		return;
 	if (cl.snapshot_active)
 		cl.snapshot_active[entnum] = 1;
 	if (cl.snapshot_last_update_time)
-		cl.snapshot_last_update_time[entnum] = cl.time;
+		cl.snapshot_last_update_time[entnum] = stamp;
 }
 
 static void CL_RecordEntitySnap (int entnum, const snapshot_state_t *state)
@@ -1322,7 +1382,7 @@ static void CL_RecordEntitySnap (int entnum, const snapshot_state_t *state)
 		cl.entity_snap_count[entnum]++;
 
 	snap = &cl.entity_snapshots[base + head];
-	snap->servertime = cl.mtime[0];
+	snap->servertime = cl.snapshot_time > 0.0 ? cl.snapshot_time : cl.mtime[0];
 	VectorCopy (state->state.origin, snap->origin);
 	VectorCopy (state->state.angles, snap->angles);
 }
@@ -1339,6 +1399,7 @@ static void CL_ApplySnapshotState (int entnum, const snapshot_state_t *state)
 	entity_t	*ent;
 	qboolean	forcelink;
 	double		oldtime;
+	double		stamp;
 	int			i;
 	int			skin;
 	qmodel_t	*model;
@@ -1346,11 +1407,12 @@ static void CL_ApplySnapshotState (int entnum, const snapshot_state_t *state)
 	ent = CL_EntityNum (entnum);
 	forcelink = (ent->msgtime != cl.mtime[1]);
 	oldtime = ent->msgtime;
+	stamp = cl.snapshot_time > 0.0 ? cl.snapshot_time : cl.mtime[0];
 
-	if (oldtime + 0.2 < cl.mtime[0])
+	if (oldtime + 0.2 < stamp)
 		ent->lerpflags |= LERP_RESETANIM;
 
-	ent->msgtime = cl.mtime[0];
+	ent->msgtime = stamp;
 
 	VectorCopy (ent->msg_origins[0], ent->msg_origins[1]);
 	VectorCopy (ent->msg_angles[0], ent->msg_angles[1]);
@@ -1456,6 +1518,176 @@ static void CL_LogSnapshotDebug (const char *label, unsigned int seq, unsigned i
 		removes_parsed, touched, base_advanced ? 1 : 0);
 }
 
+static void CL_CountSnapshotEntities (const byte *prev_present, const byte *cur_present,
+	int *out_total, int *out_created, int *out_missing, int *out_dormant)
+{
+	int total = 0;
+	int created = 0;
+	int missing = 0;
+	int dormant = 0;
+	int i;
+	double dormant_s = cl_entity_dormant_ms.value * 0.001;
+	double now = cl.snapshot_time > 0.0 ? cl.snapshot_time : cl.mtime[0];
+
+	if (!cur_present)
+	{
+		if (out_total)
+			*out_total = 0;
+		if (out_created)
+			*out_created = 0;
+		if (out_missing)
+			*out_missing = 0;
+		if (out_dormant)
+			*out_dormant = 0;
+		return;
+	}
+
+	for (i = 1; i < cl_max_edicts; i++)
+	{
+		if (cur_present[i])
+		{
+			total++;
+			if (prev_present && !prev_present[i])
+				created++;
+		}
+		else if (prev_present && prev_present[i])
+		{
+			missing++;
+			if (dormant_s > 0.0 && cl.snapshot_last_update_time)
+			{
+				if (cl.snapshot_last_update_time[i] > 0.0
+					&& (now - cl.snapshot_last_update_time[i]) <= dormant_s)
+				{
+					dormant++;
+				}
+			}
+		}
+	}
+
+	if (out_total)
+		*out_total = total;
+	if (out_created)
+		*out_created = created;
+	if (out_missing)
+		*out_missing = missing;
+	if (out_dormant)
+		*out_dormant = dormant;
+}
+
+static void CL_NetDbg_LogWatchEnt (const snapshot_header_t *header, int removed)
+{
+	int watch = (int)cl_netdbg_watch_ent.value;
+	cl_entity_snap_t *snaps;
+	const cl_entity_snap_t *newest = NULL;
+	const cl_entity_snap_t *prev = NULL;
+	int count;
+	int head;
+	const snapshot_state_t *state;
+	const char *status = "absent";
+	const char *reason = "absent";
+
+	if (watch <= 0 || watch >= cl_max_edicts)
+		return;
+	if (!cl.snapshot_present)
+		return;
+
+	if (removed)
+	{
+		status = "removed";
+		reason = "remove_list";
+	}
+	else if (cl.snapshot_present[watch])
+	{
+		status = "present";
+		reason = "present";
+	}
+
+	state = &cl.snapshot_baseline[watch];
+	if (cl.entity_snapshots && cl.entity_snap_head && cl.entity_snap_count)
+	{
+		count = cl.entity_snap_count[watch];
+		head = cl.entity_snap_head[watch];
+		snaps = &cl.entity_snapshots[watch * CL_ENTITY_SNAP_HISTORY];
+		if (count > 0)
+		{
+			newest = &snaps[head];
+			if (count > 1)
+			{
+				int prev_idx = (head - 1 + CL_ENTITY_SNAP_HISTORY) % CL_ENTITY_SNAP_HISTORY;
+				prev = &snaps[prev_idx];
+			}
+		}
+	}
+
+	Con_Printf ("NETDBG: watch_ent %d seq %u base %u state %s reason %s origin %.1f %.1f %.1f "
+		"vel %d %d %d",
+		watch, header->seq, header->base_seq, status, reason,
+		state->state.origin[0], state->state.origin[1], state->state.origin[2],
+		state->velocity[0], state->velocity[1], state->velocity[2]);
+
+	if (newest)
+	{
+		Con_Printf (" snap0 %.1f %.1f %.1f", newest->origin[0], newest->origin[1], newest->origin[2]);
+	}
+	if (prev)
+	{
+		Con_Printf (" snap1 %.1f %.1f %.1f", prev->origin[0], prev->origin[1], prev->origin[2]);
+	}
+	Con_Printf ("\n");
+}
+
+static void CL_NetDbg_LogInterpSnapshot (const snapshot_header_t *header, int removes_parsed,
+	const byte *prev_present)
+{
+	double interp_delay;
+	double server_now;
+	double render_time;
+	double arrival_dt = 0.0;
+	double oldest = 0.0;
+	double newest = 0.0;
+	double buffer_fill_ms = 0.0;
+	int psnap_count = 0;
+	int total = 0;
+	int created = 0;
+	int missing = 0;
+	int dormant = 0;
+
+	if (cl_netdbg_interp.value <= 0.0f)
+		return;
+
+	if (cl.snap_last_arrival_time > 0.0)
+		arrival_dt = realtime - cl.snap_last_arrival_time;
+	cl.snap_last_arrival_time = realtime;
+
+	interp_delay = cl_interp.value;
+	if (interp_delay <= 0.0)
+		interp_delay = cl_lerp_ms.value * 0.001;
+	else
+		interp_delay += q_max (0.0, cl_jitter.value);
+
+	if (cl.clock_offset != 0.0)
+		server_now = realtime + cl.clock_offset;
+	else if (cl.latest_server_time > 0.0)
+		server_now = cl.latest_server_time;
+	else
+		server_now = cl.mtime[0];
+
+	render_time = server_now - interp_delay;
+
+	CL_GetPlayerSnapRange (&oldest, &newest, &psnap_count);
+	if (psnap_count > 1)
+		buffer_fill_ms = (newest - oldest) * 1000.0;
+
+	CL_CountSnapshotEntities (prev_present, cl.snapshot_present, &total, &created, &missing, &dormant);
+
+	Con_Printf ("NETDBG: interp seq %u base %u srvtime %.3f arrival_dt %.3f "
+		"render_time %.3f interp_delay %.3f buf_oldest %.3f buf_newest %.3f buf_fill_ms %.1f "
+		"ents total %d created %d removed %d missing %d dormant %d\n",
+		header->seq, header->base_seq, cl.snapshot_time > 0.0 ? cl.snapshot_time : header->server_time,
+		arrival_dt, render_time, interp_delay, oldest, newest, buffer_fill_ms,
+		total, created, removes_parsed, missing, dormant);
+}
+
 /*
 ==================
 CL_ParseBaseline
@@ -1547,9 +1779,16 @@ static void CL_ParseSnapshotFull (void)
 
 	{
 		qboolean reset_interp = (!cl.has_full_snapshot || cl.need_full_snapshot);
+		double snap_time = CL_ClampSnapshotServerTime (cl.mtime[0], seq);
 
 		if (reset_interp)
 			CL_PrepareFullSnapshotInterpReset ();
+
+		if (snap_time > 0.0)
+		{
+			cl.snapshot_time = snap_time;
+			CL_UpdateServerTimeEstimate (snap_time, "snap_full");
+		}
 
 		// INV-5: commit staged snapshot only after full parse.
 		CL_StoreSnapshotBaseline (seq, cl.snapshot_stage, cl.snapshot_stage_present);
@@ -1785,6 +2024,15 @@ static void CL_ParseSnapshotDelta (void)
 	if (!drop && baseline_match)
 	{
 		CL_StoreSnapshotBaselineFromBase (seq, base_states, base_present);
+		{
+			double snap_time = CL_ClampSnapshotServerTime (cl.mtime[0], seq);
+
+			if (snap_time > 0.0)
+			{
+				cl.snapshot_time = snap_time;
+				CL_UpdateServerTimeEstimate (snap_time, "snap_delta");
+			}
+		}
 		if (base_is_current)
 		{
 			for (i = 1; i < cl_max_edicts; i++)
@@ -1847,6 +2095,7 @@ typedef struct
 	unsigned short	chunk_total_entities;
 	unsigned short	chunk_index;
 	unsigned short	chunk_total_chunks;
+	double		server_time;
 } snapshot_header_t;
 
 static void CL_ReadSnapshotHeader (snapshot_header_t *header)
@@ -1859,6 +2108,7 @@ static void CL_ReadSnapshotHeader (snapshot_header_t *header)
 	header->chunk_total_entities = 0;
 	header->chunk_index = 0;
 	header->chunk_total_chunks = 0;
+	header->server_time = (cl.latest_server_time > 0.0) ? cl.latest_server_time : cl.mtime[0];
 	if (header->flags & SNAPSHOT_FLAG_CHUNKINFO)
 	{
 		header->chunk_total_entities = (unsigned short)MSG_ReadShort ();
@@ -2037,9 +2287,17 @@ static qboolean CL_ParseSnapshot2FullPayload (const snapshot_header_t *header, q
 		if (!incomplete)
 		{
 			qboolean reset_interp = (!cl.has_full_snapshot || cl.need_full_snapshot);
+			const byte *prev_present = cl.snapshot_present;
+			double snap_time = CL_ClampSnapshotServerTime (header->server_time, header->seq);
 
 			if (reset_interp)
 				CL_PrepareFullSnapshotInterpReset ();
+
+			if (snap_time > 0.0)
+			{
+				cl.snapshot_time = snap_time;
+				CL_UpdateServerTimeEstimate (snap_time, "snap2_full");
+			}
 
 			// INV-5: commit staged snapshot only after full parse.
 			CL_StoreSnapshotBaseline (header->seq, cl.snapshot_stage, cl.snapshot_stage_present);
@@ -2076,9 +2334,18 @@ static qboolean CL_ParseSnapshot2FullPayload (const snapshot_header_t *header, q
 				cl.has_full_snapshot ? 1 : 0);
 			CL_LogSnapshotDebug ("snap2_full", header->seq, header->flags, true,
 				0, touched, base_advanced);
+			CL_NetDbg_LogInterpSnapshot (header, 0, prev_present);
+			CL_NetDbg_LogWatchEnt (header, 0);
 		}
 		else
 		{
+			double snap_time = CL_ClampSnapshotServerTime (header->server_time, header->seq);
+
+			if (snap_time > 0.0)
+			{
+				cl.snapshot_time = snap_time;
+				CL_UpdateServerTimeEstimate (snap_time, "snap2_full_incomplete");
+			}
 			// INCOMPLETE snapshots: keep existing entities, overlay only touched updates.
 			touched = CL_ApplySnapshotOverlay (cl.snapshot_stage, cl.snapshot_stage_present);
 			cl.snap_parse_consecutive = 0;
@@ -2287,6 +2554,7 @@ static void CL_ParseSnapshot2 (void)
 				chunk->active = true;
 				chunk->seq = header.seq;
 				chunk->start_time = realtime;
+				chunk->server_time = header.server_time;
 				chunk->packets = 0;
 				chunk->total_chunks = total_chunks;
 				chunk->total_entities = total_entities;
@@ -2304,6 +2572,8 @@ static void CL_ParseSnapshot2 (void)
 					CL_ResetSnapshotChunkAssembly (chunk);
 					drop = true;
 				}
+				if (chunk->server_time <= 0.0 && header.server_time > 0.0)
+					chunk->server_time = header.server_time;
 			}
 
 			if (chunk)
@@ -2435,6 +2705,7 @@ static void CL_ParseSnapshot2 (void)
 				full_header.flags &= ~(SNAPSHOT_FLAG_CONTINUE | SNAPSHOT_FLAG_CHUNKINFO);
 				full_header.num_entities = chunk->total_entities;
 				full_header.num_removed = 0;
+				full_header.server_time = chunk->server_time;
 
 				for (i = 0; i < chunk->total_chunks; i++)
 				{
@@ -2661,6 +2932,15 @@ static void CL_ParseSnapshot2 (void)
 	{
 		if (!incomplete)
 		{
+			const byte *prev_present = cl.snapshot_present;
+			double snap_time = CL_ClampSnapshotServerTime (header.server_time, header.seq);
+
+			if (snap_time > 0.0)
+			{
+				cl.snapshot_time = snap_time;
+				CL_UpdateServerTimeEstimate (snap_time, "snap2_delta");
+			}
+
 			CL_StoreSnapshotBaselineFromBase (header.seq, base_states, base_present);
 			if (base_is_current)
 			{
@@ -2712,6 +2992,18 @@ static void CL_ParseSnapshot2 (void)
 				cl.has_full_snapshot ? 1 : 0);
 			CL_LogSnapshotDebug ("snap2_delta", header.seq, header.flags, true,
 				removes_parsed, touched, base_advanced);
+			CL_NetDbg_LogInterpSnapshot (&header, removes_parsed, prev_present);
+			{
+				int watch_removed = 0;
+				int watch = (int)cl_netdbg_watch_ent.value;
+
+				if (watch > 0 && watch < cl_max_edicts && cl.snapshot_stage_remove
+					&& cl.snapshot_stage_remove[watch])
+				{
+					watch_removed = 1;
+				}
+				CL_NetDbg_LogWatchEnt (&header, watch_removed);
+			}
 		}
 		else
 		{
@@ -2722,6 +3014,13 @@ static void CL_ParseSnapshot2 (void)
 			}
 			else
 			{
+				double snap_time = CL_ClampSnapshotServerTime (header.server_time, header.seq);
+
+				if (snap_time > 0.0)
+				{
+					cl.snapshot_time = snap_time;
+					CL_UpdateServerTimeEstimate (snap_time, "snap2_delta_incomplete");
+				}
 				// INCOMPLETE snapshots: keep existing entities, overlay only touched updates.
 				touched = CL_ApplySnapshotOverlay (cl.snapshot_stage, cl.snapshot_stage_present);
 				CL_TrackSnapshotIncomplete (seq16, "delta");
@@ -3237,14 +3536,7 @@ void CL_ParseServerMessage (void)
 
 			cl.mtime[1] = cl.mtime[0];
 			cl.mtime[0] = server_time;
-			cl.latest_server_time = server_time;
-			{
-				double offset = server_time - realtime;
-				if (cl.clock_offset == 0.0)
-					cl.clock_offset = offset;
-				else
-					cl.clock_offset += (offset - cl.clock_offset) * 0.1;
-			}
+			CL_UpdateServerTimeEstimate (server_time, "svc_time");
 			cl.fixangle = false;
 			if (cls.signon == SIGNONS - 1)
 			{	// allow map loads with no visible entity updates to finish signon

--- a/Quake/cl_predict.c
+++ b/Quake/cl_predict.c
@@ -32,6 +32,7 @@ typedef struct
 static cl_pred_t cl_pred;
 static qboolean cl_netdbg_predict_ran;
 static qboolean cl_pred_warned_solid;
+static vec3_t cl_pred_error;
 
 #define CL_PREDICT_MAX_CLIP_PLANES 5
 #define CL_PREDICT_STEP_SIZE 18.0f
@@ -103,16 +104,39 @@ static qboolean CL_Predict_IsEnabled (void)
 
 static void CL_Predict_ApplyToClient (void)
 {
+	vec3_t smooth_origin;
+	float smooth_ms;
+	float decay;
+	vec3_t correction;
+
 	if (!CL_Predict_IsEnabled () || !cl_pred.has_base)
 		return;
 
-	VectorCopy (cl_pred.predicted.origin, cl.simorg);
-	VectorCopy (cl_pred.predicted.origin, cl_entities[cl.viewentity].origin);
-	VectorCopy (cl_pred.predicted.origin, cl_entities[cl.viewentity].msg_origins[0]);
-	VectorCopy (cl_pred.predicted.origin, cl_entities[cl.viewentity].msg_origins[1]);
+	smooth_ms = cl_pred_smooth_ms.value;
+	if (smooth_ms <= 0.0f)
+		VectorClear (cl_pred_error);
+
+	VectorAdd (cl_pred.predicted.origin, cl_pred_error, smooth_origin);
+	VectorCopy (smooth_origin, cl.simorg);
+	VectorCopy (smooth_origin, cl_entities[cl.viewentity].origin);
+	VectorCopy (smooth_origin, cl_entities[cl.viewentity].msg_origins[0]);
+	VectorCopy (smooth_origin, cl_entities[cl.viewentity].msg_origins[1]);
 	VectorCopy (cl_pred.predicted.velocity, cl.mvelocity[0]);
 	VectorCopy (cl_pred.predicted.velocity, cl.mvelocity[1]);
 	cl.onground = cl_pred.predicted.onground;
+
+	if (smooth_ms > 0.0f)
+	{
+		decay = host_frametime / (smooth_ms * 0.001f);
+		decay = CLAMP (0.0f, decay, 1.0f);
+		VectorScale (cl_pred_error, decay, correction);
+		VectorSubtract (cl_pred_error, correction, cl_pred_error);
+		if (cl_netdbg_pred.value > 0.0f)
+		{
+			Con_Printf ("NETDBG: pred_smooth apply %.2f remaining %.2f\n",
+				VectorLength (correction), VectorLength (cl_pred_error));
+		}
+	}
 
 	CL_EnsureViewEntityOrigin ("predict");
 }
@@ -530,6 +554,7 @@ void CL_Predict_Clear (void)
 {
 	memset (&cl_pred, 0, sizeof(cl_pred));
 	cl_pred_warned_solid = false;
+	VectorClear (cl_pred_error);
 }
 
 void CL_Predict_SetupCmd (usercmd_t *cmd)
@@ -563,6 +588,9 @@ void CL_Predict_ServerUpdate (unsigned int ack, const vec3_t origin, const vec3_
 {
 	unsigned int seq;
 	float correction;
+	vec3_t error;
+	float error_len;
+	float teleport_dist = cl_pred_teleport_dist.value;
 
 	if (cl_pred.has_base && !CL_Predict_SeqNewer (ack, cl_pred.seq_acked))
 		return;
@@ -580,6 +608,30 @@ void CL_Predict_ServerUpdate (unsigned int ack, const vec3_t origin, const vec3_
 	}
 
 	cl_pred.seq_acked = ack;
+	if (cl_pred.has_base)
+	{
+		VectorSubtract (origin, cl_pred.predicted.origin, error);
+		error_len = VectorLength (error);
+		if (cl_netdbg_pred.value > 0.0f)
+		{
+			Con_Printf ("NETDBG: pred_error %.2f (server %.1f %.1f %.1f client %.1f %.1f %.1f)\n",
+				error_len,
+				origin[0], origin[1], origin[2],
+				cl_pred.predicted.origin[0], cl_pred.predicted.origin[1], cl_pred.predicted.origin[2]);
+		}
+		if (teleport_dist > 0.0f && error_len > teleport_dist)
+		{
+			VectorClear (cl_pred_error);
+		}
+		else
+		{
+			VectorAdd (cl_pred_error, error, cl_pred_error);
+		}
+	}
+	else
+	{
+		VectorClear (cl_pred_error);
+	}
 	VectorCopy (origin, cl_pred.base.origin);
 	VectorCopy (origin, cl.simorg);
 	VectorCopy (velocity, cl_pred.base.velocity);

--- a/Quake/client.h
+++ b/Quake/client.h
@@ -92,6 +92,7 @@ typedef struct cl_snapshot_chunk_asm_s
 	unsigned short sizes[CL_SNAPSHOT_MAX_CHUNKS];
 	byte		received_mask[CL_SNAPSHOT_MAX_CHUNKS];
 	double		start_time;
+	double		server_time;
 	int			packets;
 } cl_snapshot_chunk_asm_t;
 
@@ -286,6 +287,11 @@ typedef struct
 								// to decay light values and smooth step ups
 	double		latest_server_time;	// most recent server time from snapshots
 	double		clock_offset;		// smoothed server_time - realtime offset
+	double		server_time_base;	// last server time sample
+	double		server_time_skew;	// realtime when sample captured
+	double		snapshot_time;		// time applied for snapshot entity state
+	double		snap_last_server_time;	// last applied snapshot time
+	double		snap_last_arrival_time;	// realtime of last snapshot apply
 
 
 	float		last_received_message;	// (realtime) for net trouble icon
@@ -423,9 +429,15 @@ extern	cvar_t	cl_snap_incomplete_timeout_ms;
 extern	cvar_t	cl_snap_chunk_drop;
 extern	cvar_t	cl_test_drop;
 extern	cvar_t	cl_entity_timeout_ms;
+extern	cvar_t	cl_entity_dormant_ms;
 extern	cvar_t	cl_lerp_ms;
 extern	cvar_t	cl_lerp_max_gap_ms;
 extern	cvar_t	cl_lerp_debug;
+extern	cvar_t	cl_netdbg_interp;
+extern	cvar_t	cl_netdbg_watch_ent;
+extern	cvar_t	cl_netdbg_pred;
+extern	cvar_t	cl_pred_smooth_ms;
+extern	cvar_t	cl_pred_teleport_dist;
 extern	float	cl_lerpfrac;
 
 
@@ -499,6 +511,7 @@ void CL_Predict_SetupCmd (usercmd_t *cmd);
 void CL_Predict_ServerUpdate (unsigned int ack, const vec3_t origin, const vec3_t velocity, const vec3_t viewangles, qboolean onground);
 void CL_Predict_Reapply (void);
 qboolean CL_Predict_GetCmd (unsigned int seq, usercmd_t *out);
+void CL_GetPlayerSnapRange (double *out_oldest, double *out_newest, int *out_count);
 int  CL_ReadFromServer (void);
 void CL_AdjustAngles (void);
 void CL_BaseMove (usercmd_t *cmd);


### PR DESCRIPTION
### Motivation
- Client-visible micro-jitter and enemy flicker appear to be caused by fragile timing/clock handling, abrupt entity removal on single missing deltas, and hard prediction snaps on server corrections.
- Snapshot2 chunking and legacy snapshots can produce skewed arrival vs server time which the client must smooth and guard against to make interpolation stable.
- Keep gameplay unchanged while adding diagnostics so engineers can confirm serverTick/servertime monotonicity, interp buffer fill, entity lifecycle reasons, and prediction error smoothing behavior.

### Description
- Implemented a server-time estimator and snapshot stamping so snapshots carry/produce a monotonic server time and the client updates `cl.server_time_base`/`cl.server_time_skew` and uses that to compute render time; added monotonic clamps and smoothing to avoid time jumps (changes in `Quake/cl_parse.c`, `Quake/cl_main.c`, `Quake/client.h`).
- Added per-snapshot instrumentation behind `cl_netdbg_interp`, `cl_netdbg_watch_ent`, and `cl_netdbg_pred` to log seq/base, serverTime, arrival delta, interp delay, player-snap buffer oldest/newest, buffer fill, entity counts (total/created/missing/dormant) and per-entity watch output (see `Quake/cl_parse.c`).
- Hardened entity lifecycle by introducing `cl_entity_dormant_ms` and a grace/dormant window that prevents immediate deletion when an entity is missing for a single delta; snapshot last-update timestamps now use the stamped snapshot time and are consulted before removal (`Quake/cl_main.c`, `Quake/cl_parse.c`, `Quake/client.h`).
- Made interpolation and extrapolation more robust: render time is computed from the server-time estimator; player interpolation allows limited extrapolation using two newest player snaps (capped) to avoid abrupt jumps on underflow; prev/next snapshot ownership and entity snapshot stamping were tightened so `prev`/`next` are snapshot states (not transient last-rendered frames) (`Quake/cl_main.c`, `Quake/cl_parse.c`).
- Smoothed prediction corrections by accumulating a `cl_pred_error` vector and blending it out over `cl_pred_smooth_ms`, with a teleport snap threshold `cl_pred_teleport_dist` for large corrections; added NETDBG lines for prediction error and smoothing (`Quake/cl_predict.c`, `Quake/cl_main.c`).
- Minor: track `server_time` on chunk assemblies so chunked full snapshots propagate a consistent server timestamp (`Quake/cl_parse.c`, `Quake/client.h`).

Files touched: `Quake/cl_parse.c`, `Quake/cl_main.c`, `Quake/cl_predict.c`, `Quake/client.h`.
New cvars: `cl_entity_dormant_ms` (400 ms default), `cl_netdbg_interp`, `cl_netdbg_watch_ent`, `cl_netdbg_pred`, `cl_pred_smooth_ms` (120 ms default), `cl_pred_teleport_dist` (128 units default).

### Testing
- Automated tests: none were executed for this change; no unit/integration test harness was run as part of this PR.
- Manual verification instructions: enable `cl_netdbg_interp 1` to observe per-snapshot logs (seq/base/serverTime/arrival/renderTime/bufferFill/ents), set `cl_netdbg_watch_ent <id>` to follow a single entity, and set `cl_netdbg_pred 1` to see prediction error and smoothing output; tune `cl_entity_dormant_ms` and `cl_pred_smooth_ms` to observe behavior changes.
- Compilation/build: not performed automatically here; changes were committed but should be built and smoke-tested on a client to confirm no regressions in connect/signon and chunked full snapshot handling.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973faafe2bc832eb3dec329790af1d2)