### PR TITLE
Host_frametime für Prediction-Substeps verwenden

### DIFF
--- a/Quake/cl_predict.c
+++ b/Quake/cl_predict.c
@@ -1210,7 +1210,7 @@ void CL_Predict_SetupCmd (usercmd_t *cmd)
 
 	cmd_dt = CL_Predict_GetCmdStepTime (cmd);
 	host_dt = host_frametime;
-	if (host_dt <= 0.0f)
+	if (host_dt < 0.001f || host_dt > 0.1f)
 		host_dt = cmd_dt;
 	substeps = 1;
 	if (host_dt > 0.0f)
@@ -1459,7 +1459,7 @@ void CL_Predict_ServerUpdate (unsigned int ack, const vec3_t origin, const vec3_
 		}
 		cmd_dt = CL_Predict_GetCmdStepTime (&cmd);
 		host_dt = host_frametime;
-		if (host_dt <= 0.0f)
+		if (host_dt < 0.001f || host_dt > 0.1f)
 			host_dt = cmd_dt;
 		substeps = 1;
 		if (host_dt > 0.0f)


### PR DESCRIPTION
### Motivation
- Korrigiere die Substep-/JITTERDBG-Logik so, dass `host_dt` aus `host_frametime` stammt und damit bei z.B. `cmd_dt=0.0167` und `host_frametime=0.0083` `substeps==2` und `dt_sub≈0.0083` resultiert.

### Description
- In `Quake/cl_predict.c` (Setup und Resim-Pfad) wird `host_dt` jetzt direkt aus `host_frametime` übernommen und nur bei ungültigen Werten auf `cmd_dt` zurückgefallen mittels `if (host_dt < 0.001f || host_dt > 0.1f) host_dt = cmd_dt;`, wobei die bestehende Substep-Berechnung (`ratio = cmd_dt/host_dt`, Rundung mit `floorf(ratio + 0.5f)`, Clamp 1..4), `dt_sub = cmd_dt/(float)substeps` und die `for (i = 0; i < substeps; i++) CL_Predict_SimulateCmd(..., dt_sub)`-Schleife unverändert bleiben.

### Testing
- Es wurden keine automatisierten Tests auf dem geänderten Code ausgeführt.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e1b6455c0832e98cede69d2b52d81)