### PR TITLE
Declare extern vec3_t lightcolor in r_decals.c to fix MSVC build

### DIFF
--- a/Quake/renderer/r_decals.c
+++ b/Quake/renderer/r_decals.c
@@ -6,6 +6,7 @@
 
 extern cvar_t r_tonemap;
 extern cvar_t r_bloom;
+extern vec3_t lightcolor;
 
 #define DECAL_MAX_DEFS 256
 #define DECAL_MAX_TEXTURES 8


### PR DESCRIPTION
### Motivation
- MSVC reported `lightcolor` as an undeclared identifier and invalid indexing in `R_Decals_ComputeLighting`, indicating the global `lightcolor` variable was not visible from `r_decals.c`.

### Description
- Add a forward declaration `extern vec3_t lightcolor;` near the top of `Quake/renderer/r_decals.c` so the file can reference `lightcolor[0..2]` in lighting calculations.

### Testing
- Verified the change via `rg` and inspected the file with `nl` to confirm the `extern vec3_t lightcolor;` declaration is present and `r_decals.c` was updated; these checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699378b11130832e8d2d4a2410735d9d)