### PR TITLE
Fix ground-entity prediction jitter by gating ground-relative motion

### DIFF
--- a/Quake/cl_predict.c
+++ b/Quake/cl_predict.c
@@ -743,6 +743,7 @@ static void CL_Predict_SimulateCmd (cl_pred_state_t *state, const usercmd_t *cmd
 	vec3_t ground_delta;
 	float ground_yaw_delta;
 	qboolean ground_applied;
+	qboolean ground_entity;
 
 	cl_pred_steps_this_frame++;
 	CL_Predict_GetPlayerBounds (mins, maxs);
@@ -755,7 +756,8 @@ static void CL_Predict_SimulateCmd (cl_pred_state_t *state, const usercmd_t *cmd
 	else if (state->onground)
 		CL_Predict_GetGroundTrace (state->origin, mins, maxs, &groundent);
 
-	if (state->onground)
+	ground_entity = (state->onground && groundent > 0);
+	if (ground_entity)
 		ground_applied = CL_Predict_ApplyGroundMotion (state, groundent, dt, ground_delta, &ground_yaw_delta);
 	else
 	{
@@ -763,6 +765,13 @@ static void CL_Predict_SimulateCmd (cl_pred_state_t *state, const usercmd_t *cmd
 		ground_applied = false;
 		VectorClear (ground_delta);
 		ground_yaw_delta = 0.0f;
+	}
+	if (!state->ground_valid)
+		ground_yaw_delta = 0.0f;
+	if (cl_netdebug_parse.value && ground_entity && !state->ground_valid)
+	{
+		Con_Printf ("NETDBG: pred ground missing ent=%d mtime=%.3f\n",
+			groundent, cl.mtime[0]);
 	}
 
 	VectorCopy (cmd->viewangles, state->viewangles);
@@ -823,7 +832,7 @@ static void CL_Predict_SimulateCmd (cl_pred_state_t *state, const usercmd_t *cmd
 		CL_Predict_ResetGroundCache (state);
 	}
 
-	cl_pred_ground_dbg.onground = state->onground;
+	cl_pred_ground_dbg.onground = (state->onground && state->groundent > 0);
 	cl_pred_ground_dbg.groundent = state->groundent;
 	cl_pred_ground_dbg.ground_valid = state->ground_valid;
 	cl_pred_ground_dbg.ground_delta_len = VectorLength (ground_delta);


### PR DESCRIPTION
### Motivation
- Prevent deterministic 180° yaw flips and render jitter caused by applying ground-relative yaw/origin corrections when there is no valid ground entity by ensuring ground-relative logic only runs for a valid entity.

### Description
- In `Quake/cl_predict.c` only call `CL_Predict_ApplyGroundMotion` when `(state->onground && groundent > 0)`, reset the ground cache when no valid entity is present, force `ground_yaw_delta` to `0.0f` when `state->ground_valid` is false, emit a `NETDBG` warning when a grounded state lacks valid ground data, and report `cl_pred_ground_dbg.onground` as true only when a valid ground entity exists.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d178e798c832e95cd30c942804053)