### PR TITLE
Fix snapshot header usage and add missing cvar externs in cl_parse.c

### DIFF
--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -38,6 +38,8 @@ extern cvar_t cl_netdebug_maxdump;
 extern cvar_t cl_signon_chunk_debug;
 extern cvar_t cl_signon_debug;
 extern qboolean cl_viewent_needs_init;
+extern cvar_t cl_interp;
+extern cvar_t cl_jitter;
 
 static qboolean warn_about_nehahra_protocol;
 
@@ -1574,7 +1576,18 @@ static void CL_CountSnapshotEntities (const byte *prev_present, const byte *cur_
 		*out_dormant = dormant;
 }
 
-typedef struct snapshot_header_s snapshot_header_t;
+typedef struct snapshot_header_s
+{
+	unsigned int	seq;
+	unsigned int	base_seq;
+	unsigned int	flags;
+	unsigned short	num_entities;
+	unsigned short	num_removed;
+	unsigned short	chunk_total_entities;
+	unsigned short	chunk_index;
+	unsigned short	chunk_total_chunks;
+	double		server_time;
+} snapshot_header_t;
 
 static void CL_NetDbg_LogWatchEnt (const snapshot_header_t *header, int removed)
 {
@@ -2086,19 +2099,6 @@ static void CL_ParseSnapshotDelta (void)
 		CL_LogSnapshotDebug ("delta", seq, 0, true, removes_parsed, touched, base_advanced);
 	}
 }
-
-struct snapshot_header_s
-{
-	unsigned int	seq;
-	unsigned int	base_seq;
-	unsigned int	flags;
-	unsigned short	num_entities;
-	unsigned short	num_removed;
-	unsigned short	chunk_total_entities;
-	unsigned short	chunk_index;
-	unsigned short	chunk_total_chunks;
-	double		server_time;
-};
 
 static void CL_ReadSnapshotHeader (snapshot_header_t *header)
 {


### PR DESCRIPTION
### Motivation
- MSVC reported undefined struct fields and undeclared identifiers when compiling `cl_parse.c`, indicating the snapshot header type and some client cvars were declared after use.
- Defining the snapshot header type before its first use and declaring the missing cvars ensures the file compiles cleanly on MSVC and other strict compilers.

### Description
- Moved and expanded the `snapshot_header_t` typedef so the full struct is defined before any functions reference it, replacing the later `struct snapshot_header_s` block with the single typedef definition. 
- Added `extern` declarations for `cl_interp` and `cl_jitter` near the other cvar externs so they are available in `cl_parse.c`.
- Removed the duplicate trailing `struct snapshot_header_s` definition to avoid conflicting forward/deferred declarations.

### Testing
- No automated tests were run as part of this change.
- The change is limited to `Quake/cl_parse.c` and addresses compile-time symbol/typedef ordering errors observed during MSVC builds.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697410bf2b5c832e849a97188ab787c2)