### PR TITLE
Fix dynamic-light key collisions for entity effect lights

### DIFF
--- a/Quake/cl_main.c
+++ b/Quake/cl_main.c
@@ -541,6 +541,11 @@ static void CL_SetDlightColorForEntity (dlight_t *dl, const entity_t *ent)
         }
 }
 
+static int CL_DlightKeyForEntityEffect (int entnum, int effect_channel)
+{
+	return (entnum << 4) | (effect_channel & 0xF);
+}
+
 /*
 ===============
 CL_RelinkEntities
@@ -665,7 +670,7 @@ void CL_RelinkEntities (void)
 		{
 			vec3_t		fv, rv, uv;
 
-			dl = CL_AllocDlight (i);
+			dl = CL_AllocDlight (CL_DlightKeyForEntityEffect (i, 1));
 			VectorCopy (ent->origin,  dl->origin);
 			dl->origin[2] += 16;
 			AngleVectors (ent->angles, fv, rv, uv);
@@ -696,7 +701,7 @@ void CL_RelinkEntities (void)
 		}
                 if (ent->effects & EF_BRIGHTLIGHT)
                 {
-                        dl = CL_AllocDlight (i);
+                        dl = CL_AllocDlight (CL_DlightKeyForEntityEffect (i, 2));
                         VectorCopy (ent->origin,  dl->origin);
                         dl->origin[2] += 16;
                         dl->radius = 400 + (rand()&31);
@@ -706,7 +711,7 @@ void CL_RelinkEntities (void)
                 }
                 if (ent->effects & EF_DIMLIGHT)
                 {
-                        dl = CL_AllocDlight (i);
+                        dl = CL_AllocDlight (CL_DlightKeyForEntityEffect (i, 3));
                         VectorCopy (ent->origin,  dl->origin);
                         dl->radius = 200 + (rand()&31);
                         dl->baseradius = dl->radius;
@@ -715,7 +720,7 @@ void CL_RelinkEntities (void)
                 }
                 if (ent->effects & EF_QEX_QUADLIGHT)
                 {
-                        dl = CL_AllocDlight (i);
+                        dl = CL_AllocDlight (CL_DlightKeyForEntityEffect (i, 4));
                         VectorCopy (ent->origin,  dl->origin);
                         dl->radius = 200 + (rand()&31);
                         dl->baseradius = dl->radius;
@@ -726,7 +731,7 @@ void CL_RelinkEntities (void)
                 }
                 if (ent->effects & EF_QEX_PENTALIGHT)
                 {
-                        dl = CL_AllocDlight (i);
+                        dl = CL_AllocDlight (CL_DlightKeyForEntityEffect (i, 5));
                         VectorCopy (ent->origin,  dl->origin);
                         dl->radius = 200 + (rand()&31);
                         dl->baseradius = dl->radius;
@@ -747,7 +752,7 @@ void CL_RelinkEntities (void)
                 else if (ent->model->flags & EF_ROCKET)
                 {
                         CL_RocketTrail (ent, 0);
-                        dl = CL_AllocDlight (i);
+                        dl = CL_AllocDlight (CL_DlightKeyForEntityEffect (i, 6));
                         VectorCopy (ent->origin, dl->origin);
                         dl->radius = 200;
                         dl->baseradius = dl->radius;


### PR DESCRIPTION
### Motivation
- Multiple per-entity effects were allocating transient dynamic lights with the same key (the entity index), causing later allocations in the same frame to overwrite earlier ones and making lights (e.g. gun muzzle flash) disappear or destabilize dlight selection.
- The change prevents different visual effects on the same entity from reusing the same dlight slot so all effects can be represented simultaneously.

### Description
- Added helper `CL_DlightKeyForEntityEffect(int entnum, int effect_channel)` which composes a small unique key from `entnum` and a 4-bit `effect_channel` to avoid collisions when allocating transient dlights.
- Replaced direct `CL_AllocDlight(i)` calls for per-entity effects in `CL_RelinkEntities` with keyed allocations using `CL_DlightKeyForEntityEffect` for the following effects: muzzleflash (channel 1), brightlight (2), dimlight (3), quadlight (4), pentalight (5), and rocket trail/rocket model light (6).
- All edits are contained to `Quake/cl_main.c` and only affect the keys passed into `CL_AllocDlight` for entity-driven temporary lights.

### Testing
- Attempted an automated build with `cmake -S . -B build && cmake --build build -j4`, which failed in this environment due to missing SDL2 CMake package files (`SDL2Config.cmake` / `sdl2-config.cmake`), so a full compile/run validation could not be completed here.
- No other automated tests were available or executed in this environment; the change is intentionally minimal and localised to light-key generation and allocations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699252d8da54832eba90433f3dcd959d)