### PR TITLE
Add centralized env ambient API and trilinear lightgrid sampling

### DIFF
--- a/Quake/Makefile
+++ b/Quake/Makefile
@@ -239,6 +239,7 @@ opengl/gl_mesh.o \
 renderer/r_sprite.o \
 renderer/r_alias.o \
 renderer/r_brush.o \
+renderer/r_envlight.o \
 	opengl/gl_model.o
 
 OBJS = strlcat.o \

--- a/Quake/Makefile.w32
+++ b/Quake/Makefile.w32
@@ -244,6 +244,7 @@ GLOBJS = \
 	renderer/r_sprite.o \
 	renderer/r_alias.o \
 	renderer/r_brush.o \
+	renderer/r_envlight.o \
 	opengl/gl_model.o
 
 OBJS = strlcat.o \

--- a/Quake/opengl/gl_lightgrid.c
+++ b/Quake/opengl/gl_lightgrid.c
@@ -407,23 +407,19 @@ static void Lightgrid_DefaultSample(vec3_t out_color, float *out_ao)
         *out_ao = 1.f;
 }
 
-static qboolean Lightgrid_SampleOctreeProbe(const lightgrid_t *lg, const vec3_t pos, lightgrid_probe_t *out_probe)
+static qboolean Lightgrid_FetchOctreeCellSample(const lightgrid_octree_t *oct, const int cell[3], lightgrid_probe_t *out_probe, qboolean *out_occluded)
 {
-    const lightgrid_octree_t *oct = lg ? lg->octree : NULL;
-    int test_point[3];
     const lightgrid_octree_leaf_t *leaf = NULL;
     const lightgrid_octree_sampleset_t *set = NULL;
     uint32_t node_index;
     size_t steps = 0;
 
-    if (!oct || !out_probe)
+    if (!oct || !out_probe || !cell)
         return false;
 
     for (int i = 0; i < 3; i++)
     {
-        float local = (pos[i] - oct->header.grid_mins[i]) / oct->header.grid_dist[i];
-        test_point[i] = Q_rint(local);
-        if (test_point[i] < 0 || test_point[i] >= oct->header.grid_size[i])
+        if (cell[i] < 0 || cell[i] >= oct->header.grid_size[i])
             return false;
     }
 
@@ -454,9 +450,9 @@ static qboolean Lightgrid_SampleOctreeProbe(const lightgrid_t *lg, const vec3_t 
 
         const lightgrid_octree_node_t *node = &oct->nodes[node_index];
 
-        int signx = test_point[0] >= node->division_point[0];
-        int signy = test_point[1] >= node->division_point[1];
-        int signz = test_point[2] >= node->division_point[2];
+        int signx = cell[0] >= node->division_point[0];
+        int signy = cell[1] >= node->division_point[1];
+        int signz = cell[2] >= node->division_point[2];
         int child = 4 * signx + 2 * signy + signz;
 
         node_index = node->child[child];
@@ -469,15 +465,17 @@ static qboolean Lightgrid_SampleOctreeProbe(const lightgrid_t *lg, const vec3_t 
     if (leaf->size[0] <= 0 || leaf->size[1] <= 0 || leaf->size[2] <= 0)
         return false;
 
-    int lx = CLAMP(0, test_point[0] - leaf->mins[0], leaf->size[0] - 1);
-    int ly = CLAMP(0, test_point[1] - leaf->mins[1], leaf->size[1] - 1);
-    int lz = CLAMP(0, test_point[2] - leaf->mins[2], leaf->size[2] - 1);
+    int lx = CLAMP(0, cell[0] - leaf->mins[0], leaf->size[0] - 1);
+    int ly = CLAMP(0, cell[1] - leaf->mins[1], leaf->size[1] - 1);
+    int lz = CLAMP(0, cell[2] - leaf->mins[2], leaf->size[2] - 1);
 
     size_t idx = ((size_t)leaf->size[0] * (size_t)leaf->size[1] * (size_t)lz) + ((size_t)leaf->size[0] * (size_t)ly) + (size_t)lx;
     set = &leaf->samples[idx];
 
     if (set->occluded)
     {
+        if (out_occluded)
+            *out_occluded = true;
         VectorSet(out_probe->rgb, 0.f, 0.f, 0.f);
         VectorSet(out_probe->dir, 0.f, 0.f, 1.f);
         out_probe->ao = 0.f;
@@ -486,6 +484,8 @@ static qboolean Lightgrid_SampleOctreeProbe(const lightgrid_t *lg, const vec3_t 
     }
 
     const lightgrid_octree_sample_t *chosen = Lightgrid_SelectOctreeSample(set);
+    if (out_occluded)
+        *out_occluded = false;
 
     if (chosen)
     {
@@ -500,6 +500,99 @@ static qboolean Lightgrid_SampleOctreeProbe(const lightgrid_t *lg, const vec3_t 
 
     VectorSet(out_probe->dir, 0.f, 0.f, 1.f);
     out_probe->ao = 1.f;
+    out_probe->intensity = (out_probe->rgb[0] + out_probe->rgb[1] + out_probe->rgb[2]) * (1.f / 3.f);
+    return true;
+}
+
+static qboolean Lightgrid_SampleOctreeProbe(const lightgrid_t *lg, const vec3_t pos, lightgrid_probe_t *out_probe)
+{
+    const lightgrid_octree_t *oct = lg ? lg->octree : NULL;
+    int base[3];
+    float frac[3];
+    vec3_t accum_rgb = {0.f, 0.f, 0.f};
+    float accum_ao = 0.f;
+    float total_weight = 0.f;
+    int nearest_cell[3];
+
+    if (!oct || !out_probe)
+        return false;
+
+    for (int i = 0; i < 3; i++)
+    {
+        float local = (pos[i] - oct->header.grid_mins[i]) / oct->header.grid_dist[i];
+
+        if (!R_IsFinite(local))
+            return false;
+
+        base[i] = (int)floorf(local);
+        frac[i] = local - (float)base[i];
+
+        if (frac[i] < 0.f)
+            frac[i] = 0.f;
+        else if (frac[i] > 1.f)
+            frac[i] = 1.f;
+
+        nearest_cell[i] = Q_rint(local);
+    }
+
+    for (int sx = 0; sx <= 1; sx++)
+    {
+        float wx = sx ? frac[0] : (1.f - frac[0]);
+        int cx = base[0] + sx;
+
+        for (int sy = 0; sy <= 1; sy++)
+        {
+            float wy = sy ? frac[1] : (1.f - frac[1]);
+            int cy = base[1] + sy;
+
+            for (int sz = 0; sz <= 1; sz++)
+            {
+                float wz = sz ? frac[2] : (1.f - frac[2]);
+                int cz = base[2] + sz;
+                float weight = wx * wy * wz;
+                int cell[3] = {cx, cy, cz};
+                lightgrid_probe_t sample;
+                qboolean occluded = false;
+
+                if (weight <= 0.f)
+                    continue;
+
+                if (!Lightgrid_FetchOctreeCellSample(oct, cell, &sample, &occluded))
+                    continue;
+
+                if (occluded)
+                    continue;
+
+                VectorMA(accum_rgb, weight, sample.rgb, accum_rgb);
+                accum_ao += sample.ao * weight;
+                total_weight += weight;
+            }
+        }
+    }
+
+    if (total_weight <= 0.f)
+    {
+        qboolean occluded = false;
+
+        for (int i = 0; i < 3; i++)
+            nearest_cell[i] = CLAMP(0, nearest_cell[i], oct->header.grid_size[i] - 1);
+
+        if (!Lightgrid_FetchOctreeCellSample(oct, nearest_cell, out_probe, &occluded))
+            return false;
+
+        if (occluded)
+        {
+            VectorSet(out_probe->rgb, 0.f, 0.f, 0.f);
+            out_probe->ao = 0.f;
+            out_probe->intensity = 0.f;
+        }
+
+        return true;
+    }
+
+    VectorScale(accum_rgb, 1.f / total_weight, out_probe->rgb);
+    out_probe->ao = CLAMP(0.f, accum_ao / total_weight, 1.f);
+    VectorSet(out_probe->dir, 0.f, 0.f, 1.f);
     out_probe->intensity = (out_probe->rgb[0] + out_probe->rgb[1] + out_probe->rgb[2]) * (1.f / 3.f);
     return true;
 }

--- a/Quake/opengl/gl_rlight.c
+++ b/Quake/opengl/gl_rlight.c
@@ -22,9 +22,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // r_light.c
 
 #include "quakedef.h"
-#include "../common/lightgrid.h"
 #include "opengl/gl_lightgrid.h"
 #include "renderer/r_dlight_pool.h"
+#include "renderer/r_envlight.h"
 #include <float.h>
 #include <math.h>
 
@@ -1816,34 +1816,11 @@ qboolean R_EntityStaticLight (entity_t *e, vec3_t out_color255, entity_lightinfo
 
         VectorClear (out_color255);
 
-        if (r_model_lightgrid.value > 0.f && R_LightgridEnabled ())
+        if (R_EnvLight_SampleEntityAmbient (e, lightgrid_color, &lightgrid_ao))
         {
-                vec3_t sample_pos;
-                VectorCopy (e->origin, sample_pos);
-
-                for (int attempt = 0; attempt < 2; attempt++)
-                {
-                        const lightgrid_probe_t *probe = R_GetLightgridSample (sample_pos);
-                        if (!probe)
-                                break;
-
-                        VectorCopy (probe->rgb, lightgrid_color);
-                        lightgrid_ao = CLAMP (0.f, probe->ao, 1.f);
-                        lightgrid_valid = probe->intensity > 0.f || lightgrid_ao > 0.f;
-                        if (lightgrid_valid || attempt == 1 || !e->model)
-                                break;
-
-                        float ofs = e->model->maxs[2] * 0.5f;
-                        if (ofs <= 0.f)
-                                break;
-                        sample_pos[2] += ofs;
-                }
-
-                if (lightgrid_valid)
-                {
-                        VectorScale (lightgrid_color, lightgrid_ao * 255.f, out_color255);
-                        used_lightgrid = true;
-                }
+                lightgrid_valid = true;
+                VectorScale (lightgrid_color, lightgrid_ao * 255.f, out_color255);
+                used_lightgrid = true;
         }
 
         if (!used_lightgrid)
@@ -1894,18 +1871,4 @@ qboolean R_EntityStaticLight (entity_t *e, vec3_t out_color255, entity_lightinfo
         }
 
         return used_lightgrid || used_lightpoint || used_minlight;
-}
-
-const lightgrid_probe_t *R_GetLightgridSample (const vec3_t pos)
-{
-        static lightgrid_probe_t probe;
-        const lightgrid_t *lg = Lightgrid_Get ();
-
-        if (!R_LightgridEnabledInternal (lg))
-                return NULL;
-
-        if (!Lightgrid_SampleProbe (lg, pos, &probe))
-                return NULL;
-
-        return &probe;
 }

--- a/Quake/render.h
+++ b/Quake/render.h
@@ -167,7 +167,6 @@ void R_ParticleExplosion (vec3_t org);
 void R_ParticleExplosion2 (vec3_t org, int colorStart, int colorLength);
 void R_LavaSplash (vec3_t org);
 void R_TeleportSplash (vec3_t org);
-const lightgrid_probe_t *R_GetLightgridSample (const vec3_t pos);
 
 
 void R_PushDlights (void);

--- a/Quake/renderer/r_envlight.c
+++ b/Quake/renderer/r_envlight.c
@@ -1,0 +1,53 @@
+#include "quakedef.h"
+#include "renderer/r_envlight.h"
+#include "opengl/gl_lightgrid.h"
+
+qboolean R_EnvLight_SampleEntityAmbient (const entity_t *e, vec3_t out_rgb_linear, float *out_ao)
+{
+	const lightgrid_t *lg;
+	lightgrid_probe_t probe;
+	vec3_t sample_pos;
+	float ao = 1.f;
+
+	if (out_ao)
+		*out_ao = 1.f;
+	if (out_rgb_linear)
+		VectorSet (out_rgb_linear, 0.f, 0.f, 0.f);
+
+	if (!e || !out_rgb_linear)
+		return false;
+
+	if (!r_model_lightgrid.value)
+		return false;
+
+	lg = Lightgrid_Get ();
+	if (!lg || !r_lightgrid.value)
+		return false;
+
+	VectorCopy (e->origin, sample_pos);
+
+	for (int attempt = 0; attempt < 2; attempt++)
+	{
+		if (!Lightgrid_SampleProbe (lg, sample_pos, &probe))
+			break;
+
+		VectorCopy (probe.rgb, out_rgb_linear);
+		ao = CLAMP (0.f, probe.ao, 1.f);
+		if (probe.intensity > 0.f || ao > 0.f)
+			break;
+
+		if (attempt == 1 || !e->model)
+			break;
+
+		const float ofs = e->model->maxs[2] * 0.5f;
+		if (ofs <= 0.f)
+			break;
+
+		sample_pos[2] += ofs;
+	}
+
+	if (out_ao)
+		*out_ao = ao;
+
+	return (out_rgb_linear[0] + out_rgb_linear[1] + out_rgb_linear[2]) > 0.f || ao > 0.f;
+}

--- a/Quake/renderer/r_envlight.h
+++ b/Quake/renderer/r_envlight.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "quakedef.h"
+
+qboolean R_EnvLight_SampleEntityAmbient (const entity_t *e, vec3_t out_rgb_linear, float *out_ao);


### PR DESCRIPTION
### Motivation
- Centralize environment/ambient sampling for entities into a single API so alias/entity lighting uses one consistent path and avoids parallel lightgrid sampling logic.
- Improve sample quality by replacing nearest-cell probes with trilinear interpolation of neighboring lightgrid cells and by interpolating RGB and AO together in linear space.
- Reduce hard black edges from occluded lightgrid cells by treating occluded neighbors as zero-weight (best-effort renormalization) instead of blending in hard black.

### Description
- Added a new renderer module and public API: `Quake/renderer/r_envlight.c` + `Quake/renderer/r_envlight.h` and the function `R_EnvLight_SampleEntityAmbient(...)` which returns linear RGB + AO for an entity (with a second-attempt Z offset behavior preserved).
- Extended the octree lightgrid sampler in `Quake/opengl/gl_lightgrid.c`: added `Lightgrid_FetchOctreeCellSample(...)` and a new `Lightgrid_SampleOctreeProbe(...)` implementation that computes local grid coordinates and fractional `frac` components, queries up to 8 neighbor cells, accumulates samples with trilinear weights, interpolates RGB and AO in linear domain, and uses a nearest-cell fallback when no weighted neighbors are available.
- Occluded cells are reported via the cell fetch helper and are skipped (weight 0) during interpolation to avoid hard black contamination; results are renormalized by `total_weight` when any valid neighbors are present.
- Rewired entity/alias lighting to use the new API: `R_EntityStaticLight` in `Quake/opengl/gl_rlight.c` now calls `R_EnvLight_SampleEntityAmbient(...)` instead of sampling `R_GetLightgridSample` directly, and the old `R_GetLightgridSample` path was removed from public headers.
- Build integration: added `renderer/r_envlight.o` to `Quake/Makefile` and `Quake/Makefile.w32` and updated `Quake/render.h` to remove the old probe accessor prototype.
- All changes were committed.

### Testing
- Attempted to build with `make -C Quake -j4`, but the build failed in the environment due to missing SDL development dependencies (`sdl2-config` / `SDL.h`), so a full compile verification could not be completed (failure).
- Ran repository checks and searches (`rg`) to verify symbols and call-sites were updated, confirming `R_EnvLight_SampleEntityAmbient` is used and the old `R_GetLightgridSample` declaration was removed (succeeded).
- Changes are committed locally (git commit completed) and ready for CI/build verification on an environment with SDL installed (manual compile required to fully validate runtime behavior).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993447af3c0832eb9a6e301407011b0)