### PR TITLE
Fix froxel fog world-space reconstruction

### DIFF
--- a/Quake/shaders/atmos_froxel_build.comp
+++ b/Quake/shaders/atmos_froxel_build.comp
@@ -23,6 +23,12 @@ vec3 Atmosphere_Froxel_InvProjRay(vec2 uv)
     return normalize(vec3(ndc, 1.0));
 }
 
+vec3 Atmosphere_ViewToWorld(vec3 viewPos)
+{
+    mat3 invViewRot = transpose(mat3(View));
+    return EyePos + invViewRot * viewPos;
+}
+
 void Atmosphere_EvalMedium(vec3 worldPos, vec3 viewPos, out float sigma_t, out vec3 sigma_s)
 {
     float h = max(0.0, worldPos.z);
@@ -42,7 +48,7 @@ void main()
     float viewDepth = Atmosphere_Froxel_ZToViewDepth(float(coord.z));
     vec3 ray = Atmosphere_Froxel_InvProjRay(uv);
     vec3 viewPos = ray * viewDepth;
-    vec3 worldPos = EyePos + viewPos;
+    vec3 worldPos = Atmosphere_ViewToWorld(viewPos);
 
     float sigma_t;
     vec3 sigma_s;

--- a/Quake/shaders/atmos_froxel_integrate.comp
+++ b/Quake/shaders/atmos_froxel_integrate.comp
@@ -29,6 +29,12 @@ vec3 Atmosphere_Froxel_InvProjRay(vec2 uv)
     return normalize(vec3(ndc, 1.0));
 }
 
+vec3 Atmosphere_ViewToWorld(vec3 viewPos)
+{
+    mat3 invViewRot = transpose(mat3(View));
+    return EyePos + invViewRot * viewPos;
+}
+
 void main()
 {
     ivec3 coord = ivec3(gl_GlobalInvocationID.xyz);
@@ -45,7 +51,7 @@ void main()
     float z1 = Atmosphere_Froxel_ZToViewDepth(float(coord.z + 1));
     float stepLen = max(1e-3, z1 - z0);
     vec3 viewPos = ray * (z0 + 0.5 * stepLen);
-    vec3 worldPos = EyePos + viewPos;
+    vec3 worldPos = Atmosphere_ViewToWorld(viewPos);
 
     float T = exp(-sigma_t * stepLen);
     float phase = PhaseHG(1.0, clamp(LightParams0.x, 0.0, 0.99));


### PR DESCRIPTION
### Motivation
- The froxel fog code reconstructed world-space samples as `EyePos + viewPos`, which ignored camera rotation and produced angle-dependent darkening/blackouts and unstable fog artifacts when the view rotated or the player moved.

### Description
- Add a helper `Atmosphere_ViewToWorld` to convert view-space positions to world-space using the inverse view rotation via `transpose(mat3(View))` and `EyePos`.
- Replace direct `EyePos + viewPos` usages with `Atmosphere_ViewToWorld(viewPos)` in `atmos_froxel_build.comp` and `atmos_froxel_integrate.comp` so volume tests and shadow sampling use correctly rotated world positions.
- Changes are limited to the two froxel compute shaders and preserve existing medium evaluation and injection logic while fixing world-space reconstruction.

### Testing
- Attempted an automated local build with `cmake -S . -B build && cmake --build build -j4`, but configuration failed in this environment due to a missing SDL2 development package so runtime validation could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69925dfcea24832eb634be5dfbc2f1a7)