### PR TITLE
Improve QuakeWorld-style movement prediction and yaw-only movement

### DIFF
--- a/Quake/cl_predict.c
+++ b/Quake/cl_predict.c
@@ -9,6 +9,7 @@ extern cvar_t sv_accelerate;
 extern cvar_t sv_friction;
 extern cvar_t sv_stopspeed;
 extern cvar_t sv_gravity;
+extern cvar_t sv_altnoclip;
 extern cvar_t cl_netdebug_parse;
 extern cvar_t cl_predict;
 extern cvar_t cl_cmdrate;
@@ -153,6 +154,7 @@ static qboolean CL_Predict_AnglesSane (const vec3_t a);
 static qboolean CL_Predict_EntityStateSane (const entity_t *e);
 static void CL_Predict_StoreFrame (unsigned int seq, const cl_pred_state_t *state);
 static qboolean CL_Predict_GetFrame (unsigned int seq, cl_pred_frame_t *out);
+static qboolean CL_Predict_GetLocalMovementState (byte *movetype, byte *waterlevel);
 
 #define CL_PREDICT_MAX_CLIP_PLANES 5
 #define CL_PREDICT_STEP_SIZE 18.0f
@@ -306,6 +308,29 @@ static qboolean CL_Predict_EntityStateSane (const entity_t *e)
 		&& VectorCompare (e->msg_origins[1], vec3_origin))
 		return false;
 
+	return true;
+}
+
+static qboolean CL_Predict_GetLocalMovementState (byte *movetype, byte *waterlevel)
+{
+	const snapshot_state_t *state;
+
+	if (movetype)
+		*movetype = MOVETYPE_WALK;
+	if (waterlevel)
+		*waterlevel = 0;
+	if (!cl.snapshot_baseline || !cl.snapshot_present)
+		return false;
+	if (cl.viewentity <= 0 || cl.viewentity >= cl_max_edicts)
+		return false;
+	if (!cl.snapshot_present[cl.viewentity])
+		return false;
+
+	state = &cl.snapshot_baseline[cl.viewentity];
+	if (movetype)
+		*movetype = state->movetype;
+	if (waterlevel)
+		*waterlevel = state->waterlevel;
 	return true;
 }
 
@@ -1529,6 +1554,7 @@ static void CL_Predict_StepSlideMove (cl_pred_state_t *state, const vec3_t mins,
 static void CL_Predict_SimulateCmd (cl_pred_state_t *state, const usercmd_t *cmd, float dt, qboolean is_render)
 {
 	vec3_t forward, right, up;
+	vec3_t moveangles;
 	vec3_t wishvel, wishdir;
 	float wishspeed;
 	vec3_t mins, maxs;
@@ -1538,6 +1564,12 @@ static void CL_Predict_SimulateCmd (cl_pred_state_t *state, const usercmd_t *cmd
 	qboolean ground_applied;
 	qboolean ground_entity;
 	int ground_reason = CL_GROUND_REASON_OK;
+	byte movetype = MOVETYPE_WALK;
+	byte waterlevel = 0;
+	qboolean use_full_angles = false;
+	qboolean use_alt_noclip = false;
+	qboolean use_noclip = false;
+	qboolean in_water = false;
 
 	if (sys_step_debug.value > 0.0f)
 		sys_step_debug_info.cl_pred_steps++;
@@ -1639,12 +1671,29 @@ static void CL_Predict_SimulateCmd (cl_pred_state_t *state, const usercmd_t *cmd
 
 	VectorCopy (cmd->viewangles, state->viewangles);
 
-	AngleVectors (cmd->viewangles, forward, right, up);
+	CL_Predict_GetLocalMovementState (&movetype, &waterlevel);
+	use_alt_noclip = (movetype == MOVETYPE_NOCLIP && sv_altnoclip.value > 0.0f);
+	use_noclip = (movetype == MOVETYPE_NOCLIP || noclip_anglehack);
+	in_water = (waterlevel >= 2 && movetype != MOVETYPE_NOCLIP);
+	use_full_angles = (movetype == MOVETYPE_NOCLIP || movetype == MOVETYPE_FLY || noclip_anglehack);
+
+	VectorCopy (cmd->viewangles, moveangles);
+	if (!use_full_angles)
+	{
+		moveangles[PITCH] = 0.0f;
+		moveangles[ROLL] = 0.0f;
+	}
+	AngleVectors (moveangles, forward, right, up);
 
 	wishvel[0] = forward[0] * cmd->forwardmove + right[0] * cmd->sidemove;
 	wishvel[1] = forward[1] * cmd->forwardmove + right[1] * cmd->sidemove;
-	wishvel[2] = forward[2] * cmd->forwardmove + right[2] * cmd->sidemove;
-	wishvel[2] += cmd->upmove;
+	wishvel[2] = 0.0f;
+	if (use_full_angles)
+		wishvel[2] += forward[2] * cmd->forwardmove + right[2] * cmd->sidemove;
+	if (use_full_angles || in_water)
+		wishvel[2] += cmd->upmove;
+	if (in_water && !cmd->forwardmove && !cmd->sidemove && !cmd->upmove)
+		wishvel[2] -= 60.0f;
 
 	VectorCopy (wishvel, wishdir);
 	wishspeed = VectorNormalize (wishdir);
@@ -1654,15 +1703,55 @@ static void CL_Predict_SimulateCmd (cl_pred_state_t *state, const usercmd_t *cmd
 		wishspeed = sv_maxspeed.value;
 	}
 
-	if (noclip_anglehack)
+	if (use_noclip)
 	{
+		if (use_alt_noclip)
+			wishvel[2] += cmd->upmove;
 		VectorCopy (wishvel, state->velocity);
 		VectorMA (state->origin, dt, state->velocity, state->origin);
 		state->onground = false;
 		return;
 	}
 
-	if (state->onground)
+	if (in_water)
+	{
+		float speed, newspeed, addspeed, accelspeed;
+
+		wishspeed = VectorLength (wishvel);
+		if (wishspeed > sv_maxspeed.value)
+		{
+			VectorScale (wishvel, sv_maxspeed.value / wishspeed, wishvel);
+			wishspeed = sv_maxspeed.value;
+		}
+		wishspeed *= 0.7f;
+
+		speed = VectorLength (state->velocity);
+		if (speed)
+		{
+			newspeed = speed - dt * speed * sv_friction.value;
+			if (newspeed < 0.0f)
+				newspeed = 0.0f;
+			VectorScale (state->velocity, newspeed / speed, state->velocity);
+		}
+		else
+		{
+			newspeed = 0.0f;
+		}
+
+		if (wishspeed > 0.0f)
+		{
+			addspeed = wishspeed - newspeed;
+			if (addspeed > 0.0f)
+			{
+				VectorNormalize (wishvel);
+				accelspeed = sv_accelerate.value * wishspeed * dt;
+				if (accelspeed > addspeed)
+					accelspeed = addspeed;
+				VectorMA (state->velocity, accelspeed, wishvel, state->velocity);
+			}
+		}
+	}
+	else if (state->onground)
 	{
 		if (cmd->buttons & 2)
 		{

--- a/Quake/sv_user.c
+++ b/Quake/sv_user.c
@@ -276,13 +276,17 @@ void SV_WaterMove (void)
 	int		i;
 	vec3_t	wishvel;
 	float	speed, newspeed, wishspeed, addspeed, accelspeed;
+	vec3_t	moveangles;
 
 	SV_PLAYER_GUARD_VOID ("SV_WaterMove", 0);
 
 //
 // user intentions
 //
-	AngleVectors (sv_player->v.v_angle, forward, right, up);
+	VectorCopy (sv_player->v.v_angle, moveangles);
+	moveangles[PITCH] = 0.0f;
+	moveangles[ROLL] = 0.0f;
+	AngleVectors (moveangles, forward, right, up);
 
 	for (i=0 ; i<3 ; i++)
 		wishvel[i] = forward[i]*cmd.forwardmove + right[i]*cmd.sidemove;
@@ -383,10 +387,17 @@ void SV_AirMove (void)
 	vec3_t		wishvel, wishdir;
 	float		wishspeed;
 	float		fmove, smove;
+	vec3_t		moveangles;
 
 	SV_PLAYER_GUARD_VOID ("SV_AirMove", 0);
 
-	AngleVectors (sv_player->v.angles, forward, right, up);
+	VectorCopy (sv_player->v.angles, moveangles);
+	if ((int)sv_player->v.movetype == MOVETYPE_WALK)
+	{
+		moveangles[PITCH] = 0.0f;
+		moveangles[ROLL] = 0.0f;
+	}
+	AngleVectors (moveangles, forward, right, up);
 
 	fmove = cmd.forwardmove;
 	smove = cmd.sidemove;


### PR DESCRIPTION
### Motivation
- Make client-side prediction align better with server-side QuakeWorld movement by honoring snapshot `movetype`/`waterlevel`, handling noclip consistently, and applying yaw-only movement when appropriate.
- Improve movement feel for water, noclip and walking by using existing move functions and small, localized changes rather than large refactors.

### Description
- Add `extern cvar_t sv_altnoclip` and a helper `CL_Predict_GetLocalMovementState` to read the local snapshot `movetype` and `waterlevel` for prediction.
- Update `CL_Predict_SimulateCmd` in `Quake/cl_predict.c` to consult snapshot `movetype`/`waterlevel` and choose movement behavior accordingly, including yaw-only movement vectors, alternative noclip handling, and QuakeWorld-style water acceleration/friction during prediction.
- Introduce local `moveangles` processing so `PITCH`/`ROLL` can be zeroed for walk/movetype-specific yaw-only movement while preserving full-angle movement for noclip/fly cases and `noclip_anglehack`.
- Add `use_noclip` / `use_alt_noclip` logic to align prediction with server behavior for `MOVETYPE_NOCLIP` and `sv_altnoclip`.
- Mirror the yaw-only movement change server-side by modifying `SV_WaterMove` and `SV_AirMove` in `Quake/sv_user.c` so `MOVETYPE_WALK` uses yaw-only angle vectors (zeroing pitch/roll) to match the prediction assumptions.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988aba9489c832eb37b50fcfc745c47)