### PR TITLE
fog/froxel: add volume shadow-visibility debug mode

### DIFF
--- a/Quake/opengl/gl_rmain.c
+++ b/Quake/opengl/gl_rmain.c
@@ -2493,7 +2493,7 @@ static void Atmosphere_Froxel_LightIntegrate (const atmosphere_settings_t *setti
 	R_Shadow_BindShadowMap (GL_TEXTURE6);
 	GL_BindImageTextureFunc (0, framebufs.atmos_froxel.scatter_tex, 0, GL_TRUE, 0, GL_READ_WRITE, GL_RGBA16F);
 	GL_BindImageTextureFunc (1, framebufs.atmos_froxel.transmittance_tex, 0, GL_TRUE, 0, GL_READ_WRITE, GL_RG16F);
-	debug_mode = (r_fog_debug.value > 0.f) ? CLAMP (0, (int)Q_rint (r_fog_debug_mode.value), 6) : 0;
+	debug_mode = (r_fog_debug.value > 0.f) ? CLAMP (0, (int)Q_rint (r_fog_debug_mode.value), 7) : 0;
 	if (debug_mode <= 0)
 	{
 		if (r_fog_debug_density.value > 0.f)
@@ -2578,7 +2578,7 @@ static atmosphere_settings_t Atmosphere_ReadSettings (void)
 	}
 	settings.steps = (float)(16 + quality * 16);
 	settings.history_weight = CLAMP (0.f, r_fog_history_weight.value, 1.f);
-	settings.debug_mode = (r_fog_debug.value > 0.f) ? CLAMP (0.f, r_fog_debug_mode.value, 6.f) : 0.f;
+	settings.debug_mode = (r_fog_debug.value > 0.f) ? CLAMP (0.f, r_fog_debug_mode.value, 7.f) : 0.f;
 	settings.debug_slice = CLAMP (0.f, r_fog_debug_slice.value, (float)q_max (framebufs.atmos_froxel.depth - 1, 0));
 	settings.noise_scale = q_max (0.0001f, r_fog_noise_scale.value);
 	settings.noise_drift = q_max (0.f, r_fog_noise_drift.value);
@@ -3017,7 +3017,7 @@ void GL_PostProcess (void)
 		q_max (view_zfar, 1.f),
 		0.f);
 	{
-		float dbg_mode = (r_fog_debug.value > 0.f) ? CLAMP (0.f, r_fog_debug_mode.value, 6.f) : 0.f;
+		float dbg_mode = (r_fog_debug.value > 0.f) ? CLAMP (0.f, r_fog_debug_mode.value, 7.f) : 0.f;
 		if (dbg_mode <= 0.f)
 		{
 			if (r_fog_debug_density.value > 0.f) dbg_mode = 1.f;

--- a/Quake/shaders/atmos_froxel_integrate.comp
+++ b/Quake/shaders/atmos_froxel_integrate.comp
@@ -201,6 +201,11 @@ void main()
         scatter = vec3(zSlice, 1.0 - zSlice, 0.5) * checker;
         T = 1.0;
     }
+    else if (debugMode == 7)
+    {
+        scatter = vec3(clamp(shadow, 0.0, 1.0));
+        T = 1.0;
+    }
 
     imageStore(InOutScatter, coord, vec4(scatter, sigma_t));
     imageStore(InOutTransmittance, coord, vec4(T, transData.g, 0.0, 0.0));

--- a/docs/froxel_capability_matrix.md
+++ b/docs/froxel_capability_matrix.md
@@ -1,0 +1,29 @@
+# Froxel/Volumetric Fog Audit – Capability Matrix
+
+Scope audited:
+- Froxel grid setup (XY/Z resolution + logarithmic slice mapping)
+- Density field (global height fog + per-volume noise)
+- Lighting injection (sun + clustered dynamic lights)
+- Sun shadow sampling in froxel integration
+- In-scatter + transmittance integration and post-compose
+- Temporal history blend (froxel history ping-pong)
+- Reverse-Z/depth reconstruction paths in fog/shadow helpers
+- Existing fog debug modes
+
+## Capability Matrix
+
+- ✅ Froxel grid setup is present and correctly parameterized via existing CVars (`r_fog_froxel_res`, `r_fog_zslices`) and log-depth slicing in build/integrate shaders.
+- ✅ World-space density/noise sampling is already present (`viewPos -> worldPos`, then height/noise in world space).
+- ✅ Sun lighting + shadowmap visibility are already integrated in the froxel integrate pass using existing shadow sampling helpers (`shadow_sample.glsl`).
+- ✅ Transmittance (`exp(-sigma_t * ds)`) and in-scatter integration are present and composed in postprocess.
+- ✅ Temporal accumulation exists (history ping-pong + neighborhood clamp) and uses existing frame-valid gating.
+- ✅ Reverse-Z handling is centralized in existing depth/shadow helper code used by fog paths.
+- ⚠️ Debug coverage gap: no dedicated froxel debug mode for **volume shadow visibility** despite requirement/useful validation path.
+
+## Changes made in this patch
+
+- ⚠️ Fixed/extended only debug instrumentation:
+  - Added froxel integrate debug mode **7** = "Shadow visibility in volume".
+  - Extended debug-mode clamping from `[0..6]` to `[0..7]` where fog debug mode is interpreted.
+
+No new render path, no new CVar, no new texture/buffer/pass.


### PR DESCRIPTION
### Motivation
- An audit showed the froxel volumetric pipeline is feature-complete but lacked a direct debug view for per-froxel sun shadow visibility, which is required to prove correct shadow coupling without adding render paths or CVars.
- Only a minimal diagnostic was required to validate shadow sampling inside the froxel integration pass.

### Description
- Add a new debug mode `7` in `Quake/shaders/atmos_froxel_integrate.comp` that outputs the sampled shadow visibility into the froxel `scatter` channel for easy visualization (`scatter = clamp(shadow, 0.0, 1.0)`).
- Extend existing debug-mode clamping from `0..6` to `0..7` in `Quake/opengl/gl_rmain.c` at all fog debug ingestion points so the new mode is threaded through build/integrate/compose.
- Add `docs/froxel_capability_matrix.md` with a concise audit scope and capability matrix documenting what was verified and what was changed.

### Testing
- Verified wiring with `rg` to ensure the `debugMode == 7` branch and updated `CLAMP(..., 7)` usages appear in the shader and C code.
- Ran `git diff --check` to ensure no whitespace/patch issues and inspected the modified files to confirm the new debug mode is correctly emitted to the froxel outputs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993216ac46c832e98bb9d282e615f1e)