### PR TITLE
Fallback hybrid world_dlight shader to existing world_dlight program

### DIFF
--- a/Quake/opengl/gl_shaders.c
+++ b/Quake/opengl/gl_shaders.c
@@ -636,7 +636,7 @@ void GL_CreateShaders (void)
         for (alphatest = 0; alphatest < 2; alphatest++)
                 glprogs.world_dlight[alphatest] = GL_CreateProgram (GLSL_PATH("world_dlight.vert"), GLSL_PATH("world_dlight.frag"), "world dlight|ALPHATEST %d", alphatest);
         for (alphatest = 0; alphatest < 2; alphatest++)
-                glprogs.world_dlight_hybrid[alphatest] = GL_CreateProgram (GLSL_PATH("world_dlight.vert"), GLSL_PATH("world_dlight_hybrid.frag"), "world dlight hybrid|ALPHATEST %d", alphatest);
+                glprogs.world_dlight_hybrid[alphatest] = glprogs.world_dlight[alphatest];
 
         glprogs.shadow_depth = GL_CreateProgram (GLSL_PATH("shadow_depth.vert"), GLSL_PATH("shadow_depth.frag"), "shadow depth");
 	for (md5 = 0; md5 < 2; md5++)


### PR DESCRIPTION
### Motivation
- Prevent startup OpenGL initialization failure when `shaders/world_dlight_hybrid.frag` is missing by reusing the existing `world_dlight` program for the hybrid variant.

### Description
- Replace creation of `glprogs.world_dlight_hybrid[alphatest]` with an alias to `glprogs.world_dlight[alphatest]` in `Quake/opengl/gl_shaders.c` so the hybrid program no longer attempts to load `world_dlight_hybrid.frag`.

### Testing
- Ran `rg -n "world_dlight_hybrid\.frag" Quake` after the change and observed no matches, indicating the runtime dependency is removed (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994edce36b8832ea05d2c8fb5ae61d7)