### PR TITLE
Add forward declaration for CL_Predict_ApplyToClient

### DIFF
--- a/Quake/cl_predict.c
+++ b/Quake/cl_predict.c
@@ -404,6 +404,7 @@ static qboolean CL_Predict_FindExactFrame (unsigned int seq, cl_pred_frame_t *ou
 static qboolean CL_Predict_FindNewestNotNewer (unsigned int seq, cl_pred_frame_t *out, unsigned int *found_seq);
 static qboolean CL_Predict_GetLocalMovementState (byte *movetype, byte *waterlevel);
 static qboolean CL_Predict_SelfCheck (unsigned int ack, const char *context);
+static void CL_Predict_ApplyToClient (const cl_pred_state_t *state, qboolean is_render);
 static void CL_Predict_AccumSelftest_f (void);
 static void CL_Predict_StateDump_f (void);
 static void CL_Predict_CvarDump_f (void);


### PR DESCRIPTION
### Motivation
- The compiler produced implicit-declaration and redefinition errors (`C4013`, `C2371`) because `CL_Predict_ApplyToClient` was referenced earlier in the file before its definition, so a forward declaration is needed to avoid warnings treated as errors.

### Description
- Insert a static prototype `static void CL_Predict_ApplyToClient (const cl_pred_state_t *state, qboolean is_render);` into `Quake/cl_predict.c` alongside the other static function declarations.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a60e18d10832e95e36b17d6a293e3)