### PR TITLE
Bind client prediction dt to usercmd->msec, add debug CVARs & hard-resync, and server-physics instrumentation

### DIFF
--- a/Quake/cl_predict.c
+++ b/Quake/cl_predict.c
@@ -15,6 +15,8 @@ extern cvar_t cl_cmdrate;
 extern cvar_t cl_physrate;
 extern cvar_t cl_jitter_debug;
 
+static cvar_t cl_pred_debug = {"cl_pred_debug", "0", CVAR_NONE};
+
 typedef struct
 {
 	int		id;
@@ -80,6 +82,8 @@ static vec3_t cl_pred_error;
 static vec3_t cl_pred_angle_error;
 static int cl_pred_steps_this_frame;
 static qboolean cl_pred_server_update_this_frame;
+static qboolean cl_pred_debug_registered;
+static qboolean cl_pred_prev_enabled;
 static cl_pred_ground_debug_t cl_pred_ground_dbg;
 static float cl_pred_last_trace_fraction;
 static float cl_pred_last_trace_normal_z;
@@ -92,6 +96,7 @@ static int cl_pred_last_trace_fallback;
 #define CL_PREDICT_STEP_SIZE 18.0f
 #define CL_PREDICT_GROUND_EPSILON 2.0f
 #define CL_PREDICT_CORRECTION_THRESHOLD 64.0f
+#define CL_PREDICT_SNAP_THRESHOLD 8.0f
 #define CL_PREDICT_GROUND_STABLE_FRAMES 2
 #define CL_PREDICT_GROUND_KEEP_FRAMES 2
 
@@ -135,6 +140,15 @@ static void CL_EnsureViewEntityOrigin (const char *reason)
 		Con_Printf ("NETDBG: viewentity origin repaired (%s): simorg=%f %f %f\n",
 			reason ? reason : "unknown", cl.simorg[0], cl.simorg[1], cl.simorg[2]);
 	}
+}
+
+static void CL_Predict_RegisterDebugCvars (void)
+{
+	if (cl_pred_debug_registered)
+		return;
+
+	Cvar_RegisterVariable (&cl_pred_debug);
+	cl_pred_debug_registered = true;
 }
 
 static qboolean CL_Predict_SeqNewer (unsigned int seq, unsigned int ref)
@@ -183,6 +197,72 @@ static void CL_Predict_ResetGroundDebug (void)
 	cl_pred_last_trace_startsolid = 0;
 	cl_pred_last_trace_allsolid = 0;
 	cl_pred_last_trace_fallback = 0;
+}
+
+static float CL_Predict_GetCmdStepTime (const usercmd_t *cmd)
+{
+	if (cmd && cmd->msec > 0)
+		return cmd->msec * 0.001f;
+
+	return CL_Predict_GetStepTime ();
+}
+
+static qboolean CL_Predict_IsLocalListenServer (void)
+{
+	return (sv.active && cls.state == ca_connected && !cls.demoplayback);
+}
+
+static void CL_Predict_DebugLogCmd (const char *tag, const usercmd_t *cmd, float dt)
+{
+	vec3_t error;
+	float error_len;
+	const vec3_t *base_origin;
+	int is_local;
+
+	if (cl_pred_debug.value <= 0.0f || !cmd || !cl_pred.has_base)
+		return;
+
+	base_origin = &cl_pred.base.origin;
+	VectorSubtract (cl_pred.predicted.origin, *base_origin, error);
+	error_len = VectorLength (error);
+	is_local = CL_Predict_IsLocalListenServer () ? 1 : 0;
+
+	Con_Printf ("PREDDBG: %s seq=%u msec=%d dt=%.4f pred=%.2f %.2f %.2f base=%.2f %.2f %.2f err=%.3f local=%d\n",
+		tag ? tag : "cmd",
+		cmd->sequence,
+		cmd->msec,
+		dt,
+		cl_pred.predicted.origin[0],
+		cl_pred.predicted.origin[1],
+		cl_pred.predicted.origin[2],
+		(*base_origin)[0],
+		(*base_origin)[1],
+		(*base_origin)[2],
+		error_len,
+		is_local);
+}
+
+static void CL_Predict_HardResetToBase (const char *reason)
+{
+	if (!cl_pred.has_base)
+		return;
+
+	cl_pred.predicted = cl_pred.base;
+	VectorClear (cl_pred_error);
+	VectorClear (cl_pred_angle_error);
+	CL_Predict_InvalidateGroundCache (&cl_pred.base);
+	CL_Predict_ResetGroundCache (&cl_pred.predicted);
+	cl_pred.predicted.onground = cl_pred.base.onground;
+	cl_pred.predicted.groundent = cl_pred.base.groundent;
+
+	if (cl_pred_debug.value > 0.0f)
+	{
+		Con_Printf ("PREDDBG: HardReset reason=%s base=%.2f %.2f %.2f\n",
+			reason ? reason : "unknown",
+			cl_pred.base.origin[0],
+			cl_pred.base.origin[1],
+			cl_pred.base.origin[2]);
+	}
 }
 
 static void CL_Predict_ApplyGroundTransition (cl_pred_state_t *state, qboolean trace_onground, int trace_groundent)
@@ -1058,6 +1138,7 @@ static void CL_Predict_SimulateCmd (cl_pred_state_t *state, const usercmd_t *cmd
 
 void CL_Predict_Clear (void)
 {
+	CL_Predict_RegisterDebugCvars ();
 	memset (&cl_pred, 0, sizeof(cl_pred));
 	cl_pred_warned_solid = false;
 	cl_pred_warned_no_snapshot = false;
@@ -1065,6 +1146,7 @@ void CL_Predict_Clear (void)
 	VectorClear (cl_pred_angle_error);
 	cl_pred_steps_this_frame = 0;
 	cl_pred_server_update_this_frame = false;
+	cl_pred_prev_enabled = false;
 	CL_Predict_ResetGroundDebug ();
 }
 
@@ -1079,15 +1161,24 @@ void CL_Predict_ResetGround (void)
 
 void CL_Predict_BeginFrame (void)
 {
+	qboolean enabled;
+
+	CL_Predict_RegisterDebugCvars ();
 	cl_pred_steps_this_frame = 0;
 	cl_pred_server_update_this_frame = false;
 	CL_Predict_ResetGroundDebug ();
+
+	enabled = CL_Predict_IsEnabled ();
+	if (enabled && !cl_pred_prev_enabled && cl_pred.has_base)
+		CL_Predict_HardResetToBase ("predict reenabled");
+	cl_pred_prev_enabled = enabled;
 }
 
 void CL_Predict_SetupCmd (usercmd_t *cmd)
 {
 	float dt;
 
+	CL_Predict_RegisterDebugCvars ();
 	cl_netdbg_predict_ran = false;
 	cmd->sequence = cl_pred.seq_latest + 1;
 	cl_pred.seq_latest = cmd->sequence;
@@ -1096,8 +1187,9 @@ void CL_Predict_SetupCmd (usercmd_t *cmd)
 	if (!CL_Predict_IsEnabled () || !cl_pred.has_base)
 		return;
 
-	dt = CL_Predict_GetStepTime ();
+	dt = CL_Predict_GetCmdStepTime (cmd);
 	CL_Predict_SimulateCmd (&cl_pred.predicted, cmd, dt);
+	CL_Predict_DebugLogCmd ("setup", cmd, dt);
 	CL_Predict_ApplyToClient ();
 	cl_netdbg_predict_ran = true;
 }
@@ -1120,17 +1212,20 @@ void CL_Predict_ServerUpdate (unsigned int ack, const vec3_t origin, const vec3_
 	float correction;
 	vec3_t error;
 	vec3_t angle_error;
-	float error_len;
+	float error_len = 0.0f;
 	float teleport_dist = cl_pred_teleport_dist.value;
 	float dt;
 	int i;
 	int prev_pred_ground_ent = 0;
 	vec3_t prev_pred_ground_offset;
 	float prev_pred_ground_yaw_delta = 0.0f;
+	qboolean had_base;
 
+	CL_Predict_RegisterDebugCvars ();
 	if (cl_pred.has_base && !CL_Predict_SeqNewer (ack, cl_pred.seq_acked))
 		return;
 
+	had_base = cl_pred.has_base;
 	VectorClear (prev_pred_ground_offset);
 	if (cl_pred.has_base)
 	{
@@ -1218,7 +1313,6 @@ void CL_Predict_ServerUpdate (unsigned int ack, const vec3_t origin, const vec3_
 		VectorClear (cl_pred_angle_error);
 	}
 	VectorCopy (origin, cl_pred.base.origin);
-	VectorCopy (origin, cl.simorg);
 	VectorCopy (velocity, cl_pred.base.velocity);
 	VectorCopy (viewangles, cl_pred.base.viewangles);
 	cl_pred.base.onground = onground;
@@ -1284,17 +1378,42 @@ void CL_Predict_ServerUpdate (unsigned int ack, const vec3_t origin, const vec3_
 		cl_pred.predicted.pred_ground_yaw_delta = 0.0f;
 	}
 
-	if (!CL_Predict_IsEnabled ())
-		return;
+	if (!had_base)
+		CL_Predict_HardResetToBase ("new base");
 
-	dt = CL_Predict_GetStepTime ();
+	if (!CL_Predict_IsEnabled ())
+	{
+		VectorCopy (origin, cl.simorg);
+		return;
+	}
+
+	if (error_len > CL_PREDICT_SNAP_THRESHOLD)
+	{
+		VectorCopy (origin, cl.simorg);
+		VectorClear (cl_pred_error);
+		VectorClear (cl_pred_angle_error);
+	}
+
+	if (CL_Predict_SeqNewer (ack, cl_pred.seq_latest))
+	{
+		CL_Predict_HardResetToBase ("ack ahead of latest");
+		CL_Predict_ApplyToClient ();
+		return;
+	}
+
 	for (seq = ack + 1; !CL_Predict_SeqNewer (seq, cl_pred.seq_latest); seq++)
 	{
 		usercmd_t cmd;
 
 		if (!CL_Predict_GetCmd (seq, &cmd))
-			break;
+		{
+			CL_Predict_HardResetToBase ("cmd chain broken");
+			CL_Predict_ApplyToClient ();
+			return;
+		}
+		dt = CL_Predict_GetCmdStepTime (&cmd);
 		CL_Predict_SimulateCmd (&cl_pred.predicted, &cmd, dt);
+		CL_Predict_DebugLogCmd ("resim", &cmd, dt);
 	}
 
 	CL_Predict_ApplyToClient ();

--- a/Quake/sv_phys.c
+++ b/Quake/sv_phys.c
@@ -47,11 +47,23 @@ cvar_t	sv_gravity = {"sv_gravity","800",CVAR_NOTIFY|CVAR_SERVERINFO};
 cvar_t	sv_maxvelocity = {"sv_maxvelocity","2000",CVAR_NONE};
 cvar_t	sv_nostep = {"sv_nostep","0",CVAR_NONE};
 cvar_t	sv_freezenonclients = {"sv_freezenonclients","0",CVAR_NONE};
+cvar_t	sv_phys_debug = {"sv_phys_debug","0",CVAR_NONE};
 
 
 #define	MOVE_EPSILON	0.01
 
 void SV_Physics_Toss (edict_t *ent);
+
+static qboolean sv_phys_debug_registered;
+
+static void SV_Phys_RegisterDebugCvars (void)
+{
+	if (sv_phys_debug_registered)
+		return;
+
+	Cvar_RegisterVariable (&sv_phys_debug);
+	sv_phys_debug_registered = true;
+}
 
 /*
 ================
@@ -1228,6 +1240,13 @@ void SV_Physics (void)
 	int	i;
 	int	entity_cap; // For sv_freezenonclients 
 	edict_t	*ent;
+	int steps = 1;
+
+	SV_Phys_RegisterDebugCvars ();
+	if (sv_phys_debug.value > 0.0f)
+	{
+		Con_Printf ("SVPHYS: frametime=%.4f steps=%d\n", host_frametime, steps);
+	}
 
 // let the progs know that a new frame has started
 	pr_global_struct->self = EDICT_TO_PROG(qcvm->edicts);
@@ -1293,4 +1312,20 @@ void SV_Physics (void)
 
 	if (!sv_freezenonclients.value) 
 	  qcvm->time += host_frametime;
+
+	if (sv_phys_debug.value > 0.0f)
+	{
+		for (i = 1; i <= svs.maxclients; i++)
+		{
+			edict_t *player = EDICT_NUM (i);
+
+			if (!player || player->free)
+				continue;
+			Con_Printf ("SVPHYS: player %d origin=%.2f %.2f %.2f\n",
+				i,
+				player->v.origin[0],
+				player->v.origin[1],
+				player->v.origin[2]);
+		}
+	}
 }


### PR DESCRIPTION
### Motivation
- Eliminate movement jitter by ensuring client-side prediction uses the actual per-command timebase instead of an averaged rate and add instrumentation to prove and observe timing/drift. 
- Provide deterministic hard-resync rules so prediction doesn't accumulate an eternal offset when packet/sequence chains break.
- Add lightweight server-side physics logging to detect local SP/listen-server double-simulation / server-origin drift.

### Description
- Files modified: `Quake/cl_predict.c`, `Quake/sv_phys.c`.
- Prediction timing: added `CL_Predict_GetCmdStepTime(const usercmd_t *cmd)` and replaced uses of `CL_Predict_GetStepTime()` in `CL_Predict_SetupCmd()` and the server resimulation loop so `dt = (cmd->msec>0 ? cmd->msec*0.001f : fallback)` is used per command. This binds prediction step time to `cmd->msec` as required.
- Debug CVARs and instrumentation: added `cl_pred_debug` (register helper `CL_Predict_RegisterDebugCvars`) and per-command logging `CL_Predict_DebugLogCmd()` that prints sequence, `msec`, computed `dt`, predicted origin, base origin, error magnitude, and a local/listen-server flag when `cl_pred_debug` is enabled.
- Hard-resync logic: added `CL_Predict_HardResetToBase(const char *reason)` and call sites: when a new base is first set (`new base`), when prediction is re-enabled after being disabled (`predict reenabled`), when the ack/seq logic indicates inconsistency (`ack ahead of latest`), and when the command replay chain is broken during resim (`cmd chain broken`). Hard reset clears `cl_pred_error`/angle error and ground caches and logs the reason if debug is enabled.
- Snap / reconciliation threshold: added `CL_PREDICT_SNAP_THRESHOLD` (8 units) and, on server update, if the positional error exceeds the threshold the client `cl.simorg` is snapped to server origin and prediction errors cleared to avoid long small corrections that cause buzzing.
- Safety: if `CL_Predict_IsEnabled()` is false, server update now copies server origin into `cl.simorg` and returns (avoids leaving client in stale predicted state).
- Server physics instrumentation: added `sv_phys_debug` CVAR and registration helper; `SV_Physics()` now prints `host_frametime`/steps and dumps each connected player's origin when `sv_phys_debug` is enabled to help detect server origin drift in local/SP setups.

### Testing
- Automated tests: none were executed as part of this PR (no build/test run in this rollout). 
- How to validate with the new instrumentation: enable `cl_pred_debug 1` on the client to get per-command lines `PREDDBG: ... seq=... msec=... dt=... pred=... base=... err=... local=...` and verify `dt` equals `cmd->msec*0.001f` when `msec>0`; enable `sv_phys_debug 1` on the server to log `SVPHYS: frametime=...` and each player origin to check server-frame origin drift. Hard resets will print `PREDDBG: HardReset reason=...` when triggered. These logs are intentionally added so automated or manual runs can demonstrate dt equality, the presence/absence of per-frame snap events, and that error magnitude resets to ~0 immediately after a hard reset.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697dee1907d0832e85dfd3602e6c2ff6)