### PR TITLE
Fix invalid free of hunk-allocated decal image data

### DIFF
--- a/Quake/r_decals.c
+++ b/Quake/r_decals.c
@@ -478,7 +478,6 @@ static gltexture_t *R_Decals_LoadTexture (decal_def_t *def, int def_index)
 		{
 			def->textures[0] = TexMgr_LoadImage (NULL, def->texture_paths[0], width, height, fmt, data, image_name, 0,
 				TEXPREF_ALPHA | TEXPREF_MIPMAP | TEXPREF_CLAMP);
-			free (data);
 		}
 		else if (!decal_warned_missing_tex[def_index][0])
 		{


### PR DESCRIPTION
### Motivation
- Loading a decal image via `Image_LoadImage` returns memory allocated from the hunk allocator (`Hunk_AllocNameNoFill`), but `R_Decals_LoadTexture` called `free(data)`, causing invalid-free/heap-corruption and triggered debug-breaks.
- The change aligns allocator ownership conventions so hunk-managed image data is not freed with the C heap allocator.

### Description
- Removed the `free(data)` call from `R_Decals_LoadTexture` in `Quake/r_decals.c` so hunk-allocated image buffers returned by `Image_LoadImage` are no longer freed with `free`.
- The decal texture upload call to `TexMgr_LoadImage` remains unchanged and will continue to use the provided `data` pointer without modifying allocator lifetime semantics.

### Testing
- Attempted to configure a build with `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`, which failed in this environment due to a missing SDL2 package configuration (`SDL2Config.cmake`).
- Verified the source change with a diff of `Quake/r_decals.c` to confirm the removal of `free(data)`; no runtime build/test could be completed here due to the missing dependency.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69926439f6a4832e95bd4f1d66288e1f)