### PR TITLE
Fix cl_predict interpolation argument order and angle lerp helper

### DIFF
--- a/Quake/cl_predict.c
+++ b/Quake/cl_predict.c
@@ -943,8 +943,8 @@ static qboolean CL_Predict_GetGroundMotion (cl_pred_state_t *state, int grounden
 	frac = (float)((sample_t - t0) / (t1 - t0));
 	frac = CLAMP (0.0f, frac, 1.0f);
 
-	VectorLerp (ent->msg_origins[1], frac, ent->msg_origins[0], ground_now);
-	yaw_now = CL_LerpAngle (ent->msg_angles[1][YAW], ent->msg_angles[0][YAW], frac);
+	VectorLerp (ent->msg_origins[1], ent->msg_origins[0], frac, ground_now);
+	yaw_now = LerpAngleShortest (ent->msg_angles[1][YAW], ent->msg_angles[0][YAW], frac);
 
 	if (!state->ground_cache.valid || state->ground_cache.id != groundent)
 	{


### PR DESCRIPTION
### Motivation
- Fix MSVC compile/type-mismatch errors and an undefined symbol around ground-motion interpolation in the prediction code by correcting incorrect call usage and selecting the proper angle-lerp helper.

### Description
- Corrected the `VectorLerp` call in `CL_Predict_GetGroundMotion` to use the proper parameter order `from, to, frac, dst`.
- Replaced the out-of-scope `CL_LerpAngle` call with the in-scope helper `LerpAngleShortest` for angle interpolation.
- Changed code in `Quake/cl_predict.c` (around the ground-motion sampling at the interpolation step).

### Testing
- Ran `make -C Quake -j2` to validate the tree, but the build could not complete in this environment due to missing SDL2 tooling/headers (`sdl2-config: No such file or directory`, `SDL.h: No such file or directory`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984ff441654832eabbe21ca1ae7065c)