### PR TITLE
Fix MSVC build break in shadow uniform logging

### DIFF
--- a/Quake/renderer/r_shadow.c
+++ b/Quake/renderer/r_shadow.c
@@ -294,9 +294,9 @@ void R_Shadow_LogReceiverUniformUpload (const char *tag, GLuint target_program)
 
 	glGetIntegerv (GL_CURRENT_PROGRAM, &gl_current);
 
-	loc_shadow_viewproj = glGetUniformLocation (target_program, "ShadowViewProj");
-	loc_shadow_params = glGetUniformLocation (target_program, "ShadowParams");
-	loc_shadow_debug = glGetUniformLocation (target_program, "ShadowDebug");
+	loc_shadow_viewproj = GL_GetUniformLocationFunc (target_program, "ShadowViewProj");
+	loc_shadow_params = GL_GetUniformLocationFunc (target_program, "ShadowParams");
+	loc_shadow_debug = GL_GetUniformLocationFunc (target_program, "ShadowDebug");
 
 	R_Shadow_Log_BeginFrame ();
 	if (shdlog.active)


### PR DESCRIPTION
### Motivation
- Prevent MSVC build errors (`C4013`/`C2220`) caused by implicit use of `glGetUniformLocation` in `R_Shadow_LogReceiverUniformUpload` by switching to the engine's loaded OpenGL entrypoint.

### Description
- Replace three direct calls to `glGetUniformLocation` with `GL_GetUniformLocationFunc` in `Quake/renderer/r_shadow.c` inside `R_Shadow_LogReceiverUniformUpload`.

### Testing
- Ran `rg "glGetUniformLocation" -n Quake/renderer/r_shadow.c Quake` which returned no direct usages, indicating the replacement succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699388a65cf0832ea1fdf81de335ef4e)