### PR TITLE
Fix godrays clip vector overflow in R_ComputeGodraysSunScreenPos

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -1760,7 +1760,8 @@ static qboolean R_GodraysReady (void)
 
 static qboolean R_ComputeGodraysSunScreenPos (float *out_x, float *out_y, qboolean *out_visible)
 {
-	vec3_t sun_dir, sun_point, clip;
+	vec3_t sun_dir, sun_point;
+	vec4_t clip;
 	float inv_w;
 
 	if (!out_x || !out_y || !out_visible)


### PR DESCRIPTION
### Motivation
- Resolve a compiler/runtime overflow warning by ensuring the `clip` vector used in `R_ComputeGodraysSunScreenPos` has room for four components so `clip[3]` is a valid write.

### Description
- Change `clip` from `vec3_t` to `vec4_t` in `Quake/gl_rmain.c` so the function writes into a correctly sized buffer and avoids out-of-bounds access.

### Testing
- Verified the change with `git diff` to ensure only the intended modification to `Quake/gl_rmain.c` was made; change was committed.
- Attempted to build with `make -j4` in the repo root (no Makefile) and in `Quake/` where the build failed because `sdl2-config`/`SDL.h` are not available, so a full compile validation could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69925e5038bc832ea86eb26efe1671a0)