### PR TITLE
Add missing shadow cvar externs in r_alias.c and r_world.c

### DIFF
--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -33,6 +33,8 @@ extern cvar_t r_lightgrid_force;
 extern cvar_t r_lightgrid_debug;
 extern cvar_t r_shadow_bias_mdl;
 extern cvar_t r_shadow_normalbias_mdl;
+extern cvar_t r_shadows;
+extern cvar_t r_shadow_sun;
 extern cvar_t r_shadow_pcf;
 extern cvar_t r_shadow_pcf_taps;
 extern cvar_t r_shadow_twosided_mdl;

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -39,6 +39,13 @@ extern gltexture_t *lightmap_dir_texture;
 extern cvar_t r_lightingdir;
 extern cvar_t r_dlight_mode;
 
+extern cvar_t r_shadows;
+extern cvar_t r_shadow_sun;
+extern cvar_t r_shadow_bias;
+extern cvar_t r_shadow_normalbias;
+extern cvar_t r_shadow_pcf;
+extern cvar_t r_shadow_pcf_taps;
+
 extern GLuint gl_bmodel_vbo;
 extern size_t gl_bmodel_vbo_size;
 extern GLuint gl_bmodel_ibo;


### PR DESCRIPTION
### Motivation
- Fix MSVC compile errors caused by undefined shadow cvar identifiers referenced by shadow logging calls by declaring the missing `extern cvar_t` variables in the renderer translation units.

### Description
- Add `extern cvar_t` declarations for `r_shadows` and `r_shadow_sun` to `Quake/r_alias.c` and add `extern cvar_t` declarations for `r_shadows`, `r_shadow_sun`, `r_shadow_bias`, `r_shadow_normalbias`, `r_shadow_pcf`, and `r_shadow_pcf_taps` to `Quake/r_world.c` so the referenced symbols are available to those files.

### Testing
- Ran a CMake configure/build attempt with `cmake -S . -B build && cmake --build build`, which failed at configuration due to a missing SDL2 development package in the environment, preventing a full compile verification (configure step failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bd7dad6cc832e80ba14b860490fae)