### PR TITLE
Route framebuffer and texture binds through renderer backend

### DIFF
--- a/Quake/gl_ktx2.c
+++ b/Quake/gl_ktx2.c
@@ -1,6 +1,7 @@
 #include "quakedef.h"
 #include "gl_ktx2.h"
 #include "gl_texmgr.h"
+#include "renderer_backend.h"
 #include "basisu_transcoder.h"
 
 static const uint8_t KTX2_MAGIC[12] = {
@@ -336,7 +337,7 @@ gltexture_t *R_LoadKTX2Texture(const char *name, const uint8_t *data, size_t siz
     tex->mipmap = decoded.mip_count;
     tex->internal_format = gl_internal_format;
 
-    glBindTexture(GL_TEXTURE_2D, tex->texnum);
+    RB_BindTexture(GL_TEXTURE_2D, tex->texnum);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -732,7 +732,7 @@ static GLuint GL_CreateFBO (GLenum target, const GLuint* colors, int numcolors, 
 
 	GL_GenFramebuffersFunc (1, &fbo);
 	Con_DPrintf ("GL_CreateFBO: %s id=%u\n", name ? name : "(unnamed)", fbo);
-	GL_BindFramebufferFunc (GL_FRAMEBUFFER, fbo);
+	RB_BindFramebuffer (GL_FRAMEBUFFER, fbo);
 	GL_ObjectLabelFunc (GL_FRAMEBUFFER, fbo, -1, name);
 	GL_LogErrorIfDeveloper ("GL_CreateFBO bind");
 
@@ -939,7 +939,7 @@ void GL_CreateFrameBuffers (void)
 		);
 	}
 
-        GL_BindFramebufferFunc (GL_FRAMEBUFFER, 0);
+        RB_BindFramebuffer (GL_FRAMEBUFFER, 0);
         GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, 0);
 }
 
@@ -970,7 +970,7 @@ void GL_DeleteFrameBuffers (void)
 		GL_DeleteFramebuffersFunc (1, &framebufs.ssao.ao_fbo[i]);
 		GL_DeleteFramebuffersFunc (1, &framebufs.ssao.blur_fbo[i]);
 	}
-	GL_BindFramebufferFunc (GL_FRAMEBUFFER, 0);
+	RB_BindFramebuffer (GL_FRAMEBUFFER, 0);
 
 	GL_DeleteNativeTexture (framebufs.resolved_scene.color_tex);
 	GL_DeleteNativeTexture (framebufs.resolved_scene.velocity_tex);
@@ -1060,7 +1060,7 @@ static GLuint GL_GenerateBloomTexture (void)
 	float mask_enabled = velocity_texture ? 1.f : 0.f;
 
 	GL_BeginGroup ("Bloom extract");
-	GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.bloom.extract_fbo);
+	RB_BindFramebuffer (GL_FRAMEBUFFER, framebufs.bloom.extract_fbo);
 	RB_Viewport (0, 0, width, height);
 	GL_UseProgram (glprogs.bloom_extract);
 	GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
@@ -1079,7 +1079,7 @@ static GLuint GL_GenerateBloomTexture (void)
 	for (int pass = 0; pass < passes; ++pass)
 	{
 		int target_index = pass & 1;
-		GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.bloom.pingpong_fbo[target_index]);
+		RB_BindFramebuffer (GL_FRAMEBUFFER, framebufs.bloom.pingpong_fbo[target_index]);
 		RB_Viewport (0, 0, width, height);
 		GL_UseProgram (glprogs.bloom_blur);
 		GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
@@ -1114,7 +1114,7 @@ static GLuint GL_GenerateBloomTextureFrom (GLuint source_tex, float threshold, f
 		radius = 1.f;
 
 	GL_BeginGroup ("Dlight bloom extract");
-	GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.bloom.extract_fbo);
+	RB_BindFramebuffer (GL_FRAMEBUFFER, framebufs.bloom.extract_fbo);
 	RB_Viewport (0, 0, width, height);
 	GL_UseProgram (glprogs.bloom_extract);
 	GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
@@ -1133,7 +1133,7 @@ static GLuint GL_GenerateBloomTextureFrom (GLuint source_tex, float threshold, f
 	for (int pass = 0; pass < passes; ++pass)
 	{
 		int target_index = pass & 1;
-		GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.bloom.pingpong_fbo[target_index]);
+		RB_BindFramebuffer (GL_FRAMEBUFFER, framebufs.bloom.pingpong_fbo[target_index]);
 		RB_Viewport (0, 0, width, height);
 		GL_UseProgram (glprogs.bloom_blur);
 		GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
@@ -1360,7 +1360,7 @@ static GLuint GL_GenerateSSAOTexture (float view_min_x, float view_min_y, float 
 
 	while (glGetError () != GL_NO_ERROR) {}
 	GL_BeginGroup ("SSAO");
-	GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.ssao.ao_fbo[index]);
+	RB_BindFramebuffer (GL_FRAMEBUFFER, framebufs.ssao.ao_fbo[index]);
 #ifndef NDEBUG
 	{
 		static qboolean ssao_fbo_validated = false;
@@ -1456,7 +1456,7 @@ static GLuint GL_GenerateSSAOTexture (float view_min_x, float view_min_y, float 
 		GL_Uniform1iFunc (7, 0);
 		GL_UniformMatrix4fvFunc (8, 1, GL_FALSE, r_matinvproj);
 
-		GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.ssao.blur_fbo[index]);
+		RB_BindFramebuffer (GL_FRAMEBUFFER, framebufs.ssao.blur_fbo[index]);
 		GL_LogErrorIfDeveloper ("SSAO blur bind FBO");
 		glDisable (GL_SCISSOR_TEST);
 		glColorMask (GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
@@ -1466,7 +1466,7 @@ static GLuint GL_GenerateSSAOTexture (float view_min_x, float view_min_y, float 
 		glDrawArrays (GL_TRIANGLES, 0, 3);
 		GL_LogErrorIfDeveloper ("SSAO blur horizontal draw");
 
-		GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.ssao.ao_fbo[index]);
+		RB_BindFramebuffer (GL_FRAMEBUFFER, framebufs.ssao.ao_fbo[index]);
 		glDisable (GL_SCISSOR_TEST);
 		glColorMask (GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
 		GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, framebufs.ssao.blur_tex[index]);
@@ -1633,7 +1633,7 @@ static void GL_GenerateGodraysSource (qboolean draw_sky, qboolean draw_brush)
 	float mask_knee = q_max (0.f, r_godrays_mask_knee.value);
 
 	GL_BeginGroup ("Godrays source");
-	GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.godrays.source_fbo);
+	RB_BindFramebuffer (GL_FRAMEBUFFER, framebufs.godrays.source_fbo);
 	RB_Viewport (0, 0, width, height);
 	{
 		const float zero[4] = { 0.f, 0.f, 0.f, 0.f };
@@ -1807,7 +1807,7 @@ static GLuint GL_GenerateGodraysTexture (GLuint *out_mask)
 		emit_brush = false;
 
 	GL_BeginGroup ("Godrays scatter");
-	GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.godrays.shafts_fbo);
+	RB_BindFramebuffer (GL_FRAMEBUFFER, framebufs.godrays.shafts_fbo);
 	RB_Viewport (0, 0, width, height);
 	{
 		const float zero[4] = { 0.f, 0.f, 0.f, 0.f };
@@ -1826,7 +1826,7 @@ static GLuint GL_GenerateGodraysTexture (GLuint *out_mask)
 			GL_GenerateGodraysSource (true, false);
 
 			GL_BeginGroup ("Godrays mask (sky)");
-			GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.godrays.mask_fbo);
+			RB_BindFramebuffer (GL_FRAMEBUFFER, framebufs.godrays.mask_fbo);
 			RB_Viewport (0, 0, width, height);
 			{
 				const float zero[4] = { 0.f, 0.f, 0.f, 0.f };
@@ -1843,7 +1843,7 @@ static GLuint GL_GenerateGodraysTexture (GLuint *out_mask)
 			GL_EndGroup ();
 
 			GL_BeginGroup ("Godrays scatter (sky)");
-			GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.godrays.shafts_fbo);
+			RB_BindFramebuffer (GL_FRAMEBUFFER, framebufs.godrays.shafts_fbo);
 			RB_Viewport (0, 0, width, height);
 			GL_UseProgram (glprogs.godrays);
 			GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
@@ -1867,7 +1867,7 @@ static GLuint GL_GenerateGodraysTexture (GLuint *out_mask)
 			GL_GenerateGodraysSource (false, true);
 
 			GL_BeginGroup ("Godrays mask (brush)");
-			GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.godrays.mask_fbo);
+			RB_BindFramebuffer (GL_FRAMEBUFFER, framebufs.godrays.mask_fbo);
 			RB_Viewport (0, 0, width, height);
 			{
 				const float zero[4] = { 0.f, 0.f, 0.f, 0.f };
@@ -1884,7 +1884,7 @@ static GLuint GL_GenerateGodraysTexture (GLuint *out_mask)
 			GL_EndGroup ();
 
 			GL_BeginGroup ("Godrays scatter (brush)");
-			GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.godrays.shafts_fbo);
+			RB_BindFramebuffer (GL_FRAMEBUFFER, framebufs.godrays.shafts_fbo);
 			RB_Viewport (0, 0, width, height);
 			GL_UseProgram (glprogs.godrays);
 			GL_SetState ((first_pass ? GLS_BLEND_OPAQUE : GLS_BLEND_ADD) | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
@@ -1975,11 +1975,11 @@ static void GL_PostProcessFallback (void)
 	if (!pixels)
 		return;
 
-	GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.composite.fbo);
+	RB_BindFramebuffer (GL_FRAMEBUFFER, framebufs.composite.fbo);
 	glReadBuffer (GL_COLOR_ATTACHMENT0);
 	glPixelStorei (GL_PACK_ALIGNMENT, 1);
 	glReadPixels (0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
-	GL_BindFramebufferFunc (GL_FRAMEBUFFER, 0);
+	RB_BindFramebuffer (GL_FRAMEBUFFER, 0);
 	glReadBuffer (GL_BACK);
 	glPixelStorei (GL_UNPACK_ALIGNMENT, 1);
 	{
@@ -2097,14 +2097,14 @@ static qboolean GL_SampleAutoExposureLuminance (float *out_luminance)
 	if (width <= 0 || height <= 0 || pixel_count > (int)countof (luminance_samples))
 		return false;
 
-	GL_BindFramebufferFunc (GL_READ_FRAMEBUFFER, framebufs.composite.fbo);
-	GL_BindFramebufferFunc (GL_DRAW_FRAMEBUFFER, framebufs.autoexposure.fbo);
+	RB_BindFramebuffer (GL_READ_FRAMEBUFFER, framebufs.composite.fbo);
+	RB_BindFramebuffer (GL_DRAW_FRAMEBUFFER, framebufs.autoexposure.fbo);
 	GL_BlitFramebufferFunc (0, 0, vid.width, vid.height, 0, 0, width, height, GL_COLOR_BUFFER_BIT, GL_LINEAR);
 
-	GL_BindFramebufferFunc (GL_READ_FRAMEBUFFER, framebufs.autoexposure.fbo);
+	RB_BindFramebuffer (GL_READ_FRAMEBUFFER, framebufs.autoexposure.fbo);
 	glReadBuffer (GL_COLOR_ATTACHMENT0);
 	glReadPixels (0, 0, width, height, GL_RGBA, GL_FLOAT, pixels);
-	GL_BindFramebufferFunc (GL_FRAMEBUFFER, 0);
+	RB_BindFramebuffer (GL_FRAMEBUFFER, 0);
 	glReadBuffer (GL_BACK);
 
 	for (int i = 0; i < pixel_count; ++i)
@@ -2276,12 +2276,12 @@ void GL_PostProcess (void)
 	if (!framesetup.composite_ready)
 	{
 		GL_BeginGroup ("Postprocess backbuffer copy");
-		GL_BindFramebufferFunc (GL_READ_FRAMEBUFFER, 0);
-		GL_BindFramebufferFunc (GL_DRAW_FRAMEBUFFER, framebufs.composite.fbo);
+		RB_BindFramebuffer (GL_READ_FRAMEBUFFER, 0);
+		RB_BindFramebuffer (GL_DRAW_FRAMEBUFFER, framebufs.composite.fbo);
 		glReadBuffer (GL_BACK);
 		glDrawBuffer (GL_COLOR_ATTACHMENT0);
 		GL_BlitFramebufferFunc (0, 0, vid.width, vid.height, 0, 0, vid.width, vid.height, GL_COLOR_BUFFER_BIT, GL_NEAREST);
-		GL_BindFramebufferFunc (GL_FRAMEBUFFER, 0);
+		RB_BindFramebuffer (GL_FRAMEBUFFER, 0);
 		glDrawBuffer (GL_BACK);
 		glReadBuffer (GL_BACK);
 		framesetup.composite_ready = true;
@@ -2438,7 +2438,7 @@ void GL_PostProcess (void)
 	}
 	motion_enabled = (motion_effective_shutter > 0.f && motion_max_samples > 0 && velocity_texture != 0);
 
-	GL_BindFramebufferFunc (GL_FRAMEBUFFER, 0);
+	RB_BindFramebuffer (GL_FRAMEBUFFER, 0);
 	RB_Viewport (glx, gly, glwidth, glheight);
 	{
 		int debug_mode = (int)Q_rint (CLAMP (0.f, r_debug_colorspace.value, 4.f));
@@ -3238,7 +3238,7 @@ void GL_ApplyFilmgrainUI (void)
 
 	GL_BeginGroup ("Filmgrain UI");
 
-	GL_BindFramebufferFunc (GL_FRAMEBUFFER, 0);
+	RB_BindFramebuffer (GL_FRAMEBUFFER, 0);
 	RB_Viewport (glx, gly, glwidth, glheight);
 	glReadBuffer (GL_BACK);
 	GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, framebufs.composite.color_tex);
@@ -3265,7 +3265,7 @@ void R_SetupGL (void)
 		GLuint target = GL_NeedsPostprocess () ? framebufs.composite.fbo : 0u;
 		qboolean srgb_output = (target == 0u) && GL_UseSRGBFramebuffer ();
 
-		GL_BindFramebufferFunc (GL_FRAMEBUFFER, target);
+		RB_BindFramebuffer (GL_FRAMEBUFFER, target);
 		GL_SetFramebufferSRGB (srgb_output);
 		framesetup.scene_fbo = framebufs.composite.fbo;
 		framesetup.oit_fbo = framebufs.oit.fbo_composite;
@@ -3284,7 +3284,7 @@ void R_SetupGL (void)
 	}
 	else
 	{
-		GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.scene.fbo);
+		RB_BindFramebuffer (GL_FRAMEBUFFER, framebufs.scene.fbo);
 		GL_SetFramebufferSRGB (false);
 		framesetup.scene_fbo = framebufs.scene.fbo;
 		framesetup.oit_fbo = framebufs.oit.fbo_scene;
@@ -4517,7 +4517,7 @@ static void R_BeginTranslucency (void)
 
 	if (R_GetEffectiveAlphaMode () == ALPHAMODE_OIT)
 	{
-		GL_BindFramebufferFunc (GL_FRAMEBUFFER, framesetup.oit_fbo);
+		RB_BindFramebuffer (GL_FRAMEBUFFER, framesetup.oit_fbo);
 		GL_ClearBufferfvFunc (GL_COLOR, 0, zeroes);
 		GL_ClearBufferfvFunc (GL_COLOR, 1, ones);
 
@@ -4539,7 +4539,7 @@ static void R_EndTranslucency (void)
 	{
 		GL_BeginGroup ("OIT resolve");
 
-		GL_BindFramebufferFunc (GL_FRAMEBUFFER, framesetup.scene_fbo);
+		RB_BindFramebuffer (GL_FRAMEBUFFER, framesetup.scene_fbo);
 
 		glStencilFunc (GL_EQUAL, 2, 2);
 		glStencilOp (GL_KEEP, GL_KEEP, GL_KEEP);
@@ -4600,7 +4600,7 @@ static void R_DrawDLightPass (void)
 	{
 		use_buffer = true;
 		r_dlight_buffered_frame = true;
-		GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.dlight.fbo);
+		RB_BindFramebuffer (GL_FRAMEBUFFER, framebufs.dlight.fbo);
 		glDrawBuffer (GL_COLOR_ATTACHMENT0);
 		glReadBuffer (GL_COLOR_ATTACHMENT0);
 		{
@@ -4652,7 +4652,7 @@ static void R_DrawDLightPass (void)
 
 	if (use_buffer)
 	{
-		GL_BindFramebufferFunc (GL_FRAMEBUFFER, framesetup.scene_fbo);
+		RB_BindFramebuffer (GL_FRAMEBUFFER, framesetup.scene_fbo);
 		if (framesetup.scene_fbo)
 		{
 			glDrawBuffer (GL_COLOR_ATTACHMENT0);
@@ -4741,8 +4741,8 @@ void R_WarpScaleView (void)
 	{
 		GL_BeginGroup ("MSAA resolve");
 
-		GL_BindFramebufferFunc (GL_READ_FRAMEBUFFER, framebufs.scene.fbo);
-		GL_BindFramebufferFunc (GL_DRAW_FRAMEBUFFER, framebufs.resolved_scene.fbo);
+		RB_BindFramebuffer (GL_READ_FRAMEBUFFER, framebufs.scene.fbo);
+		RB_BindFramebuffer (GL_DRAW_FRAMEBUFFER, framebufs.resolved_scene.fbo);
 
 		glReadBuffer (GL_COLOR_ATTACHMENT0);
 		glDrawBuffer (GL_COLOR_ATTACHMENT0);
@@ -4759,9 +4759,9 @@ void R_WarpScaleView (void)
 
 		if (!needwarpscale)
 		{
-			GL_BindFramebufferFunc (GL_READ_FRAMEBUFFER, framebufs.resolved_scene.fbo);
+			RB_BindFramebuffer (GL_READ_FRAMEBUFFER, framebufs.resolved_scene.fbo);
 			glReadBuffer (GL_COLOR_ATTACHMENT0);
-			GL_BindFramebufferFunc (GL_DRAW_FRAMEBUFFER, fbodest);
+			RB_BindFramebuffer (GL_DRAW_FRAMEBUFFER, fbodest);
 			if (fbodest)
 				glDrawBuffer (GL_COLOR_ATTACHMENT0);
 			else
@@ -4780,18 +4780,18 @@ void R_WarpScaleView (void)
 		int dstw = (r_refdef.scale != 1) ? r_refdef.vrect.width : srcw;
 		int dsth = (r_refdef.scale != 1) ? r_refdef.vrect.height : srch;
 
-		GL_BindFramebufferFunc (GL_READ_FRAMEBUFFER, framebufs.scene.fbo);
+		RB_BindFramebuffer (GL_READ_FRAMEBUFFER, framebufs.scene.fbo);
 		glReadBuffer (GL_COLOR_ATTACHMENT0);
-		GL_BindFramebufferFunc (GL_DRAW_FRAMEBUFFER, framebufs.composite.fbo);
+		RB_BindFramebuffer (GL_DRAW_FRAMEBUFFER, framebufs.composite.fbo);
 		glDrawBuffer (GL_COLOR_ATTACHMENT0);
 		GL_BlitFramebufferFunc (0, 0, srcw, srch, srcx, srcy, srcx + dstw, srcy + dsth, GL_DEPTH_BUFFER_BIT, GL_NEAREST);
 	}
 
 	if (!msaa && !needwarpscale)
 	{
-		GL_BindFramebufferFunc (GL_READ_FRAMEBUFFER, framebufs.scene.fbo);
+		RB_BindFramebuffer (GL_READ_FRAMEBUFFER, framebufs.scene.fbo);
 		glReadBuffer (GL_COLOR_ATTACHMENT0);
-		GL_BindFramebufferFunc (GL_DRAW_FRAMEBUFFER, fbodest);
+		RB_BindFramebuffer (GL_DRAW_FRAMEBUFFER, fbodest);
 		if (fbodest)
 			glDrawBuffer (GL_COLOR_ATTACHMENT0);
 		else
@@ -4801,7 +4801,7 @@ void R_WarpScaleView (void)
 			GL_COLOR_BUFFER_BIT, GL_NEAREST);
 	}
 
-	GL_BindFramebufferFunc (GL_FRAMEBUFFER, fbodest);
+	RB_BindFramebuffer (GL_FRAMEBUFFER, fbodest);
 	if (fbodest)
 	{
 		glDrawBuffer (GL_COLOR_ATTACHMENT0);

--- a/Quake/gl_texmgr.c
+++ b/Quake/gl_texmgr.c
@@ -26,6 +26,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "glquake.h"
 #include "bc7enc.h"
 #include "gl_ktx2.h"
+#include "renderer_backend.h"
 #include <ctype.h>
 
 #ifndef GL_COMPRESSED_RED_GREEN_RGTC2
@@ -2176,7 +2177,7 @@ GLuint TexMgr_LoadDDS (const char *path)
 	}
 
 	glGenTextures (1, &texnum);
-	glBindTexture (GL_TEXTURE_2D, texnum);
+	RB_BindTexture (GL_TEXTURE_2D, texnum);
 	glPixelStorei (GL_UNPACK_ALIGNMENT, 1);
 
 	{
@@ -2830,7 +2831,7 @@ qboolean GL_BindNative (GLenum texunit, GLenum type, GLuint handle)
 	}
 
 	GL_SelectTexture (texunit);
-	glBindTexture (type, handle);
+	RB_BindTexture (type, handle);
 
 	return true;
 }
@@ -2889,7 +2890,7 @@ void GL_ClearBindings(void)
 		for (i = 0; i < countof (currenttexture); i++)
 		{
 			GL_SelectTexture (GL_TEXTURE0 + i);
-			glBindTexture (GL_TEXTURE_2D, 0);
+			RB_BindTexture (GL_TEXTURE_2D, 0);
 			GL_BindSamplerFunc (i, 0);
 		}
 }

--- a/Quake/gl_vidsdl.c
+++ b/Quake/gl_vidsdl.c
@@ -1061,7 +1061,7 @@ static void GL_CheckExtensions (void)
 		// test to make sure we really have control over it
 		// 1.0 and 2.0 should always be legal values
 		glGenTextures(1, &tex);
-		glBindTexture (GL_TEXTURE_2D, tex);
+		RB_BindTexture (GL_TEXTURE_2D, tex);
 		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, 1.0f);
 		glGetTexParameterfv (GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, &test1);
 		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, 2.0f);

--- a/Quake/r_fogvol.c
+++ b/Quake/r_fogvol.c
@@ -669,8 +669,8 @@ void R_FogVol_Render (void)
 			src_tex = framebufs.fogvol.color_tex[fog_src_index];
 		src_fbo = (i == 0) ? framebufs.composite.fbo : framebufs.fogvol.fbo[fog_src_index];
 		RB_Disable (GL_SCISSOR_TEST);
-		GL_BindFramebufferFunc (GL_READ_FRAMEBUFFER, src_fbo);
-		GL_BindFramebufferFunc (GL_DRAW_FRAMEBUFFER, dst_fbo);
+		RB_BindFramebuffer (GL_READ_FRAMEBUFFER, src_fbo);
+		RB_BindFramebuffer (GL_DRAW_FRAMEBUFFER, dst_fbo);
 		glReadBuffer (GL_COLOR_ATTACHMENT0);
 		glDrawBuffer (GL_COLOR_ATTACHMENT0);
 		if (use_halfres && i == 0)
@@ -686,7 +686,7 @@ void R_FogVol_Render (void)
 				GL_COLOR_BUFFER_BIT, GL_NEAREST);
 		}
 
-		GL_BindFramebufferFunc (GL_FRAMEBUFFER, dst_fbo);
+		RB_BindFramebuffer (GL_FRAMEBUFFER, dst_fbo);
 		glDrawBuffer (GL_COLOR_ATTACHMENT0);
 		glReadBuffer (GL_COLOR_ATTACHMENT0);
 		GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, src_tex);
@@ -706,7 +706,7 @@ void R_FogVol_Render (void)
 
 	if (!has_drawn)
 	{
-		GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.composite.fbo);
+		RB_BindFramebuffer (GL_FRAMEBUFFER, framebufs.composite.fbo);
 		glDrawBuffer (GL_COLOR_ATTACHMENT0);
 		glReadBuffer (GL_COLOR_ATTACHMENT0);
 		RB_Viewport (glx, gly, glwidth, glheight);
@@ -730,7 +730,7 @@ void R_FogVol_Render (void)
 
 		GL_UseProgram (glprogs.fogvol_temporal);
 		GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
-		GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.fogvol.history_fbo[history_dst]);
+		RB_BindFramebuffer (GL_FRAMEBUFFER, framebufs.fogvol.history_fbo[history_dst]);
 		glDrawBuffer (GL_COLOR_ATTACHMENT0);
 		glReadBuffer (GL_COLOR_ATTACHMENT0);
 		RB_Viewport (0, 0, fog_width, fog_height);
@@ -754,7 +754,7 @@ void R_FogVol_Render (void)
 
 	if (has_drawn)
 	{
-		GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.composite.fbo);
+		RB_BindFramebuffer (GL_FRAMEBUFFER, framebufs.composite.fbo);
 		glDrawBuffer (GL_COLOR_ATTACHMENT0);
 		glReadBuffer (GL_COLOR_ATTACHMENT0);
 		RB_Viewport (glx, gly, glwidth, glheight);
@@ -775,8 +775,8 @@ void R_FogVol_Render (void)
 			}
 			else
 			{
-				GL_BindFramebufferFunc (GL_READ_FRAMEBUFFER, final_fbo);
-				GL_BindFramebufferFunc (GL_DRAW_FRAMEBUFFER, framebufs.composite.fbo);
+				RB_BindFramebuffer (GL_READ_FRAMEBUFFER, final_fbo);
+				RB_BindFramebuffer (GL_DRAW_FRAMEBUFFER, framebufs.composite.fbo);
 				GL_BlitFramebufferFunc (0, 0, fog_width, fog_height,
 					0, 0, glwidth, glheight,
 					GL_COLOR_BUFFER_BIT, GL_LINEAR);
@@ -784,8 +784,8 @@ void R_FogVol_Render (void)
 		}
 		else
 		{
-			GL_BindFramebufferFunc (GL_READ_FRAMEBUFFER, final_fbo);
-			GL_BindFramebufferFunc (GL_DRAW_FRAMEBUFFER, framebufs.composite.fbo);
+			RB_BindFramebuffer (GL_READ_FRAMEBUFFER, final_fbo);
+			RB_BindFramebuffer (GL_DRAW_FRAMEBUFFER, framebufs.composite.fbo);
 			GL_BlitFramebufferFunc (0, 0, glwidth, glheight,
 				0, 0, glwidth, glheight,
 				GL_COLOR_BUFFER_BIT, GL_NEAREST);

--- a/Quake/r_shadow.c
+++ b/Quake/r_shadow.c
@@ -411,7 +411,7 @@ static void R_Shadow_ResizeDlightAtlasIfNeeded (void)
 	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0);
 
 	GL_GenFramebuffersFunc (1, &shadow_dlight_fbo);
-	GL_BindFramebufferFunc (GL_FRAMEBUFFER, shadow_dlight_fbo);
+	RB_BindFramebuffer (GL_FRAMEBUFFER, shadow_dlight_fbo);
 	GL_ObjectLabelFunc (GL_FRAMEBUFFER, shadow_dlight_fbo, -1, "shadowmap dlight fbo");
 	GL_FramebufferTexture2DFunc (GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, shadow_dlight_depth_tex, 0);
 	glDrawBuffer (GL_NONE);
@@ -484,7 +484,7 @@ void R_ResizeShadowMapIfNeeded (void)
 	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0);
 
 	GL_GenFramebuffersFunc (1, &shadow_fbo);
-	GL_BindFramebufferFunc (GL_FRAMEBUFFER, shadow_fbo);
+	RB_BindFramebuffer (GL_FRAMEBUFFER, shadow_fbo);
 	GL_ObjectLabelFunc (GL_FRAMEBUFFER, shadow_fbo, -1, "shadowmap fbo");
 	GL_FramebufferTexture2DFunc (GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, shadow_depth_tex, 0);
 	glDrawBuffer (GL_NONE);
@@ -536,7 +536,7 @@ void R_Shadow_SunPass (void)
 
 	GL_BeginGroup ("Shadow map (sun)");
 
-	GL_BindFramebufferFunc (GL_FRAMEBUFFER, shadow_fbo);
+	RB_BindFramebuffer (GL_FRAMEBUFFER, shadow_fbo);
 	RB_Viewport (0, 0, shadowmap_size, shadowmap_size);
 	glDrawBuffer (GL_NONE);
 	glReadBuffer (GL_NONE);
@@ -653,7 +653,7 @@ void R_Shadow_DlightPass (void)
 
 	GL_BeginGroup ("Shadow map (dlights)");
 
-	GL_BindFramebufferFunc (GL_FRAMEBUFFER, shadow_dlight_fbo);
+	RB_BindFramebuffer (GL_FRAMEBUFFER, shadow_dlight_fbo);
 	glDrawBuffer (GL_NONE);
 	glReadBuffer (GL_NONE);
 	RB_Enable (GL_SCISSOR_TEST);

--- a/Quake/renderer_backend.c
+++ b/Quake/renderer_backend.c
@@ -202,6 +202,20 @@ void RB_Scissor(int x, int y, int width, int height)
 	rb_backend->scissor(x, y, width, height);
 }
 
+void RB_BindFramebuffer(int target, unsigned int framebuffer)
+{
+	if (!rb_backend || !rb_backend->bind_framebuffer)
+		return;
+	rb_backend->bind_framebuffer(target, framebuffer);
+}
+
+void RB_BindTexture(int target, unsigned int texture)
+{
+	if (!rb_backend || !rb_backend->bind_texture)
+		return;
+	rb_backend->bind_texture(target, texture);
+}
+
 void RB_GenBuffers(int n, unsigned int *buffers)
 {
 	if (!rb_backend || !rb_backend->gen_buffers)

--- a/Quake/renderer_backend.h
+++ b/Quake/renderer_backend.h
@@ -113,6 +113,8 @@ typedef struct rb_backend_api_s
 	void				(*depth_mask)(int flag);
 	void				(*viewport)(int x, int y, int width, int height);
 	void				(*scissor)(int x, int y, int width, int height);
+	void				(*bind_framebuffer)(int target, unsigned int framebuffer);
+	void				(*bind_texture)(int target, unsigned int texture);
 	void				(*gen_buffers)(int n, unsigned int *buffers);
 	void				(*delete_buffers)(int n, const unsigned int *buffers);
 	void				(*bind_buffer)(int target, unsigned int buffer);
@@ -151,6 +153,8 @@ void			RB_CullFace(int mode);
 void			RB_DepthMask(int flag);
 void			RB_Viewport(int x, int y, int width, int height);
 void			RB_Scissor(int x, int y, int width, int height);
+void			RB_BindFramebuffer(int target, unsigned int framebuffer);
+void			RB_BindTexture(int target, unsigned int texture);
 void			RB_GenBuffers(int n, unsigned int *buffers);
 void			RB_DeleteBuffers(int n, const unsigned int *buffers);
 void			RB_BindBuffer(int target, unsigned int buffer);

--- a/Quake/renderer_backend_gl.c
+++ b/Quake/renderer_backend_gl.c
@@ -85,6 +85,16 @@ static void RBGL_Scissor(int x, int y, int width, int height)
 	glScissor (x, y, width, height);
 }
 
+static void RBGL_BindFramebuffer(int target, unsigned int framebuffer)
+{
+	GL_BindFramebufferFunc(target, framebuffer);
+}
+
+static void RBGL_BindTexture(int target, unsigned int texture)
+{
+	glBindTexture(target, texture);
+}
+
 static void RBGL_GenBuffers(int n, unsigned int *buffers)
 {
 	GL_GenBuffersFunc (n, buffers);
@@ -411,6 +421,8 @@ static const rb_backend_api_t rb_gl_api = {
 	RBGL_DepthMask,
 	RBGL_Viewport,
 	RBGL_Scissor,
+	RBGL_BindFramebuffer,
+	RBGL_BindTexture,
 	RBGL_GenBuffers,
 	RBGL_DeleteBuffers,
 	RBGL_BindBuffer,

--- a/Quake/renderer_backend_null.c
+++ b/Quake/renderer_backend_null.c
@@ -117,6 +117,18 @@ static void RB_NULL_Scissor(int x, int y, int width, int height)
 	(void)height;
 }
 
+static void RB_NULL_BindFramebuffer(int target, unsigned int framebuffer)
+{
+	(void)target;
+	(void)framebuffer;
+}
+
+static void RB_NULL_BindTexture(int target, unsigned int texture)
+{
+	(void)target;
+	(void)texture;
+}
+
 static void RB_NULL_GenBuffers(int n, unsigned int *buffers)
 {
 	(void)n;
@@ -196,6 +208,8 @@ static const rb_backend_api_t rb_null_api = {
 	RB_NULL_DepthMask,
 	RB_NULL_Viewport,
 	RB_NULL_Scissor,
+	RB_NULL_BindFramebuffer,
+	RB_NULL_BindTexture,
 	RB_NULL_GenBuffers,
 	RB_NULL_DeleteBuffers,
 	RB_NULL_BindBuffer,


### PR DESCRIPTION
### Motivation

- Centralize low-level graphics API calls and state tracking behind the renderer backend interface to keep frontend code backend-agnostic.
- Provide a clean path to implement a null backend and other backends by routing framebuffer and texture binds through `RB_*` wrappers.
- Replace scattered direct OpenGL calls with backend calls to improve maintainability and enable backend-level caching or validation.

### Description

- Added `bind_framebuffer` and `bind_texture` function pointers to `rb_backend_api_t` and declared `RB_BindFramebuffer` and `RB_BindTexture` in `Quake/renderer_backend.h` and implemented their wrappers in `Quake/renderer_backend.c`.
- Implemented OpenGL backend helpers `RBGL_BindFramebuffer` (calls `GL_BindFramebufferFunc`) and `RBGL_BindTexture` (calls `glBindTexture`) inside `Quake/renderer_backend_gl.c`, and corresponding no-op stubs inside `Quake/renderer_backend_null.c`.
- Updated renderer frontend code to use the new backend wrappers instead of direct GL calls, replacing occurrences in `Quake/gl_rmain.c`, `Quake/r_shadow.c`, `Quake/r_fogvol.c` (framebuffer binds) and `Quake/gl_texmgr.c`, `Quake/gl_vidsdl.c`, `Quake/gl_ktx2.c` (texture binds), and added `#include "renderer_backend.h"` where needed.

### Testing

- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981fdff1a20832eac2bdc1c62ce7a22)