### PR TITLE
Use `GL_DrawBuffersFunc` in GL backend to avoid implicit declaration

### DIFF
--- a/Quake/renderer_backend_gl.c
+++ b/Quake/renderer_backend_gl.c
@@ -323,7 +323,7 @@ static rb_fbo_t RBGL_CreateFBO(const rb_fbo_desc_t *desc)
 		const rb_gl_tex_t *color_tex = (const rb_gl_tex_t *)desc->color;
 		GL_FramebufferTexture2DFunc(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, color_tex->target, color_tex->id, 0);
 		draw_buffers[0] = GL_COLOR_ATTACHMENT0;
-		glDrawBuffers(1, draw_buffers);
+		GL_DrawBuffersFunc(1, draw_buffers);
 	}
 	else
 	{


### PR DESCRIPTION
### Motivation
- MSVC reported an implicit declaration for `glDrawBuffers` which is treated as an error, so the backend should call the loaded GL function pointer instead.

### Description
- Replace the direct call to `glDrawBuffers(1, draw_buffers)` with the function-pointer call `GL_DrawBuffersFunc(1, draw_buffers)` in `Quake/renderer_backend_gl.c` to use the resolved GL entry point.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698244cd6cc8832e91d96293acb04e2a)