### PR TITLE
Add forward declaration for CL_Predict_SimulateCmd to fix MSVC redefinition

### DIFF
--- a/Quake/cl_predict.c
+++ b/Quake/cl_predict.c
@@ -106,6 +106,7 @@ static int cl_pred_apply_pred_reason;
 static int cl_pred_apply_render_reason;
 
 static float CL_Predict_GetStepTime (void);
+static void CL_Predict_SimulateCmd (cl_pred_state_t *state, const usercmd_t *cmd, float dt, qboolean is_render);
 
 #define CL_PREDICT_MAX_CLIP_PLANES 5
 #define CL_PREDICT_STEP_SIZE 18.0f


### PR DESCRIPTION
### Motivation
- Fix MSVC compiler diagnostics (warning C4013 and error C2371) caused by calling `CL_Predict_SimulateCmd` before its definition in `Quake/cl_predict.c`.

### Description
- Add the forward declaration `static void CL_Predict_SimulateCmd (cl_pred_state_t *state, const usercmd_t *cmd, float dt, qboolean is_render);` alongside other static prototypes in `Quake/cl_predict.c`.

### Testing
- No automated tests were run; this is a single-line prototype addition intended to resolve the compile-time signature mismatch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e2756c040832eaa9dac6e24c1977e)