### PR TITLE
Restore continuous prediction stepping and harden accumulator handling

### DIFF
--- a/Quake/cl_predict.c
+++ b/Quake/cl_predict.c
@@ -683,6 +683,7 @@ static void CL_Predict_RunFrameSteps (void)
 	float step_dt;
 	int max_steps;
 	int steps = 0;
+	const float PRED_EPS = 0.002f;
 
 	if (!CL_Predict_IsEnabled () || !cl_pred.has_base)
 		return;
@@ -706,7 +707,19 @@ static void CL_Predict_RunFrameSteps (void)
 	if (max_steps < 1)
 		max_steps = 1;
 
-	while (cl_pred_frame_accum >= step_dt && steps < max_steps)
+	if (fabsf (cl_pred_frame_accum - step_dt) < PRED_EPS)
+		cl_pred_frame_accum = step_dt;
+
+	if (cl_pred_nullcmd_injected)
+	{
+		cmd.forwardmove = 0;
+		cmd.sidemove = 0;
+		cmd.upmove = 0;
+		cmd.buttons = 0;
+		cmd.impulse = 0;
+	}
+
+	while (cl_pred_frame_accum + PRED_EPS >= step_dt && steps < max_steps)
 	{
 		cl_pred_render_from = cl_pred.predicted;
 		CL_Predict_SimulateCmd (&cl_pred.predicted, &cmd, step_dt, false);
@@ -714,7 +727,11 @@ static void CL_Predict_RunFrameSteps (void)
 		if (cl_pred_render_cmd_valid && cmd.sequence > 0)
 			CL_Predict_StoreFrame (cmd.sequence, &cl_pred.predicted);
 		cl_pred_frame_accum -= step_dt;
+		if (cl_pred_frame_accum < 0.0f)
+			cl_pred_frame_accum = 0.0f;
 		steps++;
+		Con_Printf ("CONT_PRED step executed acc=%f\n", cl_pred_frame_accum);
+		JITTER_LOG ("CONT_PRED step executed acc=%f\n", cl_pred_frame_accum);
 	}
 
 	cl_pred_last_substeps = steps;


### PR DESCRIPTION
### Motivation
- Prediction stepping was intermittent because the time accumulator could drift just below the frame step and be starved, causing prediction to run only during server resim; the goal is to restore continuous, frame-driven prediction stepping.
- Null/injected commands could prevent prediction from executing for timing consistency, creating jitter and inconsistent simulation progression.

### Description
- Add an epsilon tolerance `PRED_EPS = 0.002f` and change the loop to `while (cl_pred_frame_accum + PRED_EPS >= step_dt)` to allow near-threshold accumulator values to trigger steps. 
- Clamp near-threshold drift by setting `cl_pred_frame_accum = step_dt` when `fabsf(cl_pred_frame_accum - step_dt) < PRED_EPS`.
- Prevent accumulator starvation after stepping by forcing `cl_pred_frame_accum = 0.0f` if it becomes negative after subtracting `step_dt`.
- Ensure prediction still advances when a null command was injected by zeroing movement fields (`forwardmove`, `sidemove`, `upmove`, `buttons`, `impulse`) on the simulated `cmd` so `CL_Predict_SimulateCmd` runs for timing consistency.
- Add debug instrumentation logging via `Con_Printf` and `JITTER_LOG` with the message `"CONT_PRED step executed acc=%f"` on each substep.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698906e42c0c832e9ba8079d6cd82886)