### PR TITLE
Fix SSAO FBO context validation and logging

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -621,7 +621,7 @@ static void ExtractFrustumPlane (float mvp[16], int axis, float ndcval, qboolean
 //
 //==============================================================================
 
-glframebufs_t framebufs;
+glframebufs_t framebufs = {0};
 
 #define SSAO_MAX_SAMPLES 32
 // SSAO FIX: Use a larger noise tile to reduce visible tiling in half-res AO.
@@ -724,6 +724,7 @@ static GLuint GL_CreateFBO (GLenum target, const GLuint* colors, int numcolors, 
 		Sys_Error ("GL_CreateFBO: too many color buffers (%d)", numcolors);
 
 	GL_GenFramebuffersFunc (1, &fbo);
+	Con_DPrintf ("GL_CreateFBO: %s id=%u\n", name ? name : "(unnamed)", fbo);
 	GL_BindFramebufferFunc (GL_FRAMEBUFFER, fbo);
 	GL_ObjectLabelFunc (GL_FRAMEBUFFER, fbo, -1, name);
 	GL_LogErrorIfDeveloper ("GL_CreateFBO bind");
@@ -842,6 +843,10 @@ void GL_CreateFrameBuffers (void)
 	framebufs.ssao.height[0] = vid.height;
 	framebufs.ssao.width[1] = q_max (1, vid.width / 2);
 	framebufs.ssao.height[1] = q_max (1, vid.height / 2);
+#ifndef NDEBUG
+	if (!VID_GLContextIsCurrent ())
+		Sys_Error ("SSAO framebuffer init requires an active GL context.");
+#endif
 	framebufs.ssao.noise_tex = GL_CreateSSAONoiseTexture ();
 	// SSAO FIX: Prefer higher precision AO targets to avoid R8 banding in dark areas.
 	GLenum ssao_format = (Q_rint (r_ssao_format.value) > 0) ? GL_R16F : GL_R8;
@@ -850,6 +855,8 @@ void GL_CreateFrameBuffers (void)
 		int width = framebufs.ssao.width[i];
 		int height = framebufs.ssao.height[i];
 		const char *suffix = (i == 0) ? "full" : "half";
+		framebufs.ssao.ao_fbo[i] = 0;
+		framebufs.ssao.blur_fbo[i] = 0;
 		framebufs.ssao.ao_tex[i] = GL_CreateTexture2D (ssao_format, width, height, GL_NEAREST, va ("ssao %s", suffix));
 		framebufs.ssao.blur_tex[i] = GL_CreateTexture2D (ssao_format, width, height, GL_NEAREST, va ("ssao blur %s", suffix));
 		framebufs.ssao.ao_fbo[i] = GL_CreateSimpleFBO (GL_TEXTURE_2D, framebufs.ssao.ao_tex[i], 0, 0, va ("ssao fbo %s", suffix));
@@ -1285,6 +1292,11 @@ static float R_SanitizeSSAOValue (float value, float fallback, float minval, flo
 
 static GLuint GL_GenerateSSAOTexture (float view_min_x, float view_min_y, float view_max_x, float view_max_y)
 {
+	if (!VID_GLContextIsCurrent ())
+	{
+		Con_Warning ("SSAO skipped: no current GL context.\n");
+		return 0;
+	}
 	if ((r_ssao.value <= 0.f || r_ssao_intensity.value <= 0.f) && r_ssao_debug.value <= 0.f)
 		return 0;
 	if (!glprogs.ssao || !framebufs.composite.depth_stencil_tex || !framebufs.ssao.noise_tex)
@@ -1339,8 +1351,20 @@ static GLuint GL_GenerateSSAOTexture (float view_min_x, float view_min_y, float 
 		ssao_logged = true;
 	}
 
+	while (glGetError () != GL_NO_ERROR) {}
 	GL_BeginGroup ("SSAO");
 	GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.ssao.ao_fbo[index]);
+#ifndef NDEBUG
+	{
+		static qboolean ssao_fbo_validated = false;
+		if (!ssao_fbo_validated)
+		{
+			if (framebufs.ssao.ao_fbo[index] != 0 && !glIsFramebuffer (framebufs.ssao.ao_fbo[index]))
+				Con_Warning ("SSAO FBO invalid: %u\n", framebufs.ssao.ao_fbo[index]);
+			ssao_fbo_validated = true;
+		}
+	}
+#endif
 	GL_LogErrorIfDeveloper ("SSAO bind FBO");
 	{
 		GLenum status = GL_CheckFramebufferStatusFunc (GL_FRAMEBUFFER);

--- a/Quake/gl_vidsdl.c
+++ b/Quake/gl_vidsdl.c
@@ -345,6 +345,16 @@ void *VID_GetWindow (void)
 
 /*
 ====================
+VID_GLContextIsCurrent
+====================
+*/
+qboolean VID_GLContextIsCurrent (void)
+{
+	return gl_context && SDL_GL_GetCurrentContext () == gl_context;
+}
+
+/*
+====================
 VID_SetWindowTitle
 ====================
 */

--- a/Quake/vid.h
+++ b/Quake/vid.h
@@ -94,6 +94,7 @@ typedef enum
 } mousecursor_t;
 
 void		*VID_GetWindow (void);
+qboolean	VID_GLContextIsCurrent (void);
 qboolean	VID_HasMouseOrInputFocus (void);
 qboolean	VID_IsMinimized (void);
 void		VID_Lock (void);


### PR DESCRIPTION
### Motivation
- Address a GL_INVALID_OPERATION observed after the "SSAO bind FBO" step by ensuring SSAO FBO state and generation happen only with a valid GL context and by making FBO creation visible in logs.
- Make SSAO initialization and runtime binding more defensive to avoid stale/uninitialized FBO ids and to ensure SSAO code runs on the active render context/thread.

### Description
- Initialize the global `framebufs` structure to zero (`glframebufs_t framebufs = {0};`) to avoid uninitialized FBO ids.
- Log newly-generated framebuffer ids immediately after `glGenFramebuffers` with `Con_DPrintf` to aid debugging of FBO creation.
- Add `VID_GLContextIsCurrent()` to `vid.h` and implement it in `gl_vidsdl.c` to detect whether the OpenGL context is the current active context.
- Require an active GL context for SSAO framebuffer creation (debug build: `Sys_Error` if missing) and proactively zero `framebufs.ssao.ao_fbo[]` and `framebufs.ssao.blur_fbo[]` before creating SSAO FBOs.
- Guard SSAO texture generation with a runtime check that the GL context is current and return early if it is not.
- Clear sticky GL errors before the SSAO pass using `while (glGetError() != GL_NO_ERROR) {}` and add a one-time `glIsFramebuffer()` validation in debug builds to warn if the SSAO FBO is not a valid framebuffer.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e0b291a08832eaf751ba131c97c87)