### PR TITLE
Fix signed/unsigned comparison in clustered light build loop

### DIFF
--- a/Quake/gl_rlight.c
+++ b/Quake/gl_rlight.c
@@ -451,6 +451,7 @@ void R_Clustered_Shutdown (void)
 void R_Clustered_BuildLists (void)
 {
 	int i;
+	unsigned int light_index;
 	int tile_size;
 	int grid_x, grid_y, z_slices;
 	gpu_cluster_inputs_t inputs;
@@ -478,10 +479,10 @@ void R_Clustered_BuildLists (void)
 	if (!r_clustered_headers_cpu)
 		return;
 
-	for (i = 0; i < r_framedata.numlights; i++)
+	for (light_index = 0; light_index < r_framedata.numlights; light_index++)
 	{
-		clustered_light_t *out = &lights_local[i];
-		const gpulight_t *in = &r_lightbuffer.lights[i];
+		clustered_light_t *out = &lights_local[light_index];
+		const gpulight_t *in = &r_lightbuffer.lights[light_index];
 		out->pos_radius[0] = in->pos[0];
 		out->pos_radius[1] = in->pos[1];
 		out->pos_radius[2] = in->pos[2];


### PR DESCRIPTION
### Motivation
- Resolve MSVC `C4018` signed/unsigned comparison warning (treated as error `C2220`) in `R_Clustered_BuildLists` by matching the loop index type to `r_framedata.numlights`.

### Description
- Replace the signed loop index with an unsigned `light_index` and update `lights_local` and `r_lightbuffer.lights` indexing to use `light_index` in `Quake/gl_rlight.c`.

### Testing
- Ran `cmake -S . -B build && cmake --build build -j2`, which failed in this environment due to a missing `SDL2` CMake package, so a full build could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69922b0defb0832ebe7f916d8354c2d9)