### PR TITLE
Clear pause on respawn and add long-pause NETDBG log

### DIFF
--- a/Quake/host.c
+++ b/Quake/host.c
@@ -1104,6 +1104,8 @@ Host_ServerFrame
 static void SV_RunOneTick (double tick_dt)
 {
 	static double next_sv_skip_log = 0.0;
+	static int paused_frame_count = 0;
+	const int paused_frame_threshold = 120;
 
 	host_frametime = tick_dt;
 	pr_global_struct->frametime = host_frametime;
@@ -1114,13 +1116,23 @@ static void SV_RunOneTick (double tick_dt)
 	// move things around and think
 	if (!sv.paused)
 	{
+		paused_frame_count = 0;
 		SV_Physics ();
 	}
-	else if (realtime >= next_sv_skip_log)
+	else
 	{
-		Con_Printf ("NETDBG SV_Physics skipped (SV_RunOneTick) paused=%d key_dest=%d\n",
-			sv.paused, key_dest);
-		next_sv_skip_log = realtime + 1.0;
+		paused_frame_count++;
+		if (paused_frame_count == paused_frame_threshold)
+		{
+			Con_Printf ("NETDBG SV_RunOneTick paused for %d frames (paused=%d key_dest=%d)\n",
+				paused_frame_count, sv.paused, key_dest);
+		}
+		if (realtime >= next_sv_skip_log)
+		{
+			Con_Printf ("NETDBG SV_Physics skipped (SV_RunOneTick) paused=%d key_dest=%d\n",
+				sv.paused, key_dest);
+			next_sv_skip_log = realtime + 1.0;
+		}
 	}
 }
 

--- a/Quake/host_cmd.c
+++ b/Quake/host_cmd.c
@@ -3163,6 +3163,9 @@ static void Host_Spawn_f (void)
 		PR_ExecuteProgram (pr_global_struct->PutClientInServer);
 	}
 
+	sv.paused = false;
+	cl.paused = false;
+
 // send all current names, colors, and frag counts
 	SZ_Clear (&host_client->message);
 


### PR DESCRIPTION
### Motivation

- Respawning could leave the server permanently paused because pause flags set during death/menu/intermission were not reliably cleared, causing `SV_RunOneTick` to skip physics every frame and hang or crash later. 
- Make a minimal, safe fix that explicitly clears pause state on player spawn and adds diagnostics to detect future regressions without changing gameplay or network protocol.

### Description

- Explicitly clear server and client pause flags after the spawn sequence by setting `sv.paused = false` and `cl.paused = false` in `Host_Spawn_f` (file `Quake/host_cmd.c`).
- Add a frame counter `paused_frame_count` and a threshold `paused_frame_threshold = 120` to `SV_RunOneTick` in `Quake/host.c` to track consecutive paused ticks. 
- Emit a `NETDBG` `Con_Printf` when the pause persists for the configured threshold and preserve the existing per-second skip log behavior.

### Testing

- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697dd3371598832e9978c2eb5a5c0403)