### PR TITLE
Fix alias rim lighting normal orientation

### DIFF
--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -244,8 +244,14 @@ void main()
 	{
 		vec3 N = normalize_safe(gl_FrontFacing ? in_normal : -in_normal);
 		vec3 V = normalize_safe(-in_pos);
-		// Use abs(dot(N,V)) to avoid blown-out fronts on assets with inconsistent normal orientation/winding.
-		float ndv = saturate(abs(dot(N, V)));
+		// Keep shading normals oriented with the geometric face normal so inconsistent
+		// asset normals don't force a full rim contribution on front-facing polygons.
+		vec3 Ng = normalize_safe(cross(dFdx(in_pos), dFdy(in_pos)));
+		if (!gl_FrontFacing)
+			Ng = -Ng;
+		if (dot(N, Ng) < 0.0)
+			N = -N;
+		float ndv = saturate(dot(N, V));
 		float rim_raw = pow(saturate(1.0 - ndv), RimParams0.z) * RimParams0.y;
 
 		vec3 direct_static = RimParams0.w * L_static * shadow_term;


### PR DESCRIPTION
### Motivation
- Prevent exaggerated rim highlights on front-facing alias models caused by inconsistent vertex normals by ensuring the shading normal is oriented with the geometric face normal before computing rim contribution.

### Description
- In `Quake/shaders/alias.frag` compute a geometric face normal with `Ng = normalize_safe(cross(dFdx(in_pos), dFdy(in_pos)))`, flip `Ng` for back faces, flip the shading normal `N` when `dot(N, Ng) < 0`, and replace `abs(dot(N, V))` with `dot(N, V)` for `ndv`.

### Testing
- Attempted to configure and build with `cmake -S . -B build && cmake --build build -j2`, which failed due to missing SDL2 development package in the environment so no runtime rendering tests were performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699244aaa908832e9c9893c462d7f04a)