### PR TITLE
shaders: guard depth_common.glsl against double inclusion

### DIFF
--- a/Quake/shaders/depth_common.glsl
+++ b/Quake/shaders/depth_common.glsl
@@ -1,3 +1,6 @@
+#ifndef DEPTH_COMMON_GLSL
+#define DEPTH_COMMON_GLSL
+
 // Shared depth helpers for both normal-Z and reversed-Z paths.
 //
 // Canonical depth convention used here:
@@ -49,3 +52,5 @@ float ShadowReferenceFromProjZ(float projZ)
         return clamp(projZ * 0.5 + 0.5, 0.0, 1.0);
 #endif
 }
+
+#endif


### PR DESCRIPTION
### Motivation
- Prevent duplicate GLSL function definitions (e.g. `DepthRawToCanonical`, `DepthRawToNdc`, `DepthIsSkyDepth`, `ShadowReferenceFromProjZ`) caused when `depth_common.glsl` is included directly and transitively, which produced shader compile errors on some drivers.

### Description
- Add a conventional include guard (`#ifndef DEPTH_COMMON_GLSL` / `#define DEPTH_COMMON_GLSL` / `#endif`) around `Quake/shaders/depth_common.glsl` so its helpers are defined only once.

### Testing
- Ran `rg -n "DepthRawToCanonical|DepthRawToNdc|DepthIsSkyDepth|ShadowReferenceFromProjZ" Quake -S` to inspect include usage and confirm the duplicate-include scenario, then verified the patch with `git diff -- Quake/shaders/depth_common.glsl`, inspected the file with `nl -ba Quake/shaders/depth_common.glsl`, and committed with `git commit`; all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699367c5b5fc832ea780a73e67edd437)