### PR TITLE
Consolidate fullscreen PostFX gating to CVAR-only (remove material bloom/godray gates)

### DIFF
--- a/Quake/bspfile.h
+++ b/Quake/bspfile.h
@@ -227,7 +227,6 @@ typedef struct texinfo_s
 #define TEX_MISSING		2		// johnfitz -- this texinfo does not have a texture
 #define     TEX_VERTEXNORMALS       0x800   // bspx smooth shading
 #define	TEX_LIGHT		0x1000	// explicitly marks a light-emitting texture
-#define	TEX_GODRAY_EMIT	TEX_LIGHT
 
 // note that edge 0 is never used, because negative edge nums are used for
 // counterclockwise use of the edge in a face

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -835,8 +835,6 @@ void Sky_LoadSkyBox (const char *name);
 void Sky_SetupFrame (void);
 qboolean Sky_IsAnimated (void);
 
-qboolean R_TextureEmitsGodrays (texture_t *t);
-qboolean R_SurfaceEmitsGodrays (msurface_t *s);
 
 void GL_BindBuffer (GLenum target, GLuint buffer);
 void GL_BindBufferRange (GLenum target, GLuint index, GLuint buffer, GLintptr offset, GLsizeiptr size);

--- a/Quake/mat_shader.c
+++ b/Quake/mat_shader.c
@@ -100,9 +100,7 @@ static const mat_shader_keyword_def_t mat_shader_keyword_table[] =
 	{ "sort", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL, MAT_SHADER_KEYWORD_STATUS_PARTIAL, "Keys: sky/opaque/seeThrough/decal/banner/underwater/additive/nearest or numeric." },
 	{ "polygonOffset", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Optional boolean or factor/units pair." },
 	{ "emissive", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Non-Q3 extension." },
-	{ "bloom", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Non-Q3 extension." },
 	{ "emissive_scale", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Non-Q3 extension." },
-	{ "bloom_scale", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Non-Q3 extension." },
 	{ "skyParms", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL, MAT_SHADER_KEYWORD_STATUS_PARTIAL, "Parses farbox/cloudheight/nearbox and marks sky surfaces." },
 	{ "fogParms", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL, MAT_SHADER_KEYWORD_STATUS_PARTIAL, "Parses fog color and distance into material metadata." },
 	{ "deformVertexes", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL, MAT_SHADER_KEYWORD_STATUS_PARTIAL, "Parses deform parameters; render-time deformation is still pending." },
@@ -120,9 +118,7 @@ static const mat_shader_keyword_def_t mat_shader_keyword_table[] =
 	{ "tcGen", MAT_SHADER_KEYWORD_SCOPE_STAGE, MAT_SHADER_KEYWORD_STATUS_PARTIAL, "Modes: base/environment/lightmap/vector." },
 	{ "tcMod", MAT_SHADER_KEYWORD_SCOPE_STAGE, MAT_SHADER_KEYWORD_STATUS_PARTIAL, "Types: scroll/scale/rotate/turb/stretch/transform." },
 	{ "emissive", MAT_SHADER_KEYWORD_SCOPE_STAGE, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Stage-level emissive toggle." },
-	{ "bloom", MAT_SHADER_KEYWORD_SCOPE_STAGE, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Stage-level bloom toggle." },
 	{ "emissiveScale", MAT_SHADER_KEYWORD_SCOPE_STAGE, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Stage-level emissive scale." },
-	{ "bloomScale", MAT_SHADER_KEYWORD_SCOPE_STAGE, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Stage-level bloom scale." },
 
 	{ "solid", MAT_SHADER_KEYWORD_SCOPE_SURFACEPARM, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Surface solid." },
 	{ "nonsolid", MAT_SHADER_KEYWORD_SCOPE_SURFACEPARM, MAT_SHADER_KEYWORD_STATUS_IMPLEMENTED, "Surface non-solid." },
@@ -1205,8 +1201,6 @@ unsigned int Mat_Shader_GetTextureFlags (const shader_material_t *material)
 		flags |= MAT_SHADERFLAG_STONE;
 	if (material->emissive_enable)
 		flags |= MAT_SHADERFLAG_EMISSIVE;
-	if (material->bloom_enable)
-		flags |= MAT_SHADERFLAG_BLOOM;
 
 	return flags;
 }
@@ -1292,7 +1286,6 @@ void Mat_Shader_Print (const shader_material_t *material)
 	else
 		Con_Printf ("  polygon offset: off\n");
 	Con_Printf ("  emissive: %s (scale %.2f)\n", material->emissive_enable ? "on" : "off", material->emissive_scale);
-	Con_Printf ("  bloom: %s (scale %.2f)\n", material->bloom_enable ? "on" : "off", material->bloom_scale);
 	if (material->has_skyparms)
 		Con_Printf ("  skyParms: far=%s cloudheight=%.2f near=%s\n",
 			material->skybox_far ? material->skybox_far : "-",

--- a/Quake/mat_shader.h
+++ b/Quake/mat_shader.h
@@ -209,8 +209,7 @@ typedef enum
 	MAT_SHADERFLAG_PLAYERCLIP	= (1u << 7),
 	MAT_SHADERFLAG_MONSTERCLIP	= (1u << 8),
 	MAT_SHADERFLAG_STONE		= (1u << 9),
-	MAT_SHADERFLAG_EMISSIVE		= (1u << 10),
-	MAT_SHADERFLAG_BLOOM		= (1u << 11)
+	MAT_SHADERFLAG_EMISSIVE		= (1u << 10)
 } mat_shader_flags_t;
 
 typedef struct mat_shader_stage_s
@@ -218,9 +217,7 @@ typedef struct mat_shader_stage_s
 	unsigned int		outputs;
 	unsigned int		output_overrides;
 	float			emissive_scale;
-	float			bloom_scale;
 	qboolean		emissive_scale_set;
-	qboolean		bloom_scale_set;
 	char		*map_path;
 	mat_rgbgen_t	rgbgen;
 	mat_alphagen_t	alphagen;
@@ -252,8 +249,7 @@ typedef struct mat_shader_stage_s
 typedef enum
 {
 	MAT_STAGE_OUT_COLOR		= (1u << 0),
-	MAT_STAGE_OUT_EMISSIVE		= (1u << 1),
-	MAT_STAGE_OUT_BLOOM		= (1u << 2)
+	MAT_STAGE_OUT_EMISSIVE		= (1u << 1)
 } mat_stage_output_flags_t;
 
 typedef struct shader_material_s
@@ -270,11 +266,9 @@ typedef struct shader_material_s
 	float			polygon_offset_factor;
 	float			polygon_offset_units;
 	qboolean		emissive_enable;
-	qboolean		bloom_enable;
 	qboolean		has_skyparms;
 	qboolean		has_fogparms;
 	float			emissive_scale;
-	float			bloom_scale;
 	vec3_t		fog_color;
 	float			fog_distance;
 	char			*skybox_far;
@@ -286,8 +280,8 @@ typedef struct shader_material_s
 } shader_material_t;
 
 // Developer note:
-// Supported directives: qer_editorimage, surfaceparm, emissive, bloom, emissive_scale,
-// bloom_scale, emissiveScale, bloomScale, and a single stage block
+// Supported directives: qer_editorimage, surfaceparm, emissive, emissive_scale,
+// emissiveScale, and a single stage block
 // with map + rgbGen identity.
 // To add new surfaceparms, extend mat_surfaceparm_table in mat_shader_parse.c and map to flags.
 

--- a/Quake/mat_shader_parse.c
+++ b/Quake/mat_shader_parse.c
@@ -1558,23 +1558,7 @@ static const char *ParseStageBlock (const char *data, shader_material_t *materia
 				stage.outputs &= ~MAT_STAGE_OUT_EMISSIVE;
 			continue;
 		}
-		if (!q_strcasecmp (com_token, "bloom"))
-		{
-			Mat_Shader_MarkKeywordSeen ("bloom", MAT_SHADER_KEYWORD_SCOPE_STAGE);
-			qboolean parsed = false;
-			qboolean value_bool = true;
 
-			parsed = ParseOptionalBool (&data, &value_bool, state);
-			if (!parsed)
-				value_bool = true;
-
-			stage.output_overrides |= MAT_STAGE_OUT_BLOOM;
-			if (value_bool)
-				stage.outputs |= MAT_STAGE_OUT_BLOOM;
-			else
-				stage.outputs &= ~MAT_STAGE_OUT_BLOOM;
-			continue;
-		}
 		if (!q_strcasecmp (com_token, "emissiveScale"))
 		{
 			Mat_Shader_MarkKeywordSeen ("emissiveScale", MAT_SHADER_KEYWORD_SCOPE_STAGE);
@@ -1592,23 +1576,7 @@ static const char *ParseStageBlock (const char *data, shader_material_t *materia
 			stage.emissive_scale_set = true;
 			continue;
 		}
-		if (!q_strcasecmp (com_token, "bloomScale"))
-		{
-			Mat_Shader_MarkKeywordSeen ("bloomScale", MAT_SHADER_KEYWORD_SCOPE_STAGE);
-			float validated_scale = 1.f;
-			float scale;
 
-			if (!ParseFloat (&data, &scale, state))
-			{
-				data = ResyncMaterialBlock (data, state);
-				break;
-			}
-
-			Mat_Shader_ValidateFiniteFloat (state, "bloomScale", scale, 1.f, &validated_scale);
-			stage.bloom_scale = CLAMP (0.f, validated_scale, MAT_SHADER_SCALE_MAX);
-			stage.bloom_scale_set = true;
-			continue;
-		}
 
 		Mat_Shader_ReportUnknownToken (com_token, MAT_SHADER_KEYWORD_SCOPE_STAGE, material->name,
 			state ? state->source_file : material->source_file,
@@ -1662,7 +1630,6 @@ static const char *ParseMaterialBlock (const char *data, const char *name, const
 	material.name = Mat_Shader_DupString (canonical);
 	material.source_file = Mat_Shader_DupString (source_file ? source_file : "");
 	material.emissive_scale = 1.f;
-	material.bloom_scale = 1.f;
 	material.cull_mode = MAT_CULL_BACK;
 	material.sort_key = MAT_SORT_OPAQUE;
 	material.polygon_offset = false;
@@ -1936,16 +1903,7 @@ static const char *ParseMaterialBlock (const char *data, const char *name, const
 			}
 			continue;
 		}
-		if (!q_strcasecmp (com_token, "bloom"))
-		{
-			Mat_Shader_MarkKeywordSeen ("bloom", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL);
-			if (!ParseRequiredBool (&data, &material.bloom_enable, state))
-			{
-				data = ResyncMaterialBlock (data, state);
-				break;
-			}
-			continue;
-		}
+
 		if (!q_strcasecmp (com_token, "emissive_scale"))
 		{
 			Mat_Shader_MarkKeywordSeen ("emissive_scale", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL);
@@ -1959,19 +1917,7 @@ static const char *ParseMaterialBlock (const char *data, const char *name, const
 			material.emissive_scale = CLAMP (0.f, validated_scale, MAT_SHADER_SCALE_MAX);
 			continue;
 		}
-		if (!q_strcasecmp (com_token, "bloom_scale"))
-		{
-			Mat_Shader_MarkKeywordSeen ("bloom_scale", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL);
-			float validated_scale = 1.f;
-			if (!ParseFloat (&data, &scale, state))
-			{
-				data = ResyncMaterialBlock (data, state);
-				break;
-			}
-			Mat_Shader_ValidateFiniteFloat (state, "bloom_scale", scale, 1.f, &validated_scale);
-			material.bloom_scale = CLAMP (0.f, validated_scale, MAT_SHADER_SCALE_MAX);
-			continue;
-		}
+
 		Mat_Shader_ReportUnknownToken (com_token, MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL, material.name,
 			state ? state->source_file : material.source_file,
 			state ? state->token_line : 0u);
@@ -1984,7 +1930,6 @@ static const char *ParseMaterialBlock (const char *data, const char *name, const
 	{
 		size_t stage_count = VEC_SIZE (material.stages);
 		qboolean has_emissive = false;
-		qboolean has_bloom = false;
 
 		for (size_t i = 0; i < stage_count; ++i)
 		{
@@ -1993,22 +1938,15 @@ static const char *ParseMaterialBlock (const char *data, const char *name, const
 			stage->outputs |= MAT_STAGE_OUT_COLOR;
 			if ((stage->output_overrides & MAT_STAGE_OUT_EMISSIVE) == 0u && material.emissive_enable)
 				stage->outputs |= MAT_STAGE_OUT_EMISSIVE;
-			if ((stage->output_overrides & MAT_STAGE_OUT_BLOOM) == 0u && material.bloom_enable)
-				stage->outputs |= MAT_STAGE_OUT_BLOOM;
 
 			if (!stage->emissive_scale_set)
 				stage->emissive_scale = material.emissive_scale;
-			if (!stage->bloom_scale_set)
-				stage->bloom_scale = material.bloom_scale;
 
 			if (stage->outputs & MAT_STAGE_OUT_EMISSIVE)
 				has_emissive = true;
-			if (stage->outputs & MAT_STAGE_OUT_BLOOM)
-				has_bloom = true;
 		}
 
 		material.emissive_enable = has_emissive;
-		material.bloom_enable = has_bloom;
 		material.stage0 = material.stages[0];
 	}
 
@@ -2147,7 +2085,6 @@ void Mat_Shader_DebugFuzzParse (void)
 		"fuzz_nonfinite\n"
 		"{\n"
 		" emissive_scale nan\n"
-		" bloom_scale inf\n"
 		" { map $whiteimage }\n"
 		"}\n";
 	const char *fuzz_duplicate =

--- a/Quake/renderer/r_world.c
+++ b/Quake/renderer/r_world.c
@@ -501,9 +501,6 @@ static void R_FlushBModelCalls (void)
 #define CALLFLAG_EMISSIVE        (1u << 3)
 #define CALLFLAG_ALPHA_TEST      (1u << 4)
 #define CALLFLAG_NOLIGHTMAP      (1u << 2)
-#define CALLFLAG_GODRAYS_LIGHT   (1u << 5) /* deprecated */
-#define CALLFLAG_GODRAYS_EMISSIVE (1u << 6) /* deprecated */
-#define CALLFLAG_MAT_BLOOM       (1u << 7)
 #define CALLFLAG_MAT_EMISSIVE    (1u << 8)
 #define CALLFLAG_MAT_TRANS       (1u << 10)
 #define CALLFLAG_MAT_SKY         (1u << 11)
@@ -515,25 +512,13 @@ static unsigned R_StageOutputCallFlags (const mat_shader_stage_t *stage)
 
 	if (!stage)
 		return flags;
-	if (stage->outputs & MAT_STAGE_OUT_BLOOM)
-		flags |= CALLFLAG_MAT_BLOOM;
 	if (stage->outputs & MAT_STAGE_OUT_EMISSIVE)
 		flags |= CALLFLAG_MAT_EMISSIVE;
 
 	return flags;
 }
 
-qboolean R_TextureEmitsGodrays (texture_t *t)
-{
-	(void)t;
-	return false;
-}
 
-qboolean R_SurfaceEmitsGodrays (msurface_t *s)
-{
-	(void)s;
-	return false;
-}
 
 
 /*

--- a/Quake/shaders/bloom_extract.frag
+++ b/Quake/shaders/bloom_extract.frag
@@ -32,19 +32,15 @@ void main()
                         {
                                 float rawMask = texelFetch(MaskTexture, ivec2(sampleCoord), 0).w;
                                 int maskBits = int(floor(rawMask + 0.5));
-                                bool bloomMask = (maskBits & 1) != 0;
                                 bool emissiveMask = (maskBits & 4) != 0;
-                                if (bloomMask)
-                                {
-                                        accum_bloom += sampleColor.rgb;
-                                        weight_bloom += 1.0;
-                                }
+                                accum_bloom += sampleColor.rgb;
+                                weight_bloom += 1.0;
                                 if (emissiveMask)
                                 {
                                         accum_emissive += sampleColor.rgb;
                                         weight_emissive += 1.0;
                                 }
-                                mask = (bloomMask || emissiveMask) ? 1.0 : 0.0;
+                                mask = 1.0;
                         }
                         accum += sampleColor.rgb * mask;
                         weight += mask;

--- a/Quake/shaders/water.frag
+++ b/Quake/shaders/water.frag
@@ -14,7 +14,6 @@ const uint
         CF_NOLIGHTMAP = 4u,
         CF_USE_EMISSIVE = 8u,
         CF_ALPHA_TEST = 16u,
-        CF_MAT_BLOOM = 128u,
         CF_MAT_EMISSIVE = 256u,
         CF_MAT_HAS_SHADER = 4096u
 ;
@@ -174,9 +173,8 @@ void main()
         vec2 velocityOut = vec2(0.0);
         if (result.a >= 0.999)
                 velocityOut = velocity * result.a;
-        float bloomMask = ((in_flags & CF_MAT_BLOOM) != 0u) ? 1.0 : 0.0;
         float emissiveMask = ((in_flags & CF_MAT_EMISSIVE) != 0u) ? 4.0 : 0.0;
-        float materialMask = 2.0 + bloomMask + emissiveMask;
+        float materialMask = 2.0 + emissiveMask;
         out_velocity = vec4(velocityOut, 0.0, materialMask);
 #endif
 #if DITHER

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -112,7 +112,6 @@ const uint
 	CF_NOLIGHTMAP = 4u,
 	CF_USE_EMISSIVE = 8u,
 	CF_ALPHA_TEST = 16u,
-	CF_MAT_BLOOM = 128u,
 	CF_MAT_EMISSIVE = 256u,
 	CF_MAT_TRANS = 1024u,
 	CF_MAT_SKY = 2048u,
@@ -746,9 +745,9 @@ void main()
 #if !OIT
 	vec2 velocity = ComputeVelocity(in_curr_clip, in_prev_clip);
 	vec2 velocityOut = (result.a >= 0.999) ? (velocity * result.a) : vec2(0.0);
-	float materialMask = ((in_flags & CF_MAT_BLOOM) != 0u) ? 1.0 : 0.0;
+	float materialMask = 0.0;
 	if ((in_flags & CF_MAT_EMISSIVE) != 0u)
-		materialMask += 4.0;
+		materialMask = 4.0;
 	if ((in_flags & CF_MAT_TRANS) != 0u)
 		materialMask += 2.0;
 	out_velocity = vec4(velocityOut, 0.0, materialMask);

--- a/docs/postfx_gating.md
+++ b/docs/postfx_gating.md
@@ -1,0 +1,31 @@
+# Fullscreen PostFX Gating Audit and Consolidation
+
+## Scope and decision rules
+
+Fullscreen post effects are now enabled only by renderer CVAR gates in `gl_rmain.c`.
+Material or shader metadata may still contribute **input energy** (for example emissive), but it no longer gates whether a fullscreen pass exists.
+
+### Fullscreen PostFX (CVAR-only gating)
+- Bloom (`r_bloom`, plus threshold/intensity controls)
+- Godrays / light shafts (`r_godrays`, debug/quality companions)
+- Tonemap / exposure / LUT stack (`r_tonemap*`, `r_autoexposure*`, `r_postfx_lut*`)
+- Screen-space post toggles already centralized (`r_ssao*`, motion blur, filmgrain, vignette, chromatic aberration)
+
+### Material/surface features (remain material-driven)
+- Emissive/glow maps and emissive stage output (as lighting/post input)
+- Surface rendering semantics (`surfaceparm`, blend/depth/cull, alpha test, etc.)
+
+## Fullscreen-PostFX gates found and removed
+
+| Effect | Gate type | Previous behavior | Status |
+|---|---|---|---|
+| Bloom | Mat shader keyword (`bloom` top-level + stage) | Could tag material stages with bloom mask bits, which altered bloom extract selection via velocity mask | Removed |
+| Bloom | Mat shader scalar keywords (`bloom_scale`, `bloomScale`) | Per-material/stage bloom scaling metadata flowed into stage bookkeeping | Removed |
+| Bloom | Shader per-drawcall define/flag (`CF_MAT_BLOOM`) | World/water wrote bloom bit into velocity alpha mask; bloom extract sampled this bit | Removed |
+| Godrays | Deprecated call flags / helper API | Historical texture/surface godray emit toggles retained as dead stubs | Removed |
+
+## Breaking change
+
+`bloom`/`bloom_scale`/`bloomScale` material keywords no longer control fullscreen bloom participation.
+Bloom pass execution is controlled by `r_bloom` only, while emissive inputs still contribute energy when present.
+


### PR DESCRIPTION
### Motivation
- Fullscreen post-processing (bloom, godrays, tonemap/LUT, etc.) must be controlled centrally by CVARs instead of per-material shader keywords/flags to avoid fragmented gating paths and inconsistencies.
- Remove legacy/duplicate gating code paths while retaining per-material emissive as an input to the global postFX pipeline.

### Description
- Remove material-level bloom gating and bookkeeping by deleting/stripping `bloom`, `bloom_scale`/`bloomScale` parsing and related fields and prints in `mat_shader.h`, `mat_shader.c`, and `mat_shader_parse.c`.
- Remove the per-drawcall / velocity-mask bloom bit and associated call/flag usage and update world/water shader packing so velocity mask no longer carries a bloom gate (`CF_MAT_BLOOM` / `CALLFLAG_MAT_BLOOM` removed); emissive masking remains.
- Update bloom extraction shader (`shaders/bloom_extract.frag`) to stop sampling a bloom-bit gate and instead use global extraction with emissive contribution still supported.
- Remove small godrays/gating dead stubs and aliases (`R_TextureEmitsGodrays`, `R_SurfaceEmitsGodrays`, `TEX_GODRAY_EMIT`) and tidy related headers; add `docs/postfx_gating.md` documenting the audit, classification, removed gates and breaking changes.

### Testing
- Ran targeted repository searches (`rg`) for bloom/godrays/gating symbols to verify legacy gating tokens were removed from active code paths; the searches returned expected removals (success).
- Executed `git diff --check` / whitespace sanity to ensure no trivial diff errors (success).
- Attempted to configure a full build with `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`, but configuration failed due to missing SDL2 development package in the environment, so a full compile/test could not be completed (blocked by missing dependency).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994eb3d85b0832e9437905f8280d0d8)