### PR TITLE
Improve froxel fog integration and temporal weighting

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -2430,7 +2430,7 @@ static void Atmosphere_Froxel_TemporalResolve (const atmosphere_settings_t *sett
 	GL_BindImageTextureFunc (1, framebufs.atmos_froxel.scatter_resolved_tex, 0, GL_TRUE, 0, GL_WRITE_ONLY, GL_RGBA16F);
 	GL_BindImageTextureFunc (2, framebufs.atmos_froxel.scatter_history_tex[dst], 0, GL_TRUE, 0, GL_WRITE_ONLY, GL_RGBA16F);
 	GL_Uniform4fFunc (0, (float)framebufs.atmos_froxel.width, (float)framebufs.atmos_froxel.height, (float)framebufs.atmos_froxel.depth, 0.f);
-	GL_Uniform4fFunc (1, CLAMP (0.f, r_atmos_historyweight.value, 0.99f), r_prev_frame_valid ? 1.f : 0.f, settings->history_weight, 0.f);
+	GL_Uniform4fFunc (1, CLAMP (0.f, settings->history_weight, 0.99f), r_prev_frame_valid ? 1.f : 0.f, settings->history_weight, 0.f);
 	GL_DispatchComputeFunc (gx, gy, gz);
 	glMemoryBarrier (GL_SHADER_IMAGE_ACCESS_BARRIER_BIT | GL_TEXTURE_FETCH_BARRIER_BIT);
 	framebufs.atmos_froxel.history_index = dst;

--- a/Quake/shaders/atmos_froxel_build.comp
+++ b/Quake/shaders/atmos_froxel_build.comp
@@ -27,7 +27,8 @@ void Atmosphere_EvalMedium(vec3 worldPos, vec3 viewPos, out float sigma_t, out v
     float h = max(0.0, worldPos.z);
     float density = MediumParams0.x * exp(-MediumParams0.y * h);
     sigma_t = max(density, 0.0);
-    sigma_s = sigma_t * MediumParams1.rgb * MediumParams0.z;
+    sigma_s = sigma_t * MediumParams1.rgb * MediumParams0.z * max(MediumParams1.w, 0.0);
+    sigma_s += MediumParams1.rgb * max(MediumParams0.w, 0.0);
 }
 
 void main()

--- a/Quake/shaders/atmos_froxel_integrate.comp
+++ b/Quake/shaders/atmos_froxel_integrate.comp
@@ -18,6 +18,19 @@ float PhaseHG(float cosTheta, float g)
     return (1.0 - g2) / (4.0 * 3.14159265 * d);
 }
 
+float Atmosphere_Froxel_ZToViewDepth(float z)
+{
+    float zn = clamp((z + 0.5) / max(FroxelParams0.z, 1.0), 0.0, 1.0);
+    float zfar = max(ShadowDebug.w, 2048.0);
+    return exp2(zn * log2(zfar + 1.0)) - 1.0;
+}
+
+vec3 Atmosphere_Froxel_InvProjRay(vec2 uv)
+{
+    vec2 ndc = uv * 2.0 - 1.0;
+    return normalize(vec3(ndc, 1.0));
+}
+
 void main()
 {
     ivec3 coord = ivec3(gl_GlobalInvocationID.xyz);
@@ -27,11 +40,19 @@ void main()
     vec4 packed = imageLoad(InOutScatter, coord);
     float sigma_t = packed.a;
     vec3 sigma_s = packed.rgb;
-    float stepLen = 1.0;
+
+    vec2 uv = (vec2(coord.xy) + vec2(0.5)) / max(FroxelParams0.xy, vec2(1.0));
+    vec3 ray = Atmosphere_Froxel_InvProjRay(uv);
+    float z0 = Atmosphere_Froxel_ZToViewDepth(float(coord.z));
+    float z1 = Atmosphere_Froxel_ZToViewDepth(float(coord.z + 1));
+    float stepLen = max(1e-3, z1 - z0);
+    vec3 viewPos = ray * (z0 + 0.5 * stepLen);
+    vec3 worldPos = EyePos + viewPos;
+
     float T = exp(-sigma_t * stepLen);
     float phase = PhaseHG(1.0, clamp(LightParams0.x, 0.0, 0.99));
     float inRange = 1.0;
-    float shadow = (LightParams0.z > 0.5) ? ShadowVisibility(EyePos, vec3(0.0, 0.0, 1.0), inRange) : 1.0;
+    float shadow = (LightParams0.z > 0.5) ? ShadowVisibility(worldPos, vec3(0.0, 0.0, 1.0), inRange) : 1.0;
     vec3 scatter = T * sigma_s * (LightParams0.y * shadow * phase) * stepLen;
 
     imageStore(InOutScatter, coord, vec4(scatter, sigma_t));

--- a/Quake/shaders/atmos_froxel_temporal.comp
+++ b/Quake/shaders/atmos_froxel_temporal.comp
@@ -30,7 +30,8 @@ void main()
     }
 
     history.rgb = clamp(history.rgb, minC, maxC);
-    float w = (TemporalParams.y > 0.5) ? clamp(TemporalParams.x, 0.0, 0.99) : 0.0;
+    float wTarget = (TemporalParams.z > 0.0) ? TemporalParams.z : TemporalParams.x;
+    float w = (TemporalParams.y > 0.5) ? clamp(wTarget, 0.0, 0.99) : 0.0;
     vec4 outv = mix(current, history, w);
     imageStore(OutResolved, coord, outv);
     imageStore(OutHistory, coord, outv);


### PR DESCRIPTION
### Motivation
- Close gaps in the froxel/atmosphere pipeline so per-froxel scattering honors medium intensity and emissive terms and integration uses correct per-slice geometry for accurate lighting and shadows.
- Ensure temporal resolve uses the resolved runtime history-weight setting so temporal blending matches configured behavior.

### Description
- Update `Quake/shaders/atmos_froxel_build.comp` to apply both medium intensity and emissive components when writing per-froxel `scatter` (`MediumParams1.w` and `MediumParams0.w` are now used in `Atmosphere_EvalMedium`).
- Rewrite `Quake/shaders/atmos_froxel_integrate.comp` to compute per-slice `stepLen` and per-froxel `worldPos` for shadow sampling and scattering accumulation instead of using a constant step and camera-origin shadow lookup.
- Change `Quake/shaders/atmos_froxel_temporal.comp` to allow a resolved history-weight override (use `TemporalParams.z` if present) and clamp it before blending.
- Patch `Quake/gl_rmain.c` so the temporal compute dispatch uploads `settings->history_weight` to the shader uniform (replace the previous direct use of `r_atmos_historyweight`).
- Committed changes with the message: `Improve froxel fog integration and temporal weighting`.

### Testing
- Attempted an automated build with `cmake -S . -B build && cmake --build build -j2`, which failed in this environment because the SDL2 CMake package files (`SDL2Config.cmake` / `sdl2-config.cmake`) are not present, so a full build/test could not be completed.
- Verified diffs and committed the modified files (`Quake/shaders/atmos_froxel_build.comp`, `Quake/shaders/atmos_froxel_integrate.comp`, `Quake/shaders/atmos_froxel_temporal.comp`, `Quake/gl_rmain.c`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f6e698d84832ea08c1b7de7f04190)