### PR TITLE
Windows: add envlight renderer files to Visual Studio project

### DIFF
--- a/Windows/VisualStudio/ironwail.vcxproj
+++ b/Windows/VisualStudio/ironwail.vcxproj
@@ -314,6 +314,7 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
     <ClCompile Include="..\..\Quake\renderer\r_brush.c" />
     <ClCompile Include="..\..\Quake\renderer\r_decals.c" />
     <ClCompile Include="..\..\Quake\renderer\r_dlight_pool.c" />
+    <ClCompile Include="..\..\Quake\renderer\r_envlight.c" />
     <ClCompile Include="..\..\Quake\renderer\r_shadow.c" />
     <ClCompile Include="..\..\Quake\renderer\r_postfx.c" />
     <ClCompile Include="..\..\Quake\renderer\r_part.c" />
@@ -422,6 +423,7 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
     <ClInclude Include="..\..\Quake\render.h" />
     <ClInclude Include="..\..\Quake\renderer\r_decals.h" />
     <ClInclude Include="..\..\Quake\renderer\r_dlight_pool.h" />
+    <ClInclude Include="..\..\Quake\renderer\r_envlight.h" />
     <ClInclude Include="..\..\Quake\resource.h" />
     <ClInclude Include="..\..\Quake\sbar.h" />
     <ClInclude Include="..\..\Quake\screen.h" />

--- a/Windows/VisualStudio/ironwail.vcxproj.filters
+++ b/Windows/VisualStudio/ironwail.vcxproj.filters
@@ -186,6 +186,9 @@
     <ClCompile Include="..\..\Quake\renderer\r_dlight_pool.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Quake\renderer\r_envlight.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\Quake\renderer\r_shadow.c">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -444,6 +447,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Quake\renderer\r_dlight_pool.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Quake\renderer\r_envlight.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Quake\resource.h">


### PR DESCRIPTION
### Motivation
- Visual Studio builds failed at link time with unresolved symbols from the envlight subsystem because its implementation file was not included in the project. 
- The project must list both the implementation and header so the linker finds `R_EnvLight_*` symbols and the IDE shows the files in the correct filters.

### Description
- Added `..\..\Quake\renderer\r_envlight.c` to the compile inputs in `Windows/VisualStudio/ironwail.vcxproj` so the envlight implementation is built by MSVC. 
- Added `..\..\Quake\renderer\r_envlight.h` to the header list in `Windows/VisualStudio/ironwail.vcxproj` for completeness. 
- Mirrored both entries in `Windows/VisualStudio/ironwail.vcxproj.filters` so the files appear under the `Source Files` and `Header Files` filters in the IDE.

### Testing
- Verified the project diffs with `git diff -- Windows/VisualStudio/ironwail.vcxproj Windows/VisualStudio/ironwail.vcxproj.filters` to confirm the new entries were added. 
- Validated the file locations/line placements with `nl -ba Windows/VisualStudio/ironwail.vcxproj | sed -n '306,332p'` and related `sed` slices to ensure the entries appear at the expected positions. 
- Attempted `msbuild -version` to run a Windows build, but MSBuild is not available in this environment so a full Visual Studio build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993659e9b10832e9dee22e336c3287b)