### PR TITLE
Extend jitter debug logging for timing, prediction and physics diagnostics

### DIFF
--- a/Quake/cl_main.c
+++ b/Quake/cl_main.c
@@ -2124,7 +2124,10 @@ void CL_SendCmd (void)
 	if (sys_step_debug.value > 0.0f)
 	{
 		if (cmds_built == 0)
+		{
 			sys_step_debug_info.cl_cmd_no_cmd++;
+			sys_step_debug_info.cl_cmd_skipped_frame = 1;
+		}
 		sys_step_debug_info.cl_cmds_built += cmds_built;
 		sys_step_debug_info.cl_cmd_accum_us_after = cl_cmd_accum_us;
 	}

--- a/Quake/host.c
+++ b/Quake/host.c
@@ -1028,6 +1028,24 @@ static void Sys_StepDebug_LogFrame (void)
 		sys_step_debug_info.cl_time,
 		sys_step_debug_info.cl_servertime,
 		sys_step_debug_info.cl_snapshot_time);
+	Con_Printf ("[TIMING] rt %.6f host_frametime %.6f cl.time %.6f\n",
+		sys_step_debug_info.realtime,
+		sys_step_debug_info.host_frametime,
+		sys_step_debug_info.cl_time);
+	JITTER_LOG ("[TIMING] rt %.6f host_frametime %.6f cl.time %.6f\n",
+		sys_step_debug_info.realtime,
+		sys_step_debug_info.host_frametime,
+		sys_step_debug_info.cl_time);
+	Con_Printf ("[PRED] steps %d cmd.msec %d skipped %d zero %d\n",
+		sys_step_debug_info.cl_pred_steps,
+		sys_step_debug_info.cl_cmd_msec_last,
+		sys_step_debug_info.cl_cmd_skipped_frame,
+		sys_step_debug_info.cl_cmd_msec_zero > 0 ? 1 : 0);
+	JITTER_LOG ("[PRED] steps %d cmd.msec %d skipped %d zero %d\n",
+		sys_step_debug_info.cl_pred_steps,
+		sys_step_debug_info.cl_cmd_msec_last,
+		sys_step_debug_info.cl_cmd_skipped_frame,
+		sys_step_debug_info.cl_cmd_msec_zero > 0 ? 1 : 0);
 	Con_Printf ("STEPDBG sv ticks %d phys %d tick_us %lld frame_us %lld accum %lld->%lld maxsteps %d\n",
 		sys_step_debug_info.sv_ticks,
 		sys_step_debug_info.sv_physics_calls,
@@ -1133,6 +1151,39 @@ static void Sys_StepDebug_LogFrame (void)
 			sys_step_debug_info.player_ground_vel[0],
 			sys_step_debug_info.player_ground_vel[1],
 			sys_step_debug_info.player_ground_vel[2]);
+		Con_Printf ("[PHYS] onground %d->%d groundent %d->%d basevel %.2f %.2f %.2f\n",
+			sys_step_debug_info.player_onground_before,
+			sys_step_debug_info.player_onground_after,
+			sys_step_debug_info.player_groundent_before,
+			sys_step_debug_info.player_groundent_after,
+			sys_step_debug_info.player_basevel_after[0],
+			sys_step_debug_info.player_basevel_after[1],
+			sys_step_debug_info.player_basevel_after[2]);
+		JITTER_LOG ("[PHYS] onground %d->%d groundent %d->%d basevel %.2f %.2f %.2f\n",
+			sys_step_debug_info.player_onground_before,
+			sys_step_debug_info.player_onground_after,
+			sys_step_debug_info.player_groundent_before,
+			sys_step_debug_info.player_groundent_after,
+			sys_step_debug_info.player_basevel_after[0],
+			sys_step_debug_info.player_basevel_after[1],
+			sys_step_debug_info.player_basevel_after[2]);
+		if (sys_step_debug_info.player_ground_is_mover)
+		{
+			vec3_t vel_delta;
+			VectorSubtract (sys_step_debug_info.player_vel_after, sys_step_debug_info.player_vel_before, vel_delta);
+			Con_Printf ("[MOVER] groundent %d mover_vel %.2f %.2f %.2f player_dvel %.2f %.2f %.2f\n",
+				sys_step_debug_info.player_groundent_after,
+				sys_step_debug_info.player_ground_vel[0],
+				sys_step_debug_info.player_ground_vel[1],
+				sys_step_debug_info.player_ground_vel[2],
+				vel_delta[0], vel_delta[1], vel_delta[2]);
+			JITTER_LOG ("[MOVER] groundent %d mover_vel %.2f %.2f %.2f player_dvel %.2f %.2f %.2f\n",
+				sys_step_debug_info.player_groundent_after,
+				sys_step_debug_info.player_ground_vel[0],
+				sys_step_debug_info.player_ground_vel[1],
+				sys_step_debug_info.player_ground_vel[2],
+				vel_delta[0], vel_delta[1], vel_delta[2]);
+		}
 	}
 
 	if (sys_step_debug_info.warn_host_frametime_clamped)
@@ -1151,6 +1202,33 @@ static void Sys_StepDebug_LogFrame (void)
 		JITTER_LOG ("STEPWARN sim dt is zero\n");
 	if (sys_step_debug_info.warn_many_ticks)
 		JITTER_LOG ("STEPWARN max ticks exceeded in frame\n");
+	if (sys_step_debug_info.host_frametime < 0.001 || sys_step_debug_info.host_frametime > 0.05)
+	{
+		Con_Printf ("[WARN] host_frametime out of range %.6f\n", sys_step_debug_info.host_frametime);
+		JITTER_LOG ("[WARN] host_frametime out of range %.6f\n", sys_step_debug_info.host_frametime);
+	}
+	if (sys_step_debug_info.cl_cmd_msec_zero > 0)
+	{
+		Con_Printf ("[WARN] cmd.msec == 0 encountered count %d\n", sys_step_debug_info.cl_cmd_msec_zero);
+		JITTER_LOG ("[WARN] cmd.msec == 0 encountered count %d\n", sys_step_debug_info.cl_cmd_msec_zero);
+	}
+	if (sys_step_debug_info.sv_ticks > 4)
+	{
+		Con_Printf ("[WARN] simulation ran %d ticks in one frame\n", sys_step_debug_info.sv_ticks);
+		JITTER_LOG ("[WARN] simulation ran %d ticks in one frame\n", sys_step_debug_info.sv_ticks);
+	}
+	if (sys_step_debug_info.player_valid
+		&& sys_step_debug_info.player_groundent_before != sys_step_debug_info.player_groundent_after
+		&& VectorLength (sys_step_debug_info.player_vel_before) < 5.0f
+		&& VectorLength (sys_step_debug_info.player_vel_after) < 5.0f)
+	{
+		Con_Printf ("[WARN] groundent changed at near-zero velocity %d -> %d\n",
+			sys_step_debug_info.player_groundent_before,
+			sys_step_debug_info.player_groundent_after);
+		JITTER_LOG ("[WARN] groundent changed at near-zero velocity %d -> %d\n",
+			sys_step_debug_info.player_groundent_before,
+			sys_step_debug_info.player_groundent_after);
+	}
 
 	if (sys_step_hitch_ms.value > 0.0f)
 	{
@@ -1395,6 +1473,53 @@ static void SV_RunOneTick (double tick_dt)
 				sv.paused, key_dest);
 			MSG_WriteByte (&sv.reliable_datagram, svc_setpause);
 			MSG_WriteByte (&sv.reliable_datagram, sv.paused);
+		}
+	}
+
+	if (sys_step_debug.value > 0.0f)
+	{
+		Con_Printf ("[PHYS] sv.time %.6f sv.frametime %.6f ticks_this_frame %d\n",
+			qcvm->time, host_frametime, sys_step_debug_info.sv_ticks);
+		JITTER_LOG ("[PHYS] sv.time %.6f sv.frametime %.6f ticks_this_frame %d\n",
+			qcvm->time, host_frametime, sys_step_debug_info.sv_ticks);
+		if (sys_step_debug_info.player_valid)
+		{
+			Con_Printf ("[PHYS] player org %.2f %.2f %.2f -> %.2f %.2f %.2f vel %.2f %.2f %.2f -> %.2f %.2f %.2f onground %d groundent %d basevel %.2f %.2f %.2f\n",
+				sys_step_debug_info.player_origin_before[0],
+				sys_step_debug_info.player_origin_before[1],
+				sys_step_debug_info.player_origin_before[2],
+				sys_step_debug_info.player_origin_after[0],
+				sys_step_debug_info.player_origin_after[1],
+				sys_step_debug_info.player_origin_after[2],
+				sys_step_debug_info.player_vel_before[0],
+				sys_step_debug_info.player_vel_before[1],
+				sys_step_debug_info.player_vel_before[2],
+				sys_step_debug_info.player_vel_after[0],
+				sys_step_debug_info.player_vel_after[1],
+				sys_step_debug_info.player_vel_after[2],
+				sys_step_debug_info.player_onground_after,
+				sys_step_debug_info.player_groundent_after,
+				sys_step_debug_info.player_basevel_after[0],
+				sys_step_debug_info.player_basevel_after[1],
+				sys_step_debug_info.player_basevel_after[2]);
+			JITTER_LOG ("[PHYS] player org %.2f %.2f %.2f -> %.2f %.2f %.2f vel %.2f %.2f %.2f -> %.2f %.2f %.2f onground %d groundent %d basevel %.2f %.2f %.2f\n",
+				sys_step_debug_info.player_origin_before[0],
+				sys_step_debug_info.player_origin_before[1],
+				sys_step_debug_info.player_origin_before[2],
+				sys_step_debug_info.player_origin_after[0],
+				sys_step_debug_info.player_origin_after[1],
+				sys_step_debug_info.player_origin_after[2],
+				sys_step_debug_info.player_vel_before[0],
+				sys_step_debug_info.player_vel_before[1],
+				sys_step_debug_info.player_vel_before[2],
+				sys_step_debug_info.player_vel_after[0],
+				sys_step_debug_info.player_vel_after[1],
+				sys_step_debug_info.player_vel_after[2],
+				sys_step_debug_info.player_onground_after,
+				sys_step_debug_info.player_groundent_after,
+				sys_step_debug_info.player_basevel_after[0],
+				sys_step_debug_info.player_basevel_after[1],
+				sys_step_debug_info.player_basevel_after[2]);
 		}
 	}
 }

--- a/Quake/quakedef.h
+++ b/Quake/quakedef.h
@@ -354,6 +354,7 @@ typedef struct sys_step_debug_info_s
 	int		cl_cmd_msec_wild;
 	int		cl_cmd_msec_zero;
 	int		cl_cmd_msec_over;
+	int		cl_cmd_skipped_frame;
 	int64_t		sv_accum_us_before;
 	int64_t		sv_accum_us_after;
 	int64_t		cl_cmd_accum_us_before;
@@ -369,6 +370,7 @@ typedef struct sys_step_debug_info_s
 	vec3_t		player_origin_after;
 	vec3_t		player_vel_before;
 	vec3_t		player_vel_after;
+	vec3_t		player_basevel_after;
 	int		player_groundent_before;
 	int		player_groundent_after;
 	int		player_onground_before;

--- a/Quake/sv_phys.c
+++ b/Quake/sv_phys.c
@@ -1059,6 +1059,7 @@ void SV_Physics_Client (edict_t	*ent, int num)
 
 			VectorCopy (ent->v.origin, sys_step_debug_info.player_origin_after);
 			VectorCopy (ent->v.velocity, sys_step_debug_info.player_vel_after);
+			VectorCopy (ent->v.basevelocity, sys_step_debug_info.player_basevel_after);
 			sys_step_debug_info.player_groundent_after = (int)ent->v.groundentity;
 			sys_step_debug_info.player_onground_after = ((int)ent->v.flags & FL_ONGROUND) ? 1 : 0;
 			VectorClear (sys_step_debug_info.player_ground_vel);


### PR DESCRIPTION
### Motivation
- Improve existing jitter debug output with minimal additional prints to diagnose timing, prediction and physics jitter without redesigning the logging system.

### Description
- Added new debug fields to `sys_step_debug_info_t`: `cl_cmd_skipped_frame` and `player_basevel_after` to track skipped command frames and entity basevelocity.
- Set the `cl_cmd_skipped_frame` flag in `CL_SendCmd` when no usercmds are built in a frame, and capture `ent->v.basevelocity` in `SV_Physics_Client` for server-side player state.
- Extended `Sys_StepDebug_LogFrame` and `SV_RunOneTick` to emit additional `Con_Printf` and `JITTER_LOG` lines prefixed with `[TIMING]`, `[PRED]`, `[PHYS]`, `[MOVER]`, and `[WARN]` that print realtime, host_frametime, `cl.time`, prediction steps, `cmd.msec`, ticks-per-frame, player origin/velocity before/after physics, onground/groundent, mover velocity and player velocity delta, and basevelocity.
- Added warning prints for out-of-range `host_frametime` (<0.001 or >0.05), `cmd.msec == 0` occurrences, simulation running more than 4 ticks in a frame, and groundent changes while player velocity is near zero.

### Testing
- Performed source-level checks with pattern searches and diffs to confirm the new fields and log lines are present in `Quake/quakedef.h`, `Quake/cl_main.c`, `Quake/sv_phys.c`, and `Quake/host.c`, and the diffs reflect the intended additions (success).
- Attempted to build `Quake/` to validate compilation, but the build failed in this environment due to missing SDL2 tooling/headers (`sdl2-config` / `SDL.h`), so full compile-time verification could not be completed (expected environment limitation).
- Ran repository-level `make` from the workspace root which failed due to no top-level targets, confirming only partial verification was possible here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984de10aa4c832eb48f18013c31cb09)