### PR TITLE
Use GL_GetFramebufferAttachmentParameterivFunc in fog volume debug

### DIFF
--- a/Quake/r_fogvol.c
+++ b/Quake/r_fogvol.c
@@ -234,11 +234,11 @@ static GLuint R_FogVol_GetFramebufferColorAttachmentTexture (GLenum target)
 	GLint object_type = GL_NONE;
 	GLint object_name = 0;
 
-	glGetFramebufferAttachmentParameteriv (target, GL_COLOR_ATTACHMENT0,
+	GL_GetFramebufferAttachmentParameterivFunc (target, GL_COLOR_ATTACHMENT0,
 		GL_FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE, &object_type);
 	if (object_type == GL_TEXTURE)
 	{
-		glGetFramebufferAttachmentParameteriv (target, GL_COLOR_ATTACHMENT0,
+		GL_GetFramebufferAttachmentParameterivFunc (target, GL_COLOR_ATTACHMENT0,
 			GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME, &object_name);
 		return (GLuint)object_name;
 	}


### PR DESCRIPTION
### Motivation
- MSVC builds treated the implicit declaration of `glGetFramebufferAttachmentParameteriv` as a warning-as-error (C4013/C2220), breaking the build when compiling the fog volume debug code.

### Description
- Replace direct `glGetFramebufferAttachmentParameteriv` calls with the engine wrapper `GL_GetFramebufferAttachmentParameterivFunc` inside `R_FogVol_GetFramebufferColorAttachmentTexture` in `Quake/r_fogvol.c` so the resolved function pointer is used.

### Testing
- Ran `rg "\bglGetFramebufferAttachmentParameteriv\b" -n Quake/r_fogvol.c` which returned no matches and ran `rg "GL_GetFramebufferAttachmentParameterivFunc" -n Quake/r_fogvol.c` which confirmed the wrapper is present, and both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bcce1845c832e9acbcde3dab2e423)