### PR TITLE
Fix prediction ground motion validation on viewentity change

### DIFF
--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -3731,6 +3731,7 @@ void CL_ParseServerMessage (void)
 		case svc_setview:
 			// Viewentity is per-client and must be set immediately for snapshot2/clientdata merge.
 			cl.viewentity = MSG_ReadShort ();
+			CL_Predict_ResetGround ();
 			break;
 
 		case svc_lightstyle:

--- a/Quake/cl_predict.c
+++ b/Quake/cl_predict.c
@@ -93,6 +93,21 @@ static qboolean CL_Predict_SeqNewer (unsigned int seq, unsigned int ref)
 	return NETSEQ_GT (seq, ref);
 }
 
+static qboolean CL_Predict_IsGroundEntityValid (int groundent)
+{
+	if (groundent <= 0 || groundent >= cl_max_edicts)
+		return false;
+	if (!cl_entities)
+		return false;
+	if (cl.mtime[0] <= 0.0)
+		return false;
+	if (cl.snapshot_present && !cl.snapshot_present[groundent])
+		return false;
+	if (cl_entities[groundent].msgtime != cl.mtime[0])
+		return false;
+	return true;
+}
+
 static float CL_Predict_GetStepTime (void)
 {
 	double cmd_rate = cl_cmdrate.value > 0.0 ? cl_cmdrate.value : 60.0;
@@ -345,8 +360,15 @@ static qboolean CL_Predict_GetGroundMotion (int groundent, float dt, vec3_t out_
 	if (out_yaw_delta)
 		*out_yaw_delta = 0.0f;
 
-	if (groundent <= 0 || groundent >= cl_max_edicts)
+	if (!CL_Predict_IsGroundEntityValid (groundent))
+	{
+		if (cl_netdebug_parse.value)
+		{
+			Con_Printf ("NETDBG: pred ground invalid ent=%d mtime=%.3f\n",
+				groundent, cl.mtime[0]);
+		}
 		return false;
+	}
 
 	msg_dt = cl.mtime[0] - cl.mtime[1];
 	if (msg_dt <= 0.0)
@@ -375,7 +397,7 @@ static void CL_Predict_ApplyGroundMotion (cl_pred_state_t *state, int groundent,
 	float radians;
 	float c, s;
 
-	if (groundent <= 0 || groundent >= cl_max_edicts)
+	if (!CL_Predict_IsGroundEntityValid (groundent))
 	{
 		state->groundent = 0;
 		state->ground_valid = false;
@@ -704,6 +726,17 @@ void CL_Predict_Clear (void)
 	VectorClear (cl_pred_angle_error);
 	cl_pred_steps_this_frame = 0;
 	cl_pred_server_update_this_frame = false;
+}
+
+void CL_Predict_ResetGround (void)
+{
+	if (!cl_pred.has_base)
+		return;
+
+	cl_pred.base.groundent = 0;
+	cl_pred.base.ground_valid = false;
+	cl_pred.predicted.groundent = 0;
+	cl_pred.predicted.ground_valid = false;
 }
 
 void CL_Predict_BeginFrame (void)

--- a/Quake/client.h
+++ b/Quake/client.h
@@ -540,6 +540,7 @@ void CL_Predict_SetupCmd (usercmd_t *cmd);
 void CL_Predict_ServerUpdate (unsigned int ack, const vec3_t origin, const vec3_t velocity, const vec3_t viewangles, qboolean onground);
 void CL_Predict_Reapply (void);
 qboolean CL_Predict_GetCmd (unsigned int seq, usercmd_t *out);
+void CL_Predict_ResetGround (void);
 qboolean CL_Predict_GetDebug (cl_pred_debug_t *out);
 void CL_JitterDebug_Log (void);
 void CL_GetPlayerSnapRange (double *out_oldest, double *out_newest, int *out_count);


### PR DESCRIPTION
### Motivation
- A crash occurred ~1s after player spawn due to prediction applying moving-ground deltas using stale/invalid ground entity data that wasn’t present in the current snapshot and could result in out-of-range or use-after-free access. 
- The change focuses on the moving-ground/prediction/smoothing codepath to validate ground entity references and clear cached ground state when the player/viewentity changes.

### Description
- Added `CL_Predict_IsGroundEntityValid` to `Quake/cl_predict.c` which validates a ground entity id against `cl_max_edicts`, `cl_entities`, current `cl.mtime`, and `cl.snapshot_present` to prevent using stale snapshot data. 
- Replaced raw `groundent` range checks in `CL_Predict_GetGroundMotion` and `CL_Predict_ApplyGroundMotion` with the new validator, and emit a `NETDBG` print behind `cl_netdebug_parse` when an invalid ground entity is detected. 
- Implemented `CL_Predict_ResetGround` in `Quake/cl_predict.c` and exposed it in `Quake/client.h` as `void CL_Predict_ResetGround(void);` to clear prediction ground caches (`base` and `predicted`) safely. 
- Call `CL_Predict_ResetGround()` from `Quake/cl_parse.c` when `svc_setview` (viewentity change) is processed so a spawn or view switch does not carry stale ground state into prediction.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697cf3834c3c832ea6b128ceab7ec642)