### PR TITLE
Ensure buffer bound before glMapBufferRange by adding RB_BufferMapRange

### DIFF
--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -1290,136 +1290,6 @@ static size_t		frameres_device_offset = 0;
 static size_t		frameres_host_buffer_size = 1 * 1024 * 1024;
 static size_t		frameres_device_buffer_size = 1 * 1024 * 1024;
 
-static const char *GL_TargetName (GLenum target)
-{
-	switch (target)
-	{
-		case GL_ARRAY_BUFFER:
-			return "GL_ARRAY_BUFFER";
-		case GL_ELEMENT_ARRAY_BUFFER:
-			return "GL_ELEMENT_ARRAY_BUFFER";
-		case GL_UNIFORM_BUFFER:
-			return "GL_UNIFORM_BUFFER";
-		case GL_SHADER_STORAGE_BUFFER:
-			return "GL_SHADER_STORAGE_BUFFER";
-		case GL_PIXEL_UNPACK_BUFFER:
-			return "GL_PIXEL_UNPACK_BUFFER";
-		case GL_DRAW_INDIRECT_BUFFER:
-			return "GL_DRAW_INDIRECT_BUFFER";
-		default:
-			return "UNKNOWN_TARGET";
-	}
-}
-
-static GLenum GL_TargetBindingEnum (GLenum target)
-{
-	switch (target)
-	{
-		case GL_ARRAY_BUFFER:
-			return GL_ARRAY_BUFFER_BINDING;
-		case GL_ELEMENT_ARRAY_BUFFER:
-			return GL_ELEMENT_ARRAY_BUFFER_BINDING;
-		case GL_UNIFORM_BUFFER:
-			return GL_UNIFORM_BUFFER_BINDING;
-		case GL_SHADER_STORAGE_BUFFER:
-			return GL_SHADER_STORAGE_BUFFER_BINDING;
-		case GL_PIXEL_UNPACK_BUFFER:
-			return GL_PIXEL_UNPACK_BUFFER_BINDING;
-		case GL_DRAW_INDIRECT_BUFFER:
-			return GL_DRAW_INDIRECT_BUFFER_BINDING;
-		default:
-			return 0;
-	}
-}
-
-static void *GL_TryMapRange (GLenum target, GLuint buffer, GLintptr offset, GLsizeiptr length, GLbitfield flags, GLsizeiptr full_size, const char *label)
-{
-	GLenum err;
-	GLenum binding_enum;
-	GLint binding = 0;
-	GLint mapped = 0;
-	GLint64 buffer_size = 0;
-	void *ptr;
-	const char *target_name = GL_TargetName (target);
-
-	while (glGetError () != GL_NO_ERROR)
-	{
-	}
-
-	GL_BindBuffer (target, buffer);
-
-	binding_enum = GL_TargetBindingEnum (target);
-	if (binding_enum)
-		glGetIntegerv (binding_enum, &binding);
-	GL_GetBufferParameteri64vFunc (target, GL_BUFFER_SIZE, &buffer_size);
-	GL_GetBufferParameterivFunc (target, GL_BUFFER_MAPPED, &mapped);
-
-	if (length <= 0)
-		Con_Printf ("%s: warning: non-positive map length=%" SDL_PRIu64 " for %s buffer=%u\n",
-			label ? label : "GL_TryMapRange",
-			(uint64_t) length,
-			target_name,
-			buffer);
-	if (buffer_size == 0 || (uint64_t) (offset + length) > (uint64_t) buffer_size)
-		Con_Printf ("%s: warning: map range offset=%" SDL_PRIu64 " length=%" SDL_PRIu64 " exceeds size=%" SDL_PRIu64 " for %s buffer=%u\n",
-			label ? label : "GL_TryMapRange",
-			(uint64_t) offset,
-			(uint64_t) length,
-			(uint64_t) buffer_size,
-			target_name,
-			buffer);
-
-	Con_Printf ("%s: %s target=0x%04X buffer=%u bound=%d offset=%" SDL_PRIu64 " length=%" SDL_PRIu64 " flags=0x%08X size=%" SDL_PRIu64 " mapped=%d thread=%lu ctx=%p\n",
-		label ? label : "GL_TryMapRange",
-		target_name,
-		target,
-		buffer,
-		binding,
-		(uint64_t) offset,
-		(uint64_t) length,
-		(unsigned int) flags,
-		(uint64_t) buffer_size,
-		mapped,
-		(unsigned long) SDL_ThreadID (),
-		(void *) SDL_GL_GetCurrentContext ());
-
-	SDL_assert (!mapped);
-
-	ptr = GL_MapBufferRangeFunc (target, offset, length, flags);
-	if (!ptr)
-	{
-		err = glGetError ();
-		Con_Printf ("%s: glMapBufferRange failed (err=0x%04X) on %s buffer=%u offset=%" SDL_PRIu64 " length=%" SDL_PRIu64 "\n",
-			label ? label : "GL_TryMapRange",
-			err,
-			target_name,
-			buffer,
-			(uint64_t) offset,
-			(uint64_t) length);
-
-		GL_BufferDataFunc (target, full_size, NULL, GL_STREAM_DRAW);
-		ptr = GL_MapBufferRangeFunc (target, offset, length, flags);
-		if (!ptr)
-		{
-			err = glGetError ();
-			Sys_Error ("%s: MapBufferRange failed after orphan (err=0x%04X) target=%s(0x%04X) buffer=%u bound=%d offset=%" SDL_PRIu64 " length=%" SDL_PRIu64 " size=%" SDL_PRIu64 " flags=0x%08X mapped=%d ctx=%p",
-				label ? label : "GL_TryMapRange",
-				err,
-				target_name,
-				target,
-				buffer,
-				binding,
-				(uint64_t) offset,
-				(uint64_t) length,
-				(uint64_t) buffer_size,
-				(unsigned int) flags,
-				mapped,
-				(void *) SDL_GL_GetCurrentContext ());
-		}
-	}
-
-	return ptr;
-}
 
 /*
 ====================
@@ -1465,7 +1335,7 @@ static void GL_AllocFrameResources (frameres_bits_t bits)
 			if (gl_buffer_storage_able)
 			{
 				GL_BufferStorageFunc (GL_ARRAY_BUFFER, frameres_host_buffer_size, NULL, flags);
-				frame->host_ptr = GL_TryMapRange (GL_ARRAY_BUFFER, frame->host_buffer, 0, frameres_host_buffer_size, flags, frameres_host_buffer_size, "GL_AllocFrameResources");
+				frame->host_ptr = RB_BufferMapRange (GL_ARRAY_BUFFER, frame->host_buffer, 0, frameres_host_buffer_size, flags, frameres_host_buffer_size, "GL_AllocFrameResources");
 				if (!frame->host_ptr)
 					Sys_Error ("GL_AllocFrameResources: MapBufferRange failed on %" SDL_PRIu64 " bytes", (uint64_t)frameres_host_buffer_size);
 			}

--- a/Quake/gl_texmgr.c
+++ b/Quake/gl_texmgr.c
@@ -2350,7 +2350,7 @@ static qboolean TexMgr_EnsureLightmapUploadBuffer (GLsizeiptr size)
 	        GL_BindBuffer (GL_PIXEL_UNPACK_BUFFER, lightmap_upload_pbo);
 	        GL_ObjectLabelFunc (GL_BUFFER, lightmap_upload_pbo, -1, "lightmap upload");
 	        GL_BufferStorageFunc (GL_PIXEL_UNPACK_BUFFER, size, NULL, flags);
-	        lightmap_upload_ptr = (byte *) GL_MapBufferRangeFunc (GL_PIXEL_UNPACK_BUFFER, 0, size, flags);
+	        lightmap_upload_ptr = (byte *) RB_BufferMapRange (GL_PIXEL_UNPACK_BUFFER, lightmap_upload_pbo, 0, size, flags, size, "TexMgr_EnsureLightmapUploadBuffer");
 	        if (!lightmap_upload_ptr)
 	        {
 	                TexMgr_DestroyLightmapUploadBuffer ();

--- a/Quake/gl_vidsdl.c
+++ b/Quake/gl_vidsdl.c
@@ -751,6 +751,7 @@ static void VID_Restart (void)
 		return;
 	}
 
+	GL_DeleteFrameResources ();
 	GL_DeleteFrameBuffers ();
 
 //
@@ -762,6 +763,8 @@ static void VID_Restart (void)
 	VID_RecalcInterfaceSize ();
 
 	GL_CreateFrameBuffers ();
+	GL_ClearBufferBindings ();
+	GL_CreateFrameResources ();
 //
 // keep cvars in line with actual mode
 //

--- a/Quake/renderer_backend.c
+++ b/Quake/renderer_backend.c
@@ -244,6 +244,13 @@ void RB_BufferData(int target, size_t size, const void *data, int usage)
 	rb_backend->buffer_data(target, size, data, usage);
 }
 
+void *RB_BufferMapRange(int target, unsigned int buffer, size_t offset, size_t length, unsigned int flags, size_t full_size, const char *label)
+{
+	if (!rb_backend || !rb_backend->buffer_map_range)
+		return NULL;
+	return rb_backend->buffer_map_range(target, buffer, offset, length, flags, full_size, label);
+}
+
 void RB_GenVertexArrays(int n, unsigned int *arrays)
 {
 	if (!rb_backend || !rb_backend->gen_vertex_arrays)

--- a/Quake/renderer_backend.h
+++ b/Quake/renderer_backend.h
@@ -119,6 +119,7 @@ typedef struct rb_backend_api_s
 	void				(*delete_buffers)(int n, const unsigned int *buffers);
 	void				(*bind_buffer)(int target, unsigned int buffer);
 	void				(*buffer_data)(int target, size_t size, const void *data, int usage);
+	void				*(*buffer_map_range)(int target, unsigned int buffer, size_t offset, size_t length, unsigned int flags, size_t full_size, const char *label);
 	void				(*gen_vertex_arrays)(int n, unsigned int *arrays);
 	void				(*delete_vertex_arrays)(int n, const unsigned int *arrays);
 	void				(*bind_vertex_array)(unsigned int array);
@@ -159,6 +160,7 @@ void			RB_GenBuffers(int n, unsigned int *buffers);
 void			RB_DeleteBuffers(int n, const unsigned int *buffers);
 void			RB_BindBuffer(int target, unsigned int buffer);
 void			RB_BufferData(int target, size_t size, const void *data, int usage);
+void			*RB_BufferMapRange(int target, unsigned int buffer, size_t offset, size_t length, unsigned int flags, size_t full_size, const char *label);
 void			RB_GenVertexArrays(int n, unsigned int *arrays);
 void			RB_DeleteVertexArrays(int n, const unsigned int *arrays);
 void			RB_BindVertexArray(unsigned int array);

--- a/Quake/renderer_backend_gl.c
+++ b/Quake/renderer_backend_gl.c
@@ -115,6 +115,111 @@ static void RBGL_BufferData(int target, size_t size, const void *data, int usage
 	GL_BufferDataFunc (target, size, data, usage);
 }
 
+static const char *RBGL_TargetName(int target)
+{
+	switch (target)
+	{
+	case GL_ARRAY_BUFFER:
+		return "GL_ARRAY_BUFFER";
+	case GL_ELEMENT_ARRAY_BUFFER:
+		return "GL_ELEMENT_ARRAY_BUFFER";
+	case GL_UNIFORM_BUFFER:
+		return "GL_UNIFORM_BUFFER";
+	case GL_SHADER_STORAGE_BUFFER:
+		return "GL_SHADER_STORAGE_BUFFER";
+	case GL_PIXEL_UNPACK_BUFFER:
+		return "GL_PIXEL_UNPACK_BUFFER";
+	case GL_DRAW_INDIRECT_BUFFER:
+		return "GL_DRAW_INDIRECT_BUFFER";
+	default:
+		return "UNKNOWN_TARGET";
+	}
+}
+
+static int RBGL_TargetBindingEnum(int target)
+{
+	switch (target)
+	{
+	case GL_ARRAY_BUFFER:
+		return GL_ARRAY_BUFFER_BINDING;
+	case GL_ELEMENT_ARRAY_BUFFER:
+		return GL_ELEMENT_ARRAY_BUFFER_BINDING;
+	case GL_UNIFORM_BUFFER:
+		return GL_UNIFORM_BUFFER_BINDING;
+	case GL_SHADER_STORAGE_BUFFER:
+		return GL_SHADER_STORAGE_BUFFER_BINDING;
+	case GL_PIXEL_UNPACK_BUFFER:
+		return GL_PIXEL_UNPACK_BUFFER_BINDING;
+	case GL_DRAW_INDIRECT_BUFFER:
+		return GL_DRAW_INDIRECT_BUFFER_BINDING;
+	default:
+		return 0;
+	}
+}
+
+static void *RBGL_BufferMapRange(int target, unsigned int buffer, size_t offset, size_t length, unsigned int flags, size_t full_size, const char *label)
+{
+	GLenum err;
+	int binding_enum;
+	GLint binding = 0;
+	GLint mapped = 0;
+	GLint64 buffer_size = 0;
+	void *ptr;
+	const char *target_name = RBGL_TargetName(target);
+
+	assert(buffer != 0);
+
+	while (glGetError() != GL_NO_ERROR)
+	{
+	}
+
+	GL_BindBufferFunc(target, buffer);
+
+	binding_enum = RBGL_TargetBindingEnum(target);
+	if (binding_enum)
+		glGetIntegerv(binding_enum, &binding);
+	GL_GetBufferParameteri64vFunc(target, GL_BUFFER_SIZE, &buffer_size);
+	GL_GetBufferParameterivFunc(target, GL_BUFFER_MAPPED, &mapped);
+
+	assert(binding != 0);
+	assert((uint64_t)(offset + length) <= (uint64_t)buffer_size);
+
+	ptr = GL_MapBufferRangeFunc(target, (GLintptr)offset, (GLsizeiptr)length, flags);
+	if (!ptr)
+	{
+		err = glGetError();
+		Con_Printf("%s: glMapBufferRange failed (err=0x%04X) on %s buffer=%u offset=%" SDL_PRIu64 " length=%" SDL_PRIu64 "\n",
+			label ? label : "RBGL_BufferMapRange",
+			err,
+			target_name,
+			buffer,
+			(uint64_t)offset,
+			(uint64_t)length);
+
+		GL_BufferDataFunc(target, full_size, NULL, GL_STREAM_DRAW);
+		ptr = GL_MapBufferRangeFunc(target, (GLintptr)offset, (GLsizeiptr)length, flags);
+		if (!ptr)
+		{
+			err = glGetError();
+			Sys_Error("%s: MapBufferRange failed after orphan (err=0x%04X) target=%s(0x%04X) buffer=%u bound=%d offset=%" SDL_PRIu64 " length=%" SDL_PRIu64 " size=%" SDL_PRIu64 " flags=0x%08X mapped=%d ctx=%p",
+				label ? label : "RBGL_BufferMapRange",
+				err,
+				target_name,
+				target,
+				buffer,
+				binding,
+				(uint64_t)offset,
+				(uint64_t)length,
+				(uint64_t)buffer_size,
+				flags,
+				mapped,
+				(void *)SDL_GL_GetCurrentContext());
+		}
+	}
+
+	return ptr;
+}
+
 static void RBGL_GenVertexArrays(int n, unsigned int *arrays)
 {
 	GL_GenVertexArraysFunc (n, arrays);
@@ -427,6 +532,7 @@ static const rb_backend_api_t rb_gl_api = {
 	RBGL_DeleteBuffers,
 	RBGL_BindBuffer,
 	RBGL_BufferData,
+	RBGL_BufferMapRange,
 	RBGL_GenVertexArrays,
 	RBGL_DeleteVertexArrays,
 	RBGL_BindVertexArray,

--- a/Quake/renderer_backend_null.c
+++ b/Quake/renderer_backend_null.c
@@ -155,6 +155,18 @@ static void RB_NULL_BufferData(int target, size_t size, const void *data, int us
 	(void)usage;
 }
 
+static void *RB_NULL_BufferMapRange(int target, unsigned int buffer, size_t offset, size_t length, unsigned int flags, size_t full_size, const char *label)
+{
+	(void)target;
+	(void)buffer;
+	(void)offset;
+	(void)length;
+	(void)flags;
+	(void)full_size;
+	(void)label;
+	return NULL;
+}
+
 static void RB_NULL_GenVertexArrays(int n, unsigned int *arrays)
 {
 	(void)n;
@@ -214,6 +226,7 @@ static const rb_backend_api_t rb_null_api = {
 	RB_NULL_DeleteBuffers,
 	RB_NULL_BindBuffer,
 	RB_NULL_BufferData,
+	RB_NULL_BufferMapRange,
 	RB_NULL_GenVertexArrays,
 	RB_NULL_DeleteVertexArrays,
 	RB_NULL_BindVertexArray,


### PR DESCRIPTION
### Motivation
- Fix glMapBufferRange failures caused by mapping with no buffer bound after the renderer backend refactor, and make buffer mapping responsibilities part of the backend so frontend code no longer assumes GL bindings.
- Provide defensive checks and an orphan-retry path for persistent/dynamic mappings to avoid hard GL errors and to surface correct diagnostics.
- Ensure frame resource buffers are recreated after context resets so cached/stale bindings cannot cause map failures.

### Description
- Added a new backend API `buffer_map_range` / `RB_BufferMapRange` in `renderer_backend.h` and exposed a wrapper `RB_BufferMapRange` in `renderer_backend.c` so the backend owns binding + mapping logic.
- Implemented `RBGL_BufferMapRange` in `renderer_backend_gl.c` which explicitly binds the buffer, verifies binding and size via asserts, calls `glMapBufferRange`, and on failure performs an orphan via `glBufferData(..., NULL, GL_STREAM_DRAW)` and retries, printing diagnostics and erroring if retry fails; also added helper functions to map target -> name and binding enum.
- Added a null-backend stub `RB_NULL_BufferMapRange` to keep the backend interface consistent.
- Replaced direct `GL_MapBufferRangeFunc` uses in `GL_AllocFrameResources` (frame resources host buffer) and `TexMgr_EnsureLightmapUploadBuffer` with calls to `RB_BufferMapRange` so binding is handled in the backend.
- On video mode changes / `vid_restart` ensured frame resources are deleted and recreated and buffer-binding caches cleared by calling `GL_DeleteFrameResources`, `GL_ClearBufferBindings` and `GL_CreateFrameResources` during restart to avoid stale bindings after context reset.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982748089e0832e9f7845406b33d6cf)