### PR TITLE
Fix mouselook regression: avoid prediction clobbering of viewangles and add mouselook diagnostics

### DIFF
--- a/Quake/cl_main.c
+++ b/Quake/cl_main.c
@@ -532,7 +532,7 @@ void CL_JitterDebug_Log (void)
 	}
 
 	Con_Printf ("JITTERDBG cl.time %.3f realtime %.3f host_frametime %.4f interp_target %.3f interp_delay %.3f "
-		"pred_accum %.4f pred_step_dt %.4f pred_substeps %d/%d nullcmd %d ang_norm %d "
+		"pred_accum %.4f pred_step_dt %.4f pred_substeps %d/%d nullcmd %d ang_norm %d mouse_applied %d "
 		"pred_apply_reason %d render_apply_reason %d "
 		"server_applied %d pred_steps %d pred_err %.2f ang_err %.2f ang_delta %.2f %.2f %.2f "
 		"onground %d groundent %d ground_valid %d reason %d trace_frac %.2f trace_nz %.2f trace_ent %d trace_solid %d/%d trace_fallback %d "
@@ -547,6 +547,7 @@ void CL_JitterDebug_Log (void)
 		pred.pred_max_substeps,
 		pred.pred_nullcmd,
 		pred.pred_angles_normalized,
+		IN_DidApplyMouseDelta () ? 1 : 0,
 		pred.pred_apply_pred_reason,
 		pred.pred_apply_render_reason,
 		pred.server_update_applied ? 1 : 0,
@@ -1893,6 +1894,10 @@ Spike: split from CL_SendCmd, to do clientside viewangle changes separately from
 void CL_AccumulateCmd (void)
 {
 	CL_Predict_BeginFrame ();
+	if (CL_InputBlocked ())
+		// Force prediction to stop immediately when UI/console owns input.
+		CL_Predict_ForceNullCmd ();
+	CL_Predict_Reapply ();
 	if (cls.signon == SIGNONS)
 	{
 		//basic keyboard looking
@@ -1901,10 +1906,6 @@ void CL_AccumulateCmd (void)
 		//accumulate movement from other devices
 		IN_Move (&cl.pendingcmd);
 	}
-	if (CL_InputBlocked ())
-		// Force prediction to stop immediately when UI/console owns input.
-		CL_Predict_ForceNullCmd ();
-	CL_Predict_Reapply ();
 }
 
 /*

--- a/Quake/cl_predict.c
+++ b/Quake/cl_predict.c
@@ -820,14 +820,15 @@ static qboolean CL_Predict_ApplyGroundMotion (cl_pred_state_t *state, int ground
 			for (i = 0; i < 3; i++)
 				delta_raw[i] = ent->msg_origins[0][i] - ent->msg_origins[1][i];
 
-			Con_Printf ("JITTERDBG groundent %d msg_origins0 %.2f %.2f %.2f msg_origins1 %.2f %.2f %.2f msg_dt %.4f yaw0 %.2f yaw1 %.2f yaw_raw %.2f platform_delta_raw %.3f %.3f %.3f ground_delta %.3f %.3f %.3f\n",
+			Con_Printf ("JITTERDBG groundent %d msg_origins0 %.2f %.2f %.2f msg_origins1 %.2f %.2f %.2f msg_dt %.4f yaw0 %.2f yaw1 %.2f yaw_raw %.2f platform_delta_raw %.3f %.3f %.3f ground_delta %.3f %.3f %.3f mouse_applied %d\n",
 				groundent,
 				ent->msg_origins[0][0], ent->msg_origins[0][1], ent->msg_origins[0][2],
 				ent->msg_origins[1][0], ent->msg_origins[1][1], ent->msg_origins[1][2],
 				msg_dt,
 				ent->msg_angles[0][YAW], ent->msg_angles[1][YAW], yaw_raw,
 				delta_raw[0], delta_raw[1], delta_raw[2],
-				state->pred_ground_offset[0], state->pred_ground_offset[1], state->pred_ground_offset[2]);
+				state->pred_ground_offset[0], state->pred_ground_offset[1], state->pred_ground_offset[2],
+				IN_DidApplyMouseDelta () ? 1 : 0);
 		}
 	}
 	else
@@ -1371,8 +1372,8 @@ void CL_Predict_SetupCmd (usercmd_t *cmd)
 	CL_Predict_GetSubstepInfo (cmd_dt, host_dt, &substeps, &dt_sub);
 	if (cl_jitter_debug.value > 0.0f)
 	{
-		Con_Printf ("JITTERDBG setup seq %u cmd_dt %.4f host_dt %.4f substeps %d dt_sub %.4f\n",
-			cmd->sequence, cmd_dt, host_dt, substeps, dt_sub);
+		Con_Printf ("JITTERDBG setup seq %u cmd_dt %.4f host_dt %.4f substeps %d dt_sub %.4f mouse_applied %d\n",
+			cmd->sequence, cmd_dt, host_dt, substeps, dt_sub, IN_DidApplyMouseDelta () ? 1 : 0);
 	}
 	for (i = 0; i < substeps; i++)
 		CL_Predict_SimulateCmd (&cl_pred.predicted, cmd, dt_sub, false);
@@ -1460,7 +1461,7 @@ void CL_Predict_ServerUpdate (unsigned int ack, const vec3_t origin, const vec3_
 		}
 		if (cl_jitter_debug.value > 0.0f && error_len >= 2.0f)
 		{
-			Con_Printf ("JITTERDBG ground onground %d groundent %d ground_valid %d reason %d trace_frac %.2f trace_nz %.2f trace_ent %d trace_solid %d/%d trace_fallback %d wishspeed %.1f wishvel_z %.1f dt %.4f flags %d ground_delta %.2f ground_yaw %.2f apply_pred %d apply_render %d\n",
+			Con_Printf ("JITTERDBG ground onground %d groundent %d ground_valid %d reason %d trace_frac %.2f trace_nz %.2f trace_ent %d trace_solid %d/%d trace_fallback %d wishspeed %.1f wishvel_z %.1f dt %.4f flags %d ground_delta %.2f ground_yaw %.2f apply_pred %d apply_render %d mouse_applied %d\n",
 				cl_pred_ground_dbg.onground ? 1 : 0,
 				cl_pred_ground_dbg.groundent,
 				cl_pred_ground_dbg.ground_valid ? 1 : 0,
@@ -1478,7 +1479,8 @@ void CL_Predict_ServerUpdate (unsigned int ack, const vec3_t origin, const vec3_
 				cl_pred_ground_dbg.ground_delta_len,
 				cl_pred_ground_dbg.ground_yaw_delta,
 				cl_pred_ground_dbg.ground_apply_pred,
-				cl_pred_ground_dbg.ground_apply_render);
+				cl_pred_ground_dbg.ground_apply_render,
+				IN_DidApplyMouseDelta () ? 1 : 0);
 		}
 		if (teleport_dist > 0.0f && error_len > teleport_dist)
 		{
@@ -1615,8 +1617,8 @@ void CL_Predict_ServerUpdate (unsigned int ack, const vec3_t origin, const vec3_
 		CL_Predict_GetSubstepInfo (cmd_dt, host_dt, &substeps, &dt_sub);
 		if (cl_jitter_debug.value > 0.0f)
 		{
-			Con_Printf ("JITTERDBG resim seq %u cmd_dt %.4f host_dt %.4f substeps %d dt_sub %.4f\n",
-				cmd.sequence, cmd_dt, host_dt, substeps, dt_sub);
+			Con_Printf ("JITTERDBG resim seq %u cmd_dt %.4f host_dt %.4f substeps %d dt_sub %.4f mouse_applied %d\n",
+				cmd.sequence, cmd_dt, host_dt, substeps, dt_sub, IN_DidApplyMouseDelta () ? 1 : 0);
 		}
 		for (i = 0; i < substeps; i++)
 			CL_Predict_SimulateCmd (&cl_pred.predicted, &cmd, dt_sub, false);

--- a/Quake/in_sdl.c
+++ b/Quake/in_sdl.c
@@ -39,6 +39,14 @@ static textmode_t textmode = TEXTMODE_OFF;
 static keydevice_t lastactivetype = KD_NONE;
 
 static cvar_t in_debugkeys = {"in_debugkeys", "0", CVAR_NONE};
+static cvar_t cl_mouselook_dbg = {"cl_mouselook_dbg", "0", CVAR_NONE};
+
+static qboolean in_mouse_applied = false;
+static double in_mouse_dbg_next = 0.0;
+static float in_mouse_dbg_dmx = 0.0f;
+static float in_mouse_dbg_dmy = 0.0f;
+static vec3_t in_mouse_dbg_before = {0};
+static vec3_t in_mouse_dbg_after = {0};
 
 #ifdef __APPLE__
 /* Mouse acceleration needs to be disabled on OS X */
@@ -666,6 +674,7 @@ void IN_Init (void)
 	Cvar_RegisterVariable(&in_disablemacosxmouseaccel);
 #endif
 	Cvar_RegisterVariable(&in_debugkeys);
+	Cvar_RegisterVariable(&cl_mouselook_dbg);
 	Cvar_RegisterVariable(&joy_sensitivity_yaw);
 	Cvar_RegisterVariable(&joy_sensitivity_pitch);
 	Cvar_RegisterVariable(&joy_deadzone_look);
@@ -1266,6 +1275,7 @@ void IN_MouseMove(usercmd_t *cmd)
 	float		dmx, dmy;
 	float		sens;
 	qboolean	mlook = (in_mlook.state & 1) || freelook.value;
+	vec3_t		before;
 
 	sens = sensitivity.value * IN_FovScale ();
 
@@ -1274,6 +1284,8 @@ void IN_MouseMove(usercmd_t *cmd)
 
 	total_dx = 0;
 	total_dy = 0;
+
+	VectorCopy (cl.viewangles, before);
 
 	if ((in_strafe.state & 1) || (lookstrafe.value && mlook))
 		cmd->sidemove += m_side.value * dmx;
@@ -1302,10 +1314,32 @@ void IN_MouseMove(usercmd_t *cmd)
 		else
 			cmd->forwardmove -= m_forward.value * dmy;
 	}
+
+	in_mouse_dbg_dmx = dmx;
+	in_mouse_dbg_dmy = dmy;
+	VectorCopy (before, in_mouse_dbg_before);
+	VectorCopy (cl.viewangles, in_mouse_dbg_after);
+	if (dmx != 0.0f || dmy != 0.0f)
+		in_mouse_applied = true;
+
+	if (cl_mouselook_dbg.value > 0.0f && realtime >= in_mouse_dbg_next)
+	{
+		qboolean input_blocked = (key_dest != key_game) || con_forcedup;
+		int in_console = (key_dest == key_console);
+
+		Con_Printf ("MOUSEDBG time %.3f key_dest %d in_console %d input_blocked %d mouse_dx %.2f mouse_dy %.2f "
+			"view_before %.2f %.2f %.2f view_after %.2f %.2f %.2f\n",
+			realtime, key_dest, in_console, input_blocked ? 1 : 0,
+			in_mouse_dbg_dmx, in_mouse_dbg_dmy,
+			in_mouse_dbg_before[0], in_mouse_dbg_before[1], in_mouse_dbg_before[2],
+			in_mouse_dbg_after[0], in_mouse_dbg_after[1], in_mouse_dbg_after[2]);
+		in_mouse_dbg_next = realtime + 1.0;
+	}
 }
 
 void IN_Move(usercmd_t *cmd)
 {
+	in_mouse_applied = false;
 	IN_JoyMove(cmd);
 	IN_GyroMove(cmd);
 	IN_MouseMove(cmd);
@@ -1328,6 +1362,11 @@ void IN_UpdateInputMode (void)
 qboolean IN_EmulatedCharEvents (void)
 {
 	return textmode == TEXTMODE_NOPOPUP && !SDL_IsTextInputActive ();
+}
+
+qboolean IN_DidApplyMouseDelta (void)
+{
+	return in_mouse_applied;
 }
 
 keydevice_t IN_GetLastActiveDeviceType (void)
@@ -1749,4 +1788,3 @@ void IN_SendKeyEvents (void)
 		}
 	}
 }
-

--- a/Quake/input.h
+++ b/Quake/input.h
@@ -94,5 +94,6 @@ void IN_Activate (void);
 void IN_Deactivate (qboolean free_cursor);
 void IN_DeactivateForConsole (void);
 void IN_DeactivateForMenu (void);
+qboolean IN_DidApplyMouseDelta (void);
 
 #endif


### PR DESCRIPTION
### Motivation
- Recent prediction/angle-normalization work caused `CL_Predict_Reapply()` to overwrite `cl.viewangles` after mouse deltas were applied, breaking mouselook in normal gameplay while still nulling movement for UI/console input.
- Need the smallest safe change to restore mouse look while preserving the null-command behavior for blocked input and keeping prediction substep behavior and angle wrap fixes.

### Description
- Reordered prediction handling so `CL_Predict_ForceNullCmd()` and `CL_Predict_Reapply()` run before per-frame input accumulation, preventing prediction from overwriting mouse-applied viewangles while preserving immediate null-cmd injection when input is blocked (`Quake/cl_main.c`).
- Added per-frame mouse-delta tracking and an exported helper `IN_DidApplyMouseDelta()` so other subsystems can know whether mouse deltas were applied this frame (`Quake/in_sdl.c`, `Quake/input.h`).
- Introduced the `cl_mouselook_dbg` cvar that prints (once per second) `key_dest`, console/input-blocked state, mouse dx/dy, and viewangles before/after applying deltas to help diagnose input gating (`Quake/in_sdl.c`).
- Augmented existing JITTERDBG/NETDBG lines to include a `mouse_applied` / `mouse_applied` flag so prediction logs correlate with whether mouse deltas were applied that frame (`Quake/cl_predict.c`, `Quake/cl_main.c`).
- Files changed: `Quake/cl_main.c`, `Quake/cl_predict.c`, `Quake/in_sdl.c`, `Quake/input.h`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e2bb11614832e83ad808690536a79)