### PR TITLE
matshader: parse skyParms metadata and reclassify Q3 support

### DIFF
--- a/Quake/mat_shader.c
+++ b/Quake/mat_shader.c
@@ -105,9 +105,9 @@ static const mat_shader_keyword_def_t mat_shader_keyword_table[] =
 	{ "emissive_scale", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Non-Q3 extension." },
 	{ "bloom_scale", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Non-Q3 extension." },
 	{ "godray_scale", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Non-Q3 extension." },
-	{ "skyParms", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL, MAT_SHADER_KEYWORD_STATUS_KNOWN_UNIMPLEMENTED, "Q3 sky parameters." },
-	{ "fogParms", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL, MAT_SHADER_KEYWORD_STATUS_KNOWN_UNIMPLEMENTED, "Q3 fog parameters." },
-	{ "deformVertexes", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL, MAT_SHADER_KEYWORD_STATUS_KNOWN_UNIMPLEMENTED, "Q3 vertex deformation." },
+	{ "skyParms", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL, MAT_SHADER_KEYWORD_STATUS_PARTIAL, "Parses farbox/cloudheight/nearbox and marks sky surfaces." },
+	{ "fogParms", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL, MAT_SHADER_KEYWORD_STATUS_PARTIAL, "Parses fog color and distance into material metadata." },
+	{ "deformVertexes", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL, MAT_SHADER_KEYWORD_STATUS_PARTIAL, "Parses deform parameters; render-time deformation is still pending." },
 	{ "q3map_*", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL, MAT_SHADER_KEYWORD_STATUS_KNOWN_UNIMPLEMENTED, "Q3Map compile-time directives." },
 
 	{ "map", MAT_SHADER_KEYWORD_SCOPE_STAGE, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Supports $lightmap/$white/$black and textures." },
@@ -193,6 +193,10 @@ static void Mat_Shader_FreeMaterial (shader_material_t *material)
 
 	if (material->editor_image)
 		Z_Free (material->editor_image);
+	if (material->skybox_far)
+		Z_Free (material->skybox_far);
+	if (material->skybox_near)
+		Z_Free (material->skybox_near);
 	if (material->name)
 		Z_Free (material->name);
 	if (material->source_file)
@@ -1296,6 +1300,11 @@ void Mat_Shader_Print (const shader_material_t *material)
 	Con_Printf ("  emissive: %s (scale %.2f)\n", material->emissive_enable ? "on" : "off", material->emissive_scale);
 	Con_Printf ("  bloom: %s (scale %.2f)\n", material->bloom_enable ? "on" : "off", material->bloom_scale);
 	Con_Printf ("  godray: %s (scale %.2f)\n", material->godray_enable ? "on" : "off", material->godray_scale);
+	if (material->has_skyparms)
+		Con_Printf ("  skyParms: far=%s cloudheight=%.2f near=%s\n",
+			material->skybox_far ? material->skybox_far : "-",
+			material->sky_cloudheight,
+			material->skybox_near ? material->skybox_near : "-");
 	if (material->has_fogparms)
 		Con_Printf ("  fogparms: (%.2f %.2f %.2f) dist %.2f\n", material->fog_color[0], material->fog_color[1], material->fog_color[2], material->fog_distance);
 	if (material->deforms)

--- a/Quake/mat_shader.h
+++ b/Quake/mat_shader.h
@@ -276,12 +276,16 @@ typedef struct shader_material_s
 	qboolean		emissive_enable;
 	qboolean		bloom_enable;
 	qboolean		godray_enable;
+	qboolean		has_skyparms;
 	qboolean		has_fogparms;
 	float			emissive_scale;
 	float			bloom_scale;
 	float			godray_scale;
 	vec3_t		fog_color;
 	float			fog_distance;
+	char			*skybox_far;
+	char			*skybox_near;
+	float			sky_cloudheight;
 	mat_deform_t	*deforms;
 	mat_shader_stage_t	stage0;
 	mat_shader_stage_t	*stages;

--- a/Quake/mat_shader_parse.c
+++ b/Quake/mat_shader_parse.c
@@ -1779,6 +1779,43 @@ static const char *ParseMaterialBlock (const char *data, const char *name, const
 			Mat_Shader_ApplySurfaceParm (&material, value, state);
 			continue;
 		}
+		if (!q_strcasecmp (com_token, "skyparms") || !q_strcasecmp (com_token, "skyParms"))
+		{
+			const char *farbox;
+			const char *cloudheight_token;
+			const char *nearbox;
+			float cloudheight = 0.f;
+
+			Mat_Shader_MarkKeywordSeen ("skyParms", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL);
+			if (!ParseIdentExpected (&data, &farbox, state, "skyParms farbox")
+				|| !ParseIdentExpected (&data, &cloudheight_token, state, "skyParms cloudheight")
+				|| !ParseIdentExpected (&data, &nearbox, state, "skyParms nearbox"))
+			{
+				data = ResyncMaterialBlock (data, state);
+				break;
+			}
+
+			if (Mat_Shader_IsNumericToken (cloudheight_token))
+				cloudheight = Q_atof (cloudheight_token);
+			else if (q_strcasecmp (cloudheight_token, "-"))
+			{
+				Mat_Shader_WarnExpectedToken (state, "skyParms cloudheight float or '-'", cloudheight_token);
+				data = ResyncMaterialBlock (data, state);
+				break;
+			}
+
+			if (material.skybox_far)
+				Z_Free (material.skybox_far);
+			if (material.skybox_near)
+				Z_Free (material.skybox_near);
+
+			material.skybox_far = (q_strcasecmp (farbox, "-") == 0) ? NULL : Mat_Shader_DupString (farbox);
+			material.skybox_near = (q_strcasecmp (nearbox, "-") == 0) ? NULL : Mat_Shader_DupString (nearbox);
+			material.sky_cloudheight = q_max (0.f, cloudheight);
+			material.has_skyparms = true;
+			material.render_flags |= MAT_RENDER_SKY;
+			continue;
+		}
 		if (!q_strcasecmp (com_token, "fogparms") || !q_strcasecmp (com_token, "fogParms"))
 		{
 			float r,g,b,dist;


### PR DESCRIPTION
### Motivation
- Align the engine's material/shader parser with Quake 3 shader semantics by recognizing additional top-level Q3 keywords and making parsed sky data available to the renderer.
- Ensure parsed Q3 features are represented in the material model and reflected in the engine's shader capability reporting.

### Description
- Reclassified `skyParms`, `fogParms`, and `deformVertexes` from `KNOWN_UNIMPLEMENTED` to `PARTIAL` in the keyword capability table to match actual parser/engine behavior (`Quake/mat_shader.c`).
- Added sky metadata to the material structure: `has_skyparms`, `skybox_far`, `skybox_near`, and `sky_cloudheight` (`Quake/mat_shader.h`).
- Implemented top-level `skyParms` parsing in `ParseMaterialBlock` to accept `skyParms <farbox|-> <cloudheight|-> <nearbox|->`, validate the cloudheight token, store the parsed values on the `shader_material_t`, and set the `MAT_RENDER_SKY` render flag (`Quake/mat_shader_parse.c`).
- Wired lifecycle and debug paths: free new sky strings in material cleanup and print `skyParms` in `Mat_Shader_Print` when present (`Quake/mat_shader.c`).

### Testing
- Attempted build: ran `make -C Quake -j2` to validate compile integration, but the build could not complete because SDL2 development tools/headers are missing in the container (`sdl2-config: No such file or directory`, `SDL.h: No such file or directory`).
- Source-level validation: applied changes and committed the patch; `git` shows the three modified files were added and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f05bf627c832ea5cffa7127df371f)