### PR TITLE
Unify depth handling for Reverse‑Z and Normal‑Z (shared shader helpers + shader refactor)

### DIFF
--- a/Quake/opengl/gl_rmain.c
+++ b/Quake/opengl/gl_rmain.c
@@ -3091,6 +3091,26 @@ Wrapper around glDepthRange that handles clip control/reversed Z differences
 */
 void GL_DepthRange (zrange_t range)
 {
+	/*
+	Reverse-Z / Normal-Z invariants (source of truth):
+
+	1) Context setup (GL_SetupState):
+	   - Reverse-Z path (gl_clipcontrol_able):
+	       ClipControl = GL_ZERO_TO_ONE, ClearDepth = 0, DepthFunc = GL_GEQUAL.
+	   - Normal path:
+	       default clip space (-1..1), ClearDepth = 1, DepthFunc = GL_LEQUAL.
+
+	2) Depth range wrappers must preserve draw ordering semantics:
+	   - ZRANGE_FULL:      [0, 1] in both modes.
+	   - ZRANGE_VIEWMODEL: [0.7, 1] in reverse-Z, [0, 0.3] in normal-Z.
+	   - ZRANGE_NEAR:      [1, 1] in reverse-Z, [0, 0] in normal-Z.
+
+	3) All mode-dependent depth compares map through R_MapDepthFunc(),
+	   so material depth funcs keep the same logical meaning across modes.
+
+	These invariants are consumed by projection/depth reconstruction shaders and
+	the sky-depth cutoffs sent from GL_GenerateLegacySSAOTexture().
+	*/
 	switch (range)
 	{
 	default:

--- a/Quake/shaders/ao_common.glsl
+++ b/Quake/shaders/ao_common.glsl
@@ -1,3 +1,5 @@
+#include "depth_common.glsl"
+
 float AO_Hash12(vec2 p)
 {
         vec3 p3 = fract(vec3(p.xyx) * 0.1031);
@@ -5,16 +7,9 @@ float AO_Hash12(vec2 p)
         return fract((p3.x + p3.y) * p3.z);
 }
 
-float AO_DepthToNdc(float depth, float reversedZ)
-{
-        if (reversedZ > 0.5)
-                return depth;
-        return depth * 2.0 - 1.0;
-}
-
 vec3 AO_ReconstructViewPos(mat4 invProj, vec2 uv, float depth, float reversedZ)
 {
-        vec4 clip = vec4(uv * 2.0 - 1.0, AO_DepthToNdc(depth, reversedZ), 1.0);
+        vec4 clip = vec4(uv * 2.0 - 1.0, DepthRawToNdc(depth, reversedZ), 1.0);
         vec4 view = invProj * clip;
         float w = max(abs(view.w), 1e-6);
         return view.xyz / w;

--- a/Quake/shaders/depth_common.glsl
+++ b/Quake/shaders/depth_common.glsl
@@ -1,0 +1,51 @@
+// Shared depth helpers for both normal-Z and reversed-Z paths.
+//
+// Canonical depth convention used here:
+//   0.0 = near plane, 1.0 = far plane (independent of runtime depth mode).
+
+float DepthRawToCanonical(float depth, float reversedZ)
+{
+        return (reversedZ > 0.5) ? (1.0 - depth) : depth;
+}
+
+float DepthRawToNdc(float depth, float reversedZ)
+{
+        if (reversedZ > 0.5)
+                return depth;
+        return depth * 2.0 - 1.0;
+}
+
+float DepthRawToNdcDebug(float depth, float reversedZ, int mode)
+{
+        float raw = depth;
+        if (mode == 1)
+                raw = 1.0 - raw;
+        if (reversedZ > 0.5)
+        {
+                if (mode == 2)
+                        raw = 1.0 - raw;
+                return raw;
+        }
+        float ndc = raw * 2.0 - 1.0;
+        if (mode == 2)
+                ndc = -ndc;
+        return ndc;
+}
+
+bool DepthIsSkyDepth(float depth, float reversedZ, float skyCutoff)
+{
+        if (reversedZ > 0.5)
+                return depth <= skyCutoff;
+        return depth >= skyCutoff;
+}
+
+float ShadowReferenceFromProjZ(float projZ)
+{
+#if REVERSED_Z
+        // clip-control path stores depth in [0..1]
+        return clamp(projZ, 0.0, 1.0);
+#else
+        // legacy OpenGL projection stores NDC Z in [-1..1]
+        return clamp(projZ * 0.5 + 0.5, 0.0, 1.0);
+#endif
+}

--- a/Quake/shaders/godrays_mask.frag
+++ b/Quake/shaders/godrays_mask.frag
@@ -1,14 +1,10 @@
 layout(binding=0) uniform sampler2D DepthTexture;
 
 layout(location=0) uniform vec4 MaskParams; // x: sun x, y: sun y, z: reversed-z flag, w: debug mode
+#include "depth_common.glsl"
 layout(location=1) uniform vec4 DownsampleParams; // xy: source size, zw: scale from target to source
 
 layout(location=0) out vec4 outColor;
-
-float DecodeLinearDepth(float d, bool reversedZ)
-{
-        return reversedZ ? (1.0 - d) : d;
-}
 
 void main()
 {
@@ -18,9 +14,9 @@ void main()
         ivec2 coord = ivec2(clamp(base, vec2(0.0), max(sourceSize - vec2(1.0), vec2(0.0))));
         float depth = texelFetch(DepthTexture, coord, 0).r;
         bool reversedZ = MaskParams.z > 0.5;
-        float linearDepth = DecodeLinearDepth(depth, reversedZ);
+        float linearDepth = DepthRawToCanonical(depth, reversedZ ? 1.0 : 0.0);
 
-        float skyVis = reversedZ ? step(depth, 0.0015) : step(0.9985, depth);
+        float skyVis = DepthIsSkyDepth(depth, reversedZ ? 1.0 : 0.0, reversedZ ? 0.0015 : 0.9985) ? 1.0 : 0.0;
         vec2 uv = (gl_FragCoord.xy + vec2(0.5)) / max(vec2(textureSize(DepthTexture, 0)) / max(scale, vec2(1.0)), vec2(1.0));
         float distToSun = length(uv - MaskParams.xy);
         float sunDisk = smoothstep(0.25, 0.0, distToSun);

--- a/Quake/shaders/shadow_sample.glsl
+++ b/Quake/shaders/shadow_sample.glsl
@@ -1,6 +1,8 @@
 #ifndef SHADOW_SAMPLE_GLSL
 #define SHADOW_SAMPLE_GLSL
 
+#include "depth_common.glsl"
+
 // -----------------------------------------------------------------------------
 // Matrix multiplication robustness
 //
@@ -45,13 +47,7 @@ vec4 ShadowMul(mat4 M, vec4 v)
 
 float ShadowReference01(float proj_z)
 {
-    // Robustly convert proj.z into [0..1].
-    // If the engine already uses clip-control 0..1, proj_z will already be in-range.
-    // If it's OpenGL NDC (-1..1), this remaps.
-    float ref = proj_z;
-    if (ref < 0.0 || ref > 1.0)
-        ref = ref * 0.5 + 0.5;
-    return clamp(ref, 0.0, 1.0);
+    return ShadowReferenceFromProjZ(proj_z);
 }
 
 #ifdef SHADOW_SUN

--- a/Quake/shaders/ssao.frag
+++ b/Quake/shaders/ssao.frag
@@ -2,6 +2,7 @@ layout(binding=0) uniform sampler2D DepthTexture;
 layout(binding=1) uniform sampler2D NoiseTexture;
 
 #include "frame_uniforms.glsl"
+#include "depth_common.glsl"
 
 layout(location=0) uniform mat4 u_proj;
 layout(location=1) uniform mat4 u_invProj;
@@ -145,23 +146,6 @@ vec2 ScreenUvFromPixel(ivec2 pixel)
 }
 
 // Ironwail uses reverse-Z with clip control: near depth ~1, far depth ~0 when reversed is enabled.
-float DepthToNdcZ(float depth, float reversed, int mode)
-{
-        float raw = depth;
-        if (mode == 1)
-                raw = 1.0 - raw;
-        if (reversed > 0.5)
-        {
-                if (mode == 2)
-                        raw = 1.0 - raw;
-                return raw;
-        }
-        float ndc = raw * 2.0 - 1.0;
-        if (mode == 2)
-                ndc = -ndc;
-        return ndc;
-}
-
 vec3 ReconstructViewPos(vec2 uv, float depth);
 
 // Centralized SSAO depth conversion. Returns positive view-space depth (+X forward).
@@ -184,7 +168,7 @@ float DepthRawFromUv(vec2 uv)
 
 vec3 ReconstructViewPos(vec2 uv, float depth)
 {
-        float ndcDepth = DepthToNdcZ(depth, u_depthParams.z, u_reversedZMode);
+        float ndcDepth = DepthRawToNdcDebug(depth, u_depthParams.z, u_reversedZMode);
         vec4 clip = vec4(uv * 2.0 - 1.0, ndcDepth, 1.0);
         vec4 view = u_invProj * clip;
         float w = view.w;
@@ -207,15 +191,6 @@ vec3 ComputeNormalFromViewPos(vec3 viewPos)
         return normal;
 }
 
-bool IsSkyDepth(float depth, vec4 depthParams)
-{
-        float reversed = depthParams.z;
-        float cutoff = depthParams.w;
-        if (reversed > 0.5)
-                return depth <= cutoff;
-        return depth >= cutoff;
-}
-
 vec3 ReconstructNormalFromDepth(vec2 uv)
 {
         ivec2 centerPixel = ScreenPixelFromUv(uv);
@@ -227,21 +202,21 @@ vec3 ReconstructNormalFromDepth(vec2 uv)
         ivec2 downPixel = ivec2(clamp(vec2(centerPixel - ivec2(0, 1)), viewMinPx, viewMaxPx));
 
         float centerDepth = DepthRawFromPixel(centerPixel);
-        if (IsSkyDepth(centerDepth, u_depthParams))
+        if (DepthIsSkyDepth(centerDepth, u_depthParams.z, u_depthParams.w))
                 return vec3(0.0, 0.0, 1.0);
 
         vec2 uvCenter = ScreenUvFromPixel(centerPixel);
         vec3 p = ReconstructViewPos(uvCenter, centerDepth);
         float depthRight = DepthRawFromPixel(rightPixel);
-        if (IsSkyDepth(depthRight, u_depthParams))
+        if (DepthIsSkyDepth(depthRight, u_depthParams.z, u_depthParams.w))
                 depthRight = DepthRawFromPixel(leftPixel);
-        vec2 uvRight = ScreenUvFromPixel(IsSkyDepth(depthRight, u_depthParams) ? centerPixel : rightPixel);
+        vec2 uvRight = ScreenUvFromPixel(DepthIsSkyDepth(depthRight, u_depthParams.z, u_depthParams.w) ? centerPixel : rightPixel);
         vec3 pr = ReconstructViewPos(uvRight, depthRight);
 
         float depthUp = DepthRawFromPixel(upPixel);
-        if (IsSkyDepth(depthUp, u_depthParams))
+        if (DepthIsSkyDepth(depthUp, u_depthParams.z, u_depthParams.w))
                 depthUp = DepthRawFromPixel(downPixel);
-        vec2 uvUp = ScreenUvFromPixel(IsSkyDepth(depthUp, u_depthParams) ? centerPixel : upPixel);
+        vec2 uvUp = ScreenUvFromPixel(DepthIsSkyDepth(depthUp, u_depthParams.z, u_depthParams.w) ? centerPixel : upPixel);
         vec3 pu = ReconstructViewPos(uvUp, depthUp);
 
         vec3 normal = normalize(cross(pr - p, pu - p));
@@ -339,7 +314,7 @@ void main()
         }
         if (debugMode == 5)
         {
-                if (IsSkyDepth(depth, u_depthParams))
+                if (DepthIsSkyDepth(depth, u_depthParams.z, u_depthParams.w))
                 {
                         outColor = vec4(1.0);
                         return;
@@ -356,7 +331,7 @@ void main()
         }
         if (debugMode == 6)
         {
-                if (IsSkyDepth(depth, u_depthParams))
+                if (DepthIsSkyDepth(depth, u_depthParams.z, u_depthParams.w))
                 {
                         outColor = vec4(1.0);
                         return;
@@ -372,7 +347,7 @@ void main()
                 outColor = vec4(v, v, v, 1.0);
                 return;
         }
-        if (IsSkyDepth(depth, u_depthParams))
+        if (DepthIsSkyDepth(depth, u_depthParams.z, u_depthParams.w))
         {
                 outColor = vec4(1.0);
                 return;
@@ -421,7 +396,7 @@ void main()
                 if (!all(greaterThanEqual(sampleUV, u_viewRect.xy)) || !all(lessThanEqual(sampleUV, u_viewRect.zw)))
                         continue;
                 float sampleDepth = DepthRawFromUv(sampleUV);
-                if (IsSkyDepth(sampleDepth, u_depthParams))
+                if (DepthIsSkyDepth(sampleDepth, u_depthParams.z, u_depthParams.w))
                         continue;
                 float sampleViewDepth = ViewZFromDepth(sampleUV, sampleDepth, u_depthParams.z > 0.5);
                 if (IsInvalidFloat(sampleViewDepth))

--- a/Quake/shaders/ssao_blur.frag
+++ b/Quake/shaders/ssao_blur.frag
@@ -11,6 +11,8 @@ layout(location=6) uniform int u_reversedZMode; // 0: default, 1: invert raw, 2:
 layout(location=7) uniform int u_yFlip; // 0: none, 1: flip Y
 layout(location=8) uniform mat4 u_invProj;
 
+#include "depth_common.glsl"
+
 layout(location=0) out vec4 outColor;
 
 vec2 ApplyYFlip(vec2 uv)
@@ -96,28 +98,11 @@ ivec2 ScreenPixelFromUv(vec2 uv)
         return ClampScreenPixel(screenPixel);
 }
 
-float DepthToNdcZ(float depth, float reversed, int mode)
-{
-        float raw = depth;
-        if (mode == 1)
-                raw = 1.0 - raw;
-        if (reversed > 0.5)
-        {
-                if (mode == 2)
-                        raw = 1.0 - raw;
-                return raw;
-        }
-        float ndc = raw * 2.0 - 1.0;
-        if (mode == 2)
-                ndc = -ndc;
-        return ndc;
-}
-
 // Centralized SSAO depth conversion. Returns positive view-space depth (+X forward).
 float ViewZFromDepth(vec2 uv, float depth01, bool reversedZ)
 {
         // SSAO FIX: Use inverse projection to keep blur depth comparisons consistent with SSAO reconstruction.
-        float ndcDepth = DepthToNdcZ(depth01, reversedZ ? 1.0 : 0.0, u_reversedZMode);
+        float ndcDepth = DepthRawToNdcDebug(depth01, reversedZ ? 1.0 : 0.0, u_reversedZMode);
         vec4 clip = vec4(uv * 2.0 - 1.0, ndcDepth, 1.0);
         vec4 view = u_invProj * clip;
         float w = view.w;
@@ -141,15 +126,6 @@ bool IsInvalidFloat(float v)
         return !(v > -1e20 && v < 1e20);
 }
 
-bool IsSkyDepth(float depth, vec4 depthParams)
-{
-        float reversed = depthParams.z;
-        float cutoff = depthParams.w;
-        if (reversed > 0.5)
-                return depth <= cutoff;
-        return depth >= cutoff;
-}
-
 float Gaussian(float x, float sigma)
 {
         float denom = max(2.0 * sigma * sigma, 1e-6);
@@ -170,7 +146,7 @@ void main()
         ivec2 screenPixel = ScreenPixelFromAoPixelNearest(aoPixel);
         vec2 screenUv = ScreenUvFromPixel(screenPixel);
         float centerDepthRaw = DepthRawFromPixel(screenPixel);
-        if (IsSkyDepth(centerDepthRaw, u_depthParams))
+        if (DepthIsSkyDepth(centerDepthRaw, u_depthParams.z, u_depthParams.w))
         {
                 outColor = vec4(1.0);
                 return;
@@ -199,7 +175,7 @@ void main()
                 vec2 sampleUV = clamp(uv + offset, u_viewRect.xy, u_viewRect.zw);
                 vec2 sampleDepthUv = ScreenUvFromAoUv(sampleUV);
                 float sampleDepthRaw = DepthRawFromUv(sampleDepthUv);
-                if (IsSkyDepth(sampleDepthRaw, u_depthParams))
+                if (DepthIsSkyDepth(sampleDepthRaw, u_depthParams.z, u_depthParams.w))
                         continue;
                 float sampleDepth = ViewZFromDepth(sampleDepthUv, sampleDepthRaw, u_depthParams.z > 0.5);
                 if (IsInvalidFloat(sampleDepth))

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -10,6 +10,7 @@ layout(binding=3) uniform sampler2D LMTexDir;
 layout(binding=5) uniform sampler2D ShadowMap;
 layout(binding=6) uniform samplerCube ReflectionTex;
 #include "frame_uniforms.glsl"
+#include "depth_common.glsl"
 #define SHADOW_SUN 1
 #include "shadow_sample.glsl"
 
@@ -279,9 +280,9 @@ vec2 ComputeVelocity(vec4 curr_clip, vec4 prev_clip)
 float DepthToCanonical(float depth)
 {
 #if REVERSED_Z
-	return 1.0 - depth;
+	return DepthRawToCanonical(depth, 1.0);
 #else
-	return depth;
+	return DepthRawToCanonical(depth, 0.0);
 #endif
 }
 


### PR DESCRIPTION
### Motivation
- Multiple shader passes had divergent depth conversion and sky‑cutoff logic which caused fragile, mode‑dependent behavior; the intent is to centralize semantics so both Reverse‑Z and Normal‑Z modes behave identically across passes (evidence: SSAO/SSAO_blur/AO/godrays/world had local depth conversions before consolidation; see `Quake/shaders/ssao.frag` and `Quake/shaders/ssao_blur.frag`).
- The engine already exposes a compile‑time `REVERSED_Z` define for shaders and runtime flag `gl_clipcontrol_able`, so we must document the invariants and reuse existing helpers rather than adding parallel implementations (compile injection: `Quake/opengl/gl_shaders.c`:L140-L147; clip control/runtime: `Quake/opengl/gl_vidsdl.c`:L1266-L1280).【F:Quake/opengl/gl_shaders.c†L140-L147】【F:Quake/opengl/gl_vidsdl.c†L1266-L1280】【F:Quake/opengl/gl_rmain.c†L3094-L3133】

### Description
- Add a single shared depth helper file `Quake/shaders/depth_common.glsl` implementing canonical conventions and utilities (`DepthRawToCanonical`, `DepthRawToNdc/DepthRawToNdcDebug`, `DepthIsSkyDepth`, `ShadowReferenceFromProjZ`) and document the canonical meaning (0=near, 1=far).【F:Quake/shaders/depth_common.glsl†L1-L51】
- Replaced duplicated pass‑local depth conversion logic with the shared helpers in `ssao.frag`, `ssao_blur.frag`, `ao_common.glsl`, `godrays_mask.frag` and `world.frag` so reconstruction, sky detection and blur upscaling use identical semantics (examples: `Quake/shaders/ao_common.glsl`:L1-L16, `Quake/shaders/ssao.frag`:L169-L176, `Quake/shaders/ssao_blur.frag`:L101-L106, `Quake/shaders/godrays_mask.frag`:L14-L20).【F:Quake/shaders/ao_common.glsl†L1-L16】【F:Quake/shaders/ssao.frag†L169-L176】【F:Quake/shaders/ssao_blur.frag†L101-L106】【F:Quake/shaders/godrays_mask.frag†L14-L20】
- Make shadow projection→reference conversion deterministic and mode‑correct by routing through `ShadowReferenceFromProjZ` (used in `shadow_sample.glsl`) to avoid heuristic remapping; shadow compare direction still respects `REVERSED_Z`.【F:Quake/shaders/shadow_sample.glsl†L48-L51】【F:Quake/shaders/depth_common.glsl†L42-L50】
- Record the verified Reverse‑Z / Normal‑Z invariants as an explicit commented block in `GL_DepthRange` so the C source is the single source of truth for ClearDepth, DepthFunc and DepthRange mapping.【F:Quake/opengl/gl_rmain.c†L3094-L3133】

### Testing
- Ran static checks: `git diff --check` / whitespace checks passed and ripgrep confirmed the new include and helper usages in shaders (examples: `Quake/shaders/ssao.frag` now includes `depth_common.glsl` at L5 and calls `DepthRawToNdcDebug`; `Quake/shaders/depth_common.glsl` exists).【F:Quake/shaders/ssao.frag†L5-L11】【F:Quake/shaders/depth_common.glsl†L1-L10】 — result: success.
- Attempted an out‑of‑tree configure/build with CMake to validate compile, but it failed in this environment due to missing system dependency `SDL2` (CMake error: `Find_package(SDL2)` failure at `CMakeLists.txt`:11), so full build/test could not be completed here; please run a full build in CI or a local dev environment with SDL2 dev files installed to validate shader compilation. (See CMake error emitted during `cmake -S . -B build`.)
- Recommended manual runtime validation checklist (execute in both clip‑control enabled and disabled modes): load map, check sky visibility, toggle SSAO (and `r_ssao_debug`), toggle godrays, toggle DoF, toggle shadows and dlight shadows, verify viewmodel/near range behavior and polygon offset correctness; watch for visual differences in shadow bias or sky mask which indicate needed adjustments to the small thresholds (skyCutoff/bias).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993184954e8832e94b7bba623ea4537)