### PR TITLE
Fix empty shadow caster passes by drawing world geometry

### DIFF
--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -538,6 +538,7 @@ void R_DrawBrushModels_SkyLayers (entity_t **ents, int count);
 void R_DrawBrushModels_SkyCubemap (entity_t **ents, int count);
 void R_DrawBrushModels_SkyStencil (entity_t **ents, int count);
 void R_DrawBrushModels_Shadow (entity_t **ents, int count);
+qboolean R_DrawWorld_Shadow (void);
 void R_Shadow_ResetBrushAuditCounters (void);
 void R_Shadow_GetBrushAuditCounters (int *out_entities_input, int *out_entities_instanced, int *out_surfaces_considered, int *out_surfaces_submitted);
 void R_DrawAliasModels (entity_t **ents, int count);

--- a/Quake/renderer/r_shadow.c
+++ b/Quake/renderer/r_shadow.c
@@ -98,6 +98,7 @@ static qboolean shadow_dlight_validated_once;
 static qboolean shadow_warned_sun_dir_sanitize;
 static qboolean shadow_warned_receiver_program_mismatch;
 static qboolean shadow_warned_matrix_sanitize;
+static char shadow_last_empty_sunpass_map[MAX_QPATH];
 
 static void R_Shadow_LogWrite (const char *fmt, ...);
 
@@ -384,6 +385,9 @@ void R_Shadow_LogReceiverUniformUpload (const char *tag, GLuint target_program)
 	GLint loc_shadow_viewproj = 0;
 	GLint loc_shadow_params = 0;
 	GLint loc_shadow_debug = 0;
+	GLuint frame_ubo_index = GL_INVALID_INDEX;
+	GLint frame_ubo_binding = -1;
+	GLint frame_ubo_data_size = -1;
 	const char *target_name = GL_GetProgramDebugName (target_program);
 	const char *target_defines = GL_GetProgramDebugDefines (target_program);
 	const char *target_vert = GL_GetProgramVertexShaderPath (target_program);
@@ -395,6 +399,12 @@ void R_Shadow_LogReceiverUniformUpload (const char *tag, GLuint target_program)
 	loc_shadow_viewproj = GL_GetUniformLocationFunc (target_program, "ShadowViewProj");
 	loc_shadow_params = GL_GetUniformLocationFunc (target_program, "ShadowParams");
 	loc_shadow_debug = GL_GetUniformLocationFunc (target_program, "ShadowDebug");
+	frame_ubo_index = GL_GetUniformBlockIndexFunc (target_program, "FrameDataUBO");
+	if (frame_ubo_index != GL_INVALID_INDEX)
+	{
+		glGetActiveUniformBlockiv (target_program, frame_ubo_index, GL_UNIFORM_BLOCK_BINDING, &frame_ubo_binding);
+		glGetActiveUniformBlockiv (target_program, frame_ubo_index, GL_UNIFORM_BLOCK_DATA_SIZE, &frame_ubo_data_size);
+	}
 
 	R_Shadow_Log_BeginFrame ();
 	if (shdlog.active)
@@ -412,7 +422,17 @@ void R_Shadow_LogReceiverUniformUpload (const char *tag, GLuint target_program)
 			(int)loc_shadow_viewproj,
 			(int)loc_shadow_params,
 			(int)loc_shadow_debug);
-		if (((tag && !q_strcasecmp (tag, "WORLD")) || (tag && !q_strcasecmp (tag, "ALIAS"))) && loc_shadow_viewproj == -1)
+		if (frame_ubo_index != GL_INVALID_INDEX)
+		{
+			R_Shadow_LogWrite ("UPLOAD shadow uniforms via UBO: tag=%s block=FrameDataUBO index=%u binding=%d data_size=%d\n",
+				tag ? tag : "SHADOW", (unsigned)frame_ubo_index, (int)frame_ubo_binding, (int)frame_ubo_data_size);
+		}
+		else if (loc_shadow_viewproj == -1 && loc_shadow_params == -1 && loc_shadow_debug == -1)
+		{
+			R_Shadow_LogWrite ("WARN %s has no shadow uniforms and no FrameDataUBO block (likely shadows not compiled in this receiver variant)\n",
+				tag ? tag : "SHADOW");
+		}
+		if (((tag && !q_strcasecmp (tag, "WORLD")) || (tag && !q_strcasecmp (tag, "ALIAS"))) && loc_shadow_viewproj == -1 && frame_ubo_index == GL_INVALID_INDEX)
 		{
 			R_Shadow_DumpActiveUniforms (target_program);
 			R_Shadow_DumpActiveUniformBlocks (target_program);
@@ -1205,6 +1225,9 @@ void R_Shadow_SunPass (void)
 	double t0, t1;
 	int draws0, tris0;
 	int shadow_drawcalls = 0;
+	int brush_count = 0;
+	int alias_count = 0;
+	qboolean drew_world_caster = false;
 	shadow_gl_state_t saved_state;
 
 	R_Shadow_Log_BeginFrame ();
@@ -1264,17 +1287,17 @@ void R_Shadow_SunPass (void)
 	glClear (GL_DEPTH_BUFFER_BIT);
 
 	{
-		int count = 0;
-		entity_t **ents = R_GetVisEntities (mod_brush, false, &count);
-		R_Shadow_LogWrite ("SUNPASS vis brush_entities=%d\n", count);
-		R_DrawBrushModels_Shadow (ents, count);
+		entity_t **ents = R_GetVisEntities (mod_brush, false, &brush_count);
+		R_Shadow_LogWrite ("SUNPASS vis brush_entities=%d\n", brush_count);
+		R_DrawBrushModels_Shadow (ents, brush_count);
 	}
 	{
-		int count = 0;
-		entity_t **ents = R_GetVisEntities (mod_alias, false, &count);
-		R_Shadow_LogWrite ("SUNPASS vis alias_entities=%d\n", count);
-		R_DrawAliasModels_Shadow (ents, count);
+		entity_t **ents = R_GetVisEntities (mod_alias, false, &alias_count);
+		R_Shadow_LogWrite ("SUNPASS vis alias_entities=%d\n", alias_count);
+		R_DrawAliasModels_Shadow (ents, alias_count);
 	}
+	drew_world_caster = R_DrawWorld_Shadow ();
+	R_Shadow_LogWrite ("SUNPASS world_caster=%s\n", drew_world_caster ? "drawn" : "missing");
 	t1 = Sys_DoubleTime ();
 	{
 		int brush_in = 0, brush_inst = 0, surf_considered = 0, surf_submitted = 0;
@@ -1286,6 +1309,19 @@ void R_Shadow_SunPass (void)
 		shadow_drawcalls = surf_submitted + alias_submitted;
 		R_Shadow_LogWrite ("SUNPASS audit brush_entities_in=%d brush_entities_after_cull=%d brush_surfaces=%d brush_surfaces_after_filters=%d alias_entities_in=%d alias_entities_after_cull=%d drawcalls_est=%d legacy_draws=%d legacy_tris=%d\n",
 			brush_in, brush_inst, surf_considered, surf_submitted, alias_in, alias_submitted, shadow_drawcalls, legacy_draws, legacy_tris);
+		if (shadow_drawcalls <= 0)
+		{
+			if (q_strcasecmp (shadow_last_empty_sunpass_map, cl.mapname))
+			{
+				q_strlcpy (shadow_last_empty_sunpass_map, cl.mapname, sizeof (shadow_last_empty_sunpass_map));
+				Con_Warning ("SUNPASS produced no casters on map '%s' (brush=%d alias=%d world=%s). World caster missing?\n",
+					cl.mapname[0] ? cl.mapname : "<unknown>", brush_count, alias_count, drew_world_caster ? "yes" : "no");
+			}
+		}
+		else
+		{
+			shadow_last_empty_sunpass_map[0] = '\0';
+		}
 	}
 	R_Shadow_Log_ShadowPassSnapshot ("SUNPASS", shadow_fbo, shadow_depth_tex, shadowmap_size, shadowmap_size,
 		shadow_drawcalls, shadow_drawcalls, (t1 - t0) * 1000.0);
@@ -1489,18 +1525,21 @@ void R_Shadow_DlightPass (void)
 		glClear (GL_DEPTH_BUFFER_BIT);
 
 		GL_UseProgram (glprogs.shadow_depth);
-		GL_SetState (GLS_BLEND_OPAQUE | GLS_CULL_FRONT | GLS_ATTRIBS (6));
+		GL_SetState (GLS_BLEND_OPAQUE | GLS_CULL_BACK | GLS_ATTRIBS (6));
 
 		{
 			int count = 0;
 			entity_t **ents = R_GetVisEntities (mod_brush, false, &count);
+			R_Shadow_LogWrite ("DLIGHTPASS tile=%d vis brush_entities=%d\n", i, count);
 			R_DrawBrushModels_Shadow (ents, count);
 		}
 		{
 			int count = 0;
 			entity_t **ents = R_GetVisEntities (mod_alias, false, &count);
+			R_Shadow_LogWrite ("DLIGHTPASS tile=%d vis alias_entities=%d\n", i, count);
 			R_DrawAliasModels_Shadow (ents, count);
 		}
+		R_Shadow_LogWrite ("DLIGHTPASS tile=%d world_caster=%s\n", i, R_DrawWorld_Shadow () ? "drawn" : "missing");
 	}
 
 	GL_SetScissorEnabled (false);

--- a/Quake/renderer/r_world.c
+++ b/Quake/renderer/r_world.c
@@ -1298,7 +1298,7 @@ static void R_DrawBrushModels_Real (entity_t **ents, int count, brushpass_t pass
         else if (pass == BP_SHADOW)
         {
                 state &= ~GLS_MASK_CULL;
-                state |= GLS_BLEND_OPAQUE | GLS_CULL_FRONT;
+                state |= GLS_BLEND_OPAQUE | GLS_CULL_BACK;
         }
         else if (!translucent)
                 state |= GLS_BLEND_OPAQUE;
@@ -1717,6 +1717,17 @@ void R_DrawBrushModels_SkyStencil (entity_t **ents, int count)
 void R_DrawBrushModels_Shadow (entity_t **ents, int count)
 {
 	R_DrawBrushModels_Real (ents, count, BP_SHADOW, false);
+}
+
+qboolean R_DrawWorld_Shadow (void)
+{
+	entity_t *world = &cl_entities[0];
+
+	if (!world->model || !Mod_IsKnownModel (world->model))
+		return false;
+
+	R_DrawBrushModels_Real (&world, 1, BP_SHADOW, false);
+	return true;
 }
 
 /*


### PR DESCRIPTION
### Motivation
- SUNPASS was repeatedly reporting `draws=0 tris=0` and produced an empty shadow depth texture because the caster pass drew only entities from `R_GetVisEntities(mod_brush/mod_alias, ...)`, which can omit the worldspawn geometry.
- Shadow caster state used front-face culling for brush shadow draws which tends to drop most Quake BSP/model fragments, making depth maps empty in many maps.

### Description
- Add `R_DrawWorld_Shadow()` that reuses the existing world/brush draw pipeline (calls `R_DrawBrushModels_Real(..., BP_SHADOW, ...)`) to explicitly render worldspawn as a caster when present (`Quake/renderer/r_world.c`).
- Invoke the new world-caster draw from `R_Shadow_SunPass()` and per-tile in `R_Shadow_DlightPass()` so world geometry is included in both sun and dlight shadow maps (`Quake/renderer/r_shadow.c`).
- Change shadow-caster culling from front-face to back-face for the shadow passes (BP_SHADOW and DLight tile state) to avoid dropping one-sided BSP geometry (`Quake/renderer/r_world.c`, `Quake/renderer/r_shadow.c`).
- Improve shadow diagnostics and rate-limited warnings: log brush/alias visible counts in SUNPASS/DLIGHTPASS, log world-caster presence, and emit a once-per-map warning when SUNPASS produces zero caster draws (`Quake/renderer/r_shadow.c`).
- Harden receiver-uniform upload logging: detect `FrameDataUBO` uniform block and log block index/binding/data size and avoid treating `-1` uniform locations as errors when UBOs are used (`Quake/renderer/r_shadow.c`).
- Export new prototype `qboolean R_DrawWorld_Shadow(void);` in the public header (`Quake/glquake.h`).

Files changed: `Quake/renderer/r_world.c`, `Quake/renderer/r_shadow.c`, `Quake/glquake.h`.

### Testing
- Attempted an automated build with `cmake -S . -B build && cmake --build build -j4`, which failed during configure due to a missing SDL2 CMake package (`SDL2Config.cmake` / `sdl2-config.cmake` not found) in this environment, so runtime smoke tests could not be executed here (build failed).
- No other automated tests were available in this environment; changes are limited to rendering path reuse and logging, and should be validated at runtime on a system where the project builds (verify `SUNPASS draws>0 tris>0` on map start and `r_shadow_debug 1` shows non-empty depth).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699393fd3528832eaea813d4343a3631)