### PR TITLE
Renderer-Backend: Grundgerüst (Header + GL/Null Stubs) hinzufügen

### DIFF
--- a/Quake/Makefile
+++ b/Quake/Makefile
@@ -220,6 +220,9 @@ GLOBJS = \
 	gl_rmain.o \
 	gl_fog.o \
 	gl_rmisc.o \
+	renderer_backend.o \
+	renderer_backend_gl.o \
+	renderer_backend_null.o \
 	r_shadow.o \
 	r_postfx.o \
 	r_godrayvol.o \

--- a/Quake/Makefile.w32
+++ b/Quake/Makefile.w32
@@ -226,6 +226,9 @@ GLOBJS = \
 	gl_rmain.o \
 	gl_fog.o \
 	gl_rmisc.o \
+	renderer_backend.o \
+	renderer_backend_gl.o \
+	renderer_backend_null.o \
 	r_shadow.o \
 	r_postfx.o \
 	r_godrayvol.o \

--- a/Quake/Makefile.w64
+++ b/Quake/Makefile.w64
@@ -219,6 +219,9 @@ GLOBJS = \
 	gl_rmain.o \
 	gl_fog.o \
 	gl_rmisc.o \
+	renderer_backend.o \
+	renderer_backend_gl.o \
+	renderer_backend_null.o \
 	r_shadow.o \
 	r_postfx.o \
 	r_godrayvol.o \

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -24,6 +24,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "quakedef.h"
 #include "cl_postfx.h"
 #include "r_postfx.h"
+#include "renderer_backend.h"
 #include "r_fogvol.h"
 #include "r_godray_emit.h"
 #include "r_godrayvol.h"
@@ -4860,6 +4861,9 @@ void R_RenderView (void)
         else if (gl_finish.value)
                 glFinish ();
 
+	// TODO BACKEND: begin frame once backend owns frame sequencing.
+	RB_BeginFrame();
+
         R_SetupView (); //johnfitz -- this does everything that should be done once per frame
         Fog_EnableGFog ();
         R_RenderScene ();
@@ -4868,6 +4872,9 @@ void R_RenderView (void)
         R_FogVol_Render ();
         Fog_DisableGFog (); // Leave fog disabled for 2D overlays
 	R_Shadow_DrawDebug ();
+
+	// TODO BACKEND: end frame once backend owns frame sequencing.
+	RB_EndFrame();
 
 	r_frame_rendered_this_update = true;
 

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -31,6 +31,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "r_fogvol.h"
 #include "r_godray_emit.h"
 #include "r_godrayvol.h"
+#include "renderer_backend.h"
 
 //johnfitz -- new cvars
 extern cvar_t r_clearcolor;
@@ -534,6 +535,9 @@ void R_Init (void)
 {
         cmd_function_t *cmd;
 
+        // TODO BACKEND: initialize renderer backend (stub in phase 1).
+        RB_Init();
+
         Cmd_AddCommand ("timerefresh", R_TimeRefresh_f);
         Cmd_AddCommand ("pointfile", R_ReadPointFile_f);
         cmd = Cmd_AddCommand ("r_showbboxes_filter", R_ShowbboxesFilter_f);
@@ -996,6 +1000,9 @@ R_NewMap
 void R_NewMap (void)
 {
 	int		i;
+
+	// TODO BACKEND: notify renderer backend of new map (stub in phase 1).
+	RB_NewMap();
 
 	for (i=0 ; i<256 ; i++)
 		d_lightstylevalue[i] = 264;		// normal light value

--- a/Quake/renderer_backend.c
+++ b/Quake/renderer_backend.c
@@ -1,0 +1,148 @@
+/*
+Copyright (C) 2024
+
+This file is part of Ironwail.
+*/
+
+#include "quakedef.h"
+#include "renderer_backend.h"
+#include "renderer_backend_gl.h"
+#include "renderer_backend_null.h"
+
+static const rb_backend_api_t *rb_backend = NULL;
+static rb_caps_t rb_caps_fallback = {0, 0};
+
+static const rb_backend_api_t *RB_SelectBackend(void)
+{
+#if RENDERER_BACKEND_GL
+	return RB_GL_GetApi();
+#else
+	return RB_NULL_GetApi();
+#endif
+}
+
+void RB_Init(void)
+{
+	if (rb_backend)
+		return;
+
+	rb_backend = RB_SelectBackend();
+	if (!rb_backend)
+	{
+		Con_Printf("RB_Init: no backend available.\n");
+		return;
+	}
+	if (rb_backend->init)
+		rb_backend->init();
+}
+
+void RB_Shutdown(void)
+{
+	if (!rb_backend)
+		return;
+	if (rb_backend->shutdown)
+		rb_backend->shutdown();
+	rb_backend = NULL;
+}
+
+void RB_BeginFrame(void)
+{
+	if (!rb_backend)
+		return;
+	if (rb_backend->begin_frame)
+		rb_backend->begin_frame();
+}
+
+void RB_EndFrame(void)
+{
+	if (!rb_backend)
+		return;
+	if (rb_backend->end_frame)
+		rb_backend->end_frame();
+}
+
+void RB_Resize(int width, int height)
+{
+	if (!rb_backend)
+		return;
+	if (rb_backend->resize)
+		rb_backend->resize(width, height);
+}
+
+void RB_NewMap(void)
+{
+	if (!rb_backend)
+		return;
+	if (rb_backend->new_map)
+		rb_backend->new_map();
+}
+
+rb_tex_t RB_CreateTexture(const rb_tex_desc_t *desc)
+{
+	if (!rb_backend || !rb_backend->create_texture)
+		return NULL;
+	return rb_backend->create_texture(desc);
+}
+
+void RB_DestroyTexture(rb_tex_t tex)
+{
+	if (!rb_backend || !rb_backend->destroy_texture)
+		return;
+	rb_backend->destroy_texture(tex);
+}
+
+rb_buf_t RB_CreateBuffer(const rb_buf_desc_t *desc)
+{
+	if (!rb_backend || !rb_backend->create_buffer)
+		return NULL;
+	return rb_backend->create_buffer(desc);
+}
+
+void RB_DestroyBuffer(rb_buf_t buf)
+{
+	if (!rb_backend || !rb_backend->destroy_buffer)
+		return;
+	rb_backend->destroy_buffer(buf);
+}
+
+rb_fbo_t RB_CreateFBO(const rb_fbo_desc_t *desc)
+{
+	if (!rb_backend || !rb_backend->create_fbo)
+		return NULL;
+	return rb_backend->create_fbo(desc);
+}
+
+void RB_DestroyFBO(rb_fbo_t fbo)
+{
+	if (!rb_backend || !rb_backend->destroy_fbo)
+		return;
+	rb_backend->destroy_fbo(fbo);
+}
+
+void RB_Submit(const rb_draw_desc_t *desc)
+{
+	if (!rb_backend || !rb_backend->submit)
+		return;
+	rb_backend->submit(desc);
+}
+
+const rb_caps_t *RB_GetCaps(void)
+{
+	if (!rb_backend || !rb_backend->get_caps)
+		return &rb_caps_fallback;
+	return rb_backend->get_caps();
+}
+
+void RB_DebugMarkerBegin(const char *label)
+{
+	if (!rb_backend || !rb_backend->debug_marker_begin)
+		return;
+	rb_backend->debug_marker_begin(label);
+}
+
+void RB_DebugMarkerEnd(void)
+{
+	if (!rb_backend || !rb_backend->debug_marker_end)
+		return;
+	rb_backend->debug_marker_end();
+}

--- a/Quake/renderer_backend.h
+++ b/Quake/renderer_backend.h
@@ -1,0 +1,130 @@
+/*
+Copyright (C) 2024
+
+This file is part of Ironwail.
+*/
+
+#ifndef RENDERER_BACKEND_H
+#define RENDERER_BACKEND_H
+
+#include "q_stdinc.h"
+
+#include <stddef.h>
+
+#ifndef RENDERER_BACKEND_GL
+#define RENDERER_BACKEND_GL 1
+#endif
+
+typedef struct rb_tex_s *rb_tex_t;
+typedef struct rb_buf_s *rb_buf_t;
+typedef struct rb_fbo_s *rb_fbo_t;
+
+typedef enum rb_tex_format_e
+{
+	RB_TEXFMT_RGBA8 = 0,
+	RB_TEXFMT_DEPTH24_STENCIL8
+} rb_tex_format_t;
+
+typedef enum rb_buffer_type_e
+{
+	RB_BUFFER_VERTEX = 0,
+	RB_BUFFER_INDEX,
+	RB_BUFFER_UNIFORM
+} rb_buffer_type_t;
+
+typedef enum rb_buffer_usage_e
+{
+	RB_BUFFER_USAGE_STATIC = 0,
+	RB_BUFFER_USAGE_DYNAMIC
+} rb_buffer_usage_t;
+
+typedef struct rb_tex_desc_s
+{
+	int				width;
+	int				height;
+	int				mip_levels;
+	rb_tex_format_t	format;
+	const void		*data;
+	size_t			data_size;
+} rb_tex_desc_t;
+
+typedef struct rb_buf_desc_s
+{
+	rb_buffer_type_t	type;
+	rb_buffer_usage_t	usage;
+	size_t				size;
+	const void			*data;
+	size_t				data_size;
+} rb_buf_desc_t;
+
+typedef struct rb_fbo_desc_s
+{
+	rb_tex_t			color;
+	rb_tex_t			depth_stencil;
+} rb_fbo_desc_t;
+
+typedef struct rb_draw_desc_s
+{
+	rb_buf_t			vertex_buffer;
+	rb_buf_t			index_buffer;
+	int				first_vertex;
+	int				vertex_count;
+	int				first_index;
+	int				index_count;
+} rb_draw_desc_t;
+
+typedef struct rb_caps_s
+{
+	int				supports_debug_markers;
+	int				supports_instancing;
+} rb_caps_t;
+
+typedef struct rb_backend_api_s
+{
+	const char			*name;
+	void				(*init)(void);
+	void				(*shutdown)(void);
+	void				(*begin_frame)(void);
+	void				(*end_frame)(void);
+	void				(*resize)(int width, int height);
+	void				(*new_map)(void);
+	rb_tex_t			(*create_texture)(const rb_tex_desc_t *desc);
+	void				(*destroy_texture)(rb_tex_t tex);
+	rb_buf_t			(*create_buffer)(const rb_buf_desc_t *desc);
+	void				(*destroy_buffer)(rb_buf_t buf);
+	rb_fbo_t			(*create_fbo)(const rb_fbo_desc_t *desc);
+	void				(*destroy_fbo)(rb_fbo_t fbo);
+	void				(*submit)(const rb_draw_desc_t *desc);
+	const rb_caps_t	(*get_caps)(void);
+	void				(*debug_marker_begin)(const char *label);
+	void				(*debug_marker_end)(void);
+} rb_backend_api_t;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void			RB_Init(void);
+void			RB_Shutdown(void);
+void			RB_BeginFrame(void);
+void			RB_EndFrame(void);
+void			RB_Resize(int width, int height);
+void			RB_NewMap(void);
+
+rb_tex_t		RB_CreateTexture(const rb_tex_desc_t *desc);
+void			RB_DestroyTexture(rb_tex_t tex);
+rb_buf_t		RB_CreateBuffer(const rb_buf_desc_t *desc);
+void			RB_DestroyBuffer(rb_buf_t buf);
+rb_fbo_t		RB_CreateFBO(const rb_fbo_desc_t *desc);
+void			RB_DestroyFBO(rb_fbo_t fbo);
+
+void			RB_Submit(const rb_draw_desc_t *desc);
+const rb_caps_t	*RB_GetCaps(void);
+void			RB_DebugMarkerBegin(const char *label);
+void			RB_DebugMarkerEnd(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Quake/renderer_backend_gl.c
+++ b/Quake/renderer_backend_gl.c
@@ -1,0 +1,131 @@
+/*
+Copyright (C) 2024
+
+This file is part of Ironwail.
+*/
+
+#include "quakedef.h"
+#include "renderer_backend_gl.h"
+
+typedef struct rb_gl_tex_s
+{
+	int unused;
+} rb_gl_tex_t;
+
+typedef struct rb_gl_buf_s
+{
+	int unused;
+} rb_gl_buf_t;
+
+typedef struct rb_gl_fbo_s
+{
+	int unused;
+} rb_gl_fbo_t;
+
+static rb_caps_t rb_gl_caps = {0, 0};
+
+static void RB_GL_Init(void)
+{
+	Con_DPrintf("RB_GL_Init: stub backend initialized.\n");
+}
+
+static void RB_GL_Shutdown(void)
+{
+	Con_DPrintf("RB_GL_Shutdown: stub backend shutdown.\n");
+}
+
+static void RB_GL_BeginFrame(void)
+{
+}
+
+static void RB_GL_EndFrame(void)
+{
+}
+
+static void RB_GL_Resize(int width, int height)
+{
+	(void)width;
+	(void)height;
+}
+
+static void RB_GL_NewMap(void)
+{
+}
+
+static rb_tex_t RB_GL_CreateTexture(const rb_tex_desc_t *desc)
+{
+	(void)desc;
+	return (rb_tex_t)Z_Malloc(sizeof(rb_gl_tex_t));
+}
+
+static void RB_GL_DestroyTexture(rb_tex_t tex)
+{
+	Z_Free(tex);
+}
+
+static rb_buf_t RB_GL_CreateBuffer(const rb_buf_desc_t *desc)
+{
+	(void)desc;
+	return (rb_buf_t)Z_Malloc(sizeof(rb_gl_buf_t));
+}
+
+static void RB_GL_DestroyBuffer(rb_buf_t buf)
+{
+	Z_Free(buf);
+}
+
+static rb_fbo_t RB_GL_CreateFBO(const rb_fbo_desc_t *desc)
+{
+	(void)desc;
+	return (rb_fbo_t)Z_Malloc(sizeof(rb_gl_fbo_t));
+}
+
+static void RB_GL_DestroyFBO(rb_fbo_t fbo)
+{
+	Z_Free(fbo);
+}
+
+static void RB_GL_Submit(const rb_draw_desc_t *desc)
+{
+	(void)desc;
+}
+
+static const rb_caps_t *RB_GL_GetCaps(void)
+{
+	return &rb_gl_caps;
+}
+
+static void RB_GL_DebugMarkerBegin(const char *label)
+{
+	if (label && *label)
+		Con_DPrintf("RB_GL_DebugMarkerBegin: %s\n", label);
+}
+
+static void RB_GL_DebugMarkerEnd(void)
+{
+}
+
+static const rb_backend_api_t rb_gl_api = {
+	"OpenGL",
+	RB_GL_Init,
+	RB_GL_Shutdown,
+	RB_GL_BeginFrame,
+	RB_GL_EndFrame,
+	RB_GL_Resize,
+	RB_GL_NewMap,
+	RB_GL_CreateTexture,
+	RB_GL_DestroyTexture,
+	RB_GL_CreateBuffer,
+	RB_GL_DestroyBuffer,
+	RB_GL_CreateFBO,
+	RB_GL_DestroyFBO,
+	RB_GL_Submit,
+	RB_GL_GetCaps,
+	RB_GL_DebugMarkerBegin,
+	RB_GL_DebugMarkerEnd
+};
+
+const rb_backend_api_t *RB_GL_GetApi(void)
+{
+	return &rb_gl_api;
+}

--- a/Quake/renderer_backend_gl.h
+++ b/Quake/renderer_backend_gl.h
@@ -1,0 +1,14 @@
+/*
+Copyright (C) 2024
+
+This file is part of Ironwail.
+*/
+
+#ifndef RENDERER_BACKEND_GL_H
+#define RENDERER_BACKEND_GL_H
+
+#include "renderer_backend.h"
+
+const rb_backend_api_t *RB_GL_GetApi(void);
+
+#endif

--- a/Quake/renderer_backend_null.c
+++ b/Quake/renderer_backend_null.c
@@ -1,0 +1,115 @@
+/*
+Copyright (C) 2024
+
+This file is part of Ironwail.
+*/
+
+#include "quakedef.h"
+#include "renderer_backend_null.h"
+
+static rb_caps_t rb_null_caps = {0, 0};
+
+static void RB_NULL_Init(void)
+{
+	Con_DPrintf("RB_NULL_Init: null backend initialized.\n");
+}
+
+static void RB_NULL_Shutdown(void)
+{
+	Con_DPrintf("RB_NULL_Shutdown: null backend shutdown.\n");
+}
+
+static void RB_NULL_BeginFrame(void)
+{
+}
+
+static void RB_NULL_EndFrame(void)
+{
+}
+
+static void RB_NULL_Resize(int width, int height)
+{
+	(void)width;
+	(void)height;
+}
+
+static void RB_NULL_NewMap(void)
+{
+}
+
+static rb_tex_t RB_NULL_CreateTexture(const rb_tex_desc_t *desc)
+{
+	(void)desc;
+	return NULL;
+}
+
+static void RB_NULL_DestroyTexture(rb_tex_t tex)
+{
+	(void)tex;
+}
+
+static rb_buf_t RB_NULL_CreateBuffer(const rb_buf_desc_t *desc)
+{
+	(void)desc;
+	return NULL;
+}
+
+static void RB_NULL_DestroyBuffer(rb_buf_t buf)
+{
+	(void)buf;
+}
+
+static rb_fbo_t RB_NULL_CreateFBO(const rb_fbo_desc_t *desc)
+{
+	(void)desc;
+	return NULL;
+}
+
+static void RB_NULL_DestroyFBO(rb_fbo_t fbo)
+{
+	(void)fbo;
+}
+
+static void RB_NULL_Submit(const rb_draw_desc_t *desc)
+{
+	(void)desc;
+}
+
+static const rb_caps_t *RB_NULL_GetCaps(void)
+{
+	return &rb_null_caps;
+}
+
+static void RB_NULL_DebugMarkerBegin(const char *label)
+{
+	(void)label;
+}
+
+static void RB_NULL_DebugMarkerEnd(void)
+{
+}
+
+static const rb_backend_api_t rb_null_api = {
+	"Null",
+	RB_NULL_Init,
+	RB_NULL_Shutdown,
+	RB_NULL_BeginFrame,
+	RB_NULL_EndFrame,
+	RB_NULL_Resize,
+	RB_NULL_NewMap,
+	RB_NULL_CreateTexture,
+	RB_NULL_DestroyTexture,
+	RB_NULL_CreateBuffer,
+	RB_NULL_DestroyBuffer,
+	RB_NULL_CreateFBO,
+	RB_NULL_DestroyFBO,
+	RB_NULL_Submit,
+	RB_NULL_GetCaps,
+	RB_NULL_DebugMarkerBegin,
+	RB_NULL_DebugMarkerEnd
+};
+
+const rb_backend_api_t *RB_NULL_GetApi(void)
+{
+	return &rb_null_api;
+}

--- a/Quake/renderer_backend_null.h
+++ b/Quake/renderer_backend_null.h
@@ -1,0 +1,14 @@
+/*
+Copyright (C) 2024
+
+This file is part of Ironwail.
+*/
+
+#ifndef RENDERER_BACKEND_NULL_H
+#define RENDERER_BACKEND_NULL_H
+
+#include "renderer_backend.h"
+
+const rb_backend_api_t *RB_NULL_GetApi(void);
+
+#endif


### PR DESCRIPTION
### Motivation
- Vorbereitung für schrittweises Auslagern des bisherigen Renderers in ein separates Backend-Modul ohne Verhaltensänderung in Phase 1.
- Schaffe eine klare Backend-API mit C-kompatiblen, undurchsichtigen Handles als Grundlage für spätere Refactors.
- Füge minimale Hook-Punkte in bestehende Renderer-Einstiegspunkte ein, wobei die eigentliche Rendering-Logik unverändert bleibt (nur TODO-Stubs). 

### Description
- Neue Backend-API und Dispatch-Layer hinzugefügt mit opaque Handles und minimalem Interface (`renderer_backend.h`, `renderer_backend.c`) inklusive `RB_Init`, `RB_Shutdown`, `RB_BeginFrame`, `RB_EndFrame`, `RB_Resize`, `RB_NewMap`, Ressource-Funktionen (`RB_CreateTexture`/`RB_DestroyTexture`, `RB_CreateBuffer`/`RB_DestroyBuffer`, `RB_CreateFBO`/`RB_DestroyFBO`), `RB_Submit`, `RB_GetCaps` und Debug-Marker (`RB_DebugMarkerBegin`/`RB_DebugMarkerEnd`).
- Zwei Stub-Implementierungen ergänzt: OpenGL-stub (`renderer_backend_gl.c`, `renderer_backend_gl.h`) und Null/headless-stub (`renderer_backend_null.c`, `renderer_backend_null.h`) welche Platzhalter-Allokationen/Freeing (`Z_Malloc`/`Z_Free`) und `Con_DPrintf`-Logging verwenden.
- Minimale Integrations-Hooks in bestehende Renderer-Einstiegspunkte eingefügt: `RB_Init()` in `Quake/gl_rmisc.c` (innerhalb `R_Init`) und `RB_NewMap()` in `R_NewMap` sowie `RB_BeginFrame()` / `RB_EndFrame()` in `Quake/gl_rmain.c` mit erklärenden `// TODO BACKEND` Kommentaren.
- Build-Skripte erweitert, so dass die neuen Objektdateien in die Quake-Makefiles aufgenommen werden (`Quake/Makefile`, `Quake/Makefile.w32`, `Quake/Makefile.w64`).
- Compile-Guard/Default-Define bereitgestellt: `RENDERER_BACKEND_GL` defaultet auf `1` in `renderer_backend.h` (kann vom Buildsystem überschrieben werden).

### Testing
- Keine automatisierten Tests wurden ausgeführt; es wurden keine Laufzeit- oder Build-Checks angefordert oder durchgeführt.
- Änderungen sind strikt inkrementell und enthalten nur Stubs und TODO-Markierungen, so dass keine funktionalen Änderungen beabsichtigt sind.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fd3c27454832e97c9d5a631791f5a)