### PR TITLE
Remove dynlight gating from render pipeline

### DIFF
--- a/Quake/opengl/gl_rlight.c
+++ b/Quake/opengl/gl_rlight.c
@@ -592,8 +592,6 @@ static qboolean R_ClusteredEnabled (void)
 		return false;
 	if (r_clustered_lighting.value <= 0.f)
 		return false;
-	if (r_dynamic.value <= 0.f)
-		return false;
 	if (r_framedata.numlights <= 0)
 		return false;
 	return true;
@@ -1006,28 +1004,19 @@ void R_PushDlights (void)
 	r_framedata.numlights = 0;
 	memset (r_dlight_sources, 0, sizeof (r_dlight_sources));
 
-	// Dynamic lights are controlled exclusively by r_dynamic.
-	if (r_dynamic.value > 0.f)
-	{
-		int hard_cap = CLAMP (1, (int)r_dlight_max.value, DLIGHT_GPU_MAX);
-		if (r_dlight_quality.value < 2.f)
-			hard_cap = q_min (hard_cap, 32);
-		const int budget = q_min (q_min (q_max (1, DLightPool_GetBudget ()), DLIGHT_GPU_MAX), hard_cap);
-		DLightPool_NewFrame (cl.time, r_framecount);
-		const int num_submit = DLightPool_CollectForRender (cl.time, r_refdef.vieworg, r_viewleaf, submit, budget);
-		if (num_submit > 0)
-			R_PushDlightArray (submit, num_submit);
-		DLightPool_DebugPrintIfEnabled ();
-	}
-	else
-	{
-		DLightPool_NewFrame (cl.time, r_framecount);
-		DLightPool_DebugPrintIfEnabled ();
-	}
+	int hard_cap = CLAMP (1, (int)r_dlight_max.value, DLIGHT_GPU_MAX);
+	if (r_dlight_quality.value < 2.f)
+		hard_cap = q_min (hard_cap, 32);
+	const int budget = q_min (q_min (q_max (1, DLightPool_GetBudget ()), DLIGHT_GPU_MAX), hard_cap);
+	DLightPool_NewFrame (cl.time, r_framecount);
+	const int num_submit = DLightPool_CollectForRender (cl.time, r_refdef.vieworg, r_viewleaf, submit, budget);
+	if (num_submit > 0)
+		R_PushDlightArray (submit, num_submit);
+	DLightPool_DebugPrintIfEnabled ();
 
 	R_UploadFrameData ();
 
-	clustered_enabled = (r_clustered_lighting.value > 0.f && r_dynamic.value > 0.f && r_framedata.numlights > 0);
+	clustered_enabled = (r_clustered_lighting.value > 0.f && r_framedata.numlights > 0);
 	if (clustered_enabled)
 	{
 		GL_BeginGroup ("Light clustering");
@@ -1116,9 +1105,6 @@ static void R_AddDynamicLights_LightgridArray (const dlight_t *const *lights, in
 
 void R_AddDynamicLights_Lightgrid (const vec3_t pos, vec3_t lightcolor)
 {
-	if (!r_dynamic.value)
-		return;
-
 	int count = 0;
 	const dlight_t *const *active = DLightPool_GetActiveList (&count);
 	if (active && count > 0)

--- a/Quake/opengl/gl_rmain.c
+++ b/Quake/opengl/gl_rmain.c
@@ -68,15 +68,11 @@ static qboolean r_prev_frame_valid = false;
 static qboolean r_frame_rendered_this_update;
 static qboolean r_dlight_buffered_frame = false;
 
-extern cvar_t r_dynamic;
 extern cvar_t r_clustered_lighting;
 
 static qboolean R_DlightsAdditivePassEnabled (void)
 {
-	if (r_clustered_lighting.value > 0.f)
-		return false;
-
-	return (r_dynamic.value > 0.f);
+	return (r_clustered_lighting.value <= 0.f);
 }
 
 typedef struct godrays_stabilization_s
@@ -3775,7 +3771,7 @@ qboolean GL_NeedsSceneEffects (void)
         if (framebufs.scene.samples > 1 || water_warp || r_refdef.scale != 1)
 		return true;
 
-	if (r_dlight_mode.value > 0.f && R_DlightsAdditivePassEnabled () && r_dlight_buffer.value > 0.f && framebufs.dlight.fbo)
+	if (r_dlight_mode.value > 0.f && R_DlightsAdditivePassEnabled () && r_dlight_buffer.value > 0.f && framebufs.dlight.fbo && r_framedata.numlights > 0)
 		return true;
 
         if (GL_ShouldApplyMotionBlur ())


### PR DESCRIPTION
### Motivation
- Align dynamic-light collection, clustered build, and additive composition so collected dlights are actually drawn instead of being silently blocked by multiple mismatched gates.
- Implement the user intent to remove extraneous `r_dynamic` gating so non-clustered additive dlight behavior is controlled only by clustered-mode exclusion and actual frame data.

### Description
- Changed `R_DlightsAdditivePassEnabled` in `Quake/opengl/gl_rmain.c` to depend only on clustered-mode exclusion (`r_clustered_lighting`) instead of `r_dynamic` so additive-pass eligibility no longer requires `r_dynamic` to be set.
- In `Quake/opengl/gl_rmain.c` added a requirement that scene-effects/`dlight` buffered composite only signal when there are actual lights in the frame by adding `r_framedata.numlights > 0` to the `GL_NeedsSceneEffects` check.
- In `Quake/opengl/gl_rlight.c` removed `r_dynamic` gating from light collection and submission paths so `R_PushDlights` always collects/submits according to the dlight pool, `R_ClusteredEnabled` no longer checks `r_dynamic`, and `R_AddDynamicLights_Lightgrid` no longer early-returns on `r_dynamic`.
- Adjusted clustered-enable logic to depend on submitted lights and clustered cvars (removed the `r_dynamic` dependency) so clustered build runs only when there are lights to process.

### Testing
- Performed repository searches with `rg` to verify references and gates were updated throughout the renderer (searches completed successfully).
- Attempted to configure a build with `cmake -S . -B build`, which failed due to a missing SDL2 CMake package (`SDL2Config.cmake` / `sdl2-config.cmake`), so a full build/test run could not be executed in this environment.
- Verified modified source diffs with `git diff`/`nl` to confirm the intended edits to `gl_rmain.c` and `gl_rlight.c` (diff inspection succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993ab7907b8832eb5a68f1bd3c427f0)