### PR TITLE
Remove duplicate GLSL directives from froxel compute shaders

### DIFF
--- a/Quake/shaders/atmos_froxel_integrate.comp
+++ b/Quake/shaders/atmos_froxel_integrate.comp
@@ -1,11 +1,9 @@
-#version 430
 layout(local_size_x=4, local_size_y=4, local_size_z=4) in;
 layout(rgba16f, binding=0) uniform image3D InOutScatter;
 layout(r16f, binding=1) uniform image3D InOutTransmittance;
 layout(binding=6) uniform sampler2D ShadowMap;
 #include "frame_uniforms.glsl"
 #define SHADOW_SUN 1
-#define REVERSED_Z 0
 #include "shadow_sample.glsl"
 
 layout(location=0) uniform vec4 FroxelParams0; // xyz dims, w steps

--- a/Quake/shaders/atmos_froxel_temporal.comp
+++ b/Quake/shaders/atmos_froxel_temporal.comp
@@ -1,4 +1,3 @@
-#version 430
 layout(local_size_x=4, local_size_y=4, local_size_z=4) in;
 layout(binding=10) uniform sampler3D HistoryScatter;
 layout(rgba16f, binding=0) readonly uniform image3D CurrentScatter;


### PR DESCRIPTION
### Motivation
- The froxel compute shaders contained `#version`/`REVERSED_Z` directives that conflicted with the engine-injected GLSL header and caused shader compile errors such as "version directive must be first statement" and redefinition diagnostics.

### Description
- Removed `#version 430` and the local `#define REVERSED_Z 0` from `Quake/shaders/atmos_froxel_integrate.comp` and removed `#version 430` from `Quake/shaders/atmos_froxel_temporal.comp` so the common header added by `GL_CreateShader` is the sole source of those directives.

### Testing
- Verified there are no remaining `#version` or `REVERSED_Z` directives in `Quake/shaders/atmos_froxel_*.comp` using `rg`; attempted to run `cmake -S . -B build && cmake --build build -j2`, which failed due to a missing `SDL2` package in the environment and not because of the shader changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69922eb15d88832eb6fd53bfc9375b77)