### PR TITLE
Fix C4090 const qualifier warning in R_Decals_TraceNormal

### DIFF
--- a/Quake/r_decals.c
+++ b/Quake/r_decals.c
@@ -610,12 +610,14 @@ static qboolean R_Decals_TraceNormal (const vec3_t point, vec3_t out_normal)
 {
 	trace_t trace;
 	vec3_t end;
+	vec3_t start;
 	if (!cl.worldmodel)
 		return false;
+	VectorCopy (point, start);
 	VectorMA (point, 32.f, vpn, end);
 	memset (&trace, 0, sizeof (trace));
 	trace.fraction = 1.f;
-	SV_RecursiveHullCheck (cl.worldmodel->hulls, 0, 0.f, 1.f, end, point, &trace);
+	SV_RecursiveHullCheck (cl.worldmodel->hulls, 0, 0.f, 1.f, end, start, &trace);
 	if (trace.fraction < 1.f && VectorLengthSquared (trace.plane.normal) > 0.001f)
 	{
 		VectorCopy (trace.plane.normal, out_normal);


### PR DESCRIPTION
### Motivation
- The MSVC build treated warning `C4090` (different `const` qualifiers) as error `C2220` because `R_Decals_TraceNormal` passed a `const vec3_t` into `SV_RecursiveHullCheck`, so the call must use a mutable vector to match the callee signature and restore successful compilation.

### Description
- Added a local mutable vector `start` in `Quake/r_decals.c`, copied `point` into `start`, and passed `start` to `SV_RecursiveHullCheck` instead of the `const` `point`, leaving runtime behavior unchanged.

### Testing
- Ran `git diff --check` to validate the patch formatting and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69922cc4abd0832e8c17a01d1bf66cc9)