### PR TITLE
Fix lightgrid precompiled header include

### DIFF
--- a/common/lightgrid.c
+++ b/common/lightgrid.c
@@ -1,4 +1,4 @@
-#include "../Quake/quakedef.h"
+#include "quakedef.h"
 #include "lightgrid.h"
 
 void Lightgrid_Free(lightgrid_t *lg)


### PR DESCRIPTION
### Motivation
- Resolve Visual Studio build error `C1010` by ensuring `lightgrid.c` uses the precompiled header `quakedef.h` from the compiler include path rather than a relative path.

### Description
- Replace `#include "../Quake/quakedef.h"` with `#include "quakedef.h"` in `common/lightgrid.c` so the project's precompiled header configuration is honored.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975676d9930832ebb324f083bfebc14)