### PR TITLE
Rim lighting: compute in view-space, add debug modes

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -3414,7 +3414,7 @@ void R_SetupView (void)
         r_framedata.rim_params0[2] = r_rim_strength.value;
         r_framedata.rim_params0[3] = r_rim_lightscale.value;
         r_framedata.rim_params1[0] = r_rim_ambientscale.value;
-        r_framedata.rim_params1[1] = (r_rim_debug.value > 0.f) ? 1.f : 0.f;
+        r_framedata.rim_params1[1] = CLAMP (0.f, r_rim_debug.value, 2.f);
         r_framedata.rim_params1[2] = 0.f;
         r_framedata.rim_params1[3] = 0.f;
         r_framedata.shadow_params[0] = r_shadow_bias.value;

--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -91,6 +91,7 @@ struct ibuf_s {
 	struct {
 		float	matviewproj[16];
 		float	prev_matviewproj[16];
+		float	view[16];
 		vec3_t	eyepos;
 		float	_pad;
 		vec4_t	fog;
@@ -564,10 +565,11 @@ void R_FlushAliasInstances (qboolean showtris)
 		state |= GLS_BLEND_ALPHA_OIT | GLS_NO_ZWRITE;
 	GL_SetState (state);
 
-memcpy (ibuf.global.matviewproj, r_matviewproj, sizeof (r_matviewproj));
-memcpy (ibuf.global.prev_matviewproj, r_framedata.prev_viewproj, sizeof (r_framedata.prev_viewproj));
-memcpy (ibuf.global.eyepos, r_refdef.vieworg, sizeof (r_refdef.vieworg));
-memcpy (ibuf.global.fog, r_framedata.fogdata, 3 * sizeof (float));
+	memcpy (ibuf.global.matviewproj, r_matviewproj, sizeof (r_matviewproj));
+	memcpy (ibuf.global.prev_matviewproj, r_framedata.prev_viewproj, sizeof (r_framedata.prev_viewproj));
+	memcpy (ibuf.global.view, r_framedata.view, sizeof (r_framedata.view));
+	memcpy (ibuf.global.eyepos, r_refdef.vieworg, sizeof (r_refdef.vieworg));
+	memcpy (ibuf.global.fog, r_framedata.fogdata, 3 * sizeof (float));
 // use fog density sign bit as overbright flag
 ibuf.global.fog[3] =
 gl_overbright_models.value ?
@@ -582,7 +584,7 @@ gl_overbright_models.value ?
 	ibuf.global.rim_params0[2] = r_rim_strength.value;
 	ibuf.global.rim_params0[3] = r_rim_lightscale.value;
 	ibuf.global.rim_params1[0] = r_rim_ambientscale.value;
-	ibuf.global.rim_params1[1] = (r_rim_debug.value > 0.f) ? 1.f : 0.f;
+	ibuf.global.rim_params1[1] = CLAMP (0.f, r_rim_debug.value, 2.f);
 	ibuf.global.rim_params1[2] = 0.f;
 	ibuf.global.rim_params1[3] = 0.f;
 	memcpy (ibuf.global.shadow_viewproj, r_framedata.shadow_viewproj, sizeof (r_framedata.shadow_viewproj));
@@ -729,6 +731,7 @@ static void R_FlushAliasInstances_Shadow (void)
 
 	memcpy (ibuf.global.matviewproj, r_matviewproj, sizeof (r_matviewproj));
 	memcpy (ibuf.global.prev_matviewproj, r_framedata.prev_viewproj, sizeof (r_framedata.prev_viewproj));
+	memcpy (ibuf.global.view, r_framedata.view, sizeof (r_framedata.view));
 	memcpy (ibuf.global.eyepos, r_refdef.vieworg, sizeof (r_refdef.vieworg));
 	memcpy (ibuf.global.shadow_viewproj, r_framedata.shadow_viewproj, sizeof (r_framedata.shadow_viewproj));
 	ibuf.global.shadow_params[0] = r_shadow_bias_mdl.value;
@@ -742,7 +745,7 @@ static void R_FlushAliasInstances_Shadow (void)
 	ibuf.global.rim_params0[2] = r_rim_strength.value;
 	ibuf.global.rim_params0[3] = r_rim_lightscale.value;
 	ibuf.global.rim_params1[0] = r_rim_ambientscale.value;
-	ibuf.global.rim_params1[1] = (r_rim_debug.value > 0.f) ? 1.f : 0.f;
+	ibuf.global.rim_params1[1] = CLAMP (0.f, r_rim_debug.value, 2.f);
 	ibuf.global.rim_params1[2] = 0.f;
 	ibuf.global.rim_params1[3] = 0.f;
 

--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -14,6 +14,7 @@ layout(std430, binding=1) restrict readonly buffer InstanceBuffer
 {
 	mat4	inst_ViewProj;
 	mat4	inst_PrevViewProj;
+	mat4	inst_View;
 	vec3	inst_EyePos;
 	float	inst_Pad0;
 	vec4	inst_Fog;
@@ -127,6 +128,8 @@ layout(location=5) flat in int in_flags;
 layout(location=6) in vec3 in_normal;
 layout(location=7) flat in vec3 in_ambient;
 layout(location=8) flat in vec3 in_direct;
+layout(location=9) in vec3 in_view_pos;
+layout(location=10) in vec3 in_view_normal;
 
 #define OUT_COLOR out_fragcolor
 #if OIT
@@ -221,10 +224,8 @@ void main()
 
 	if (inst_RimParams0.x > 0.5)
 	{
-		vec3 normal = normalize(gl_FrontFacing ? in_normal : -in_normal);
-		vec3 to_eye = -in_pos;
-		float view_len = length(to_eye);
-		vec3 view_dir = (view_len > 0.0) ? (to_eye / view_len) : vec3(0.0, 0.0, 1.0);
+		vec3 normal = normalize(gl_FrontFacing ? in_view_normal : -in_view_normal);
+		vec3 view_dir = normalize(-in_view_pos);
 		float ndotv = clamp(dot(normal, view_dir), 0.0, 1.0);
 		float rim_base = pow(1.0 - ndotv, inst_RimParams0.y);
 		float light_len = length(inst_ShadowSunDir.xyz);
@@ -238,9 +239,18 @@ void main()
 		float rim_visibility = mix(inst_RimParams1.x, 1.0, direct_w) * rim_shadow;
 		vec3 rim_color = mix(ambient_color, direct_color, rim_light_mix);
 		vec3 rim_term = rim_base * inst_RimParams0.z * rim_visibility * rim_color;
-		if (inst_RimParams1.y > 0.5)
+		int rim_debug = int(clamp(inst_RimParams1.y, 0.0, 2.0) + 0.5);
+		if (rim_debug == 1)
 		{
 			out_fragcolor = vec4(vec3(rim_base), 1.0);
+#if !OIT
+			out_velocity = vec4(0.0);
+#endif
+			return;
+		}
+		else if (rim_debug == 2)
+		{
+			out_fragcolor = vec4(vec3(ndotv), 1.0);
 #if !OIT
 			out_velocity = vec4(0.0);
 #endif

--- a/Quake/shaders/alias.vert
+++ b/Quake/shaders/alias.vert
@@ -14,6 +14,7 @@ layout(std430, binding=1) restrict readonly buffer InstanceBuffer
 {
 	mat4	inst_ViewProj;
 	mat4	inst_PrevViewProj;
+	mat4	inst_View;
 	vec3	inst_EyePos;
 	float	inst_Pad0;
 	vec4	inst_Fog;
@@ -100,6 +101,8 @@ layout(location=5) flat out int out_flags;
 layout(location=6) out vec3 out_normal;
 layout(location=7) flat out vec3 out_ambient;
 layout(location=8) flat out vec3 out_direct;
+layout(location=9) out vec3 out_view_pos;
+layout(location=10) out vec3 out_view_normal;
 
 const int ALIAS_FLAG_VIEWMODEL = 2;
 
@@ -131,6 +134,8 @@ void main()
 	vec3 blended_normal = normalize(mix(pose1.nor, pose2.nor, inst.Blend));
 	mat3 world_orientation = mat3(worldmatrix[0].xyz, worldmatrix[1].xyz, worldmatrix[2].xyz);
 	vec3 world_normal = normalize(world_orientation * blended_normal);
+	vec3 view_pos = (inst_View * vec4(world_vert, 1.0)).xyz;
+	vec3 view_normal = normalize((inst_View * vec4(world_normal, 0.0)).xyz);
 	vec3 ambient = max(inst.LightColor.rgb - inst.DLightColor.rgb, vec3(0.0));
 	vec3 litAmbient = ambient * (mix(0.35, 1.0, lighting) * inst_Overbright);
 	vec3 litDlight = inst.DLightColor.rgb * lighting;
@@ -139,4 +144,6 @@ void main()
 	out_ambient = ambient;
 	out_direct = inst.DLightColor.rgb;
 	out_normal = world_normal;
+	out_view_pos = view_pos;
+	out_view_normal = view_normal;
 }

--- a/Quake/shaders/shadow_depth_alias.vert
+++ b/Quake/shaders/shadow_depth_alias.vert
@@ -14,6 +14,7 @@ layout(std430, binding=1) restrict readonly buffer InstanceBuffer
 {
 	mat4	inst_ViewProj;
 	mat4	inst_PrevViewProj;
+	mat4	inst_View;
 	vec3	inst_EyePos;
 	float	inst_Pad0;
 	vec4	inst_Fog;

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -155,6 +155,8 @@ layout(location=13) in vec3 in_normal;
 layout(location=14) in vec3 in_lightgrid;
 layout(location=15) flat in vec4 in_stage_color;
 layout(location=16) flat in uint in_tcgen;
+layout(location=18) in vec3 in_view_pos;
+layout(location=19) in vec3 in_view_normal;
 
 // Utility: ALU-only 16x16 Bayer matrix
 float bayer01(ivec2 coord)
@@ -617,8 +619,9 @@ void main()
 	// Rim lighting (edge highlight)
 	if (RimParams0.x > 0.5)
 	{
-		vec3 view_dir = normalize(EyePos - in_pos);
-		float ndotv = clamp(dot(surface_normal, view_dir), 0.0, 1.0);
+		vec3 view_dir = normalize(-in_view_pos);
+		vec3 view_normal = normalize(in_view_normal);
+		float ndotv = clamp(dot(view_normal, view_dir), 0.0, 1.0);
 		float rim_base = pow(1.0 - ndotv, RimParams0.y);
 		float light_len = length(ShadowSunDir.xyz);
 		vec3 light_dir = (light_len > 0.0) ? normalize(-ShadowSunDir.xyz) : vec3(0.0, 0.0, 1.0);
@@ -631,9 +634,18 @@ void main()
 		float rim_visibility = mix(RimParams1.x, 1.0, direct_w) * rim_shadow_mix;
 		vec3 rim_color = mix(ambient_color, direct_color, rim_light_mix);
 		vec3 rim_term = rim_base * RimParams0.z * rim_visibility * rim_color;
-		if (RimParams1.y > 0.5)
+		int rim_debug = int(clamp(RimParams1.y, 0.0, 2.0) + 0.5);
+		if (rim_debug == 1)
 		{
 			out_fragcolor = vec4(vec3(rim_base), 1.0);
+#if !OIT
+			out_velocity = vec4(0.0);
+#endif
+			return;
+		}
+		else if (rim_debug == 2)
+		{
+			out_fragcolor = vec4(vec3(ndotv), 1.0);
 #if !OIT
 			out_velocity = vec4(0.0);
 #endif

--- a/Quake/shaders/world.vert
+++ b/Quake/shaders/world.vert
@@ -157,6 +157,8 @@ layout(location=14) out vec3 out_lightgrid;
 layout(location=15) flat out vec4 out_stage_color;
 layout(location=16) flat out uint out_tcgen;
 layout(location=17) flat out vec2 out_emitter_center_ss;
+layout(location=18) out vec3 out_view_pos;
+layout(location=19) out vec3 out_view_normal;
 
 vec2 ComputeEnvUV(vec3 world_pos, vec3 world_normal)
 {
@@ -180,6 +182,8 @@ void main()
 	Instance instance = instance_data[instance_id];
 	vec3 world_pos = Transform(in_pos, instance);
         vec3 world_normal = TransformDirection(in_normal, instance);
+	vec3 view_pos = (View * vec4(world_pos, 1.0)).xyz;
+	vec3 view_normal = normalize((View * vec4(world_normal, 0.0)).xyz);
 	vec3 prev_world_pos = TransformPrev(in_pos, instance);
 	vec4 curr_clip = ViewProj * vec4(world_pos, 1.0);
 	vec4 prev_clip = PrevViewProj * vec4(prev_world_pos, 1.0);
@@ -201,6 +205,8 @@ void main()
         out_pos = world_pos;
         out_normal = normalize(world_normal);
         out_lightgrid = in_lightgrid;
+	out_view_pos = view_pos;
+	out_view_normal = view_normal;
 	vec2 uv = in_uv.xy;
 	if (call.tcgen == TCGEN_LIGHTMAP)
 		uv = in_uv.zw;


### PR DESCRIPTION
### Motivation
- Rim lighting used mixtures of world/eye-space that produced incorrect highlights; this change moves rim computation into view-space to fix direction/space mismatches.
- Provide easier debugging of rim term by adding explicit debug modes for visualizing rim base and NdotV.

### Description
- Compute and pass view-space position and normal from vertex shaders and use them in fragment shaders, i.e. `v_viewPos = (View * vec4(worldPos,1)).xyz` and `v_viewN = normalize((View * vec4(worldN,0)).xyz)`, then `V = normalize(-v_viewPos)` and `N = normalize(v_viewN)` to derive `NdotV` and `rimBase` as `pow(1 - NdotV, r_rim_power)`; implemented in `Quake/shaders/alias.vert/.frag` and `Quake/shaders/world.vert/.frag` (and `shadow_depth_alias.vert`).
- Add `inst_View` / `View` uploads and wiring so the GPU frame/instance data includes the view matrix by adding `view` to `ibuf.global` and copying `r_framedata.view` in `Quake/r_alias.c`, and adding `mat4 inst_View` in shader instance buffers.
- Clamp and expand the rim debug parameter to support modes 0/1/2 by changing `r_rim_debug` handling to `CLAMP(0.f, r_rim_debug.value, 2.f)` in `Quake/gl_rmain.c` and `Quake/r_alias.c`, and wire shader behavior to: `0=normal`, `1=output rimBase`, `2=output NdotV`.
- Files modified: `Quake/shaders/alias.vert`, `Quake/shaders/alias.frag`, `Quake/shaders/world.vert`, `Quake/shaders/world.frag`, `Quake/shaders/shadow_depth_alias.vert`, `Quake/r_alias.c`, and `Quake/gl_rmain.c`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69813760c220832ebc87d1ca38d7f345)