### PR TITLE
Enhance NETDBG logging with socket, cmd and snapshot diagnostics

### DIFF
--- a/Quake/cl_main.c
+++ b/Quake/cl_main.c
@@ -322,6 +322,20 @@ static void CL_NetDbg_LogMovement (const usercmd_t *cmd, qboolean sendcmd_ran)
 	int forward = 0;
 	int side = 0;
 	int up = 0;
+	unsigned int cmd_seq = 0u;
+	unsigned int cmd_ack = cl.last_cmd_ack;
+	unsigned int cmd_ack_echo = cl.last_cmd_ack_echo;
+	unsigned int snap_ack = cl.last_snapshot_ack_sent;
+	unsigned int net_rx_seq = 0u;
+	unsigned int net_tx_seq = 0u;
+	unsigned int net_rel_recv_seq = 0u;
+	unsigned int net_rel_send_base = 0u;
+	unsigned int net_unrel_rx = 0u;
+	double net_last_msg_age = 0.0;
+	double net_last_send_age = 0.0;
+	int net_rate_budget = 0;
+	int net_disconnected = 0;
+	int net_can_send = 0;
 
 	if (!cl_netdebug_parse.value)
 		return;
@@ -337,13 +351,33 @@ static void CL_NetDbg_LogMovement (const usercmd_t *cmd, qboolean sendcmd_ran)
 
 	if (cmd)
 	{
+		cmd_seq = cmd->sequence;
 		forward = cmd->forwardmove;
 		side = cmd->sidemove;
 		up = cmd->upmove;
 	}
 
+	if (cls.netcon)
+	{
+		net_rx_seq = cls.netcon->receiveSequence;
+		net_tx_seq = cls.netcon->sendSequence;
+		net_rel_recv_seq = cls.netcon->reliableReceiveSequence;
+		net_rel_send_base = cls.netcon->sendReliableBase;
+		net_unrel_rx = cls.netcon->unreliableReceiveSequence;
+		net_rate_budget = cls.netcon->rate_budget;
+		net_disconnected = cls.netcon->disconnected ? 1 : 0;
+		net_can_send = cls.netcon->canSend ? 1 : 0;
+		if (cls.netcon->lastMessageTime > 0.0)
+			net_last_msg_age = now - cls.netcon->lastMessageTime;
+		if (cls.netcon->lastSendTime > 0.0)
+			net_last_send_age = now - cls.netcon->lastSendTime;
+	}
+
 	Con_Printf ("NETDBG move signon %d has_full %d need_full %d viewent_init %d world %d paused %d intermission %d "
-		"vieworg %.1f %.1f %.1f simorg %.1f %.1f %.1f cmd %d %d %d predict %d sendcmd %d\n",
+		"vieworg %.1f %.1f %.1f simorg %.1f %.1f %.1f cmd %d %d %d predict %d sendcmd %d "
+		"cmd_seq %u cmd_ack %u ack_echo %u snap_ack %u cmd_accum %.4f cmd_dt %.4f "
+		"net_rx %u net_tx %u net_rel_rx %u net_rel_base %u net_unrel_rx %u "
+		"net_last_msg %.3f net_last_send %.3f net_budget %d net_can_send %d net_disc %d\n",
 		cls.signon,
 		cl.has_full_snapshot ? 1 : 0,
 		cl.need_full_snapshot ? 1 : 0,
@@ -355,7 +389,11 @@ static void CL_NetDbg_LogMovement (const usercmd_t *cmd, qboolean sendcmd_ran)
 		cl.simorg[0], cl.simorg[1], cl.simorg[2],
 		forward, side, up,
 		CL_NetDbg_PredictRan () ? 1 : 0,
-		sendcmd_ran ? 1 : 0);
+		sendcmd_ran ? 1 : 0,
+		cmd_seq, cmd_ack, cmd_ack_echo, snap_ack,
+		cl_cmd_accum, host_netinterval,
+		net_rx_seq, net_tx_seq, net_rel_recv_seq, net_rel_send_base, net_unrel_rx,
+		net_last_msg_age, net_last_send_age, net_rate_budget, net_can_send, net_disconnected);
 }
 
 static float CL_LerpAngle (float a, float b, float f)

--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -191,12 +191,29 @@ static void CL_NetDebugHeader (void)
 		net_message.cursize, realtime, cls.state, cls.signon);
 	if (cls.netcon)
 	{
-		Con_Printf ("NETDBG: from %s rseq %u sseq %u rack %u unrel %u\n",
+		double now = Sys_DoubleTime ();
+		double last_msg_age = 0.0;
+		double last_send_age = 0.0;
+
+		if (cls.netcon->lastMessageTime > 0.0)
+			last_msg_age = now - cls.netcon->lastMessageTime;
+		if (cls.netcon->lastSendTime > 0.0)
+			last_send_age = now - cls.netcon->lastSendTime;
+
+		Con_Printf ("NETDBG: from %s rseq %u sseq %u rack %u unrel %u "
+			"rmask 0x%x sbase %u rate_budget %d can_send %d disc %d "
+			"lastmsg %.3f lastsend %.3f\n",
 			NET_QSocketGetAddressString (cls.netcon),
 			cls.netcon->receiveSequence,
 			cls.netcon->sendSequence,
 			cls.netcon->reliableReceiveSequence,
-			cls.netcon->unreliableReceiveSequence);
+			cls.netcon->unreliableReceiveSequence,
+			cls.netcon->reliableReceiveMask,
+			cls.netcon->sendReliableBase,
+			cls.netcon->rate_budget,
+			cls.netcon->canSend ? 1 : 0,
+			cls.netcon->disconnected ? 1 : 0,
+			last_msg_age, last_send_age);
 	}
 	if (net_last_incoming.valid)
 	{
@@ -1661,6 +1678,11 @@ static void CL_NetDbg_LogInterpSnapshot (const snapshot_header_t *header, int re
 	double oldest = 0.0;
 	double newest = 0.0;
 	double buffer_fill_ms = 0.0;
+	double render_vs_oldest_ms = 0.0;
+	double render_vs_newest_ms = 0.0;
+	double server_time = 0.0;
+	double server_skew_age = 0.0;
+	double snap_age = 0.0;
 	int psnap_count = 0;
 	int total = 0;
 	int created = 0;
@@ -1688,19 +1710,35 @@ static void CL_NetDbg_LogInterpSnapshot (const snapshot_header_t *header, int re
 		server_now = cl.mtime[0];
 
 	render_time = server_now - interp_delay;
+	server_time = cl.snapshot_time > 0.0 ? cl.snapshot_time : header->server_time;
+	if (cl.server_time_skew > 0.0)
+		server_skew_age = realtime - cl.server_time_skew;
+	if (server_now > 0.0 && server_time > 0.0)
+		snap_age = server_now - server_time;
 
 	CL_GetPlayerSnapRange (&oldest, &newest, &psnap_count);
 	if (psnap_count > 1)
 		buffer_fill_ms = (newest - oldest) * 1000.0;
+	if (psnap_count > 0)
+	{
+		render_vs_oldest_ms = (render_time - oldest) * 1000.0;
+		render_vs_newest_ms = (render_time - newest) * 1000.0;
+	}
 
 	CL_CountSnapshotEntities (prev_present, cl.snapshot_present, &total, &created, &missing, &dormant);
 
 	Con_Printf ("NETDBG: interp seq %u base %u srvtime %.3f arrival_dt %.3f "
 		"render_time %.3f interp_delay %.3f buf_oldest %.3f buf_newest %.3f buf_fill_ms %.1f "
-		"ents total %d created %d removed %d missing %d dormant %d\n",
-		header->seq, header->base_seq, cl.snapshot_time > 0.0 ? cl.snapshot_time : header->server_time,
+		"render_gap_ms oldest %.1f newest %.1f srvnow %.3f srv_skew_age %.3f snap_age %.3f "
+		"ents total %d created %d removed %d missing %d dormant %d "
+		"snap_seq last %u complete %u incomplete %u need_full %d delta_mismatch %d parse_err %d incomplete_cnt %d\n",
+		header->seq, header->base_seq, server_time,
 		arrival_dt, render_time, interp_delay, oldest, newest, buffer_fill_ms,
-		total, created, removes_parsed, missing, dormant);
+		render_vs_oldest_ms, render_vs_newest_ms, server_now, server_skew_age, snap_age,
+		total, created, removes_parsed, missing, dormant,
+		cl.snap_last_applied_seq, cl.snap_last_complete_seq, cl.snap_last_incomplete_seq,
+		cl.need_full_snapshot ? 1 : 0, cl.snap_delta_mismatch, cl.snap_parse_errors,
+		cl.snap_incomplete_count);
 }
 
 /*


### PR DESCRIPTION
### Motivation
- Improve in-game debugging output to help diagnose connection errors, lag, flickering, and position jumps by making NETDBG logs include more relevant runtime and network state.
- Provide timeline and sequence information for movement commands and snapshots so developers can correlate client inputs, ACKs, and socket activity with visible issues.

### Description
- Extended `CL_NetDbg_LogMovement` in `Quake/cl_main.c` to include command sequence (`cmd_seq`), command ACKs/echoes and snapshot ACK, command accumulation and dt, and per-socket metrics including receive/send sequences, reliable/unreliable sequences, reliable base, rate budget, last message/send ages, `canSend` and `disconnected` flags, and print them in the NETDBG movement line.
- Enhanced `CL_NetDebugHeader` in `Quake/cl_parse.c` to log socket timing and metadata such as `lastMessageTime`/`lastSendTime` ages, `reliableReceiveMask`, `sendReliableBase`, `rate_budget`, `canSend`, and `disconnected` along with the existing sequence fields.
- Improved `CL_NetDbg_LogInterpSnapshot` in `Quake/cl_parse.c` to compute and log render gaps vs oldest/newest buffered player snapshots, server timing/skew/age, and snapshot health counters including last applied/complete/incomplete snapshot seqs, `need_full_snapshot`, `snap_delta_mismatch`, `snap_parse_errors`, and `snap_incomplete_count`.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69741269212c832ea03fdddd0b11f896)