### PR TITLE
Pin GL state for post-fog passes to prevent alpha-blend leakage

### DIFF
--- a/Quake/opengl/gl_rmain.c
+++ b/Quake/opengl/gl_rmain.c
@@ -2638,6 +2638,16 @@ static void R_Fog_BeginFrame (void)
 
 static void R_Fog_Render (void)
 {
+	/*
+	 * Volumetric fog is compute-driven, but still explicitly pins baseline GL
+	 * state so this pass never depends on whatever transparent/world pass ran
+	 * before it.  STATEDBG markers around POST_FOG_* then reflect deterministic
+	 * state instead of leaks from previous draws.
+	 */
+	GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
+	glDisable (GL_SCISSOR_TEST);
+	glColorMask (GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+
 	if (!r_atmosphere.settings_valid)
 		r_atmosphere.settings = Atmosphere_ReadSettings ();
 
@@ -2681,10 +2691,18 @@ static void R_Fog_Render (void)
 		Atmosphere_Froxel_TemporalResolve (&r_atmosphere.settings);
 		r_atmosphere.settings.enabled_shafts = false;
 	}
+
+	/* Keep post-fog stage hand-off explicit as well. */
+	GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
 }
 
 static void R_Fog_Composite (void)
 {
+	/* Composite setup must be explicit: no inherited alpha blending. */
+	GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
+	glDisable (GL_SCISSOR_TEST);
+	glColorMask (GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+
 	static int last_composite_log_frame = -1000000;
 	if (r_fog_debug_composite_stage.value > 0.f && r_framecount - last_composite_log_frame >= 60)
 	{
@@ -2696,6 +2714,8 @@ static void R_Fog_Composite (void)
 		r_atmosphere.godrays_texture = GL_GenerateGodraysTexture (&r_atmosphere.godrays_mask);
 		r_atmosphere.godrays_ready = (r_atmosphere.godrays_texture != 0 || r_godrays_debug.value > 0.f);
 	}
+
+	GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
 }
 
 static void R_Fog_EndFrame (void)


### PR DESCRIPTION
### Motivation
- STATEDBG logs showed `POST_FOG_*` stages running with alpha blending enabled which can cause whiteout/over-fog when the fog composite math is already producing final colors in-shader.
- The volumetric froxel pipeline is compute/shader-driven and must not rely on inherited GL fixed-function blending or other leaked state from prior passes.
- Make fog render/composite self-contained so subsequent passes see a known baseline GL state and fog is not composited twice.

### Description
- Explicitly set a known baseline GL state at the start of `R_Fog_Render`: `GL_SetState(GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS(0))`, `glDisable(GL_SCISSOR_TEST)` and `glColorMask(GL_TRUE,GL_TRUE,GL_TRUE,GL_TRUE)`.
- Re-apply the same baseline at the end of `R_Fog_Render` to make the hand-off deterministic.
- Apply the same explicit baseline and disables at the start of `R_Fog_Composite` and re-assert it after composite setup so `POST_FOG_COMPOSITE` cannot inherit alpha blending.
- Modified file: `Quake/opengl/gl_rmain.c` (fog render/composite state setup and resets).

### Testing
- Static inspection/search: used `rg`/`sed` to verify `POST_FOG_*` markers, GL state logging, and confirmed the froxel composite math (`postprocess.frag` uses `combined = combined * accumT + accumScatter`) which requires disabling fixed-function blending; these checks succeeded.
- Attempted automated build: `cmake -S . -B build && cmake --build build -j4` which failed at configure time due to missing SDL2 CMake package (`SDL2Config.cmake` / `sdl2-config.cmake`) in the environment, so a full binary validation could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993717f036c832e91e799713f167a39)