### PR TITLE
Fix ground entity bounds check in prediction

### DIFF
--- a/Quake/cl_predict.c
+++ b/Quake/cl_predict.c
@@ -487,7 +487,7 @@ static qboolean CL_Predict_IsGroundEntityValid (int groundent)
 	entity_t *ent;
 	int i;
 
-	if (groundent <= 0 || groundent >= MAX_EDICTS)
+	if (groundent <= 0 || groundent >= cl_max_edicts)
 		return false;
 
 	if (!cl_entities)


### PR DESCRIPTION
### Motivation
- Prevent out-of-bounds access when validating ground entity indices during client-side prediction by using the client’s actual edict limit rather than a compile-time server constant.

### Description
- In `Quake/cl_predict.c` updated the bounds check in `CL_Predict_IsGroundEntityValid` to use `cl_max_edicts` instead of `MAX_EDICTS` so ground entity validation is compared against the client-side edict limit (`cl_max_edicts`) and avoids indexing `cl_entities` out of range.

### Testing
- Automated tests were not run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988a6962b40832ea0f51334c2aef451)