### PR TITLE
Fix ground-entity gating for prediction jitter

### DIFF
--- a/Quake/cl_predict.c
+++ b/Quake/cl_predict.c
@@ -756,6 +756,11 @@ static void CL_Predict_SimulateCmd (cl_pred_state_t *state, const usercmd_t *cmd
 	else if (state->onground)
 		CL_Predict_GetGroundTrace (state->origin, mins, maxs, &groundent);
 
+	if (state->onground && groundent == 0 && cl_netdebug_parse.value)
+	{
+		Con_Printf ("NETDBG: pred onground without ground entity (groundent 0)\n");
+	}
+
 	ground_entity = (state->onground && groundent > 0);
 	if (ground_entity)
 		ground_applied = CL_Predict_ApplyGroundMotion (state, groundent, dt, ground_delta, &ground_yaw_delta);
@@ -763,6 +768,13 @@ static void CL_Predict_SimulateCmd (cl_pred_state_t *state, const usercmd_t *cmd
 	{
 		CL_Predict_ResetGroundCache (state);
 		ground_applied = false;
+		VectorClear (ground_delta);
+		ground_yaw_delta = 0.0f;
+	}
+	if (groundent <= 0)
+		state->ground_valid = false;
+	if (!state->ground_valid || groundent <= 0)
+	{
 		VectorClear (ground_delta);
 		ground_yaw_delta = 0.0f;
 	}
@@ -826,13 +838,23 @@ static void CL_Predict_SimulateCmd (cl_pred_state_t *state, const usercmd_t *cmd
 		state->velocity[2] = 0;
 
 	if (state->onground)
+	{
 		state->groundent = groundent;
+		if (state->groundent <= 0)
+		{
+			state->ground_valid = false;
+			if (cl_netdebug_parse.value)
+			{
+				Con_Printf ("NETDBG: pred onground without ground entity (post-move)\n");
+			}
+		}
+	}
 	else
 	{
 		CL_Predict_ResetGroundCache (state);
 	}
 
-	cl_pred_ground_dbg.onground = (state->onground && state->groundent > 0);
+	cl_pred_ground_dbg.onground = (state->onground && state->groundent > 0 && state->ground_valid);
 	cl_pred_ground_dbg.groundent = state->groundent;
 	cl_pred_ground_dbg.ground_valid = state->ground_valid;
 	cl_pred_ground_dbg.ground_delta_len = VectorLength (ground_delta);
@@ -995,12 +1017,18 @@ void CL_Predict_ServerUpdate (unsigned int ack, const vec3_t origin, const vec3_
 	{
 		vec3_t mins, maxs;
 		int groundent = 0;
+		qboolean ground_trace;
 
 		CL_Predict_GetPlayerBounds (mins, maxs);
-		if (CL_Predict_GetGroundTrace (cl_pred.base.origin, mins, maxs, &groundent))
+		ground_trace = CL_Predict_GetGroundTrace (cl_pred.base.origin, mins, maxs, &groundent);
+		if (ground_trace)
 		{
 			cl_pred.base.groundent = groundent;
 			cl_pred.predicted.groundent = groundent;
+		}
+		if (groundent == 0 && cl_netdebug_parse.value)
+		{
+			Con_Printf ("NETDBG: server onground without ground entity (groundent 0)\n");
 		}
 	}
 


### PR DESCRIPTION
### Motivation
- Prevent deterministic yaw re-normalization and render jitter caused by applying ground-relative motion/angle corrections when there is no valid non-world ground entity. 
- Enforce the invariant that `onground` implies a positive `groundent` and `ground_valid` to avoid applying entity-ground adjustments to world-ground or invalid cases. 
- Add debug visibility when the server/client reports `onground` without an associated entity so invalid state can be diagnosed. 

### Description
- In `CL_Predict_SimulateCmd` added a `NETDBG` message when `state->onground` is true but `groundent == 0` to surface pred-side invalid onground cases. 
- Force `state->ground_valid = false` when `groundent <= 0`, and clear `ground_delta`/`ground_yaw_delta` whenever the ground is invalid or `groundent <= 0`, preventing any ground-relative yaw/position remapping from running. 
- After movement, ensure `state->groundent` is set and mark `ground_valid = false` (with a `NETDBG` message) when `state->groundent <= 0` to avoid treating world-ground as entity-ground. 
- Tighten debug reporting so `cl_pred_ground_dbg.onground` only reports true for cases that are both entity-ground and `ground_valid`. 
- In `CL_Predict_ServerUpdate` use an explicit `ground_trace` result and emit a `NETDBG` message when the server reports `onground` but the local ground trace yields `groundent == 0`. 
- Changes are localized to `Quake/cl_predict.c` and are a minimal client-side fix (no protocol changes). 

### Testing
- No automated tests were run as part of this change; only code inspection, searches, and commits were performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d338dcce0832ea8b4d1bfd3a96517)