### PR TITLE
Fix cl_predict build error from invalid client_state member access

### DIFF
--- a/Quake/cl_predict.c
+++ b/Quake/cl_predict.c
@@ -916,7 +916,7 @@ static qboolean CL_GetEntityTransform (int entnum, vec3_t origin, vec3_t angles)
 	if (entnum <= 0 || entnum >= MAX_EDICTS)
 		return false;
 
-	ent = &cl.entities[entnum];
+	ent = &cl_entities[entnum];
 	VectorCopy (ent->origin, origin);
 	VectorCopy (ent->angles, angles);
 


### PR DESCRIPTION
### Motivation
- Fix the MSVC compile error `C2039` caused by accessing `cl.entities` (which is not a member of `client_state_t`) in the prediction code and align the function with the project-wide `cl_entities` storage.

### Description
- Replace `ent = &cl.entities[entnum];` with `ent = &cl_entities[entnum];` in `Quake/cl_predict.c` inside `CL_GetEntityTransform` to use the correct global entity array.

### Testing
- Inspected usages with `rg` and attempted to configure and build with `cmake -S . -B build && cmake --build build -j2`, but configuration failed due to a missing SDL2 development package so a full build could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69852cc733d0832ebb9b896bfd772e32)