### PR TITLE
Compute trace.entnum while sv.qcvm is active to avoid NUM_FOR_EDICT NULL deref

### DIFF
--- a/Quake/cl_predict.c
+++ b/Quake/cl_predict.c
@@ -300,6 +300,8 @@ static trace_t CL_Predict_TraceBox (const vec3_t start, const vec3_t end, const 
 	sv.worldmodel = cl.worldmodel;
 	PR_PushQCVM(&sv.qcvm, &oldvm);
 	trace = SV_Move (start_copy, mins_copy, maxs_copy, end_copy, typeflags, NULL);
+	// NUM_FOR_EDICT depends on qcvm; compute ent->num before popping sv.qcvm.
+	trace.entnum = trace.ent ? NUM_FOR_EDICT (trace.ent) : 0;
 	PR_PopQCVM(oldvm);
 	sv.worldmodel = saved;
 
@@ -323,7 +325,7 @@ static int CL_Predict_TraceEntNum (const trace_t *trace)
 {
 	if (!trace->ent)
 		return 0;
-	return NUM_FOR_EDICT (trace->ent);
+	return trace->entnum;
 }
 
 static qboolean CL_Predict_GetGroundTrace (const vec3_t origin, const vec3_t mins, const vec3_t maxs, int *groundent)

--- a/Quake/world.h
+++ b/Quake/world.h
@@ -38,6 +38,7 @@ typedef struct
 	vec3_t	endpos;			// final position
 	plane_t	plane;			// surface normal at impact
 	edict_t	*ent;			// entity the surface is on
+	int		entnum;			// NUM_FOR_EDICT(ent) while qcvm context is active
 } trace_t;
 
 
@@ -84,4 +85,3 @@ trace_t SV_Move (vec3_t start, vec3_t mins, vec3_t maxs, vec3_t end, int type, e
 qboolean SV_RecursiveHullCheck (const hull_t *hull, int num, float p1f, float p2f, vec3_t p1, vec3_t p2, trace_t *trace);
 
 #endif	/* _QUAKE_WORLD_H */
-


### PR DESCRIPTION
### Motivation
- A prediction trace returned from `SV_Move` can reference `trace.ent` that lives in the server QCVM (`sv.qcvm`), but `NUM_FOR_EDICT()` dereferences `qcvm` and can crash if called after `PR_PopQCVM(oldvm)` leaves the global `qcvm` NULL. 
- The intent is to compute the entity number while the server QCVM is still active so callers can use the precomputed value after the QCVM is popped without changing `trace.ent` semantics or protocol.

### Description
- Added an `int entnum` field to `trace_t` to store `NUM_FOR_EDICT(ent)` computed while the QCVM context is active by updating `Quake/world.h`.
- In `Quake/cl_predict.c`, capture `trace.entnum = trace.ent ? NUM_FOR_EDICT(trace.ent) : 0;` immediately after `SV_Move` and before `PR_PopQCVM(oldvm)` so the conversion happens under the correct QCVM.
- Updated `CL_Predict_TraceEntNum` to return `trace->entnum` instead of calling `NUM_FOR_EDICT(trace->ent)`, and added a comment documenting that the ent→num conversion must be done while the QCVM context is active.
- Changes are limited to the minimal safe fix: storing the computed entity number and switching helpers to use it, without altering trace pointer semantics or external behavior.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697cfea6cf44832ea115a7313da546b5)