### PR TITLE
Fix qsocket_s access in cl_main by including network headers

### DIFF
--- a/Quake/cl_main.c
+++ b/Quake/cl_main.c
@@ -22,6 +22,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // cl_main.c  -- client main loop
 
 #include "quakedef.h"
+#include "arch_def.h"
+#include "net_sys.h"
+#include "net_defs.h"
 #include "cl_postfx.h"
 #include "bgmusic.h"
 #include "../common/lightgrid.h"


### PR DESCRIPTION
### Motivation

- Resolve C2037 compiler errors from accessing members of `struct qsocket_s` in `Quake/cl_main.c` by ensuring the struct and related types are visible to that translation unit.

### Description

- Add `#include "arch_def.h"`, `#include "net_sys.h"`, and `#include "net_defs.h"` to the top of `Quake/cl_main.c` so `qsocket_s` and `sys_socket_t` are defined before `cls.netcon` fields are accessed.

### Testing

- Installed `libsdl2-dev` and ran `cmake -S . -B build` and `cmake --build build`, and compiled `cl_main.c` with `cc $(sdl2-config --cflags) -IQuake -Icommon -c Quake/cl_main.c`; these automated build steps completed successfully in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974adf6ec38832e8a1452a3ded6ff22)