### PR TITLE
Fix Windows linker error for glBlendEquation by using engine GL function pointer

### DIFF
--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -192,6 +192,7 @@ extern	const char	*gl_version;
 	x(void,			BlitFramebuffer, (GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0, GLint dstX1, GLint dstY1, GLbitfield mask, GLenum filter))\
 	x(void,			DrawBuffers, (GLsizei n, const GLenum *bufs))\
 	x(void,			ClearBufferfv, (GLenum buffer, GLint drawbuffer, const GLfloat *value))\
+	x(void,			BlendEquation, (GLenum mode))\
 	x(void,			BlendFunci, (GLuint buf, GLenum sfactor, GLenum dfactor))\
 	x(void,			DebugMessageCallback, (GLDEBUGPROC callback, const void *userParam))\
 	x(void,			ObjectLabel, (GLenum identifier, GLuint name, GLsizei length, const GLchar *label))\

--- a/Quake/r_fogvol.c
+++ b/Quake/r_fogvol.c
@@ -140,7 +140,7 @@ static void R_FogVol_TestState_Restore (const fogvol_test_state_t *state)
 	else
 		glDisable (GL_BLEND);
 	glBlendFunc (state->blend_src_rgb, state->blend_dst_rgb);
-	glBlendEquation (state->blend_equation_rgb);
+	GL_BlendEquationFunc (state->blend_equation_rgb);
 
 	if (state->depth_test)
 		glEnable (GL_DEPTH_TEST);


### PR DESCRIPTION
### Motivation
- Direct references to `glBlendEquation` can produce unresolved externals on Windows/MSVC, so the engine should call it via the same dynamically loaded GL function-pointer mechanism used elsewhere.

### Description
- Added `BlendEquation` to the core GL function list in `Quake/glquake.h` so a `GL_BlendEquationFunc` pointer is declared and loadable.
- Replaced the direct call `glBlendEquation(...)` with `GL_BlendEquationFunc(...)` in `Quake/r_fogvol.c` to avoid linker reliance on the import symbol.

### Testing
- Verified occurrences and updated references with `rg` searches for `BlendEquation`, which showed the header declaration and the modified usage (succeeded).
- Attempted a Windows Visual Studio build via `cmake --build Windows/VisualStudio/Build-ironwail --config Release --target ironwail`, which failed because the specified build directory is not present in this environment (failed).
- Attempted a local CMake build with `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build -j4`, which failed configuration due to missing SDL2 CMake package (`SDL2Config.cmake` not found), so full compile validation could not be completed here (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bbcf8da78832e9e4495d11290c8f6)