### PR TITLE
Prefix alias SSBO fields to avoid GLSL name collisions

### DIFF
--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -12,20 +12,20 @@ struct InstanceData
 
 layout(std430, binding=1) restrict readonly buffer InstanceBuffer
 {
-	mat4	ViewProj;
-	mat4	PrevViewProj;
-	vec3	EyePos;
-	float	_Pad0;
-	vec4	Fog;
-	float	ScreenDither;
-	float	Overbright;
-	float	ModelHalfLambert;
-	float	_Pad1;
-	mat4	ShadowViewProj;
-	vec4	ShadowParams;
-	vec4	ShadowDebug;
-	vec4	ShadowSunDir;
-	InstanceData instances[];
+	mat4	inst_ViewProj;
+	mat4	inst_PrevViewProj;
+	vec3	inst_EyePos;
+	float	inst_Pad0;
+	vec4	inst_Fog;
+	float	inst_ScreenDither;
+	float	inst_Overbright;
+	float	inst_ModelHalfLambert;
+	float	inst_Pad1;
+	mat4	inst_ShadowViewProj;
+	vec4	inst_ShadowParams;
+	vec4	inst_ShadowDebug;
+	vec4	inst_ShadowSunDir;
+	InstanceData inst_instances[];
 };
 // ALU-only 16x16 Bayer matrix
 float bayer01(ivec2 coord)
@@ -47,9 +47,9 @@ float bayer(ivec2 coord)
 
 vec3 ApplyFog(vec3 clr, vec3 p)
 {
-        float fog = exp2(-abs(Fog.w) * dot(p, p));
+        float fog = exp2(-abs(inst_Fog.w) * dot(p, p));
         fog = clamp(fog, 0.0, 1.0);
-        return mix(Fog.rgb, clr, fog);
+        return mix(inst_Fog.rgb, clr, fog);
 }
 
 // Hash without Sine
@@ -102,7 +102,15 @@ layout(binding=2) uniform sampler2D EmissiveTex;
 layout(binding=5) uniform sampler2D ShadowMap;
 
 #define SHADOW_SUN 1
+#define SHADOW_VIEWPROJ inst_ShadowViewProj
+#define SHADOW_PARAMS inst_ShadowParams
+#define SHADOW_DEBUG inst_ShadowDebug
+#define SHADOW_SUN_DIR inst_ShadowSunDir
 #include "shadow_sample.glsl"
+#undef SHADOW_VIEWPROJ
+#undef SHADOW_PARAMS
+#undef SHADOW_DEBUG
+#undef SHADOW_SUN_DIR
 
 #if MODE == 2
 	layout(location=0) noperspective in vec2 in_texcoord;
@@ -162,14 +170,14 @@ void main()
         float shadow_term = 1.0;
 	vec4 lit_color = in_color;
 
-	if (ShadowDebug.x > 0.5 && (in_flags & ALIAS_FLAG_VIEWMODEL) == 0)
+	if (inst_ShadowDebug.x > 0.5 && (in_flags & ALIAS_FLAG_VIEWMODEL) == 0)
 	{
-		vec3 world_pos = in_pos + EyePos;
+		vec3 world_pos = in_pos + inst_EyePos;
 		vec3 shadow_normal = gl_FrontFacing ? in_normal : -in_normal;
 		shadow_term = ShadowVisibility(world_pos, shadow_normal, shadow_range);
-		if (ShadowDebug.y > 1.5)
+		if (inst_ShadowDebug.y > 1.5)
 		{
-			float debug_value = (ShadowDebug.y > 2.5) ? shadow_range : shadow_term;
+			float debug_value = (inst_ShadowDebug.y > 2.5) ? shadow_range : shadow_term;
 			out_fragcolor = vec4(vec3(debug_value), 1.0);
 #if !OIT
 			out_velocity = vec4(0.0);
@@ -220,13 +228,13 @@ void main()
 #endif
 #if MODE == 1 || MODE == 2
 	// Note: sign bit is used as overbright flag
-	if (abs(Fog.w) > 0.)
+	if (abs(inst_Fog.w) > 0.)
 	{
 		out_fragcolor.rgb = sqrt(out_fragcolor.rgb);
-		out_fragcolor.rgb += SCREEN_SPACE_NOISE() * ScreenDither;
+		out_fragcolor.rgb += SCREEN_SPACE_NOISE() * inst_ScreenDither;
 		out_fragcolor.rgb *= out_fragcolor.rgb;
 	}
 #else
-	out_fragcolor.rgb += SUPPRESS_BANDING() * ScreenDither;
+	out_fragcolor.rgb += SUPPRESS_BANDING() * inst_ScreenDither;
 #endif
 }

--- a/Quake/shaders/alias.vert
+++ b/Quake/shaders/alias.vert
@@ -12,20 +12,20 @@ struct InstanceData
 
 layout(std430, binding=1) restrict readonly buffer InstanceBuffer
 {
-	mat4	ViewProj;
-	mat4	PrevViewProj;
-	vec3	EyePos;
-	float	_Pad0;
-	vec4	Fog;
-	float	ScreenDither;
-	float	Overbright;
-	float	ModelHalfLambert;
-	float	_Pad1;
-	mat4	ShadowViewProj;
-	vec4	ShadowParams;
-	vec4	ShadowDebug;
-	vec4	ShadowSunDir;
-	InstanceData instances[];
+	mat4	inst_ViewProj;
+	mat4	inst_PrevViewProj;
+	vec3	inst_EyePos;
+	float	inst_Pad0;
+	vec4	inst_Fog;
+	float	inst_ScreenDither;
+	float	inst_Overbright;
+	float	inst_ModelHalfLambert;
+	float	inst_Pad1;
+	mat4	inst_ShadowViewProj;
+	vec4	inst_ShadowParams;
+	vec4	inst_ShadowDebug;
+	vec4	inst_ShadowSunDir;
+	InstanceData inst_instances[];
 };
 
 struct PoseVertex
@@ -81,7 +81,7 @@ float r_avertexnormal_dot(vec3 vertexnormal, vec3 dir) // from MH, blended with 
         float halfLambert = max(d, 0.0) * 0.5 + 0.5;
         // wtf - this reproduces anorm_dots within as reasonable a degree of tolerance as the >= 0 case
         float quakeShade = d < 0.0 ? 1.0 + d * (13.0 / 44.0) : 1.0 + d;
-        float halfLambertMix = clamp(ModelHalfLambert, 0.0, 1.0);
+        float halfLambertMix = clamp(inst_ModelHalfLambert, 0.0, 1.0);
         return mix(quakeShade, halfLambert, halfLambertMix);
 }
 
@@ -101,7 +101,7 @@ const int ALIAS_FLAG_VIEWMODEL = 2;
 
 void main()
 {
-	InstanceData inst = instances[gl_InstanceID];
+	InstanceData inst = inst_instances[gl_InstanceID];
 	out_texcoord = in_uv;
 	PoseVertex pose1 = GetPoseVertex(inst.Pose1);
 	PoseVertex pose2 = GetPoseVertex(inst.Pose2);
@@ -110,13 +110,13 @@ void main()
 	mat4x3 prev_worldmatrix = transpose(mat3x4(inst.PrevWorldMatrix[0], inst.PrevWorldMatrix[1], inst.PrevWorldMatrix[2]));
 	vec3 world_vert = (worldmatrix * vec4(local_vert, 1.0)).xyz;
 	vec3 prev_world_vert = (prev_worldmatrix * vec4(local_vert, 1.0)).xyz;
-	vec4 curr_clip = ViewProj * vec4(world_vert, 1.0);
-	vec4 prev_clip = PrevViewProj * vec4(prev_world_vert, 1.0);
+	vec4 curr_clip = inst_ViewProj * vec4(world_vert, 1.0);
+	vec4 prev_clip = inst_PrevViewProj * vec4(prev_world_vert, 1.0);
 	gl_Position = curr_clip;
 	out_curr_clip = curr_clip;
 	out_prev_clip = prev_clip;
 	out_flags = inst.Flags;
-	out_pos = world_vert - EyePos;
+	out_pos = world_vert - inst_EyePos;
 	// transform world X and Z axes to local space
         mat3 orientation = mat3(normalize(worldmatrix[0].xyz), normalize(worldmatrix[1].xyz), normalize(worldmatrix[2].xyz));
         orientation = transpose(orientation);
@@ -130,11 +130,11 @@ void main()
         vec3 view_dir = normalize(-out_pos);
         float rim = pow(max(1.0 - dot(world_normal, view_dir), 0.0), 3.0) * 0.3;
         vec3 ambient = max(inst.LightColor.rgb - inst.DLightColor.rgb, vec3(0.0));
-        vec3 litAmbient = ambient * (mix(0.35, 1.0, lighting) * Overbright);
+        vec3 litAmbient = ambient * (mix(0.35, 1.0, lighting) * inst_Overbright);
         vec3 litDlight = inst.DLightColor.rgb * lighting;
         vec3 base_color = litAmbient + litDlight;
         bool is_viewmodel = (inst.Flags & ALIAS_FLAG_VIEWMODEL) != 0;
         vec3 final_color = is_viewmodel ? base_color + vec3(rim) : base_color;
-        out_color = clamp(vec4(final_color, inst.LightColor.a), 0.0, Overbright);
+        out_color = clamp(vec4(final_color, inst.LightColor.a), 0.0, inst_Overbright);
 	out_normal = world_normal;
 }

--- a/Quake/shaders/shadow_depth_alias.vert
+++ b/Quake/shaders/shadow_depth_alias.vert
@@ -12,20 +12,20 @@ struct InstanceData
 
 layout(std430, binding=1) restrict readonly buffer InstanceBuffer
 {
-	mat4	ViewProj;
-	mat4	PrevViewProj;
-	vec3	EyePos;
-	float	_Pad0;
-	vec4	Fog;
-	float	ScreenDither;
-	float	Overbright;
-	float	ModelHalfLambert;
-	float	_Pad1;
-	mat4	ShadowViewProj;
-	vec4	ShadowParams;
-	vec4	ShadowDebug;
-	vec4	ShadowSunDir;
-	InstanceData instances[];
+	mat4	inst_ViewProj;
+	mat4	inst_PrevViewProj;
+	vec3	inst_EyePos;
+	float	inst_Pad0;
+	vec4	inst_Fog;
+	float	inst_ScreenDither;
+	float	inst_Overbright;
+	float	inst_ModelHalfLambert;
+	float	inst_Pad1;
+	mat4	inst_ShadowViewProj;
+	vec4	inst_ShadowParams;
+	vec4	inst_ShadowDebug;
+	vec4	inst_ShadowSunDir;
+	InstanceData inst_instances[];
 };
 
 struct PoseVertex
@@ -77,11 +77,11 @@ struct PoseVertex
 
 void main()
 {
-	InstanceData inst = instances[gl_InstanceID];
+	InstanceData inst = inst_instances[gl_InstanceID];
 	PoseVertex pose1 = GetPoseVertex(inst.Pose1);
 	PoseVertex pose2 = GetPoseVertex(inst.Pose2);
 	vec3 local_vert = mix(pose1.pos, pose2.pos, inst.Blend);
 	mat4x3 worldmatrix = transpose(mat3x4(inst.WorldMatrix[0], inst.WorldMatrix[1], inst.WorldMatrix[2]));
 	vec3 world_vert = (worldmatrix * vec4(local_vert, 1.0)).xyz;
-	gl_Position = ShadowViewProj * vec4(world_vert, 1.0);
+	gl_Position = inst_ShadowViewProj * vec4(world_vert, 1.0);
 }

--- a/Quake/shaders/shadow_sample.glsl
+++ b/Quake/shaders/shadow_sample.glsl
@@ -1,6 +1,22 @@
 #ifndef SHADOW_SAMPLE_GLSL
 #define SHADOW_SAMPLE_GLSL
 
+#ifndef SHADOW_VIEWPROJ
+#define SHADOW_VIEWPROJ ShadowViewProj
+#endif
+
+#ifndef SHADOW_PARAMS
+#define SHADOW_PARAMS ShadowParams
+#endif
+
+#ifndef SHADOW_DEBUG
+#define SHADOW_DEBUG ShadowDebug
+#endif
+
+#ifndef SHADOW_SUN_DIR
+#define SHADOW_SUN_DIR ShadowSunDir
+#endif
+
 // -----------------------------------------------------------------------------
 // Matrix multiplication robustness
 //
@@ -118,13 +134,13 @@ float ShadowSamplePCF(vec2 uv, float reference, float bias, int taps)
 
 float ShadowVisibility(vec3 world_pos, vec3 normal, out float in_range)
 {
-	if (ShadowDebug.x < 0.5)
+	if (SHADOW_DEBUG.x < 0.5)
 	{
 		in_range = 1.0;
 		return 1.0;
 	}
 
-	vec4 clip = ShadowMul(ShadowViewProj, vec4(world_pos, 1.0));
+	vec4 clip = ShadowMul(SHADOW_VIEWPROJ, vec4(world_pos, 1.0));
 	if (clip.w <= 0.0)
 	{
 		in_range = 0.0;
@@ -141,11 +157,11 @@ float ShadowVisibility(vec3 world_pos, vec3 normal, out float in_range)
 	if (!inside)
 		return 1.0;
 
-	float ndotl = clamp(dot(normal, -ShadowSunDir.xyz), 0.0, 1.0);
-	float bias = ShadowParams.x + ShadowParams.y * (1.0 - ndotl);
+	float ndotl = clamp(dot(normal, -SHADOW_SUN_DIR.xyz), 0.0, 1.0);
+	float bias = SHADOW_PARAMS.x + SHADOW_PARAMS.y * (1.0 - ndotl);
 
-	if (ShadowParams.z > 0.5)
-		return ShadowSamplePCF(uv, reference, bias, int(ShadowParams.w + 0.5));
+	if (SHADOW_PARAMS.z > 0.5)
+		return ShadowSamplePCF(uv, reference, bias, int(SHADOW_PARAMS.w + 0.5));
 
 	return ShadowSampleRaw(uv, reference, bias);
 }


### PR DESCRIPTION
### Motivation
- Resolve OpenGL GLSL compile errors caused by name collisions between SSBO fields (e.g. `ViewProj`, `Fog`, `EyePos`, `ShadowViewProj`, etc.) and existing uniforms/varyings by making all alias-instance SSBO fields unique.
- Ensure MD5/alias shaders and shared shadow sampling code reference the new names consistently with no functional change.
- Keep shader behavior identical while eliminating ambiguous symbol names that break compilation.

### Description
- Renamed SSBO fields in the alias instance buffer to use an `inst_` prefix (examples: `ViewProj` → `inst_ViewProj`, `Fog` → `inst_Fog`, `EyePos` → `inst_EyePos`) and renamed the `instances[]` array to `inst_instances[]` in `Quake/shaders/alias.vert` and `Quake/shaders/alias.frag`.
- Updated all shader accesses in `alias.vert` and `alias.frag` to the new `inst_` names and switched instance lookups to `inst_instances[gl_InstanceID]` so behavior is preserved.
- Updated `shadow_depth_alias.vert` to use the prefixed `inst_ShadowViewProj` when computing shadow clip coordinates.
- Introduced macro indirection in `Quake/shaders/shadow_sample.glsl` (`SHADOW_VIEWPROJ`, `SHADOW_PARAMS`, `SHADOW_DEBUG`, `SHADOW_SUN_DIR`) so callers can remap shadow SSBO names (the alias fragment shader defines those macros around the `#include` and then undefines them).
- No algorithmic or rendering logic changes; only symbol renames and include/macro wiring to avoid collisions.

### Testing
- Ran automated repository searches (`rg`) and inspected updated shader sources (`sed`/`nl`) to verify all occurrences of the affected SSBO names were updated and that the `shadow_sample.glsl` macros are defined/used; these inspections succeeded and show the four modified shader files now reference `inst_` symbols.
- Performed static edits and validation of the modified shader files to ensure consistent renames across `alias.vert`, `alias.frag`, `shadow_depth_alias.vert`, and `shadow_sample.glsl`; file-level checks passed.
- Note: an actual OpenGL shader compile or full build was not executed in this run, so runtime shader compilation should be validated in CI or locally to confirm the build now completes without GLSL compiler errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bac578348832e8efd6563f7ca7394)