### PR TITLE
Make decals lit by default and gate emissive contribution

### DIFF
--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -650,6 +650,7 @@ typedef struct glprogs_s {
 	GLuint		skyboxside[2];		// [dither]
 	GLuint		alias[2][3][2][2];	// [OIT][mode:standard/dithered/noperspective][alpha test][md5]
 	GLuint		sprites[2];			// [dither]
+	GLuint		decals[2];			// [dither]
 	GLuint		particles[2][2];	// [OIT][dither]
 	GLuint		debug3d;
 	GLuint		dlight_composite;

--- a/Quake/opengl/gl_shaders.c
+++ b/Quake/opengl/gl_shaders.c
@@ -559,6 +559,7 @@ void GL_CreateShaders (void)
                 glprogs.skylayers[dither] = GL_CreateProgram (GLSL_PATH("sky_layers.vert"), GLSL_PATH("sky_layers.frag"), "sky layers|DITHER %d", dither);
                 glprogs.skyboxside[dither] = GL_CreateProgram (GLSL_PATH("sky_boxside.vert"), GLSL_PATH("sky_boxside.frag"), "skybox side|DITHER %d", dither);
                 glprogs.sprites[dither] = GL_CreateProgram (GLSL_PATH("sprites.vert"), GLSL_PATH("sprites.frag"), "sprites|DITHER %d", dither);
+                glprogs.decals[dither] = GL_CreateProgram (GLSL_PATH("decals.vert"), GLSL_PATH("decals.frag"), "decals|DITHER %d", dither);
         }
         glprogs.skystencil = GL_CreateProgram (GLSL_PATH("skystencil.vert"), NULL, "sky stencil");
 

--- a/Quake/renderer/r_decals.c
+++ b/Quake/renderer/r_decals.c
@@ -4,6 +4,9 @@
 #include "world.h"
 #include <float.h>
 
+extern cvar_t r_tonemap;
+extern cvar_t r_bloom;
+
 #define DECAL_MAX_DEFS 256
 #define DECAL_MAX_TEXTURES 8
 
@@ -38,6 +41,7 @@ typedef struct decal_def_s
 	int priority;
 	int random_rotation;
 	decal_blend_t blend;
+	float emissive_scale;
 	decal_category_t category;
 } decal_def_t;
 
@@ -45,6 +49,8 @@ typedef struct decalvertex_s
 {
 	vec3_t pos;
 	float uv[2];
+	float color[3];
+	float params[2];
 } decalvertex_t;
 
 typedef struct decal_instance_s
@@ -62,7 +68,9 @@ typedef struct decal_instance_s
 	gltexture_t *texture;
 	vec3_t origin;
 	vec3_t verts[4];
+	vec3_t light;
 	float alpha;
+	float emissive_scale;
 	qboolean selected;
 } decal_instance_t;
 
@@ -97,6 +105,9 @@ static int decal_spawned_this_frame;
 static int decal_next_spawn_id;
 static int decal_frame;
 static decal_stats_t decal_stats;
+
+static void R_Decals_ComputeLighting (decal_instance_t *d);
+static void R_Decals_DebugState (void);
 
 #define DECAL_BATCH_MAX 256
 
@@ -243,6 +254,7 @@ static decal_def_t *R_Decal_GetOrCreateDef (const char *name)
 	VectorSet (def->color, 1.f, 1.f, 1.f);
 	def->random_rotation = true;
 	def->blend = DECAL_BLEND_ALPHA;
+	def->emissive_scale = 0.f;
 	def->category = DECAL_CAT_GENERIC;
 	def->priority = 2;
 	return def;
@@ -329,6 +341,7 @@ static void R_Decals_ParseFile (const char *path, const char *buffer)
 			else if (!q_strcasecmp (com_token, "lifetime")) { data = COM_Parse (data); if (!data) break; def->lifetime = atof (com_token); }
 			else if (!q_strcasecmp (com_token, "fade")) { data = COM_Parse (data); if (!data) break; def->fade = atof (com_token); }
 			else if (!q_strcasecmp (com_token, "blend")) { data = COM_Parse (data); if (!data) break; def->blend = R_Decal_ParseBlend (com_token); }
+			else if (!q_strcasecmp (com_token, "emissive") || !q_strcasecmp (com_token, "decal_emissive")) { data = COM_Parse (data); if (!data) break; def->emissive_scale = q_max (0.f, atof (com_token)); }
 			else if (!q_strcasecmp (com_token, "random_rotation")) { data = COM_Parse (data); if (!data) break; def->random_rotation = atof (com_token) != 0.f; }
 			else if (!q_strcasecmp (com_token, "priority")) { data = COM_Parse (data); if (!data) break; def->priority = (int)atof (com_token); }
 			else if (!q_strcasecmp (com_token, "category")) { data = COM_Parse (data); if (!data) break; def->category = R_Decal_ParseCategory (com_token); }
@@ -497,6 +510,8 @@ static void R_Decals_InitInstance (decal_instance_t *d, const decal_def_t *def, 
 	d->lifetime = def->lifetime > 0.f ? def->lifetime : q_max (1.f, r_decals_lifetime.value);
 	d->fade = def->fade > 0.f ? def->fade : q_max (0.f, r_decals_fade.value);
 	d->alpha = CLAMP (0.f, alpha, 1.f);
+	VectorSet (d->light, 1.f, 1.f, 1.f);
+	d->emissive_scale = q_max (0.f, def->emissive_scale);
 }
 
 static void R_Decals_GetRotationAxes (const decal_def_t *def, float *out_c, float *out_s)
@@ -579,6 +594,7 @@ void R_Decals_Add (const char *name, const vec3_t org, const vec3_t normal, cons
 	R_Decals_BuildOrthonormalQuad (org, normal, def, size_opt, center, verts);
 	alpha = R_Decals_GetSpawnAlpha (def, rgba_opt);
 	R_Decals_InitInstance (d, def, center, verts, alpha);
+	R_Decals_ComputeLighting (d);
 	d->texture = R_Decals_LoadTexture (def, def_index);
 	if (!d->texture)
 	{
@@ -652,16 +668,16 @@ static void R_Decals_SetBlend (decal_blend_t blend, qboolean showtris)
 {
 	if (showtris)
 	{
-		GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZWRITE | GLS_CULL_BACK | GLS_ATTRIBS (2));
+		GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZWRITE | GLS_CULL_BACK | GLS_ATTRIBS (4));
 		return;
 	}
 	switch (blend)
 	{
 	default:
-	case DECAL_BLEND_ALPHA: GL_SetState (GLS_BLEND_ALPHA | GLS_NO_ZWRITE | GLS_CULL_BACK | GLS_ATTRIBS (2)); break;
-	case DECAL_BLEND_ADD: GL_SetState (GLS_BLEND_ADD | GLS_NO_ZWRITE | GLS_CULL_BACK | GLS_ATTRIBS (2)); break;
-	case DECAL_BLEND_MODULATE: GL_SetState (GLS_BLEND_MULTIPLY | GLS_NO_ZWRITE | GLS_CULL_BACK | GLS_ATTRIBS (2)); break;
-	case DECAL_BLEND_PREMUL: GL_SetState (GLS_BLEND_ALPHA | GLS_NO_ZWRITE | GLS_CULL_BACK | GLS_ATTRIBS (2)); break;
+	case DECAL_BLEND_ALPHA: GL_SetState (GLS_BLEND_ALPHA | GLS_NO_ZWRITE | GLS_CULL_BACK | GLS_ATTRIBS (4)); break;
+	case DECAL_BLEND_ADD: GL_SetState (GLS_BLEND_ADD | GLS_NO_ZWRITE | GLS_CULL_BACK | GLS_ATTRIBS (4)); break;
+	case DECAL_BLEND_MODULATE: GL_SetState (GLS_BLEND_MULTIPLY | GLS_NO_ZWRITE | GLS_CULL_BACK | GLS_ATTRIBS (4)); break;
+	case DECAL_BLEND_PREMUL: GL_SetState (GLS_BLEND_ALPHA | GLS_NO_ZWRITE | GLS_CULL_BACK | GLS_ATTRIBS (4)); break;
 	}
 }
 
@@ -678,6 +694,8 @@ static void R_Decals_FlushBatch (const decalvertex_t *verts, const GLushort *idx
 	GL_BindBuffer (GL_ARRAY_BUFFER, buf);
 	GL_VertexAttribPointerFunc (0, 3, GL_FLOAT, GL_FALSE, sizeof (decalvertex_t), ofs + offsetof (decalvertex_t, pos));
 	GL_VertexAttribPointerFunc (1, 2, GL_FLOAT, GL_FALSE, sizeof (decalvertex_t), ofs + offsetof (decalvertex_t, uv));
+	GL_VertexAttribPointerFunc (2, 3, GL_FLOAT, GL_FALSE, sizeof (decalvertex_t), ofs + offsetof (decalvertex_t, color));
+	GL_VertexAttribPointerFunc (3, 2, GL_FLOAT, GL_FALSE, sizeof (decalvertex_t), ofs + offsetof (decalvertex_t, params));
 	GL_Upload (GL_ELEMENT_ARRAY_BUFFER, idx, sizeof (GLushort) * count * 6, &buf, &ofs);
 	GL_BindBuffer (GL_ELEMENT_ARRAY_BUFFER, buf);
 	glDrawElements (GL_TRIANGLES, count * 6, GL_UNSIGNED_SHORT, ofs);
@@ -691,6 +709,11 @@ static void R_Decals_WriteBatchEntry (const decal_instance_t *d, decalvertex_t *
 		VectorCopy (d->verts[k], verts[batch_index * 4 + k].pos);
 		verts[batch_index * 4 + k].uv[0] = (k == 0 || k == 1) ? 0.f : 1.f;
 		verts[batch_index * 4 + k].uv[1] = (k == 0 || k == 3) ? 1.f : 0.f;
+		verts[batch_index * 4 + k].color[0] = d->light[0];
+		verts[batch_index * 4 + k].color[1] = d->light[1];
+		verts[batch_index * 4 + k].color[2] = d->light[2];
+		verts[batch_index * 4 + k].params[0] = d->alpha;
+		verts[batch_index * 4 + k].params[1] = d->emissive_scale;
 	}
 	idx[batch_index * 6 + 0] = batch_index * 4 + 0;
 	idx[batch_index * 6 + 1] = batch_index * 4 + 1;
@@ -698,6 +721,36 @@ static void R_Decals_WriteBatchEntry (const decal_instance_t *d, decalvertex_t *
 	idx[batch_index * 6 + 3] = batch_index * 4 + 0;
 	idx[batch_index * 6 + 4] = batch_index * 4 + 2;
 	idx[batch_index * 6 + 5] = batch_index * 4 + 3;
+}
+
+static void R_Decals_ComputeLighting (decal_instance_t *d)
+{
+	lightcache_t cache = {0};
+	if (!cl.worldmodel)
+	{
+		VectorSet (d->light, 1.f, 1.f, 1.f);
+		return;
+	}
+	R_LightPoint (cl.worldmodel, d->origin, 0.f, &cache);
+	d->light[0] = CLAMP (0.f, lightcolor[0] * (1.f / 255.f), 4.f);
+	d->light[1] = CLAMP (0.f, lightcolor[1] * (1.f / 255.f), 4.f);
+	d->light[2] = CLAMP (0.f, lightcolor[2] * (1.f / 255.f), 4.f);
+}
+
+static void R_Decals_DebugState (void)
+{
+	GLint fbo = 0, src = 0, dst = 0, depthfunc = 0, drawbuf = 0;
+	GLboolean blend = GL_FALSE, srgb = GL_FALSE, depth = GL_FALSE;
+	glGetIntegerv (GL_DRAW_FRAMEBUFFER_BINDING, &fbo);
+	glGetIntegerv (GL_BLEND_SRC_RGB, &src);
+	glGetIntegerv (GL_BLEND_DST_RGB, &dst);
+	glGetBooleanv (GL_BLEND, &blend);
+	glGetBooleanv (GL_FRAMEBUFFER_SRGB, &srgb);
+	glGetBooleanv (GL_DEPTH_TEST, &depth);
+	glGetIntegerv (GL_DEPTH_FUNC, &depthfunc);
+	glGetIntegerv (GL_DRAW_BUFFER, &drawbuf);
+	Con_DPrintf ("decals debug: fbo=%d drawbuf=0x%x blend=%d src=0x%x dst=0x%x depth=%d depthfunc=0x%x srgb=%d tonemap=%.0f bloom=%.2f\n",
+		fbo, drawbuf, blend != GL_FALSE, src, dst, depth != GL_FALSE, depthfunc, srgb != GL_FALSE, r_tonemap.value, r_bloom.value);
 }
 
 static qboolean R_Decals_PrepareVisible (decal_instance_t *d, double now, float drawdist, float drawdist_sq)
@@ -755,7 +808,10 @@ void R_DrawDecals (qboolean showtris)
 		decal_stats.skipped_render_budget += (vis_count - budget);
 
 	GL_BeginGroup ("Decals");
-	GL_UseProgram (glprogs.sprites[softemu == SOFTEMU_COARSE && !showtris]);
+	GL_UseProgram (glprogs.decals[softemu == SOFTEMU_COARSE && !showtris]);
+	GL_Uniform1iFunc (0, r_decals_debug.value >= 2.f ? 1 : 0);
+	if (r_decals_debug.value >= 1.f)
+		R_Decals_DebugState ();
 	GL_PolygonOffset (OFFSET_DECAL);
 
 	for (i = 0; i < vis_count && draw_count < budget; ++i)

--- a/Quake/scripts/decals.shader
+++ b/Quake/scripts/decals.shader
@@ -1,3 +1,4 @@
+// emissive <scale> enables HDR emissive contribution (default: 0 / lit only)
 // Base decal definitions (override in mods/paks with later searchpath priority)
 
 decal bullet_hole_default {
@@ -116,3 +117,12 @@ decal concrete_hit {
   priority 2
   category dirt
 }
+
+// Example:
+// decal test_neon_mark {
+//   texture "decals/neon/mark_01"
+//   size 10 10
+//   alpha 0.8 0.8
+//   emissive 1.5
+//   blend alpha
+// }

--- a/Quake/shaders/decals.frag
+++ b/Quake/shaders/decals.frag
@@ -1,0 +1,91 @@
+#include "frame_uniforms.glsl"
+
+vec3 ApplyFog(vec3 clr, vec3 p)
+{
+	float fog = exp2(-Fog.w * dot(p, p));
+	fog = clamp(fog, 0.0, 1.0);
+	return mix(Fog.rgb, clr, fog);
+}
+
+float bayer01(ivec2 coord)
+{
+	coord &= 15;
+	coord.y ^= coord.x;
+	uint v = uint(coord.y | (coord.x << 8));
+	v = (v ^ (v << 2)) & 0x3333;
+	v = (v ^ (v << 1)) & 0x5555;
+	v |= v >> 7;
+	v = bitfieldReverse(v) >> 24;
+	return float(v) * (1.0/256.0);
+}
+
+float bayer(ivec2 coord)
+{
+	return bayer01(coord) - 0.5;
+}
+
+float tri(float x)
+{
+	float orig = x * 2.0 - 1.0;
+	uint signbit = floatBitsToUint(orig) & 0x80000000u;
+	x = sqrt(abs(orig)) - 1.;
+	x = uintBitsToFloat(floatBitsToUint(x) ^ signbit);
+	return x;
+}
+
+#define DITHER_NOISE(uv) tri(bayer01(ivec2(uv)))
+#define SCREEN_SPACE_NOISE() DITHER_NOISE(floor(gl_FragCoord.xy)+0.5)
+#define SUPPRESS_BANDING() bayer(ivec2(gl_FragCoord.xy))
+
+layout(binding=0) uniform sampler2D Tex;
+layout(location=0) uniform int u_debug_mode = 0;
+
+layout(location=0) in vec2 in_uv;
+layout(location=1) in vec3 in_pos;
+layout(location=2) in vec3 in_color;
+layout(location=3) in vec2 in_params;
+
+layout(location=0) out vec4 out_fragcolor;
+layout(location=1) out vec4 out_velocity;
+
+void main()
+{
+	vec4 texel = texture(Tex, in_uv);
+	if (texel.a < (1.0 / 255.0))
+		discard;
+
+	vec3 lit = texel.rgb * in_color.rgb;
+	float alpha = texel.a * in_params.x;
+	float emissive = max(0.0, in_params.y);
+	vec3 result = lit + texel.rgb * emissive;
+
+	if (u_debug_mode != 0)
+	{
+		bool overshoot = any(greaterThan(result, vec3(1.0)));
+		bool emissive_path = emissive > 0.0;
+		vec3 debug_color = vec3(0.0);
+		if (overshoot)
+			debug_color.r = 1.0;
+		if (emissive_path)
+			debug_color.g = 1.0;
+		if (!emissive_path)
+			debug_color.b = 1.0;
+		out_fragcolor = vec4(debug_color, alpha);
+	}
+	else
+	{
+		result = ApplyFog(result, in_pos);
+		out_fragcolor = vec4(result, alpha);
+	#if DITHER
+		if (Fog.w > 0.)
+		{
+			out_fragcolor.rgb = sqrt(out_fragcolor.rgb);
+			out_fragcolor.rgb += SCREEN_SPACE_NOISE() * ScreenDither;
+			out_fragcolor.rgb *= out_fragcolor.rgb;
+		}
+	#else
+		out_fragcolor.rgb += SUPPRESS_BANDING() * ScreenDither;
+	#endif
+	}
+	out_velocity = vec4(0.0, 0.0, 0.0, 2.0);
+}

--- a/Quake/shaders/decals.vert
+++ b/Quake/shaders/decals.vert
@@ -1,0 +1,20 @@
+#include "frame_uniforms.glsl"
+
+layout(location=0) in vec3 in_pos;
+layout(location=1) in vec2 in_uv;
+layout(location=2) in vec3 in_color;
+layout(location=3) in vec2 in_params;
+
+layout(location=0) out vec2 out_uv;
+layout(location=1) out vec3 out_pos;
+layout(location=2) out vec3 out_color;
+layout(location=3) out vec2 out_params;
+
+void main()
+{
+	gl_Position = ViewProj * vec4(in_pos, 1.0);
+	out_pos = in_pos - EyePos;
+	out_uv = in_uv;
+	out_color = in_color;
+	out_params = in_params;
+}


### PR DESCRIPTION
### Motivation
- Decals were appearing unlit/emissive (causing glow/bloom) because they used the sprite shader path and were not receiving world lighting or fog by default. The intent is to make decals behave as lit overlays and only contribute emissive/HDR when explicitly requested. 

### Description
- Added a dedicated decal shader program and assets: `Quake/shaders/decals.vert` and `Quake/shaders/decals.frag`, and wired them into shader creation as `glprogs.decals` so decals no longer use the sprite shader path.
- Modified decal runtime to sample world lighting at spawn (`R_LightPoint`) and pass per-decal lighting + params as vertex attributes, and adjusted batching/vertex layout and GL attribute pointers in `Quake/renderer/r_decals.c` to send those values to the new shader.
- Added explicit emissive support gated by a new script token (`emissive` / `decal_emissive`) parsed in `Quake/renderer/r_decals.c` and documented the usage/example in `Quake/scripts/decals.shader`; default emissive is 0 (lit-only behavior).
- Added debug instrumentation: `r_decals_debug` modes write a GL-state dump (blend/sRGB/FBO/depth/tonemap/bloom) and the decal fragment shader supports a false-color debug mode to visualize HDR overshoot vs emissive vs lit path.

### Testing
- Attempted a full build with `make -C Quake -j4`, but the container is missing SDL2 development tools/headers (`sdl2-config` / `SDL.h`), so a full compile/run validation could not be completed (build aborted during dependency generation).
- No automated unit tests exist for the renderer path in this environment; changes were validated by static review of emitted diffs and symbol wiring (shader registration + attribute usage) in the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699376939fb0832e88f0a0f316650fd2)