### PR TITLE
Gate alias model rim by direct light, use lightgrid ambient, add clamp + debug modes

### DIFF
--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -98,9 +98,9 @@ struct ibuf_s {
 		float	overbright;
 		float	half_lambert;
 		float	_pad1;
-		vec4_t	rim_params0; // x=enable y=strength z=power w=staticScale
-		vec4_t	rim_params1; // x=dynScale y=ambScale z=gateK w=gateBias
-		vec4_t	rim_params2; // x=colorScale y=clampDirect z=clampAmb w=debug
+		vec4_t	rim_params0; // x=enable y=scale z=power w=staticScale
+		vec4_t	rim_params1; // x=dynScale y=ambientScale z=directK w=gateBias
+		vec4_t	rim_params2; // x=colorScale y=clampDirect z=ambientLimit w=debug
 		float	shadow_viewproj[16];
 		vec4_t	shadow_params;
 		vec4_t	shadow_debug;
@@ -589,7 +589,7 @@ ibuf.global.rim_params1[3] = r_rim_gateBias.value;
 ibuf.global.rim_params2[0] = q_max (0.f, r_rim_colorScale.value);
 ibuf.global.rim_params2[1] = q_max (0.f, r_rim_clampDirect.value);
 ibuf.global.rim_params2[2] = q_max (0.f, r_rim_clampAmb.value);
-ibuf.global.rim_params2[3] = CLAMP (0.f, r_rim_debug.value, 4.f);
+ibuf.global.rim_params2[3] = CLAMP (0.f, r_rim_debug.value, 5.f);
 	memcpy (ibuf.global.shadow_viewproj, r_framedata.shadow_viewproj, sizeof (r_framedata.shadow_viewproj));
 	ibuf.global.shadow_params[0] = r_shadow_bias_mdl.value;
 	ibuf.global.shadow_params[1] = r_shadow_normalbias_mdl.value;

--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -247,34 +247,35 @@ void main()
 		float ndv = saturate(dot(N, V));
 		float rim_raw = pow(1.0 - ndv, RimParams0.z) * RimParams0.y;
 
-		vec3 scaled_static = RimParams0.w * L_static;
-		vec3 scaled_dyn = RimParams1.x * L_dyn;
-		vec3 scaled_amb = RimParams1.y * L_amb;
-		vec3 L_total = scaled_static + scaled_dyn + scaled_amb;
-
-		float direct_intensity = luminance(scaled_static + scaled_dyn);
+		vec3 direct_static = RimParams0.w * L_static * shadow_term;
+		vec3 direct_dyn = RimParams1.x * L_dyn;
+		vec3 direct_rgb = direct_static + direct_dyn;
+		vec3 ambient_rgb = L_amb;
+		float direct_intensity = luminance(direct_rgb);
 		float gate = saturate(direct_intensity * RimParams1.z + RimParams1.w);
 		float rim = rim_raw * gate;
 
-		vec3 rim_color = normalize_safe(L_total);
-		vec3 rim_light = rim * rim_color * RimParams2.x;
-
-		vec3 clamp_ceiling = (RimParams2.y * (scaled_static + scaled_dyn))
-			+ (RimParams2.z * scaled_amb);
-		rim_light = min(rim_light, clamp_ceiling);
+		vec3 rim_light_preclamp = rim * (direct_rgb + RimParams1.y * ambient_rgb) * RimParams2.x;
+		vec3 local_limit_rgb = (RimParams2.y * direct_rgb) + (RimParams2.z * ambient_rgb);
+		vec3 rim_light = min(rim_light_preclamp, local_limit_rgb);
 
 		result.rgb += rim_light;
 
 		if (RimParams2.w > 0.5)
 		{
 			if (RimParams2.w < 1.5)
-				result.rgb = vec3(rim_raw);
+				result.rgb = vec3(rim);
 			else if (RimParams2.w < 2.5)
-				result.rgb = vec3(gate);
+				result.rgb = vec3(direct_intensity);
 			else if (RimParams2.w < 3.5)
-				result.rgb = rim_light;
+				result.rgb = direct_rgb;
+			else if (RimParams2.w < 4.5)
+				result.rgb = ambient_rgb;
 			else
-				result.rgb = L_total;
+			{
+				vec3 clamp_delta = max(rim_light_preclamp - rim_light, vec3(0.0));
+				result.rgb = vec3(saturate(luminance(clamp_delta) * 8.0));
+			}
 			result.a = 1.0;
 		}
 	}


### PR DESCRIPTION
### Motivation
- Fix and harden the existing alias-model rim-lighting so rim only appears where direct lighting exists and ambient is color-correct from the lightgrid without adding a second rim system.
- Prevent rim from producing outline-like artifacts by clamping rim contribution to a local lighting ceiling and ensure rim follows shadowing where available.
- Provide debug views to validate rim factor, direct gating, ambient source, and clamp behavior at runtime.

### Description
- Reworked the alias-model rim math in `Quake/shaders/alias.frag` to compute `rim = pow(1 - saturate(dot(N,V)), power) * scale` and gate it by `direct_intensity = luminance(direct_rgb)` producing `rim *= saturate(direct_intensity * directK + bias)` so rim is driven by direct (static+dyn) light.
- Use color-correct ambient from the shader inputs (`in_amb_light` / lightgrid sample) scaled by the existing ambient scale and combine it with direct RGB for the rim contribution instead of a constant white sockel.
- Add anti-outline ceiling: compute `rim_light_preclamp = rim * (direct_rgb + ambientScale * ambient_rgb) * colorScale` and clamp with `local_limit_rgb = clampDirect * direct_rgb + ambientLimit * ambient_rgb`, applying `min(preclamp, local_limit_rgb)` component-wise.
- Include `shadow_term` when computing static direct contribution so rim respects shadow visibility where the renderer supplies it (no separate rim pass added).
- Expand `r_rim_debug` modes and bump the wired clamp to allow an extra debug mode; updated parameter comments in `Quake/r_alias.c` for clarity and adjusted the uniform debug range to `0..5`.
- All changes applied in-place on the existing rim path and uniforms; no new render passes or duplicate rim systems were introduced.

### Testing
- Performed repository audit and static verification using `rg`/`sed` to find and inspect rim-related cvars and the alias shader inputs and outputs, which confirmed the wiring (`in_static_light`, `in_dyn_light`, `in_amb_light`) and where uniforms are uploaded.
- Attempted a full CMake configure/build with `cmake -S . -B build && cmake --build build -j4`, which failed to configure in this environment due to a missing SDL2 CMake package (`SDL2Config.cmake` / `sdl2-config.cmake`), so a full binary build/test could not be executed here.
- Verified the source edits and generated commit with `git diff`/`git show` to confirm the expected changes in `Quake/shaders/alias.frag` and `Quake/r_alias.c` and committed the patch successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69908be7e894832e999852ca5a695634)