### PR TITLE
Fix prediction timing when usercmd lacks msec

### DIFF
--- a/Quake/cl_predict.c
+++ b/Quake/cl_predict.c
@@ -92,6 +92,8 @@ static int cl_pred_last_trace_startsolid;
 static int cl_pred_last_trace_allsolid;
 static int cl_pred_last_trace_fallback;
 
+static float CL_Predict_GetStepTime (void);
+
 #define CL_PREDICT_MAX_CLIP_PLANES 5
 #define CL_PREDICT_STEP_SIZE 18.0f
 #define CL_PREDICT_GROUND_EPSILON 2.0f
@@ -201,9 +203,7 @@ static void CL_Predict_ResetGroundDebug (void)
 
 static float CL_Predict_GetCmdStepTime (const usercmd_t *cmd)
 {
-	if (cmd && cmd->msec > 0)
-		return cmd->msec * 0.001f;
-
+	(void)cmd;
 	return CL_Predict_GetStepTime ();
 }
 
@@ -227,10 +227,9 @@ static void CL_Predict_DebugLogCmd (const char *tag, const usercmd_t *cmd, float
 	error_len = VectorLength (error);
 	is_local = CL_Predict_IsLocalListenServer () ? 1 : 0;
 
-	Con_Printf ("PREDDBG: %s seq=%u msec=%d dt=%.4f pred=%.2f %.2f %.2f base=%.2f %.2f %.2f err=%.3f local=%d\n",
+	Con_Printf ("PREDDBG: %s seq=%u dt=%.4f pred=%.2f %.2f %.2f base=%.2f %.2f %.2f err=%.3f local=%d\n",
 		tag ? tag : "cmd",
 		cmd->sequence,
-		cmd->msec,
 		dt,
 		cl_pred.predicted.origin[0],
 		cl_pred.predicted.origin[1],


### PR DESCRIPTION
### Motivation
- Fix MSVC build errors caused by `usercmd_t` no longer exposing a `msec` field by removing code paths that access it.
- Avoid implicit prototype warnings by declaring `CL_Predict_GetStepTime` before use.
- Ensure prediction timing uses the canonical step time rather than a missing per-command `msec` field.

### Description
- Add a forward declaration `static float CL_Predict_GetStepTime (void);` to `Quake/cl_predict.c`.
- Modify `CL_Predict_GetCmdStepTime` to ignore the `cmd->msec` field, cast the parameter with `(void)cmd`, and return `CL_Predict_GetStepTime()` instead.
- Remove the `msec` value from the `Con_Printf` debug format in `CL_Predict_DebugLogCmd` and its argument list.
- These changes remove references to the absent `msec` member and simplify prediction timing behavior.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697df67fd4f0832e91577af701c669f2)