### PR TITLE
Integrate fog volumes into froxel volumetric pipeline

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -2397,6 +2397,8 @@ static void Atmosphere_Froxel_BuildVolume (const atmosphere_settings_t *settings
 	GL_Uniform4fFunc (3, jitter[0], jitter[1], 0.f, 0.f);
 	GL_DispatchComputeFunc (gx, gy, gz);
 	GL_MemoryBarrierFunc (GL_SHADER_IMAGE_ACCESS_BARRIER_BIT | GL_TEXTURE_FETCH_BARRIER_BIT);
+	if (R_FogVol_BindForFroxelBuild () > 0)
+		R_FogVol_InjectBuiltIntoFroxel ();
 	GL_EndGroup ();
 }
 

--- a/Quake/r_fogvol.c
+++ b/Quake/r_fogvol.c
@@ -66,6 +66,15 @@ static int r_fogvol_history_width = 0;
 static int r_fogvol_history_height = 0;
 static double r_fogvol_debug_summary_time = 0.0;
 
+typedef struct froxel_grid_s
+{
+	int width;
+	int height;
+	int depth;
+	GLuint scatter_tex;
+	GLuint transmittance_tex;
+} froxel_grid_t;
+
 typedef struct fogvol_test_state_s
 {
 	unsigned statebits;
@@ -1550,9 +1559,70 @@ void R_FogVol_LogEndFrameState (void)
 	R_FogVol_LogPipelineState ("END_FRAME");
 }
 
+int R_FogVol_BindForFroxelBuild (void)
+{
+	R_FogVol_BuildList ();
+	if (r_fogvol.value <= 0.f)
+		return 0;
+	if (r_fogvolume_count <= 0)
+		return 0;
+	return r_fogvolume_count;
+}
+
+void R_FogVol_InjectBuiltIntoFroxel (void)
+{
+	froxel_grid_t grid;
+	if (r_fogvolume_count <= 0)
+		return;
+	grid.width = framebufs.atmos_froxel.width;
+	grid.height = framebufs.atmos_froxel.height;
+	grid.depth = framebufs.atmos_froxel.depth;
+	grid.scatter_tex = framebufs.atmos_froxel.scatter_tex;
+	grid.transmittance_tex = framebufs.atmos_froxel.transmittance_tex;
+	R_FogVol_InjectIntoGrid (&grid, r_fogvolumes, r_fogvolume_count);
+}
+
 void R_FogVol_InjectIntoGrid (froxel_grid_t *grid, const fog_volume_t *vols, int num)
 {
-	(void)grid;
-	(void)vols;
-	(void)num;
+	int gx, gy, gz;
+
+	if (!grid || !vols || num <= 0)
+		return;
+	if (grid->scatter_tex == 0 || grid->transmittance_tex == 0)
+		return;
+	if (grid->width <= 0 || grid->height <= 0 || grid->depth <= 0)
+		return;
+	if (!glprogs.atmos_froxel_build)
+		return;
+
+	gx = (grid->width + 3) / 4;
+	gy = (grid->height + 3) / 4;
+	gz = (grid->depth + 3) / 4;
+
+	GL_BeginGroup ("Atmosphere: FogVol Inject");
+	GL_UseProgram (glprogs.atmos_froxel_build);
+	GL_BindImageTextureFunc (0, grid->scatter_tex, 0, GL_TRUE, 0, GL_READ_WRITE, GL_RGBA16F);
+	GL_BindImageTextureFunc (1, grid->transmittance_tex, 0, GL_TRUE, 0, GL_READ_WRITE, GL_R16F);
+	GL_Uniform4fFunc (0, (float)grid->width, (float)grid->height, (float)grid->depth, 0.f);
+
+	for (int i = 0; i < num; ++i)
+	{
+		const fog_volume_t *v = &vols[i];
+		float albedo = CLAMP (0.f, v->noiseAmount, 1.f);
+		float emissive = q_max (0.f, v->noiseBias);
+		float intensity = q_max (0.f, v->density);
+
+		if (!v->enabled || v->density <= 0.f)
+			continue;
+
+		GL_Uniform4fFunc (1, q_max (0.f, v->density), q_max (0.f, v->falloff), albedo, emissive);
+		GL_Uniform4fFunc (2, CLAMP (0.f, v->color[0], 4.f), CLAMP (0.f, v->color[1], 4.f), CLAMP (0.f, v->color[2], 4.f), intensity);
+		GL_Uniform4fFunc (3, 0.f, 0.f, 1.f, 0.f);
+		GL_Uniform4fFunc (4, v->mins[0], v->mins[1], v->mins[2], 1.f);
+		GL_Uniform4fFunc (5, v->maxs[0], v->maxs[1], v->maxs[2], 0.f);
+		GL_DispatchComputeFunc (gx, gy, gz);
+	}
+
+	GL_MemoryBarrierFunc (GL_SHADER_IMAGE_ACCESS_BARRIER_BIT | GL_TEXTURE_FETCH_BARRIER_BIT);
+	GL_EndGroup ();
 }

--- a/Quake/r_fogvol.h
+++ b/Quake/r_fogvol.h
@@ -36,6 +36,8 @@ void R_FogVol_Render (void);
 void R_FogVol_DrawDebug2D (void);
 void R_FogVol_LogEndFrameState (void);
 void R_FogVol_InjectIntoGrid (froxel_grid_t *grid, const fog_volume_t *vols, int num);
+int R_FogVol_BindForFroxelBuild (void);
+void R_FogVol_InjectBuiltIntoFroxel (void);
 qboolean R_FogVol_ProjectAABBToScreenRect (const fog_volume_t *v, int *x0, int *y0, int *x1, int *y1, qboolean fullres);
 
 #endif // R_FOGVOL_H

--- a/Quake/shaders/atmos_froxel_build.comp
+++ b/Quake/shaders/atmos_froxel_build.comp
@@ -7,6 +7,8 @@ layout(location=0) uniform vec4 FroxelDims;
 layout(location=1) uniform vec4 MediumParams0; // x density, y falloff, z albedo, w emissive
 layout(location=2) uniform vec4 MediumParams1; // rgb color, w intensity
 layout(location=3) uniform vec4 Jitter;
+layout(location=4) uniform vec4 VolumeMins; // xyz mins, w enable
+layout(location=5) uniform vec4 VolumeMaxs; // xyz maxs, w reserved
 
 float Atmosphere_Froxel_ZToViewDepth(float z)
 {
@@ -44,8 +46,31 @@ void main()
 
     float sigma_t;
     vec3 sigma_s;
+    bool injectMode = (Jitter.z > 0.5);
+
     Atmosphere_EvalMedium(worldPos, viewPos, sigma_t, sigma_s);
 
-    imageStore(OutScatter, coord, vec4(sigma_s, sigma_t));
-    imageStore(OutTransmittance, coord, vec4(exp(-sigma_t), 0.0, 0.0, 0.0));
+    if (injectMode)
+    {
+        if (VolumeMins.w > 0.5)
+        {
+            bvec3 geMin = greaterThanEqual(worldPos, VolumeMins.xyz);
+            bvec3 leMax = lessThanEqual(worldPos, VolumeMaxs.xyz);
+            if (!(all(geMin) && all(leMax)))
+                return;
+        }
+
+        vec4 prevScatter = imageLoad(OutScatter, coord);
+        vec4 prevTrans = imageLoad(OutTransmittance, coord);
+        float newSigmaT = max(0.0, prevScatter.a + sigma_t);
+        vec3 newSigmaS = max(vec3(0.0), prevScatter.rgb + sigma_s);
+        float newTrans = clamp(prevTrans.r * exp(-sigma_t), 0.0, 1.0);
+        imageStore(OutScatter, coord, vec4(newSigmaS, newSigmaT));
+        imageStore(OutTransmittance, coord, vec4(newTrans, 0.0, 0.0, 0.0));
+    }
+    else
+    {
+        imageStore(OutScatter, coord, vec4(sigma_s, sigma_t));
+        imageStore(OutTransmittance, coord, vec4(exp(-sigma_t), 0.0, 0.0, 0.0));
+    }
 }


### PR DESCRIPTION
### Motivation

- Enable entity-driven fog volumes to participate in the unified froxel volumetric path so FogVolumes are visible when the froxel pipeline is used instead of remaining a CPU/GPU-only legacy path.

### Description

- Add public API hooks `R_FogVol_BindForFroxelBuild()` and `R_FogVol_InjectBuiltIntoFroxel()` and expose them in `r_fogvol.h` so the atmosphere/froxel code can trigger fog-volume injection. 
- Implement `R_FogVol_InjectIntoGrid()` in `r_fogvol.c` to validate input, bind froxel `scatter`/`transmittance` image textures, set uniforms (medium params, color, AABB), and dispatch the `atmos_froxel_build` compute shader per active volume to accumulate contributions.
- Extend `Atmosphere_Froxel_BuildVolume` (in `gl_rmain.c`) to call `R_FogVol_BindForFroxelBuild()` and `R_FogVol_InjectBuiltIntoFroxel()` after the base froxel build pass so fog volumes are injected into the live froxel textures.
- Update `Quake/shaders/atmos_froxel_build.comp` to add `VolumeMins/VolumeMaxs` uniforms, an `injectMode` path (controlled via jitter.z), AABB gating and accumulation logic that reads previous image values and accumulates scatter (`RGB`) and extinction (`A`/transmittance) instead of overwriting unconditionally.

### Testing

- Ran `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` to validate project configuration, but configuration failed due to a missing SDL2 CMake config (`SDL2Config.cmake`) in the environment, so a full build/test could not be executed (failure).
- Verified file-level diffs and compiled shader/text edits via local textual checks and committed the changes; no runtime or rendering validation was possible in this environment due to the missing dependency.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699257166748832e81344768fd6c2884)