### PR TITLE
Fix FBO attachment query call for MSVC build

### DIFF
--- a/Quake/opengl/gl_rmain.c
+++ b/Quake/opengl/gl_rmain.c
@@ -300,8 +300,8 @@ static void R_LogWorldDlightState (const char *marker)
 		for (i = 0; i < 4; ++i)
 		{
 			GLenum attach = GL_COLOR_ATTACHMENT0 + i;
-			glGetFramebufferAttachmentParameteriv (GL_DRAW_FRAMEBUFFER, attach, GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME, &attachment[i]);
-			glGetFramebufferAttachmentParameteriv (GL_DRAW_FRAMEBUFFER, attach, GL_FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE, &attachment_type[i]);
+			GL_GetFramebufferAttachmentParameterivFunc (GL_DRAW_FRAMEBUFFER, attach, GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME, &attachment[i]);
+			GL_GetFramebufferAttachmentParameterivFunc (GL_DRAW_FRAMEBUFFER, attach, GL_FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE, &attachment_type[i]);
 		}
 	}
 


### PR DESCRIPTION
### Motivation
- MSVC treats implicit GL function declarations as errors (warning C4013 promoted to error C2220), which occurred when `glGetFramebufferAttachmentParameteriv` was referenced directly, so the engine should use its loaded GL entrypoint wrapper instead.

### Description
- Replaced direct `glGetFramebufferAttachmentParameteriv` calls with `GL_GetFramebufferAttachmentParameterivFunc` in `R_LogWorldDlightState` (`Quake/opengl/gl_rmain.c`) to use the project's QGL function pointer wrapper.

### Testing
- No automated build or test run was executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994ff714c44832eb090fc403149f078)