### PR TITLE
Fix world dlight clustered Z-slice and add r_dlight_debug telemetry

### DIFF
--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -539,6 +539,7 @@ GLuint R_Shadow_GetDlightShadowMapTextureId (void);
 void R_DrawBrushModels (entity_t **ents, int count);
 void R_DrawBrushModels_Water (entity_t **ents, int count, qboolean translucent);
 void R_DrawBrushModels_DLights (entity_t **ents, int count);
+void R_GetBrushDlightPassDebugStats (int *out_drawcalls, int *out_instances, int *out_batches);
 void R_DrawBrushModels_SkyLayers (entity_t **ents, int count);
 void R_DrawBrushModels_SkyCubemap (entity_t **ents, int count);
 void R_DrawBrushModels_SkyStencil (entity_t **ents, int count);
@@ -604,6 +605,7 @@ qboolean R_SampleLightmapAndDeluxemapAtPoint(const vec3_t pos, vec3_t out_rgb, v
 qboolean R_LightgridEnabled (void);
 void R_LightgridLighting (const vec3_t pos, vec3_t out_color, float *out_ao);
 void R_AddDynamicLights_Lightgrid (const vec3_t pos, vec3_t lightcolor);
+void R_GetClusterDlightDebugStats (int *out_clusters, int *out_indices, const int **out_light_hits, int *out_max_hits);
 
 extern cvar_t r_debug_itemlight;
 extern cvar_t r_minlight_models;

--- a/Quake/opengl/gl_rlight.c
+++ b/Quake/opengl/gl_rlight.c
@@ -35,6 +35,7 @@ extern cvar_t r_dlight_max;
 extern cvar_t r_dlight_quality;
 extern cvar_t r_dlight_entities;
 extern cvar_t r_dlight_mode;
+extern cvar_t r_dlight_debug;
 extern cvar_t r_dlight_radius_scale;
 extern cvar_t r_clustered_lighting;
 extern cvar_t r_clustered_tilesize;
@@ -576,6 +577,9 @@ static struct {
 } r_clustered;
 
 static clustered_header_t *r_clustered_headers_cpu;
+static int r_clustered_debug_light_cluster_hits[DLIGHT_GPU_MAX];
+static int r_clustered_debug_cluster_count;
+static int r_clustered_debug_index_count;
 
 typedef struct gpu_cluster_inputs_s {
 	int pass_mode;
@@ -682,6 +686,9 @@ void R_Clustered_Shutdown (void)
 	memset (&r_clustered, 0, sizeof (r_clustered));
 	free (r_clustered_headers_cpu);
 	r_clustered_headers_cpu = NULL;
+	memset (r_clustered_debug_light_cluster_hits, 0, sizeof (r_clustered_debug_light_cluster_hits));
+	r_clustered_debug_cluster_count = 0;
+	r_clustered_debug_index_count = 0;
 }
 
 
@@ -860,6 +867,36 @@ void R_Clustered_BuildLists (void)
 		r_clustered.last_overflow_log = realtime;
 	}
 
+	r_clustered_debug_cluster_count = r_clustered.cluster_count;
+	r_clustered_debug_index_count = 0;
+	memset (r_clustered_debug_light_cluster_hits, 0, sizeof (r_clustered_debug_light_cluster_hits));
+	if (r_dlight_debug.value > 0.f)
+	{
+		GLuint *indices_mapped = NULL;
+
+		for (i = 0; i < r_clustered.cluster_count; i++)
+			r_clustered_debug_index_count += (int)r_clustered_headers_cpu[i].count;
+
+		GL_BindBufferFunc (GL_SHADER_STORAGE_BUFFER, r_clustered.indices_ssbo);
+		indices_mapped = (GLuint *)GL_MapBufferRangeFunc (GL_SHADER_STORAGE_BUFFER, 0,
+			(GLsizeiptr)(sizeof (GLuint) * (size_t)r_clustered.max_indices), GL_MAP_READ_BIT);
+		if (indices_mapped)
+		{
+			for (i = 0; i < r_clustered.cluster_count; i++)
+			{
+				GLuint ofs = r_clustered_headers_cpu[i].offset;
+				GLuint cnt = r_clustered_headers_cpu[i].count;
+				for (GLuint j = 0; j < cnt; j++)
+				{
+					GLuint light_id = indices_mapped[ofs + j];
+					if (light_id < DLIGHT_GPU_MAX)
+						r_clustered_debug_light_cluster_hits[light_id]++;
+				}
+			}
+			GL_UnmapBufferFunc (GL_SHADER_STORAGE_BUFFER);
+		}
+	}
+
 	free (temp_counts);
 	GL_BindBufferFunc (GL_SHADER_STORAGE_BUFFER, 0);
 	GL_BindBufferFunc (GL_UNIFORM_BUFFER, 0);
@@ -878,6 +915,18 @@ void R_Clustered_BindForShading (void)
 		(GLsizeiptr)(sizeof (GLuint) * (size_t)r_clustered.max_indices));
 	GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 6, r_clustered.counters_ssbo, 0, sizeof (GLuint) * 2);
 	GL_BindBufferRange (GL_UNIFORM_BUFFER, 2, r_clustered.params_ubo, 0, sizeof (clustered_params_t));
+}
+
+void R_GetClusterDlightDebugStats (int *out_clusters, int *out_indices, const int **out_light_hits, int *out_max_hits)
+{
+	if (out_clusters)
+		*out_clusters = r_clustered_debug_cluster_count;
+	if (out_indices)
+		*out_indices = r_clustered_debug_index_count;
+	if (out_light_hits)
+		*out_light_hits = r_clustered_debug_light_cluster_hits;
+	if (out_max_hits)
+		*out_max_hits = (int)countof (r_clustered_debug_light_cluster_hits);
 }
 
 const vec3_t *R_GetDynamicLightTemperature (int type)

--- a/Quake/opengl/gl_rmain.c
+++ b/Quake/opengl/gl_rmain.c
@@ -5163,6 +5163,55 @@ static void R_SetDlightConfig (GLuint program, float scale, float falloff, float
 	GL_Uniform4fFunc (2, satchop, 0.f, 0.f, 0.f);
 }
 
+static void R_DlightDebugReport (int vis_brush_count)
+{
+	const int *cluster_hits = NULL;
+	int max_hits = 0;
+	int clusters = 0;
+	int indices = 0;
+	int drawcalls = 0;
+	int instances = 0;
+	int batches = 0;
+	dlight_pool_stats_t pool_stats;
+	int best = -1;
+	float best_dist2 = FLT_MAX;
+
+	if (r_dlight_debug.value <= 0.f)
+		return;
+
+	DLightPool_GetStats (&pool_stats);
+	R_GetBrushDlightPassDebugStats (&drawcalls, &instances, &batches);
+	R_GetClusterDlightDebugStats (&clusters, &indices, &cluster_hits, &max_hits);
+
+	for (int i = 0; i < r_framedata.numlights; i++)
+	{
+		if (!r_dlight_sources[i])
+			continue;
+		vec3_t delta;
+		VectorSubtract (r_dlight_sources[i]->origin, r_refdef.vieworg, delta);
+		float dist2 = DotProduct (delta, delta);
+		if (dist2 < best_dist2)
+		{
+			best_dist2 = dist2;
+			best = i;
+		}
+	}
+
+	Con_DPrintf ("dlight world: active=%d submitted=%d gpu=%u vis_brush=%d dlight_batches=%d dlight_instances=%d dlight_drawcalls=%d clustered=%d mode=%d\n",
+		pool_stats.active, pool_stats.submitted, r_framedata.numlights, vis_brush_count, batches, instances, drawcalls,
+		(r_clustered_lighting.value > 0.f) ? 1 : 0, (r_dlight_mode.value > 0.f) ? 1 : 0);
+	Con_DPrintf ("dlight world checks: r_dynamic=%.0f gl_flashblend=%.0f r_dlight_enable=%.0f cluster_cells=%d cluster_indices=%d\n",
+		r_dynamic.value, gl_flashblend.value, r_dlight_enable.value, clusters, indices);
+
+	if (best >= 0 && r_dlight_sources[best])
+	{
+		dlight_t *dl = r_dlight_sources[best];
+		int touched = (cluster_hits && best < max_hits) ? cluster_hits[best] : 0;
+		Con_DPrintf ("dlight focus[%d]: org=(%.1f %.1f %.1f) radius=%.1f color=(%.2f %.2f %.2f) world_clusters=%d\n",
+			best, dl->origin[0], dl->origin[1], dl->origin[2], dl->radius, dl->color[0], dl->color[1], dl->color[2], touched);
+	}
+}
+
 static void R_DrawDLightPass (void)
 {
         int count = 0;
@@ -5251,6 +5300,8 @@ static void R_DrawDLightPass (void)
 			glReadBuffer (GL_BACK);
 		}
 	}
+
+	R_DlightDebugReport (count);
 
         GL_EndGroup ();
 }

--- a/Quake/renderer/r_world.c
+++ b/Quake/renderer/r_world.c
@@ -319,6 +319,9 @@ static union {
 } bmodel_calls;
 static bmodel_gpu_call_remap_t		bmodel_call_remap[MAX_BMODEL_DRAWS];
 static int							num_bmodel_calls;
+static int							r_brush_dlight_debug_drawcalls;
+static int							r_brush_dlight_debug_instances;
+static int							r_brush_dlight_debug_batches;
 static GLuint						bmodel_batch_program;
 static int							shadow_brush_entities_input;
 static int							shadow_brush_entities_instanced;
@@ -445,6 +448,10 @@ static void R_FlushBModelCalls (void)
 
 	if (!num_bmodel_calls)
 		return;
+
+	if (bmodel_batch_program == glprogs.world_dlight[0] || bmodel_batch_program == glprogs.world_dlight[1] ||
+		bmodel_batch_program == glprogs.world_dlight_hybrid[0] || bmodel_batch_program == glprogs.world_dlight_hybrid[1])
+		r_brush_dlight_debug_drawcalls += num_bmodel_calls;
 
 	GL_ReserveDeviceMemory (GL_DRAW_INDIRECT_BUFFER, sizeof (bmodel_draw_indirect_t) * num_bmodel_calls, &cmdbuf, &dstcmdofs);
 
@@ -1292,6 +1299,12 @@ static void R_DrawBrushModels_Real (entity_t **ents, int count, brushpass_t pass
 	if (pass == BP_SHADOW)
 		shadow_brush_entities_instanced += totalinst;
 
+	if (pass == BP_DLIGHT_SOLID || pass == BP_DLIGHT_ALPHA)
+	{
+		r_brush_dlight_debug_batches++;
+		r_brush_dlight_debug_instances += totalinst;
+	}
+
         state = GLS_CULL_BACK | GLS_ATTRIBS(6);
         if (pass == BP_DLIGHT_SOLID || pass == BP_DLIGHT_ALPHA)
                 state |= GLS_BLEND_ADD | GLS_NO_ZWRITE;
@@ -1678,11 +1691,25 @@ void R_DrawBrushModels (entity_t **ents, int count)
 
 void R_DrawBrushModels_DLights (entity_t **ents, int count)
 {
+	r_brush_dlight_debug_drawcalls = 0;
+	r_brush_dlight_debug_instances = 0;
+	r_brush_dlight_debug_batches = 0;
+
         if (!count)
                 return;
 
         R_DrawBrushModels_Real (ents, count, BP_DLIGHT_SOLID, false);
         R_DrawBrushModels_Real (ents, count, BP_DLIGHT_ALPHA, false);
+}
+
+void R_GetBrushDlightPassDebugStats (int *out_drawcalls, int *out_instances, int *out_batches)
+{
+	if (out_drawcalls)
+		*out_drawcalls = r_brush_dlight_debug_drawcalls;
+	if (out_instances)
+		*out_instances = r_brush_dlight_debug_instances;
+	if (out_batches)
+		*out_batches = r_brush_dlight_debug_batches;
 }
 
 /*

--- a/Quake/shaders/world_dlight.frag
+++ b/Quake/shaders/world_dlight.frag
@@ -126,7 +126,7 @@ void main()
                 ivec3 cluster_coord = ivec3(
                         int(floor(in_coord.x)),
                         int(floor(in_coord.y)),
-                        int(floor(log2(in_depth) * ZLogScale + ZLogBias))
+                        int(floor(log2(max(in_depth, 1e-4)) * ZLogScale + ZLogBias))
                 );
 
                 uvec2 clusterdata = imageLoad(LightClusters, cluster_coord).xy;

--- a/Quake/shaders/world_dlight_hybrid.frag
+++ b/Quake/shaders/world_dlight_hybrid.frag
@@ -126,7 +126,7 @@ void main()
                 ivec3 cluster_coord = ivec3(
                         int(floor(in_coord.x)),
                         int(floor(in_coord.y)),
-                        int(floor(log2(in_depth) * ZLogScale + ZLogBias))
+                        int(floor(log2(max(in_depth, 1e-4)) * ZLogScale + ZLogBias))
                 );
 
                 uvec2 clusterdata = imageLoad(LightClusters, cluster_coord).xy;


### PR DESCRIPTION
### Motivation
- World BSP surfaces were not receiving dynamic light contributions while alias/models were, indicating a divergence in the clustered dlight world path that selects z-slices for clustered lighting and/or the world-dlight drawpath lacked runtime visibility instrumentation.
- Investigation showed the world dlight fragment shaders used `log2(in_depth)` without guarding against near-zero depth, which can produce invalid/unstable z-slice selection and drop world lighting while model lighting (using other paths) remained unaffected.
- The change aims to restore classic behavior by fixing the clustered z-slice calculation and adding gated debug telemetry to verify marking/clustered-hit/drawcall counts with minimal, low-risk edits and no second dlight implementation.

### Description
- Clamp depth before log2 in the two world dlight fragment shaders by changing the z-slice selector to `log2(max(in_depth, 1e-4))` in `Quake/shaders/world_dlight.frag` and `Quake/shaders/world_dlight_hybrid.frag` to prevent invalid slice selection for world BSP surfaces.
- Add lightweight dlight-pass diagnostics and plumbing: new debug getters in `Quake/glquake.h`, per-pass counters (`drawcalls`, `instances`, `batches`) and `R_GetBrushDlightPassDebugStats` in `Quake/renderer/r_world.c`, and counters reset at `R_DrawBrushModels_DLights` entry.
- Collect clustered light-hit statistics in `Quake/opengl/gl_rlight.c` by readback of clustered indices when `r_dlight_debug` is enabled, storing per-light cluster-hit counts and adding `R_GetClusterDlightDebugStats` to expose them.
- Hook up a concise per-frame report in `Quake/opengl/gl_rmain.c` (`R_DlightDebugReport`) that is gated by `r_dlight_debug` and prints active/submitted/gpu lights, visible brush count, batches/instances/drawcalls, cluster totals and the closest dlight origin/radius/color + cluster-hit count; this function is called from the world dlight pass and is non-invasive when debug is off.

### Testing
- Ran static checks and repository hygiene: `git diff --check` returned clean results (success).
- Attempted a full configure/build via CMake (`cmake -S . -B build && cmake --build build -j4`) but the build was blocked by a missing SDL2 CMake package in the test environment, so a full compile/test could not be completed here (environment limitation).
- Performed targeted source validation (searches/edits and small script-driven edits) and verified the new debug code paths are gated by `r_dlight_debug` and do not change runtime behavior when disabled.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993c345e1e4832e88bb7f1e7b9e0fa0)