### PR TITLE
Add shared envlight.glsl and conservative envmap integration for world+alias

### DIFF
--- a/Quake/renderer/r_alias.c
+++ b/Quake/renderer/r_alias.c
@@ -73,6 +73,7 @@ typedef struct aliasinstance_s {
 	float		_pad0;
 	vec3_t		ambientcolor;
 	float		_pad1;
+	vec4_t		envmap_params;
 	int32_t		pose1;
 	int32_t		pose2;
 	float		blend;
@@ -113,6 +114,25 @@ COMPILE_TIME_ASSERT (alias_global_size_matches_std430, sizeof (ibuf.global) % 16
 
 static qboolean r_lightgrid_debug_sample_reported = false;
 static const qmodel_t *r_lightgrid_debug_last_world = NULL;
+
+static float R_AliasLuma (const vec3_t rgb)
+{
+	return rgb[0] * 0.2126f + rgb[1] * 0.7152f + rgb[2] * 0.0722f;
+}
+
+static float R_AliasEnvIndoorHint (const entity_t *e)
+{
+	float luma = 0.f;
+	float ao = 1.f;
+
+	if (e && e->lightcache.lightgrid_has_sample)
+	{
+		luma = CLAMP (0.f, R_AliasLuma (e->lightcache.lightgrid_color), 1.f);
+		ao = CLAMP (0.f, e->lightcache.lightgrid_ao, 1.f);
+	}
+
+	return CLAMP (0.f, (1.f - luma) * (1.f - 0.5f * ao), 1.f);
+}
 
 static void R_DebugLightgridSample (const entity_t *e, const vec3_t ambient_add)
 {
@@ -959,6 +979,14 @@ static void R_DrawAliasModel_Real (entity_t *e, qboolean showtris)
 		instance->flags |= ALIAS_INSTANCE_FLAG_NO_MOTION_BLUR | ALIAS_INSTANCE_FLAG_VIEWMODEL;
 	if (!Q_strncmp (e->model->name, "progs/bolt", 10))
 		instance->flags |= ALIAS_INSTANCE_FLAG_LIGHTNING;
+	{
+		const qboolean env_hint = (instance->flags & ALIAS_INSTANCE_FLAG_LIGHTNING)
+			|| (e->model->flags & MOD_FBRIGHTHACK);
+		instance->envmap_params[0] = (r_reflection_probes.value > 0.f && env_hint) ? 1.f : 0.f;
+		instance->envmap_params[1] = (instance->flags & ALIAS_INSTANCE_FLAG_LIGHTNING) ? 0.95f : 0.55f;
+		instance->envmap_params[2] = R_AliasEnvIndoorHint (e);
+		instance->envmap_params[3] = (instance->flags & ALIAS_INSTANCE_FLAG_LIGHTNING) ? 0.14f : 0.08f;
+	}
 	instance->pose1 = lerpdata.pose1;
 	instance->pose2 = lerpdata.pose2;
 	instance->blend = lerpdata.blend;
@@ -1032,6 +1060,7 @@ static void R_DrawAliasModel_Shadow_Real (entity_t *e)
 	VectorClear (instance->dlightcolor);
 	VectorClear (instance->ambientcolor);
 	instance->alpha = entalpha;
+	Vector4Set (instance->envmap_params, 0.f, 0.f, 0.f, 0.f);
 	instance->pose1 = lerpdata.pose1;
 	instance->pose2 = lerpdata.pose2;
 	instance->blend = lerpdata.blend;

--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -5,6 +5,7 @@ struct InstanceData
 	vec4	LightColor; // xyz=LightColor w=Alpha
 	vec4	DLightColor; // xyz=DLightColor
 	vec4	AmbientColor; // xyz=AmbientColor
+	vec4	EnvMapParams; // x=enable y=glossMask z=indoorHint w=intensity
 	int		Pose1;
 	int		Pose2;
 	float	Blend;
@@ -104,7 +105,9 @@ layout(binding=0) uniform sampler2D Tex;
 layout(binding=1) uniform sampler2D FullbrightTex;
 layout(binding=2) uniform sampler2D EmissiveTex;
 layout(binding=5) uniform sampler2D ShadowMap;
+layout(binding=6) uniform samplerCube ReflectionTex;
 
+#include "envlight.glsl"
 #define SHADOW_SUN 1
 #include "shadow_sample.glsl"
 
@@ -123,6 +126,7 @@ layout(location=6) in vec3 in_normal;
 layout(location=7) in vec3 in_static_light;
 layout(location=8) in vec3 in_dyn_light;
 layout(location=9) in vec3 in_amb_light;
+layout(location=10) flat in vec4 in_env_params;
 
 #define OUT_COLOR out_fragcolor
 #if OIT
@@ -240,6 +244,22 @@ void main()
                 float ghost = pow(1.0 - d, 3.0) * 0.2;
                 result.rgb += ghost * vec3(0.5, 0.7, 1.3);
         }
+
+	vec3 N_env = normalize_safe(gl_FrontFacing ? in_normal : -in_normal);
+	vec3 V_env = normalize_safe(-in_pos);
+	float ambient_luma = EnvLightLuma(clamp(L_amb / max(Overbright, 1e-4), 0.0, 1.0));
+	float indoor_factor = DeriveIndoorFactor(ambient_luma, in_env_params.z, shadow_term);
+	float env_mask = max(in_env_params.x, 0.0);
+	vec3 env_spec = EvaluateReflectionProbe(
+		ReflectionTex,
+		1.0,
+		in_pos + EyePos,
+		N_env,
+		V_env,
+		in_env_params.y * env_mask,
+		indoor_factor,
+		in_env_params.w * env_mask);
+	result.rgb += env_spec;
 
 	if (RimParams0.x > 0.5)
 	{

--- a/Quake/shaders/alias.vert
+++ b/Quake/shaders/alias.vert
@@ -5,6 +5,7 @@ struct InstanceData
 	vec4	LightColor; // xyz=LightColor w=Alpha
 	vec4	DLightColor; // xyz=DLightColor
 	vec4	AmbientColor; // xyz=AmbientColor
+	vec4	EnvMapParams; // x=enable y=glossMask z=indoorHint w=intensity
 	int		Pose1;
 	int		Pose2;
 	float	Blend;
@@ -103,6 +104,7 @@ layout(location=6) out vec3 out_normal;
 layout(location=7) out vec3 out_static_light;
 layout(location=8) out vec3 out_dyn_light;
 layout(location=9) out vec3 out_amb_light;
+layout(location=10) flat out vec4 out_env_params;
 
 
 void main()
@@ -144,4 +146,5 @@ void main()
 	out_static_light = litStatic;
 	out_dyn_light = litDlight;
 	out_amb_light = litAmbient;
+	out_env_params = inst.EnvMapParams;
 }

--- a/Quake/shaders/envlight.glsl
+++ b/Quake/shaders/envlight.glsl
@@ -1,0 +1,44 @@
+#ifndef ENVLIGHT_GLSL
+#define ENVLIGHT_GLSL
+
+float EnvLightLuma(vec3 rgb)
+{
+	return dot(rgb, vec3(0.2126, 0.7152, 0.0722));
+}
+
+float DeriveIndoorFactor(float lightgridLuma, float aoHint, float visibilityHint)
+{
+	float luma = clamp(lightgridLuma, 0.0, 1.0);
+	float ao = clamp(aoHint, 0.0, 1.0);
+	float visibility = clamp(visibilityHint, 0.0, 1.0);
+	float openness = luma * mix(0.35, 1.0, ao) * visibility;
+	return clamp(1.0 - openness, 0.0, 1.0);
+}
+
+vec3 EvaluateReflectionProbe(
+	samplerCube reflectionTex,
+	float probesEnabled,
+	vec3 worldPos,
+	vec3 normal,
+	vec3 viewDir,
+	float glossOrSpecMask,
+	float indoorFactor,
+	float intensity)
+{
+	if (probesEnabled <= 0.5 || intensity <= 0.0 || glossOrSpecMask <= 0.0)
+		return vec3(0.0);
+
+	vec3 N = normalize(normal);
+	vec3 V = normalize(viewDir);
+	vec3 refl = reflect(-V, N);
+	float maxMip = 6.0;
+	float lod = clamp(1.0 - glossOrSpecMask, 0.0, 1.0) * maxMip;
+	vec3 reflColor = textureLod(reflectionTex, refl, lod).rgb;
+
+	float indoorAtten = mix(1.0, 0.3, clamp(indoorFactor, 0.0, 1.0));
+	float fresnel = pow(1.0 - max(dot(N, V), 0.0), 5.0);
+	float fresnelTerm = mix(0.04, 1.0, fresnel);
+	return reflColor * (intensity * glossOrSpecMask * indoorAtten * fresnelTerm);
+}
+
+#endif // ENVLIGHT_GLSL

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -11,6 +11,7 @@ layout(binding=5) uniform sampler2D ShadowMap;
 layout(binding=6) uniform samplerCube ReflectionTex;
 #include "frame_uniforms.glsl"
 #include "depth_common.glsl"
+#include "envlight.glsl"
 #define SHADOW_SUN 1
 #include "shadow_sample.glsl"
 
@@ -256,16 +257,13 @@ vec3 EvaluateDirectionalAmbient(vec3 ambientColor, vec3 normal)
 	return ambientColor * (ambientBias + (1.0 - ambientBias) * nd);
 }
 
-vec3 EvaluateReflectionProbe(vec3 worldPos, vec3 normal, vec3 viewDir, float roughness)
+float ComputeEnvVisibilityHint(float shadowTerm, bool shadowEnabled)
 {
-	if (LightingParams.x <= 0.5)
-		return vec3(0.0);
-	vec3 refl = reflect(-viewDir, normalize(normal));
-	float maxMip = 6.0;
-	float lod = clamp(roughness, 0.0, 1.0) * maxMip;
-	vec3 reflColor = textureLod(ReflectionTex, refl, lod).rgb;
-	return reflColor * 0.12;
+	if (!shadowEnabled)
+		return 1.0;
+	return clamp(shadowTerm, 0.0, 1.0);
 }
+
 
 vec2 ComputeVelocity(vec4 curr_clip, vec4 prev_clip)
 {
@@ -430,6 +428,9 @@ void main()
 	float view_length = length(to_eye);
 	vec3 view_dir = (view_length > 0.0) ? (to_eye / view_length) : vec3(0.0, 0.0, 1.0);
 
+	float shadow_term = 1.0;
+	bool shadow_enabled = false;
+
 	if ((in_flags & CF_NOLIGHTMAP) == 0u)
 	{
 #if DITHER
@@ -499,8 +500,8 @@ void main()
 		}
 
 		float shadow_range = 1.0;
-		float shadow_term = ShadowVisibility(in_pos, surface_normal, shadow_range);
-		bool shadow_enabled = ShadowDebug.x > 0.5;
+		shadow_term = ShadowVisibility(in_pos, surface_normal, shadow_range);
+		shadow_enabled = ShadowDebug.x > 0.5;
 		bool lightgrid_shadow = LightgridParams.z > 0.5 && LightgridParams.x > 0.5;
 
 		if (ShadowDebug.x > 0.5 && ShadowDebug.y > 1.5)
@@ -638,10 +639,24 @@ void main()
 
 	result.rgb += fullbright + emissive;
 
-	float roughness = 0.65;
-	if (in_tcgen == TCGEN_ENVIRONMENT)
-		roughness = 0.25;
-	vec3 reflection_spec = EvaluateReflectionProbe(in_pos, surface_normal, view_dir, roughness);
+	bool env_hint_tcgen = (in_tcgen == TCGEN_ENVIRONMENT);
+	bool env_hint_shader = ((in_flags & CF_MAT_HAS_SHADER) != 0u);
+	float env_spec_mask = (env_hint_tcgen || env_hint_shader) ? 1.0 : 0.0;
+	float env_gloss = env_hint_tcgen ? 0.90 : (env_hint_shader ? 0.55 : 0.0);
+	float static_luma = EnvLightLuma(clamp(total_lightmap / max(Overbright, 1e-4), 0.0, 1.0));
+	float ao_hint = clamp(EnvLightLuma(in_lightgrid), 0.0, 1.0);
+	float visibility_hint = ComputeEnvVisibilityHint(shadow_term, shadow_enabled);
+	float indoor_factor = DeriveIndoorFactor(static_luma, ao_hint, visibility_hint);
+	float env_intensity = env_hint_tcgen ? 0.12 : 0.07;
+	vec3 reflection_spec = EvaluateReflectionProbe(
+		ReflectionTex,
+		LightingParams.x,
+		in_pos,
+		surface_normal,
+		view_dir,
+		env_gloss * env_spec_mask,
+		indoor_factor,
+		env_intensity);
 	specular_light += reflection_spec;
 	if (int(LightingParams.w + 0.5) == 6)
 	{
@@ -668,6 +683,14 @@ void main()
 	if (lighting_debug == 2)
 	{
 		out_fragcolor = vec4(vec3(clamp(length(reflection_spec) * 6.0, 0.0, 1.0)), 1.0);
+#if !OIT
+		out_velocity = vec4(0.0);
+#endif
+		return;
+	}
+	if (lighting_debug == 7)
+	{
+		out_fragcolor = vec4(clamp(reflection_spec, 0.0, 1.0), 1.0);
 #if !OIT
 		out_velocity = vec4(0.0);
 #endif


### PR DESCRIPTION
### Motivation
- Zentralisiere Envmap/Probe helpers und wiederverwendbare Heuristiken in einem gemeinsamen GLSL-Include statt duplizierter Funktionalität in Shadern. 
- Ermögliche optionale, konservative Envmap-Beleuchtung für Welt- und Alias-Shader ohne neues Materialsystem oder neue Realtime-Lichter, und leite Indoor-Dämpfung aus vorhandenen statischen Signalen ab. 

### Description
- Neue Datei `Quake/shaders/envlight.glsl` mit `EnvLightLuma`, `DeriveIndoorFactor` und einer generischen `EvaluateReflectionProbe(...)` (Parametrisierung: `reflectionTex`, `probesEnabled`, `worldPos`, `normal`, `viewDir`, `glossOrSpecMask`, `indoorFactor`, `intensity`).
- `Quake/shaders/world.frag` bindet `envlight.glsl` ein, entfernt die alte lokale `EvaluateReflectionProbe`-Implementierung und ruft die neue generische Funktion auf; Envmap-Term wird nur angewendet, wenn vorhandene Materialhinweise aktiv sind (`TCGEN_ENVIRONMENT` oder `CF_MAT_HAS_SHADER`) und hat konservative Default-Werte; Indoor-Dämpfung wird aus Lightmap/Lightgrid/Shadow-Visibility-Hinweisen abgeleitet.
- `Quake/shaders/alias.vert`/`alias.frag`: Instanzlayout erweitert um `EnvMapParams` (`x=enable y=glossMask z=indoorHint w=intensity`), Vertex shader gibt die Werte aus und Fragment shader inkludiert `envlight.glsl`, fragt `ReflectionTex` ab und addiert den optionalen Envmap-Term in die Beleuchtung.
- `Quake/renderer/r_alias.c`: Instanzstruktur `aliasinstance_t` um `envmap_params` erweitert; helper-Funktionen `R_AliasLuma` und `R_AliasEnvIndoorHint` hinzugefügt, die Indoor-Hinweis aus Lightgrid/AO ableiten; Instanzdaten werden konservativ gefüllt (aktivierung nur über bestehende Flags/Hints wie `ALIAS_INSTANCE_FLAG_LIGHTNING` oder `MOD_FBRIGHTHACK`) und im Shadow-Pfad auf null initialisiert.
- Debug: Reine Envmap-Darstellung als neues Lighting-Debug-View integriert (`lighting_debug == 7`).

### Testing
- `git diff --check` ausgeführt und es wurden keine whitespace- oder diff-Fehler gemeldet (Success).
- `cmake -S . -B build` ausgeführt; Konfiguration schlug fehl wegen fehlender SDL2 CMake-Paketdateien (`SDL2Config.cmake` / `sdl2-config.cmake`) in der Umgebung (konfigurationsfehler, erwartetes Umgebungs-issue).
- Änderungen lokal committed (`Add shared envlight include and conservative envmap terms`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69935ea6235c832eafb67baeb87c7803)