### PR TITLE
Add jitter debug log mirror (jitter_log_enable, jitter_log_file)

### DIFF
--- a/Quake/cl_input.c
+++ b/Quake/cl_input.c
@@ -468,6 +468,11 @@ void CL_SendMove (const usercmd_t *cmd)
 				"cmd_ack=long cmd_count=byte ucmd_seq=long angles=short moves=short buttons=byte impulse=byte]\n",
 				realtime, buf.cursize, clc_move, cl.protocolflags, cmd->sequence,
 				cl.last_cmd_ack, cl.last_snapshot_ack_sent, reliable_seq, reliable_base);
+			JITTER_LOG ("NETDBG time %.3f cmd_move_write msg %d type %d flags 0x%x cmd_seq %u "
+				"cmd_ack %u snap_ack %u rel_seq %u rel_base %u widths[mtime=float cmd_seq=long "
+				"cmd_ack=long cmd_count=byte ucmd_seq=long angles=short moves=short buttons=byte impulse=byte]\n",
+				realtime, buf.cursize, clc_move, cl.protocolflags, cmd->sequence,
+				cl.last_cmd_ack, cl.last_snapshot_ack_sent, reliable_seq, reliable_base);
 		}
 	}
 

--- a/Quake/cl_main.c
+++ b/Quake/cl_main.c
@@ -276,6 +276,8 @@ static void CL_EnsureViewEntityOrigin (const char *reason)
 	{
 		Con_Printf ("NETDBG: viewentity origin repaired (%s): simorg=%f %f %f\n",
 			reason ? reason : "unknown", cl.simorg[0], cl.simorg[1], cl.simorg[2]);
+		JITTER_LOG ("NETDBG: viewentity origin repaired (%s): simorg=%f %f %f\n",
+			reason ? reason : "unknown", cl.simorg[0], cl.simorg[1], cl.simorg[2]);
 	}
 }
 
@@ -416,6 +418,27 @@ static void CL_NetDbg_LogMovement (const usercmd_t *cmd, qboolean sendcmd_ran)
 		cmd_accum_s, cmd_dt,
 		net_rx_seq, net_tx_seq, net_rel_recv_seq, net_rel_send_base, net_unrel_rx,
 		net_last_msg_age, net_last_send_age, net_rate_budget, net_can_send, net_disconnected);
+	JITTER_LOG ("NETDBG move signon %d has_full %d need_full %d viewent_init %d world %d paused %d intermission %d "
+		"vieworg %.1f %.1f %.1f simorg %.1f %.1f %.1f cmd %d %d %d predict %d sendcmd %d "
+		"cmd_seq %u cmd_ack %u ack_echo %u snap_ack %u cmd_accum %.4f cmd_dt %.4f "
+		"net_rx %u net_tx %u net_rel_rx %u net_rel_base %u net_unrel_rx %u "
+		"net_last_msg %.3f net_last_send %.3f net_budget %d net_can_send %d net_disc %d\n",
+		cls.signon,
+		cl.has_full_snapshot ? 1 : 0,
+		cl.need_full_snapshot ? 1 : 0,
+		cl_viewent_needs_init ? 1 : 0,
+		cl.worldmodel ? 1 : 0,
+		cl.paused ? 1 : 0,
+		cl.intermission ? 1 : 0,
+		vieworg[0], vieworg[1], vieworg[2],
+		cl.simorg[0], cl.simorg[1], cl.simorg[2],
+		forward, side, up,
+		CL_NetDbg_PredictRan () ? 1 : 0,
+		sendcmd_ran ? 1 : 0,
+		cmd_seq, cmd_ack, cmd_ack_echo, snap_ack,
+		cmd_accum_s, cmd_dt,
+		net_rx_seq, net_tx_seq, net_rel_recv_seq, net_rel_send_base, net_unrel_rx,
+		net_last_msg_age, net_last_send_age, net_rate_budget, net_can_send, net_disconnected);
 }
 
 static float CL_LerpAngle (float a, float b, float f)
@@ -532,6 +555,56 @@ void CL_JitterDebug_Log (void)
 	}
 
 	Con_Printf ("JITTERDBG cl.time %.3f realtime %.3f host_frametime %.4f interp_target %.3f interp_delay %.3f "
+		"pred_accum %.4f pred_step_dt %.4f pred_substeps %d/%d nullcmd %d ang_norm %d mouse_applied %d "
+		"pred_apply_reason %d render_apply_reason %d "
+		"server_applied %d pred_steps %d pred_err %.2f ang_err %.2f ang_delta %.2f %.2f %.2f "
+		"onground %d groundent %d ground_valid %d reason %d trace_frac %.2f trace_nz %.2f trace_ent %d trace_solid %d/%d trace_fallback %d "
+		"wishspeed %.1f wishvel_z %.1f dt %.4f flags %d ground_delta %.2f ground_yaw %.2f apply_pred %d apply_render %d "
+		"auth_org %.2f %.2f %.2f auth_ang %.2f %.2f %.2f "
+		"pred_org %.2f %.2f %.2f pred_ang %.2f %.2f %.2f "
+		"rend_org %.2f %.2f %.2f rend_ang %.2f %.2f %.2f\n",
+		cl.time, realtime, host_frametime, interp_target, interp_delay,
+		pred.pred_accum_time,
+		pred.pred_step_dt,
+		pred.pred_substeps,
+		pred.pred_max_substeps,
+		pred.pred_nullcmd,
+		pred.pred_angles_normalized,
+		IN_DidApplyMouseDelta () ? 1 : 0,
+		pred.pred_apply_pred_reason,
+		pred.pred_apply_render_reason,
+		pred.server_update_applied ? 1 : 0,
+		pred.prediction_steps,
+		pred.pred_error_len,
+		pred.pred_angle_error_len,
+		pred.pred_angle_delta_shortest[0],
+		pred.pred_angle_delta_shortest[1],
+		pred.pred_angle_delta_shortest[2],
+		pred.onground ? 1 : 0,
+		pred.groundent,
+		pred.ground_valid ? 1 : 0,
+		pred.ground_valid_reason,
+		pred.ground_trace_fraction,
+		pred.ground_trace_normal_z,
+		pred.ground_trace_ent,
+		pred.ground_trace_startsolid,
+		pred.ground_trace_allsolid,
+		pred.ground_trace_fallback,
+		pred.wishspeed,
+		pred.wishvel_z,
+		pred.cmd_frametime,
+		pred.flags,
+		pred.ground_delta_len,
+		pred.ground_yaw_delta,
+		pred.ground_apply_pred,
+		pred.ground_apply_render,
+		pred.base_origin[0], pred.base_origin[1], pred.base_origin[2],
+		pred.base_angles[0], pred.base_angles[1], pred.base_angles[2],
+		pred.predicted_origin[0], pred.predicted_origin[1], pred.predicted_origin[2],
+		pred.predicted_angles[0], pred.predicted_angles[1], pred.predicted_angles[2],
+		render_org[0], render_org[1], render_org[2],
+		render_ang[0], render_ang[1], render_ang[2]);
+	JITTER_LOG ("JITTERDBG cl.time %.3f realtime %.3f host_frametime %.4f interp_target %.3f interp_delay %.3f "
 		"pred_accum %.4f pred_step_dt %.4f pred_substeps %d/%d nullcmd %d ang_norm %d mouse_applied %d "
 		"pred_apply_reason %d render_apply_reason %d "
 		"server_applied %d pred_steps %d pred_err %.2f ang_err %.2f ang_delta %.2f %.2f %.2f "
@@ -2060,6 +2133,8 @@ void CL_SendCmd (void)
 	{
 		Con_Printf ("NETDBG cmdrate catchup clamped accum %.6f dt %.6f\n",
 			(double)cl_cmd_accum_us / 1000000.0, cmd_dt);
+		JITTER_LOG ("NETDBG cmdrate catchup clamped accum %.6f dt %.6f\n",
+			(double)cl_cmd_accum_us / 1000000.0, cmd_dt);
 	}
 
 	if (send_move)
@@ -2089,6 +2164,9 @@ void CL_SendCmd (void)
 		if (realtime >= cl_cmd_debug_next_time)
 		{
 			Con_Printf ("NETDBG cmdrate built %u sent_cmds %u packets %u cmd_dt %.4f accum %.4f\n",
+				cl_cmds_built_since_log, cl_cmds_sent_since_log, cl_cmd_packets_since_log,
+				cmd_dt, (double)cl_cmd_accum_us / 1000000.0);
+			JITTER_LOG ("NETDBG cmdrate built %u sent_cmds %u packets %u cmd_dt %.4f accum %.4f\n",
 				cl_cmds_built_since_log, cl_cmds_sent_since_log, cl_cmd_packets_since_log,
 				cmd_dt, (double)cl_cmd_accum_us / 1000000.0);
 			cl_cmds_built_since_log = 0;

--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -145,6 +145,7 @@ static void CL_NetHexDump (const byte *data, int len, int max)
 		return;
 
 	Con_Printf ("NETDBG: hexdump %d bytes\n", dump_len);
+	JITTER_LOG ("NETDBG: hexdump %d bytes\n", dump_len);
 	for (i = 0; i < dump_len; i += 16)
 	{
 		int j;
@@ -157,6 +158,7 @@ static void CL_NetHexDump (const byte *data, int len, int max)
 			out += q_snprintf (out, (size_t)(line + sizeof(line) - out), " %02x", data[i + j]);
 		*out = '\0';
 		Con_Printf ("%s\n", line);
+		JITTER_LOG ("%s\n", line);
 	}
 }
 
@@ -192,6 +194,8 @@ static void CL_NetDebugHeader (void)
 
 	Con_Printf ("NETDBG: msg len %d time %.3f state %d signon %d\n",
 		net_message.cursize, realtime, cls.state, cls.signon);
+	JITTER_LOG ("NETDBG: msg len %d time %.3f state %d signon %d\n",
+		net_message.cursize, realtime, cls.state, cls.signon);
 	if (cls.netcon)
 	{
 		double now = Sys_DoubleTime ();
@@ -217,10 +221,30 @@ static void CL_NetDebugHeader (void)
 			cls.netcon->canSend ? 1 : 0,
 			cls.netcon->disconnected ? 1 : 0,
 			last_msg_age, last_send_age);
+		JITTER_LOG ("NETDBG: from %s rseq %u sseq %u rack %u unrel %u "
+			"rmask 0x%x sbase %u rate_budget %d can_send %d disc %d "
+			"lastmsg %.3f lastsend %.3f\n",
+			NET_QSocketGetAddressString (cls.netcon),
+			cls.netcon->receiveSequence,
+			cls.netcon->sendSequence,
+			cls.netcon->reliableReceiveSequence,
+			cls.netcon->unreliableReceiveSequence,
+			cls.netcon->reliableReceiveMask,
+			cls.netcon->sendReliableBase,
+			cls.netcon->rate_budget,
+			cls.netcon->canSend ? 1 : 0,
+			cls.netcon->disconnected ? 1 : 0,
+			last_msg_age, last_send_age);
 	}
 	if (net_last_incoming.valid)
 	{
 		Con_Printf ("NETDBG: packet seq %u flags 0x%x len %u payload %u %s\n",
+			net_last_incoming.sequence,
+			net_last_incoming.flags,
+			net_last_incoming.packet_length,
+			net_last_incoming.payload_length,
+			net_last_incoming.unreliable ? "unreliable" : "reliable");
+		JITTER_LOG ("NETDBG: packet seq %u flags 0x%x len %u payload %u %s\n",
 			net_last_incoming.sequence,
 			net_last_incoming.flags,
 			net_last_incoming.packet_length,
@@ -238,14 +262,23 @@ static void CL_NetHexDumpTail (const byte *data, int len, int tail)
 	int dump_len = q_min (tail, len);
 	int start = len - dump_len;
 	int i;
+	char line[256];
+	char *out = line;
+	char *line_end = line + sizeof(line);
 
 	if (dump_len <= 0)
 		return;
 
 	Con_Printf ("NETDBG: tail %d bytes (cursize %d):", dump_len, len);
+	out += q_snprintf (out, (size_t)(line_end - out), "NETDBG: tail %d bytes (cursize %d):", dump_len, len);
 	for (i = 0; i < dump_len; i++)
+	{
 		Con_Printf (" %02x", data[start + i]);
+		out += q_snprintf (out, (size_t)(line_end - out), " %02x", data[start + i]);
+	}
 	Con_Printf ("\n");
+	out += q_snprintf (out, (size_t)(line_end - out), "\n");
+	JITTER_LOG ("%s", line);
 }
 
 static void CL_BadServerMessage (const char *reason, int cmd, int cmd_offset,
@@ -254,7 +287,14 @@ static void CL_BadServerMessage (const char *reason, int cmd, int cmd_offset,
 	if (cl_netdebug_parse.value || cl_netdebug_hexdump.value)
 	{
 		Con_Printf ("NETDBG: bad server message: %s\n", reason);
+		JITTER_LOG ("NETDBG: bad server message: %s\n", reason);
 		Con_Printf ("NETDBG: readcount %d/%d cmd %d (%s) @%d last %d (%s) @%d prev %d (%s) @%d badread %d\n",
+			msg_readcount, net_message.cursize,
+			cmd, CL_SvcName (cmd), cmd_offset,
+			lastcmd, CL_SvcName (lastcmd), lastcmd_offset,
+			prevcmd, CL_SvcName (prevcmd), prevcmd_offset,
+			msg_badread);
+		JITTER_LOG ("NETDBG: readcount %d/%d cmd %d (%s) @%d last %d (%s) @%d prev %d (%s) @%d badread %d\n",
 			msg_readcount, net_message.cursize,
 			cmd, CL_SvcName (cmd), cmd_offset,
 			lastcmd, CL_SvcName (lastcmd), lastcmd_offset,
@@ -267,7 +307,11 @@ static void CL_BadServerMessage (const char *reason, int cmd, int cmd_offset,
 	if (cls.signon < SIGNONS)
 	{
 		Con_Printf ("NETDBG: disconnecting due to parse error: %s\n", reason);
+		JITTER_LOG ("NETDBG: disconnecting due to parse error: %s\n", reason);
 		Con_Printf ("NETDBG: last svc %d (%s) @%d readpos %d cursize %d state %d signon %d\n",
+			cmd, CL_SvcName (cmd), cmd_offset, msg_readcount, net_message.cursize,
+			(int)cls.state, (int)cls.signon);
+		JITTER_LOG ("NETDBG: last svc %d (%s) @%d readpos %d cursize %d state %d signon %d\n",
 			cmd, CL_SvcName (cmd), cmd_offset, msg_readcount, net_message.cursize,
 			(int)cls.state, (int)cls.signon);
 		CL_NetHexDumpTail (net_message.data, net_message.cursize, 64);
@@ -798,6 +842,8 @@ static void CL_EnsureViewEntityOrigin (const char *reason)
 	{
 		Con_Printf ("NETDBG: viewentity origin repaired (%s): simorg=%f %f %f\n",
 			reason ? reason : "unknown", cl.simorg[0], cl.simorg[1], cl.simorg[2]);
+		JITTER_LOG ("NETDBG: viewentity origin repaired (%s): simorg=%f %f %f\n",
+			reason ? reason : "unknown", cl.simorg[0], cl.simorg[1], cl.simorg[2]);
 	}
 }
 
@@ -1194,6 +1240,8 @@ static void CL_UpdateServerTimeEstimate (double server_time, const char *source)
 		{
 			Con_Printf ("NETDBG: server_time non-monotonic %.3f < %.3f (%s)\n",
 				server_time, cl.latest_server_time, source ? source : "unknown");
+			JITTER_LOG ("NETDBG: server_time non-monotonic %.3f < %.3f (%s)\n",
+				server_time, cl.latest_server_time, source ? source : "unknown");
 		}
 		server_time = cl.latest_server_time;
 	}
@@ -1228,6 +1276,8 @@ static double CL_ClampSnapshotServerTime (double snap_time, unsigned int seq)
 		if (cl_netdbg_interp.value > 0.0f)
 		{
 			Con_Printf ("NETDBG: snap_time non-monotonic %.3f < %.3f seq %u\n",
+				snap_time, cl.snap_last_server_time, seq);
+			JITTER_LOG ("NETDBG: snap_time non-monotonic %.3f < %.3f seq %u\n",
 				snap_time, cl.snap_last_server_time, seq);
 		}
 		snap_time = cl.snap_last_server_time;
@@ -1685,16 +1735,34 @@ static void CL_NetDbg_LogWatchEnt (const snapshot_header_t *header, int removed)
 		watch, header->seq, header->base_seq, status, reason,
 		state->state.origin[0], state->state.origin[1], state->state.origin[2],
 		state->velocity[0], state->velocity[1], state->velocity[2]);
+	{
+		char line[512];
+		char *out = line;
+		char *line_end = line + sizeof(line);
+
+		out += q_snprintf (out, (size_t)(line_end - out),
+			"NETDBG: watch_ent %d seq %u base %u state %s reason %s origin %.1f %.1f %.1f "
+			"vel %d %d %d",
+			watch, header->seq, header->base_seq, status, reason,
+			state->state.origin[0], state->state.origin[1], state->state.origin[2],
+			state->velocity[0], state->velocity[1], state->velocity[2]);
 
 	if (newest)
 	{
 		Con_Printf (" snap0 %.1f %.1f %.1f", newest->origin[0], newest->origin[1], newest->origin[2]);
+		out += q_snprintf (out, (size_t)(line_end - out), " snap0 %.1f %.1f %.1f",
+			newest->origin[0], newest->origin[1], newest->origin[2]);
 	}
 	if (prev)
 	{
 		Con_Printf (" snap1 %.1f %.1f %.1f", prev->origin[0], prev->origin[1], prev->origin[2]);
+		out += q_snprintf (out, (size_t)(line_end - out), " snap1 %.1f %.1f %.1f",
+			prev->origin[0], prev->origin[1], prev->origin[2]);
 	}
 	Con_Printf ("\n");
+	out += q_snprintf (out, (size_t)(line_end - out), "\n");
+	JITTER_LOG ("%s", line);
+	}
 }
 
 static double CL_GetInterpDelaySecondsDebug (void)
@@ -1782,6 +1850,18 @@ static void CL_NetDbg_LogInterpSnapshot (const snapshot_header_t *header, int re
 	CL_CountSnapshotEntities (prev_present, cl.snapshot_present, &total, &created, &missing, &dormant);
 
 	Con_Printf ("NETDBG: interp seq %u base %u srvtime %.3f arrival_dt %.3f "
+		"render_time %.3f interp_delay %.3f buf_oldest %.3f buf_newest %.3f buf_fill_ms %.1f "
+		"render_gap_ms oldest %.1f newest %.1f srvnow %.3f srv_skew_age %.3f snap_age %.3f "
+		"ents total %d created %d removed %d missing %d dormant %d "
+		"snap_seq last %u complete %u incomplete %u need_full %d delta_mismatch %d parse_err %d incomplete_cnt %d\n",
+		header->seq, header->base_seq, server_time,
+		arrival_dt, render_time, interp_delay, oldest, newest, buffer_fill_ms,
+		render_vs_oldest_ms, render_vs_newest_ms, server_now, server_skew_age, snap_age,
+		total, created, removes_parsed, missing, dormant,
+		cl.snap_last_applied_seq, cl.snap_last_complete_seq, cl.snap_last_incomplete_seq,
+		cl.need_full_snapshot ? 1 : 0, cl.snap_delta_mismatch, cl.snap_parse_errors,
+		cl.snap_incomplete_count);
+	JITTER_LOG ("NETDBG: interp seq %u base %u srvtime %.3f arrival_dt %.3f "
 		"render_time %.3f interp_delay %.3f buf_oldest %.3f buf_newest %.3f buf_fill_ms %.1f "
 		"render_gap_ms oldest %.1f newest %.1f srvnow %.3f srv_skew_age %.3f snap_age %.3f "
 		"ents total %d created %d removed %d missing %d dormant %d "
@@ -3683,6 +3763,8 @@ void CL_ParseServerMessage (void)
 		}
 		if (cl_netdebug_parse.value)
 			Con_Printf ("NETDBG: cmd %s (%d) @%d\n", CL_SvcName (cmd), cmd, cmd_offset);
+		if (cl_netdebug_parse.value)
+			JITTER_LOG ("NETDBG: cmd %s (%d) @%d\n", CL_SvcName (cmd), cmd, cmd_offset);
 
 	// other commands
 		switch (cmd)
@@ -4050,6 +4132,8 @@ void CL_ParseServerMessage (void)
 			if (cmd_end < cmd_offset)
 				cmd_end = cmd_offset;
 			Con_Printf ("NETDBG: cmd %s end %d bytes %d\n",
+				CL_SvcName (cmd), cmd_end, cmd_end - cmd_offset);
+			JITTER_LOG ("NETDBG: cmd %s end %d bytes %d\n",
 				CL_SvcName (cmd), cmd_end, cmd_end - cmd_offset);
 		}
 

--- a/Quake/cl_predict.c
+++ b/Quake/cl_predict.c
@@ -164,6 +164,8 @@ static void CL_EnsureViewEntityOrigin (const char *reason)
 	{
 		Con_Printf ("NETDBG: viewentity origin repaired (%s): simorg=%f %f %f\n",
 			reason ? reason : "unknown", cl.simorg[0], cl.simorg[1], cl.simorg[2]);
+		JITTER_LOG ("NETDBG: viewentity origin repaired (%s): simorg=%f %f %f\n",
+			reason ? reason : "unknown", cl.simorg[0], cl.simorg[1], cl.simorg[2]);
 	}
 }
 
@@ -536,6 +538,8 @@ static void CL_Predict_RunFrameSteps (void)
 	{
 		Con_Printf ("JITTERDBG pred_accum %.4f step_dt %.4f steps %d render_frac %.3f\n",
 			cl_pred_frame_accum, step_dt, steps, cl_pred_render_frac);
+		JITTER_LOG ("JITTERDBG pred_accum %.4f step_dt %.4f steps %d render_frac %.3f\n",
+			cl_pred_frame_accum, step_dt, steps, cl_pred_render_frac);
 	}
 }
 
@@ -588,12 +592,17 @@ static void CL_Predict_ApplyToClient (const cl_pred_state_t *state, qboolean is_
 			cl.has_full_snapshot ? 1 : 0,
 			cl.snapshot_present ? 1 : 0,
 			cl.mtime[0]);
+		JITTER_LOG ("NETDBG: prediction apply without valid snapshot (full %d present %d mtime %.3f)\n",
+			cl.has_full_snapshot ? 1 : 0,
+			cl.snapshot_present ? 1 : 0,
+			cl.mtime[0]);
 		cl_pred_warned_no_snapshot = true;
 	}
 
 	if (!CL_Predict_Vec3IsFinite (state->origin) || !CL_Predict_Vec3IsFinite (state->velocity))
 	{
 		Con_Printf ("NETDBG: prediction apply with invalid state origin/velocity\n");
+		JITTER_LOG ("NETDBG: prediction apply with invalid state origin/velocity\n");
 		VectorClear (cl_pred_error);
 		VectorClear (cl_pred_angle_error);
 		return;
@@ -611,6 +620,7 @@ static void CL_Predict_ApplyToClient (const cl_pred_state_t *state, qboolean is_
 	if (!CL_Predict_Vec3IsFinite (cl_pred_error) || !CL_Predict_Vec3IsFinite (cl_pred_angle_error))
 	{
 		Con_Printf ("NETDBG: prediction apply with invalid error vectors\n");
+		JITTER_LOG ("NETDBG: prediction apply with invalid error vectors\n");
 		VectorClear (cl_pred_error);
 		VectorClear (cl_pred_angle_error);
 	}
@@ -619,6 +629,7 @@ static void CL_Predict_ApplyToClient (const cl_pred_state_t *state, qboolean is_
 	if (!isfinite (frame_dt) || frame_dt < 0.0f)
 	{
 		Con_Printf ("NETDBG: prediction apply with invalid host_frametime %.4f\n", frame_dt);
+		JITTER_LOG ("NETDBG: prediction apply with invalid host_frametime %.4f\n", frame_dt);
 		frame_dt = 0.0f;
 	}
 
@@ -660,6 +671,8 @@ static void CL_Predict_ApplyToClient (const cl_pred_state_t *state, qboolean is_
 		if (cl_netdbg_pred.value > 0.0f)
 		{
 			Con_Printf ("NETDBG: pred_smooth apply %.2f remaining %.2f\n",
+				VectorLength (correction), VectorLength (cl_pred_error));
+			JITTER_LOG ("NETDBG: pred_smooth apply %.2f remaining %.2f\n",
 				VectorLength (correction), VectorLength (cl_pred_error));
 		}
 	}
@@ -795,6 +808,8 @@ static void CL_Predict_LogSolidTrace (const char *context, const trace_t *trace)
 	{
 		Con_Printf ("NETDBG: prediction trace %s startsolid=%d allsolid=%d\n",
 			context ? context : "unknown", trace->startsolid, trace->allsolid);
+		JITTER_LOG ("NETDBG: prediction trace %s startsolid=%d allsolid=%d\n",
+			context ? context : "unknown", trace->startsolid, trace->allsolid);
 		cl_pred_warned_solid = true;
 	}
 }
@@ -878,6 +893,8 @@ static qboolean CL_Predict_GetGroundMotion (cl_pred_state_t *state, int grounden
 		{
 			Con_Printf ("NETDBG: pred ground invalid ent=%d mtime=%.3f\n",
 				groundent, cl.mtime[0]);
+			JITTER_LOG ("NETDBG: pred ground invalid ent=%d mtime=%.3f\n",
+				groundent, cl.mtime[0]);
 		}
 		return false;
 	}
@@ -936,6 +953,8 @@ static qboolean CL_Predict_ApplyGroundMotion (cl_pred_state_t *state, int ground
 		{
 			Con_Printf ("NETDBG: pred groundent invalid ent=%d full=%d mtime=%.3f\n",
 				groundent, cl.has_full_snapshot ? 1 : 0, cl.mtime[0]);
+			JITTER_LOG ("NETDBG: pred groundent invalid ent=%d full=%d mtime=%.3f\n",
+				groundent, cl.has_full_snapshot ? 1 : 0, cl.mtime[0]);
 		}
 		if (groundent <= 0 || groundent >= cl_max_edicts)
 			SDL_assert (!"prediction groundent out of range");
@@ -976,6 +995,15 @@ static qboolean CL_Predict_ApplyGroundMotion (cl_pred_state_t *state, int ground
 				delta_raw[i] = ent->msg_origins[0][i] - ent->msg_origins[1][i];
 
 			Con_Printf ("JITTERDBG groundent %d msg_origins0 %.2f %.2f %.2f msg_origins1 %.2f %.2f %.2f msg_dt %.4f yaw0 %.2f yaw1 %.2f yaw_raw %.2f platform_delta_raw %.3f %.3f %.3f ground_delta %.3f %.3f %.3f mouse_applied %d\n",
+				groundent,
+				ent->msg_origins[0][0], ent->msg_origins[0][1], ent->msg_origins[0][2],
+				ent->msg_origins[1][0], ent->msg_origins[1][1], ent->msg_origins[1][2],
+				msg_dt,
+				ent->msg_angles[0][YAW], ent->msg_angles[1][YAW], yaw_raw,
+				delta_raw[0], delta_raw[1], delta_raw[2],
+				state->pred_ground_offset[0], state->pred_ground_offset[1], state->pred_ground_offset[2],
+				IN_DidApplyMouseDelta () ? 1 : 0);
+			JITTER_LOG ("JITTERDBG groundent %d msg_origins0 %.2f %.2f %.2f msg_origins1 %.2f %.2f %.2f msg_dt %.4f yaw0 %.2f yaw1 %.2f yaw_raw %.2f platform_delta_raw %.3f %.3f %.3f ground_delta %.3f %.3f %.3f mouse_applied %d\n",
 				groundent,
 				ent->msg_origins[0][0], ent->msg_origins[0][1], ent->msg_origins[0][2],
 				ent->msg_origins[1][0], ent->msg_origins[1][1], ent->msg_origins[1][2],
@@ -1277,6 +1305,7 @@ static void CL_Predict_SimulateCmd (cl_pred_state_t *state, const usercmd_t *cmd
 	if (state->onground && groundent == 0 && cl_netdebug_parse.value)
 	{
 		Con_Printf ("NETDBG: pred onground without ground entity (groundent 0)\n");
+		JITTER_LOG ("NETDBG: pred onground without ground entity (groundent 0)\n");
 	}
 
 	ground_entity = (state->onground && groundent > 0);
@@ -1305,6 +1334,8 @@ static void CL_Predict_SimulateCmd (cl_pred_state_t *state, const usercmd_t *cmd
 	if (cl_netdebug_parse.value && ground_entity && !state->ground_valid)
 	{
 		Con_Printf ("NETDBG: pred ground missing ent=%d mtime=%.3f\n",
+			groundent, cl.mtime[0]);
+		JITTER_LOG ("NETDBG: pred ground missing ent=%d mtime=%.3f\n",
 			groundent, cl.mtime[0]);
 	}
 
@@ -1381,6 +1412,7 @@ static void CL_Predict_SimulateCmd (cl_pred_state_t *state, const usercmd_t *cmd
 			if (cl_netdebug_parse.value)
 			{
 				Con_Printf ("NETDBG: pred onground without ground entity (post-move)\n");
+				JITTER_LOG ("NETDBG: pred onground without ground entity (post-move)\n");
 			}
 		}
 	}
@@ -1496,6 +1528,8 @@ void CL_Predict_BeginFrame (void)
 	{
 		Con_Printf ("PREDACCUM dt %.4f accum %.4f step_dt %.4f\n",
 			host_frametime, cl_pred_frame_accum, cl_pred_last_substep_dt);
+		JITTER_LOG ("PREDACCUM dt %.4f accum %.4f step_dt %.4f\n",
+			host_frametime, cl_pred_frame_accum, cl_pred_last_substep_dt);
 	}
 
 	if (!enabled)
@@ -1540,6 +1574,8 @@ void CL_Predict_SetupCmd (usercmd_t *cmd)
 		host_dt = host_frametime;
 		CL_Predict_GetSubstepInfo (cmd_dt, host_dt, &substeps, &dt_sub);
 		Con_Printf ("JITTERDBG setup seq %u cmd_dt %.4f host_dt %.4f substeps %d dt_sub %.4f mouse_applied %d\n",
+			cmd->sequence, cmd_dt, host_dt, substeps, dt_sub, IN_DidApplyMouseDelta () ? 1 : 0);
+		JITTER_LOG ("JITTERDBG setup seq %u cmd_dt %.4f host_dt %.4f substeps %d dt_sub %.4f mouse_applied %d\n",
 			cmd->sequence, cmd_dt, host_dt, substeps, dt_sub, IN_DidApplyMouseDelta () ? 1 : 0);
 	}
 	CL_Predict_DebugLogCmd ("setup", cmd, cmd_dt);
@@ -1606,6 +1642,10 @@ void CL_Predict_ServerUpdate (unsigned int ack, const vec3_t origin, const vec3_
 				correction,
 				origin[0], origin[1], origin[2],
 				cl.simorg[0], cl.simorg[1], cl.simorg[2]);
+			JITTER_LOG ("NETDBG: prediction correction %.1f units (server %f %f %f, client %f %f %f)\n",
+				correction,
+				origin[0], origin[1], origin[2],
+				cl.simorg[0], cl.simorg[1], cl.simorg[2]);
 		}
 	}
 
@@ -1624,10 +1664,34 @@ void CL_Predict_ServerUpdate (unsigned int ack, const vec3_t origin, const vec3_
 				error_len,
 				origin[0], origin[1], origin[2],
 				cl_pred.predicted.origin[0], cl_pred.predicted.origin[1], cl_pred.predicted.origin[2]);
+			JITTER_LOG ("NETDBG: pred_error %.2f (server %.1f %.1f %.1f client %.1f %.1f %.1f)\n",
+				error_len,
+				origin[0], origin[1], origin[2],
+				cl_pred.predicted.origin[0], cl_pred.predicted.origin[1], cl_pred.predicted.origin[2]);
 		}
 		if (cl_jitter_debug.value > 0.0f && error_len >= 2.0f)
 		{
 			Con_Printf ("JITTERDBG ground onground %d groundent %d ground_valid %d reason %d trace_frac %.2f trace_nz %.2f trace_ent %d trace_solid %d/%d trace_fallback %d wishspeed %.1f wishvel_z %.1f dt %.4f flags %d ground_delta %.2f ground_yaw %.2f apply_pred %d apply_render %d mouse_applied %d\n",
+				cl_pred_ground_dbg.onground ? 1 : 0,
+				cl_pred_ground_dbg.groundent,
+				cl_pred_ground_dbg.ground_valid ? 1 : 0,
+				cl_pred_ground_dbg.ground_valid_reason,
+				cl_pred_ground_dbg.ground_trace_fraction,
+				cl_pred_ground_dbg.ground_trace_normal_z,
+				cl_pred_ground_dbg.ground_trace_ent,
+				cl_pred_ground_dbg.ground_trace_startsolid,
+				cl_pred_ground_dbg.ground_trace_allsolid,
+				cl_pred_ground_dbg.ground_trace_fallback,
+				cl_pred_ground_dbg.wishspeed,
+				cl_pred_ground_dbg.wishvel_z,
+				cl_pred_ground_dbg.cmd_frametime,
+				cl_pred_ground_dbg.flags,
+				cl_pred_ground_dbg.ground_delta_len,
+				cl_pred_ground_dbg.ground_yaw_delta,
+				cl_pred_ground_dbg.ground_apply_pred,
+				cl_pred_ground_dbg.ground_apply_render,
+				IN_DidApplyMouseDelta () ? 1 : 0);
+			JITTER_LOG ("JITTERDBG ground onground %d groundent %d ground_valid %d reason %d trace_frac %.2f trace_nz %.2f trace_ent %d trace_solid %d/%d trace_fallback %d wishspeed %.1f wishvel_z %.1f dt %.4f flags %d ground_delta %.2f ground_yaw %.2f apply_pred %d apply_render %d mouse_applied %d\n",
 				cl_pred_ground_dbg.onground ? 1 : 0,
 				cl_pred_ground_dbg.groundent,
 				cl_pred_ground_dbg.ground_valid ? 1 : 0,
@@ -1710,6 +1774,7 @@ void CL_Predict_ServerUpdate (unsigned int ack, const vec3_t origin, const vec3_
 		if (groundent == 0 && cl_netdebug_parse.value)
 		{
 			Con_Printf ("NETDBG: server onground without ground entity (groundent 0)\n");
+			JITTER_LOG ("NETDBG: server onground without ground entity (groundent 0)\n");
 		}
 		if (groundent > 0)
 		{
@@ -1788,6 +1853,8 @@ void CL_Predict_ServerUpdate (unsigned int ack, const vec3_t origin, const vec3_
 		if (cl_jitter_debug.value > 0.0f)
 		{
 			Con_Printf ("JITTERDBG resim seq %u cmd_dt %.4f host_dt %.4f substeps %d dt_sub %.4f mouse_applied %d\n",
+				cmd.sequence, cmd_dt, host_dt, substeps, dt_sub, IN_DidApplyMouseDelta () ? 1 : 0);
+			JITTER_LOG ("JITTERDBG resim seq %u cmd_dt %.4f host_dt %.4f substeps %d dt_sub %.4f mouse_applied %d\n",
 				cmd.sequence, cmd_dt, host_dt, substeps, dt_sub, IN_DidApplyMouseDelta () ? 1 : 0);
 		}
 		for (i = 0; i < substeps; i++)

--- a/Quake/common.c
+++ b/Quake/common.c
@@ -31,6 +31,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include <limits.h>
 #include "miniz.h"
 #include "unicode_translit.h"
+#include <stdarg.h>
 
 static const char	*largv[MAX_NUM_ARGVS + 1];
 static char	argvdummy[] = " ";
@@ -38,6 +39,92 @@ static char	argvdummy[] = " ";
 int		safemode;
 
 cvar_t	registered = {"registered","1",CVAR_ROM}; /* set to correct value in COM_CheckRegistered() */
+cvar_t	jitter_log_enable = {"jitter_log_enable", "0", CVAR_NONE};
+cvar_t	jitter_log_file = {"jitter_log_file", "jitter_debug.log", CVAR_NONE};
+
+static FILE *jitter_log_fp;
+static qboolean jitter_log_tried;
+
+static const char *Jitter_LogContext (void)
+{
+	if (sv.active && (cls.state == ca_disconnected || cls.state == ca_dedicated))
+		return "SV";
+	return "CL";
+}
+
+static const char *Jitter_LogPath (char *buffer, size_t buffer_size)
+{
+	const char *filename = jitter_log_file.string;
+
+	if (!filename || !filename[0])
+		return NULL;
+
+	if (host_parms && host_parms->userdir && host_parms->userdir[0])
+		q_snprintf (buffer, buffer_size, "%s/%s", host_parms->userdir, filename);
+	else if (host_parms && host_parms->basedir && host_parms->basedir[0])
+		q_snprintf (buffer, buffer_size, "%s/%s", host_parms->basedir, filename);
+	else
+		q_snprintf (buffer, buffer_size, "%s", filename);
+
+	return buffer;
+}
+
+void Jitter_Log_Close (void)
+{
+	if (jitter_log_fp)
+	{
+		fclose (jitter_log_fp);
+		jitter_log_fp = NULL;
+	}
+	jitter_log_tried = false;
+}
+
+void Jitter_LogV (const char *fmt, va_list argptr)
+{
+	char text[4096];
+	int len;
+	int prefix_len;
+
+	if (jitter_log_enable.value <= 0.0f)
+		return;
+
+	if (!jitter_log_fp && !jitter_log_tried)
+	{
+		char path[MAX_OSPATH];
+		const char *logpath = Jitter_LogPath (path, sizeof(path));
+
+		jitter_log_tried = true;
+		if (logpath)
+			jitter_log_fp = Sys_fopen (logpath, "ab");
+	}
+
+	if (!jitter_log_fp)
+		return;
+
+	prefix_len = q_snprintf (text, sizeof(text), "[%.3f][%d][%s] ",
+		realtime, host_framecount, Jitter_LogContext ());
+	if (prefix_len < 0)
+		return;
+	if (prefix_len >= (int)sizeof(text))
+		prefix_len = (int)sizeof(text) - 1;
+
+	len = q_vsnprintf (text + prefix_len, sizeof(text) - (size_t)prefix_len, fmt, argptr);
+	if (len < 0)
+		return;
+	if (len >= (int)(sizeof(text) - (size_t)prefix_len))
+		len = (int)(sizeof(text) - (size_t)prefix_len) - 1;
+
+	fwrite (text, 1, (size_t)(prefix_len + len), jitter_log_fp);
+}
+
+void Jitter_Log (const char *fmt, ...)
+{
+	va_list argptr;
+
+	va_start (argptr, fmt);
+	Jitter_LogV (fmt, argptr);
+	va_end (argptr);
+}
 cvar_t	standalone = {"standalone","0"}; /* allow standalone mods without pak0/CRC gating */
 cvar_t	cmdline = {"cmdline","",CVAR_ROM/*|CVAR_SERVERINFO*/}; /* sending cmdline upon CCREQ_RULE_INFO is evil */
 cvar_t	language = {"language","auto",CVAR_ARCHIVE}; /* for 2021 rerelease text */

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -4119,6 +4119,7 @@ static void R_ShowBoundingBoxes (void)
 	if (!sv_player)
 	{
 		Con_Printf ("NETDBG sv_player NULL cl %d reason showbboxes\n", SV_CurrentClientIndex ());
+		JITTER_LOG ("NETDBG sv_player NULL cl %d reason showbboxes\n", SV_CurrentClientIndex ());
 		SV_PlayerNullTrap (__func__, 0);
 		return;
 	}

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -359,6 +359,7 @@ static void R_ShowbboxesFilter_Completion_f (const char *partial)
 	if (!sv_player)
 	{
 		Con_Printf ("NETDBG sv_player NULL cl %d reason showbboxes_filter_completion\n", SV_CurrentClientIndex ());
+		JITTER_LOG ("NETDBG sv_player NULL cl %d reason showbboxes_filter_completion\n", SV_CurrentClientIndex ());
 		SV_PlayerNullTrap (__func__, 0);
 		return;
 	}

--- a/Quake/host.c
+++ b/Quake/host.c
@@ -520,6 +520,8 @@ void Host_InitLocal (void)
 	Cvar_RegisterVariable (&sys_step_debug);
 	Cvar_RegisterVariable (&sys_step_dump);
 	Cvar_RegisterVariable (&sys_step_hitch_ms);
+	Cvar_RegisterVariable (&jitter_log_enable);
+	Cvar_RegisterVariable (&jitter_log_file);
 
 	Cvar_RegisterVariable (&fraglimit);
 	Cvar_RegisterVariable (&timelimit);
@@ -1016,7 +1018,23 @@ static void Sys_StepDebug_LogFrame (void)
 		sys_step_debug_info.cl_time,
 		sys_step_debug_info.cl_servertime,
 		sys_step_debug_info.cl_snapshot_time);
+	JITTER_LOG ("STEPDBG frame %d rt %.6f ft %.6f raw %.6f cl.time %.6f cl.srv %.6f cl.snap %.6f\n",
+		sys_step_debug_info.frame,
+		sys_step_debug_info.realtime,
+		sys_step_debug_info.host_frametime,
+		sys_step_debug_info.host_rawframetime,
+		sys_step_debug_info.cl_time,
+		sys_step_debug_info.cl_servertime,
+		sys_step_debug_info.cl_snapshot_time);
 	Con_Printf ("STEPDBG sv ticks %d phys %d tick_us %lld frame_us %lld accum %lld->%lld maxsteps %d\n",
+		sys_step_debug_info.sv_ticks,
+		sys_step_debug_info.sv_physics_calls,
+		(long long)sys_step_debug_info.tick_us,
+		(long long)sys_step_debug_info.frame_us,
+		(long long)sys_step_debug_info.sv_accum_us_before,
+		(long long)sys_step_debug_info.sv_accum_us_after,
+		(int)(sv_maxsteps_per_frame.value > 0 ? sv_maxsteps_per_frame.value : sv_tick_maxcatchup.value));
+	JITTER_LOG ("STEPDBG sv ticks %d phys %d tick_us %lld frame_us %lld accum %lld->%lld maxsteps %d\n",
 		sys_step_debug_info.sv_ticks,
 		sys_step_debug_info.sv_physics_calls,
 		(long long)sys_step_debug_info.tick_us,
@@ -1034,7 +1052,26 @@ static void Sys_StepDebug_LogFrame (void)
 		sys_step_debug_info.cl_cmd_packets,
 		(long long)sys_step_debug_info.cl_cmd_accum_us_before,
 		(long long)sys_step_debug_info.cl_cmd_accum_us_after);
+	JITTER_LOG ("STEPDBG cl sendcmd %d read %d parse %d predsteps %d cmds built %d sent %d packets %d accum %lld->%lld\n",
+		sys_step_debug_info.cl_sendcmd_calls,
+		sys_step_debug_info.cl_readfromserver_calls,
+		sys_step_debug_info.cl_parse_calls,
+		sys_step_debug_info.cl_pred_steps,
+		sys_step_debug_info.cl_cmds_built,
+		sys_step_debug_info.cl_cmds_sent,
+		sys_step_debug_info.cl_cmd_packets,
+		(long long)sys_step_debug_info.cl_cmd_accum_us_before,
+		(long long)sys_step_debug_info.cl_cmd_accum_us_after);
 	Con_Printf ("STEPDBG cmd msec min %d max %d last %d no_cmd %d dropped %d wild %d zero %d over %d\n",
+		cmd_msec_min,
+		cmd_msec_max,
+		sys_step_debug_info.cl_cmd_msec_last,
+		sys_step_debug_info.cl_cmd_no_cmd,
+		sys_step_debug_info.cl_cmds_dropped,
+		sys_step_debug_info.cl_cmd_msec_wild,
+		sys_step_debug_info.cl_cmd_msec_zero,
+		sys_step_debug_info.cl_cmd_msec_over);
+	JITTER_LOG ("STEPDBG cmd msec min %d max %d last %d no_cmd %d dropped %d wild %d zero %d over %d\n",
 		cmd_msec_min,
 		cmd_msec_max,
 		sys_step_debug_info.cl_cmd_msec_last,
@@ -1059,7 +1096,31 @@ static void Sys_StepDebug_LogFrame (void)
 			sys_step_debug_info.player_vel_after[0],
 			sys_step_debug_info.player_vel_after[1],
 			sys_step_debug_info.player_vel_after[2]);
+		JITTER_LOG ("STEPDBG player org %.2f %.2f %.2f -> %.2f %.2f %.2f vel %.2f %.2f %.2f -> %.2f %.2f %.2f\n",
+			sys_step_debug_info.player_origin_before[0],
+			sys_step_debug_info.player_origin_before[1],
+			sys_step_debug_info.player_origin_before[2],
+			sys_step_debug_info.player_origin_after[0],
+			sys_step_debug_info.player_origin_after[1],
+			sys_step_debug_info.player_origin_after[2],
+			sys_step_debug_info.player_vel_before[0],
+			sys_step_debug_info.player_vel_before[1],
+			sys_step_debug_info.player_vel_before[2],
+			sys_step_debug_info.player_vel_after[0],
+			sys_step_debug_info.player_vel_after[1],
+			sys_step_debug_info.player_vel_after[2]);
 		Con_Printf ("STEPDBG player onground %d->%d groundent %d->%d trace frac %.3f normalz %.3f mover %d gvel %.2f %.2f %.2f\n",
+			sys_step_debug_info.player_onground_before,
+			sys_step_debug_info.player_onground_after,
+			sys_step_debug_info.player_groundent_before,
+			sys_step_debug_info.player_groundent_after,
+			sys_step_debug_info.player_ground_trace_fraction,
+			sys_step_debug_info.player_ground_trace_normal_z,
+			sys_step_debug_info.player_ground_is_mover,
+			sys_step_debug_info.player_ground_vel[0],
+			sys_step_debug_info.player_ground_vel[1],
+			sys_step_debug_info.player_ground_vel[2]);
+		JITTER_LOG ("STEPDBG player onground %d->%d groundent %d->%d trace frac %.3f normalz %.3f mover %d gvel %.2f %.2f %.2f\n",
 			sys_step_debug_info.player_onground_before,
 			sys_step_debug_info.player_onground_after,
 			sys_step_debug_info.player_groundent_before,
@@ -1080,17 +1141,28 @@ static void Sys_StepDebug_LogFrame (void)
 		Con_Printf ("STEPWARN sim dt is zero\n");
 	if (sys_step_debug_info.warn_many_ticks)
 		Con_Printf ("STEPWARN max ticks exceeded in frame\n");
+	if (sys_step_debug_info.warn_host_frametime_clamped)
+		JITTER_LOG ("STEPWARN host_frametime clamped raw %.6f ft %.6f\n", host_rawframetime, host_frametime);
+	if (sys_step_debug_info.warn_zero_frametime)
+		JITTER_LOG ("STEPWARN host_frametime <= 0\n");
+	if (sys_step_debug_info.warn_zero_sim_dt)
+		JITTER_LOG ("STEPWARN sim dt is zero\n");
+	if (sys_step_debug_info.warn_many_ticks)
+		JITTER_LOG ("STEPWARN max ticks exceeded in frame\n");
 
 	if (sys_step_hitch_ms.value > 0.0f)
 	{
 		double hitch_ms = sys_step_hitch_ms.value;
 		if (host_rawframetime * 1000.0 >= hitch_ms)
 			Con_Printf ("STEPWARN hitch %.2fms >= %.2fms\n", host_rawframetime * 1000.0, hitch_ms);
+		if (host_rawframetime * 1000.0 >= hitch_ms)
+			JITTER_LOG ("STEPWARN hitch %.2fms >= %.2fms\n", host_rawframetime * 1000.0, hitch_ms);
 	}
 
 	if (dump_frame && debug_level <= 0)
 	{
 		Con_Printf ("STEPDBG dump requested; enable sys_step_debug for continuous logging.\n");
+		JITTER_LOG ("STEPDBG dump requested; enable sys_step_debug for continuous logging.\n");
 	}
 }
 
@@ -1158,24 +1230,28 @@ static void Host_CheckAutosave (void)
 	if (!sv_player)
 	{
 		Con_Printf ("NETDBG autosave skipped: sv_player NULL cl %d\n", SV_CurrentClientIndex ());
+		JITTER_LOG ("NETDBG autosave skipped: sv_player NULL cl %d\n", SV_CurrentClientIndex ());
 		return;
 	}
 
 	if (cls.state != ca_connected)
 	{
 		Con_Printf ("NETDBG autosave skipped: cls.state %d\n", cls.state);
+		JITTER_LOG ("NETDBG autosave skipped: cls.state %d\n", cls.state);
 		return;
 	}
 
 	if (cls.signon != SIGNONS)
 	{
 		Con_Printf ("NETDBG autosave skipped: signon %d\n", cls.signon);
+		JITTER_LOG ("NETDBG autosave skipped: signon %d\n", cls.signon);
 		return;
 	}
 
 	if (cl.intermission)
 	{
 		Con_Printf ("NETDBG autosave skipped: intermission\n");
+		JITTER_LOG ("NETDBG autosave skipped: intermission\n");
 		return;
 	}
 
@@ -1295,10 +1371,14 @@ static void SV_RunOneTick (double tick_dt)
 		{
 			Con_Printf ("NETDBG SV_RunOneTick paused for %d frames (paused=%d key_dest=%d)\n",
 				paused_frame_count, sv.paused, key_dest);
+			JITTER_LOG ("NETDBG SV_RunOneTick paused for %d frames (paused=%d key_dest=%d)\n",
+				paused_frame_count, sv.paused, key_dest);
 		}
 		if (realtime >= next_sv_skip_log)
 		{
 			Con_Printf ("NETDBG SV_Physics skipped (SV_RunOneTick) paused=%d key_dest=%d\n",
+				sv.paused, key_dest);
+			JITTER_LOG ("NETDBG SV_Physics skipped (SV_RunOneTick) paused=%d key_dest=%d\n",
 				sv.paused, key_dest);
 			next_sv_skip_log = realtime + 1.0;
 		}
@@ -1308,6 +1388,8 @@ static void SV_RunOneTick (double tick_dt)
 			cl.paused = false;
 			paused_frame_count = 0;
 			Con_Printf ("NETDBG SV_RunOneTick forced unpause (paused=%d key_dest=%d)\n",
+				sv.paused, key_dest);
+			JITTER_LOG ("NETDBG SV_RunOneTick forced unpause (paused=%d key_dest=%d)\n",
 				sv.paused, key_dest);
 			MSG_WriteByte (&sv.reliable_datagram, svc_setpause);
 			MSG_WriteByte (&sv.reliable_datagram, sv.paused);
@@ -1347,6 +1429,8 @@ void Host_ServerFrame (void)
 		{
 			Con_Printf ("NETDBG sv.frametime <= 0 (%.6f) clamping; sv.time %.3f\n",
 				host_frametime, qcvm->time);
+			JITTER_LOG ("NETDBG sv.frametime <= 0 (%.6f) clamping; sv.time %.3f\n",
+				host_frametime, qcvm->time);
 			next_sv_zero_frametime_log = realtime + 1.0;
 		}
 		clamped_frametime = 0.0001f;
@@ -1385,6 +1469,8 @@ void Host_ServerFrame (void)
 	{
 		Con_Printf ("NETDBG sv.time %.3f sv.frametime %.6f edicts %d active_clients %d\n",
 			qcvm->time, clamped_frametime, qcvm->num_edicts, active_clients);
+		JITTER_LOG ("NETDBG sv.time %.3f sv.frametime %.6f edicts %d active_clients %d\n",
+			qcvm->time, clamped_frametime, qcvm->num_edicts, active_clients);
 		next_sv_report_time = realtime + 1.0;
 	}
 
@@ -1421,6 +1507,8 @@ void Host_ServerFrame (void)
 			{
 				Con_Printf ("NETDBG sv_tick catchup clamped ticks %d accum %.6f dt %.6f\n",
 					ticks, (double)sv_accum_us / 1000000.0, tick_dt);
+				JITTER_LOG ("NETDBG sv_tick catchup clamped ticks %d accum %.6f dt %.6f\n",
+					ticks, (double)sv_accum_us / 1000000.0, tick_dt);
 			}
 		}
 	}
@@ -1441,6 +1529,8 @@ void Host_ServerFrame (void)
 			{
 				Con_Printf ("NETDBG sv_tick catchup clamped ticks %d accum %.6f dt %.6f\n",
 					ticks, sv_accum, tick_dt);
+				JITTER_LOG ("NETDBG sv_tick catchup clamped ticks %d accum %.6f dt %.6f\n",
+					ticks, sv_accum, tick_dt);
 			}
 		}
 	}
@@ -1460,6 +1550,8 @@ void Host_ServerFrame (void)
 		else if (sv_tick_debug.value && qcvm->time <= last_sv_time && realtime >= next_sv_stall_log)
 		{
 			Con_Printf ("NETDBG sv.time stalled at %.3f (frametime %.6f)\n",
+				qcvm->time, clamped_frametime);
+			JITTER_LOG ("NETDBG sv.time stalled at %.3f (frametime %.6f)\n",
 				qcvm->time, clamped_frametime);
 			next_sv_stall_log = realtime + 1.0;
 		}
@@ -1500,6 +1592,8 @@ void Host_ServerFrame (void)
 		{
 			Con_Printf ("NETDBG sv_snap_send time %.3f next %.3f clients %d bytes %d\n",
 				qcvm->time, sv_next_snapshot_time + net_dt, active_clients, temp_bytes);
+			JITTER_LOG ("NETDBG sv_snap_send time %.3f next %.3f clients %d bytes %d\n",
+				qcvm->time, sv_next_snapshot_time + net_dt, active_clients, temp_bytes);
 		}
 		SV_ClearDatagram ();
 		sv_next_snapshot_time += net_dt;
@@ -1512,6 +1606,8 @@ void Host_ServerFrame (void)
 		double accum_s = sv_fixedtick.value > 0.0f ? (double)sv_accum_us / 1000000.0 : sv_accum;
 
 		Con_Printf ("NETDBG sv_tick frame_dt %.6f tick_dt %.6f ticks %d accum %.6f time %.3f sends %d\n",
+			clamped_frametime, tick_dt, ticks, accum_s, qcvm->time, sends);
+		JITTER_LOG ("NETDBG sv_tick frame_dt %.6f tick_dt %.6f ticks %d accum %.6f time %.3f sends %d\n",
 			clamped_frametime, tick_dt, ticks, accum_s, qcvm->time, sends);
 		next_sv_tick_log = realtime + 1.0;
 	}
@@ -2044,6 +2140,7 @@ void Host_Shutdown(void)
 
 	Host_ShutdownSave ();
 	Host_WriteConfiguration ();
+	Jitter_Log_Close ();
 
 // stop downloads before shutting down networking
         Modlist_ShutDown ();

--- a/Quake/host_cmd.c
+++ b/Quake/host_cmd.c
@@ -43,6 +43,7 @@ int	current_skill;
 		if (!sv_player) \
 		{ \
 			Con_Printf ("NETDBG sv_player NULL cl %d reason %s\n", SV_CurrentClientIndex (), reason); \
+			JITTER_LOG ("NETDBG sv_player NULL cl %d reason %s\n", SV_CurrentClientIndex (), reason); \
 			SV_PlayerNullTrap (__func__, 0); \
 			return; \
 		} \
@@ -53,6 +54,7 @@ int	current_skill;
 		if (!sv_player) \
 		{ \
 			Con_Printf ("NETDBG sv_player NULL cl %d reason %s\n", SV_CurrentClientIndex (), reason); \
+			JITTER_LOG ("NETDBG sv_player NULL cl %d reason %s\n", SV_CurrentClientIndex (), reason); \
 			SV_PlayerNullTrap (__func__, 0); \
 			return retval; \
 		} \

--- a/Quake/net_dgrm.c
+++ b/Quake/net_dgrm.c
@@ -97,6 +97,7 @@ static void NET_DebugLogV (qboolean force, const char *fmt, va_list argptr)
 {
 	char text[2048];
 	int len;
+	va_list argcopy;
 
 	if (!NET_DebugEnabled () && (!force || !net_debug_log))
 		return;
@@ -113,13 +114,19 @@ static void NET_DebugLogV (qboolean force, const char *fmt, va_list argptr)
 	if (!net_debug_log)
 		return;
 
+	va_copy (argcopy, argptr);
 	len = q_vsnprintf (text, sizeof(text), fmt, argptr);
 	if (len < 0)
+	{
+		va_end (argcopy);
 		return;
+	}
 	if (len >= (int)sizeof(text))
 		len = (int)sizeof(text) - 1;
 	fwrite (text, 1, (size_t)len, net_debug_log);
 	fflush (net_debug_log);
+	Jitter_LogV (fmt, argcopy);
+	va_end (argcopy);
 }
 
 void NET_DebugLogEvent (qboolean force, const char *fmt, ...)

--- a/Quake/quakedef.h
+++ b/Quake/quakedef.h
@@ -321,6 +321,8 @@ extern	cvar_t		sz_debug_hexdump;
 extern	cvar_t		sys_step_debug;
 extern	cvar_t		sys_step_dump;
 extern	cvar_t		sys_step_hitch_ms;
+extern	cvar_t		jitter_log_enable;
+extern	cvar_t		jitter_log_file;
 extern	cvar_t		sv_fixedtick;
 extern	cvar_t		sv_maxsteps_per_frame;
 
@@ -385,6 +387,17 @@ extern	int		host_framecount;	// incremented every frame, never reset
 extern	double		realtime;		// not bounded in any way, changed at
 							// start of every frame, never reset
 
+void Jitter_Log (const char *fmt, ...) FUNCP_PRINTF(1,2);
+void Jitter_LogV (const char *fmt, va_list argptr);
+void Jitter_Log_Close (void);
+
+#define JITTER_LOG(...) \
+	do \
+	{ \
+		if (jitter_log_enable.value > 0.0f) \
+			Jitter_Log (__VA_ARGS__); \
+	} while (0)
+
 static inline int SV_CurrentClientIndex (void)
 {
 	if (!host_client || !svs.clients || svs.maxclients <= 0)
@@ -401,7 +414,12 @@ static inline void SV_PlayerNullTrap (const char *where, int fatal)
 
 	Con_Printf ("NETDBG sv_player NULL cl %d name %s where %s fatal %d\n",
 		client_index, client_name, where ? where : "(unknown)", fatal);
+	JITTER_LOG ("NETDBG sv_player NULL cl %d name %s where %s fatal %d\n",
+		client_index, client_name, where ? where : "(unknown)", fatal);
 	Con_Printf ("NETDBG sv_player NULL sv.active %d sv.state %d cls.state %d cls.demoplayback %d "
+		"signon %d frame %d\n",
+		sv.active, sv.state, cls.state, cls.demoplayback, cls.signon, host_framecount);
+	JITTER_LOG ("NETDBG sv_player NULL sv.active %d sv.state %d cls.state %d cls.demoplayback %d "
 		"signon %d frame %d\n",
 		sv.active, sv.state, cls.state, cls.demoplayback, cls.signon, host_framecount);
 
@@ -410,8 +428,12 @@ static inline void SV_PlayerNullTrap (const char *where, int fatal)
 		void *stack[32];
 		USHORT frames = RtlCaptureStackBackTrace (0, (ULONG)(sizeof (stack) / sizeof (stack[0])), stack, NULL);
 		Con_Printf ("NETDBG sv_player NULL stack frames %u\n", frames);
+		JITTER_LOG ("NETDBG sv_player NULL stack frames %u\n", frames);
 		for (USHORT i = 0; i < frames; ++i)
+		{
 			Con_Printf ("NETDBG sv_player NULL  #%u %p\n", i, stack[i]);
+			JITTER_LOG ("NETDBG sv_player NULL  #%u %p\n", i, stack[i]);
+		}
 	}
 #endif
 
@@ -423,6 +445,7 @@ static inline void SV_PlayerNullTrap (const char *where, int fatal)
 	if (cls.demoplayback)
 	{
 		Con_Printf ("NETDBG sv_player NULL cl %d reason demo_playback_abort\n", client_index);
+		JITTER_LOG ("NETDBG sv_player NULL cl %d reason demo_playback_abort\n", client_index);
 		CL_StopPlayback ();
 	}
 }

--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -1800,6 +1800,9 @@ static qboolean SV_Snapshot2ForceFull (client_t *client, snapshot_full_reason_t 
 			Con_Printf ("NETDBG: midgame force_full cl %d %s reason %s last_full %.3f\n",
 				SV_ClientSlot (client), client->name, SV_SnapshotFullReasonName (reason),
 				client->snapshot_last_full_time);
+			JITTER_LOG ("NETDBG: midgame force_full cl %d %s reason %s last_full %.3f\n",
+				SV_ClientSlot (client), client->name, SV_SnapshotFullReasonName (reason),
+				client->snapshot_last_full_time);
 		}
 		if (SV_SnapshotFullReasonIsBaseMismatch (reason))
 			client->snapshot_base_mismatch_count++;
@@ -3421,6 +3424,9 @@ static void SV_SendSnapshot (client_t *client, sizebuf_t *msg, snapshot_write_st
 			if (midgame_active && !SV_SnapshotFullReasonBypassesCooldown (full_reason, client))
 			{
 				Con_Printf ("NETDBG: midgame full decision cl %d %s base %u reason %s last_full %.3f\n",
+					SV_ClientSlot (client), client->name, base_log, SV_SnapshotFullReasonName (full_reason),
+					client->snapshot_last_full_time);
+				JITTER_LOG ("NETDBG: midgame full decision cl %d %s base %u reason %s last_full %.3f\n",
 					SV_ClientSlot (client), client->name, base_log, SV_SnapshotFullReasonName (full_reason),
 					client->snapshot_last_full_time);
 			}
@@ -7274,6 +7280,7 @@ void SV_SpawnServer (const char *server)
 	if (hostname.string[0] == 0)
 		Cvar_Set ("hostname", "UNNAMED");
 	scr_centertime_off = 0;
+	Jitter_Log_Close ();
 
 	Con_DPrintf ("SpawnServer: %s\n",server);
 	svs.changelevel_issued = false;		// now safe to issue another

--- a/Quake/sv_user.c
+++ b/Quake/sv_user.c
@@ -51,6 +51,7 @@ qboolean	onground;
 		if (!sv_player) \
 		{ \
 			Con_Printf ("NETDBG sv_player NULL cl %d reason %s\n", SV_CurrentClientIndex (), reason); \
+			JITTER_LOG ("NETDBG sv_player NULL cl %d reason %s\n", SV_CurrentClientIndex (), reason); \
 			SV_PlayerNullTrap (__func__, fatal); \
 			return; \
 		} \
@@ -61,6 +62,7 @@ qboolean	onground;
 		if (!sv_player) \
 		{ \
 			Con_Printf ("NETDBG sv_player NULL cl %d reason %s\n", SV_CurrentClientIndex (), reason); \
+			JITTER_LOG ("NETDBG sv_player NULL cl %d reason %s\n", SV_CurrentClientIndex (), reason); \
 			SV_PlayerNullTrap (__func__, fatal); \
 			return retval; \
 		} \
@@ -523,6 +525,8 @@ static void SV_CmdAckResync (client_t *client, const char *reason)
 	{
 		Con_Printf ("NETDBG time %.3f cmd_ack_resync %s reason %s\n",
 			realtime, client->name, reason ? reason : "unknown");
+		JITTER_LOG ("NETDBG time %.3f cmd_ack_resync %s reason %s\n",
+			realtime, client->name, reason ? reason : "unknown");
 	}
 }
 
@@ -530,11 +534,20 @@ static void SV_NetHexDump (const byte *data, int len, int max)
 {
 	int dump_len = q_min(len, max);
 	int i;
+	char line[256];
+	char *out = line;
+	char *line_end = line + sizeof(line);
 
 	Con_Printf ("NETDBG cmd_ack_hexdump %d bytes (cursize %d):", dump_len, len);
+	out += q_snprintf (out, (size_t)(line_end - out), "NETDBG cmd_ack_hexdump %d bytes (cursize %d):", dump_len, len);
 	for (i = 0; i < dump_len; i++)
+	{
 		Con_Printf (" %02x", data[i]);
+		out += q_snprintf (out, (size_t)(line_end - out), " %02x", data[i]);
+	}
 	Con_Printf ("\n");
+	out += q_snprintf (out, (size_t)(line_end - out), "\n");
+	JITTER_LOG ("%s", line);
 }
 
 void SV_ReadClientMove (usercmd_t *move)
@@ -577,18 +590,21 @@ qboolean SV_ReadClientMessage (void)
 	if (!sv.active || sv.state != ss_active)
 	{
 		Con_Printf ("NETDBG sv_readclientmessage skipped cl %d reason server_inactive\n", SV_CurrentClientIndex ());
+		JITTER_LOG ("NETDBG sv_readclientmessage skipped cl %d reason server_inactive\n", SV_CurrentClientIndex ());
 		return true;
 	}
 
 	if (cls.demoplayback)
 	{
 		Con_Printf ("NETDBG sv_readclientmessage skipped cl %d reason demo_playback\n", SV_CurrentClientIndex ());
+		JITTER_LOG ("NETDBG sv_readclientmessage skipped cl %d reason demo_playback\n", SV_CurrentClientIndex ());
 		return true;
 	}
 
 	if (!host_client || !host_client->netconnection)
 	{
 		Con_Printf ("NETDBG sv_readclientmessage skipped cl %d reason no_client_context\n", SV_CurrentClientIndex ());
+		JITTER_LOG ("NETDBG sv_readclientmessage skipped cl %d reason no_client_context\n", SV_CurrentClientIndex ());
 		SV_PlayerNullTrap (__func__, 0);
 		return false;
 	}
@@ -741,6 +757,8 @@ nextmsg:
 				{
 					Con_Printf ("SV_ReadClientMessage: truncated clc_move header from %s\n",
 						host_client->name);
+					JITTER_LOG ("SV_ReadClientMessage: truncated clc_move header from %s\n",
+						host_client->name);
 					return true;
 				}
 				readcount_before_time = msg_readcount;
@@ -765,6 +783,15 @@ nextmsg:
 					unsigned int slack = (unsigned int)q_max(0, (int)sv_cmd_ack_slack.value);
 					unsigned int window_tail = last_cmd_acked - slack;
 					Con_Printf ("NETDBG time %.3f cmd_ack_read %s cmd %d flags 0x%x "
+						"mtime %d->%d seq %d->%d ack %d->%d rem %d cmd_ack %u "
+						"newest_cmd %u last_recv %u last_ack %u win_tail %u slack %u\n",
+						realtime, host_client->name, clc_move, sv.protocolflags,
+						readcount_before_time, readcount_after_time,
+						readcount_before_seq, readcount_after_seq,
+						readcount_before_ack, readcount_after_ack,
+						remaining, cmd_ack, newest_cmd_seq,
+						last_cmd_received, last_cmd_acked, window_tail, slack);
+					JITTER_LOG ("NETDBG time %.3f cmd_ack_read %s cmd %d flags 0x%x "
 						"mtime %d->%d seq %d->%d ack %d->%d rem %d cmd_ack %u "
 						"newest_cmd %u last_recv %u last_ack %u win_tail %u slack %u\n",
 						realtime, host_client->name, clc_move, sv.protocolflags,
@@ -808,6 +835,10 @@ nextmsg:
 						if (sv_cmd_ack_debug.value)
 						{
 							Con_Printf ("NETDBG cmd_ack_invalid %s ack %u newest %u last_ack %u "
+								"behind_delta %u slack %u reason %s count %d\n",
+								host_client->name, cmd_ack, newest_cmd_seq, last_cmd_acked,
+								ack_behind_delta, slack, reason, host_client->invalid_cmd_ack_count);
+							JITTER_LOG ("NETDBG cmd_ack_invalid %s ack %u newest %u last_ack %u "
 								"behind_delta %u slack %u reason %s count %d\n",
 								host_client->name, cmd_ack, newest_cmd_seq, last_cmd_acked,
 								ack_behind_delta, slack, reason, host_client->invalid_cmd_ack_count);
@@ -1203,6 +1234,7 @@ void SV_RunClients (void)
 	if (cls.demoplayback)
 	{
 		Con_Printf ("NETDBG sv_runclients skipped cl %d reason demo_playback\n", SV_CurrentClientIndex ());
+		JITTER_LOG ("NETDBG sv_runclients skipped cl %d reason demo_playback\n", SV_CurrentClientIndex ());
 		return;
 	}
 
@@ -1214,6 +1246,8 @@ void SV_RunClients (void)
 		if (!host_client->edict)
 		{
 			Con_Printf ("NETDBG sv_player NULL cl %d reason runclients_no_edict\n",
+				SV_CurrentClientIndex ());
+			JITTER_LOG ("NETDBG sv_player NULL cl %d reason runclients_no_edict\n",
 				SV_CurrentClientIndex ());
 			SV_PlayerNullTrap (__func__, 0);
 			continue;

--- a/Quake/view.c
+++ b/Quake/view.c
@@ -1070,6 +1070,12 @@ void V_CalcRefdef (void)
 			ent->msg_origins[1][0], ent->msg_origins[1][1], ent->msg_origins[1][2],
 			cl_lerpfrac,
 			r_refdef.vieworg[0], r_refdef.vieworg[1], r_refdef.vieworg[2]);
+		JITTER_LOG ("NETDBG vieworg ent %d cur %.2f %.2f %.2f prev %.2f %.2f %.2f lerp %.3f view %.2f %.2f %.2f\n",
+			cl.viewentity,
+			ent->msg_origins[0][0], ent->msg_origins[0][1], ent->msg_origins[0][2],
+			ent->msg_origins[1][0], ent->msg_origins[1][1], ent->msg_origins[1][2],
+			cl_lerpfrac,
+			r_refdef.vieworg[0], r_refdef.vieworg[1], r_refdef.vieworg[2]);
 	}
 
 	if (chase_active.value)

--- a/Quake/world.c
+++ b/Quake/world.c
@@ -303,6 +303,9 @@ SV_AreaTriggerEdicts ( edict_t *ent, areanode_t *node, edict_t **list, int *list
 				Con_Printf ("STEPDBG trigger_no_touch ent %s #%d trigger %s #%d\n",
 					PR_GetString (ent->v.classname), NUM_FOR_EDICT (ent),
 					PR_GetString (touch->v.classname), NUM_FOR_EDICT (touch));
+				JITTER_LOG ("STEPDBG trigger_no_touch ent %s #%d trigger %s #%d\n",
+					PR_GetString (ent->v.classname), NUM_FOR_EDICT (ent),
+					PR_GetString (touch->v.classname), NUM_FOR_EDICT (touch));
 			}
 		}
 		if (!touch->v.touch || touch->v.solid != SOLID_TRIGGER)


### PR DESCRIPTION
### Motivation
- Provide a very small, plain-text global mirror file for existing jitter/timing/prediction/net debug output so all related debug prints can be collected into one file without reworking the existing logging.
- Keep runtime overhead minimal when disabled by making the file logger lazy-open and gated by a simple `jitter_log_enable` quick check.

### Description
- Added two cvars `jitter_log_enable` and `jitter_log_file` and registered them in `Host_InitLocal` as `jitter_log_enable`/`jitter_log_file` with defaults `0` and `jitter_debug.log`. 
- Implemented a tiny logger API: `Jitter_Log`, `Jitter_LogV`, and `Jitter_Log_Close` in `common.c` with lazy `Sys_fopen(..., "ab")`, per-line prefixing `[realtime][framecount][CL/SV]`, and safe-close on shutdown/map change via `Jitter_Log_Close` calls from `Host_Shutdown` and `SV_SpawnServer`.
- Mirrored existing jitter/timing/step/net debug output by adding `JITTER_LOG(...)` calls next to many `Con_Printf`/debug locations (client prediction, cl_parse/net, host step/tick, sv_user/net ack paths, view, world, etc.) and by invoking `Jitter_LogV` from `NET_DebugLogV` so net debug events are also mirrored.
- Minor safety/robustness: use `va_copy` where needed to forward varargs, buffer-size checks for formatted output, and avoid extra processing when `jitter_log_enable` is `0` via the `JITTER_LOG` macro.

### Testing
- No automated tests were executed for this change (no build/test run was requested during the rollout).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983ea267218832eb93066493335f8c8)