### PR TITLE
Remove obsolete SDL_inttypes include from GL renderer backend

### DIFF
--- a/Quake/renderer_backend_gl.c
+++ b/Quake/renderer_backend_gl.c
@@ -8,7 +8,6 @@ This file is part of Ironwail.
 #include "renderer_backend_gl.h"
 
 #include <assert.h>
-#include <SDL_inttypes.h>
 #include <SDL_stdinc.h>
 
 typedef struct rb_gl_tex_s


### PR DESCRIPTION
### Motivation
- Fix a Windows build error where `SDL_inttypes.h` could not be found and align the GL backend with the SDL2 header layout.

### Description
- Remove the unused/incorrect `#include <SDL_inttypes.h>` line from `Quake/renderer_backend_gl.c` so only `#include <SDL_stdinc.h>` remains.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698283e7b56c832eb352633756789503)