### PR TITLE
Always compute prediction render fraction and add accumulator debug logging

### DIFF
--- a/Quake/cl_predict.c
+++ b/Quake/cl_predict.c
@@ -750,8 +750,6 @@ static void CL_Predict_RunFrameSteps (void)
 
 	if (!CL_Predict_IsEnabled () || !cl_pred.has_base)
 		return;
-	if (cl_pred_frame_accum <= 0.0)
-		return;
 
 	if (cl_pred_render_cmd_valid)
 	{
@@ -835,11 +833,14 @@ static void CL_Predict_RunFrameSteps (void)
 	if (!cl_pred_render_interp_valid)
 		CL_Predict_ResetRenderInterp ();
 	if (step_dt > 0.0f)
-	{
 		cl_pred_render_frac = (float)(cl_pred_frame_accum / step_dt);
-		cl_pred_render_frac = CLAMP (0.0f, cl_pred_render_frac, 1.0f);
-	}
 	cl_pred_render_interp_valid = true;
+
+	if (cl_pred_accum_debug.value > 0.0f)
+	{
+		Con_Printf ("ACCUM=%f RENDER_FRAC=%f\n", cl_pred_frame_accum, cl_pred_render_frac);
+		JITTER_LOG ("ACCUM=%f RENDER_FRAC=%f\n", cl_pred_frame_accum, cl_pred_render_frac);
+	}
 
 	if (cl_jitter_debug.value > 0.0f)
 	{


### PR DESCRIPTION
### Motivation
- Ensure deterministic render interpolation by computing `cl_pred_render_frac` every frame instead of early-returning when the accumulator is zero. 
- Add lightweight runtime diagnostics to observe `cl_pred_frame_accum` and `cl_pred_render_frac` for debugging prediction accumulator behavior.

### Description
- Removed the early-return check `if (cl_pred_frame_accum <= 0.0) return;` from `CL_Predict_RunFrameSteps` so render fraction computation always runs. 
- Always assign `cl_pred_render_frac = (float)(cl_pred_frame_accum / step_dt)` after stepping logic instead of skipping it when accumulator is zero. 
- Added gated debug logging that prints `"ACCUM=%f RENDER_FRAC=%f"` to `Con_Printf` and `JITTER_LOG` when `cl_pred_accum_debug.value > 0.0f`.

### Testing
- No automated tests were run for this change (no CI/unit tests executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698923549f60832e8b4cdf3827f67877)