### PR TITLE
Use Cvar_SetValueQuick to reset sys_step_dump

### DIFF
--- a/Quake/host.c
+++ b/Quake/host.c
@@ -994,7 +994,7 @@ static void Sys_StepDebug_LogFrame (void)
 	debug_level = (int)sys_step_debug.value;
 	dump_frame = sys_step_dump.value > 0.0f;
 	if (dump_frame)
-		Cvar_SetValue (&sys_step_dump, 0.0f);
+		Cvar_SetValueQuick (&sys_step_dump, 0.0f);
 
 	sys_step_debug_info.realtime = realtime;
 	sys_step_debug_info.host_frametime = host_frametime;


### PR DESCRIPTION
### Motivation
- Resolve a compilation warning C4133 (treated as an error) caused by using `Cvar_SetValue` with a `cvar_t *` and prevent build failure.

### Description
- Replace the call `Cvar_SetValue(&sys_step_dump, 0.0f);` with `Cvar_SetValueQuick(&sys_step_dump, 0.0f);` in `Quake/host.c` so the cvar-pointer setter is used.

### Testing
- No automated tests or build were run after this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983e8dc1878832e88e936eab65d1b4b)