### PR TITLE
Add `cl_predict` cvar to toggle client-side movement prediction

### DIFF
--- a/Quake/cl_main.c
+++ b/Quake/cl_main.c
@@ -72,6 +72,7 @@ cvar_t	cl_lerp_debug = {"cl_lerp_debug", "0", CVAR_NONE};
 cvar_t	cl_netdbg_interp = {"cl_netdbg_interp", "0", CVAR_NONE};
 cvar_t	cl_netdbg_watch_ent = {"cl_netdbg_watch_ent", "0", CVAR_NONE};
 cvar_t	cl_netdbg_pred = {"cl_netdbg_pred", "0", CVAR_NONE};
+cvar_t	cl_predict = {"cl_predict", "1", CVAR_ARCHIVE};
 cvar_t	cl_pred_smooth_ms = {"cl_pred_smooth_ms", "120", CVAR_NONE};
 cvar_t	cl_pred_teleport_dist = {"cl_pred_teleport_dist", "128", CVAR_NONE};
 cvar_t	cl_pred_deadzone = {"cl_pred_deadzone", "0.25", CVAR_NONE};
@@ -2193,6 +2194,7 @@ void CL_Init (void)
 	Cvar_RegisterVariable (&cl_netdbg_interp);
 	Cvar_RegisterVariable (&cl_netdbg_watch_ent);
 	Cvar_RegisterVariable (&cl_netdbg_pred);
+	Cvar_RegisterVariable (&cl_predict);
 	Cvar_RegisterVariable (&cl_pred_smooth_ms);
 	Cvar_RegisterVariable (&cl_pred_teleport_dist);
 	Cvar_RegisterVariable (&cl_pred_deadzone);

--- a/Quake/cl_predict.c
+++ b/Quake/cl_predict.c
@@ -10,6 +10,7 @@ extern cvar_t sv_friction;
 extern cvar_t sv_stopspeed;
 extern cvar_t sv_gravity;
 extern cvar_t cl_netdebug_parse;
+extern cvar_t cl_predict;
 extern cvar_t cl_cmdrate;
 extern cvar_t cl_physrate;
 extern cvar_t cl_jitter_debug;
@@ -198,6 +199,8 @@ static qboolean CL_Predict_IsEnabled (void)
 	if (cls.demoplayback)
 		return false;
 	if (cl.intermission)
+		return false;
+	if (!cl_predict.value)
 		return false;
 	if (!cl.has_valid_worldstate)
 		return false;

--- a/Quake/client.h
+++ b/Quake/client.h
@@ -448,6 +448,7 @@ extern	cvar_t	cl_lerp_debug;
 extern	cvar_t	cl_netdbg_interp;
 extern	cvar_t	cl_netdbg_watch_ent;
 extern	cvar_t	cl_netdbg_pred;
+extern	cvar_t	cl_predict;
 extern	cvar_t	cl_pred_smooth_ms;
 extern	cvar_t	cl_pred_teleport_dist;
 extern	cvar_t	cl_pred_deadzone;


### PR DESCRIPTION
### Motivation
- Provide a runtime toggle to enable or disable client-side player movement prediction so users or configs can opt out of prediction behavior.

### Description
- Add a new `cvar_t` definition `cl_predict` with default `"1"` to `Quake/cl_main.c` so prediction can be configured. 
- Register `cl_predict` in `CL_Init` by calling `Cvar_RegisterVariable(&cl_predict)` so it is exposed to the console and persisted. 
- Export `extern cvar_t cl_predict;` in `Quake/client.h` so other client code can reference the toggle. 
- Gate prediction logic in `Quake/cl_predict.c` by checking `if (!cl_predict.value) return false;` inside `CL_Predict_IsEnabled()` to disable prediction when `cl_predict` is zero.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d4315f99c832e96f304c3974bf671)