### PR TITLE
Avoid sv_player null trap during DoF autofocus

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -565,15 +565,11 @@ static float R_GetDynamicDoFFocus (float fallback)
 	if (sv.active)
 	{
 		extern edict_t* sv_player;
-		qcvm_t* oldvm = qcvm;
 
-		if (!sv_player)
+		if (sv_player)
 		{
-			Con_Printf ("NETDBG sv_player NULL cl %d reason dof_autofocus\n", SV_CurrentClientIndex ());
-			SV_PlayerNullTrap (__func__, 0);
-		}
-		else
-		{
+			qcvm_t* oldvm = qcvm;
+
 			PR_SwitchQCVM (NULL);
 			PR_SwitchQCVM (&sv.qcvm);
 


### PR DESCRIPTION
### Motivation
- Prevent noisy `sv_player NULL` debug prints and potential traps triggered during DoF autofocus when the server-side player entity is not present.
- Ensure autofocus still produces a valid target by keeping the world-hull fallback path when server tracing is skipped.

### Description
- Add a guard in `R_GetDynamicDoFFocus` (`Quake/gl_rmain.c`) to only switch QCVM and call `SV_Move` when `sv_player` is non-null.
- Remove the server-side path that invoked `SV_PlayerNullTrap`/`Con_Printf` from the autofocus trace logic and limit `oldvm` scope to when it is used.
- Preserve the existing `SV_RecursiveHullCheck` fallback so autofocus target selection continues to work when the server trace is skipped.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d32c0b9d8832e8b09dc982019c727)