### PR TITLE
Fix mat_shader type declaration order

### DIFF
--- a/Quake/mat_shader.h
+++ b/Quake/mat_shader.h
@@ -85,14 +85,6 @@ typedef enum
 	MAT_DEFORM_AUTOSPRITE
 } mat_deform_type_t;
 
-typedef struct mat_deform_s
-{
-	mat_deform_type_t type;
-	mat_wave_t	wave;
-	vec3_t		move;
-	float		args[4];
-} mat_deform_t;
-
 typedef enum
 {
 	MAT_WAVE_SIN = 0,
@@ -109,6 +101,14 @@ typedef struct mat_wave_s
 	float		phase;
 	float		freq;
 } mat_wave_t;
+
+typedef struct mat_deform_s
+{
+	mat_deform_type_t type;
+	mat_wave_t	wave;
+	vec3_t		move;
+	float		args[4];
+} mat_deform_t;
 
 typedef enum
 {


### PR DESCRIPTION
### Motivation
- MSVC compilation failed with syntax errors because `mat_deform_t` referenced `mat_wave_t` before `mat_wave_t` was defined, causing cascading parse errors.

### Description
- Move the `mat_deform_t` (`typedef struct mat_deform_s`) definition to follow the `mat_wave_t` definition in `Quake/mat_shader.h` so `mat_wave_t` is declared before use.

### Testing
- Ran `make -C Quake -j4`; the build could not complete due to missing SDL2 tools/headers (`sdl2-config` / `SDL.h`), but the header ordering issue in `mat_shader.h` has been corrected and should resolve the prior MSVC syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699228ae4b5c832e953e5b70ea94ba0b)