### PR TITLE
Include <SDL_stdinc.h> to fix SDL_PRId64 errors in GL backend

### DIFF
--- a/Quake/renderer_backend_gl.c
+++ b/Quake/renderer_backend_gl.c
@@ -8,6 +8,7 @@ This file is part of Ironwail.
 #include "renderer_backend_gl.h"
 
 #include <assert.h>
+#include <SDL_stdinc.h>
 
 typedef struct rb_gl_tex_s
 {


### PR DESCRIPTION
### Motivation
- Ensure the `SDL_PRId64` and related SDL formatting macros are available in `Quake/renderer_backend_gl.c` to address MSVC compilation errors referencing `SDL_PRId64`.

### Description
- Add `#include <SDL_stdinc.h>` to `Quake/renderer_backend_gl.c` so the SDL format macros used in log and error messages are defined.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982812d03c4832eb404a29f6fe0d6dc)