### PR TITLE
Include SDL_inttypes.h in OpenGL renderer to define SDL_PRId64/SDL_PRIu64

### DIFF
--- a/Quake/renderer_backend_gl.c
+++ b/Quake/renderer_backend_gl.c
@@ -8,6 +8,7 @@ This file is part of Ironwail.
 #include "renderer_backend_gl.h"
 
 #include <assert.h>
+#include <SDL_inttypes.h>
 #include <SDL_stdinc.h>
 
 typedef struct rb_gl_tex_s


### PR DESCRIPTION
### Motivation
- MSVC builds of the OpenGL renderer emitted syntax errors where `SDL_PRId64`/`SDL_PRIu64` format macros were not defined in `renderer_backend_gl.c`, causing compile-time failures in format strings.

### Description
- Add `#include <SDL_inttypes.h>` to `Quake/renderer_backend_gl.c` so the SDL integer format macros (`SDL_PRId64`, `SDL_PRIu64`, etc.) are available for the debug/error `printf` and `Sys_Error` format strings.

### Testing
- No automated tests or builds were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982827eb270832e939215147405b815)