### PR TITLE
Fix OpenGL buffer parameter function usage on Windows

### DIFF
--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -1351,8 +1351,8 @@ static void *GL_TryMapRange (GLenum target, GLuint buffer, GLintptr offset, GLsi
 	binding_enum = GL_TargetBindingEnum (target);
 	if (binding_enum)
 		glGetIntegerv (binding_enum, &binding);
-	glGetBufferParameteri64v (target, GL_BUFFER_SIZE, &buffer_size);
-	glGetBufferParameteriv (target, GL_BUFFER_MAPPED, &mapped);
+	GL_GetBufferParameteri64vFunc (target, GL_BUFFER_SIZE, &buffer_size);
+	GL_GetBufferParameterivFunc (target, GL_BUFFER_MAPPED, &mapped);
 
 	if (length <= 0)
 		Con_Printf ("%s: warning: non-positive map length=%" SDL_PRIu64 " for %s buffer=%u\n",

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -141,6 +141,8 @@ extern	const char	*gl_version;
 	x(void,			BindBufferRange, (GLenum target, GLuint index, GLuint buffer, GLintptr offset, GLsizeiptr size))\
 	x(void,			BufferData, (GLenum target, GLsizeiptr size, const GLvoid *data, GLenum usage))\
 	x(void,			BufferSubData, (GLenum target, GLintptr offset, GLsizeiptr size, const GLvoid *data))\
+	x(void,			GetBufferParameteriv, (GLenum target, GLenum pname, GLint *params))\
+	x(void,			GetBufferParameteri64v, (GLenum target, GLenum pname, GLint64 *params))\
 	x(GLvoid*,		MapBuffer, (GLenum target, GLenum access))\
 	x(GLboolean,	UnmapBuffer, (GLenum target))\
 	x(void*,		MapBufferRange, (GLenum target, GLintptr offset, GLsizeiptr length, GLbitfield access))\


### PR DESCRIPTION
### Motivation
- MSVC complained about `glGetBufferParameteri64v` and `glGetBufferParameteriv` being undefined (warnings treated as errors), causing Windows builds to fail.
- Buffer size and mapped-state queries must use the runtime-loaded GL function pointers instead of direct symbol calls to ensure portability and proper function resolution.

### Description
- Register `GetBufferParameteriv` and `GetBufferParameteri64v` in the core GL function list by adding them to `QGL_CORE_FUNCTIONS` in `Quake/glquake.h`.
- Replace direct calls to `glGetBufferParameteri64v` and `glGetBufferParameteriv` with the loaded pointers `GL_GetBufferParameteri64vFunc` and `GL_GetBufferParameterivFunc` in `Quake/gl_rmisc.c`.
- Changes apply to `Quake/glquake.h` and `Quake/gl_rmisc.c` to ensure the functions are loaded via `SDL_GL_GetProcAddress` and used through the wrapper pointers.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69824b5b6a8c832eb219e6cccb8957dd)