### PR TITLE
Fix froxel integrate shader compile failure on NVIDIA drivers

### DIFF
--- a/Quake/shaders/atmos_froxel_integrate.comp
+++ b/Quake/shaders/atmos_froxel_integrate.comp
@@ -35,9 +35,9 @@ void main()
     if (any(greaterThanEqual(coord, ivec3(FroxelParams0.xyz))))
         return;
 
-    vec4 packed = imageLoad(InOutScatter, coord);
-    float sigma_t = packed.a;
-    vec3 sigma_s = packed.rgb;
+    vec4 froxelData = imageLoad(InOutScatter, coord);
+    float sigma_t = froxelData.a;
+    vec3 sigma_s = froxelData.rgb;
 
     vec2 uv = (vec2(coord.xy) + vec2(0.5)) / max(FroxelParams0.xy, vec2(1.0));
     vec3 ray = Atmosphere_Froxel_InvProjRay(uv);


### PR DESCRIPTION
### Motivation
- An OpenGL compile error during `atmos froxel integrate` was observed on NVIDIA drivers reporting unexpected tokens and undefined `sigma_t`/`sigma_s`, indicating a shader parser/name issue.

### Description
- Rename the local `vec4` variable loaded from `imageLoad` from `packed` to `froxelData` in `Quake/shaders/atmos_froxel_integrate.comp` without changing any math or behavior.

### Testing
- Located and inspected shader sources with `rg` and `nl`, applied the patch, and verified the change with `git diff` and `git show --stat --oneline`, and those commands completed successfully; no runtime shader compilation was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69922f59e10c832e8e45f4b9a2e91fba)