### PR TITLE
Fix clustered dynamic lights view-space depth (cluster_lights.comp)

### DIFF
--- a/Quake/shaders/cluster_lights.comp
+++ b/Quake/shaders/cluster_lights.comp
@@ -73,12 +73,14 @@ void main()
 
 	PackedLight l = lights[lightId];
 	vec4 v = viewMatrix * vec4(l.posRadius.xyz, 1.0);
-	float vz = max(1e-4, v.x);
+	// View-space forward is -Z; using X here breaks depth slicing and
+	// effectively culls most lights from clustered assignment.
+	float vz = max(1e-4, -v.z);
 	float radius = max(0.0, l.posRadius.w);
 	if (radius <= 0.0)
 		return;
 
-	vec4 clip = projMatrix * vec4(l.posRadius.xyz, 1.0);
+	vec4 clip = projMatrix * v;
 	if (clip.w <= 0.0001)
 		return;
 	vec2 ndc = clip.xy / clip.w;


### PR DESCRIPTION
### Motivation
- Clustered dynamic lights were being dropped from depth slices because the compute shader used the wrong view-space axis (`v.x`) for depth, causing most lights to be excluded from clusters and become invisible.

### Description
- Update `Quake/shaders/cluster_lights.comp` to compute view-space depth as `-v.z` instead of `v.x` and use the already-transformed view-space position `v` for clip projection to ensure correct depth slicing and consistent projection.

### Testing
- Ran the project configuration/build attempt with `cmake -S . -B build && cmake --build build -j2`, which failed due to missing SDL2 CMake package on the environment so no full build verification was possible.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69932a991a40832e94004a51ad7d757c)