### PR TITLE
Add forward declaration for CL_Predict_IsEnabled to fix build warning

### DIFF
--- a/Quake/cl_predict.c
+++ b/Quake/cl_predict.c
@@ -107,6 +107,7 @@ static double cl_pred_frame_accum;
 static float cl_pred_frame_dt_last;
 
 static float CL_Predict_GetStepTime (void);
+static qboolean CL_Predict_IsEnabled (void);
 static void CL_Predict_SimulateCmd (cl_pred_state_t *state, const usercmd_t *cmd, float dt, qboolean is_render);
 
 #define CL_PREDICT_MAX_CLIP_PLANES 5


### PR DESCRIPTION
### Motivation
- Prevent the implicit function declaration warning (which is treated as an error) when compiling `Quake/cl_predict.c` by ensuring `CL_Predict_IsEnabled` is declared before use.

### Description
- Add the forward declaration `static qboolean CL_Predict_IsEnabled (void);` to `Quake/cl_predict.c` above the `CL_Predict_SimulateCmd` prototype.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e76acd4e4832e923c1886e4ccb473)