### PR TITLE
Fix prediction error tracking and enhance jitter debug output

### DIFF
--- a/Quake/cl_main.c
+++ b/Quake/cl_main.c
@@ -564,7 +564,14 @@ void CL_JitterDebug_Log (void)
 		VectorClear (pred.base_angles);
 		VectorClear (pred.predicted_origin);
 		VectorClear (pred.predicted_angles);
+		pred.pred_error_len = 0.0f;
+		pred.pred_smooth_error_len = 0.0f;
+		pred.pred_angle_error_len = 0.0f;
 		pred.onground = false;
+		pred.ack_seq = 0;
+		pred.pred_frame_found = false;
+		pred.replay_count = 0;
+		pred.snap_count = 0;
 		pred.groundent = 0;
 		pred.ground_valid = false;
 		pred.ground_valid_reason = CL_GROUND_REASON_OK;
@@ -596,7 +603,8 @@ void CL_JitterDebug_Log (void)
 	Con_Printf ("JITTERDBG cl.time %.3f realtime %.3f host_frametime %.4f interp_target %.3f interp_delay %.3f "
 		"pred_accum %.4f pred_step_dt %.4f pred_substeps %d/%d nullcmd %d ang_norm %d mouse_applied %d "
 		"pred_apply_reason %d render_apply_reason %d "
-		"server_applied %d pred_steps %d pred_err %.2f ang_err %.2f ang_delta %.2f %.2f %.2f "
+		"server_applied %d pred_steps %d ack %u pred_frame %d true_pred_err %.2f smooth_err %.2f replay %d snaps %d "
+		"pred_err %.2f ang_err %.2f ang_delta %.2f %.2f %.2f "
 		"local_interp_bypassed %d viewheight %.2f view_src %d "
 		"onground %d groundent %d ground_valid %d reason %d trace_frac %.2f trace_nz %.2f trace_ent %d trace_solid %d/%d trace_fallback %d "
 		"wishspeed %.1f wishvel_z %.1f dt %.4f flags %d ground_delta %.2f ground_yaw %.2f apply_pred %d apply_render %d "
@@ -615,6 +623,12 @@ void CL_JitterDebug_Log (void)
 		pred.pred_apply_render_reason,
 		pred.server_update_applied ? 1 : 0,
 		pred.prediction_steps,
+		pred.ack_seq,
+		pred.pred_frame_found ? 1 : 0,
+		pred.pred_error_len,
+		pred.pred_smooth_error_len,
+		pred.replay_count,
+		pred.snap_count,
 		pred.pred_error_len,
 		pred.pred_angle_error_len,
 		pred.pred_angle_delta_shortest[0],
@@ -650,7 +664,8 @@ void CL_JitterDebug_Log (void)
 	JITTER_LOG ("JITTERDBG cl.time %.3f realtime %.3f host_frametime %.4f interp_target %.3f interp_delay %.3f "
 		"pred_accum %.4f pred_step_dt %.4f pred_substeps %d/%d nullcmd %d ang_norm %d mouse_applied %d "
 		"pred_apply_reason %d render_apply_reason %d "
-		"server_applied %d pred_steps %d pred_err %.2f ang_err %.2f ang_delta %.2f %.2f %.2f "
+		"server_applied %d pred_steps %d ack %u pred_frame %d true_pred_err %.2f smooth_err %.2f replay %d snaps %d "
+		"pred_err %.2f ang_err %.2f ang_delta %.2f %.2f %.2f "
 		"local_interp_bypassed %d viewheight %.2f view_src %d "
 		"onground %d groundent %d ground_valid %d reason %d trace_frac %.2f trace_nz %.2f trace_ent %d trace_solid %d/%d trace_fallback %d "
 		"wishspeed %.1f wishvel_z %.1f dt %.4f flags %d ground_delta %.2f ground_yaw %.2f apply_pred %d apply_render %d "
@@ -669,6 +684,12 @@ void CL_JitterDebug_Log (void)
 		pred.pred_apply_render_reason,
 		pred.server_update_applied ? 1 : 0,
 		pred.prediction_steps,
+		pred.ack_seq,
+		pred.pred_frame_found ? 1 : 0,
+		pred.pred_error_len,
+		pred.pred_smooth_error_len,
+		pred.replay_count,
+		pred.snap_count,
 		pred.pred_error_len,
 		pred.pred_angle_error_len,
 		pred.pred_angle_delta_shortest[0],

--- a/Quake/cl_predict.c
+++ b/Quake/cl_predict.c
@@ -38,7 +38,7 @@ static cvar_t cl_pred_correct_angles = {"cl_pred_correct_angles", "0", CVAR_NONE
 static cvar_t cl_pred_inherit_ground = {"cl_pred_inherit_ground", "1", CVAR_ARCHIVE};
 static cvar_t cl_pred_ground_yaw = {"cl_pred_ground_yaw", "0", CVAR_ARCHIVE};
 
-#define CL_PRED_FRAME_RING 128
+#define CL_PRED_FRAME_RING 256
 
 typedef struct
 {
@@ -159,6 +159,9 @@ static double cl_pred_error_time;
 static int cl_pred_replay_count;
 static int cl_pred_snap_count;
 static int cl_pred_smooth_count;
+static float cl_pred_true_error_len;
+static qboolean cl_pred_pred_frame_found;
+static unsigned int cl_pred_last_ack_seq;
 
 static float CL_Predict_GetStepTime (void);
 static qboolean CL_Predict_IsEnabled (void);
@@ -1929,6 +1932,7 @@ void CL_Predict_Clear (void)
 	cl_pred_replay_count = 0;
 	cl_pred_snap_count = 0;
 	cl_pred_smooth_count = 0;
+	cl_pred_last_ack_seq = 0;
 }
 
 void CL_Predict_ResetGround (void)
@@ -1953,6 +1957,8 @@ void CL_Predict_BeginFrame (void)
 	cl_pred_replay_count = 0;
 	cl_pred_snap_count = 0;
 	cl_pred_smooth_count = 0;
+	cl_pred_true_error_len = 0.0f;
+	cl_pred_pred_frame_found = false;
 
 	enabled = CL_Predict_IsEnabled ();
 	if (enabled && !cl_pred_prev_enabled && cl_pred.has_base)
@@ -2116,9 +2122,11 @@ void CL_Predict_ServerUpdate (unsigned int ack, const vec3_t origin, const vec3_
 
 	cl_pred.seq_acked = ack;
 	cl_pred_server_update_this_frame = true;
+	cl_pred_last_ack_seq = ack;
 	allow_angle_correction = (cl_pred_correct_angles.value > 0.0f);
 	if (cl_pred.has_base)
 		pred_frame_valid = CL_Predict_GetFrame (ack, &pred_frame);
+	cl_pred_pred_frame_found = pred_frame_valid ? true : false;
 	if (cl_pred.has_base)
 	{
 		if (pred_frame_valid)
@@ -2285,6 +2293,7 @@ void CL_Predict_ServerUpdate (unsigned int ack, const vec3_t origin, const vec3_
 		VectorClear (cl_pred_angle_error);
 		cl_pred_reset = false;
 	}
+	cl_pred_true_error_len = error_len;
 	VectorCopy (origin, cl_pred.base.origin);
 	VectorCopy (velocity, cl_pred.base.velocity);
 	cl_pred.base.viewangles[0] = NormalizeAngle180 (viewangles[0]);
@@ -2462,10 +2471,15 @@ qboolean CL_Predict_GetDebug (cl_pred_debug_t *out)
 	memset (out, 0, sizeof(*out));
 	out->prediction_steps = cl_pred_steps_this_frame;
 	out->server_update_applied = cl_pred_server_update_this_frame;
-	out->pred_error_len = VectorLength (cl_pred_error);
+	out->pred_error_len = cl_pred_true_error_len;
+	out->pred_smooth_error_len = VectorLength (cl_pred_error);
 	out->pred_angle_error_len = VectorLength (cl_pred_angle_error);
 	VectorCopy (cl_pred_error, out->pred_error);
 	VectorCopy (cl_pred_angle_error, out->pred_angle_error);
+	out->ack_seq = cl_pred_last_ack_seq;
+	out->pred_frame_found = cl_pred_pred_frame_found;
+	out->replay_count = cl_pred_replay_count;
+	out->snap_count = cl_pred_snap_count;
 	out->onground = cl_pred_ground_dbg.onground;
 	out->groundent = cl_pred_ground_dbg.groundent;
 	out->ground_valid = cl_pred_ground_dbg.ground_valid;

--- a/Quake/client.h
+++ b/Quake/client.h
@@ -532,9 +532,14 @@ typedef struct
 	vec3_t		pred_error;
 	vec3_t		pred_angle_error;
 	float		pred_error_len;
+	float		pred_smooth_error_len;
 	float		pred_angle_error_len;
 	int			prediction_steps;
 	qboolean	server_update_applied;
+	unsigned int	ack_seq;
+	qboolean	pred_frame_found;
+	int			replay_count;
+	int			snap_count;
 	qboolean	onground;
 	int			groundent;
 	qboolean	ground_valid;


### PR DESCRIPTION
### Motivation
- Ensure the client reports the true (server - predicted_at_ack) prediction error and exposes ack/frame metadata for accurate debugging and smoothing decisions.
- Reduce confusion where `pred_err` could be a decayed/smoothed value instead of the instantaneous mismatch at the server-ack point.

### Description
- Increased the prediction frame ring from `128` to `256` (`CL_PRED_FRAME_RING`) to reduce frame overwrite risk for stored predicted frames.
- Added fields and bookkeeping: tracked `cl_pred_last_ack_seq`, `cl_pred_true_error_len`, and `cl_pred_pred_frame_found`, and exposed `ack_seq`, `pred_frame_found`, `replay_count`, and `snap_count` through the prediction debug struct (`cl_pred_debug_t`) in `client.h`.
- On server updates (`CL_Predict_ServerUpdate`) record the acknowledged seq, look up the matching stored predicted frame, compute the true instantaneous error (`error_len`) between server origin and the predicted frame origin, store it in `cl_pred_true_error_len`, and set `pred_frame_found` accordingly.
- Updated `CL_Predict_GetDebug` to return `pred_error_len = cl_pred_true_error_len` (true mismatch) and `pred_smooth_error_len = |cl_pred_error|` (accumulated/smoothed error), plus the new metadata fields.
- Enhanced `CL_JitterDebug_Log` output to include `ack`, whether the acked predicted frame was found, the `true_pred_err`, the current `smooth_err`, plus replay and snap counters to aid diagnosis.

### Testing
- No automated tests were run as part of this change.
- The change is limited to prediction bookkeeping and debug reporting; it intentionally avoids altering physics or adding extra traces per constraints.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988fd69c760832eaf610f79d1c9f140)