### PR TITLE
Relax ground-entity validation to avoid ground-cache thrash and fix platform jitter

### DIFF
--- a/Quake/cl_predict.c
+++ b/Quake/cl_predict.c
@@ -431,16 +431,29 @@ static void CL_Predict_ApplyGroundTransition (cl_pred_state_t *state, qboolean t
 static qboolean CL_Predict_IsGroundEntityValid (int groundent)
 {
 	entity_t *ent;
+	int i;
 
-	if (groundent <= 0 || groundent >= cl_max_edicts)
+	if (groundent <= 0 || groundent >= MAX_EDICTS)
 		return false;
+
 	if (!cl_entities)
 		return false;
+
 	if (cl.mtime[0] <= 0.0)
 		return false;
+
 	ent = &cl_entities[groundent];
-	if (!CL_Predict_EntityStateSane (ent))
-		return false;
+
+	// Validate origin sanity only.
+	for (i = 0; i < 3; i++)
+	{
+		if (!isfinite (ent->msg_origins[0][i]) || !isfinite (ent->msg_origins[1][i]))
+			return false;
+
+		if (fabs (ent->msg_origins[0][i]) > 65536 || fabs (ent->msg_origins[1][i]) > 65536)
+			return false;
+	}
+
 	return true;
 }
 
@@ -994,18 +1007,15 @@ static qboolean CL_Predict_GetGroundMotion (cl_pred_state_t *state, int grounden
 
 	if (!CL_Predict_IsGroundEntityValid (groundent))
 	{
-		CL_Predict_ResetGroundCache (state);
 		if (cl_netdebug_parse.value)
 		{
-			int present = (cl.snapshot_present && groundent > 0 && groundent < cl_max_edicts) ? (cl.snapshot_present[groundent] ? 1 : 0) : -1;
-			double msgtime = (groundent > 0 && groundent < cl_max_edicts) ? cl_entities[groundent].msgtime : 0.0;
-			Con_Printf ("NETDBG: pred ground invalid ent=%d present=%d ent_msg=%.3f mtime0=%.3f mtime1=%.3f sane=%d\n",
-				groundent, present, msgtime, cl.mtime[0], cl.mtime[1],
-				(groundent > 0 && groundent < cl_max_edicts) ? (CL_Predict_EntityStateSane (&cl_entities[groundent]) ? 1 : 0) : 0);
-			JITTER_LOG ("NETDBG: pred ground invalid ent=%d present=%d ent_msg=%.3f mtime0=%.3f mtime1=%.3f sane=%d\n",
-				groundent, present, msgtime, cl.mtime[0], cl.mtime[1],
-				(groundent > 0 && groundent < cl_max_edicts) ? (CL_Predict_EntityStateSane (&cl_entities[groundent]) ? 1 : 0) : 0);
+			Con_Printf ("PREDDBG invalid groundent %d cache_id %d\n", groundent, state->ground_cache.id);
 		}
+
+		// Only invalidate if entity changed.
+		if (state->ground_cache.id != groundent)
+			state->ground_cache.valid = false;
+
 		return false;
 	}
 


### PR DESCRIPTION
### Motivation
- Delta snapshots can omit entities in the current snapshot while still providing interpolatable state, and the previous strict validation (presence/msgtime checks) caused the ground cache to be reset every few frames, producing zero ground deltas and visible moving-platform jitter.

### Description
- Replace `CL_Predict_IsGroundEntityValid` with a tolerant validation that checks `groundent` bounds (`MAX_EDICTS`), presence of `cl_entities`, positive `cl.mtime[0]`, and only validates the sanity (finiteness and reasonable magnitude) of `msg_origins` instead of requiring snapshot presence or exact `msgtime` matching.
- Remove reliance on transient `snapshot_present`/`msgtime` gating in the validation path to tolerate delta snapshots.
- In `CL_Predict_GetGroundMotion`, avoid thrashing the ground cache on brief/partial validation failures by only invalidating the cache when the ground entity ID actually changes, and add a lightweight debug print (`PREDDBG invalid groundent ...`) when validation fails.
- Use `MAX_EDICTS` in the bounds check and retain existing interpolation/time logic and ground-motion calculation.

### Testing
- Searched for and inspected relevant symbols and changed locations with `rg` to ensure target functions and diagnostic strings were updated; the searches succeeded and showed updated lines.
- Verified the modified source sections with `sed`/`nl` to confirm the new `CL_Predict_IsGroundEntityValid` implementation and the adjusted invalid-ground handling in `CL_Predict_GetGroundMotion`; the file excerpts match the intended patch.
- Reviewed the produced diff with `git diff` to verify only the intended hunks were changed and the new debug message and cache-invalidation logic were applied; the diff matches the described changes and contains no unrelated edits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698535fb9780832eacd698e9364c29a7)