### PR TITLE
Gate dynamic lighting only by `r_dynamic` (remove other cvar gates)

### DIFF
--- a/Quake/opengl/gl_rlight.c
+++ b/Quake/opengl/gl_rlight.c
@@ -31,10 +31,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 extern cvar_t r_flatlightstyles; //johnfitz
 extern cvar_t r_lerplightstyles;
 extern cvar_t r_dynamic;
-extern cvar_t r_dlight_enable;
 extern cvar_t r_dlight_max;
 extern cvar_t r_dlight_quality;
-extern cvar_t r_dlight_style;
 extern cvar_t r_dlight_entities;
 extern cvar_t r_dlight_mode;
 extern cvar_t r_dlight_radius_scale;
@@ -594,9 +592,7 @@ static qboolean R_ClusteredEnabled (void)
 		return false;
 	if (r_clustered_lighting.value <= 0.f)
 		return false;
-	if (r_dynamic.value <= 0.f || r_dlight_enable.value <= 0.f)
-		return false;
-	if (r_dlight_quality.value <= 0.f)
+	if (r_dynamic.value <= 0.f)
 		return false;
 	if (r_framedata.numlights <= 0)
 		return false;
@@ -1010,18 +1006,13 @@ void R_PushDlights (void)
 	r_framedata.numlights = 0;
 	memset (r_dlight_sources, 0, sizeof (r_dlight_sources));
 
-        // Collect dynamic lights both when the legacy r_dynamic toggle is
-        // enabled and when the Quake3-style additive path is requested via
-        // r_dlight_style. The latter needs the light list even if r_dynamic
-        // was disabled by the user.
-	if ((r_dynamic.value > 0.f || r_dlight_style.value > 0.f) && r_dlight_enable.value > 0.f)
+	// Dynamic lights are controlled exclusively by r_dynamic.
+	if (r_dynamic.value > 0.f)
 	{
-		int hard_cap = CLAMP (0, (int)r_dlight_max.value, DLIGHT_GPU_MAX);
-		if (r_dlight_quality.value <= 0.f)
-			hard_cap = 0;
-		else if (r_dlight_quality.value < 2.f)
+		int hard_cap = CLAMP (1, (int)r_dlight_max.value, DLIGHT_GPU_MAX);
+		if (r_dlight_quality.value < 2.f)
 			hard_cap = q_min (hard_cap, 32);
-		const int budget = q_min (q_min (DLightPool_GetBudget (), DLIGHT_GPU_MAX), hard_cap);
+		const int budget = q_min (q_min (q_max (1, DLightPool_GetBudget ()), DLIGHT_GPU_MAX), hard_cap);
 		DLightPool_NewFrame (cl.time, r_framecount);
 		const int num_submit = DLightPool_CollectForRender (cl.time, r_refdef.vieworg, r_viewleaf, submit, budget);
 		if (num_submit > 0)
@@ -1036,7 +1027,7 @@ void R_PushDlights (void)
 
 	R_UploadFrameData ();
 
-	clustered_enabled = (r_clustered_lighting.value > 0.f && r_dynamic.value > 0.f && r_dlight_enable.value > 0.f && r_framedata.numlights > 0);
+	clustered_enabled = (r_clustered_lighting.value > 0.f && r_dynamic.value > 0.f && r_framedata.numlights > 0);
 	if (clustered_enabled)
 	{
 		GL_BeginGroup ("Light clustering");

--- a/Quake/opengl/gl_rmain.c
+++ b/Quake/opengl/gl_rmain.c
@@ -69,7 +69,6 @@ static qboolean r_frame_rendered_this_update;
 static qboolean r_dlight_buffered_frame = false;
 
 extern cvar_t r_dynamic;
-extern cvar_t r_dlight_style;
 extern cvar_t r_clustered_lighting;
 
 static qboolean R_DlightsAdditivePassEnabled (void)
@@ -77,7 +76,7 @@ static qboolean R_DlightsAdditivePassEnabled (void)
 	if (r_clustered_lighting.value > 0.f)
 		return false;
 
-	return (r_dlight_style.value > 0.f || r_dynamic.value > 0.f);
+	return (r_dynamic.value > 0.f);
 }
 
 typedef struct godrays_stabilization_s


### PR DESCRIPTION
### Motivation
- Ensure dynamic lights are active by default and only disabled when `r_dynamic` is explicitly set to `0`, removing accidental global suppression by other cvars.
- Remove secondary cvar gating paths (`r_dlight_enable`, `r_dlight_style`, `r_dlight_quality`) that left lights collected but not drawn or entirely disabled in some configurations.

### Description
- Modified `Quake/opengl/gl_rlight.c` to make `R_ClusteredEnabled()` require only `r_clustered_lighting`, `r_dynamic`, and non-zero `r_framedata.numlights`, removing `r_dlight_enable` and `r_dlight_quality` checks.
- Updated `R_PushDlights()` in `Quake/opengl/gl_rlight.c` to collect and submit dynamic lights only when `r_dynamic.value > 0.f`, removed `r_dlight_style`/`r_dlight_enable` gating, and adjusted `hard_cap`/`budget` logic to avoid forcing a zero budget.
- Changed clustered enablement in `R_PushDlights()` to rely on `r_clustered_lighting` + `r_dynamic` + `r_framedata.numlights` (removed `r_dlight_enable`).
- Updated `Quake/opengl/gl_rmain.c` to make `R_DlightsAdditivePassEnabled()` depend on `r_dynamic` only (keeping clustered-mode exclusion), and removed the now-unused `r_dlight_style` externs from the local translation unit.
- Files changed and committed: `Quake/opengl/gl_rlight.c` and `Quake/opengl/gl_rmain.c` with the above logic simplifications.

### Testing
- Ran targeted code searches with `rg` to verify references and ensure shader paths still use `DLightParams` and that no other logic still forcibly gates dynlights; these searches completed successfully.
- Performed `sed`/inspection of affected functions to confirm the new gating logic is applied to `R_PushDlights`, `R_ClusteredEnabled`, and `R_DlightsAdditivePassEnabled` successfully.
- Attempted to configure and build with `cmake -S . -B build && cmake --build build -j2`, but the build failed due to a missing `SDL2` CMake package in the environment, so a full compile/run test could not be performed.
- Changes were staged and committed (`git commit`) successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993919cbda8832e87e3da23c2148820)