### PR TITLE
Add jitter_time_debug timing diagnostics to NETDBG/jitter logs

### DIFF
--- a/Quake/cl_main.c
+++ b/Quake/cl_main.c
@@ -149,6 +149,8 @@ static double			cl_cmd_debug_next_time = 0.0;
 static unsigned int		cl_cmds_built_since_log = 0;
 static unsigned int		cl_cmds_sent_since_log = 0;
 static unsigned int		cl_cmd_packets_since_log = 0;
+static int			cl_cmd_msec_last_generated = 0;
+static int			cl_cmds_generated_last_frame = 0;
 
 static inline void CL_SetValidBit (cl_player_snap_t *snap, int idx)
 {
@@ -509,8 +511,17 @@ void CL_JitterDebug_Log (void)
 	vec3_t render_ang;
 	qboolean has_pred;
 
+	if (jitter_time_debug.value > 0.0f)
+	{
+		Con_Printf ("JITTIME CL rt=%.6f hf=%.6f clt=%.6f cmdmsec=%d cmds=%u predsteps=%d\n",
+			realtime, host_frametime, cl.time, cl_cmd_msec_last_generated, cl_cmds_generated_last_frame, sys_step_debug_info.cl_pred_steps);
+		JITTER_LOG ("JITTIME CL rt=%.6f hf=%.6f clt=%.6f cmdmsec=%d cmds=%u predsteps=%d\n",
+			realtime, host_frametime, cl.time, cl_cmd_msec_last_generated, cl_cmds_generated_last_frame, sys_step_debug_info.cl_pred_steps);
+	}
+
 	if (cl_jitter_debug.value <= 0.0f)
 		return;
+
 
 	interp_delay = CL_GetInterpDelaySeconds ();
 	interp_target = CL_GetInterpTargetTime ();
@@ -2049,12 +2060,22 @@ void CL_SendCmd (void)
 			{
 				if (sys_step_debug.value > 0.0f)
 					sys_step_debug_info.cl_cmd_msec_zero++;
+				if (jitter_time_debug.value > 0.0f)
+				{
+					Con_Printf ("JITWARN cmdmsec_zero_or_out_of_range\n");
+					JITTER_LOG ("JITWARN cmdmsec_zero_or_out_of_range\n");
+				}
 				cmd_msec = 1;
 			}
 		else if (cmd_msec > 255)
 		{
 			if (sys_step_debug.value > 0.0f)
 				sys_step_debug_info.cl_cmd_msec_over++;
+			if (jitter_time_debug.value > 0.0f)
+			{
+				Con_Printf ("JITWARN cmdmsec_zero_or_out_of_range\n");
+				JITTER_LOG ("JITWARN cmdmsec_zero_or_out_of_range\n");
+			}
 			cmd_msec = 255;
 		}
 		if (sys_step_debug.value > 0.0f)
@@ -2120,6 +2141,10 @@ void CL_SendCmd (void)
 		cmds_built++;
 		sendcmd_ran = true;
 	}
+
+	cl_cmds_generated_last_frame = cmds_built;
+	if (cmds_built > 0 && last_cmd_msec >= 0)
+		cl_cmd_msec_last_generated = last_cmd_msec;
 
 	if (sys_step_debug.value > 0.0f)
 	{

--- a/Quake/host.c
+++ b/Quake/host.c
@@ -77,6 +77,7 @@ cvar_t	serverprofile = {"serverprofile","0",CVAR_NONE};
 cvar_t	sys_step_debug = {"sys_step_debug", "0", CVAR_NONE};
 cvar_t	sys_step_dump = {"sys_step_dump", "0", CVAR_NONE};
 cvar_t	sys_step_hitch_ms = {"sys_step_hitch_ms", "50", CVAR_NONE};
+cvar_t	jitter_time_debug = {"jitter_time_debug", "0", CVAR_NONE};
 
 cvar_t	fraglimit = {"fraglimit","0",CVAR_NOTIFY|CVAR_SERVERINFO};
 cvar_t	timelimit = {"timelimit","0",CVAR_NOTIFY|CVAR_SERVERINFO};
@@ -520,6 +521,7 @@ void Host_InitLocal (void)
 	Cvar_RegisterVariable (&sys_step_debug);
 	Cvar_RegisterVariable (&sys_step_dump);
 	Cvar_RegisterVariable (&sys_step_hitch_ms);
+	Cvar_RegisterVariable (&jitter_time_debug);
 	Cvar_RegisterVariable (&jitter_log_enable);
 	Cvar_RegisterVariable (&jitter_log_file);
 	Cvar_RegisterVariable (&jitter_log_flush);
@@ -1271,6 +1273,11 @@ static void Host_AdvanceTime (double dt)
 		if (host_frametime != host_rawframetime)
 			sys_step_debug_info.warn_host_frametime_clamped = 1;
 	}
+	if (jitter_time_debug.value > 0.0f && host_frametime != host_rawframetime)
+	{
+		Con_Printf ("JITWARN host_frametime_clamped\n");
+		JITTER_LOG ("JITWARN host_frametime_clamped\n");
+	}
 	if (sys_step_debug.value > 0.0f && host_frametime <= 0.0)
 		sys_step_debug_info.warn_zero_frametime = 1;
 }
@@ -1476,6 +1483,20 @@ static void SV_RunOneTick (double tick_dt)
 		}
 	}
 
+	if (jitter_time_debug.value > 0.0f && sv_player)
+	{
+		Con_Printf ("JITTIME SV tick svt=%.6f svft=%.6f plorg=%.2f %.2f %.2f plvel=%.2f %.2f %.2f ongr=%d grent=%d\n",
+			qcvm->time, host_frametime,
+			sv_player->v.origin[0], sv_player->v.origin[1], sv_player->v.origin[2],
+			sv_player->v.velocity[0], sv_player->v.velocity[1], sv_player->v.velocity[2],
+			((int)sv_player->v.flags & FL_ONGROUND) ? 1 : 0, (int)sv_player->v.groundentity);
+		JITTER_LOG ("JITTIME SV tick svt=%.6f svft=%.6f plorg=%.2f %.2f %.2f plvel=%.2f %.2f %.2f ongr=%d grent=%d\n",
+			qcvm->time, host_frametime,
+			sv_player->v.origin[0], sv_player->v.origin[1], sv_player->v.origin[2],
+			sv_player->v.velocity[0], sv_player->v.velocity[1], sv_player->v.velocity[2],
+			((int)sv_player->v.flags & FL_ONGROUND) ? 1 : 0, (int)sv_player->v.groundentity);
+	}
+
 	if (sys_step_debug.value > 0.0f)
 	{
 		Con_Printf ("[PHYS] sv.time %.6f sv.frametime %.6f ticks_this_frame %d\n",
@@ -1540,6 +1561,7 @@ void Host_ServerFrame (void)
 	double		clamped_frametime;
 	double		tick_dt;
 	double		net_dt;
+	double		jit_accum_before;
 	int64_t		frame_us;
 	int64_t		tick_dt_us;
 	int64_t		max_accum_us;
@@ -1579,6 +1601,8 @@ void Host_ServerFrame (void)
 		tick_dt_us = 1;
 	if (sys_step_debug.value > 0.0f)
 		sys_step_debug_info.tick_us = tick_dt_us;
+
+	jit_accum_before = sv_fixedtick.value > 0.0f ? (double)sv_accum_us / 1000000.0 : sv_accum;
 
 	if (sv_fixedtick.value > 0.0f)
 	{
@@ -1659,6 +1683,19 @@ void Host_ServerFrame (void)
 				JITTER_LOG ("NETDBG sv_tick catchup clamped ticks %d accum %.6f dt %.6f\n",
 					ticks, sv_accum, tick_dt);
 			}
+		}
+	}
+
+	if (jitter_time_debug.value > 0.0f)
+	{
+		double accum_before = jit_accum_before;
+		double accum_after = sv_fixedtick.value > 0.0f ? (double)sv_accum_us / 1000000.0 : sv_accum;
+		Con_Printf ("JITTIME SV frame rt=%.6f hf=%.6f ticks=%d acc=%.6f->%.6f\n", realtime, clamped_frametime, ticks, accum_before, accum_after);
+		JITTER_LOG ("JITTIME SV frame rt=%.6f hf=%.6f ticks=%d acc=%.6f->%.6f\n", realtime, clamped_frametime, ticks, accum_before, accum_after);
+		if (ticks == 0 || ticks > 3)
+		{
+			Con_Printf ("JITWARN ticks_this_frame==0 or >3\n");
+			JITTER_LOG ("JITWARN ticks_this_frame==0 or >3\n");
 		}
 	}
 
@@ -1973,6 +2010,11 @@ void _Host_Frame (double time)
 // decide the simulation time
 	accumtime += host_netinterval?CLAMP(0.0, time, 0.2):0.0;	//for renderer/server isolation
 	Host_AdvanceTime (time);
+	if (jitter_time_debug.value > 0.0f && host_frametime <= 0.0)
+	{
+		Con_Printf ("JITWARN host_frame_skipped\n");
+		JITTER_LOG ("JITWARN host_frame_skipped\n");
+	}
 
 // run async procs
 	AsyncQueue_Drain (&async_queue);

--- a/Quake/quakedef.h
+++ b/Quake/quakedef.h
@@ -325,6 +325,7 @@ extern	cvar_t		jitter_log_enable;
 extern	cvar_t		jitter_log_file;
 extern	cvar_t		jitter_log_flush;
 extern	cvar_t		jitter_log_force_developer;
+extern	cvar_t		jitter_time_debug;
 extern	cvar_t		sv_fixedtick;
 extern	cvar_t		sv_maxsteps_per_frame;
 


### PR DESCRIPTION
### Motivation
- Investigate severe local single-player jitter by emitting minimal, plain-text timing diagnostics into existing NETDBG / jitter logs when enabled. 
- Provide per-render and per-server-frame/tick timing lines and simple WARN markers to make timing anomalies obvious in logs without refactoring existing logging.

### Description
- Add a new cvar `jitter_time_debug` (declaration in `Quake/quakedef.h`, definition in `Quake/host.c`, and registration in `Host_InitLocal`) to toggle the diagnostics.
- Client: emit a per-rendered-frame line `JITTIME CL rt=<realtime> hf=<host_frametime> clt=<cl.time> cmdmsec=<cmd.msec> cmds=<num_cmds_generated> predsteps=<pred_steps>` from `CL_JitterDebug_Log` and track `cl_cmds_generated_last_frame` / `cl_cmd_msec_last_generated` used in that line.
- Client: emit `JITWARN cmdmsec_zero_or_out_of_range` from `CL_SendCmd` when generated `cmd.msec` is clamped (<1 or >255).
- Server: emit per-tick `JITTIME SV tick svt=<sv.time> svft=<sv.frametime> plorg=<x y z> plvel=<x y z> ongr=<0/1> grent=<id>` from `SV_RunOneTick` (when `sv_player` is present).
- Server: emit per-frame `JITTIME SV frame rt=<realtime> hf=<host_frametime> ticks=<ticks_this_frame> acc=<tick_accumulator_before>-><after>` from `Host_ServerFrame` and warn `JITWARN ticks_this_frame==0 or >3` when ticks appear abnormal.
- Host timing WARNs: emit `JITWARN host_frametime_clamped` in `Host_AdvanceTime` and `JITWARN host_frame_skipped` in `_Host_Frame` when a frame is skipped or clamped.
- All `JITTIME` / `JITWARN` messages are printed with `Con_Printf` and also sent to the existing `JITTER_LOG` macro to preserve current log behavior; logging was added inline close to the existing Host/CL/SV timing code as requested.

### Testing
- Ran a CMake configure/build attempt with `cmake -S . -B build && cmake --build build -j4`; configuration failed due to missing SDL2 package files (`SDL2Config.cmake` / `sdl2-config.cmake`) in the environment, so a full build/test could not be completed.
- Per-file edits and inserted log lines were validated via repository search/inspection (automated `rg`/scripted edits) to ensure the new messages and cvar are present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984df4e3084832e9058c912087a245e)