### PR TITLE
Fix fog volume framebuffer attachment query on MSVC

### DIFF
--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -189,6 +189,7 @@ extern	const char	*gl_version;
 	x(void,			DeleteFramebuffers, (GLsizei n, const GLuint *framebuffers))\
 	x(void,			FramebufferTexture2D, (GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level))\
 	x(void,			FramebufferTextureLayer, (GLenum target, GLenum attachment, GLuint texture, GLint level, GLint layer))\
+	x(void,			GetFramebufferAttachmentParameteriv, (GLenum target, GLenum attachment, GLenum pname, GLint *params))\
 	x(GLenum,		CheckFramebufferStatus, (GLenum target))\
 	x(void,			BlitFramebuffer, (GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0, GLint dstX1, GLint dstY1, GLbitfield mask, GLenum filter))\
 	x(void,			DrawBuffers, (GLsizei n, const GLenum *bufs))\

--- a/Quake/r_fogvol.c
+++ b/Quake/r_fogvol.c
@@ -161,15 +161,15 @@ static void R_FogVol_TestState_Capture (fogvol_test_state_t *state)
 		draw_color_attachment = GL_COLOR_ATTACHMENT0;
 	if (state->read_fbo)
 		read_color_attachment = GL_COLOR_ATTACHMENT0;
-	glGetFramebufferAttachmentParameteriv (GL_DRAW_FRAMEBUFFER, draw_color_attachment,
+	GL_GetFramebufferAttachmentParameterivFunc (GL_DRAW_FRAMEBUFFER, draw_color_attachment,
 		GL_FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE, &state->draw_color_type[0]);
-	glGetFramebufferAttachmentParameteriv (GL_DRAW_FRAMEBUFFER, draw_color_attachment,
+	GL_GetFramebufferAttachmentParameterivFunc (GL_DRAW_FRAMEBUFFER, draw_color_attachment,
 		GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME, &state->draw_color_name[0]);
 	if (state->draw_fbo)
 	{
-		glGetFramebufferAttachmentParameteriv (GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT1,
+		GL_GetFramebufferAttachmentParameterivFunc (GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT1,
 			GL_FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE, &state->draw_color_type[1]);
-		glGetFramebufferAttachmentParameteriv (GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT1,
+		GL_GetFramebufferAttachmentParameterivFunc (GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT1,
 			GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME, &state->draw_color_name[1]);
 	}
 	else
@@ -177,17 +177,17 @@ static void R_FogVol_TestState_Capture (fogvol_test_state_t *state)
 		state->draw_color_type[1] = GL_NONE;
 		state->draw_color_name[1] = 0;
 	}
-	glGetFramebufferAttachmentParameteriv (GL_DRAW_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
+	GL_GetFramebufferAttachmentParameterivFunc (GL_DRAW_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
 		GL_FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE, &state->draw_depth_type);
-	glGetFramebufferAttachmentParameteriv (GL_DRAW_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
+	GL_GetFramebufferAttachmentParameterivFunc (GL_DRAW_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
 		GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME, &state->draw_depth_name);
-	glGetFramebufferAttachmentParameteriv (GL_READ_FRAMEBUFFER, read_color_attachment,
+	GL_GetFramebufferAttachmentParameterivFunc (GL_READ_FRAMEBUFFER, read_color_attachment,
 		GL_FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE, &state->read_color_type);
-	glGetFramebufferAttachmentParameteriv (GL_READ_FRAMEBUFFER, read_color_attachment,
+	GL_GetFramebufferAttachmentParameterivFunc (GL_READ_FRAMEBUFFER, read_color_attachment,
 		GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME, &state->read_color_name);
-	glGetFramebufferAttachmentParameteriv (GL_READ_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
+	GL_GetFramebufferAttachmentParameterivFunc (GL_READ_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
 		GL_FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE, &state->read_depth_type);
-	glGetFramebufferAttachmentParameteriv (GL_READ_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
+	GL_GetFramebufferAttachmentParameterivFunc (GL_READ_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
 		GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME, &state->read_depth_name);
 	glGetIntegerv (GL_CURRENT_PROGRAM, &state->program);
 	glGetIntegerv (GL_VERTEX_ARRAY_BINDING, &state->vao);


### PR DESCRIPTION
### Motivation
- MSVC treated the implicit declaration of `glGetFramebufferAttachmentParameteriv` as warning C4013 which became error C2220, breaking the build on MSVC.

### Description
- Add `GetFramebufferAttachmentParameteriv` to the engine's dynamic GL function table in `Quake/glquake.h` so the symbol is loaded through the existing loader.
- Replace direct calls to `glGetFramebufferAttachmentParameteriv` with the loader pointer `GL_GetFramebufferAttachmentParameterivFunc` in `Quake/r_fogvol.c`.

### Testing
- Ran `rg` searches to verify that all `glGetFramebufferAttachmentParameteriv` usages in `r_fogvol.c` were replaced and the new loader symbol exists in `glquake.h`, and the search returned the expected matches.
- Ran `git diff --check` to ensure the patch has no whitespace/formatting issues and the code changes are clean.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bc2a33874832e98629a9ceee8e3da)