### PR TITLE
Gate WORLD_DLIGHT STATEDBG logging behind debug cvars

### DIFF
--- a/Quake/opengl/gl_rmain.c
+++ b/Quake/opengl/gl_rmain.c
@@ -280,6 +280,11 @@ static void R_LogWorldDlightState (const char *marker)
 	qboolean blend = false;
 	GLint blend_src_rgb = 0, blend_dst_rgb = 0;
 
+	if (r_state_debug.value <= 0.f)
+		return;
+	if (!GL_StateDebugMatchesFilter (marker))
+		return;
+
 	glGetIntegerv (GL_DRAW_FRAMEBUFFER_BINDING, &draw_fbo);
 	glGetIntegerv (GL_DRAW_BUFFER0, &draw_buf[0]);
 	glGetIntegerv (GL_DRAW_BUFFER1, &draw_buf[1]);


### PR DESCRIPTION
### Motivation
- Prevent unconditional `STATEDBG` console spam from the world dynamic light logging path and make WORLD_DLIGHT diagnostics opt-in and filterable like other render-state debug output.

### Description
- Add early returns to `R_LogWorldDlightState` so it only runs when `r_state_debug.value > 0` and `GL_StateDebugMatchesFilter(marker)` matches, in `Quake/opengl/gl_rmain.c`.

### Testing
- Ran `git diff --check`, which completed without issues; no additional automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995011c3abc832eb4e28e8790ed05db)