### PR TITLE
Unify AO controls and rendering path (use r_ao_* consistently)

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -1665,11 +1665,11 @@ static GLuint GL_GenerateSSAOTexture (float view_min_x, float view_min_y, float 
 	if (!framebufs.composite.depth_stencil_tex)
 		return 0;
 	if (method == 1 && !glprogs.ao_assao_main)
-		return GL_GenerateLegacySSAOTexture (view_min_x, view_min_y, view_max_x, view_max_y);
+		return 0;
 	if (method == 2 && (!glprogs.ao_gtao_prefilter || !glprogs.ao_gtao_main || !glprogs.ao_denoise))
-		return GL_GenerateLegacySSAOTexture (view_min_x, view_min_y, view_max_x, view_max_y);
+		return 0;
 	if (!glprogs.ao_denoise)
-		return GL_GenerateLegacySSAOTexture (view_min_x, view_min_y, view_max_x, view_max_y);
+		return 0;
 
 	/*
 	Integration Plan
@@ -3564,7 +3564,7 @@ qboolean GL_NeedsPostprocess (void)
 		return true;
 	if (r_filmgrain.value > 0.f && r_filmgrain_affect_ui.value <= 0.f)
 		return true;
-	if (r_ssao.value > 0.f)
+	if (r_ao_method.value > 0.f)
 		return true;
 	if (r_godrays.value > 0.f)
 		return true;
@@ -5110,7 +5110,7 @@ void R_WarpScaleView (void)
 	needwarpscale = r_refdef.scale != 1 || water_warp;
 	fbodest = GL_NeedsPostprocess () ? framebufs.composite.fbo : 0;
 	need_depth_resolve = (fbodest == framebufs.composite.fbo)
-		&& (R_DoFEnabled () || r_ssao.value > 0.f || r_ssao_debug.value > 0.f || r_fogvol.value > 0.f);
+		&& (R_DoFEnabled () || r_ao_method.value > 0.f || r_ao_debug.value > 0.f || r_fogvol.value > 0.f);
 
 	if (msaa)
 	{


### PR DESCRIPTION
### Motivation
- Consolidate ambient occlusion control so all AO modes are driven by the unified `r_ao_*` cvars and rendered via a single AO path instead of mixing legacy `r_ssao` controls and render code.

### Description
- In `GL_GenerateSSAOTexture` return `0` when the selected compute AO programs are not available instead of falling back into the legacy `GL_GenerateLegacySSAOTexture` path.
- Replace postprocess gating that used `r_ssao` with `r_ao_method` so postprocess activation follows unified AO controls.
- Update depth-resolve gating in `R_WarpScaleView` to check `r_ao_method` and `r_ao_debug` instead of the legacy `r_ssao`/`r_ssao_debug` cvars.

### Testing
- Ran `cmake -S . -B build && cmake --build build -j4`, which failed in this environment because the SDL2 CMake package/configuration is not available.
- Performed source inspections (`rg`/`nl`) to confirm the replacements and committed the changes with `git commit` successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69923d37d1c0832e82d3e4e1ecc67c83)