### PR TITLE
Use entity->model pointer in CL_Predict_EntityStateSane to fix build error

### DIFF
--- a/Quake/cl_predict.c
+++ b/Quake/cl_predict.c
@@ -250,7 +250,7 @@ static qboolean CL_Predict_EntityStateSane (const entity_t *e)
 		return false;
 	if (!CL_Predict_AnglesSane (e->msg_angles[1]))
 		return false;
-	if (e->modelindex == 0
+	if (e->model == NULL
 		&& VectorCompare (e->msg_origins[0], vec3_origin)
 		&& VectorCompare (e->msg_origins[1], vec3_origin))
 		return false;


### PR DESCRIPTION
### Motivation
- Fix an MSVC compile error where `CL_Predict_EntityStateSane` accessed a non-existent `entity_t` member `modelindex` by using the actual model indicator.

### Description
- Replace the check `e->modelindex == 0` with `e->model == NULL` in `Quake/cl_predict.c` inside `CL_Predict_EntityStateSane` so it matches the `entity_t` definition in `Quake/render.h`.

### Testing
- Inspected `entity_t` in `Quake/render.h`, examined the updated lines with `nl`, and ran `rg -n "modelindex" Quake/cl_predict.c` to confirm the invalid reference was removed; the checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698534439b24832e9dcfca4aed1e7053)