### PR TITLE
Guard autosave before client is active

### DIFF
--- a/Quake/host.c
+++ b/Quake/host.c
@@ -1009,12 +1009,29 @@ static void Host_CheckAutosave (void)
 
 	if (!sv_player)
 	{
-		Con_Printf ("NETDBG sv_player NULL cl %d reason autosave\n", SV_CurrentClientIndex ());
-		SV_PlayerNullTrap (__func__, 0);
+		Con_Printf ("NETDBG autosave skipped: sv_player NULL cl %d\n", SV_CurrentClientIndex ());
 		return;
 	}
 
-	if (!sv_autosave.value || sv_autosave_interval.value <= 0.f || svs.maxclients != 1 || sv_player->v.health <= 0.f || cl.intermission)
+	if (cls.state != ca_connected)
+	{
+		Con_Printf ("NETDBG autosave skipped: cls.state %d\n", cls.state);
+		return;
+	}
+
+	if (cls.signon != SIGNONS)
+	{
+		Con_Printf ("NETDBG autosave skipped: signon %d\n", cls.signon);
+		return;
+	}
+
+	if (cl.intermission)
+	{
+		Con_Printf ("NETDBG autosave skipped: intermission\n");
+		return;
+	}
+
+	if (!sv_autosave.value || sv_autosave_interval.value <= 0.f || svs.maxclients != 1 || sv_player->v.health <= 0.f)
 		return;
 
 	if (cls.signon == SIGNONS)


### PR DESCRIPTION
### Motivation
- Prevent a crash when `sv_player` is NULL during autosave which can occur while a client is still signing on or during map load/intermission.
- Ensure autosave never runs before the client is fully active (`cls.state == ca_connected` and `cls.signon == SIGNONS`) while preserving normal autosave behavior in gameplay.

### Description
- Centralized guards added to `Host_CheckAutosave` to early-return (non-fatal) when `!sv_player`, `cls.state != ca_connected`, `cls.signon != SIGNONS`, or `cl.intermission`, each with a `NETDBG` `Con_Printf` explaining why autosave was skipped.
- Removed the previous `SV_PlayerNullTrap` call and replaced the old `sv_player NULL` message with a clearer `NETDBG autosave skipped: sv_player NULL` log.
- Left existing autosave scoring and save logic unchanged so autosave behavior during normal in-game conditions is preserved.

### Testing
- No automated tests were executed on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e1c6f3ea8832ea5929e5fcc161427)