### PR TITLE
Fix client prediction jitter, console input freeze, and angle wrap/lerp

### DIFF
--- a/Quake/cl_input.c
+++ b/Quake/cl_input.c
@@ -287,7 +287,7 @@ void CL_AdjustAngles (void)
 	{
 		cl.viewangles[YAW] -= speed*cl_yawspeed.value*CL_KeyState (&in_right);
 		cl.viewangles[YAW] += speed*cl_yawspeed.value*CL_KeyState (&in_left);
-		cl.viewangles[YAW] -= floor (cl.viewangles[YAW]/360.0) * 360.0;
+		cl.viewangles[YAW] = NormalizeAngle180 (cl.viewangles[YAW]);
 	}
 	if (in_klook.state & 1)
 	{

--- a/Quake/cl_main.c
+++ b/Quake/cl_main.c
@@ -77,6 +77,10 @@ cvar_t	cl_pred_smooth_ms = {"cl_pred_smooth_ms", "120", CVAR_NONE};
 cvar_t	cl_pred_teleport_dist = {"cl_pred_teleport_dist", "128", CVAR_NONE};
 cvar_t	cl_pred_deadzone = {"cl_pred_deadzone", "0.25", CVAR_NONE};
 cvar_t	cl_pred_angle_deadzone = {"cl_pred_angle_deadzone", "0.1", CVAR_NONE};
+cvar_t	cl_pred_substeps = {"cl_pred_substeps", "0", CVAR_ARCHIVE};
+cvar_t	cl_pred_max_substeps = {"cl_pred_max_substeps", "6", CVAR_ARCHIVE};
+cvar_t	cl_pred_step_hz = {"cl_pred_step_hz", "60", CVAR_ARCHIVE};
+cvar_t	cl_pred_accum_debug = {"cl_pred_accum_debug", "0", CVAR_NONE};
 
 cvar_t	cfg_unbindall = {"cfg_unbindall", "1", CVAR_ARCHIVE};
 
@@ -113,6 +117,7 @@ entity_t		*cl_visedicts[MAX_VISEDICTS];
 
 extern cvar_t	r_lerpmodels, r_lerpmove; //johnfitz
 extern float	host_netinterval;	//Spike
+extern qboolean	con_forcedup;
 
 extern vec3_t	v_punchangles[2];
 extern qboolean	CL_NetDbg_PredictRan (void);
@@ -415,13 +420,7 @@ static void CL_NetDbg_LogMovement (const usercmd_t *cmd, qboolean sendcmd_ran)
 
 static float CL_LerpAngle (float a, float b, float f)
 {
-	float d = b - a;
-
-	while (d > 180.0f)
-		d -= 360.0f;
-	while (d < -180.0f)
-		d += 360.0f;
-	return a + f * d;
+	return LerpAngleShortest (a, b, f);
 }
 
 static double CL_GetInterpDelaySeconds (void)
@@ -476,6 +475,8 @@ static int64_t CL_SecondsToUsec (double seconds)
 	return (int64_t)(seconds * 1000000.0 + 0.5);
 }
 
+static qboolean CL_InputBlocked (void);
+
 void CL_JitterDebug_Log (void)
 {
 	double interp_delay;
@@ -519,20 +520,42 @@ void CL_JitterDebug_Log (void)
 		pred.ground_yaw_delta = 0.0f;
 		pred.ground_apply_pred = 0;
 		pred.ground_apply_render = 0;
+		pred.pred_accum_time = 0.0f;
+		pred.pred_step_dt = 0.0f;
+		pred.pred_substeps = 0;
+		pred.pred_max_substeps = 0;
+		pred.pred_nullcmd = 0;
+		pred.pred_angles_normalized = 0;
+		pred.pred_apply_pred_reason = CL_PRED_APPLY_SKIP_NO_BASE;
+		pred.pred_apply_render_reason = CL_PRED_APPLY_SKIP_NO_BASE;
+		VectorClear (pred.pred_angle_delta_shortest);
 	}
 
 	Con_Printf ("JITTERDBG cl.time %.3f realtime %.3f host_frametime %.4f interp_target %.3f interp_delay %.3f "
-		"server_applied %d pred_steps %d pred_err %.2f ang_err %.2f "
+		"pred_accum %.4f pred_step_dt %.4f pred_substeps %d/%d nullcmd %d ang_norm %d "
+		"pred_apply_reason %d render_apply_reason %d "
+		"server_applied %d pred_steps %d pred_err %.2f ang_err %.2f ang_delta %.2f %.2f %.2f "
 		"onground %d groundent %d ground_valid %d reason %d trace_frac %.2f trace_nz %.2f trace_ent %d trace_solid %d/%d trace_fallback %d "
 		"wishspeed %.1f wishvel_z %.1f dt %.4f flags %d ground_delta %.2f ground_yaw %.2f apply_pred %d apply_render %d "
 		"auth_org %.2f %.2f %.2f auth_ang %.2f %.2f %.2f "
 		"pred_org %.2f %.2f %.2f pred_ang %.2f %.2f %.2f "
 		"rend_org %.2f %.2f %.2f rend_ang %.2f %.2f %.2f\n",
 		cl.time, realtime, host_frametime, interp_target, interp_delay,
+		pred.pred_accum_time,
+		pred.pred_step_dt,
+		pred.pred_substeps,
+		pred.pred_max_substeps,
+		pred.pred_nullcmd,
+		pred.pred_angles_normalized,
+		pred.pred_apply_pred_reason,
+		pred.pred_apply_render_reason,
 		pred.server_update_applied ? 1 : 0,
 		pred.prediction_steps,
 		pred.pred_error_len,
 		pred.pred_angle_error_len,
+		pred.pred_angle_delta_shortest[0],
+		pred.pred_angle_delta_shortest[1],
+		pred.pred_angle_delta_shortest[2],
 		pred.onground ? 1 : 0,
 		pred.groundent,
 		pred.ground_valid ? 1 : 0,
@@ -1465,7 +1488,7 @@ void CL_RelinkEntities (void)
 {
 	entity_t	*ent;
 	int			i, j;
-	float		frac, f, d;
+	float		frac, f;
 	vec3_t		delta;
 	float		bobjrotate;
 	dlight_t	*dl;
@@ -1491,12 +1514,7 @@ void CL_RelinkEntities (void)
 	// interpolate the angles
 		for (j=0 ; j<3 ; j++)
 		{
-			d = cl.mviewangles[0][j] - cl.mviewangles[1][j];
-			if (d > 180)
-				d -= 360;
-			else if (d < -180)
-				d += 360;
-			cl.viewangles[j] = cl.mviewangles[1][j] + frac*d;
+			cl.viewangles[j] = LerpAngleShortest (cl.mviewangles[1][j], cl.mviewangles[0][j], frac);
 		}
 	}
 
@@ -1603,12 +1621,7 @@ void CL_RelinkEntities (void)
 			{
 				ent->origin[j] = ent->msg_origins[1][j] + f*delta[j];
 
-				d = ent->msg_angles[0][j] - ent->msg_angles[1][j];
-				if (d > 180)
-					d -= 360;
-				else if (d < -180)
-					d += 360;
-				ent->angles[j] = ent->msg_angles[1][j] + f*d;
+				ent->angles[j] = LerpAngleShortest (ent->msg_angles[1][j], ent->msg_angles[0][j], f);
 			}
 		}
 
@@ -1888,6 +1901,10 @@ void CL_AccumulateCmd (void)
 		//accumulate movement from other devices
 		IN_Move (&cl.pendingcmd);
 	}
+	if (CL_InputBlocked ())
+		// Force prediction to stop immediately when UI/console owns input.
+		CL_Predict_ForceNullCmd ();
+	CL_Predict_Reapply ();
 }
 
 /*
@@ -1895,6 +1912,11 @@ void CL_AccumulateCmd (void)
 CL_SendCmd
 =================
 */
+static qboolean CL_InputBlocked (void)
+{
+	return key_dest != key_game || con_forcedup;
+}
+
 void CL_SendCmd (void)
 {
 	usercmd_t		cmd;
@@ -1944,13 +1966,29 @@ void CL_SendCmd (void)
 			cmd.sidemove	+= cl.pendingcmd.sidemove;
 			cmd.upmove		+= cl.pendingcmd.upmove;
 
-			VectorCopy (cl.viewangles, cmd.viewangles);
+			{
+				int axis;
+
+				VectorCopy (cl.viewangles, cmd.viewangles);
+				for (axis = 0; axis < 3; axis++)
+					cmd.viewangles[axis] = NormalizeAngle180 (cmd.viewangles[axis]);
+			}
 			cmd.buttons = 0;
 			if ( in_attack.state & 3 )
 				cmd.buttons |= 1;
 			if (in_jump.state & 3)
 				cmd.buttons |= 2;
 			cmd.impulse = in_impulse;
+			if (CL_InputBlocked ())
+			{
+				// If UI/console owns input, ensure we send a null command to stop movement.
+				cmd.forwardmove = 0;
+				cmd.sidemove = 0;
+				cmd.upmove = 0;
+				cmd.buttons = 0;
+				cmd.impulse = 0;
+				CL_Predict_SetNullCmdInjected (true);
+			}
 
 			// NOTE: Never gate command generation/sending on snapshot readiness.
 			// Prediction handles world-ready checks; the server still needs cmds every tick.
@@ -2233,6 +2271,10 @@ void CL_Init (void)
 	Cvar_RegisterVariable (&cl_pred_teleport_dist);
 	Cvar_RegisterVariable (&cl_pred_deadzone);
 	Cvar_RegisterVariable (&cl_pred_angle_deadzone);
+	Cvar_RegisterVariable (&cl_pred_substeps);
+	Cvar_RegisterVariable (&cl_pred_max_substeps);
+	Cvar_RegisterVariable (&cl_pred_step_hz);
+	Cvar_RegisterVariable (&cl_pred_accum_debug);
 	Cvar_RegisterVariable (&freelook);
 	Cvar_RegisterVariable (&lookspring);
 	Cvar_RegisterVariable (&lookstrafe);

--- a/Quake/cl_predict.c
+++ b/Quake/cl_predict.c
@@ -14,6 +14,10 @@ extern cvar_t cl_predict;
 extern cvar_t cl_cmdrate;
 extern cvar_t cl_physrate;
 extern cvar_t cl_jitter_debug;
+extern cvar_t cl_pred_substeps;
+extern cvar_t cl_pred_max_substeps;
+extern cvar_t cl_pred_step_hz;
+extern cvar_t cl_pred_accum_debug;
 
 static cvar_t cl_pred_debug = {"cl_pred_debug", "0", CVAR_NONE};
 
@@ -91,6 +95,15 @@ static int cl_pred_last_trace_ent;
 static int cl_pred_last_trace_startsolid;
 static int cl_pred_last_trace_allsolid;
 static int cl_pred_last_trace_fallback;
+static double cl_pred_render_accum;
+static usercmd_t cl_pred_render_cmd;
+static qboolean cl_pred_render_cmd_valid;
+static int cl_pred_last_substeps;
+static float cl_pred_last_substep_dt;
+static int cl_pred_nullcmd_injected;
+static int cl_pred_angles_normalized;
+static int cl_pred_apply_pred_reason;
+static int cl_pred_apply_render_reason;
 
 static float CL_Predict_GetStepTime (void);
 
@@ -199,6 +212,23 @@ static void CL_Predict_ResetGroundDebug (void)
 	cl_pred_last_trace_startsolid = 0;
 	cl_pred_last_trace_allsolid = 0;
 	cl_pred_last_trace_fallback = 0;
+}
+
+void CL_Predict_SetNullCmdInjected (qboolean injected)
+{
+	cl_pred_nullcmd_injected = injected ? 1 : 0;
+}
+
+void CL_Predict_ForceNullCmd (void)
+{
+	if (!cl_pred_render_cmd_valid)
+		return;
+
+	cl_pred_render_cmd.forwardmove = 0;
+	cl_pred_render_cmd.sidemove = 0;
+	cl_pred_render_cmd.upmove = 0;
+	cl_pred_render_cmd.buttons = 0;
+	cl_pred_render_cmd.impulse = 0;
 }
 
 static float CL_Predict_GetCmdStepTime (const usercmd_t *cmd)
@@ -332,15 +362,59 @@ static float CL_Predict_GetStepTime (void)
 	return (float)cmd_dt;
 }
 
+static void CL_Predict_GetSubstepInfo (float cmd_dt, float host_dt, int *substeps, float *dt_sub)
+{
+	int steps = 1;
+	float dt = cmd_dt;
+
+	if (cl_pred_substeps.value > 0.0f)
+	{
+		// Fixed-step substepping for client prediction.
+		float step_hz = cl_pred_step_hz.value > 0.0f ? cl_pred_step_hz.value : 60.0f;
+		float step_dt = step_hz > 0.0f ? (1.0f / step_hz) : cmd_dt;
+		int max_steps = (int)cl_pred_max_substeps.value;
+
+		if (step_dt <= 0.0f)
+			step_dt = cmd_dt;
+		steps = (int)ceilf (cmd_dt / step_dt);
+		if (steps < 1)
+			steps = 1;
+		if (max_steps < 1)
+			max_steps = 1;
+		if (steps > max_steps)
+			steps = max_steps;
+		dt = cmd_dt / (float)steps;
+	}
+	else
+	{
+		float ratio;
+
+		if (host_dt < 0.001f || host_dt > 0.1f)
+			host_dt = cmd_dt;
+		if (host_dt > 0.0f)
+		{
+			ratio = cmd_dt / host_dt;
+			if (ratio > 1.25f)
+				steps = (int)floorf (ratio + 0.5f);
+		}
+		if (steps < 1)
+			steps = 1;
+		if (steps > 4)
+			steps = 4;
+		dt = cmd_dt / (float)steps;
+	}
+
+	if (substeps)
+		*substeps = steps;
+	if (dt_sub)
+		*dt_sub = dt;
+	cl_pred_last_substeps = steps;
+	cl_pred_last_substep_dt = dt;
+}
+
 static float CL_Predict_AngleDelta (float a, float b)
 {
-	float d = a - b;
-
-	while (d > 180.0f)
-		d -= 360.0f;
-	while (d < -180.0f)
-		d += 360.0f;
-	return d;
+	return AngleDeltaShortest (b, a);
 }
 
 static qboolean CL_Predict_IsEnabled (void)
@@ -369,9 +443,14 @@ static void CL_Predict_ApplyToClient (void)
 	float decay;
 	vec3_t correction;
 	vec3_t angle_correction;
+	cl_pred_state_t render_state;
+	const cl_pred_state_t *state = &cl_pred.predicted;
 
 	if (!CL_Predict_IsEnabled () || !cl_pred.has_base)
+	{
+		cl_pred_apply_pred_reason = !CL_Predict_IsEnabled () ? CL_PRED_APPLY_SKIP_DISABLED : CL_PRED_APPLY_SKIP_NO_BASE;
 		return;
+	}
 
 	if (cl_netdebug_parse.value && !cl_pred_warned_no_snapshot
 		&& (!cl.has_full_snapshot || !cl.snapshot_present || cl.mtime[0] <= 0.0))
@@ -390,16 +469,32 @@ static void CL_Predict_ApplyToClient (void)
 		VectorClear (cl_pred_angle_error);
 	}
 
-	VectorAdd (cl_pred.predicted.origin, cl_pred_error, smooth_origin);
-	VectorAdd (cl_pred.predicted.viewangles, cl_pred_angle_error, smooth_angles);
+	if (cl_pred_substeps.value > 0.0f && cl_pred_render_cmd_valid && cl_pred_render_accum > 0.0)
+	{
+		float render_dt = (float)cl_pred_render_accum;
+		float cmd_dt = CL_Predict_GetCmdStepTime (&cl_pred_render_cmd);
+
+		if (cmd_dt > 0.0f && render_dt > cmd_dt)
+			render_dt = cmd_dt;
+		render_state = cl_pred.predicted;
+		// Render-only substep to avoid frame holds between command ticks.
+		CL_Predict_SimulateCmd (&render_state, &cl_pred_render_cmd, render_dt, true);
+		state = &render_state;
+	}
+
+	VectorAdd (state->origin, cl_pred_error, smooth_origin);
+	VectorAdd (state->viewangles, cl_pred_angle_error, smooth_angles);
+	smooth_angles[0] = NormalizeAngle180 (smooth_angles[0]);
+	smooth_angles[1] = NormalizeAngle180 (smooth_angles[1]);
+	smooth_angles[2] = NormalizeAngle180 (smooth_angles[2]);
 	VectorCopy (smooth_origin, cl.simorg);
 	VectorCopy (smooth_origin, cl_entities[cl.viewentity].origin);
 	VectorCopy (smooth_origin, cl_entities[cl.viewentity].msg_origins[0]);
 	VectorCopy (smooth_origin, cl_entities[cl.viewentity].msg_origins[1]);
 	VectorCopy (smooth_angles, cl.viewangles);
-	VectorCopy (cl_pred.predicted.velocity, cl.mvelocity[0]);
-	VectorCopy (cl_pred.predicted.velocity, cl.mvelocity[1]);
-	cl.onground = cl_pred.predicted.onground;
+	VectorCopy (state->velocity, cl.mvelocity[0]);
+	VectorCopy (state->velocity, cl.mvelocity[1]);
+	cl.onground = state->onground;
 
 	if (smooth_ms > 0.0f)
 	{
@@ -417,6 +512,7 @@ static void CL_Predict_ApplyToClient (void)
 	}
 
 	CL_EnsureViewEntityOrigin ("predict");
+	cl_pred_apply_render_reason = CL_PRED_APPLY_OK;
 }
 
 static void CL_Predict_Friction (vec3_t velocity, float dt)
@@ -968,7 +1064,7 @@ static void CL_Predict_StepSlideMove (cl_pred_state_t *state, const vec3_t mins,
 	}
 }
 
-static void CL_Predict_SimulateCmd (cl_pred_state_t *state, const usercmd_t *cmd, float dt)
+static void CL_Predict_SimulateCmd (cl_pred_state_t *state, const usercmd_t *cmd, float dt, qboolean is_render)
 {
 	vec3_t forward, right, up;
 	vec3_t wishvel, wishdir;
@@ -981,7 +1077,8 @@ static void CL_Predict_SimulateCmd (cl_pred_state_t *state, const usercmd_t *cmd
 	qboolean ground_entity;
 	int ground_reason = CL_GROUND_REASON_OK;
 
-	cl_pred_steps_this_frame++;
+	if (!is_render)
+		cl_pred_steps_this_frame++;
 	CL_Predict_GetPlayerBounds (mins, maxs);
 	VectorClear (ground_delta);
 	ground_yaw_delta = 0.0f;
@@ -1149,7 +1246,12 @@ static void CL_Predict_SimulateCmd (cl_pred_state_t *state, const usercmd_t *cmd
 	cl_pred_ground_dbg.ground_delta_len = VectorLength (ground_delta);
 	cl_pred_ground_dbg.ground_yaw_delta = ground_yaw_delta;
 	if (ground_applied)
-		cl_pred_ground_dbg.ground_apply_pred++;
+	{
+		if (is_render)
+			cl_pred_ground_dbg.ground_apply_render++;
+		else
+			cl_pred_ground_dbg.ground_apply_pred++;
+	}
 }
 
 void CL_Predict_Clear (void)
@@ -1164,6 +1266,14 @@ void CL_Predict_Clear (void)
 	cl_pred_server_update_this_frame = false;
 	cl_pred_prev_enabled = false;
 	CL_Predict_ResetGroundDebug ();
+	cl_pred_render_accum = 0.0;
+	cl_pred_render_cmd_valid = false;
+	cl_pred_last_substeps = 0;
+	cl_pred_last_substep_dt = 0.0f;
+	cl_pred_nullcmd_injected = 0;
+	cl_pred_angles_normalized = 0;
+	cl_pred_apply_pred_reason = CL_PRED_APPLY_SKIP_DISABLED;
+	cl_pred_apply_render_reason = CL_PRED_APPLY_SKIP_DISABLED;
 }
 
 void CL_Predict_ResetGround (void)
@@ -1183,11 +1293,58 @@ void CL_Predict_BeginFrame (void)
 	cl_pred_steps_this_frame = 0;
 	cl_pred_server_update_this_frame = false;
 	CL_Predict_ResetGroundDebug ();
+	cl_pred_nullcmd_injected = 0;
+	cl_pred_angles_normalized = 0;
 
 	enabled = CL_Predict_IsEnabled ();
 	if (enabled && !cl_pred_prev_enabled && cl_pred.has_base)
 		CL_Predict_HardResetToBase ("predict reenabled");
 	cl_pred_prev_enabled = enabled;
+
+	if (enabled && cl_pred_render_cmd_valid)
+	{
+		float cmd_dt = CL_Predict_GetCmdStepTime (&cl_pred_render_cmd);
+		float max_accum = cmd_dt;
+		if (cl_pred_substeps.value > 0.0f)
+		{
+			float step_hz = cl_pred_step_hz.value > 0.0f ? cl_pred_step_hz.value : 60.0f;
+			float step_dt = step_hz > 0.0f ? (1.0f / step_hz) : cmd_dt;
+			int max_steps = (int)cl_pred_max_substeps.value;
+
+			if (max_steps < 1)
+				max_steps = 1;
+			max_accum = step_dt * (float)max_steps;
+		}
+		cl_pred_render_accum += host_frametime;
+		if (cl_pred_render_accum < 0.0)
+			cl_pred_render_accum = 0.0;
+		if (max_accum > 0.0f && cl_pred_render_accum > max_accum)
+			cl_pred_render_accum = max_accum;
+	}
+	else
+	{
+		cl_pred_render_accum = 0.0;
+	}
+
+	if (cl_pred_accum_debug.value > 0.0f)
+	{
+		Con_Printf ("PREDACCUM dt %.4f accum %.4f step_dt %.4f\n",
+			host_frametime, cl_pred_render_accum, cl_pred_last_substep_dt);
+	}
+
+	if (!enabled)
+		cl_pred_apply_pred_reason = CL_PRED_APPLY_SKIP_DISABLED;
+	else if (!cl_pred.has_base)
+		cl_pred_apply_pred_reason = CL_PRED_APPLY_SKIP_NO_BASE;
+	else
+		cl_pred_apply_pred_reason = CL_PRED_APPLY_SKIP_ACCUM;
+
+	if (!enabled)
+		cl_pred_apply_render_reason = CL_PRED_APPLY_SKIP_DISABLED;
+	else if (!cl_pred.has_base)
+		cl_pred_apply_render_reason = CL_PRED_APPLY_SKIP_NO_BASE;
+	else
+		cl_pred_apply_render_reason = CL_PRED_APPLY_SKIP_ACCUM;
 }
 
 void CL_Predict_SetupCmd (usercmd_t *cmd)
@@ -1195,7 +1352,6 @@ void CL_Predict_SetupCmd (usercmd_t *cmd)
 	float cmd_dt;
 	float dt_sub;
 	float host_dt;
-	float ratio;
 	int substeps;
 	int i;
 
@@ -1204,34 +1360,26 @@ void CL_Predict_SetupCmd (usercmd_t *cmd)
 	cmd->sequence = cl_pred.seq_latest + 1;
 	cl_pred.seq_latest = cmd->sequence;
 	cl_pred.cmds[cmd->sequence % CMD_RING] = *cmd;
+	cl_pred_angles_normalized = 1;
 
 	if (!CL_Predict_IsEnabled () || !cl_pred.has_base)
 		return;
 
 	cmd_dt = CL_Predict_GetCmdStepTime (cmd);
 	host_dt = host_frametime;
-	if (host_dt < 0.001f || host_dt > 0.1f)
-		host_dt = cmd_dt;
-	substeps = 1;
-	if (host_dt > 0.0f)
-	{
-		ratio = cmd_dt / host_dt;
-		if (ratio > 1.25f)
-			substeps = (int)floorf (ratio + 0.5f);
-	}
-	if (substeps < 1)
-		substeps = 1;
-	if (substeps > 4)
-		substeps = 4;
-	dt_sub = cmd_dt / (float)substeps;
+	CL_Predict_GetSubstepInfo (cmd_dt, host_dt, &substeps, &dt_sub);
 	if (cl_jitter_debug.value > 0.0f)
 	{
 		Con_Printf ("JITTERDBG setup seq %u cmd_dt %.4f host_dt %.4f substeps %d dt_sub %.4f\n",
 			cmd->sequence, cmd_dt, host_dt, substeps, dt_sub);
 	}
 	for (i = 0; i < substeps; i++)
-		CL_Predict_SimulateCmd (&cl_pred.predicted, cmd, dt_sub);
+		CL_Predict_SimulateCmd (&cl_pred.predicted, cmd, dt_sub, false);
 	CL_Predict_DebugLogCmd ("setup", cmd, cmd_dt);
+	cl_pred_render_cmd = *cmd;
+	cl_pred_render_cmd_valid = true;
+	cl_pred_render_accum = 0.0;
+	cl_pred_apply_pred_reason = CL_PRED_APPLY_OK;
 	CL_Predict_ApplyToClient ();
 	cl_netdbg_predict_ran = true;
 }
@@ -1259,15 +1407,17 @@ void CL_Predict_ServerUpdate (unsigned int ack, const vec3_t origin, const vec3_
 	float cmd_dt;
 	float dt_sub;
 	float host_dt;
-	float ratio;
 	int substeps;
 	int i;
 	int prev_pred_ground_ent = 0;
 	vec3_t prev_pred_ground_offset;
 	float prev_pred_ground_yaw_delta = 0.0f;
 	qboolean had_base;
+	qboolean resim_cmd_valid = false;
+	usercmd_t resim_cmd;
 
 	CL_Predict_RegisterDebugCvars ();
+	Q_memset (&resim_cmd, 0, sizeof(resim_cmd));
 	if (cl_pred.has_base && !CL_Predict_SeqNewer (ack, cl_pred.seq_acked))
 		return;
 
@@ -1360,7 +1510,9 @@ void CL_Predict_ServerUpdate (unsigned int ack, const vec3_t origin, const vec3_
 	}
 	VectorCopy (origin, cl_pred.base.origin);
 	VectorCopy (velocity, cl_pred.base.velocity);
-	VectorCopy (viewangles, cl_pred.base.viewangles);
+	cl_pred.base.viewangles[0] = NormalizeAngle180 (viewangles[0]);
+	cl_pred.base.viewangles[1] = NormalizeAngle180 (viewangles[1]);
+	cl_pred.base.viewangles[2] = NormalizeAngle180 (viewangles[2]);
 	cl_pred.base.onground = onground;
 	cl_pred.predicted = cl_pred.base;
 	cl_pred.has_base = true;
@@ -1459,37 +1611,40 @@ void CL_Predict_ServerUpdate (unsigned int ack, const vec3_t origin, const vec3_
 		}
 		cmd_dt = CL_Predict_GetCmdStepTime (&cmd);
 		host_dt = host_frametime;
-		if (host_dt < 0.001f || host_dt > 0.1f)
-			host_dt = cmd_dt;
-		substeps = 1;
-		if (host_dt > 0.0f)
-		{
-			ratio = cmd_dt / host_dt;
-			if (ratio > 1.25f)
-				substeps = (int)floorf (ratio + 0.5f);
-		}
-		if (substeps < 1)
-			substeps = 1;
-		if (substeps > 4)
-			substeps = 4;
-		dt_sub = cmd_dt / (float)substeps;
+		CL_Predict_GetSubstepInfo (cmd_dt, host_dt, &substeps, &dt_sub);
 		if (cl_jitter_debug.value > 0.0f)
 		{
 			Con_Printf ("JITTERDBG resim seq %u cmd_dt %.4f host_dt %.4f substeps %d dt_sub %.4f\n",
 				cmd.sequence, cmd_dt, host_dt, substeps, dt_sub);
 		}
 		for (i = 0; i < substeps; i++)
-			CL_Predict_SimulateCmd (&cl_pred.predicted, &cmd, dt_sub);
+			CL_Predict_SimulateCmd (&cl_pred.predicted, &cmd, dt_sub, false);
+		resim_cmd = cmd;
+		resim_cmd_valid = true;
 		CL_Predict_DebugLogCmd ("resim", &cmd, cmd_dt);
 	}
 
+	if (resim_cmd_valid)
+	{
+		cl_pred_render_cmd = resim_cmd;
+		cl_pred_render_cmd_valid = true;
+		cl_pred_render_accum = 0.0;
+	}
+	cl_pred_apply_pred_reason = CL_PRED_APPLY_OK;
 	CL_Predict_ApplyToClient ();
 }
 
 void CL_Predict_Reapply (void)
 {
 	if (!CL_Predict_IsEnabled () || !cl_pred.has_base)
+	{
+		cl_pred_apply_render_reason = CL_PRED_APPLY_SKIP_DISABLED;
+		if (cl_pred.has_base && !CL_Predict_IsEnabled ())
+			cl_pred_apply_render_reason = CL_PRED_APPLY_SKIP_DISABLED;
+		else if (!cl_pred.has_base)
+			cl_pred_apply_render_reason = CL_PRED_APPLY_SKIP_NO_BASE;
 		return;
+	}
 
 	CL_Predict_ApplyToClient ();
 }
@@ -1524,6 +1679,14 @@ qboolean CL_Predict_GetDebug (cl_pred_debug_t *out)
 	out->ground_yaw_delta = cl_pred_ground_dbg.ground_yaw_delta;
 	out->ground_apply_pred = cl_pred_ground_dbg.ground_apply_pred;
 	out->ground_apply_render = cl_pred_ground_dbg.ground_apply_render;
+	out->pred_accum_time = (float)cl_pred_render_accum;
+	out->pred_step_dt = cl_pred_last_substep_dt;
+	out->pred_substeps = cl_pred_last_substeps;
+	out->pred_max_substeps = (int)cl_pred_max_substeps.value;
+	out->pred_nullcmd = cl_pred_nullcmd_injected;
+	out->pred_angles_normalized = cl_pred_angles_normalized;
+	out->pred_apply_pred_reason = cl_pred_apply_pred_reason;
+	out->pred_apply_render_reason = cl_pred_apply_render_reason;
 
 	if (!cl_pred.has_base)
 		return false;
@@ -1532,5 +1695,8 @@ qboolean CL_Predict_GetDebug (cl_pred_debug_t *out)
 	VectorCopy (cl_pred.base.viewangles, out->base_angles);
 	VectorCopy (cl_pred.predicted.origin, out->predicted_origin);
 	VectorCopy (cl_pred.predicted.viewangles, out->predicted_angles);
+	out->pred_angle_delta_shortest[0] = AngleDeltaShortest (cl_pred.base.viewangles[0], cl_pred.predicted.viewangles[0]);
+	out->pred_angle_delta_shortest[1] = AngleDeltaShortest (cl_pred.base.viewangles[1], cl_pred.predicted.viewangles[1]);
+	out->pred_angle_delta_shortest[2] = AngleDeltaShortest (cl_pred.base.viewangles[2], cl_pred.predicted.viewangles[2]);
 	return true;
 }

--- a/Quake/client.h
+++ b/Quake/client.h
@@ -540,6 +540,15 @@ typedef struct
 	float		ground_yaw_delta;
 	int			ground_apply_pred;
 	int			ground_apply_render;
+	float		pred_accum_time;
+	float		pred_step_dt;
+	int			pred_substeps;
+	int			pred_max_substeps;
+	int			pred_nullcmd;
+	int			pred_angles_normalized;
+	int			pred_apply_pred_reason;
+	int			pred_apply_render_reason;
+	vec3_t		pred_angle_delta_shortest;
 } cl_pred_debug_t;
 
 enum
@@ -549,6 +558,15 @@ enum
 	CL_GROUND_REASON_TRACE_MISS,
 	CL_GROUND_REASON_BAD_PLANE,
 	CL_GROUND_REASON_INVALID_ENTITY,
+};
+
+enum
+{
+	CL_PRED_APPLY_OK = 0,
+	CL_PRED_APPLY_SKIP_DISABLED,
+	CL_PRED_APPLY_SKIP_NO_BASE,
+	CL_PRED_APPLY_SKIP_NO_CMD,
+	CL_PRED_APPLY_SKIP_ACCUM,
 };
 
 extern	kbutton_t	in_mlook, in_klook;
@@ -565,6 +583,8 @@ void CL_SendMove (const usercmd_t *cmd);
 void CL_Predict_Clear (void);
 void CL_Predict_BeginFrame (void);
 void CL_Predict_SetupCmd (usercmd_t *cmd);
+void CL_Predict_SetNullCmdInjected (qboolean injected);
+void CL_Predict_ForceNullCmd (void);
 void CL_Predict_ServerUpdate (unsigned int ack, const vec3_t origin, const vec3_t velocity, const vec3_t viewangles, qboolean onground);
 void CL_Predict_Reapply (void);
 qboolean CL_Predict_GetCmd (unsigned int seq, usercmd_t *out);

--- a/Quake/mathlib.c
+++ b/Quake/mathlib.c
@@ -117,6 +117,19 @@ float NormalizeAngle (float degrees)
 	return degrees;
 }
 
+float NormalizeAngle180 (float degrees)
+{
+	return NormalizeAngle (degrees);
+}
+
+float NormalizeAngle360 (float degrees)
+{
+	degrees -= floor (degrees * (1.f/360.f)) * 360.f;
+	if (degrees < 0.f)
+		degrees += 360.f;
+	return degrees;
+}
+
 /*
 ==================
 AngleDifference
@@ -129,6 +142,11 @@ float AngleDifference (float dega, float degb)
 	return NormalizeAngle (dega - degb);
 }
 
+float AngleDeltaShortest (float degfrom, float degto)
+{
+	return NormalizeAngle (degto - degfrom);
+}
+
 /*
 ==================
 LerpAngle
@@ -139,6 +157,11 @@ Returns a value between -180 and 180
 float LerpAngle (float degfrom, float degto, float frac)
 {
 	return NormalizeAngle (degfrom + AngleDifference (degto, degfrom) * frac);
+}
+
+float LerpAngleShortest (float degfrom, float degto, float frac)
+{
+	return NormalizeAngle (degfrom + AngleDeltaShortest (degfrom, degto) * frac);
 }
 
 

--- a/Quake/mathlib.h
+++ b/Quake/mathlib.h
@@ -131,8 +131,12 @@ int BoxOnPlaneSide (vec3_t emins, vec3_t emaxs, struct mplane_s *plane);
 float	anglemod(float a);
 
 float NormalizeAngle (float degrees);
+float NormalizeAngle180 (float degrees);
+float NormalizeAngle360 (float degrees);
 float AngleDifference (float dega, float degb);
+float AngleDeltaShortest (float degfrom, float degto);
 float LerpAngle (float degfrom, float degto, float frac);
+float LerpAngleShortest (float degfrom, float degto, float frac);
 
 void MatrixMultiply(float left[16], float right[16]);
 void RotationMatrix(float matrix[16], float angle, int axis);

--- a/docs/movement_jitter_test_plan.md
+++ b/docs/movement_jitter_test_plan.md
@@ -1,0 +1,14 @@
+# Movement/Jitter Fix Test Plan
+
+1. **Console input freeze**
+   - Hold `W` to walk forward.
+   - Open the console.
+   - Expected: player stops immediately (no continued forward drift).
+
+2. **Micro-movement smoothing**
+   - Tap movement keys rapidly (short presses).
+   - Expected: movement looks smooth without 0/1-frame holds or jumps.
+
+3. **Angle wrap/interp**
+   - Rotate across a wrap boundary (e.g., 179 → -179 or 359 → 0) while moving.
+   - Expected: no snapping; interpolation stays on the shortest arc.


### PR DESCRIPTION
### Motivation
- Remove visible micro-jitter and frame-hold jumps by making client prediction step consistently each render frame and by offering a fixed-step substep mode. 
- Stop the player from continuing to drift when UI/console owns input by ensuring prediction receives an explicit null movement command. 
- Eliminate visible angle snapping when representations cross the 0/360 / -180/180 boundary by normalizing angles and always interpolating along the shortest arc.

### Description
- Added angle helpers in `mathlib`: `NormalizeAngle180`, `NormalizeAngle360`, `AngleDeltaShortest`, and `LerpAngleShortest`, and updated math headers; applied `LerpAngleShortest`/`NormalizeAngle180` throughout (`cl_input.c`, `cl_main.c`, `cl_predict.c`) to enforce consistent [-180,180) convention and shortest-arc blending. 
- Implemented Option B (substeps) in `cl_predict.c`: introduced render-time accumulator and render-only substep smoothing (`cl_pred_render_accum`, `cl_pred_render_cmd`, `cl_pred_render_cmd_valid`) and a fixed-step substep policy controlled by new CVARs `cl_pred_substeps`, `cl_pred_max_substeps`, and `cl_pred_step_hz`; added `CL_Predict_GetSubstepInfo` to compute substeps and step dt. 
- Stopped movement when console/UI blocks input by injecting/forcing a null command path: `CL_InputBlocked()` checks `key_dest`/`con_forcedup`, `CL_Predict_SetNullCmdInjected`, and `CL_Predict_ForceNullCmd` ensure the predicted/rendered command has zero movement and clears buttons before `CL_Predict_SetupCmd`/send. Changes live in `cl_main.c` and `cl_predict.c`. 
- Made prediction/render smoothing deterministic so render frames no longer alternate between `dt=0` and `dt=cmd_dt`: `CL_Predict_SetupCmd` and `CL_Predict_ServerUpdate` now compute substeps via `CL_Predict_GetSubstepInfo`, real simulation uses `CL_Predict_SimulateCmd(..., is_render)` and `CL_Predict_ApplyToClient` will run a render-only substep when `cl_pred_substeps` is enabled and `cl_pred_render_accum` > 0. 
- Improved micro-movement smoothing by computing the render interpolation target from the predicted state or a render-stepped state and applying `cl_pred_error`/`cl_pred_angle_error` smoothing every frame in `CL_Predict_ApplyToClient`. 
- Expanded JITTERDBG and `cl_pred_debug_t` diagnostics to expose `pred_accum_time`, `pred_step_dt`, `pred_substeps`, `pred_max_substeps`, `pred_nullcmd`, `pred_angles_normalized`, `pred_apply_*_reason`, and the shortest-angle deltas for easier debugging. 
- Minor cleanup: replaced ad-hoc angle wrap logic (`>180 / < -180` branches) with the new helpers, normalized outgoing `cmd.viewangles` before sending, and added a short test plan document `docs/movement_jitter_test_plan.md` that summarizes manual repro steps. 

### Testing
- Automated tests: none executed in this patch (no CI/golden test runs were requested). 
- Manual test plan added in `docs/movement_jitter_test_plan.md` describing three repros: console freeze (hold `W` then open console), rapid micro-taps (short presses), and yaw wrap rotations (e.g. 179→-179 or 359→0) to verify no snapping; these are the recommended steps to validate the changes locally. 
- Logging: enable `cl_jitter_debug`/`cl_pred_accum_debug` to observe per-frame `pred_accum`, `pred_step_dt`, `pred_substeps`, `nullcmd` and angle-delta values reported by `JITTERDBG` for verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e213593a0832e8d573a2ceec82a69)