### PR TITLE
Stabilize tick stepping and add frame-step diagnostics

### DIFF
--- a/Quake/cl_main.c
+++ b/Quake/cl_main.c
@@ -1821,6 +1821,9 @@ int CL_ReadFromServer (void)
 	beam_t		*b; //johnfitz
 	int			i; //johnfitz
 
+	if (sys_step_debug.value > 0.0f)
+		sys_step_debug_info.cl_readfromserver_calls++;
+
 	CL_AdvanceTime ();
 
 	do
@@ -1930,9 +1933,13 @@ void CL_SendCmd (void)
 	int				cmds_built;
 	qboolean		send_move;
 	qboolean		sendcmd_ran;
+	static int		last_cmd_msec = -1;
 
 	if (cls.state != ca_connected)
 		return;
+
+	if (sys_step_debug.value > 0.0f)
+		sys_step_debug_info.cl_sendcmd_calls++;
 
 	cmd_rate = cl_cmdrate.value > 0.0 ? cl_cmdrate.value : 60.0;
 	cmd_dt = 1.0 / cmd_rate;
@@ -1943,13 +1950,19 @@ void CL_SendCmd (void)
 	if (max_catchup < 1)
 		max_catchup = 1;
 
-	frame_us = CL_SecondsToUsec (host_frametime);
+	frame_us = CL_SecondsToUsec (host_rawframetime);
+	if (sys_step_debug.value > 0.0f)
+		sys_step_debug_info.cl_cmd_accum_us_before = cl_cmd_accum_us;
 	cl_cmd_accum_us += frame_us;
 	if (cl_cmd_accum_us < 0)
 		cl_cmd_accum_us = 0;
 	max_accum_us = cmd_dt_us * (int64_t)max_catchup * 2;
 	if (cl_cmd_accum_us > max_accum_us)
+	{
+		if (sys_step_debug.value > 0.0f)
+			sys_step_debug_info.cl_cmds_dropped++;
 		cl_cmd_accum_us = max_accum_us;
+	}
 
 	cmds_built = 0;
 	send_move = false;
@@ -1957,6 +1970,30 @@ void CL_SendCmd (void)
 
 	while (cl_cmd_accum_us >= cmd_dt_us && cmds_built < max_catchup)
 	{
+		int cmd_msec = (int)((cmd_dt_us + 500) / 1000);
+
+			if (cmd_msec < 1)
+			{
+				if (sys_step_debug.value > 0.0f)
+					sys_step_debug_info.cl_cmd_msec_zero++;
+				cmd_msec = 1;
+			}
+		else if (cmd_msec > 255)
+		{
+			if (sys_step_debug.value > 0.0f)
+				sys_step_debug_info.cl_cmd_msec_over++;
+			cmd_msec = 255;
+		}
+		if (sys_step_debug.value > 0.0f)
+		{
+			sys_step_debug_info.cl_cmd_msec_min = q_min (sys_step_debug_info.cl_cmd_msec_min, cmd_msec);
+			sys_step_debug_info.cl_cmd_msec_max = q_max (sys_step_debug_info.cl_cmd_msec_max, cmd_msec);
+			sys_step_debug_info.cl_cmd_msec_last = cmd_msec;
+			if (last_cmd_msec >= 0 && abs (cmd_msec - last_cmd_msec) >= 20)
+				sys_step_debug_info.cl_cmd_msec_wild++;
+		}
+		last_cmd_msec = cmd_msec;
+
 		if (cls.signon == SIGNONS)
 		{
 		// get basic movement from keyboard
@@ -2011,6 +2048,14 @@ void CL_SendCmd (void)
 		sendcmd_ran = true;
 	}
 
+	if (sys_step_debug.value > 0.0f)
+	{
+		if (cmds_built == 0)
+			sys_step_debug_info.cl_cmd_no_cmd++;
+		sys_step_debug_info.cl_cmds_built += cmds_built;
+		sys_step_debug_info.cl_cmd_accum_us_after = cl_cmd_accum_us;
+	}
+
 	if (cmds_built >= max_catchup && cl_cmd_accum_us >= cmd_dt_us && cl_netdebug_parse.value)
 	{
 		Con_Printf ("NETDBG cmdrate catchup clamped accum %.6f dt %.6f\n",
@@ -2024,6 +2069,8 @@ void CL_SendCmd (void)
 			CL_NetDbg_LogMovement (&cmd, sendcmd_ran);
 			CL_SendMove (&cmd);
 			cl_cmds_sent_since_log++;
+			if (sys_step_debug.value > 0.0f)
+				sys_step_debug_info.cl_cmds_sent++;
 		}
 		else
 		{
@@ -2031,6 +2078,8 @@ void CL_SendCmd (void)
 			CL_SendMove (NULL);
 		}
 		cl_cmd_packets_since_log++;
+		if (sys_step_debug.value > 0.0f)
+			sys_step_debug_info.cl_cmd_packets++;
 	}
 	if (send_move && cls.signon == SIGNONS)
 		memset(&cl.pendingcmd, 0, sizeof(cl.pendingcmd));

--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -3609,6 +3609,9 @@ void CL_ParseServerMessage (void)
 	int			prevcmd_offset;
 	int			cmd_offset;
 
+	if (sys_step_debug.value > 0.0f)
+		sys_step_debug_info.cl_parse_calls++;
+
 //
 // if recording demos, copy the message out
 //

--- a/Quake/cl_predict.c
+++ b/Quake/cl_predict.c
@@ -1234,6 +1234,9 @@ static void CL_Predict_SimulateCmd (cl_pred_state_t *state, const usercmd_t *cmd
 	qboolean ground_entity;
 	int ground_reason = CL_GROUND_REASON_OK;
 
+	if (sys_step_debug.value > 0.0f)
+		sys_step_debug_info.cl_pred_steps++;
+
 	if (!is_render)
 		cl_pred_steps_this_frame++;
 	CL_Predict_GetPlayerBounds (mins, maxs);

--- a/Quake/host.c
+++ b/Quake/host.c
@@ -74,6 +74,9 @@ cvar_t	cl_nocsqc = {"cl_nocsqc", "0", CVAR_NONE};	//spike -- blocks the loading 
 
 cvar_t	sys_ticrate = {"sys_ticrate","0.05",CVAR_NONE}; // dedicated server
 cvar_t	serverprofile = {"serverprofile","0",CVAR_NONE};
+cvar_t	sys_step_debug = {"sys_step_debug", "0", CVAR_NONE};
+cvar_t	sys_step_dump = {"sys_step_dump", "0", CVAR_NONE};
+cvar_t	sys_step_hitch_ms = {"sys_step_hitch_ms", "50", CVAR_NONE};
 
 cvar_t	fraglimit = {"fraglimit","0",CVAR_NOTIFY|CVAR_SERVERINFO};
 cvar_t	timelimit = {"timelimit","0",CVAR_NOTIFY|CVAR_SERVERINFO};
@@ -106,8 +109,12 @@ overflowtimes_t dev_overflows; //this stores the last time overflow messages wer
 extern cvar_t sv_tickrate;
 extern cvar_t sv_netrate;
 extern cvar_t sv_tick_maxcatchup;
+extern cvar_t sv_fixedtick;
+extern cvar_t sv_maxsteps_per_frame;
 extern cvar_t sv_tick_debug;
 extern cvar_t sv_timewarp;
+
+sys_step_debug_info_t sys_step_debug_info;
 
 /*
 ================
@@ -510,6 +517,9 @@ void Host_InitLocal (void)
 
 	Cvar_RegisterVariable (&sys_ticrate);
 	Cvar_RegisterVariable (&serverprofile);
+	Cvar_RegisterVariable (&sys_step_debug);
+	Cvar_RegisterVariable (&sys_step_dump);
+	Cvar_RegisterVariable (&sys_step_hitch_ms);
 
 	Cvar_RegisterVariable (&fraglimit);
 	Cvar_RegisterVariable (&timelimit);
@@ -954,6 +964,136 @@ double Host_GetFrameInterval (void)
 	return 0.0;
 }
 
+static int64_t Host_SecondsToUsec (double seconds)
+{
+	if (seconds <= 0.0)
+		return 0;
+	return (int64_t)(seconds * 1000000.0 + 0.5);
+}
+
+static void Sys_StepDebug_BeginFrame (void)
+{
+	if (sys_step_debug.value <= 0.0f)
+		return;
+
+	memset (&sys_step_debug_info, 0, sizeof (sys_step_debug_info));
+	sys_step_debug_info.frame = host_framecount;
+	sys_step_debug_info.cl_cmd_msec_min = 9999;
+}
+
+static void Sys_StepDebug_LogFrame (void)
+{
+	qboolean dump_frame;
+	int debug_level;
+	int cmd_msec_min;
+	int cmd_msec_max;
+
+	if (sys_step_debug.value <= 0.0f)
+		return;
+
+	debug_level = (int)sys_step_debug.value;
+	dump_frame = sys_step_dump.value > 0.0f;
+	if (dump_frame)
+		Cvar_SetValue (&sys_step_dump, 0.0f);
+
+	sys_step_debug_info.realtime = realtime;
+	sys_step_debug_info.host_frametime = host_frametime;
+	sys_step_debug_info.host_rawframetime = host_rawframetime;
+	sys_step_debug_info.cl_time = cl.time;
+	sys_step_debug_info.cl_servertime = cl.latest_server_time;
+	sys_step_debug_info.cl_snapshot_time = cl.snapshot_time;
+
+	cmd_msec_min = sys_step_debug_info.cl_cmd_msec_min;
+	cmd_msec_max = sys_step_debug_info.cl_cmd_msec_max;
+	if (cmd_msec_min == 9999)
+		cmd_msec_min = 0;
+
+	Con_Printf ("STEPDBG frame %d rt %.6f ft %.6f raw %.6f cl.time %.6f cl.srv %.6f cl.snap %.6f\n",
+		sys_step_debug_info.frame,
+		sys_step_debug_info.realtime,
+		sys_step_debug_info.host_frametime,
+		sys_step_debug_info.host_rawframetime,
+		sys_step_debug_info.cl_time,
+		sys_step_debug_info.cl_servertime,
+		sys_step_debug_info.cl_snapshot_time);
+	Con_Printf ("STEPDBG sv ticks %d phys %d tick_us %lld frame_us %lld accum %lld->%lld maxsteps %d\n",
+		sys_step_debug_info.sv_ticks,
+		sys_step_debug_info.sv_physics_calls,
+		(long long)sys_step_debug_info.tick_us,
+		(long long)sys_step_debug_info.frame_us,
+		(long long)sys_step_debug_info.sv_accum_us_before,
+		(long long)sys_step_debug_info.sv_accum_us_after,
+		(int)(sv_maxsteps_per_frame.value > 0 ? sv_maxsteps_per_frame.value : sv_tick_maxcatchup.value));
+	Con_Printf ("STEPDBG cl sendcmd %d read %d parse %d predsteps %d cmds built %d sent %d packets %d accum %lld->%lld\n",
+		sys_step_debug_info.cl_sendcmd_calls,
+		sys_step_debug_info.cl_readfromserver_calls,
+		sys_step_debug_info.cl_parse_calls,
+		sys_step_debug_info.cl_pred_steps,
+		sys_step_debug_info.cl_cmds_built,
+		sys_step_debug_info.cl_cmds_sent,
+		sys_step_debug_info.cl_cmd_packets,
+		(long long)sys_step_debug_info.cl_cmd_accum_us_before,
+		(long long)sys_step_debug_info.cl_cmd_accum_us_after);
+	Con_Printf ("STEPDBG cmd msec min %d max %d last %d no_cmd %d dropped %d wild %d zero %d over %d\n",
+		cmd_msec_min,
+		cmd_msec_max,
+		sys_step_debug_info.cl_cmd_msec_last,
+		sys_step_debug_info.cl_cmd_no_cmd,
+		sys_step_debug_info.cl_cmds_dropped,
+		sys_step_debug_info.cl_cmd_msec_wild,
+		sys_step_debug_info.cl_cmd_msec_zero,
+		sys_step_debug_info.cl_cmd_msec_over);
+
+	if (sys_step_debug_info.player_valid)
+	{
+		Con_Printf ("STEPDBG player org %.2f %.2f %.2f -> %.2f %.2f %.2f vel %.2f %.2f %.2f -> %.2f %.2f %.2f\n",
+			sys_step_debug_info.player_origin_before[0],
+			sys_step_debug_info.player_origin_before[1],
+			sys_step_debug_info.player_origin_before[2],
+			sys_step_debug_info.player_origin_after[0],
+			sys_step_debug_info.player_origin_after[1],
+			sys_step_debug_info.player_origin_after[2],
+			sys_step_debug_info.player_vel_before[0],
+			sys_step_debug_info.player_vel_before[1],
+			sys_step_debug_info.player_vel_before[2],
+			sys_step_debug_info.player_vel_after[0],
+			sys_step_debug_info.player_vel_after[1],
+			sys_step_debug_info.player_vel_after[2]);
+		Con_Printf ("STEPDBG player onground %d->%d groundent %d->%d trace frac %.3f normalz %.3f mover %d gvel %.2f %.2f %.2f\n",
+			sys_step_debug_info.player_onground_before,
+			sys_step_debug_info.player_onground_after,
+			sys_step_debug_info.player_groundent_before,
+			sys_step_debug_info.player_groundent_after,
+			sys_step_debug_info.player_ground_trace_fraction,
+			sys_step_debug_info.player_ground_trace_normal_z,
+			sys_step_debug_info.player_ground_is_mover,
+			sys_step_debug_info.player_ground_vel[0],
+			sys_step_debug_info.player_ground_vel[1],
+			sys_step_debug_info.player_ground_vel[2]);
+	}
+
+	if (sys_step_debug_info.warn_host_frametime_clamped)
+		Con_Printf ("STEPWARN host_frametime clamped raw %.6f ft %.6f\n", host_rawframetime, host_frametime);
+	if (sys_step_debug_info.warn_zero_frametime)
+		Con_Printf ("STEPWARN host_frametime <= 0\n");
+	if (sys_step_debug_info.warn_zero_sim_dt)
+		Con_Printf ("STEPWARN sim dt is zero\n");
+	if (sys_step_debug_info.warn_many_ticks)
+		Con_Printf ("STEPWARN max ticks exceeded in frame\n");
+
+	if (sys_step_hitch_ms.value > 0.0f)
+	{
+		double hitch_ms = sys_step_hitch_ms.value;
+		if (host_rawframetime * 1000.0 >= hitch_ms)
+			Con_Printf ("STEPWARN hitch %.2fms >= %.2fms\n", host_rawframetime * 1000.0, hitch_ms);
+	}
+
+	if (dump_frame && debug_level <= 0)
+	{
+		Con_Printf ("STEPDBG dump requested; enable sys_step_debug for continuous logging.\n");
+	}
+}
+
 /*
 ===================
 Host_AdvanceTime
@@ -973,6 +1113,14 @@ static void Host_AdvanceTime (double dt)
 		host_frametime = host_framerate.value;
 	else if (host_maxfps.value)// don't allow really long or short frames
 		host_frametime = CLAMP (0.0001, host_frametime, 0.1); //johnfitz -- use CLAMP
+
+	if (sys_step_debug.value > 0.0f && host_maxfps.value)
+	{
+		if (host_frametime != host_rawframetime)
+			sys_step_debug_info.warn_host_frametime_clamped = 1;
+	}
+	if (sys_step_debug.value > 0.0f && host_frametime <= 0.0)
+		sys_step_debug_info.warn_zero_frametime = 1;
 }
 
 /*
@@ -1125,6 +1273,9 @@ static void SV_RunOneTick (double tick_dt)
 	const int paused_frame_threshold = 120;
 	const int paused_force_threshold = 300;
 
+	if (sys_step_debug.value > 0.0f)
+		sys_step_debug_info.sv_ticks++;
+
 	host_frametime = tick_dt;
 	pr_global_struct->frametime = host_frametime;
 
@@ -1174,11 +1325,15 @@ void Host_ServerFrame (void)
 	static double last_sv_time = -1.0;
 	static double next_sv_tick_log = 0.0;
 	static double sv_accum = 0.0;
+	static int64_t sv_accum_us = 0;
 	static double sv_next_snapshot_time = 0.0;
 	int		active_clients = 0;
 	double		clamped_frametime;
 	double		tick_dt;
 	double		net_dt;
+	int64_t		frame_us;
+	int64_t		tick_dt_us;
+	int64_t		max_accum_us;
 	int		ticks = 0;
 	int		maxcatchup;
 	int		sends = 0;
@@ -1198,7 +1353,28 @@ void Host_ServerFrame (void)
 	}
 	if (clamped_frametime > 0.1f)
 		clamped_frametime = 0.1f;
-	sv_accum += clamped_frametime;
+	frame_us = Host_SecondsToUsec (clamped_frametime);
+	if (sys_step_debug.value > 0.0f)
+	{
+		sys_step_debug_info.frame_us = frame_us;
+		sys_step_debug_info.sv_accum_us_before = sv_accum_us;
+		if (frame_us == 0)
+			sys_step_debug_info.warn_zero_sim_dt = 1;
+	}
+
+	tick_dt = 1.0 / (sv_tickrate.value > 1.0 ? sv_tickrate.value : 1.0);
+	tick_dt_us = Host_SecondsToUsec (tick_dt);
+	if (tick_dt_us <= 0)
+		tick_dt_us = 1;
+	if (sys_step_debug.value > 0.0f)
+		sys_step_debug_info.tick_us = tick_dt_us;
+
+	if (sv_fixedtick.value > 0.0f)
+	{
+		sv_accum_us += frame_us;
+		if (sv_accum_us < 0)
+			sv_accum_us = 0;
+	}
 
 	for (i = 0; i < svs.maxclients; i++)
 	{
@@ -1215,26 +1391,62 @@ void Host_ServerFrame (void)
 // check for new clients
 	SV_CheckForNewClients ();
 
-	tick_dt = 1.0 / (sv_tickrate.value > 1.0 ? sv_tickrate.value : 1.0);
-	maxcatchup = (int)sv_tick_maxcatchup.value;
+	maxcatchup = (int)(sv_maxsteps_per_frame.value > 0.0f ? sv_maxsteps_per_frame.value : sv_tick_maxcatchup.value);
 	if (maxcatchup < 1)
 		maxcatchup = 1;
-	while (sv_accum >= tick_dt && ticks < maxcatchup)
+	if (sv_fixedtick.value > 0.0f)
 	{
-		SV_RunOneTick (tick_dt);
-		sv_accum -= tick_dt;
-		ticks++;
-	}
-	if (sv_accum >= tick_dt && ticks >= maxcatchup)
-	{
-		if (!sv_timewarp.value)
-			sv_accum = tick_dt;
-		if (sv_tick_debug.value)
+		max_accum_us = tick_dt_us * (int64_t)maxcatchup * 2;
+		if (max_accum_us < tick_dt_us)
+			max_accum_us = tick_dt_us;
+		if (sv_accum_us > max_accum_us)
 		{
-			Con_Printf ("NETDBG sv_tick catchup clamped ticks %d accum %.6f dt %.6f\n",
-				ticks, sv_accum, tick_dt);
+			sv_accum_us = max_accum_us;
+			if (sys_step_debug.value > 0.0f)
+				sys_step_debug_info.warn_many_ticks = 1;
+		}
+		while (sv_accum_us >= tick_dt_us && ticks < maxcatchup)
+		{
+			SV_RunOneTick (tick_dt);
+			sv_accum_us -= tick_dt_us;
+			ticks++;
+		}
+		if (sv_accum_us >= tick_dt_us && ticks >= maxcatchup)
+		{
+			if (!sv_timewarp.value)
+				sv_accum_us = tick_dt_us;
+			if (sys_step_debug.value > 0.0f)
+				sys_step_debug_info.warn_many_ticks = 1;
+			if (sv_tick_debug.value)
+			{
+				Con_Printf ("NETDBG sv_tick catchup clamped ticks %d accum %.6f dt %.6f\n",
+					ticks, (double)sv_accum_us / 1000000.0, tick_dt);
+			}
 		}
 	}
+	else
+	{
+		sv_accum += clamped_frametime;
+		while (sv_accum >= tick_dt && ticks < maxcatchup)
+		{
+			SV_RunOneTick (tick_dt);
+			sv_accum -= tick_dt;
+			ticks++;
+		}
+		if (sv_accum >= tick_dt && ticks >= maxcatchup)
+		{
+			if (!sv_timewarp.value)
+				sv_accum = tick_dt;
+			if (sv_tick_debug.value)
+			{
+				Con_Printf ("NETDBG sv_tick catchup clamped ticks %d accum %.6f dt %.6f\n",
+					ticks, sv_accum, tick_dt);
+			}
+		}
+	}
+
+	if (sys_step_debug.value > 0.0f)
+		sys_step_debug_info.sv_accum_us_after = sv_accum_us;
 
 	if (last_sv_time >= 0.0)
 	{
@@ -1242,6 +1454,7 @@ void Host_ServerFrame (void)
 		{
 			last_sv_time = qcvm->time;
 			sv_accum = 0.0;
+			sv_accum_us = 0;
 			sv_next_snapshot_time = qcvm->time;
 		}
 		else if (sv_tick_debug.value && qcvm->time <= last_sv_time && realtime >= next_sv_stall_log)
@@ -1296,8 +1509,10 @@ void Host_ServerFrame (void)
 		SV_ClearDatagram ();
 	if (sv_tick_debug.value && realtime >= next_sv_tick_log)
 	{
+		double accum_s = sv_fixedtick.value > 0.0f ? (double)sv_accum_us / 1000000.0 : sv_accum;
+
 		Con_Printf ("NETDBG sv_tick frame_dt %.6f tick_dt %.6f ticks %d accum %.6f time %.3f sends %d\n",
-			clamped_frametime, tick_dt, ticks, sv_accum, qcvm->time, sends);
+			clamped_frametime, tick_dt, ticks, accum_s, qcvm->time, sends);
 		next_sv_tick_log = realtime + 1.0;
 	}
 
@@ -1530,6 +1745,8 @@ void _Host_Frame (double time)
 // keep the random time dependent
 	rand ();
 
+	Sys_StepDebug_BeginFrame ();
+
 // decide the simulation time
 	accumtime += host_netinterval?CLAMP(0.0, time, 0.2):0.0;	//for renderer/server isolation
 	Host_AdvanceTime (time);
@@ -1656,6 +1873,8 @@ void _Host_Frame (double time)
 	}
 
 	host_framecount++;
+
+	Sys_StepDebug_LogFrame ();
 }
 
 void Host_Frame (double time)

--- a/Quake/quakedef.h
+++ b/Quake/quakedef.h
@@ -318,6 +318,64 @@ extern	cvar_t		developer;
 extern	cvar_t		map_checks;
 extern	cvar_t		max_edicts; //johnfitz
 extern	cvar_t		sz_debug_hexdump;
+extern	cvar_t		sys_step_debug;
+extern	cvar_t		sys_step_dump;
+extern	cvar_t		sys_step_hitch_ms;
+extern	cvar_t		sv_fixedtick;
+extern	cvar_t		sv_maxsteps_per_frame;
+
+typedef struct sys_step_debug_info_s
+{
+	int		frame;
+	double		realtime;
+	double		host_frametime;
+	double		host_rawframetime;
+	double		cl_time;
+	double		cl_servertime;
+	double		cl_snapshot_time;
+	int		sv_ticks;
+	int		sv_physics_calls;
+	int		cl_sendcmd_calls;
+	int		cl_readfromserver_calls;
+	int		cl_parse_calls;
+	int		cl_pred_steps;
+	int		cl_cmds_built;
+	int		cl_cmds_sent;
+	int		cl_cmd_packets;
+	int		cl_cmds_dropped;
+	int		cl_cmd_no_cmd;
+	int		cl_cmd_msec_min;
+	int		cl_cmd_msec_max;
+	int		cl_cmd_msec_last;
+	int		cl_cmd_msec_wild;
+	int		cl_cmd_msec_zero;
+	int		cl_cmd_msec_over;
+	int64_t		sv_accum_us_before;
+	int64_t		sv_accum_us_after;
+	int64_t		cl_cmd_accum_us_before;
+	int64_t		cl_cmd_accum_us_after;
+	int64_t		frame_us;
+	int64_t		tick_us;
+	int		warn_host_frametime_clamped;
+	int		warn_zero_sim_dt;
+	int		warn_many_ticks;
+	int		warn_zero_frametime;
+	int		player_valid;
+	vec3_t		player_origin_before;
+	vec3_t		player_origin_after;
+	vec3_t		player_vel_before;
+	vec3_t		player_vel_after;
+	int		player_groundent_before;
+	int		player_groundent_after;
+	int		player_onground_before;
+	int		player_onground_after;
+	float		player_ground_trace_fraction;
+	float		player_ground_trace_normal_z;
+	vec3_t		player_ground_vel;
+	int		player_ground_is_mover;
+} sys_step_debug_info_t;
+
+extern	sys_step_debug_info_t sys_step_debug_info;
 
 extern	qboolean	host_initialized;	// true if into command execution
 extern	double		host_frametime;

--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -68,6 +68,8 @@ cvar_t sv_tickrate = {"sv_tickrate", "20", CVAR_NONE};
 cvar_t sv_netrate = {"sv_netrate", "20", CVAR_NONE};
 static cvar_t sv_sendrate = {"sv_sendrate", "30", CVAR_NONE};
 cvar_t sv_tick_maxcatchup = {"sv_tick_maxcatchup", "5", CVAR_NONE};
+cvar_t sv_fixedtick = {"sv_fixedtick", "1", CVAR_NONE};
+cvar_t sv_maxsteps_per_frame = {"sv_maxsteps_per_frame", "8", CVAR_NONE};
 cvar_t sv_tick_debug = {"sv_tick_debug", "0", CVAR_NONE};
 cvar_t sv_timewarp = {"sv_timewarp", "0", CVAR_NONE};
 static cvar_t sv_signon_chunk_debug = {"sv_signon_chunk_debug", "0", CVAR_NONE};
@@ -339,6 +341,8 @@ void SV_Init (void)
 	Cvar_RegisterVariable (&sv_netrate);
 	Cvar_RegisterVariable (&sv_sendrate);
 	Cvar_RegisterVariable (&sv_tick_maxcatchup);
+	Cvar_RegisterVariable (&sv_fixedtick);
+	Cvar_RegisterVariable (&sv_maxsteps_per_frame);
 	Cvar_RegisterVariable (&sv_tick_debug);
 	Cvar_RegisterVariable (&sv_timewarp);
 	Cvar_RegisterVariable (&sv_signon_chunk_debug);

--- a/Quake/sv_phys.c
+++ b/Quake/sv_phys.c
@@ -929,6 +929,12 @@ void SV_WalkMove (edict_t *ent)
 // move down
 	downtrace = SV_PushEntity (ent, downmove);	// FIXME: don't link?
 
+	if (sys_step_debug.value > 1.0f && ((int)ent->v.flags & FL_CLIENT))
+	{
+		sys_step_debug_info.player_ground_trace_fraction = downtrace.fraction;
+		sys_step_debug_info.player_ground_trace_normal_z = downtrace.plane.normal[2];
+	}
+
 	if (downtrace.plane.normal[2] > 0.7)
 	{
 		if (ent->v.solid == SOLID_BSP)
@@ -961,6 +967,18 @@ void SV_Physics_Client (edict_t	*ent, int num)
 
 	if ( ! svs.clients[num-1].active )
 		return;		// unconnected slot
+
+	if (sys_step_debug.value > 0.0f)
+	{
+		if (num == 1)
+		{
+			sys_step_debug_info.player_valid = 1;
+			VectorCopy (ent->v.origin, sys_step_debug_info.player_origin_before);
+			VectorCopy (ent->v.velocity, sys_step_debug_info.player_vel_before);
+			sys_step_debug_info.player_groundent_before = (int)ent->v.groundentity;
+			sys_step_debug_info.player_onground_before = ((int)ent->v.flags & FL_ONGROUND) ? 1 : 0;
+		}
+	}
 
 //
 // call standard client pre-think
@@ -1031,6 +1049,27 @@ void SV_Physics_Client (edict_t	*ent, int num)
 	{
 		ent->forcewater = forceunderwater;
 		ent->sendforcewater = true;
+	}
+
+	if (sys_step_debug.value > 0.0f)
+	{
+		if (num == 1)
+		{
+			edict_t *groundent;
+
+			VectorCopy (ent->v.origin, sys_step_debug_info.player_origin_after);
+			VectorCopy (ent->v.velocity, sys_step_debug_info.player_vel_after);
+			sys_step_debug_info.player_groundent_after = (int)ent->v.groundentity;
+			sys_step_debug_info.player_onground_after = ((int)ent->v.flags & FL_ONGROUND) ? 1 : 0;
+			VectorClear (sys_step_debug_info.player_ground_vel);
+			sys_step_debug_info.player_ground_is_mover = 0;
+			groundent = PROG_TO_EDICT (ent->v.groundentity);
+			if (groundent && groundent != qcvm->edicts && groundent->v.movetype == MOVETYPE_PUSH)
+			{
+				sys_step_debug_info.player_ground_is_mover = 1;
+				VectorCopy (groundent->v.velocity, sys_step_debug_info.player_ground_vel);
+			}
+		}
 	}
 }
 
@@ -1248,6 +1287,9 @@ void SV_Physics (void)
 		Con_Printf ("SVPHYS: frametime=%.4f steps=%d\n", host_frametime, steps);
 	}
 
+	if (sys_step_debug.value > 0.0f)
+		sys_step_debug_info.sv_physics_calls++;
+
 // let the progs know that a new frame has started
 	pr_global_struct->self = EDICT_TO_PROG(qcvm->edicts);
 	pr_global_struct->other = EDICT_TO_PROG(qcvm->edicts);
@@ -1267,9 +1309,24 @@ void SV_Physics (void)
 	  entity_cap = qcvm->num_edicts;
 
 	//for (i=0 ; i<sv.num_edicts ; i++, ent = NEXT_EDICT(ent))
-	for (i=0 ; i<entity_cap ; i++, ent = NEXT_EDICT(ent))
+	for (i=0, ent = qcvm->edicts ; i<entity_cap ; i++, ent = NEXT_EDICT(ent))
 	{
 		if (ent->free)
+			continue;
+		if (ent->v.movetype != MOVETYPE_PUSH)
+			continue;
+
+		if (pr_global_struct->force_retouch)
+			SV_LinkEdict (ent, true);	// force retouch even for stationary
+
+		SV_Physics_Pusher (ent);
+	}
+
+	for (i=0, ent = qcvm->edicts ; i<entity_cap ; i++, ent = NEXT_EDICT(ent))
+	{
+		if (ent->free)
+			continue;
+		if (ent->v.movetype == MOVETYPE_PUSH)
 			continue;
 
 		if (pr_global_struct->force_retouch)
@@ -1279,8 +1336,6 @@ void SV_Physics (void)
 
 		if (i > 0 && i <= svs.maxclients)
 			SV_Physics_Client (ent, i);
-		else if (ent->v.movetype == MOVETYPE_PUSH)
-			SV_Physics_Pusher (ent);
 		else if (ent->v.movetype == MOVETYPE_NONE)
 			SV_Physics_None (ent);
 		else if (ent->v.movetype == MOVETYPE_NOCLIP)

--- a/Quake/world.c
+++ b/Quake/world.c
@@ -296,6 +296,15 @@ SV_AreaTriggerEdicts ( edict_t *ent, areanode_t *node, edict_t **list, int *list
 		touch = EDICT_FROM_AREA(l);
 		if (touch == ent)
 			continue;
+		if (touch->v.solid == SOLID_TRIGGER && !touch->v.touch)
+		{
+			if (sys_step_debug.value > 1.0f && ((int)ent->v.flags & FL_CLIENT))
+			{
+				Con_Printf ("STEPDBG trigger_no_touch ent %s #%d trigger %s #%d\n",
+					PR_GetString (ent->v.classname), NUM_FOR_EDICT (ent),
+					PR_GetString (touch->v.classname), NUM_FOR_EDICT (touch));
+			}
+		}
 		if (!touch->v.touch || touch->v.solid != SOLID_TRIGGER)
 			continue;
 		if (ent->v.absmin[0] > touch->v.absmax[0]
@@ -969,4 +978,3 @@ trace_t SV_Move (vec3_t start, vec3_t mins, vec3_t maxs, vec3_t end, int type, e
 
 	return clip.trace;
 }
-


### PR DESCRIPTION
### Motivation
- Hunting a systemic single-player jitter/timing fault caused by inconsistent stepping, dt quantization, and input/physics ordering that made gameplay feel like it ran at a low/variable simulation rate.
- Provide low-overhead per-frame instrumentation to capture realtime/frametime, simulation tick counts/accumulators, input command timing and drops, and player ground/mover state so root causes can be diagnosed reliably.
- Ensure server simulation uses a robust fixed-tick microsecond accumulator to avoid integer truncation/quantization and eliminate spirals-of-death when many ticks need catch-up.

### Description
- Add diagnostics and controls: new cvars `sys_step_debug`, `sys_step_dump`, `sys_step_hitch_ms`, `sv_fixedtick`, and `sv_maxsteps_per_frame`, and the `sys_step_debug_info_t` struct to store per-frame info (declared in `quakedef.h`).
- Implement per-frame instrumentation in `host.c`: `Sys_StepDebug_BeginFrame`, `Sys_StepDebug_LogFrame`, `Host_SecondsToUsec`, and hooks in `_Host_Frame`/`Host_AdvanceTime`/`Host_ServerFrame` to capture and print STEPDBG/STEPWARN logs (timing, sv tick counts, accumulators, cmd msec stats, player ground/mover info, hitch warnings).
- Robust fixed-tick stepping in `Host_ServerFrame`: added integer microsecond accumulator (`sv_accum_us`), tick microsecond math, `sv_fixedtick` mode, `sv_maxsteps_per_frame` limit, safe clamping of accumulators (avoid spiral of death) and related debug warnings.
- Input/command timing fixes and telemetry in `cl_main.c`: use `host_rawframetime` when accumulating client cmd time, maintain `cl_cmd_accum_us` in microseconds, clamp/record `cmd.msec` derived from microsecond ticks, and record send/build/drop counters into `sys_step_debug_info` for diagnostics.
- Client prediction instrumentation in `cl_predict.c` and parsing hooks in `cl_parse.c` to count predict steps and parse calls in debug state.
- Reordered server physics in `sv_phys.c` to process mover/pusher (`MOVETYPE_PUSH`) entities first, then clients/others, to stabilize mover-to-player base velocity/groundent application; added player ground/mover trace and velocity capture for frame diagnostics.
- Touch/trigger debug in `world.c` to report trigger entities without touch handlers when a client passes through (helps reproduce missed pickups).
- Minimal logging increments added in `sv_phys.c`, `cl_main.c`, `cl_parse.c`, and `cl_predict.c` to populate the debug struct.
- Files touched: `Quake/host.c`, `Quake/quakedef.h`, `Quake/sv_main.c`, `Quake/sv_phys.c`, `Quake/cl_main.c`, `Quake/cl_parse.c`, `Quake/cl_predict.c`, `Quake/world.c`.
- Recommended test cvars: `sys_step_debug 1` (or `2` for more detail), `sys_step_dump 1` (one-shot dump), `sys_step_hitch_ms 50`, `sv_fixedtick 1` / `0` toggle, `sv_tickrate <rate>`, `sv_maxsteps_per_frame <N>`, and `cl_nolerp 0/1` for visual interpolation checking.

### Testing
- Automated tests: none were run for this change (no CI/automated test invoked during this rollout).
- Manual verification plan (suggested, not executed): start singleplayer with `sys_step_debug 1` and exercise scenarios that previously jittered (player movement, pickups, slopes, movers); observe `STEPDBG` output showing stable `tick_us`, non-zero `cl_cmd_msec_last`, no frequent `STEPWARN` messages, and stable `sv_ticks` per frame when `sv_fixedtick` is enabled.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983deec9800832e9b4ae806b6c66fc8)