### PR TITLE
Fix prediction accumulator and prediction frame ring buffer indexing

### DIFF
--- a/Quake/cl_predict.c
+++ b/Quake/cl_predict.c
@@ -310,7 +310,7 @@ static void CL_Predict_ClearFrames (void)
 
 static void CL_Predict_StoreFrame (unsigned int seq, const cl_pred_state_t *state)
 {
-	cl_pred_frame_t *frame = &cl_pred.frames[seq % CL_PRED_FRAME_RING];
+	cl_pred_frame_t *frame = &cl_pred.frames[seq & (CL_PRED_FRAME_RING - 1)];
 
 	frame->seq = seq;
 	VectorCopy (state->origin, frame->origin);
@@ -325,7 +325,7 @@ static void CL_Predict_StoreFrame (unsigned int seq, const cl_pred_state_t *stat
 
 static qboolean CL_Predict_GetFrame (unsigned int seq, cl_pred_frame_t *out)
 {
-	cl_pred_frame_t *frame = &cl_pred.frames[seq % CL_PRED_FRAME_RING];
+	cl_pred_frame_t *frame = &cl_pred.frames[seq & (CL_PRED_FRAME_RING - 1)];
 
 	if (frame->seq != seq)
 	{
@@ -2055,7 +2055,7 @@ void CL_Predict_Clear (void)
 	cl_pred_apply_pred_reason = CL_PRED_APPLY_SKIP_DISABLED;
 	cl_pred_apply_render_reason = CL_PRED_APPLY_SKIP_DISABLED;
 	cl_pred_frame_dt_last = 0.0f;
-	cl_pred_frame_accum = cl_pred_frame_dt_last;
+	cl_pred_frame_accum = 0.0;
 	cl_pred_render_interp_valid = false;
 	cl_pred_render_frac = 0.0f;
 	memset (&cl_pred_render_from, 0, sizeof(cl_pred_render_from));
@@ -2113,10 +2113,10 @@ void CL_Predict_BeginFrame (void)
 	}
 	else if (!enabled || !cl_pred.has_base)
 	{
-		if (was_enabled || cl_pred_frame_accum > 0.0 || cl_pred_frame_dt_last > 0.0f)
+		if (was_enabled)
 		{
 			cl_pred_frame_dt_last = 0.0f;
-			cl_pred_frame_accum = cl_pred_frame_dt_last;
+			cl_pred_frame_accum = 0.0;
 		}
 		cl_pred_render_interp_valid = false;
 	}
@@ -2288,7 +2288,7 @@ void CL_Predict_ServerUpdate (unsigned int ack, const vec3_t origin, const vec3_
 		{
 			if (!pred_frame_valid && !cl_pred_warned_pred_miss)
 			{
-				pred_slot = ack % CL_PRED_FRAME_RING;
+				pred_slot = ack & (CL_PRED_FRAME_RING - 1);
 				pred_stored_seq = cl_pred.frames[pred_slot].seq;
 				Con_Printf ("PredFrame MISS: ack=%u stored=%u slot=%u latest=%u\n",
 					ack, pred_stored_seq, pred_slot, cl_pred.seq_latest);


### PR DESCRIPTION
### Motivation

- Logs showed `pred_accum` stuck at zero, low `pred_frame` hit rate and rare replays, so the goal is to restore canonical fixed-step accumulator semantics and make predicted-frame storage/lookup deterministic for reliable rewind/replay.

### Description

- Preserve a fractional accumulator by initializing `cl_pred_frame_accum` to `0.0` and only resetting it when prediction transitions from enabled to disabled instead of forced resets each frame, so `cl_pred_frame_accum` accumulates `frame_dt` while enabled (addresses accumulator/step timing).
- Use power-of-two masking for the prediction frame ring buffer indices by replacing `seq % CL_PRED_FRAME_RING` with `seq & (CL_PRED_FRAME_RING - 1)` and similarly for diagnostics (`ack & (CL_PRED_FRAME_RING - 1)`), ensuring stored `frame->seq = seq` is preserved and lookups reliably validate sequence equality.
- Keep ring overflow detection logic (comparing `latest - ack` to ring size) intact and align diagnostic slot reporting with the masked index to aid debugging when misses or overflow occur.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69891ae48e80832e9f6f60f4b81d82eb)