### PR TITLE
Fix Windows build errors: declare r_state_debug cvars and replace Vector4Set

### DIFF
--- a/Quake/opengl/gl_rmain.c
+++ b/Quake/opengl/gl_rmain.c
@@ -183,6 +183,9 @@ static const float r_identity_mat4[16] = {
 		0.f, 0.f, 0.f, 1.f
 };
 
+extern cvar_t r_state_debug;
+extern cvar_t r_state_debug_filter;
+
 static void GL_LogErrorIfDeveloper (const char *label)
 {
 	GLenum err = glGetError ();

--- a/Quake/renderer/r_alias.c
+++ b/Quake/renderer/r_alias.c
@@ -1066,7 +1066,10 @@ static void R_DrawAliasModel_Shadow_Real (entity_t *e)
 	VectorClear (instance->dlightcolor);
 	VectorClear (instance->ambientcolor);
 	instance->alpha = entalpha;
-	Vector4Set (instance->envmap_params, 0.f, 0.f, 0.f, 0.f);
+	instance->envmap_params[0] = 0.f;
+	instance->envmap_params[1] = 0.f;
+	instance->envmap_params[2] = 0.f;
+	instance->envmap_params[3] = 0.f;
 	instance->pose1 = lerpdata.pose1;
 	instance->pose2 = lerpdata.pose2;
 	instance->blend = lerpdata.blend;


### PR DESCRIPTION
### Motivation
- Resolve MSVC compile errors caused by use of undeclared render debug cvars and an undefined `Vector4Set` helper during alias instance initialization.

### Description
- Added forward declarations `extern cvar_t r_state_debug;` and `extern cvar_t r_state_debug_filter;` to `Quake/opengl/gl_rmain.c` before functions that reference them (`GL_StateDebugMatchesFilter` / `GL_DumpRenderState`).
- Replaced the undefined `Vector4Set(instance->envmap_params, ...)` call in `Quake/renderer/r_alias.c` with explicit per-component assignments to `instance->envmap_params[0..3]`.

### Testing
- Searched the tree for occurrences with `rg` to verify the new `extern` declarations and removal of `Vector4Set` references, which succeeded.
- Attempted to configure and build with `cmake -S . -B build && cmake --build build -j2`, but configure failed in this environment due to missing `SDL2` CMake package files (`SDL2Config.cmake`), so a full compile could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699364b45cfc832e829199acd3151474)