### PR TITLE
Avoid vertex-stage derivatives in shadow_depth.vert to fix shader compilation

### DIFF
--- a/Quake/shaders/shadow_depth.vert
+++ b/Quake/shaders/shadow_depth.vert
@@ -78,13 +78,10 @@ void main()
 #endif
 	if ((call.flags & CF_USE_POLYGON_OFFSET) != 0u)
 	{
-		// FIX: polygon_offset.x = factor (slope-dependent), polygon_offset.y = units (constant).
-		// Approximate slope factor from clip-space z/w gradient magnitude.
-		// This avoids adding factor+units directly which caused incorrect offsets
-		// on sloped geometry (shadow acne / peter panning).
-		vec2 dz_dxy = vec2(dFdx(clip.z / clip.w), dFdy(clip.z / clip.w));
-		float slope = clamp(length(dz_dxy), 0.0, 1.0);
-		float zoffset = (call.polygon_offset.x * slope + call.polygon_offset.y) * ZBIAS;
+		// NOTE: derivatives are not available in the vertex stage on all drivers,
+		// so applying a slope-dependent term here can fail shader compilation.
+		// Keep the constant units term to preserve a stable depth bias path.
+		float zoffset = call.polygon_offset.y * ZBIAS;
 		clip.z += zoffset * clip.w;
 	}
 	gl_Position = clip;


### PR DESCRIPTION
### Motivation
- Some GL drivers reject derivatives in vertex shaders, producing compilation errors like `unable to find compatible overloaded function "dFdx(float)"`/`dFdy(float)` and causing OpenGL initialization to fail, so the shadow depth path needs a compatibility-safe approach.

### Description
- Replace the slope-dependent polygon offset (which used `dFdx`/`dFdy`) with a constant units-only depth bias `call.polygon_offset.y * ZBIAS` in `Quake/shaders/shadow_depth.vert` and add a comment explaining the compatibility rationale.

### Testing
- Verified the shader no longer contains `dFdx`/`dFdy` with `rg -n "dFdx|dFdy" Quake/shaders/shadow_depth.vert` (no matches), reviewed the `git diff` of `Quake/shaders/shadow_depth.vert`, and committed the change successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994f0e34588832e9fa07f161c2bd307)