### PR TITLE
Use predicted origin for airborne viewentity to fix airborne render jitter

### DIFF
--- a/Quake/cl_main.c
+++ b/Quake/cl_main.c
@@ -1577,6 +1577,9 @@ void CL_RelinkEntities (void)
 			}
 		}
 
+		if (ent == &cl_entities[cl.viewentity] && !cl.onground)
+			VectorCopy (cl.simorg, ent->origin);
+
 		if (i <= cl.maxclients && i != cl.viewentity)
 		{
 			vec3_t lerp_org;


### PR DESCRIPTION
### Motivation
- Prevent vertical render drift for the local player while airborne by making the render origin follow client prediction rather than interpolated snapshots when `cl.onground` is false.

### Description
- In `Quake/cl_main.c` override the viewentity origin with the predicted simulation origin by copying `cl.simorg` to `ent->origin` when `ent == &cl_entities[cl.viewentity] && !cl.onground`, leaving angle interpolation and remote-entity snapshot interpolation unchanged.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d38ccb728832ebaa866392f295350)