### PR TITLE
Pin MSVC toolset to v143 for Visual Studio project

### DIFF
--- a/Windows/VisualStudio/ironwail.vcxproj
+++ b/Windows/VisualStudio/ironwail.vcxproj
@@ -27,13 +27,13 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v145</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>NotSet</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v145</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>NotSet</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
@@ -44,7 +44,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v145</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>NotSet</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />


### PR DESCRIPTION
### Motivation
- The project contained mixed MSVC toolset entries (some `v145`) which prevented consistent builds; pinning to `v143` ensures the solution builds with the Visual Studio 2022 toolset.

### Description
- Replaced all `PlatformToolset` entries in `Windows/VisualStudio/ironwail.vcxproj` from `v145` to `v143` so every configuration (`Debug/Release` x `Win32/x64`) uses `v143`, and committed the change.

### Testing
- Verified the update with `rg "PlatformToolset" Windows/VisualStudio/ironwail.vcxproj`, inspected the diff with `git diff -- Windows/VisualStudio/ironwail.vcxproj`, and committed with `git commit`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69925accf250832eb63198790b77504a)