### PR TITLE
Fix dynamic light pool allocation failures causing hard crashes

### DIFF
--- a/Quake/r_dlight_pool.c
+++ b/Quake/r_dlight_pool.c
@@ -149,10 +149,19 @@ void DLightPool_ClearPersistent (void)
 
 static void DLightPool_EnsureScratch (int needed)
 {
+	dlight_t **scratch;
+
 	if (needed <= dlight_pool.scratch_capacity)
 		return;
 
-	dlight_pool.scratch = (dlight_t **)realloc (dlight_pool.scratch, sizeof (dlight_pool.scratch[0]) * needed);
+	scratch = (dlight_t **)realloc (dlight_pool.scratch, sizeof (dlight_pool.scratch[0]) * needed);
+	if (!scratch)
+	{
+		Con_Printf ("WARNING: failed to grow dlight scratch buffer to %d entries\n", needed);
+		return;
+	}
+
+	dlight_pool.scratch = scratch;
 	dlight_pool.scratch_capacity = needed;
 }
 
@@ -172,7 +181,14 @@ static void DLightPool_EnsureCapacity (int desired)
 	if (new_capacity <= dlight_pool.capacity)
 		return;
 
-	dlight_pool.items = (dlight_t *)realloc (dlight_pool.items, sizeof (dlight_pool.items[0]) * new_capacity);
+	dlight_t *items = (dlight_t *)realloc (dlight_pool.items, sizeof (dlight_pool.items[0]) * new_capacity);
+	if (!items)
+	{
+		Con_Printf ("WARNING: failed to grow dlight pool to %d entries\n", new_capacity);
+		return;
+	}
+
+	dlight_pool.items = items;
 	memset (dlight_pool.items + dlight_pool.capacity, 0, sizeof (dlight_pool.items[0]) * (new_capacity - dlight_pool.capacity));
 	dlight_pool.capacity = new_capacity;
 }
@@ -442,6 +458,8 @@ const dlight_t *const *DLightPool_GetActiveList (int *count)
 		return NULL;
 
 	DLightPool_EnsureScratch (dlight_pool.capacity);
+	if (!dlight_pool.scratch || dlight_pool.scratch_capacity < dlight_pool.capacity)
+		return NULL;
 
 	int found = 0;
 	for (int i = 0; i < dlight_pool.capacity; i++)
@@ -483,6 +501,11 @@ int DLightPool_CollectForRender (double time, const vec3_t vieworg, const mleaf_
 	}
 
 	DLightPool_EnsureScratch (dlight_pool.capacity);
+	if (!dlight_pool.scratch || dlight_pool.scratch_capacity < dlight_pool.capacity)
+	{
+		dlight_pool.stats.submitted = 0;
+		return 0;
+	}
 
 	int found = 0;
 	for (int i = 0; i < dlight_pool.capacity; i++)


### PR DESCRIPTION
### Motivation
- Dynamic lights (muzzle flashes, rockets, lava balls, etc.) could trigger hard crashes when the dlight pool or its scratch list failed to grow because `realloc` returned `NULL` and the code continued to use those pointers.
- The intent is to make dynamic-light allocation robust under memory pressure by failing gracefully rather than leaving invalid state that leads to immediate crashes.

### Description
- Added null-checking on `realloc` results in `DLightPool_EnsureScratch` and `DLightPool_EnsureCapacity` and log a warning with `Con_Printf` when growth fails instead of overwriting pointers.
- Introduced temporary local variables for `realloc` results and only assign them back into `dlight_pool` after success.
- Added defensive early-outs in `DLightPool_GetActiveList` and `DLightPool_CollectForRender` that return safely (and set `stats.submitted = 0` where appropriate) when the scratch buffer cannot be guaranteed.
- Changes confined to `Quake/r_dlight_pool.c` and preserve the previous behavior when allocations succeed.

### Testing
- Attempted an automated build with `make -C Quake -j4`, but the build could not complete in this environment because `sdl2-config`/`SDL.h` are missing (so full compile+runtime validation was not possible). This is an environment limitation, not a code failure.
- Performed code inspection and grep-based scans of dynamic-light call sites to ensure callers handle a zero/empty submission list; no further automated tests were available in this environment.
- Changes were committed (`Quake/r_dlight_pool.c`) and the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69925bda3350832ea57035e4fc04abc7)