### PR TITLE
Fix signed/unsigned warning in clustered light list build

### DIFF
--- a/Quake/gl_rlight.c
+++ b/Quake/gl_rlight.c
@@ -450,7 +450,7 @@ void R_Clustered_Shutdown (void)
 
 void R_Clustered_BuildLists (void)
 {
-	unsigned int i;
+	int i;
 	int tile_size;
 	int grid_x, grid_y, z_slices;
 	gpu_cluster_inputs_t inputs;


### PR DESCRIPTION
### Motivation
- Eliminate an MSVC C4018 signed/unsigned comparison warning (treated as error under `/WX`) in the clustered lights list building code at `Quake/gl_rlight.c`.

### Description
- Change the loop index type used in `R_Clustered_BuildLists` from `unsigned int` to `int` to match the signed comparison against `r_clustered.cluster_count`.

### Testing
- No automated tests or builds were executed for this targeted one-line type fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69922a7fa950832ea74270f3f2b3415c)