### PR TITLE
Fix MSVC warning-as-error in shadow uniform debug dump

### DIFF
--- a/Quake/renderer/r_shadow.c
+++ b/Quake/renderer/r_shadow.c
@@ -106,11 +106,15 @@ static void R_Shadow_DumpActiveUniforms (GLuint program)
 	GLint uniform_count = 0;
 	GLint max_name_len = 0;
 	int i;
+	char *name;
 
 	GL_GetProgramivFunc (program, GL_ACTIVE_UNIFORMS, &uniform_count);
 	GL_GetProgramivFunc (program, GL_ACTIVE_UNIFORM_MAX_LENGTH, &max_name_len);
 	if (max_name_len < 1)
 		max_name_len = 1;
+	name = (char *)malloc ((size_t)max_name_len);
+	if (!name)
+		return;
 
 	R_Shadow_LogWrite ("UNIFORMS program=%u count=%d\n", (unsigned)program, (int)uniform_count);
 	for (i = 0; i < uniform_count; ++i)
@@ -118,12 +122,10 @@ static void R_Shadow_DumpActiveUniforms (GLuint program)
 		GLsizei length = 0;
 		GLint size = 0;
 		GLenum type = 0;
-		char *name = (char *)Hunk_TempAlloc ((size_t)max_name_len);
-		if (!name)
-			continue;
 		GL_GetActiveUniformFunc (program, (GLuint)i, (GLsizei)max_name_len, &length, &size, &type, name);
 		R_Shadow_LogWrite ("UNIFORM program=%u index=%d name=%s type=0x%X size=%d\n", (unsigned)program, i, name, (unsigned)type, (int)size);
 	}
+	free (name);
 }
 
 static void R_Shadow_DumpActiveUniformBlocks (GLuint program)
@@ -131,6 +133,7 @@ static void R_Shadow_DumpActiveUniformBlocks (GLuint program)
 	GLint block_count = 0;
 	GLint max_name_len = 0;
 	int i;
+	char *name;
 
 	GL_GetProgramivFunc (program, GL_ACTIVE_UNIFORM_BLOCKS, &block_count);
 	if (block_count <= 0)
@@ -148,17 +151,18 @@ static void R_Shadow_DumpActiveUniformBlocks (GLuint program)
 	GL_GetProgramivFunc (program, GL_ACTIVE_UNIFORM_BLOCK_MAX_NAME_LENGTH, &max_name_len);
 	if (max_name_len < 1)
 		max_name_len = 1;
+	name = (char *)malloc ((size_t)max_name_len);
+	if (!name)
+		return;
 
 	R_Shadow_LogWrite ("UNIFORM_BLOCKS program=%u count=%d\n", (unsigned)program, (int)block_count);
 	for (i = 0; i < block_count; ++i)
 	{
 		GLsizei length = 0;
-		char *name = (char *)Hunk_TempAlloc ((size_t)max_name_len);
-		if (!name)
-			continue;
 		GL_GetActiveUniformBlockNameFunc (program, (GLuint)i, (GLsizei)max_name_len, &length, name);
 		R_Shadow_LogWrite ("UNIFORM_BLOCK program=%u index=%d name=%s\n", (unsigned)program, i, name);
 	}
+	free (name);
 }
 
 typedef struct shadow_gl_state_s {


### PR DESCRIPTION
### Motivation
- MSVC treated an implicit `Hunk_TempAlloc` declaration as an error (C4013) and produced pointer-size conversion warnings (C4312) when building the shadow debug dump paths, so the allocator calls needed to be removed to compile cleanly.

### Description
- Replace per-iteration `Hunk_TempAlloc` calls in `R_Shadow_DumpActiveUniforms` and `R_Shadow_DumpActiveUniformBlocks` with a single reusable heap buffer allocated via `malloc` and released with `free` at function exit.
- Keep behavior identical by reusing the allocated buffer for each loop iteration and ensuring early return on allocation failure.

### Testing
- Searched the modified file with `rg` to confirm the `Hunk_TempAlloc` usage was removed, which succeeded. 
- Inspected the updated source lines with `nl`/file view to verify the `malloc`/`free` changes are present and the dump loops reuse the buffer, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69938d63d744832e835e6f9c087349d5)