### PR TITLE
Fix dynamic lights not rendering when r_dlight_style is left at default

### DIFF
--- a/Quake/opengl/gl_rmain.c
+++ b/Quake/opengl/gl_rmain.c
@@ -68,6 +68,14 @@ static qboolean r_prev_frame_valid = false;
 static qboolean r_frame_rendered_this_update;
 static qboolean r_dlight_buffered_frame = false;
 
+static qboolean R_DlightsAdditivePassEnabled (void)
+{
+	if (r_clustered_lighting.value > 0.f)
+		return false;
+
+	return (r_dlight_style.value > 0.f || r_dynamic.value > 0.f);
+}
+
 typedef struct godrays_stabilization_s
 {
 	qboolean	valid;
@@ -3739,7 +3747,7 @@ qboolean GL_NeedsSceneEffects (void)
         if (framebufs.scene.samples > 1 || water_warp || r_refdef.scale != 1)
 		return true;
 
-	if (r_dlight_mode.value > 0.f && r_dlight_style.value > 0.f && r_dlight_buffer.value > 0.f && framebufs.dlight.fbo)
+	if (r_dlight_mode.value > 0.f && R_DlightsAdditivePassEnabled () && r_dlight_buffer.value > 0.f && framebufs.dlight.fbo)
 		return true;
 
         if (GL_ShouldApplyMotionBlur ())
@@ -3987,7 +3995,7 @@ void R_SetupView (void)
         r_framedata.lightmap_params[2] = (r_lightingdir.value > 0.f && lightmap_dir_texture) ? 1.f : 0.f;
         r_framedata.lightmap_params[3] = r_lightstyle_framefrac;
 	R_EnvLight_BuildFrameUniforms (r_framedata.lighting_params, r_framedata.lightgrid_params);
-	r_framedata.dlight_params[0] = (r_dlight_style.value > 0.f && r_clustered_lighting.value <= 0.f) ? 1.f : 0.f;
+	r_framedata.dlight_params[0] = R_DlightsAdditivePassEnabled () ? 1.f : 0.f;
 	r_framedata.dlight_params[1] = r_dlight_debug.value > 0.f ? 1.f : 0.f;
 	r_framedata.dlight_params[2] = 0.f;
 	r_framedata.dlight_params[3] = CLAMP (0.f, r_dlight_quality.value, 3.f);
@@ -5138,7 +5146,7 @@ static void R_DrawDLightPass (void)
 
 	r_dlight_buffered_frame = false;
 
-        if (r_dlight_style.value <= 0.f || r_clustered_lighting.value > 0.f)
+	if (!R_DlightsAdditivePassEnabled ())
                 return;
 
         if (r_framedata.numlights == 0 || !r_drawworld_cheatsafe)

--- a/docs/dlight_incident_2026-02.md
+++ b/docs/dlight_incident_2026-02.md
@@ -1,0 +1,54 @@
+# Dynamic Lights Incident: additive pass unintentionally gated behind `r_dlight_style`
+
+## Root cause
+
+Dynamic lights were still spawned, culled, and uploaded (`R_PushDlights`) when `r_dynamic 1`, but the additive world dlight pass was skipped unless `r_dlight_style > 0`.
+
+In this tree, `r_dlight_style` defaults to `0`, so in typical settings (`r_dynamic 1`, `r_clustered_lighting 0`) dynamic lights existed in GPU frame data but were never drawn. This made muzzle flashes/explosions appear "off" even though the pool and upload path were active.
+
+## Evidence trail (code-level)
+
+1. Light collection path accepts either legacy dynamic toggle or style toggle:
+   - `R_PushDlights`: `(r_dynamic.value > 0.f || r_dlight_style.value > 0.f) && r_dlight_enable.value > 0.f`
+2. But draw/composite path previously required `r_dlight_style > 0`:
+   - `R_DrawDLightPass` early-return gate.
+   - `GL_NeedsSceneEffects` gate for dlight buffered composite.
+   - `r_framedata.dlight_params[0]` set only when `r_dlight_style > 0`.
+
+This mismatch created a silent logic split: lights in buffers, no additive draw pass.
+
+## Fix summary
+
+Introduced a single helper (`R_DlightsAdditivePassEnabled`) that expresses intended additive-pass eligibility:
+
+- disabled when clustered path is active.
+- enabled when either `r_dlight_style > 0` OR `r_dynamic > 0`.
+
+Then reused it in all three gate points above to keep CPU/GPU/pass scheduling aligned.
+
+## Regression test scene/cmdline
+
+Use an easy dark-scene repro where explosions or muzzle flashes are obvious.
+
+Example startup:
+
+```bash
+./ironwail -window -width 1280 -height 720 +map e1m1 +r_dynamic 1 +r_dlight_enable 1 +r_clustered_lighting 0 +r_dlight_style 0 +r_dlight_mode 1 +r_dlight_buffer 1 +notarget 1
+```
+
+Then fire repeatedly in a dark interior and verify dynamic light response.
+
+## Test matrix (manual)
+
+- Baseline:
+  - `r_dynamic 1; r_clustered_lighting 0; r_dlight_style 0`
+- Additive style explicit:
+  - `r_dlight_style 1`
+- Clustered path:
+  - `r_clustered_lighting 1` (ensure additive pass remains off)
+- Post/AA interaction:
+  - `r_msaa 0/4`
+  - `r_tonemap 0/2`
+  - `r_bloom 0/1`
+
+Expected: dynamic lights visible in non-clustered path with default style=0, no duplication when clustered path is active.


### PR DESCRIPTION
### Motivation
- Correct an inconsistent feature-gate that allowed dynamic lights to be collected/uploaded but prevented the additive dlight draw/composite pass from running when `r_dlight_style` was left at its default (`0`).
- Restore visible muzzleflash/explosion/dlight behavior for common user settings (`r_dynamic=1`) without adding a new dynlight implementation or changing clustered lighting semantics.

### Description
- Add a single helper `R_DlightsAdditivePassEnabled()` in `Quake/opengl/gl_rmain.c` that returns `false` if clustered lighting is active and otherwise enables the additive pass when `r_dlight_style > 0` or `r_dynamic > 0`.
- Replace ad-hoc checks with `R_DlightsAdditivePassEnabled()` at the three critical gate points: `GL_NeedsSceneEffects()` dlight-buffer scene-effects test, `r_framedata.dlight_params[0]` assignment in `R_SetupView()`, and the early-return gate in `R_DrawDLightPass()`.
- Add incident documentation `docs/dlight_incident_2026-02.md` containing the root-cause analysis, evidence trail, reproducer commandline, and a manual regression test matrix (AA/MSAA/HDR/tonemap/bloom/clustered variants).
- The change is minimal and centralizes additive-pass eligibility to prevent future CPU/GPU/pass-scheduler divergence while preserving clustered-path behavior.

### Testing
- Ran static code queries (`rg`) to find all prior gate sites and verified the new helper is used in each relevant location, which succeeded.
- Attempted a local `cmake -S . -B build-debug -DCMAKE_BUILD_TYPE=Debug` to validate a debug build, which failed due to a missing system dependency (`SDL2` CMake package), so a full compile/run validation could not be performed in this environment.
- No automated unit tests exist for this rendering path in-tree; the PR includes a reproducible manual run command in `docs/dlight_incident_2026-02.md` for runtime verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993789e579c832e8612ace5d2bd8638)