### PR TITLE
Guard snapshot parsing across map transitions and stabilize client prediction

### DIFF
--- a/Quake/cl_demo.c
+++ b/Quake/cl_demo.c
@@ -118,14 +118,33 @@ void CL_ClearSignons (void)
 	cls.signon = 0;
 	cl.has_full_snapshot = false;
 	cl.need_full_snapshot = true;
+	cl.has_valid_worldstate = false;
+	cl.last_cmd_ack = 0;
+	cl.last_cmd_ack_echo = 0;
+	cl.last_snapshot_ack_sent = 0;
 	cl.snap_last_applied_seq = 0;
 	cl.snap_last_complete_seq = 0;
 	cl.snap_last_incomplete_seq = 0;
 	cl.snap_last_incomplete = false;
 	cl.snap_incomplete_start_time = 0;
+	cl.snap_parse_errors = 0;
+	cl.snap_parse_consecutive = 0;
+	cl.snap_delta_mismatch = 0;
+	cl.snap_incomplete_count = 0;
+	cl.snap_base_mismatch_count = 0;
+	cl.snap_decode_error_count = 0;
 	cl.snapshot_baseline_seq = 0;
 	cl.snapshot_baseline_head = 0;
 	cl.snapshot_baseline_index = -1;
+	cl.snap_last_server_time = 0.0;
+	cl.snap_last_arrival_time = 0.0;
+	cl.snapshot_time = 0.0;
+	cl.pred_error_mag = 0.0f;
+	cl.pred_error_raw_mag = 0.0f;
+	cl.pred_correction_applied = 0.0f;
+	cl.pred_correction_remaining = 0.0f;
+	cl.pred_snapshot_age = 0.0;
+	cl.pred_cmd_age = 0.0;
 	for (i = 0; i < CL_SNAPSHOT_BASELINE_HISTORY; i++)
 	{
 		cl.snapshot_baseline_valid[i] = 0;
@@ -622,6 +641,8 @@ int CL_GetMessage (void)
 		else
 			break;
 	}
+
+	cls.conn_gen_packet = cls.conn_gen;
 
 	if (cls.demorecording)
 		CL_WriteDemoMessage ();

--- a/Quake/cl_main.c
+++ b/Quake/cl_main.c
@@ -72,6 +72,12 @@ cvar_t	cl_netdbg_watch_ent = {"cl_netdbg_watch_ent", "0", CVAR_NONE};
 cvar_t	cl_netdbg_pred = {"cl_netdbg_pred", "0", CVAR_NONE};
 cvar_t	cl_pred_smooth_ms = {"cl_pred_smooth_ms", "120", CVAR_NONE};
 cvar_t	cl_pred_teleport_dist = {"cl_pred_teleport_dist", "128", CVAR_NONE};
+cvar_t	cl_pred_tickrate = {"cl_pred_tickrate", "72", CVAR_ARCHIVE};
+cvar_t	cl_pred_frame_min_ms = {"cl_pred_frame_min_ms", "1.0", CVAR_ARCHIVE};
+cvar_t	cl_pred_frame_max_ms = {"cl_pred_frame_max_ms", "50.0", CVAR_ARCHIVE};
+cvar_t	cl_pred_corr_ms = {"cl_pred_corr_ms", "150", CVAR_ARCHIVE};
+cvar_t	cl_pred_corr_eps = {"cl_pred_corr_eps", "0.75", CVAR_ARCHIVE};
+cvar_t	cl_pred_corr_vel = {"cl_pred_corr_vel", "1", CVAR_ARCHIVE};
 
 cvar_t	cfg_unbindall = {"cfg_unbindall", "1", CVAR_ARCHIVE};
 
@@ -301,6 +307,195 @@ void CL_RecordPlayerSnap (void)
 
 	cl_psnap_head = (cl_psnap_head + 1) % CL_PLAYER_SNAP_HISTORY;
 	cl_psnap_count = q_min (cl_psnap_count + 1, CL_PLAYER_SNAP_HISTORY);
+}
+
+unsigned int CL_ConnGen (void)
+{
+	return cls.conn_gen;
+}
+
+unsigned int CL_ConnGenPacket (void)
+{
+	return cls.conn_gen_packet;
+}
+
+void CL_ConnGenBump (const char *reason)
+{
+	unsigned int next = cls.conn_gen + 1u;
+	unsigned int prev_drops = cls.conn_gen_drop_count;
+
+	if (next == 0u)
+		next = 1u;
+	cls.conn_gen = next;
+	cls.conn_gen_packet = next;
+	cls.conn_gen_frame = next;
+	cls.conn_gen_parse = next;
+	cls.conn_gen_drop_count = 0;
+	cls.conn_gen_bump_count++;
+
+	if (cl_netdbg_pred.value > 0.0f)
+	{
+		if (prev_drops > 0u)
+		{
+			Con_Printf ("NETDBG: conn_gen bump prev_drops %u\n", prev_drops);
+		}
+		Con_Printf ("NETDBG: conn_gen bump -> %u reason %s\n",
+			cls.conn_gen, reason ? reason : "unknown");
+	}
+}
+
+static void CL_ResetSnapshotSoftState (const char *reason)
+{
+	int i;
+	unsigned int prev_seq = cl.snapshot_baseline_seq;
+	unsigned int cand = (unsigned int)cl.snap_last_complete_seq;
+
+	if (NETSEQ_GT (cand, prev_seq))
+		prev_seq = cand;
+	cand = (unsigned int)cl.snap_last_applied_seq;
+	if (NETSEQ_GT (cand, prev_seq))
+		prev_seq = cand;
+	cand = (unsigned int)cl.snap_last_incomplete_seq;
+	if (NETSEQ_GT (cand, prev_seq))
+		prev_seq = cand;
+	if (NETSEQ_GT (prev_seq, cl.snapshot_reset_min_seq))
+		cl.snapshot_reset_min_seq = prev_seq;
+	cl.snapshot_reset_pending = true;
+
+	if (cl_max_edicts > 0)
+	{
+		for (i = 0; i < CL_SNAPSHOT_BASELINE_HISTORY; i++)
+		{
+			if (cl.snapshot_baselines[i])
+				memset (cl.snapshot_baselines[i], 0, cl_max_edicts * sizeof(snapshot_state_t));
+			if (cl.snapshot_baseline_present[i])
+				memset (cl.snapshot_baseline_present[i], 0, cl_max_edicts * sizeof(byte));
+			cl.snapshot_baseline_valid[i] = 0;
+			cl.snapshot_baseline_seqs[i] = 0;
+		}
+		if (cl.snapshot_active)
+			memset (cl.snapshot_active, 0, cl_max_edicts * sizeof(byte));
+		if (cl.snapshot_last_update_time)
+			memset (cl.snapshot_last_update_time, 0, cl_max_edicts * sizeof(double));
+		if (cl.snapshot_missing_grace_until)
+			memset (cl.snapshot_missing_grace_until, 0, cl_max_edicts * sizeof(double));
+		if (cl.snapshot_resync_start_time)
+			memset (cl.snapshot_resync_start_time, 0, cl_max_edicts * sizeof(double));
+		if (cl.snapshot_resync_end_time)
+			memset (cl.snapshot_resync_end_time, 0, cl_max_edicts * sizeof(double));
+		if (cl.snapshot_resync_from_origin)
+			memset (cl.snapshot_resync_from_origin, 0, cl_max_edicts * sizeof(vec3_t));
+		if (cl.snapshot_resync_from_angles)
+			memset (cl.snapshot_resync_from_angles, 0, cl_max_edicts * sizeof(vec3_t));
+		if (cl.snapshot_chunk)
+			memset (cl.snapshot_chunk, 0, cl_max_edicts * sizeof(snapshot_state_t));
+		if (cl.snapshot_chunk_present)
+			memset (cl.snapshot_chunk_present, 0, cl_max_edicts * sizeof(byte));
+		if (cl.snapshot_stage)
+			memset (cl.snapshot_stage, 0, cl_max_edicts * sizeof(snapshot_state_t));
+		if (cl.snapshot_stage_present)
+			memset (cl.snapshot_stage_present, 0, cl_max_edicts * sizeof(byte));
+		if (cl.snapshot_stage_remove)
+			memset (cl.snapshot_stage_remove, 0, cl_max_edicts * sizeof(byte));
+		if (cl.entity_snapshots)
+			memset (cl.entity_snapshots, 0, cl_max_edicts * CL_ENTITY_SNAP_HISTORY * sizeof(cl_entity_snap_t));
+		if (cl.entity_snap_head)
+			memset (cl.entity_snap_head, 0, cl_max_edicts * sizeof(byte));
+		if (cl.entity_snap_count)
+			memset (cl.entity_snap_count, 0, cl_max_edicts * sizeof(byte));
+	}
+
+	for (i = 0; i < CL_SNAPSHOT_CHUNK_INFLIGHT; i++)
+	{
+		cl_snapshot_chunk_asm_t *chunk = &cl.snapshot_chunk_assemblies[i];
+		int j;
+
+		for (j = 0; j < CL_SNAPSHOT_MAX_CHUNKS; j++)
+		{
+			if (chunk->buffers[j])
+				Z_Free (chunk->buffers[j]);
+			chunk->buffers[j] = NULL;
+			chunk->sizes[j] = 0;
+			chunk->received_mask[j] = 0;
+		}
+		memset (chunk, 0, sizeof(*chunk));
+	}
+
+	cl.snapshot_baseline_head = 0;
+	cl.snapshot_baseline_index = -1;
+	cl.snapshot_baseline_seq = 0;
+	cl.snap_last_applied_seq = 0;
+	cl.snap_last_complete_seq = 0;
+	cl.snap_last_incomplete_seq = 0;
+	cl.snap_last_incomplete = false;
+	cl.snap_incomplete_start_time = 0;
+	cl.has_full_snapshot = false;
+	cl.need_full_snapshot = true;
+	cl.has_valid_worldstate = false;
+	cl.snap_parse_errors = 0;
+	cl.snap_parse_consecutive = 0;
+	cl.snap_delta_mismatch = 0;
+	cl.snap_incomplete_count = 0;
+	cl.snap_full_midgame_count = 0;
+	cl.snap_full_midgame_soft_count = 0;
+	cl.snap_full_midgame_missing_grace = 0;
+	cl.snap_base_mismatch_count = 0;
+	cl.snap_decode_error_count = 0;
+	cl.snap_rem0_seq = 0;
+	cl.snap_rem0_base = 0;
+	cl.snap_rem0_count = 0;
+	cl.snap_last_server_time = 0.0;
+	cl.snap_last_arrival_time = 0.0;
+	cl.snapshot_time = 0.0;
+	cl.pred_snapshot_age = 0.0;
+	cl.pred_cmd_age = 0.0;
+	cl.pred_frame_dt = 0.0;
+	cl.pred_frame_dt_clamped = 0.0;
+	cl.pred_fixed_dt = 0.0;
+	cl.pred_error_mag = 0.0f;
+	cl.pred_error_raw_mag = 0.0f;
+	cl.pred_correction_applied = 0.0f;
+	cl.pred_correction_remaining = 0.0f;
+
+	CL_Predict_Clear ();
+
+	if (cl_netdbg_pred.value > 0.0f)
+	{
+		Con_Printf ("NETDBG: snapshot soft reset gen %u reason %s\n",
+			cls.conn_gen, reason ? reason : "unknown");
+	}
+}
+
+void CL_ResetNetSession (const char *reason, qboolean suppress_clearstate_bump)
+{
+	if (!suppress_clearstate_bump)
+		CL_ConnGenBump (reason);
+	cls.conn_gen_suppress_clearstate_bump = suppress_clearstate_bump;
+	cls.conn_gen_packet = cls.conn_gen;
+	cls.conn_gen_parse = cls.conn_gen;
+	cls.conn_gen_frame = cls.conn_gen;
+	memset (&net_last_incoming, 0, sizeof(net_last_incoming));
+	SZ_Clear (&net_message);
+	net_message.allowoverflow = false;
+	net_message.overflowed = false;
+	net_message.overflowed_once = false;
+	net_message.write_blocked = false;
+	net_message.bitpos = 0;
+	msg_readcount = 0;
+	msg_badread = false;
+	msg_readbitpos = 0;
+	CL_ResetSnapshotSoftState (reason);
+	CL_ResetSignonFragments ();
+	CL_ClearSignons ();
+	CL_ResetPlayerSnaps ();
+	cl.last_cmd_ack = 0;
+	cl.last_cmd_ack_echo = 0;
+	cl.last_snapshot_ack_sent = 0;
+	if (cl_netdbg_pred.value > 0.0f)
+	{
+		Con_Printf ("NETDBG: net session reset gen %u reason %s suppress_clearstate_bump %d\n",
+			cls.conn_gen, reason ? reason : "unknown", suppress_clearstate_bump ? 1 : 0);
+	}
 }
 
 qboolean CL_WorldReady (void)
@@ -804,12 +999,15 @@ void CL_ClearState (void)
 		PR_SwitchQCVM(NULL);
 	}
 
+	CL_ResetNetSession (cls.conn_gen_suppress_clearstate_bump ? "clearstate_suppressed" : "clearstate",
+		cls.conn_gen_suppress_clearstate_bump);
+
 	if (!sv.active)
 		Host_ClearMemory ();
 
 // wipe the entire cl structure
 	CL_FreeState ();
-	CL_ClearPlayerSnaps ();
+	CL_ResetPlayerSnaps ();
 
 	SZ_Clear (&cls.message);
 
@@ -938,6 +1136,8 @@ void CL_Disconnect (void)
 	if (key_dest == key_message)
 		Key_EndChat ();	// don't get stuck in chat mode
 
+	CL_ResetNetSession ("disconnect", false);
+
 // stop sounds (especially looping!)
 	S_StopAllSounds (true);
 	BGM_Pause ();
@@ -966,6 +1166,8 @@ void CL_Disconnect (void)
 	cls.demopaused = false;
 	cl.intermission = 0;
 	cl.sendprespawn = false;
+	cl.snapshot_reset_min_seq = 0;
+	cl.snapshot_reset_pending = false;
 	CL_ClearSignons ();
 
 	V_ResetEffects ();
@@ -1006,6 +1208,7 @@ void CL_EstablishConnection (const char *host)
 
 	cls.demonum = -1;			// not in the demo loop now
 	cls.state = ca_connected;
+	CL_ResetNetSession ("establish_connection", false);
 	CL_ClearSignons ();			// need all the signon messages before playing
 	MSG_WriteByte (&cls.message, clc_nop);	// NAT Fix from ProQuake
 }
@@ -1692,6 +1895,7 @@ int CL_ReadFromServer (void)
 	int			i; //johnfitz
 
 	CL_AdvanceTime ();
+	cls.conn_gen_frame = cls.conn_gen;
 
 	do
 	{
@@ -1702,7 +1906,27 @@ int CL_ReadFromServer (void)
 			break;
 
 		cl.last_received_message = realtime;
+		if (cls.conn_gen_packet != cls.conn_gen_frame)
+		{
+			cls.conn_gen_drop_count++;
+			if (cl_netdbg_pred.value > 0.0f)
+			{
+				Con_Printf ("NETDBG: drop packet due to conn_gen mismatch frame %u packet %u\n",
+					cls.conn_gen_frame, cls.conn_gen_packet);
+			}
+			continue;
+		}
+		cls.conn_gen_parse = cls.conn_gen_packet;
 		CL_ParseServerMessage ();
+		if (cls.conn_gen != cls.conn_gen_frame)
+		{
+			if (cl_netdbg_pred.value > 0.0f)
+			{
+				Con_Printf ("NETDBG: conn_gen changed mid-frame %u -> %u, abort remaining packets\n",
+					cls.conn_gen_frame, cls.conn_gen);
+			}
+			break;
+		}
 	} while (ret && cls.state == ca_connected);
 
 	if (cl_shownet.value)
@@ -1784,7 +2008,13 @@ void CL_SendCmd (void)
 	double			cmd_rate;
 	double			cmd_dt;
 	double			phys_dt;
+	double			pred_tickrate;
+	double			pred_dt;
 	double			max_accum;
+	double			frame_dt;
+	double			frame_dt_clamped;
+	double			min_dt;
+	double			max_dt;
 	float			prev_frametime;
 	int				max_catchup;
 	int				cmds_built;
@@ -1796,12 +2026,35 @@ void CL_SendCmd (void)
 
 	cmd_rate = cl_cmdrate.value > 0.0 ? cl_cmdrate.value : 60.0;
 	cmd_dt = 1.0 / cmd_rate;
-	phys_dt = (cl_physrate.value > 0.0) ? (1.0 / cl_physrate.value) : cmd_dt;
+	frame_dt = host_frametime;
+	min_dt = CLAMP (0.0, cl_pred_frame_min_ms.value, 100.0) * 0.001;
+	max_dt = CLAMP (1.0, cl_pred_frame_max_ms.value, 250.0) * 0.001;
+	if (max_dt < min_dt)
+		max_dt = min_dt;
+	frame_dt_clamped = CLAMP (min_dt, frame_dt, max_dt);
+	if (cl_pred_tickrate.value > 0.0)
+		pred_tickrate = cl_pred_tickrate.value;
+	else if (cl_physrate.value > 0.0)
+		pred_tickrate = cl_physrate.value;
+	else if (host_netinterval > 0.0f)
+		pred_tickrate = 1.0 / host_netinterval;
+	else
+		pred_tickrate = cmd_rate;
+	pred_tickrate = CLAMP (10.0, pred_tickrate, 200.0);
+	pred_dt = 1.0 / pred_tickrate;
+	phys_dt = pred_dt;
+	cl.pred_frame_dt = frame_dt;
+	cl.pred_frame_dt_clamped = frame_dt_clamped;
+	cl.pred_fixed_dt = pred_dt;
+	cl.pred_steps = 0;
+	cl.pred_correction_applied = 0.0f;
+	if (cls.signon != SIGNONS)
+		cl.pred_accumulator = 0.0;
 	max_catchup = (int)cl_cmd_maxbatch.value;
 	if (max_catchup < 1)
 		max_catchup = 1;
 
-	cl_cmd_accum += host_frametime;
+	cl_cmd_accum += frame_dt_clamped;
 	if (cl_cmd_accum < 0.0)
 		cl_cmd_accum = 0.0;
 	max_accum = cmd_dt * (double)max_catchup * 2.0;
@@ -1817,6 +2070,7 @@ void CL_SendCmd (void)
 	{
 		if (cls.signon == SIGNONS)
 		{
+			host_frametime = (float)cmd_dt;
 		// get basic movement from keyboard
 			CL_BaseMove (&cmd);
 
@@ -1835,9 +2089,7 @@ void CL_SendCmd (void)
 
 			// NOTE: Never gate command generation/sending on snapshot readiness.
 			// Prediction handles world-ready checks; the server still needs cmds every tick.
-			host_frametime = (float)phys_dt;
-			CL_Predict_SetupCmd (&cmd);
-			host_frametime = prev_frametime;
+			CL_Predict_SetupCmd (&cmd, cmd_dt, phys_dt);
 
 			in_attack.state &= ~2;
 			in_jump.state &= ~2;
@@ -1850,6 +2102,7 @@ void CL_SendCmd (void)
 			send_move = true;
 		}
 
+		host_frametime = prev_frametime;
 		cl_cmd_accum -= cmd_dt;
 		cmds_built++;
 		sendcmd_ran = true;
@@ -2112,6 +2365,12 @@ void CL_Init (void)
 	Cvar_RegisterVariable (&cl_netdbg_pred);
 	Cvar_RegisterVariable (&cl_pred_smooth_ms);
 	Cvar_RegisterVariable (&cl_pred_teleport_dist);
+	Cvar_RegisterVariable (&cl_pred_tickrate);
+	Cvar_RegisterVariable (&cl_pred_frame_min_ms);
+	Cvar_RegisterVariable (&cl_pred_frame_max_ms);
+	Cvar_RegisterVariable (&cl_pred_corr_ms);
+	Cvar_RegisterVariable (&cl_pred_corr_eps);
+	Cvar_RegisterVariable (&cl_pred_corr_vel);
 	Cvar_RegisterVariable (&freelook);
 	Cvar_RegisterVariable (&lookspring);
 	Cvar_RegisterVariable (&lookstrafe);

--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -319,6 +319,11 @@ static void CL_ResetSignonFragment (void)
 	cl.signon_frag_offset = 0;
 }
 
+void CL_ResetSignonFragments (void)
+{
+	CL_ResetSignonFragment ();
+}
+
 static void CL_ParseSignonChunkPayload (const byte *payload, int payload_len, byte stage, unsigned short seq)
 {
 	int offset = 0;
@@ -603,7 +608,11 @@ void CL_ParseServerInfo (void)
 //
 // wipe the client_state_t struct
 //
+	cls.conn_gen_suppress_clearstate_bump = true;
 	CL_ClearState ();
+	cls.conn_gen_suppress_clearstate_bump = false;
+	cls.conn_gen_parse = cls.conn_gen;
+	cls.conn_gen_packet = cls.conn_gen;
 
 // parse protocol version number
 	i = MSG_ReadLong ();
@@ -991,6 +1000,17 @@ static void CL_RequestFullSnapshot (const char *reason, qboolean count_parse_err
 
 	if (cls.demoplayback || cls.state != ca_connected)
 		return;
+	if (cls.signon < 2 || (cls.conn_gen_parse != 0 && cls.conn_gen_parse != cls.conn_gen))
+	{
+		cl.need_full_snapshot = true;
+		cl.has_valid_worldstate = false;
+		if (cl_netdbg_pred.value > 0.0f)
+		{
+			Con_Printf ("NETDBG: suppress snap request signon %d gen_parse %u gen %u reason %s\n",
+				cls.signon, cls.conn_gen_parse, cls.conn_gen, reason ? reason : "unknown");
+		}
+		return;
+	}
 	if (count_parse_error)
 	{
 		cl.snap_parse_errors++;
@@ -1285,6 +1305,19 @@ static qboolean CL_ShouldDropSnapshot (void)
 
 static qboolean CL_SnapshotWorldModelReady (const char *reason)
 {
+	if (cls.state != ca_connected || cls.signon < 2
+		|| (cls.conn_gen_parse != 0 && cls.conn_gen_parse != cls.conn_gen))
+	{
+		cl.need_full_snapshot = true;
+		cl.has_valid_worldstate = false;
+		if (cl_netdbg_pred.value > 0.0f)
+		{
+			Con_Printf ("NETDBG: snapshot apply gated signon %d state %d gen_parse %u gen %u reason %s\n",
+				cls.signon, cls.state, cls.conn_gen_parse, cls.conn_gen, reason ? reason : "unknown");
+		}
+		return false;
+	}
+
 	if (cl.worldmodel && cl.worldmodel->type == mod_brush)
 		return true;
 
@@ -1451,6 +1484,16 @@ static void CL_ApplySnapshotState (int entnum, const snapshot_state_t *state)
 	int			skin;
 	qmodel_t	*model;
 
+	if (!state || !cl_entities || cl_max_edicts <= 0 || entnum <= 0 || entnum >= cl_max_edicts)
+	{
+		if (cl_netdbg_pred.value > 0.0f)
+		{
+			Con_Printf ("NETDBG: skip snapshot apply ent %d max %d state %d\n",
+				entnum, cl_max_edicts, state ? 1 : 0);
+		}
+		return;
+	}
+
 	ent = CL_EntityNum (entnum);
 	forcelink = (ent->msgtime != cl.mtime[1]);
 	oldtime = ent->msgtime;
@@ -1470,12 +1513,14 @@ static void CL_ApplySnapshotState (int entnum, const snapshot_state_t *state)
 	ent->scale = state->state.scale;
 
 	i = state->state.colormap;
-	if (!i)
+	if (!i || !cl.scores || i > cl.maxclients)
+	{
+		if (i > cl.maxclients && cl_netdbg_pred.value > 0.0f)
+			Con_Printf ("NETDBG: snapshot colormap out of range %d max %d\n", i, cl.maxclients);
 		ent->colormap = vid.colormap;
+	}
 	else
 	{
-		if (i > cl.maxclients)
-			Sys_Error ("CL_ApplySnapshotState: i >= cl.maxclients");
 		ent->colormap = cl.scores[i-1].translations;
 	}
 
@@ -1802,6 +1847,8 @@ static void CL_ParseSnapshotFull (void)
 	int i;
 	qboolean drop;
 	unsigned short seq16;
+	qboolean apply_ready;
+	qboolean old_seq;
 
 	seq = (unsigned int)MSG_ReadLong ();
 	count = (unsigned short)MSG_ReadShort ();
@@ -1817,6 +1864,35 @@ static void CL_ParseSnapshotFull (void)
 		msg_readcount = net_message.cursize;
 		return;
 	}
+
+	apply_ready = CL_SnapshotWorldModelReady ("snapshot_full worldmodel");
+	if (!apply_ready && cl_netdbg_pred.value > 0.0f)
+	{
+		Con_Printf ("NETDBG: gate snapshot_full apply signon %d state %d gen_parse %u gen %u seq %u\n",
+			cls.signon, cls.state, cls.conn_gen_parse, cls.conn_gen, seq);
+	}
+	old_seq = (cl.snapshot_reset_min_seq != 0 && !NETSEQ_GT (seq, cl.snapshot_reset_min_seq));
+	if (old_seq && cl.snapshot_reset_pending)
+	{
+		qboolean seq_reset = (cl.snapshot_reset_min_seq > 4096u && seq < 1024u);
+
+		if (seq_reset)
+		{
+			if (cl_netdbg_pred.value > 0.0f)
+			{
+				Con_Printf ("NETDBG: snapshot seq reset detected seq %u reset_min %u\n",
+					seq, cl.snapshot_reset_min_seq);
+			}
+			cl.snapshot_reset_min_seq = 0;
+			old_seq = false;
+		}
+	}
+	if (old_seq && cl_netdbg_pred.value > 0.0f)
+	{
+		Con_Printf ("NETDBG: drop snapshot_full old seq %u reset_min %u\n",
+			seq, cl.snapshot_reset_min_seq);
+	}
+	drop = drop || !apply_ready || old_seq;
 
 	CL_ClearSnapshotStage ();
 
@@ -1895,6 +1971,7 @@ static void CL_ParseSnapshotFull (void)
 	cl.need_full_snapshot = false;
 	cl.has_valid_worldstate = true;
 	cl.has_full_snapshot = true;
+	cl.snapshot_reset_pending = false;
 	(void)CL_SendSnapshotAck (CL_GetSnapshotAckSeq ());
 	CL_RecordPlayerSnap ();
 	NET_DebugLogEvent (true,
@@ -1920,6 +1997,8 @@ static void CL_ParseSnapshotDelta (void)
 	qboolean need_full;
 	qboolean continuation_pending;
 	qboolean base_advanced = false;
+	qboolean apply_ready;
+	qboolean old_seq;
 
 	seq = (unsigned int)MSG_ReadLong ();
 	baseline_seq = (unsigned int)MSG_ReadLong ();
@@ -1948,6 +2027,35 @@ static void CL_ParseSnapshotDelta (void)
 		msg_readcount = net_message.cursize;
 		return;
 	}
+
+	apply_ready = CL_SnapshotWorldModelReady ("snapshot_delta worldmodel");
+	if (!apply_ready && cl_netdbg_pred.value > 0.0f)
+	{
+		Con_Printf ("NETDBG: gate snapshot_delta apply signon %d state %d gen_parse %u gen %u seq %u\n",
+			cls.signon, cls.state, cls.conn_gen_parse, cls.conn_gen, seq);
+	}
+	old_seq = (cl.snapshot_reset_min_seq != 0 && !NETSEQ_GT (seq, cl.snapshot_reset_min_seq));
+	if (old_seq && cl.snapshot_reset_pending)
+	{
+		qboolean seq_reset = (cl.snapshot_reset_min_seq > 4096u && seq < 1024u);
+
+		if (seq_reset)
+		{
+			if (cl_netdbg_pred.value > 0.0f)
+			{
+				Con_Printf ("NETDBG: snapshot seq reset detected seq %u reset_min %u\n",
+					seq, cl.snapshot_reset_min_seq);
+			}
+			cl.snapshot_reset_min_seq = 0;
+			old_seq = false;
+		}
+	}
+	if (old_seq && cl_netdbg_pred.value > 0.0f)
+	{
+		Con_Printf ("NETDBG: drop snapshot_delta old seq %u reset_min %u\n",
+			seq, cl.snapshot_reset_min_seq);
+	}
+	drop = drop || !apply_ready || old_seq;
 
 	if (baseline_seq == 0xFFFFFFFFu)
 	{
@@ -2151,6 +2259,7 @@ static void CL_ParseSnapshotDelta (void)
 		cl.snap_incomplete_start_time = 0;
 		cl.snap_parse_consecutive = 0;
 		cl.has_full_snapshot = true;
+		cl.snapshot_reset_pending = false;
 		base_advanced = true;
 		(void)CL_SendSnapshotAck (CL_GetSnapshotAckSeq ());
 		CL_RecordPlayerSnap ();
@@ -2461,6 +2570,7 @@ static qboolean CL_ParseSnapshot2FullPayload (const snapshot_header_t *header, q
 			cl.need_full_snapshot = false;
 			cl.has_full_snapshot = true;
 			cl.has_valid_worldstate = true;
+			cl.snapshot_reset_pending = false;
 			cl.snap_incomplete_count = 0;
 			CL_RecordPlayerSnap ();
 			CL_EnsureViewEntityOrigin ("snapshot2");
@@ -2536,6 +2646,7 @@ static void CL_ParseSnapshot2 (void)
 	qboolean base_advanced = false;
 	const char *snap_status = "drop";
 	int start_pos = msg_readcount;
+	qboolean old_seq;
 
 	CL_ReadSnapshotHeader (&header);
 	drop = CL_ShouldDropSnapshot ();
@@ -2566,6 +2677,29 @@ static void CL_ParseSnapshot2 (void)
 	}
 
 	if (!CL_SnapshotWorldModelReady ("snapshot2 worldmodel"))
+		drop = true;
+	old_seq = (cl.snapshot_reset_min_seq != 0 && !NETSEQ_GT (header.seq, cl.snapshot_reset_min_seq));
+	if (old_seq && cl.snapshot_reset_pending)
+	{
+		qboolean seq_reset = (cl.snapshot_reset_min_seq > 4096u && header.seq < 1024u);
+
+		if (seq_reset)
+		{
+			if (cl_netdbg_pred.value > 0.0f)
+			{
+				Con_Printf ("NETDBG: snapshot seq reset detected seq %u reset_min %u\n",
+					header.seq, cl.snapshot_reset_min_seq);
+			}
+			cl.snapshot_reset_min_seq = 0;
+			old_seq = false;
+		}
+	}
+	if (old_seq && cl_netdbg_pred.value > 0.0f)
+	{
+		Con_Printf ("NETDBG: drop snapshot2 old seq %u reset_min %u\n",
+			header.seq, cl.snapshot_reset_min_seq);
+	}
+	if (old_seq)
 		drop = true;
 
 	NET_DebugLogEvent (true,
@@ -3120,6 +3254,7 @@ static void CL_ParseSnapshot2 (void)
 			cl.snap_parse_consecutive = 0;
 			cl.snap_incomplete_count = 0;
 			cl.has_full_snapshot = true;
+			cl.snapshot_reset_pending = false;
 			base_advanced = true;
 			CL_RecordPlayerSnap ();
 			CL_EnsureViewEntityOrigin ("snapshot2");
@@ -3378,7 +3513,16 @@ void CL_ParseClientdata (void)
 		for (i = 0; i < 3; i++)
 			viewangles[i] = MSG_ReadAngle16 (cl.protocolflags);
 
-		CL_Predict_ServerUpdate (ack, origin, velocity, viewangles, cl.onground);
+		if (cl.has_valid_worldstate && cls.signon >= 2
+			&& (cls.conn_gen_parse == 0 || cls.conn_gen_parse == cls.conn_gen))
+		{
+			CL_Predict_ServerUpdate (ack, origin, velocity, viewangles, cl.onground);
+		}
+		else if (cl_netdbg_pred.value > 0.0f)
+		{
+			Con_Printf ("NETDBG: skip pred update signon %d valid %d gen_parse %u gen %u ack %u\n",
+				cls.signon, cl.has_valid_worldstate ? 1 : 0, cls.conn_gen_parse, cls.conn_gen, ack);
+		}
 	}
 
 	CL_SetHudStat (STAT_WEAPONFRAME);
@@ -3582,6 +3726,7 @@ void CL_ParseServerMessage (void)
 	int			prevcmd;
 	int			prevcmd_offset;
 	int			cmd_offset;
+	unsigned int		parse_gen;
 
 //
 // if recording demos, copy the message out
@@ -3599,6 +3744,17 @@ void CL_ParseServerMessage (void)
 	MSG_BeginReading ();
 
 	CL_NetDebugHeader ();
+	parse_gen = cls.conn_gen_parse ? cls.conn_gen_parse : cls.conn_gen;
+	if (parse_gen != cls.conn_gen)
+	{
+		cls.conn_gen_drop_count++;
+		if (cl_netdbg_pred.value > 0.0f)
+		{
+			Con_Printf ("NETDBG: drop parse start due to conn_gen mismatch parse %u current %u\n",
+				parse_gen, cls.conn_gen);
+		}
+		return;
+	}
 
 	lastcmd = -1;
 	lastcmd_offset = -1;
@@ -3613,6 +3769,18 @@ void CL_ParseServerMessage (void)
 
 	while (1)
 	{
+		if (parse_gen != cls.conn_gen)
+		{
+			cls.conn_gen_drop_count++;
+			if (cl_netdbg_pred.value > 0.0f)
+			{
+				Con_Printf ("NETDBG: drop parse mid-packet due to conn_gen mismatch parse %u current %u\n",
+					parse_gen, cls.conn_gen);
+			}
+			msg_readcount = net_message.cursize;
+			msg_badread = false;
+			return;
+		}
 		if (msg_badread)
 		{
 			CL_BadServerMessage ("message read past end", -1, msg_readcount,

--- a/Quake/cl_predict.c
+++ b/Quake/cl_predict.c
@@ -10,6 +10,7 @@ extern cvar_t sv_friction;
 extern cvar_t sv_stopspeed;
 extern cvar_t sv_gravity;
 extern cvar_t cl_netdebug_parse;
+extern cvar_t cl_cmd_maxbatch;
 
 typedef struct
 {
@@ -22,8 +23,12 @@ typedef struct
 typedef struct
 {
 	usercmd_t	cmds[CMD_RING];
+	double		cmd_dt[CMD_RING];
+	double		pred_dt[CMD_RING];
+	double		accum_phase[CMD_RING];
 	unsigned int	seq_latest;
 	unsigned int	seq_acked;
+	double		last_ack_time;
 	qboolean	has_base;
 	cl_pred_state_t	base;
 	cl_pred_state_t	predicted;
@@ -33,6 +38,7 @@ static cl_pred_t cl_pred;
 static qboolean cl_netdbg_predict_ran;
 static qboolean cl_pred_warned_solid;
 static vec3_t cl_pred_error;
+static vec3_t cl_pred_vel_error;
 
 #define CL_PREDICT_MAX_CLIP_PLANES 5
 #define CL_PREDICT_STEP_SIZE 18.0f
@@ -95,6 +101,8 @@ static qboolean CL_Predict_IsEnabled (void)
 		return false;
 	if (cl.intermission)
 		return false;
+	if (cls.conn_gen_parse != 0 && cls.conn_gen_parse != cls.conn_gen)
+		return false;
 	if (!cl.has_valid_worldstate)
 		return false;
 	if (!CL_WorldReady ())
@@ -105,38 +113,62 @@ static qboolean CL_Predict_IsEnabled (void)
 static void CL_Predict_ApplyToClient (void)
 {
 	vec3_t smooth_origin;
-	float smooth_ms;
+	vec3_t smooth_velocity;
+	float corr_ms;
 	float decay;
 	vec3_t correction;
+	vec3_t vel_correction;
+	float corr_len = 0.0f;
 
 	if (!CL_Predict_IsEnabled () || !cl_pred.has_base)
 		return;
 
-	smooth_ms = cl_pred_smooth_ms.value;
-	if (smooth_ms <= 0.0f)
+	corr_ms = cl_pred_corr_ms.value;
+	if (corr_ms <= 0.0f)
+		corr_ms = cl_pred_smooth_ms.value;
+	if (corr_ms <= 0.0f)
+	{
 		VectorClear (cl_pred_error);
+		VectorClear (cl_pred_vel_error);
+	}
 
 	VectorAdd (cl_pred.predicted.origin, cl_pred_error, smooth_origin);
+	if (cl_pred_corr_vel.value != 0.0f)
+		VectorAdd (cl_pred.predicted.velocity, cl_pred_vel_error, smooth_velocity);
+	else
+		VectorCopy (cl_pred.predicted.velocity, smooth_velocity);
 	VectorCopy (smooth_origin, cl.simorg);
 	VectorCopy (smooth_origin, cl_entities[cl.viewentity].origin);
 	VectorCopy (smooth_origin, cl_entities[cl.viewentity].msg_origins[0]);
 	VectorCopy (smooth_origin, cl_entities[cl.viewentity].msg_origins[1]);
-	VectorCopy (cl_pred.predicted.velocity, cl.mvelocity[0]);
-	VectorCopy (cl_pred.predicted.velocity, cl.mvelocity[1]);
+	VectorCopy (smooth_velocity, cl.mvelocity[0]);
+	VectorCopy (smooth_velocity, cl.mvelocity[1]);
 	cl.onground = cl_pred.predicted.onground;
 
-	if (smooth_ms > 0.0f)
+	if (corr_ms > 0.0f)
 	{
-		decay = host_frametime / (smooth_ms * 0.001f);
+		decay = host_frametime / (corr_ms * 0.001f);
 		decay = CLAMP (0.0f, decay, 1.0f);
 		VectorScale (cl_pred_error, decay, correction);
 		VectorSubtract (cl_pred_error, correction, cl_pred_error);
+		corr_len = VectorLength (correction);
+		if (cl_pred_corr_vel.value != 0.0f)
+		{
+			VectorScale (cl_pred_vel_error, decay, vel_correction);
+			VectorSubtract (cl_pred_vel_error, vel_correction, cl_pred_vel_error);
+		}
 		if (cl_netdbg_pred.value > 0.0f)
 		{
-			Con_Printf ("NETDBG: pred_smooth apply %.2f remaining %.2f\n",
-				VectorLength (correction), VectorLength (cl_pred_error));
+			Con_Printf ("NETDBG: pred_corr apply %.2f remaining %.2f window %.1fms\n",
+				corr_len, VectorLength (cl_pred_error), corr_ms);
 		}
 	}
+
+	cl.pred_correction_applied += corr_len;
+	cl.pred_correction_remaining = VectorLength (cl_pred_error);
+	cl.pred_error_mag = cl.pred_correction_remaining;
+	cl.pred_snapshot_age = (cl.snap_last_arrival_time > 0.0) ? (realtime - cl.snap_last_arrival_time) : 0.0;
+	cl.pred_cmd_age = (cl_pred.last_ack_time > 0.0) ? (realtime - cl_pred.last_ack_time) : 0.0;
 
 	CL_EnsureViewEntityOrigin ("predict");
 }
@@ -550,25 +582,89 @@ static void CL_Predict_SimulateCmd (cl_pred_state_t *state, const usercmd_t *cmd
 		state->velocity[2] = 0;
 }
 
+static int CL_Predict_RunCommand (cl_pred_state_t *state, const usercmd_t *cmd, double cmd_dt, double pred_dt, int max_steps)
+{
+	double accum;
+	double max_accum;
+	int steps = 0;
+
+	if (cmd_dt <= 0.0)
+		cmd_dt = host_frametime > 0.0 ? host_frametime : 0.015;
+	if (pred_dt <= 0.0)
+		pred_dt = cmd_dt;
+	pred_dt = CLAMP (0.001, pred_dt, 0.1);
+	if (max_steps < 1)
+		max_steps = 1;
+	max_accum = pred_dt * (double)max_steps;
+	accum = cl.pred_accumulator + cmd_dt;
+	if (accum > max_accum)
+		accum = max_accum;
+
+	while (accum >= pred_dt && steps < max_steps)
+	{
+		host_frametime = (float)pred_dt;
+		CL_Predict_SimulateCmd (state, cmd);
+		accum -= pred_dt;
+		steps++;
+	}
+
+	if (steps == 0 && accum > 0.0)
+	{
+		host_frametime = (float)accum;
+		CL_Predict_SimulateCmd (state, cmd);
+		accum = 0.0;
+		steps = 1;
+	}
+
+	cl.pred_accumulator = accum;
+	return steps;
+}
+
 void CL_Predict_Clear (void)
 {
 	memset (&cl_pred, 0, sizeof(cl_pred));
 	cl_pred_warned_solid = false;
 	VectorClear (cl_pred_error);
+	VectorClear (cl_pred_vel_error);
+	cl.pred_accumulator = 0.0;
+	cl.pred_steps = 0;
 }
 
-void CL_Predict_SetupCmd (usercmd_t *cmd)
+void CL_Predict_SetupCmd (usercmd_t *cmd, double cmd_dt, double pred_dt)
 {
+	int max_steps;
+	int steps;
+	float prev_frametime = host_frametime;
+
 	cl_netdbg_predict_ran = false;
 	cmd->sequence = cl_pred.seq_latest + 1;
 	cl_pred.seq_latest = cmd->sequence;
 	cl_pred.cmds[cmd->sequence % CMD_RING] = *cmd;
+	if (cmd_dt <= 0.0)
+		cmd_dt = prev_frametime > 0.0f ? prev_frametime : 0.015;
+	if (pred_dt <= 0.0)
+		pred_dt = cmd_dt;
+	pred_dt = CLAMP (0.001, pred_dt, 0.1);
+	cl_pred.cmd_dt[cmd->sequence % CMD_RING] = cmd_dt;
+	cl_pred.pred_dt[cmd->sequence % CMD_RING] = pred_dt;
 
 	if (!CL_Predict_IsEnabled () || !cl_pred.has_base)
+	{
+		cl.pred_accumulator = 0.0;
+		cl_pred.accum_phase[cmd->sequence % CMD_RING] = cl.pred_accumulator;
 		return;
+	}
 
-	CL_Predict_SimulateCmd (&cl_pred.predicted, cmd);
+	max_steps = (int)cl_cmd_maxbatch.value;
+	if (max_steps < 1)
+		max_steps = 1;
+	max_steps *= 4;
+	steps = CL_Predict_RunCommand (&cl_pred.predicted, cmd, cmd_dt, pred_dt, max_steps);
+	cl.pred_steps += (unsigned int)steps;
+	cl_pred.accum_phase[cmd->sequence % CMD_RING] = cl.pred_accumulator;
+	host_frametime = (float)cmd_dt;
 	CL_Predict_ApplyToClient ();
+	host_frametime = prev_frametime;
 	cl_netdbg_predict_ran = true;
 }
 
@@ -589,8 +685,18 @@ void CL_Predict_ServerUpdate (unsigned int ack, const vec3_t origin, const vec3_
 	unsigned int seq;
 	float correction;
 	vec3_t error;
-	float error_len;
+	vec3_t vel_error;
+	float error_len = 0.0f;
 	float teleport_dist = cl_pred_teleport_dist.value;
+	float epsilon = q_max (0.0f, cl_pred_corr_eps.value);
+	float corr_ms = cl_pred_corr_ms.value > 0.0f ? cl_pred_corr_ms.value : cl_pred_smooth_ms.value;
+	qboolean apply_correction = false;
+	qboolean teleported = false;
+	double cmd_dt;
+	double step_dt;
+	int max_steps;
+	int steps;
+	float prev_frametime = host_frametime;
 
 	if (cl_pred.has_base && !CL_Predict_SeqNewer (ack, cl_pred.seq_acked))
 		return;
@@ -608,10 +714,18 @@ void CL_Predict_ServerUpdate (unsigned int ack, const vec3_t origin, const vec3_
 	}
 
 	cl_pred.seq_acked = ack;
+	cl_pred.last_ack_time = realtime;
+	cl.snap_last_arrival_time = realtime;
+	cl.pred_snapshot_age = 0.0;
+	if (cl_pred_corr_vel.value == 0.0f)
+		VectorClear (cl_pred_vel_error);
 	if (cl_pred.has_base)
 	{
 		VectorSubtract (origin, cl_pred.predicted.origin, error);
 		error_len = VectorLength (error);
+		cl.pred_error_raw_mag = error_len;
+		apply_correction = (error_len > epsilon && corr_ms > 0.0f);
+		teleported = (teleport_dist > 0.0f && error_len > teleport_dist);
 		if (cl_netdbg_pred.value > 0.0f)
 		{
 			Con_Printf ("NETDBG: pred_error %.2f (server %.1f %.1f %.1f client %.1f %.1f %.1f)\n",
@@ -619,18 +733,37 @@ void CL_Predict_ServerUpdate (unsigned int ack, const vec3_t origin, const vec3_
 				origin[0], origin[1], origin[2],
 				cl_pred.predicted.origin[0], cl_pred.predicted.origin[1], cl_pred.predicted.origin[2]);
 		}
-		if (teleport_dist > 0.0f && error_len > teleport_dist)
+		if (teleported)
 		{
 			VectorClear (cl_pred_error);
+			VectorClear (cl_pred_vel_error);
+			cl.pred_accumulator = 0.0;
+			if (cl_netdbg_pred.value > 0.0f)
+			{
+				Con_Printf ("NETDBG: pred teleport reset err %.2f dist %.2f\n",
+					error_len, teleport_dist);
+			}
 		}
-		else
+		else if (apply_correction)
 		{
 			VectorAdd (cl_pred_error, error, cl_pred_error);
+			if (cl_pred_corr_vel.value != 0.0f)
+			{
+				VectorSubtract (velocity, cl_pred.predicted.velocity, vel_error);
+				VectorAdd (cl_pred_vel_error, vel_error, cl_pred_vel_error);
+			}
+			if (cl_netdbg_pred.value > 0.0f)
+			{
+				Con_Printf ("NETDBG: pred correction queued err %.2f eps %.2f window %.1fms\n",
+					error_len, epsilon, corr_ms);
+			}
 		}
 	}
 	else
 	{
 		VectorClear (cl_pred_error);
+		VectorClear (cl_pred_vel_error);
+		cl.pred_error_raw_mag = 0.0f;
 	}
 	VectorCopy (origin, cl_pred.base.origin);
 	VectorCopy (origin, cl.simorg);
@@ -643,16 +776,39 @@ void CL_Predict_ServerUpdate (unsigned int ack, const vec3_t origin, const vec3_
 	if (!CL_Predict_IsEnabled ())
 		return;
 
+	max_steps = (int)cl_cmd_maxbatch.value;
+	if (max_steps < 1)
+		max_steps = 1;
+	max_steps *= 4;
+	cl.pred_accumulator = 0.0;
+	if (!teleported && !CL_Predict_SeqNewer (ack, cl_pred.seq_latest))
+	{
+		usercmd_t *ack_cmd = &cl_pred.cmds[ack % CMD_RING];
+
+		if (ack_cmd->sequence == ack)
+			cl.pred_accumulator = cl_pred.accum_phase[ack % CMD_RING];
+	}
+
 	for (seq = ack + 1; !CL_Predict_SeqNewer (seq, cl_pred.seq_latest); seq++)
 	{
 		usercmd_t cmd;
 
 		if (!CL_Predict_GetCmd (seq, &cmd))
 			break;
-		CL_Predict_SimulateCmd (&cl_pred.predicted, &cmd);
+		cmd_dt = cl_pred.cmd_dt[seq % CMD_RING];
+		step_dt = cl_pred.pred_dt[seq % CMD_RING];
+		if (cmd_dt <= 0.0)
+			cmd_dt = cl.pred_frame_dt_clamped > 0.0 ? cl.pred_frame_dt_clamped : prev_frametime;
+		if (step_dt <= 0.0)
+			step_dt = cl.pred_fixed_dt > 0.0 ? cl.pred_fixed_dt : cmd_dt;
+		steps = CL_Predict_RunCommand (&cl_pred.predicted, &cmd, cmd_dt, step_dt, max_steps);
+		cl.pred_steps += (unsigned int)steps;
+		cl_pred.accum_phase[seq % CMD_RING] = cl.pred_accumulator;
 	}
 
+	host_frametime = prev_frametime;
 	CL_Predict_ApplyToClient ();
+	host_frametime = prev_frametime;
 }
 
 void CL_Predict_Reapply (void)

--- a/Quake/client.h
+++ b/Quake/client.h
@@ -25,7 +25,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 // client.h
 
-#include "../common/lightgrid.h"
+typedef struct lightgrid_s lightgrid_t;
 
 // snapshot baseline history
 #define CL_SNAPSHOT_BASELINE_HISTORY 4
@@ -207,6 +207,13 @@ typedef struct
 
 // connection information
 	int		signon;			// 0 to SIGNONS
+	unsigned int	conn_gen;		// monotonically increasing connection/map generation id
+	unsigned int	conn_gen_packet;	// generation observed when dequeuing current packet
+	unsigned int	conn_gen_frame;	// generation at frame start
+	unsigned int	conn_gen_parse;	// generation being parsed
+	unsigned int	conn_gen_drop_count;	// late packets dropped due to generation mismatch
+	unsigned int	conn_gen_bump_count;	// total generation bumps
+	qboolean	conn_gen_suppress_clearstate_bump;	// avoid mid-packet bump during expected signon resets
 	struct qsocket_s	*netcon;
 	sizebuf_t	message;		// writing buffer to send to server
 
@@ -292,6 +299,17 @@ typedef struct
 	double		snapshot_time;		// time applied for snapshot entity state
 	double		snap_last_server_time;	// last applied snapshot time
 	double		snap_last_arrival_time;	// realtime of last snapshot apply
+	double		pred_frame_dt;		// unclamped frame dt used for prediction accumulator
+	double		pred_frame_dt_clamped;	// clamped frame dt used for prediction accumulator
+	double		pred_fixed_dt;		// fixed prediction step dt
+	double		pred_accumulator;	// accumulated time for fixed-step prediction
+	unsigned int	pred_steps;		// number of prediction steps run this frame
+	float		pred_error_mag;		// smoothed prediction error magnitude
+	float		pred_error_raw_mag;	// raw prediction error magnitude
+	float		pred_correction_applied;	// correction applied this frame
+	float		pred_correction_remaining;	// remaining correction after smoothing
+	double		pred_snapshot_age;	// age of last snapshot sample
+	double		pred_cmd_age;		// age since last command ack
 
 
 	float		last_received_message;	// (realtime) for net trouble icon
@@ -317,6 +335,8 @@ typedef struct
 	int			num_statics;	// held in cl_staticentities array
 	entity_t	viewent;			// the gun model
 	unsigned int snapshot_baseline_seq;
+	unsigned int snapshot_reset_min_seq;
+	qboolean	snapshot_reset_pending;
 	unsigned short snap_last_applied_seq;
 	unsigned short snap_last_complete_seq;
 	unsigned short snap_last_incomplete_seq;
@@ -450,6 +470,12 @@ extern	cvar_t	cl_netdbg_watch_ent;
 extern	cvar_t	cl_netdbg_pred;
 extern	cvar_t	cl_pred_smooth_ms;
 extern	cvar_t	cl_pred_teleport_dist;
+extern	cvar_t	cl_pred_tickrate;
+extern	cvar_t	cl_pred_frame_min_ms;
+extern	cvar_t	cl_pred_frame_max_ms;
+extern	cvar_t	cl_pred_corr_ms;
+extern	cvar_t	cl_pred_corr_eps;
+extern	cvar_t	cl_pred_corr_vel;
 extern	float	cl_lerpfrac;
 
 
@@ -519,7 +545,7 @@ void CL_AccumulateCmd (void);
 void CL_SendCmd (void);
 void CL_SendMove (const usercmd_t *cmd);
 void CL_Predict_Clear (void);
-void CL_Predict_SetupCmd (usercmd_t *cmd);
+void CL_Predict_SetupCmd (usercmd_t *cmd, double cmd_dt, double pred_dt);
 void CL_Predict_ServerUpdate (unsigned int ack, const vec3_t origin, const vec3_t velocity, const vec3_t viewangles, qboolean onground);
 void CL_Predict_Reapply (void);
 qboolean CL_Predict_GetCmd (unsigned int seq, usercmd_t *out);
@@ -537,6 +563,10 @@ void CL_ResetPlayerSnaps (void);
 
 void CL_FreeState(void);
 void CL_ClearState (void);
+void CL_ResetNetSession (const char *reason, qboolean suppress_clearstate_bump);
+void CL_ConnGenBump (const char *reason);
+unsigned int CL_ConnGen (void);
+unsigned int CL_ConnGenPacket (void);
 
 //
 // cl_demo.c
@@ -546,6 +576,7 @@ int CL_GetMessage (void);
 void CL_ClearSignons (void);
 void CL_AdvanceTime (void);
 void CL_FinishDemoFrame (void);
+void CL_ResetSignonFragments (void);
 void CL_AddDemoRewindSound (int entnum, int channel, sfx_t *sfx, vec3_t pos, int vol, float atten);
 
 void CL_Stop_f (void);

--- a/Quake/gl_screen.c
+++ b/Quake/gl_screen.c
@@ -1030,6 +1030,64 @@ void SCR_DrawDevStats (void)
 
 /*
 ==============
+SCR_DrawNetDbgPred
+==============
+*/
+static void SCR_DrawNetDbgPred (void)
+{
+	char	str[96];
+	int	lines = 8;
+	int	y = 25 - lines;
+	int	x = 22 * 8;
+	double snap_age_ms;
+	double cmd_age_ms;
+	double frame_dt_ms;
+	double frame_dt_clamped_ms;
+	double fixed_dt_ms;
+	double pred_tickrate;
+
+	if (cl_netdbg_pred.value <= 0.0f)
+		return;
+
+	snap_age_ms = cl.pred_snapshot_age * 1000.0;
+	cmd_age_ms = cl.pred_cmd_age * 1000.0;
+	frame_dt_ms = cl.pred_frame_dt * 1000.0;
+	frame_dt_clamped_ms = cl.pred_frame_dt_clamped * 1000.0;
+	fixed_dt_ms = cl.pred_fixed_dt * 1000.0;
+	pred_tickrate = (cl.pred_fixed_dt > 0.0) ? (1.0 / cl.pred_fixed_dt) : 0.0;
+
+	GL_SetCanvas (CANVAS_BOTTOMLEFT);
+	Draw_Fill (x, y * 8, 30 * 8, lines * 8, 0, 0.5);
+
+	sprintf (str, "netdbg pred | gen %u/%u drop %u",
+		cls.conn_gen_parse, cls.conn_gen, cls.conn_gen_drop_count);
+	Draw_String (x, (y++) * 8 - x, str);
+
+	sprintf (str, "pred err    |%6.2f raw %6.2f", cl.pred_error_mag, cl.pred_error_raw_mag);
+	Draw_String (x, (y++) * 8 - x, str);
+
+	sprintf (str, "pred corr   |%6.2f rem %6.2f", cl.pred_correction_applied, cl.pred_correction_remaining);
+	Draw_String (x, (y++) * 8 - x, str);
+
+	sprintf (str, "ages (ms)   |%6.1f cmd %6.1f", snap_age_ms, cmd_age_ms);
+	Draw_String (x, (y++) * 8 - x, str);
+
+	sprintf (str, "pred steps  |%5u acc %6.3f", cl.pred_steps, cl.pred_accumulator);
+	Draw_String (x, (y++) * 8 - x, str);
+
+	sprintf (str, "dt frame ms |%6.2f clamp %6.2f", frame_dt_ms, frame_dt_clamped_ms);
+	Draw_String (x, (y++) * 8 - x, str);
+
+	sprintf (str, "dt fixed ms |%6.2f tick %6.1f", fixed_dt_ms, pred_tickrate);
+	Draw_String (x, (y++) * 8 - x, str);
+
+	sprintf (str, "snap reset  |min %10u pend %d",
+		cl.snapshot_reset_min_seq, cl.snapshot_reset_pending ? 1 : 0);
+	Draw_String (x, (y++) * 8 - x, str);
+}
+
+/*
+==============
 SCR_DrawExposureDebug
 ==============
 */
@@ -2228,6 +2286,7 @@ void SCR_UpdateScreen (void)
 		SCR_CheckDrawCenterString ();
 		Sbar_Draw ();
 		SCR_DrawDevStats (); //johnfitz
+		SCR_DrawNetDbgPred ();
 		SCR_DrawExposureDebug ();
 		SCR_DrawGodraysDebug ();
 		SCR_DrawClock (); //johnfitz

--- a/Quake/host_cmd.c
+++ b/Quake/host_cmd.c
@@ -22,6 +22,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 */
 
 #include "quakedef.h"
+#include "arch_def.h"
+#include "net_sys.h"
+#include "net_defs.h"
 #include "q_ctype.h"
 #include "json.h"
 #include <time.h>
@@ -1963,6 +1966,125 @@ SERVER TRANSITIONS
 ===============================================================================
 */
 
+#define MAPCYCLE_MAX_MAPS 16
+
+typedef struct
+{
+	qboolean	active;
+	double		interval;
+	int		map_count;
+	int		index;
+	char		maps[MAPCYCLE_MAX_MAPS][MAX_QPATH];
+} mapcycle_state_t;
+
+static mapcycle_state_t mapcycle_state;
+static void Host_MapCycle_Poll (void *unused);
+static PollProcedure mapcycle_pollproc = {NULL, 0.0, Host_MapCycle_Poll};
+
+static void Host_MapCycle_Stop (const char *reason)
+{
+	if (!mapcycle_state.active)
+		return;
+
+	mapcycle_state.active = false;
+	mapcycle_state.interval = 0.0;
+	mapcycle_state.map_count = 0;
+	mapcycle_state.index = 0;
+
+	if (reason)
+		Con_Printf ("mapcycle: stopped (%s)\n", reason);
+	else
+		Con_Printf ("mapcycle: stopped\n");
+}
+
+static void Host_MapCycle_Poll (void *unused)
+{
+	const char *map;
+
+	(void)unused;
+
+	if (!mapcycle_state.active)
+		return;
+	if (mapcycle_state.map_count <= 0)
+	{
+		Host_MapCycle_Stop ("no maps");
+		return;
+	}
+	if (!sv.active || (cls.state != ca_dedicated && cls.signon != SIGNONS))
+	{
+		SchedulePollProcedure (&mapcycle_pollproc, 1.0);
+		return;
+	}
+
+	map = mapcycle_state.maps[mapcycle_state.index];
+	mapcycle_state.index = (mapcycle_state.index + 1) % mapcycle_state.map_count;
+	if (map && *map)
+	{
+		Con_Printf ("mapcycle: map %s (interval %.1fs)\n", map, mapcycle_state.interval);
+		Cbuf_AddText (va("map %s\n", map));
+	}
+	SchedulePollProcedure (&mapcycle_pollproc, mapcycle_state.interval);
+}
+
+static void Host_MapCycle_Start_f (void)
+{
+	double interval;
+	int map_count;
+	int i;
+
+	if (cmd_source != src_command)
+		return;
+	if (Cmd_Argc () < 3)
+	{
+		Con_Printf ("mapcycle_start <interval_seconds> <map1> [map2 ...]\n");
+		return;
+	}
+
+	interval = atof (Cmd_Argv (1));
+	if (interval <= 0.0)
+		interval = 5.0;
+	interval = CLAMP (1.0, interval, 300.0);
+	map_count = Cmd_Argc () - 2;
+	if (map_count > MAPCYCLE_MAX_MAPS)
+		map_count = MAPCYCLE_MAX_MAPS;
+	if (map_count <= 0)
+	{
+		Con_Printf ("mapcycle_start requires at least one map name\n");
+		return;
+	}
+
+	memset (&mapcycle_state, 0, sizeof(mapcycle_state));
+	mapcycle_state.active = true;
+	mapcycle_state.interval = interval;
+	mapcycle_state.map_count = map_count;
+	mapcycle_state.index = 0;
+
+	for (i = 0; i < map_count; ++i)
+	{
+		char *p;
+
+		q_strlcpy (mapcycle_state.maps[i], Cmd_Argv (i + 2), sizeof(mapcycle_state.maps[i]));
+		p = strstr (mapcycle_state.maps[i], ".bsp");
+		if (p && p[4] == '\0')
+			*p = '\0';
+	}
+
+	Con_Printf ("mapcycle: starting interval %.1fs maps %d\n", mapcycle_state.interval, mapcycle_state.map_count);
+	SchedulePollProcedure (&mapcycle_pollproc, 0.0);
+}
+
+static void Host_MapCycle_Stop_f (void)
+{
+	if (cmd_source != src_command)
+		return;
+	if (!mapcycle_state.active)
+	{
+		Con_Printf ("mapcycle: not running\n");
+		return;
+	}
+	Host_MapCycle_Stop ("command");
+}
+
 /*
 ======================
 Host_Map_f
@@ -2196,7 +2318,7 @@ static void Host_Reconnect_f (void)
 		return;
 
 	SCR_BeginLoadingPlaque ();
-	CL_ClearSignons ();		// need new connection messages
+	CL_ResetNetSession ("reconnect", false);
 }
 
 /*
@@ -3865,6 +3987,8 @@ void Host_InitCommands (void)
 	Cmd_AddCommand ("changelevel", Host_Changelevel_f);
 	Cmd_AddCommand ("connect", Host_Connect_f);
 	Cmd_AddCommand_Console ("reconnect", Host_Reconnect_f);
+	Cmd_AddCommand_Console ("mapcycle_start", Host_MapCycle_Start_f);
+	Cmd_AddCommand_Console ("mapcycle_stop", Host_MapCycle_Stop_f);
 	Cmd_AddCommand_ClientCommand ("name", Host_Name_f);
 	Cmd_AddCommand_ClientCommand ("noclip", Host_Noclip_f);
 	Cmd_AddCommand_ClientCommand ("setpos", Host_SetPos_f); //QuakeSpasm

--- a/common/lightgrid.c
+++ b/common/lightgrid.c
@@ -1,4 +1,4 @@
-#include "quakedef.h"
+#include "../Quake/quakedef.h"
 #include "lightgrid.h"
 
 void Lightgrid_Free(lightgrid_t *lg)

--- a/common/lightgrid.h
+++ b/common/lightgrid.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "quakedef.h"
+#include "../Quake/q_stdinc.h"
 
 typedef struct lightcell_s {
     vec3_t rgb;


### PR DESCRIPTION
### Motivation

- Prevent crashes and inconsistent state when a server changes map / reconnects by ensuring late packets or stale snapshot chunks from a prior session cannot be parsed or applied.  
- Reduce local-view micro-jitter by stabilizing client-side prediction timestep and smoothing correction application.  
- Add targeted instrumentation and a deterministic map-cycle command to exercise transitions and aid debugging.

### Description

- Connection / generation guard: introduce a monotonic `conn_gen` and per-packet `conn_gen_packet`/`conn_gen_parse` bookkeeping and drop any packets or in-progress parse runs that belong to a previous generation; expose bump helpers `CL_ConnGenBump` and `CL_ResetNetSession` and invoke resets on `CL_ClearState`/`CL_Disconnect`/connect/reconnect flows. (key files: `Quake/cl_main.c`, `Quake/cl_parse.c`, `Quake/cl_demo.c`).
- Snapshot hardening & soft-reset: added `CL_ResetSnapshotSoftState` to clear snapshot buffers, chunk accumulators and baseline history on map/session change while tracking a reset window and dropping old sequence numbers after a reset to avoid applying late snapshots. Snapshot application is gated on signon/world readiness and generation checks. (key files: `Quake/cl_parse.c`, `Quake/cl_main.c`).
- Prediction timestep & smoothing: added clamped frame-dt + fixed-step predictor, per-command dt history and accumulator, limited re‑application steps and blended corrections controlled by new cvars: `cl_pred_tickrate`, `cl_pred_frame_min_ms`, `cl_pred_frame_max_ms`, `cl_pred_corr_ms`, `cl_pred_corr_eps`, `cl_pred_corr_vel`. Prediction loop rewritten to run deterministic steps and to only blend/apply correction when error exceeds epsilon. (key files: `Quake/cl_main.c`, `Quake/cl_predict.c`, `Quake/client.h`).
- Safety & defensive guards: bounds checks and nil checks added around snapshot/entity application to avoid crashes from malformed or late packets; snapshot signon/parse flows made robust to chunking and decode errors. (key files: `Quake/cl_parse.c`, `Quake/cl_main.c`).
- Instrumentation & overlay: added runtime debug counters and an on-screen dev overlay `SCR_DrawNetDbgPred` toggled by `cl_netdbg_pred` showing generation, prediction error, correction applied, ages, dt and snapshot reset state. (key files: `Quake/gl_screen.c`, `Quake/cl_main.c`, `Quake/cl_predict.c`).
- Repro harness: simple `mapcycle_start <interval> <map1> [map2 ...]` / `mapcycle_stop` commands added for deterministic map-change cycling to reproduce cross-map crash scenarios. (key file: `Quake/host_cmd.c`).
- Build fixes: removed circular include by forward-declaring `lightgrid_t` in `client.h` and fixed `common/lightgrid` includes so the tree builds cleanly. (key files: `Quake/client.h`, `common/lightgrid.h`, `common/lightgrid.c`).

### Testing

- Performed an out-of-source configure and full build with CMake and Ninja/Make: `cmake -S . -B build` then `cmake --build build -j4`, which completed successfully after installing needed SDL2 dev packages and fixing include issues; build result: success.  
- Ran incremental compile after edits to ensure no compile-time regressions; build errors encountered while iterating were fixed (include & type ordering) and final build passed.  
- No unit tests present; validation focused on full project build and exercising the following runtime flows manually via code paths: `CL_EstablishConnection` / `CL_Disconnect` / signon parsing and snapshot application (instrumentation messages available under `cl_netdbg_pred`) and the new `mapcycle_start` command for automated map-change stress.  

Files with primary changes: `Quake/cl_main.c`, `Quake/cl_parse.c`, `Quake/cl_predict.c`, `Quake/cl_demo.c`, `Quake/client.h`, `Quake/gl_screen.c`, `Quake/host_cmd.c`, `common/lightgrid.c`, `common/lightgrid.h`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974c54750c0832ebc1f60cd5970937f)