### PR TITLE
Fix sv_sendrate linkage for host tick pacing

### DIFF
--- a/Quake/host.c
+++ b/Quake/host.c
@@ -112,6 +112,7 @@ devstats_t dev_stats, dev_peakstats;
 overflowtimes_t dev_overflows; //this stores the last time overflow messages were displayed, not the last time overflows occured
 extern cvar_t sv_tickrate;
 extern cvar_t sv_netrate;
+extern cvar_t sv_sendrate;
 extern cvar_t sv_tick_maxcatchup;
 extern cvar_t sv_fixedtick;
 extern cvar_t sv_maxsteps_per_frame;

--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -73,7 +73,7 @@ cvar_t sv_maxupdaterate = {"sv_maxupdaterate", "0", CVAR_NONE};
 // Q3MINI BEGIN
 cvar_t sv_tickrate = {"sv_tickrate", "60", CVAR_NONE};
 cvar_t sv_netrate = {"sv_netrate", "20", CVAR_NONE};
-static cvar_t sv_sendrate = {"sv_sendrate", "30", CVAR_NONE};
+cvar_t sv_sendrate = {"sv_sendrate", "30", CVAR_NONE};
 static cvar_t sv_entprio = {"sv_entprio", "1", CVAR_NONE};
 static cvar_t sv_ent_budget = {"sv_ent_budget", "1100", CVAR_NONE};
 static cvar_t sv_ent_keepalive_ms = {"sv_ent_keepalive_ms", "250", CVAR_NONE};


### PR DESCRIPTION
### Motivation
- The host timing code referenced `sv_sendrate` but it was declared `static` in `Quake/sv_main.c`, causing an undeclared identifier/linkage error when compiling `host.c`.

### Description
- Remove `static` from the `sv_sendrate` declaration in `Quake/sv_main.c` so it has external linkage, and add `extern cvar_t sv_sendrate;` to `Quake/host.c` so the host code can access it.

### Testing
- No automated tests were run for this change (build was not executed as part of this patch).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988f1a6927c832e8681d51550525dca)