### PR TITLE
Remove reference to non-existent entvars basevelocity in server physics debug path

### DIFF
--- a/Quake/sv_phys.c
+++ b/Quake/sv_phys.c
@@ -1059,7 +1059,7 @@ void SV_Physics_Client (edict_t	*ent, int num)
 
 			VectorCopy (ent->v.origin, sys_step_debug_info.player_origin_after);
 			VectorCopy (ent->v.velocity, sys_step_debug_info.player_vel_after);
-			VectorCopy (ent->v.basevelocity, sys_step_debug_info.player_basevel_after);
+			VectorClear (sys_step_debug_info.player_basevel_after);
 			sys_step_debug_info.player_groundent_after = (int)ent->v.groundentity;
 			sys_step_debug_info.player_onground_after = ((int)ent->v.flags & FL_ONGROUND) ? 1 : 0;
 			VectorClear (sys_step_debug_info.player_ground_vel);


### PR DESCRIPTION
### Motivation
- Fix a C2039 build error caused by referencing a non-existent `entvars_t` member `basevelocity` in the server physics debug capture. 
- Keep the server-side debug snapshot consistent without depending on a missing field.

### Description
- Replace `VectorCopy(ent->v.basevelocity, sys_step_debug_info.player_basevel_after)` with `VectorClear(sys_step_debug_info.player_basevel_after)` in `Quake/sv_phys.c` inside `SV_Physics_Client` to avoid the invalid member access. 
- Only `Quake/sv_phys.c` was modified (single-line change at the debug capture block).

### Testing
- Ran `rg -n "basevelocity" Quake/sv_phys.c Quake/host.c Quake/quakedef.h` to verify no remaining references to `basevelocity`, which returned no matches. 
- Ran `make -C Quake -j2` which failed in this environment due to missing SDL development tooling/headers (`sdl2-config` / `SDL.h`), an unrelated external dependency; the failure is not caused by this code change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984e09b4ab4832e90a0f12bbeef77ea)