### PR TITLE
Add renderer backend sources to Visual Studio project

### DIFF
--- a/Windows/VisualStudio/ironwail.vcxproj
+++ b/Windows/VisualStudio/ironwail.vcxproj
@@ -259,6 +259,8 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
     <ClCompile Include="..\..\Quake\gl_rmain.c" />
     <ClCompile Include="..\..\Quake\gl_rmisc.c" />
     <ClCompile Include="..\..\Quake\renderer_backend.c" />
+    <ClCompile Include="..\..\Quake\renderer_backend_gl.c" />
+    <ClCompile Include="..\..\Quake\renderer_backend_null.c" />
     <ClCompile Include="..\..\Quake\gl_screen.c" />
     <ClCompile Include="..\..\Quake\gl_shaders.c" />
     <ClCompile Include="..\..\Quake\gl_sky.c" />

--- a/Windows/VisualStudio/ironwail.vcxproj.filters
+++ b/Windows/VisualStudio/ironwail.vcxproj.filters
@@ -312,6 +312,12 @@
     <ClCompile Include="..\..\Quake\renderer_backend.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Quake\renderer_backend_gl.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Quake\renderer_backend_null.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Quake\anorm_dots.h">


### PR DESCRIPTION
### Motivation
- Resolve a Windows link error caused by `RB_GL_GetApi` not being compiled into the Visual Studio build by ensuring the OpenGL backend implementation is included. 
- Ensure the null renderer implementation is also compiled so a fallback backend is available.

### Description
- Added `..\..\Quake\renderer_backend_gl.c` and `..\..\Quake\renderer_backend_null.c` to the `ClCompile` list in `Windows/VisualStudio/ironwail.vcxproj` so they are built on Windows. 
- Added the same two source files to `Windows/VisualStudio/ironwail.vcxproj.filters` under `Source Files` so they appear in the Visual Studio project tree. 
- Kept existing `renderer_backend.c` entry and preserved project file formatting.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fdc30a904832ea46a6ae4536cfe25)