### PR TITLE
Guard glBlendFuncSeparate for MSVC compatibility in shadow renderer

### DIFF
--- a/Quake/renderer/r_shadow.c
+++ b/Quake/renderer/r_shadow.c
@@ -315,7 +315,12 @@ static void R_Shadow_RestoreGLState (const shadow_gl_state_t *state)
 	}
 	glDepthFunc ((GLenum)state->depth_func);
 	glDepthRange (state->depth_range[0], state->depth_range[1]);
+#ifdef GL_VERSION_1_4
 	glBlendFuncSeparate (state->blend_src_rgb, state->blend_dst_rgb, state->blend_src_alpha, state->blend_dst_alpha);
+#else
+	/* Older GL headers (notably on MSVC) may not declare glBlendFuncSeparate. */
+	glBlendFunc (state->blend_src_rgb, state->blend_dst_rgb);
+#endif
 	glColorMask (state->color_mask[0], state->color_mask[1], state->color_mask[2], state->color_mask[3]);
 	glDepthMask (state->depth_mask);
 	glCullFace (state->cull_face_mode);


### PR DESCRIPTION
### Motivation
- Prevent MSVC compile errors/warnings (e.g. C4013/C2220) when `glBlendFuncSeparate` is not declared in older OpenGL headers by providing a compatible fallback.

### Description
- Wrap the `glBlendFuncSeparate` call in `R_Shadow_RestoreGLState` (in `Quake/renderer/r_shadow.c`) with `#ifdef GL_VERSION_1_4` and provide a fallback to `glBlendFunc` with a short explanatory comment.

### Testing
- Ran `git diff --check` to validate patch formatting and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993c408672c832eb49a88be5adcb2f5)