### PR TITLE
Fix renderer backend caps callback signature

### DIFF
--- a/Quake/renderer_backend.h
+++ b/Quake/renderer_backend.h
@@ -95,7 +95,7 @@ typedef struct rb_backend_api_s
 	rb_fbo_t			(*create_fbo)(const rb_fbo_desc_t *desc);
 	void				(*destroy_fbo)(rb_fbo_t fbo);
 	void				(*submit)(const rb_draw_desc_t *desc);
-	const rb_caps_t	(*get_caps)(void);
+	const rb_caps_t	*(*get_caps)(void);
 	void				(*debug_marker_begin)(const char *label);
 	void				(*debug_marker_end)(void);
 } rb_backend_api_t;


### PR DESCRIPTION
### Motivation
- Align the `get_caps` callback signature with backend implementations to resolve MSVC build error `C2440` where a `const rb_caps_t` value could not be converted to a `const rb_caps_t *` pointer.

### Description
- Update in `Quake/renderer_backend.h`: change `const rb_caps_t (*get_caps)(void);` to `const rb_caps_t *(*get_caps)(void);` so the API expects a pointer as returned by backends.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fdb7d0b2c832e9de6769a61e255e0)