### PR TITLE
Remove duplicate r_envlight_world_fill cvar definition

### DIFF
--- a/Quake/opengl/gl_rmain.c
+++ b/Quake/opengl/gl_rmain.c
@@ -613,7 +613,6 @@ cvar_t	s_ao_temporal = { "s_ao_temporal", "0", CVAR_ARCHIVE };
 /* Legacy compatibility aliases; real envlight controls live in renderer/r_envlight.c. */
 cvar_t	r_reflection_probes = { "r_reflection_probes", "0", CVAR_ARCHIVE };
 cvar_t	r_reflection_probe_debug = { "r_reflection_probe_debug", "0", CVAR_NONE };
-cvar_t	r_envlight_world_fill = { "r_envlight_world_fill", "0", CVAR_ARCHIVE };
 cvar_t	r_lightgrid_directional = { "r_lightgrid_directional", "1", CVAR_ARCHIVE };
 cvar_t	r_lighting_debug = { "r_lighting_debug", "0", CVAR_NONE };
 


### PR DESCRIPTION
### Motivation
- A duplicate definition of `r_envlight_world_fill` lived in `Quake/opengl/gl_rmain.c`, which caused Windows linker multiple-definition errors (`LNK2005`/`LNK1169`) when both renderer modules were linked.

### Description
- Removed the legacy compatibility `cvar_t r_envlight_world_fill` declaration from `Quake/opengl/gl_rmain.c` so the canonical definition in `Quake/renderer/r_envlight.c` remains authoritative.

### Testing
- Verified only one definition remains using `rg "^cvar_t\s*r_envlight_world_fill" -n Quake`, which shows the definition in `Quake/renderer/r_envlight.c` only. 
- Attempted `cmake --build Windows/VisualStudio/Build-ironwail --config Release`, but the Visual Studio build directory is not present in this environment so a full build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993670493e0832eb81295ef7f1bd385)