### PR TITLE
Remove obsolete unused cvars from renderer/screen modules

### DIFF
--- a/Quake/opengl/gl_screen.c
+++ b/Quake/opengl/gl_screen.c
@@ -99,9 +99,6 @@ cvar_t		scr_showfps = {"scr_showfps", "0", CVAR_ARCHIVE};
 cvar_t		scr_showspeed = {"scr_showspeed", "0", CVAR_ARCHIVE};
 cvar_t		scr_showspeed_ofs = {"scr_showspeed_ofs", "0", CVAR_ARCHIVE};
 cvar_t		scr_clock = {"scr_clock", "0", CVAR_ARCHIVE};
-//johnfitz
-cvar_t		scr_usekfont = {"scr_usekfont", "0", CVAR_NONE}; // 2021 re-release
-
 cvar_t		scr_hudstyle = {"hudstyle", "2", CVAR_ARCHIVE};
 cvar_t		cl_screenshotname = {"cl_screenshotname", "screenshots/%map%_%date%_%time%", CVAR_ARCHIVE};
 cvar_t		scr_demobar_timeout = {"scr_demobar_timeout", "1", CVAR_ARCHIVE};
@@ -647,7 +644,6 @@ void SCR_Init (void)
 	Cvar_RegisterVariable (&cl_screenshotname);
 	Cvar_RegisterVariable (&scr_demobar_timeout);
 	//johnfitz
-	Cvar_RegisterVariable (&scr_usekfont); // 2021 re-release
 	Cvar_SetCallback (&scr_fov, SCR_Callback_refdef);
 	Cvar_SetCallback (&scr_fov_adapt, SCR_Callback_refdef);
 	Cvar_SetCallback (&scr_zoomfov, SCR_Callback_refdef);

--- a/Quake/opengl/gl_sky.c
+++ b/Quake/opengl/gl_sky.c
@@ -33,7 +33,6 @@ skybox_t		*skybox;
 
 extern cvar_t gl_farclip;
 cvar_t r_fastsky = {"r_fastsky", "0", CVAR_NONE};
-cvar_t r_skyalpha = {"r_skyalpha", "1", CVAR_NONE};
 cvar_t r_skyfog = {"r_skyfog","0.5",CVAR_NONE};
 cvar_t r_skywind = {"r_skywind","1",CVAR_ARCHIVE};
 
@@ -649,7 +648,6 @@ Sky_Init
 void Sky_Init (void)
 {
 	Cvar_RegisterVariable (&r_fastsky);
-	Cvar_RegisterVariable (&r_skyalpha);
 	Cvar_RegisterVariable (&r_skyfog);
 	Cvar_RegisterVariable (&r_skywind);
 	Cvar_SetCallback (&r_skyfog, R_SetSkyfog_f);

--- a/Quake/renderer/r_decals.c
+++ b/Quake/renderer/r_decals.c
@@ -84,7 +84,6 @@ static cvar_t r_decals_bias = { "r_decals_bias", "0.6", CVAR_ARCHIVE };
 static cvar_t r_decals_spawn_budget = { "r_decals_spawn_budget", "8", CVAR_ARCHIVE };
 static cvar_t r_decals_render_budget_decals = { "r_decals_render_budget_decals", "256", CVAR_ARCHIVE };
 static cvar_t r_decals_debug = { "r_decals_debug", "0", CVAR_NONE };
-static cvar_t r_decals_on_liquids = { "r_decals_on_liquids", "0", CVAR_ARCHIVE };
 static cvar_t r_decals_reload = { "r_decals_reload", "0", CVAR_NONE };
 
 static decal_def_t decal_defs[DECAL_MAX_DEFS];
@@ -857,7 +856,6 @@ void R_Decals_Init (void)
 	Cvar_RegisterVariable (&r_decals_spawn_budget);
 	Cvar_RegisterVariable (&r_decals_render_budget_decals);
 	Cvar_RegisterVariable (&r_decals_debug);
-	Cvar_RegisterVariable (&r_decals_on_liquids);
 	Cvar_RegisterVariable (&r_decals_reload);
 	Cvar_SetCallback (&r_decals_max, R_Decals_Max_Changed);
 	Cvar_SetCallback (&r_decals_spawn_budget, R_Decals_Budget_Changed);


### PR DESCRIPTION
### Motivation
- Remove declared but unreferenced configuration variables to reduce dead API surface and simplify maintenance.

### Description
- Remove the `scr_usekfont` cvar declaration and its `Cvar_RegisterVariable` call from `Quake/opengl/gl_screen.c`.
- Remove the `r_skyalpha` cvar declaration and its `Cvar_RegisterVariable` call from `Quake/opengl/gl_sky.c`.
- Remove the `r_decals_on_liquids` cvar declaration and its `Cvar_RegisterVariable` call from `Quake/renderer/r_decals.c`.
- These edits only drop unused cvar declarations/registrations and do not change runtime rendering logic.

### Testing
- Verified no remaining references with `rg -n "scr_usekfont|r_skyalpha|r_decals_on_liquids" Quake` (no matches).
- Attempted a full configure/build with `cmake -S . -B build && cmake --build build -j4`, which could not complete in this environment due to missing `SDL2` development/config files (`SDL2Config.cmake`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69932786ce4c832ea959fd79b60f0ef0)