### PR TITLE
Include renderer_backend.c in Visual Studio project to fix RB_* linker errors

### DIFF
--- a/Windows/VisualStudio/ironwail.vcxproj
+++ b/Windows/VisualStudio/ironwail.vcxproj
@@ -258,6 +258,7 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
     <ClCompile Include="..\..\Quake\gl_rlight.c" />
     <ClCompile Include="..\..\Quake\gl_rmain.c" />
     <ClCompile Include="..\..\Quake\gl_rmisc.c" />
+    <ClCompile Include="..\..\Quake\renderer_backend.c" />
     <ClCompile Include="..\..\Quake\gl_screen.c" />
     <ClCompile Include="..\..\Quake\gl_shaders.c" />
     <ClCompile Include="..\..\Quake\gl_sky.c" />

--- a/Windows/VisualStudio/ironwail.vcxproj.filters
+++ b/Windows/VisualStudio/ironwail.vcxproj.filters
@@ -309,6 +309,9 @@
     <ClCompile Include="..\..\Quake\snd_mpg123.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Quake\renderer_backend.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Quake\anorm_dots.h">


### PR DESCRIPTION
### Motivation
- Resolve linker errors for unresolved symbols `RB_BeginFrame`, `RB_EndFrame`, `RB_Init`, and `RB_NewMap` by ensuring the renderer backend source is compiled into the Windows build.

### Description
- Add `..\\Quake\\renderer_backend.c` to `Windows/VisualStudio/ironwail.vcxproj` and add the same file to `Windows/VisualStudio/ironwail.vcxproj.filters` so the source is included in the Visual Studio project and appears under Source Files.

### Testing
- No automated tests or builds were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fdacdb574832e85b7606fc3a09fb3)