### PR TITLE
Fix rim lighting on alias/MD5 models and world shaders

### DIFF
--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -222,22 +222,25 @@ void main()
 	if (inst_RimParams0.x > 0.5)
 	{
 		vec3 normal = normalize(gl_FrontFacing ? in_normal : -in_normal);
-		vec3 view_dir = normalize(-in_pos);
+		vec3 to_eye = -in_pos;
+		float view_len = length(to_eye);
+		vec3 view_dir = (view_len > 0.0) ? (to_eye / view_len) : vec3(0.0, 0.0, 1.0);
 		float ndotv = clamp(dot(normal, view_dir), 0.0, 1.0);
 		float rim_base = pow(1.0 - ndotv, inst_RimParams0.y);
 		float light_len = length(inst_ShadowSunDir.xyz);
 		vec3 light_dir = (light_len > 0.0) ? normalize(-inst_ShadowSunDir.xyz) : vec3(0.0, 0.0, 1.0);
-		float rim_light = clamp(dot(normal, light_dir) * 0.5 + 0.5, 0.0, 1.0);
+		float direct_w = clamp(dot(normal, light_dir) * 0.5 + 0.5, 0.0, 1.0);
 		vec3 ambient_color = in_ambient * inst_RimParams1.x;
-		vec3 direct_color = in_direct * inst_RimParams0.w;
+		vec3 direct_color = in_direct;
 		float direct_strength = clamp(max(max(direct_color.r, direct_color.g), direct_color.b), 0.0, 1.0);
-		float rim_visibility = rim_light * direct_strength;
-		rim_visibility *= shadow_term;
-		vec3 rim_color = mix(ambient_color, direct_color, rim_light);
+		float rim_light_mix = clamp(inst_RimParams0.w * direct_strength, 0.0, 1.0);
+		float rim_shadow = mix(0.25, 1.0, shadow_term);
+		float rim_visibility = mix(inst_RimParams1.x, 1.0, direct_w) * rim_shadow;
+		vec3 rim_color = mix(ambient_color, direct_color, rim_light_mix);
 		vec3 rim_term = rim_base * inst_RimParams0.z * rim_visibility * rim_color;
 		if (inst_RimParams1.y > 0.5)
 		{
-			out_fragcolor = vec4(clamp(rim_term, 0.0, 1.0), 1.0);
+			out_fragcolor = vec4(vec3(rim_base), 1.0);
 #if !OIT
 			out_velocity = vec4(0.0);
 #endif

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -622,16 +622,18 @@ void main()
 		float rim_base = pow(1.0 - ndotv, RimParams0.y);
 		float light_len = length(ShadowSunDir.xyz);
 		vec3 light_dir = (light_len > 0.0) ? normalize(-ShadowSunDir.xyz) : vec3(0.0, 0.0, 1.0);
-		float rim_light = clamp(dot(surface_normal, light_dir) * 0.5 + 0.5, 0.0, 1.0);
+		float direct_w = clamp(dot(surface_normal, light_dir) * 0.5 + 0.5, 0.0, 1.0);
 		vec3 ambient_color = Fog.rgb * RimParams1.x;
-		vec3 direct_color = total_light * RimParams0.w;
+		vec3 direct_color = total_light;
 		float direct_strength = clamp(max(max(direct_color.r, direct_color.g), direct_color.b), 0.0, 1.0);
-		float rim_visibility = rim_light * direct_strength * rim_shadow;
-		vec3 rim_color = mix(ambient_color, direct_color, rim_light);
+		float rim_light_mix = clamp(RimParams0.w * direct_strength, 0.0, 1.0);
+		float rim_shadow_mix = mix(0.25, 1.0, rim_shadow);
+		float rim_visibility = mix(RimParams1.x, 1.0, direct_w) * rim_shadow_mix;
+		vec3 rim_color = mix(ambient_color, direct_color, rim_light_mix);
 		vec3 rim_term = rim_base * RimParams0.z * rim_visibility * rim_color;
 		if (RimParams1.y > 0.5)
 		{
-			out_fragcolor = vec4(clamp(rim_term, 0.0, 1.0), 1.0);
+			out_fragcolor = vec4(vec3(rim_base), 1.0);
 #if !OIT
 			out_velocity = vec4(0.0);
 #endif


### PR DESCRIPTION
### Motivation
- Rim was visible only on lightmapped world surfaces and not on alias/MD5 model silhouettes due to differences in view/normal handling and light mixing.
- The rim formula and light influence needed to follow a silhouette-based approach and avoid being multiplied away by lightmaps or direct light zeroing.

### Description
- Ensure model shader rim uses a proper view vector by computing `to_eye = -in_pos` with a safe `length` check and normalizing to get `view_dir`, then computing `ndotv` and `rim_base = pow(1.0 - ndotv, ...)` (updated in `Quake/shaders/alias.frag`).
- Replace the old diffuse-like rim multiplication with a corrected light mixing: compute `direct_w` from `dot(normal, light_dir)`, derive `direct_strength` from `direct_color`, use `rim_light_mix = clamp(inst_RimParams0.w * direct_strength, ...)`, mix rim color with `mix(ambient_color, direct_color, rim_light_mix)`, and compute `rim_visibility` with a softened shadow contribution instead of full suppression (changes in both `Quake/shaders/alias.frag` and `Quake/shaders/world.frag`).
- Provide a debug output mode that emits `vec3(rim_base)` when `RimParams1.y > 0.5` so silhouette/rim base can be verified on models and world surfaces (both shaders).
- Kept rim parameter usage (`inst_RimParams0/1` and `RimParams0/1`) but adjusted how they influence mixing so rim does not “stick” to lightmaps or get fully removed by shadows.

### Testing
- No automated tests were executed for these shader edits in this rollout.
- The shader files were patched and committed (`Quake/shaders/alias.frag`, `Quake/shaders/world.frag`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69811a5d8048832ea13a82a992b9407c)