### PR TITLE
Fix duplicate bindless padding field in bmodel_bindless_gpu_call_t

### DIFF
--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -292,7 +292,7 @@ typedef struct bmodel_bindless_gpu_call_s {
 	GLuint64	texture;
 	GLuint64	fullbright;
 	GLuint64	emissive;
-	GLuint64	_pad1;
+	GLuint64	_pad2;
 } bmodel_bindless_gpu_call_t;
 
 typedef struct bmodel_bound_gpu_call_s {
@@ -631,7 +631,7 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
 		call->texture = tx ? tx->bindless_handle : greytexture->bindless_handle;
 		call->fullbright = fb ? fb->bindless_handle : blacktexture->bindless_handle;
 		call->emissive = em ? em->bindless_handle : blacktexture->bindless_handle;
-		call->_pad1 = 0;
+		call->_pad2 = 0;
 	}
 	else
 	{
@@ -704,7 +704,7 @@ static void R_AddBModelCallWithTextures (int index, int first_instance, int num_
 		call->texture = tx ? tx->bindless_handle : greytexture->bindless_handle;
 		call->fullbright = fb ? fb->bindless_handle : blacktexture->bindless_handle;
 		call->emissive = em ? em->bindless_handle : blacktexture->bindless_handle;
-		call->_pad1 = 0;
+		call->_pad2 = 0;
 	}
 	else
 	{


### PR DESCRIPTION
### Motivation
- MSVC reported struct redefinition and “left operand must be l-value” errors due to a duplicated `_pad1` member in `bmodel_bindless_gpu_call_t`, so the struct needed a unique trailing padding field to compile cleanly.

### Description
- Renamed the trailing `GLuint64 _pad1` field to `GLuint64 _pad2` in `Quake/r_world.c` and updated both bindless call initializations to set `call->_pad2 = 0;`.

### Testing
- Verified the replacements with `rg -n "_pad1|_pad2" Quake/r_world.c`, confirming consistent use of `_pad2`; the command succeeded.
- Inspected the updated regions with `nl -ba Quake/r_world.c | sed -n '276,312p;618,712p'` and committed the change with `git commit`, both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bb642531c832e9fd174de19c2a400)