### PR TITLE
Fix prediction timing and add jitter diagnostics

### DIFF
--- a/Quake/cl_main.c
+++ b/Quake/cl_main.c
@@ -22,6 +22,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // cl_main.c  -- client main loop
 
 #include "quakedef.h"
+#include <stdint.h>
 #include "arch_def.h"
 #include "net_sys.h"
 #include "net_defs.h"
@@ -51,6 +52,7 @@ cvar_t	cl_cmdrate = {"cl_cmdrate", "60", CVAR_ARCHIVE};
 cvar_t	cl_cmd_maxbatch = {"cl_cmd_maxbatch", "6", CVAR_ARCHIVE};
 cvar_t	cl_interp = {"cl_interp", "0.05", CVAR_ARCHIVE};
 cvar_t	cl_jitter = {"cl_jitter", "0.02", CVAR_ARCHIVE};
+cvar_t	cl_jitter_debug = {"cl_jitter_debug", "0", CVAR_NONE};
 cvar_t	cl_physrate = {"cl_physrate", "0", CVAR_ARCHIVE};
 cvar_t	cl_snap_debug = {"cl_snap_debug", "0", CVAR_NONE};
 cvar_t	cl_snapshot_debug = {"cl_snapshot_debug", "0", CVAR_NONE};
@@ -134,7 +136,7 @@ static int				cl_lerp_hold_oldest = 0;
 static int				cl_lerp_gap_holds = 0;
 static double			cl_lerp_debug_next_time = 0.0;
 static double			cl_netdbg_move_next_time = 0.0;
-static double			cl_cmd_accum = 0.0;
+static int64_t			cl_cmd_accum_us = 0;
 static double			cl_cmd_debug_next_time = 0.0;
 static unsigned int		cl_cmds_built_since_log = 0;
 static unsigned int		cl_cmds_sent_since_log = 0;
@@ -175,7 +177,7 @@ static void CL_ClearPlayerSnaps (void)
 void CL_ResetPlayerSnaps (void)
 {
 	CL_ClearPlayerSnaps ();
-	cl_cmd_accum = 0.0;
+	cl_cmd_accum_us = 0;
 	cl_cmd_debug_next_time = 0.0;
 	cl_cmds_built_since_log = 0;
 	cl_cmds_sent_since_log = 0;
@@ -323,6 +325,9 @@ qboolean CL_WorldReady (void)
 static void CL_NetDbg_LogMovement (const usercmd_t *cmd, qboolean sendcmd_ran)
 {
 	double now;
+	double cmd_rate;
+	double cmd_dt;
+	double cmd_accum_s;
 	vec3_t vieworg;
 	int forward = 0;
 	int side = 0;
@@ -375,8 +380,12 @@ static void CL_NetDbg_LogMovement (const usercmd_t *cmd, qboolean sendcmd_ran)
 		if (cls.netcon->lastMessageTime > 0.0)
 			net_last_msg_age = now - cls.netcon->lastMessageTime;
 		if (cls.netcon->lastSendTime > 0.0)
-			net_last_send_age = now - cls.netcon->lastSendTime;
+		net_last_send_age = now - cls.netcon->lastSendTime;
 	}
+
+	cmd_rate = cl_cmdrate.value > 0.0 ? cl_cmdrate.value : 60.0;
+	cmd_dt = 1.0 / cmd_rate;
+	cmd_accum_s = (double)cl_cmd_accum_us / 1000000.0;
 
 	Con_Printf ("NETDBG move signon %d has_full %d need_full %d viewent_init %d world %d paused %d intermission %d "
 		"vieworg %.1f %.1f %.1f simorg %.1f %.1f %.1f cmd %d %d %d predict %d sendcmd %d "
@@ -396,7 +405,7 @@ static void CL_NetDbg_LogMovement (const usercmd_t *cmd, qboolean sendcmd_ran)
 		CL_NetDbg_PredictRan () ? 1 : 0,
 		sendcmd_ran ? 1 : 0,
 		cmd_seq, cmd_ack, cmd_ack_echo, snap_ack,
-		cl_cmd_accum, host_netinterval,
+		cmd_accum_s, cmd_dt,
 		net_rx_seq, net_tx_seq, net_rel_recv_seq, net_rel_send_base, net_unrel_rx,
 		net_last_msg_age, net_last_send_age, net_rate_budget, net_can_send, net_disconnected);
 }
@@ -444,6 +453,58 @@ static double CL_GetInterpTargetTime (void)
 	if (server_time > 0.0)
 		return server_time - delay;
 	return Sys_DoubleTime () - delay;
+}
+
+static int64_t CL_SecondsToUsec (double seconds)
+{
+	if (seconds <= 0.0)
+		return 0;
+	return (int64_t)(seconds * 1000000.0 + 0.5);
+}
+
+void CL_JitterDebug_Log (void)
+{
+	double interp_delay;
+	double interp_target;
+	cl_pred_debug_t pred;
+	vec3_t render_org;
+	vec3_t render_ang;
+	qboolean has_pred;
+
+	if (cl_jitter_debug.value <= 0.0f)
+		return;
+
+	interp_delay = CL_GetInterpDelaySeconds ();
+	interp_target = CL_GetInterpTargetTime ();
+	has_pred = CL_Predict_GetDebug (&pred);
+
+	VectorCopy (r_refdef.vieworg, render_org);
+	VectorCopy (r_refdef.viewangles, render_ang);
+
+	if (!has_pred)
+	{
+		VectorClear (pred.base_origin);
+		VectorClear (pred.base_angles);
+		VectorClear (pred.predicted_origin);
+		VectorClear (pred.predicted_angles);
+	}
+
+	Con_Printf ("JITTERDBG cl.time %.3f realtime %.3f host_frametime %.4f interp_target %.3f interp_delay %.3f "
+		"server_applied %d pred_steps %d pred_err %.2f ang_err %.2f "
+		"auth_org %.2f %.2f %.2f auth_ang %.2f %.2f %.2f "
+		"pred_org %.2f %.2f %.2f pred_ang %.2f %.2f %.2f "
+		"rend_org %.2f %.2f %.2f rend_ang %.2f %.2f %.2f\n",
+		cl.time, realtime, host_frametime, interp_target, interp_delay,
+		pred.server_update_applied ? 1 : 0,
+		pred.prediction_steps,
+		pred.pred_error_len,
+		pred.pred_angle_error_len,
+		pred.base_origin[0], pred.base_origin[1], pred.base_origin[2],
+		pred.base_angles[0], pred.base_angles[1], pred.base_angles[2],
+		pred.predicted_origin[0], pred.predicted_origin[1], pred.predicted_origin[2],
+		pred.predicted_angles[0], pred.predicted_angles[1], pred.predicted_angles[2],
+		render_org[0], render_org[1], render_org[2],
+		render_ang[0], render_ang[1], render_ang[2]);
 }
 
 static qboolean CL_GetInterpolatedPlayer (int player, vec3_t out_org, vec3_t out_ang)
@@ -1763,6 +1824,7 @@ Spike: split from CL_SendCmd, to do clientside viewangle changes separately from
 */
 void CL_AccumulateCmd (void)
 {
+	CL_Predict_BeginFrame ();
 	if (cls.signon == SIGNONS)
 	{
 		//basic keyboard looking
@@ -1783,9 +1845,9 @@ void CL_SendCmd (void)
 	usercmd_t		cmd;
 	double			cmd_rate;
 	double			cmd_dt;
-	double			phys_dt;
-	double			max_accum;
-	float			prev_frametime;
+	int64_t			cmd_dt_us;
+	int64_t			max_accum_us;
+	int64_t			frame_us;
 	int				max_catchup;
 	int				cmds_built;
 	qboolean		send_move;
@@ -1796,24 +1858,26 @@ void CL_SendCmd (void)
 
 	cmd_rate = cl_cmdrate.value > 0.0 ? cl_cmdrate.value : 60.0;
 	cmd_dt = 1.0 / cmd_rate;
-	phys_dt = (cl_physrate.value > 0.0) ? (1.0 / cl_physrate.value) : cmd_dt;
+	cmd_dt_us = CL_SecondsToUsec (cmd_dt);
+	if (cmd_dt_us <= 0)
+		cmd_dt_us = 1;
 	max_catchup = (int)cl_cmd_maxbatch.value;
 	if (max_catchup < 1)
 		max_catchup = 1;
 
-	cl_cmd_accum += host_frametime;
-	if (cl_cmd_accum < 0.0)
-		cl_cmd_accum = 0.0;
-	max_accum = cmd_dt * (double)max_catchup * 2.0;
-	if (cl_cmd_accum > max_accum)
-		cl_cmd_accum = max_accum;
+	frame_us = CL_SecondsToUsec (host_frametime);
+	cl_cmd_accum_us += frame_us;
+	if (cl_cmd_accum_us < 0)
+		cl_cmd_accum_us = 0;
+	max_accum_us = cmd_dt_us * (int64_t)max_catchup * 2;
+	if (cl_cmd_accum_us > max_accum_us)
+		cl_cmd_accum_us = max_accum_us;
 
 	cmds_built = 0;
 	send_move = false;
 	sendcmd_ran = false;
-	prev_frametime = host_frametime;
 
-	while (cl_cmd_accum >= cmd_dt && cmds_built < max_catchup)
+	while (cl_cmd_accum_us >= cmd_dt_us && cmds_built < max_catchup)
 	{
 		if (cls.signon == SIGNONS)
 		{
@@ -1835,9 +1899,7 @@ void CL_SendCmd (void)
 
 			// NOTE: Never gate command generation/sending on snapshot readiness.
 			// Prediction handles world-ready checks; the server still needs cmds every tick.
-			host_frametime = (float)phys_dt;
 			CL_Predict_SetupCmd (&cmd);
-			host_frametime = prev_frametime;
 
 			in_attack.state &= ~2;
 			in_jump.state &= ~2;
@@ -1850,15 +1912,15 @@ void CL_SendCmd (void)
 			send_move = true;
 		}
 
-		cl_cmd_accum -= cmd_dt;
+		cl_cmd_accum_us -= cmd_dt_us;
 		cmds_built++;
 		sendcmd_ran = true;
 	}
 
-	if (cmds_built >= max_catchup && cl_cmd_accum >= cmd_dt && cl_netdebug_parse.value)
+	if (cmds_built >= max_catchup && cl_cmd_accum_us >= cmd_dt_us && cl_netdebug_parse.value)
 	{
 		Con_Printf ("NETDBG cmdrate catchup clamped accum %.6f dt %.6f\n",
-			cl_cmd_accum, cmd_dt);
+			(double)cl_cmd_accum_us / 1000000.0, cmd_dt);
 	}
 
 	if (send_move)
@@ -1885,7 +1947,7 @@ void CL_SendCmd (void)
 		{
 			Con_Printf ("NETDBG cmdrate built %u sent_cmds %u packets %u cmd_dt %.4f accum %.4f\n",
 				cl_cmds_built_since_log, cl_cmds_sent_since_log, cl_cmd_packets_since_log,
-				cmd_dt, cl_cmd_accum);
+				cmd_dt, (double)cl_cmd_accum_us / 1000000.0);
 			cl_cmds_built_since_log = 0;
 			cl_cmds_sent_since_log = 0;
 			cl_cmd_packets_since_log = 0;
@@ -2091,6 +2153,7 @@ void CL_Init (void)
 	Cvar_RegisterVariable (&cl_cmd_maxbatch);
 	Cvar_RegisterVariable (&cl_interp);
 	Cvar_RegisterVariable (&cl_jitter);
+	Cvar_RegisterVariable (&cl_jitter_debug);
 	Cvar_RegisterVariable (&cl_physrate);
 	Cvar_RegisterVariable (&cl_snap_debug);
 	Cvar_RegisterVariable (&cl_snapshot_debug);

--- a/Quake/cl_predict.c
+++ b/Quake/cl_predict.c
@@ -10,6 +10,8 @@ extern cvar_t sv_friction;
 extern cvar_t sv_stopspeed;
 extern cvar_t sv_gravity;
 extern cvar_t cl_netdebug_parse;
+extern cvar_t cl_cmdrate;
+extern cvar_t cl_physrate;
 
 typedef struct
 {
@@ -33,6 +35,9 @@ static cl_pred_t cl_pred;
 static qboolean cl_netdbg_predict_ran;
 static qboolean cl_pred_warned_solid;
 static vec3_t cl_pred_error;
+static vec3_t cl_pred_angle_error;
+static int cl_pred_steps_this_frame;
+static qboolean cl_pred_server_update_this_frame;
 
 #define CL_PREDICT_MAX_CLIP_PLANES 5
 #define CL_PREDICT_STEP_SIZE 18.0f
@@ -86,6 +91,27 @@ static qboolean CL_Predict_SeqNewer (unsigned int seq, unsigned int ref)
 	return NETSEQ_GT (seq, ref);
 }
 
+static float CL_Predict_GetStepTime (void)
+{
+	double cmd_rate = cl_cmdrate.value > 0.0 ? cl_cmdrate.value : 60.0;
+	double cmd_dt = 1.0 / cmd_rate;
+
+	if (cl_physrate.value > 0.0)
+		return (float)(1.0 / cl_physrate.value);
+	return (float)cmd_dt;
+}
+
+static float CL_Predict_AngleDelta (float a, float b)
+{
+	float d = a - b;
+
+	while (d > 180.0f)
+		d -= 360.0f;
+	while (d < -180.0f)
+		d += 360.0f;
+	return d;
+}
+
 static qboolean CL_Predict_IsEnabled (void)
 {
 	// Prediction may be gated on world readiness, but command sending must not be.
@@ -105,22 +131,29 @@ static qboolean CL_Predict_IsEnabled (void)
 static void CL_Predict_ApplyToClient (void)
 {
 	vec3_t smooth_origin;
+	vec3_t smooth_angles;
 	float smooth_ms;
 	float decay;
 	vec3_t correction;
+	vec3_t angle_correction;
 
 	if (!CL_Predict_IsEnabled () || !cl_pred.has_base)
 		return;
 
 	smooth_ms = cl_pred_smooth_ms.value;
 	if (smooth_ms <= 0.0f)
+	{
 		VectorClear (cl_pred_error);
+		VectorClear (cl_pred_angle_error);
+	}
 
 	VectorAdd (cl_pred.predicted.origin, cl_pred_error, smooth_origin);
+	VectorAdd (cl_pred.predicted.viewangles, cl_pred_angle_error, smooth_angles);
 	VectorCopy (smooth_origin, cl.simorg);
 	VectorCopy (smooth_origin, cl_entities[cl.viewentity].origin);
 	VectorCopy (smooth_origin, cl_entities[cl.viewentity].msg_origins[0]);
 	VectorCopy (smooth_origin, cl_entities[cl.viewentity].msg_origins[1]);
+	VectorCopy (smooth_angles, cl.viewangles);
 	VectorCopy (cl_pred.predicted.velocity, cl.mvelocity[0]);
 	VectorCopy (cl_pred.predicted.velocity, cl.mvelocity[1]);
 	cl.onground = cl_pred.predicted.onground;
@@ -131,6 +164,8 @@ static void CL_Predict_ApplyToClient (void)
 		decay = CLAMP (0.0f, decay, 1.0f);
 		VectorScale (cl_pred_error, decay, correction);
 		VectorSubtract (cl_pred_error, correction, cl_pred_error);
+		VectorScale (cl_pred_angle_error, decay, angle_correction);
+		VectorSubtract (cl_pred_angle_error, angle_correction, cl_pred_angle_error);
 		if (cl_netdbg_pred.value > 0.0f)
 		{
 			Con_Printf ("NETDBG: pred_smooth apply %.2f remaining %.2f\n",
@@ -141,7 +176,7 @@ static void CL_Predict_ApplyToClient (void)
 	CL_EnsureViewEntityOrigin ("predict");
 }
 
-static void CL_Predict_Friction (vec3_t velocity)
+static void CL_Predict_Friction (vec3_t velocity, float dt)
 {
 	float	speed;
 	float	newspeed;
@@ -152,7 +187,7 @@ static void CL_Predict_Friction (vec3_t velocity)
 		return;
 
 	control = speed < sv_stopspeed.value ? sv_stopspeed.value : speed;
-	newspeed = speed - host_frametime * control * sv_friction.value;
+	newspeed = speed - dt * control * sv_friction.value;
 	if (newspeed < 0)
 		newspeed = 0;
 	newspeed /= speed;
@@ -161,7 +196,7 @@ static void CL_Predict_Friction (vec3_t velocity)
 	velocity[1] *= newspeed;
 }
 
-static void CL_Predict_Accelerate (vec3_t velocity, const vec3_t wishdir, float wishspeed, float accel)
+static void CL_Predict_Accelerate (vec3_t velocity, const vec3_t wishdir, float wishspeed, float accel, float dt)
 {
 	float	addspeed;
 	float	accelspeed;
@@ -173,7 +208,7 @@ static void CL_Predict_Accelerate (vec3_t velocity, const vec3_t wishdir, float 
 	if (addspeed <= 0)
 		return;
 
-	accelspeed = accel * host_frametime * wishspeed;
+	accelspeed = accel * dt * wishspeed;
 	if (accelspeed > addspeed)
 		accelspeed = addspeed;
 
@@ -181,7 +216,7 @@ static void CL_Predict_Accelerate (vec3_t velocity, const vec3_t wishdir, float 
 		velocity[i] += accelspeed * wishdir[i];
 }
 
-static void CL_Predict_AirAccelerate (vec3_t velocity, vec3_t wishvel, float wishspeed)
+static void CL_Predict_AirAccelerate (vec3_t velocity, vec3_t wishvel, float wishspeed, float dt)
 {
 	float	addspeed;
 	float	accelspeed;
@@ -197,7 +232,7 @@ static void CL_Predict_AirAccelerate (vec3_t velocity, vec3_t wishvel, float wis
 	if (addspeed <= 0)
 		return;
 
-	accelspeed = sv_accelerate.value * wishspeed * host_frametime;
+	accelspeed = sv_accelerate.value * wishspeed * dt;
 	if (accelspeed > addspeed)
 		accelspeed = addspeed;
 
@@ -486,13 +521,14 @@ static void CL_Predict_StepSlideMove (cl_pred_state_t *state, const vec3_t mins,
 	}
 }
 
-static void CL_Predict_SimulateCmd (cl_pred_state_t *state, const usercmd_t *cmd)
+static void CL_Predict_SimulateCmd (cl_pred_state_t *state, const usercmd_t *cmd, float dt)
 {
 	vec3_t forward, right, up;
 	vec3_t wishvel, wishdir;
 	float wishspeed;
 	vec3_t mins, maxs;
 
+	cl_pred_steps_this_frame++;
 	CL_Predict_GetPlayerBounds (mins, maxs);
 
 	if (!state->onground && state->velocity[2] <= 0)
@@ -518,7 +554,7 @@ static void CL_Predict_SimulateCmd (cl_pred_state_t *state, const usercmd_t *cmd
 	if (noclip_anglehack)
 	{
 		VectorCopy (wishvel, state->velocity);
-		VectorMA (state->origin, host_frametime, state->velocity, state->origin);
+		VectorMA (state->origin, dt, state->velocity, state->origin);
 		state->onground = false;
 		return;
 	}
@@ -531,19 +567,19 @@ static void CL_Predict_SimulateCmd (cl_pred_state_t *state, const usercmd_t *cmd
 			state->onground = false;
 		}
 
-		CL_Predict_Friction (state->velocity);
-		CL_Predict_Accelerate (state->velocity, wishdir, wishspeed, sv_accelerate.value);
+		CL_Predict_Friction (state->velocity, dt);
+		CL_Predict_Accelerate (state->velocity, wishdir, wishspeed, sv_accelerate.value, dt);
 	}
 	else
 	{
-		CL_Predict_AirAccelerate (state->velocity, wishvel, wishspeed);
-		state->velocity[2] -= sv_gravity.value * host_frametime;
+		CL_Predict_AirAccelerate (state->velocity, wishvel, wishspeed, dt);
+		state->velocity[2] -= sv_gravity.value * dt;
 	}
 
 	if (state->onground)
-		CL_Predict_StepSlideMove (state, mins, maxs, host_frametime);
+		CL_Predict_StepSlideMove (state, mins, maxs, dt);
 	else
-		CL_Predict_SlideMove (state, mins, maxs, host_frametime);
+		CL_Predict_SlideMove (state, mins, maxs, dt);
 
 	state->onground = CL_Predict_CheckGroundTrace (state->origin, mins, maxs);
 	if (state->onground && state->velocity[2] < 0)
@@ -555,10 +591,21 @@ void CL_Predict_Clear (void)
 	memset (&cl_pred, 0, sizeof(cl_pred));
 	cl_pred_warned_solid = false;
 	VectorClear (cl_pred_error);
+	VectorClear (cl_pred_angle_error);
+	cl_pred_steps_this_frame = 0;
+	cl_pred_server_update_this_frame = false;
+}
+
+void CL_Predict_BeginFrame (void)
+{
+	cl_pred_steps_this_frame = 0;
+	cl_pred_server_update_this_frame = false;
 }
 
 void CL_Predict_SetupCmd (usercmd_t *cmd)
 {
+	float dt;
+
 	cl_netdbg_predict_ran = false;
 	cmd->sequence = cl_pred.seq_latest + 1;
 	cl_pred.seq_latest = cmd->sequence;
@@ -567,7 +614,8 @@ void CL_Predict_SetupCmd (usercmd_t *cmd)
 	if (!CL_Predict_IsEnabled () || !cl_pred.has_base)
 		return;
 
-	CL_Predict_SimulateCmd (&cl_pred.predicted, cmd);
+	dt = CL_Predict_GetStepTime ();
+	CL_Predict_SimulateCmd (&cl_pred.predicted, cmd, dt);
 	CL_Predict_ApplyToClient ();
 	cl_netdbg_predict_ran = true;
 }
@@ -589,8 +637,11 @@ void CL_Predict_ServerUpdate (unsigned int ack, const vec3_t origin, const vec3_
 	unsigned int seq;
 	float correction;
 	vec3_t error;
+	vec3_t angle_error;
 	float error_len;
 	float teleport_dist = cl_pred_teleport_dist.value;
+	float dt;
+	int i;
 
 	if (cl_pred.has_base && !CL_Predict_SeqNewer (ack, cl_pred.seq_acked))
 		return;
@@ -608,10 +659,13 @@ void CL_Predict_ServerUpdate (unsigned int ack, const vec3_t origin, const vec3_
 	}
 
 	cl_pred.seq_acked = ack;
+	cl_pred_server_update_this_frame = true;
 	if (cl_pred.has_base)
 	{
 		VectorSubtract (origin, cl_pred.predicted.origin, error);
 		error_len = VectorLength (error);
+		for (i = 0; i < 3; i++)
+			angle_error[i] = CL_Predict_AngleDelta (viewangles[i], cl_pred.predicted.viewangles[i]);
 		if (cl_netdbg_pred.value > 0.0f)
 		{
 			Con_Printf ("NETDBG: pred_error %.2f (server %.1f %.1f %.1f client %.1f %.1f %.1f)\n",
@@ -622,15 +676,18 @@ void CL_Predict_ServerUpdate (unsigned int ack, const vec3_t origin, const vec3_
 		if (teleport_dist > 0.0f && error_len > teleport_dist)
 		{
 			VectorClear (cl_pred_error);
+			VectorClear (cl_pred_angle_error);
 		}
 		else
 		{
 			VectorAdd (cl_pred_error, error, cl_pred_error);
+			VectorAdd (cl_pred_angle_error, angle_error, cl_pred_angle_error);
 		}
 	}
 	else
 	{
 		VectorClear (cl_pred_error);
+		VectorClear (cl_pred_angle_error);
 	}
 	VectorCopy (origin, cl_pred.base.origin);
 	VectorCopy (origin, cl.simorg);
@@ -643,13 +700,14 @@ void CL_Predict_ServerUpdate (unsigned int ack, const vec3_t origin, const vec3_
 	if (!CL_Predict_IsEnabled ())
 		return;
 
+	dt = CL_Predict_GetStepTime ();
 	for (seq = ack + 1; !CL_Predict_SeqNewer (seq, cl_pred.seq_latest); seq++)
 	{
 		usercmd_t cmd;
 
 		if (!CL_Predict_GetCmd (seq, &cmd))
 			break;
-		CL_Predict_SimulateCmd (&cl_pred.predicted, &cmd);
+		CL_Predict_SimulateCmd (&cl_pred.predicted, &cmd, dt);
 	}
 
 	CL_Predict_ApplyToClient ();
@@ -661,4 +719,27 @@ void CL_Predict_Reapply (void)
 		return;
 
 	CL_Predict_ApplyToClient ();
+}
+
+qboolean CL_Predict_GetDebug (cl_pred_debug_t *out)
+{
+	if (!out)
+		return false;
+
+	memset (out, 0, sizeof(*out));
+	out->prediction_steps = cl_pred_steps_this_frame;
+	out->server_update_applied = cl_pred_server_update_this_frame;
+	out->pred_error_len = VectorLength (cl_pred_error);
+	out->pred_angle_error_len = VectorLength (cl_pred_angle_error);
+	VectorCopy (cl_pred_error, out->pred_error);
+	VectorCopy (cl_pred_angle_error, out->pred_angle_error);
+
+	if (!cl_pred.has_base)
+		return false;
+
+	VectorCopy (cl_pred.base.origin, out->base_origin);
+	VectorCopy (cl_pred.base.viewangles, out->base_angles);
+	VectorCopy (cl_pred.predicted.origin, out->predicted_origin);
+	VectorCopy (cl_pred.predicted.viewangles, out->predicted_angles);
+	return true;
 }

--- a/Quake/client.h
+++ b/Quake/client.h
@@ -507,6 +507,20 @@ typedef struct
 	int		state;			// low bit is down state
 } kbutton_t;
 
+typedef struct
+{
+	vec3_t		base_origin;
+	vec3_t		base_angles;
+	vec3_t		predicted_origin;
+	vec3_t		predicted_angles;
+	vec3_t		pred_error;
+	vec3_t		pred_angle_error;
+	float		pred_error_len;
+	float		pred_angle_error_len;
+	int			prediction_steps;
+	qboolean	server_update_applied;
+} cl_pred_debug_t;
+
 extern	kbutton_t	in_mlook, in_klook;
 extern 	kbutton_t 	in_strafe;
 extern 	kbutton_t 	in_speed;
@@ -519,10 +533,13 @@ void CL_AccumulateCmd (void);
 void CL_SendCmd (void);
 void CL_SendMove (const usercmd_t *cmd);
 void CL_Predict_Clear (void);
+void CL_Predict_BeginFrame (void);
 void CL_Predict_SetupCmd (usercmd_t *cmd);
 void CL_Predict_ServerUpdate (unsigned int ack, const vec3_t origin, const vec3_t velocity, const vec3_t viewangles, qboolean onground);
 void CL_Predict_Reapply (void);
 qboolean CL_Predict_GetCmd (unsigned int seq, usercmd_t *out);
+qboolean CL_Predict_GetDebug (cl_pred_debug_t *out);
+void CL_JitterDebug_Log (void);
 void CL_GetPlayerSnapRange (double *out_oldest, double *out_newest, int *out_count);
 int  CL_ReadFromServer (void);
 void CL_AdjustAngles (void);

--- a/Quake/gl_screen.c
+++ b/Quake/gl_screen.c
@@ -2183,6 +2183,8 @@ void SCR_UpdateScreen (void)
 
        V_PolyBlend ();
 
+	CL_JitterDebug_Log ();
+
        R_StorePrevFrameState ();
 
 	GL_BeginGroup ("2D");


### PR DESCRIPTION
### Motivation
- Eliminate local singleplayer movement jitter caused by prediction/render timebase mismatches and accumulator drift by unifying timelines and smoothing corrections.
- Provide per-frame instrumentation to observe `cl.time`, realtime, host frametime, prediction errors and whether server updates are applied to speed diagnosis.
- Stabilize stepping to avoid float accumulator oscillation and avoid hard corrections that produce visual snaps.

### Description
- Use a coherent prediction step time via `CL_Predict_GetStepTime()` which prefers `cl_physrate` and otherwise uses `cl_cmdrate`, and pass a `dt` into prediction paths (`CL_Predict_SimulateCmd`, slide/step calls and acceleration/friction functions) instead of using `host_frametime` inside prediction code.
- Replace the floating accumulator with an integer microsecond accumulator `cl_cmd_accum_us` and helper `CL_SecondsToUsec()` in `CL_SendCmd` to prevent fractional drift and oscillation when building commands.
- Add angle error tracking and smoothing (`cl_pred_angle_error`) and apply smoothed predicted angles to the client (`cl.viewangles`) alongside position smoothing controlled by existing `cl_pred_smooth_ms`.
- Expose per-frame prediction debug data via a new `cl_pred_debug_t` and API `CL_Predict_GetDebug()` and added `CL_Predict_BeginFrame()` to reset per-frame counters before input accumulation.
- Add `cl_jitter_debug` CVar and `CL_JitterDebug_Log()` which prints per-frame diagnostic info (interp delay/target, server update flag, prediction step count, auth/pred/render origins & angles, error magnitudes), and call it from the render path (`SCR_UpdateScreen` / `V_RenderView` sequence).
- Register the new `cl_jitter_debug` CVar and add prototypes/struct to `client.h` for the new APIs and debug struct.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c82ff4340832eb8e74f160fa3d787)