### PR TITLE
Ensure RB_MapBufferRange uses cached GL binding and add pre-map assertions/logging

### DIFF
--- a/Quake/renderer_backend_gl.c
+++ b/Quake/renderer_backend_gl.c
@@ -191,7 +191,7 @@ static void *RB_MapBufferRange(GLenum target, GLuint buffer, GLintptr offset, GL
 	{
 	}
 
-	GL_BindBufferFunc(target, buffer);
+	GL_BindBuffer(target, buffer);
 
 	binding_enum = RBGL_TargetBindingEnum(target);
 	if (binding_enum)
@@ -257,6 +257,20 @@ static void *RB_MapBufferRange(GLenum target, GLuint buffer, GLintptr offset, GL
 			thread_id,
 			context);
 	}
+
+	if (binding_enum)
+		assert(binding != 0);
+	assert((uint64_t)buffer_size >= (uint64_t)offset + (uint64_t)length);
+
+	Con_Printf("RB_MapBufferRange: target=%s(0x%04X) buffer=%u bound=%d size=%llu offset=%lld length=%llu flags=0x%08X\n",
+		target_name,
+		target,
+		buffer,
+		binding,
+		(unsigned long long)buffer_size,
+		(long long)offset,
+		(unsigned long long)length,
+		flags);
 
 	ptr = GL_MapBufferRangeFunc(target, (GLintptr)offset, (GLsizeiptr)length, flags);
 	if (!ptr)


### PR DESCRIPTION
### Motivation
- Prevent intermittent `glMapBufferRange` failures by ensuring the backend mapping path does not desynchronize the frontend cached GL binding state.
- Surface the real binding/size/range conditions that cause mapping to fail by adding hard assertions and diagnostic logging immediately before mapping.
- Keep mapping logic robust to refactors by enforcing ownership of the bind operation through the cached wrapper.

### Description
- Bind through the cached frontend wrapper by replacing `GL_BindBufferFunc(target, buffer)` with `GL_BindBuffer(target, buffer)` in `RB_MapBufferRange` to keep the frontend cache in sync with real GL state.
- Add hard assertions and diagnostics just before calling `glMapBufferRange`, including `assert(binding != 0)` (when applicable) and `assert(buffer_size >= offset + length)`, plus a `Con_Printf` that logs `target`, `buffer`, `bound`, `size`, `offset`, `length`, and `flags`.
- Retain the existing fallback orphaning path (call to `GL_BufferDataFunc` and retry) and preserve existing error messages if mapping ultimately fails.
- Changes applied to `Quake/renderer_backend_gl.c` (the backend map routine) to make binding ownership explicit and to add the debug layer.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69828bee975c832eb40f9a5d231c9b91)