### PR TITLE
Centralize envlight CVARs and frame-uniform setup

### DIFF
--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -442,11 +442,11 @@ typedef struct gpuframedata_s {
         vec4_t          prev_eye;       // xyz: prev_eyepos, w: delta_time
         vec4_t          zparams;        // x: zlogscale, y: zlogbias, zw: padding
         float           lightmap_params[4];
-        vec4_t          lightgrid_params; // x: enabled, yzw: unused
+        vec4_t          lightgrid_params; // x: enabled, y: debug, z: shadow mode, w: world fill
         vec4_t          dlight_params;  // x: style, y: debug view, z: pass selector, w: padding
         vec4_t          colorspace_params; // x: debug mode, y: manual gamma, z: output sRGB, w: unused
         vec4_t          shader_params;  // x: shader debug, y: tcgen debug, zw: unused
-        vec4_t          lighting_params; // x: reflection probes enabled, y: reflection debug, z: directional lightgrid, w: lighting debug view
+        vec4_t          lighting_params; // x: envmap enabled, y: reflection debug, z: sky SH enabled, w: lighting debug view
         float           shadow_viewproj[16];
         vec4_t          shadow_params; // x: bias, y: normal bias, z: pcf enabled, w: pcf taps
         vec4_t          shadow_debug;  // x: enabled, y: debug mode, zw: unused
@@ -597,6 +597,12 @@ extern cvar_t r_reflection_probes;
 extern cvar_t r_reflection_probe_debug;
 extern cvar_t r_lightgrid_directional;
 extern cvar_t r_lighting_debug;
+extern cvar_t r_envlight;
+extern cvar_t r_envlight_entity_intensity;
+extern cvar_t r_envlight_world_fill;
+extern cvar_t r_envlight_sky_sh;
+extern cvar_t r_envlight_envmap;
+extern cvar_t r_envlight_indoor_dampen;
 
 #define WORLDSHADER_SOLID		0
 #define WORLDSHADER_ALPHATEST	1

--- a/Quake/opengl/gl_rmain.c
+++ b/Quake/opengl/gl_rmain.c
@@ -25,6 +25,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "client/cl_postfx.h"
 #include "renderer/r_postfx.h"
 #include "renderer/r_decals.h"
+#include "renderer/r_envlight.h"
 #include "opengl/gl_lightgrid.h"
 #include "mat_shader.h"
 #include <float.h>
@@ -606,6 +607,7 @@ cvar_t	s_ao_halfres = { "s_ao_halfres", "1", CVAR_ARCHIVE };
 cvar_t	s_ao_debug = { "s_ao_debug", "0", CVAR_NONE }; /* 0=off,1=ao_only,2=inputs,3=depth_lin,4=normals,5=edges,6=history */
 cvar_t	s_ao_temporal = { "s_ao_temporal", "0", CVAR_ARCHIVE };
 
+/* Legacy compatibility aliases; real envlight controls live in renderer/r_envlight.c. */
 cvar_t	r_reflection_probes = { "r_reflection_probes", "0", CVAR_ARCHIVE };
 cvar_t	r_reflection_probe_debug = { "r_reflection_probe_debug", "0", CVAR_NONE };
 cvar_t	r_lightgrid_directional = { "r_lightgrid_directional", "1", CVAR_ARCHIVE };
@@ -3959,13 +3961,7 @@ void R_SetupView (void)
         r_framedata.lightmap_params[1] = r_tonemap.value > 0.f ? 1.f : 0.f;
         r_framedata.lightmap_params[2] = (r_lightingdir.value > 0.f && lightmap_dir_texture) ? 1.f : 0.f;
         r_framedata.lightmap_params[3] = r_lightstyle_framefrac;
-        r_framedata.lightgrid_params[0] = R_LightgridEnabled () ? 1.f : 0.f;
-        r_framedata.lightgrid_params[1] = (r_lightgrid_debug.value >= 2.f) ? 1.f : 0.f;
-        r_framedata.lightgrid_params[2] =
-                (r_shadows.value > 0.f && r_shadow_sun.value > 0.f && r_shadow_lightgrid.value > 0.f)
-                ? CLAMP (0.f, r_shadow_lightgrid_mode.value, 2.f)
-                : 0.f;
-        r_framedata.lightgrid_params[3] = 0.f;
+	R_EnvLight_BuildFrameUniforms (r_framedata.lighting_params, r_framedata.lightgrid_params);
 	r_framedata.dlight_params[0] = (r_dlight_style.value > 0.f && r_clustered_lighting.value <= 0.f) ? 1.f : 0.f;
 	r_framedata.dlight_params[1] = r_dlight_debug.value > 0.f ? 1.f : 0.f;
 	r_framedata.dlight_params[2] = 0.f;
@@ -3978,10 +3974,6 @@ void R_SetupView (void)
         r_framedata.shader_params[1] = r_tcgen_debug.value;
         r_framedata.shader_params[2] = 0.f;
         r_framedata.shader_params[3] = 0.f;
-        r_framedata.lighting_params[0] = r_reflection_probes.value > 0.f ? 1.f : 0.f;
-        r_framedata.lighting_params[1] = CLAMP (0.f, r_reflection_probe_debug.value, 1.f);
-        r_framedata.lighting_params[2] = r_lightgrid_directional.value > 0.f ? 1.f : 0.f;
-        r_framedata.lighting_params[3] = CLAMP (0.f, r_lighting_debug.value, 6.f);
         r_framedata.shadow_params[0] = r_shadow_bias.value;
         r_framedata.shadow_params[1] = r_shadow_normalbias.value;
         r_framedata.shadow_params[2] = r_shadow_pcf.value > 0.f ? 1.f : 0.f;

--- a/Quake/opengl/gl_rmisc.c
+++ b/Quake/opengl/gl_rmisc.c
@@ -28,6 +28,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "mat_shader.h"
 #include "renderer/r_dlight_pool.h"
 #include "renderer/r_postfx.h"
+#include "renderer/r_envlight.h"
 #include "simd_caps.h"
 
 //johnfitz -- new cvars
@@ -283,6 +284,12 @@ extern cvar_t r_reflection_probes;
 extern cvar_t r_reflection_probe_debug;
 extern cvar_t r_lightgrid_directional;
 extern cvar_t r_lighting_debug;
+extern cvar_t r_envlight;
+extern cvar_t r_envlight_entity_intensity;
+extern cvar_t r_envlight_world_fill;
+extern cvar_t r_envlight_sky_sh;
+extern cvar_t r_envlight_envmap;
+extern cvar_t r_envlight_indoor_dampen;
 extern cvar_t r_godrays;
 extern cvar_t r_godrays_quality;
 extern cvar_t r_godrays_debug;
@@ -664,6 +671,8 @@ Cvar_RegisterVariable (&r_drawviewmodel);
         Cvar_RegisterVariable (&r_debug_itemlight);
         Cvar_RegisterVariable (&r_minlight_models);
         Cvar_RegisterVariable (&r_model_lightgrid);
+        /* Envlight centralization: register master controls and legacy alias bridge. */
+        R_EnvLight_RegisterCvars ();
         Cvar_RegisterVariable (&r_wateralpha);
         Cvar_SetCallback (&r_wateralpha, R_SetWateralpha_f);
         Cvar_RegisterVariable (&r_litwater);
@@ -880,9 +889,8 @@ Cvar_RegisterVariable (&r_ssao_samples);
 	Cvar_RegisterVariable (&s_ao_halfres);
 	Cvar_RegisterVariable (&s_ao_debug);
 	Cvar_RegisterVariable (&s_ao_temporal);
-	Cvar_RegisterVariable (&r_reflection_probes);
+	/* Legacy aliases (r_reflection_probes/r_lightgrid_directional) are synced via R_EnvLight_RegisterCvars. */
 	Cvar_RegisterVariable (&r_reflection_probe_debug);
-	Cvar_RegisterVariable (&r_lightgrid_directional);
 	Cvar_RegisterVariable (&r_lighting_debug);
 Cvar_RegisterVariable (&r_godrays);
 	Cvar_RegisterVariable (&r_godrays_quality);

--- a/Quake/renderer/r_alias.c
+++ b/Quake/renderer/r_alias.c
@@ -982,10 +982,16 @@ static void R_DrawAliasModel_Real (entity_t *e, qboolean showtris)
 	{
 		const qboolean env_hint = (instance->flags & ALIAS_INSTANCE_FLAG_LIGHTNING)
 			|| (e->model->flags & MOD_FBRIGHTHACK);
-		instance->envmap_params[0] = (r_reflection_probes.value > 0.f && env_hint) ? 1.f : 0.f;
-		instance->envmap_params[1] = (instance->flags & ALIAS_INSTANCE_FLAG_LIGHTNING) ? 0.95f : 0.55f;
-		instance->envmap_params[2] = R_AliasEnvIndoorHint (e);
-		instance->envmap_params[3] = (instance->flags & ALIAS_INSTANCE_FLAG_LIGHTNING) ? 0.14f : 0.08f;
+		const float indoor_hint = R_AliasEnvIndoorHint (e);
+		const float envmap_base = (instance->flags & ALIAS_INSTANCE_FLAG_LIGHTNING) ? 0.95f : 0.55f;
+		const float indoor_dampen = CLAMP (0.f, r_envlight_indoor_dampen.value, 1.f);
+
+		instance->envmap_params[0] = (r_envlight.value > 0.f && r_envlight_envmap.value > 0.f && env_hint) ? 1.f : 0.f;
+		instance->envmap_params[1] = envmap_base * CLAMP (0.f, r_envlight_envmap.value, 1.f);
+		instance->envmap_params[2] = indoor_hint;
+		instance->envmap_params[3] = (instance->flags & ALIAS_INSTANCE_FLAG_LIGHTNING)
+			? 0.14f
+			: 0.08f + indoor_hint * indoor_dampen * 0.18f;
 	}
 	instance->pose1 = lerpdata.pose1;
 	instance->pose2 = lerpdata.pose2;

--- a/Quake/renderer/r_envlight.c
+++ b/Quake/renderer/r_envlight.c
@@ -2,12 +2,132 @@
 #include "renderer/r_envlight.h"
 #include "opengl/gl_lightgrid.h"
 
+extern cvar_t r_model_lightgrid;
+extern cvar_t r_reflection_probes;
+extern cvar_t r_reflection_probe_debug;
+extern cvar_t r_lightgrid_directional;
+extern cvar_t r_lighting_debug;
+extern cvar_t r_shadow_lightgrid;
+extern cvar_t r_shadow_lightgrid_mode;
+extern cvar_t r_shadows;
+extern cvar_t r_shadow_sun;
+
+/* Master switch for envlight features (entity ambient, world fill, sky SH, envmap). */
+cvar_t	r_envlight = { "r_envlight", "1", CVAR_ARCHIVE };
+/* Scales lightgrid-driven entity ambient (conservative by default). */
+cvar_t	r_envlight_entity_intensity = { "r_envlight_entity_intensity", "0.35", CVAR_ARCHIVE };
+/* Low baseline world fill packed into frame lightgrid params.w. */
+cvar_t	r_envlight_world_fill = { "r_envlight_world_fill", "0.12", CVAR_ARCHIVE };
+/* Enables lightweight sky SH contribution path (0/1 style toggle). */
+cvar_t	r_envlight_sky_sh = { "r_envlight_sky_sh", "0.35", CVAR_ARCHIVE };
+/* Envmap/reflection contribution master (default off for conservative visuals). */
+cvar_t	r_envlight_envmap = { "r_envlight_envmap", "0", CVAR_ARCHIVE };
+/* Dampens indoor envmap response used by alias shaders. */
+cvar_t	r_envlight_indoor_dampen = { "r_envlight_indoor_dampen", "0.35", CVAR_ARCHIVE };
+
+static qboolean r_envlight_compat_busy;
+
+static void R_EnvLight_CompatPushLegacyFromMaster (void)
+{
+	r_envlight_compat_busy = true;
+
+	Cvar_SetValueQuick (&r_model_lightgrid, r_envlight.value > 0.f ? 1.f : 0.f);
+	Cvar_SetValueQuick (&r_reflection_probes, r_envlight_envmap.value > 0.f ? 1.f : 0.f);
+	Cvar_SetValueQuick (&r_lightgrid_directional, r_envlight_sky_sh.value > 0.f ? 1.f : 0.f);
+
+	r_envlight_compat_busy = false;
+}
+
+static void R_EnvLight_MasterCallback (cvar_t *var)
+{
+	(void)var;
+	if (r_envlight_compat_busy)
+		return;
+
+	R_EnvLight_CompatPushLegacyFromMaster ();
+}
+
+static void R_EnvLight_LegacyAliasCallback (cvar_t *var)
+{
+	if (r_envlight_compat_busy)
+		return;
+
+	r_envlight_compat_busy = true;
+
+	if (var == &r_reflection_probes)
+	{
+		Cvar_SetValueQuick (&r_envlight_envmap, var->value > 0.f ? 1.f : 0.f);
+		if (var->value > 0.f)
+			Cvar_SetValueQuick (&r_envlight, 1.f);
+	}
+	else if (var == &r_model_lightgrid)
+	{
+		Cvar_SetValueQuick (&r_envlight, var->value > 0.f ? 1.f : 0.f);
+	}
+	else if (var == &r_lightgrid_directional)
+	{
+		Cvar_SetValueQuick (&r_envlight_sky_sh, var->value > 0.f ? 1.f : 0.f);
+		if (var->value > 0.f)
+			Cvar_SetValueQuick (&r_envlight, 1.f);
+	}
+
+	r_envlight_compat_busy = false;
+	R_EnvLight_CompatPushLegacyFromMaster ();
+}
+
+void R_EnvLight_RegisterCvars (void)
+{
+	Cvar_RegisterVariable (&r_envlight);
+	Cvar_RegisterVariable (&r_envlight_entity_intensity);
+	Cvar_RegisterVariable (&r_envlight_world_fill);
+	Cvar_RegisterVariable (&r_envlight_sky_sh);
+	Cvar_RegisterVariable (&r_envlight_envmap);
+	Cvar_RegisterVariable (&r_envlight_indoor_dampen);
+
+	Cvar_SetCallback (&r_envlight, R_EnvLight_MasterCallback);
+	Cvar_SetCallback (&r_envlight_entity_intensity, R_EnvLight_MasterCallback);
+	Cvar_SetCallback (&r_envlight_world_fill, R_EnvLight_MasterCallback);
+	Cvar_SetCallback (&r_envlight_sky_sh, R_EnvLight_MasterCallback);
+	Cvar_SetCallback (&r_envlight_envmap, R_EnvLight_MasterCallback);
+	Cvar_SetCallback (&r_envlight_indoor_dampen, R_EnvLight_MasterCallback);
+
+	/* Legacy toggles remain available as compatibility aliases. */
+	Cvar_RegisterVariable (&r_reflection_probes);
+	Cvar_RegisterVariable (&r_lightgrid_directional);
+
+	/* Legacy toggles are compatibility aliases into envlight master controls. */
+	Cvar_SetCallback (&r_reflection_probes, R_EnvLight_LegacyAliasCallback);
+	Cvar_SetCallback (&r_model_lightgrid, R_EnvLight_LegacyAliasCallback);
+	Cvar_SetCallback (&r_lightgrid_directional, R_EnvLight_LegacyAliasCallback);
+
+	R_EnvLight_CompatPushLegacyFromMaster ();
+}
+
+void R_EnvLight_BuildFrameUniforms (vec4_t lighting_params, vec4_t lightgrid_params)
+{
+	const qboolean enabled = r_envlight.value > 0.f;
+
+	lightgrid_params[0] = (enabled && R_LightgridEnabled ()) ? 1.f : 0.f;
+	lightgrid_params[1] = (r_lightgrid_debug.value >= 2.f) ? 1.f : 0.f;
+	lightgrid_params[2] =
+		(r_shadows.value > 0.f && r_shadow_sun.value > 0.f && r_shadow_lightgrid.value > 0.f)
+		? CLAMP (0.f, r_shadow_lightgrid_mode.value, 2.f)
+		: 0.f;
+	lightgrid_params[3] = CLAMP (0.f, r_envlight_world_fill.value, 1.f);
+
+	lighting_params[0] = (enabled && r_envlight_envmap.value > 0.f) ? 1.f : 0.f;
+	lighting_params[1] = CLAMP (0.f, r_reflection_probe_debug.value, 1.f);
+	lighting_params[2] = (enabled && r_envlight_sky_sh.value > 0.f) ? 1.f : 0.f;
+	lighting_params[3] = CLAMP (0.f, r_lighting_debug.value, 6.f);
+}
+
 qboolean R_EnvLight_SampleEntityAmbient (const entity_t *e, vec3_t out_rgb_linear, float *out_ao)
 {
 	const lightgrid_t *lg;
 	lightgrid_probe_t probe;
 	vec3_t sample_pos;
 	float ao = 1.f;
+	float intensity;
 
 	if (out_ao)
 		*out_ao = 1.f;
@@ -17,7 +137,7 @@ qboolean R_EnvLight_SampleEntityAmbient (const entity_t *e, vec3_t out_rgb_linea
 	if (!e || !out_rgb_linear)
 		return false;
 
-	if (!r_model_lightgrid.value)
+	if (!(r_envlight.value > 0.f && r_model_lightgrid.value > 0.f))
 		return false;
 
 	lg = Lightgrid_Get ();
@@ -45,6 +165,11 @@ qboolean R_EnvLight_SampleEntityAmbient (const entity_t *e, vec3_t out_rgb_linea
 
 		sample_pos[2] += ofs;
 	}
+
+	intensity = CLAMP (0.f, r_envlight_entity_intensity.value, 1.f);
+	out_rgb_linear[0] *= intensity;
+	out_rgb_linear[1] *= intensity;
+	out_rgb_linear[2] *= intensity;
 
 	if (out_ao)
 		*out_ao = ao;

--- a/Quake/renderer/r_envlight.h
+++ b/Quake/renderer/r_envlight.h
@@ -15,3 +15,9 @@
  *    without gamma jumps when envlight toggles on/off.
  */
 qboolean R_EnvLight_SampleEntityAmbient (const entity_t *e, vec3_t out_rgb_linear, float *out_ao);
+
+/* Registers envlight master cvars and legacy alias callbacks. */
+void R_EnvLight_RegisterCvars (void);
+
+/* Fills frame-uniform envlight/lightgrid vectors from centralized envlight state. */
+void R_EnvLight_BuildFrameUniforms (vec4_t lighting_params, vec4_t lightgrid_params);


### PR DESCRIPTION
### Motivation
- Vereinheitlichung der Envlight-/Lightgrid-Steuerung, damit Frame-Uniforms und Entity-Ambient-Verhalten an einer Stelle gepflegt werden können und alte CVARs nur noch Kompatibilitäts-Aliase sind.
- Reduzierung von doppelten Renderingpfaden durch einseitiges Mapping von Legacy-CVARs auf neue Master-CVARs und konservative Defaults, um sichtbare Änderungen für Nutzer zu minimieren.

### Description
- Neue Master-CVARs und konservative Default-Werte wurden eingeführt: `r_envlight`, `r_envlight_entity_intensity`, `r_envlight_world_fill`, `r_envlight_sky_sh`, `r_envlight_envmap`, `r_envlight_indoor_dampen` (implementiert in `Quake/renderer/r_envlight.c`).
- Legacy-Toggles (`r_reflection_probes`, `r_model_lightgrid`, `r_lightgrid_directional`) werden jetzt als Kompatibilitäts-Aliase behandelt; Änderungen an Legacy-CVARs mappen auf die Master-CVARs und umgekehrt über Callback-Synchronisation in `R_EnvLight_RegisterCvars()`.
- Frame-Uniform-Füllung für `lighting_params` und `lightgrid_params` wurde in die zentrale Funktion `R_EnvLight_BuildFrameUniforms(...)` verlagert und `R_SetupView` ruft diese jetzt auf (Änderungen in `Quake/opengl/gl_rmain.c`).
- Alias-Shader/Instanz-Envmap-Parameter nutzen die neuen Master-CVARs und `r_envlight_indoor_dampen` für indoor-Dämpfung (`Quake/renderer/r_alias.c`).
- CVAR-Registrierung wurde in `Quake/opengl/gl_rmisc.c` so angepasst, dass `R_EnvLight_RegisterCvars()` die Master-CVARs und Alias-Brücke registriert; öffentliche Deklarationen/Kommentare wurden in `glquake.h` und `renderer/r_envlight.h` dokumentiert.

### Testing
- Versucht zu bauen mit `make -C Quake -j4`; der Build-Prozess startete und lief durch die Abhängigkeitsgenerierung, scheiterte jedoch in dieser Umgebung an fehlenden SDL2-Entwicklerwerkzeugen/Headers (`sdl2-config` / `SDL.h`), weshalb kein vollständiges Link/Compile der binären Zielartefakte möglich war.
- Quellcode-Änderungen wurden statisch geprüft (Dateiansichten, `rg`-Suchen) und die modifizierten Dateien erfolgreich geparst und committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699362c5774c832eae4b2a52ce4506bf)