### PR TITLE
Add r_decals.c/h to Visual Studio project to fix decal linker errors

### DIFF
--- a/Windows/VisualStudio/ironwail.vcxproj
+++ b/Windows/VisualStudio/ironwail.vcxproj
@@ -312,6 +312,7 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
     </ClCompile>
     <ClCompile Include="..\..\Quake\r_alias.c" />
     <ClCompile Include="..\..\Quake\r_brush.c" />
+    <ClCompile Include="..\..\Quake\r_decals.c" />
     <ClCompile Include="..\..\Quake\r_dlight_pool.c" />
     <ClCompile Include="..\..\Quake\r_fogvol.c" />
     <ClCompile Include="..\..\Quake\r_shadow.c" />
@@ -421,6 +422,7 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
     <ClInclude Include="..\..\Quake\q_sound.h" />
     <ClInclude Include="..\..\Quake\q_stdinc.h" />
     <ClInclude Include="..\..\Quake\render.h" />
+    <ClInclude Include="..\..\Quake\r_decals.h" />
     <ClInclude Include="..\..\Quake\r_dlight_pool.h" />
     <ClInclude Include="..\..\Quake\r_fogvol.h" />
     <ClInclude Include="..\..\Quake\resource.h" />

--- a/Windows/VisualStudio/ironwail.vcxproj.filters
+++ b/Windows/VisualStudio/ironwail.vcxproj.filters
@@ -180,6 +180,9 @@
     <ClCompile Include="..\..\Quake\r_brush.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Quake\r_decals.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\Quake\r_dlight_pool.c">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -438,6 +441,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Quake\render.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Quake\r_decals.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Quake\r_dlight_pool.h">


### PR DESCRIPTION
### Motivation
- Windows builds were failing with unresolved externals for decal functions (e.g. `R_Decals_Add`, `R_AddScorchDecal`, `R_DrawDecals`) because their implementation file was not included in the Visual Studio project.

### Description
- Added `..\..\Quake\r_decals.c` to `Windows/VisualStudio/ironwail.vcxproj` so the decal renderer is compiled into the Windows build.
- Added `..\..\Quake\r_decals.h` to the project's header list in `Windows/VisualStudio/ironwail.vcxproj` for consistency.
- Mirrored both entries in `Windows/VisualStudio/ironwail.vcxproj.filters` so the files appear in Solution Explorer.

### Testing
- Ran `rg "R_Decals_Add|R_AddScorchDecal|R_DrawDecals" -n` to locate decal usages and confirm implementations exist, which succeeded.
- Ran `rg "r_decals\.(c|h)" -n Windows/VisualStudio/ironwail.vcxproj Windows/VisualStudio/ironwail.vcxproj.filters` to verify the new project entries, which succeeded.
- Inspected diffs with `git diff -- Windows/VisualStudio/ironwail.vcxproj Windows/VisualStudio/ironwail.vcxproj.filters` and reviewed file listings with `nl` to confirm correct insertion, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69922b9d4620832e96b8e4f6154a6d14)