### PR TITLE
Add phantasy decal shader presets for remaster-compatible effects

### DIFF
--- a/Quake/scripts/phantasy_decals.shader
+++ b/Quake/scripts/phantasy_decals.shader
@@ -1,0 +1,54 @@
+// Phantasy-themed decal defaults backed by stock Quake Remaster textures.
+// These names are safe for default remastered game VM content.
+
+decal phantasy_explosion_mark {
+  texture "decals/scorch/scorch_02"
+  size 18 30
+  alpha 0.40 0.65
+  color 1 1 1
+  lifetime 40
+  fade 12
+  blend alpha
+  random_rotation 1
+  priority 3
+  category scorch
+}
+
+decal phantasy_bullet_hole {
+  texture "decals/bullet/bhole_01"
+  size 5 8
+  alpha 0.65 0.90
+  color 1 1 1
+  lifetime 32
+  fade 8
+  blend alpha
+  random_rotation 1
+  priority 4
+  category bullet
+}
+
+decal phantasy_blood_mark {
+  texture "decals/blood/splat_02"
+  size 9 15
+  alpha 0.40 0.70
+  color 1 1 1
+  lifetime 26
+  fade 8
+  blend alpha
+  random_rotation 1
+  priority 1
+  category blood
+}
+
+decal phantasy_energy_mark {
+  texture "decals/scorch/scorch_01"
+  size 10 18
+  alpha 0.35 0.55
+  color 0.70 0.90 1.00
+  lifetime 30
+  fade 10
+  blend alpha
+  random_rotation 1
+  priority 2
+  category scorch
+}


### PR DESCRIPTION
### Motivation
- Provide a small set of default decal presets for phantasy-themed effects (explosion marks, bullet holes, blood, and energy) to simplify mod authoring and level effects.
- Ensure the presets use phantasy-style names while remaining compatible with the default Quake Remaster VM by referencing stock remaster textures.

### Description
- Add a new shader script at `Quake/scripts/phantasy_decals.shader` containing four decal definitions: `phantasy_explosion_mark`, `phantasy_bullet_hole`, `phantasy_blood_mark`, and `phantasy_energy_mark`.
- Each decal defines `texture`, `size`, `alpha`, `color`, `lifetime`, `fade`, `blend`, `random_rotation`, `priority`, and `category` with sensible defaults for in-game usage.
- Texture references point to stock remaster assets such as `decals/scorch/scorch_02`, `decals/bullet/bhole_01`, and `decals/blood/splat_02` so the script works with an unmodified remastered VM.

### Testing
- Verified file contents and line structure with `nl -ba Quake/scripts/phantasy_decals.shader`, which succeeded.
- Confirmed the new shader file appears in the `Quake/scripts` listing, which succeeded.
- Ran `git status --short` to ensure the file is present in the working tree, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699236d18c48832eb926c61d77ee7369)