### PR TITLE
Fix clustered light index allocation and clamp header counts

### DIFF
--- a/Quake/opengl/gl_rlight.c
+++ b/Quake/opengl/gl_rlight.c
@@ -780,6 +780,7 @@ void R_Clustered_BuildLists (void)
 	GL_BindBufferFunc (GL_SHADER_STORAGE_BUFFER, r_clustered.temp_counts_ssbo);
 	GL_BufferSubDataFunc (GL_SHADER_STORAGE_BUFFER, 0,
 		(GLsizeiptr)(sizeof (GLuint) * (size_t)r_clustered.cluster_count), temp_counts);
+	counters[0] = (GLuint)r_clustered.max_indices;
 	GL_BindBufferFunc (GL_SHADER_STORAGE_BUFFER, r_clustered.counters_ssbo);
 	GL_BufferSubDataFunc (GL_SHADER_STORAGE_BUFFER, 0, sizeof (counters), counters);
 	GL_BindBufferFunc (GL_UNIFORM_BUFFER, r_clustered.params_ubo);
@@ -820,10 +821,14 @@ void R_Clustered_BuildLists (void)
 			GLuint prefix = 0;
 			for (i = 0; i < r_clustered.cluster_count; i++)
 			{
-				r_clustered_headers_cpu[i].count = mapped[i].count;
+				GLuint count = mapped[i].count;
+				GLuint remaining = (prefix < (GLuint)r_clustered.max_indices) ? ((GLuint)r_clustered.max_indices - prefix) : 0u;
+				if (count > remaining)
+					count = remaining;
+				r_clustered_headers_cpu[i].count = count;
 				r_clustered_headers_cpu[i].offset = prefix;
 				temp_counts[i] = 0u;
-				prefix += mapped[i].count;
+				prefix += count;
 			}
 			GL_UnmapBufferFunc (GL_SHADER_STORAGE_BUFFER);
 		}


### PR DESCRIPTION
### Motivation
- The clustered light build path could mark all writes as overflow because the compute counter buffer was not initialized with the index capacity, and header counts from the GPU could sum past the index buffer capacity, risking out-of-bounds reads in shading code.

### Description
- Initialize the counters buffer so `clusterAlloc` (counter slot 0) is set to `r_clustered.max_indices` before dispatching the cluster compute shader in `R_Clustered_BuildLists` (`Quake/opengl/gl_rlight.c`).
- Clamp per-cluster `count` values when reconstructing CPU-side `r_clustered_headers_cpu` from the compute pass so `offset + count` cannot exceed `r_clustered.max_indices`.

### Testing
- Ran repository-wide grep checks for related symbols with `rg` to validate the change affects the compute and shading contract and found consistent usage in `cluster_lights.comp` and `world.frag`, and these searches succeeded.
- Performed `git show`/`git status` to confirm the patch was applied and committed; no runtime harness was available in this environment so no integration/run-time tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69932b777a84832e8793d7fcdfd9f345)