### PR TITLE
Detect serverinfo overflow and abort client connect/spawn

### DIFF
--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -582,7 +582,7 @@ Sends the first message from the server to a connected client.
 This will be sent on the initial connection and upon each server load.
 ================
 */
-void SV_SendServerinfo (client_t *client)
+qboolean SV_SendServerinfo (client_t *client)
 {
 	const char		**s;
 	char			message[2048];
@@ -640,8 +640,16 @@ void SV_SendServerinfo (client_t *client)
 	MSG_WriteByte (&client->message, svc_signonnum);
 	MSG_WriteByte (&client->message, 1);
 
+	if (client->message.overflowed)
+	{
+		Con_Printf ("Serverinfo message overflowed for %s (max %d).\n",
+			client->name, client->message.maxsize);
+		return false;
+	}
+
 	client->sendsignon = PRESPAWN_FLUSH;
 	client->spawned = false;		// need prespawn, spawn, etc
+	return true;
 }
 
 /*
@@ -652,7 +660,7 @@ Initializes a client_t for a new net connection.  This will only be called
 once for a player each game, not once for each level change.
 ================
 */
-void SV_ConnectClient (int clientnum)
+qboolean SV_ConnectClient (int clientnum)
 {
 	edict_t			*ent;
 	client_t		*client;
@@ -756,7 +764,18 @@ void SV_ConnectClient (int clientnum)
 
 	SV_SetUnreliableConservative (client, "connect");
 
-	SV_SendServerinfo (client);
+	if (!SV_SendServerinfo (client))
+	{
+		if (!client->is_bot && client->netconnection)
+			NET_Close (client->netconnection);
+		client->netconnection = NULL;
+		client->active = false;
+		client->is_bot = false;
+		client->name[0] = 0;
+		client->old_frags = -999999;
+		return false;
+	}
+	return true;
 }
 
 
@@ -790,9 +809,8 @@ void SV_CheckForNewClients (void)
 			Sys_Error ("Host_CheckForNewClients: no free clients");
 
 		svs.clients[i].netconnection = ret;
-		SV_ConnectClient (i);
-
-		net_activeconnections++;
+		if (SV_ConnectClient (i))
+			net_activeconnections++;
 	}
 }
 
@@ -7431,7 +7449,8 @@ void SV_SpawnServer (const char *server)
 // send serverinfo to all connected clients
 	for (i=0,host_client = svs.clients ; i<svs.maxclients ; i++, host_client++)
 		if (host_client->active)
-			SV_SendServerinfo (host_client);
+			if (!SV_SendServerinfo (host_client))
+				SV_DropClient (true);
 
 	Con_DPrintf ("Server spawned.\n");
 


### PR DESCRIPTION
### Motivation

- Prevent sending a truncated/overflowed serverinfo signon to clients which can corrupt the signon flow and leave clients in an invalid state.

### Description

- Change `SV_SendServerinfo` to return `qboolean` and detect `client->message.overflowed`, logging a message and returning failure when overflow occurs.
- Update `SV_ConnectClient` to return `qboolean` and abort/clean up the partially-initialized client when `SV_SendServerinfo` fails, closing the net connection for non-bots and clearing client state.
- Use the `SV_ConnectClient` return value in `SV_CheckForNewClients` to only increment `net_activeconnections` on successful connects.
- During server spawn, call `SV_SendServerinfo` for existing clients and drop clients that fail serverinfo generation via `SV_DropClient(true)`.

### Testing

- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697569eeb7e4832e9eaa4d477cb795f6)