### PR TITLE
Add missing `texmatrix` field to `Call` struct in world_dlight.vert

### DIFF
--- a/Quake/shaders/world_dlight.vert
+++ b/Quake/shaders/world_dlight.vert
@@ -39,6 +39,7 @@ struct Call
         float   _pad0;
         vec2    polygon_offset;
         vec4    stage_color;
+        vec4    texmatrix[3];
 #if BINDLESS
         uvec2   txhandle;
         uvec2   fbhandle;


### PR DESCRIPTION
### Motivation
- The `world dlight` vertex shader referenced `call.texmatrix[...]` but the `Call` struct in `Quake/shaders/world_dlight.vert` lacked the `texmatrix` member, causing GLSL compilation failures (`"texmatrix" is not member of struct "Call"`).

### Description
- Add a `vec4 texmatrix[3];` member to the `Call` struct in `Quake/shaders/world_dlight.vert` so the shader's layout matches the CPU-side call buffer and other world shaders.

### Testing
- Ran `git diff --check` which reported no issues and succeeded. 
- Attempted `cmake --build build -j2` but no `build` directory exists in the environment so a full build/test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69923023ba20832e8e3ec8ce3dd89ad4)