### PR TITLE
Simplify world dlights to single clustered render path

### DIFF
--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -539,8 +539,6 @@ GLuint R_Shadow_GetDlightShadowMapTextureId (void);
 
 void R_DrawBrushModels (entity_t **ents, int count);
 void R_DrawBrushModels_Water (entity_t **ents, int count, qboolean translucent);
-void R_DrawBrushModels_DLights (entity_t **ents, int count);
-void R_GetBrushDlightPassDebugStats (int *out_drawcalls, int *out_instances, int *out_batches);
 void R_DrawBrushModels_SkyLayers (entity_t **ents, int count);
 void R_DrawBrushModels_SkyCubemap (entity_t **ents, int count);
 void R_DrawBrushModels_SkyStencil (entity_t **ents, int count);
@@ -656,8 +654,6 @@ typedef struct glprogs_s {
 
 	/* 3d */
 	GLuint		world[2][3][3];		// [OIT][standard/dithered/banded][solid/alpha test/water]
-	GLuint		world_dlight[2];		// [alpha test]
-	GLuint		world_dlight_hybrid[2];		// [alpha test]
 	GLuint		water[2][2];		// [OIT][dither]
 	GLuint		shadow_depth;
 	GLuint		shadow_depth_alias[2]; // [md5]
@@ -671,7 +667,6 @@ typedef struct glprogs_s {
 	GLuint		decals[2];			// [dither]
 	GLuint		particles[2][2];	// [OIT][dither]
 	GLuint		debug3d;
-	GLuint		dlight_composite;
 
 	/* compute */
 	GLuint		clear_indirect;
@@ -743,11 +738,6 @@ typedef struct glframebufs_s {
 		int			width;
 		int			height;
 	}				bloom;
-
-	struct {
-		GLuint		tex;
-		GLuint		fbo;
-	}				dlight;
 
 	struct {
 		GLuint		mask_tex;

--- a/Quake/opengl/gl_rmain.c
+++ b/Quake/opengl/gl_rmain.c
@@ -67,14 +67,6 @@ static vec3_t r_prev_vieworg = { 0.f, 0.f, 0.f };
 static double r_prev_frame_time = 0.0;
 static qboolean r_prev_frame_valid = false;
 static qboolean r_frame_rendered_this_update;
-static qboolean r_dlight_buffered_frame = false;
-
-extern cvar_t r_clustered_lighting;
-
-static qboolean R_DlightsAdditivePassEnabled (void)
-{
-	return (r_clustered_lighting.value <= 0.f);
-}
 
 static void R_DlightLogf (const char *pass, const char *fmt, ...)
 {
@@ -1264,18 +1256,6 @@ void GL_CreateFrameBuffers (void)
 		);
 	}
 
-	framebufs.dlight.tex = 0;
-	framebufs.dlight.fbo = 0;
-	if (framebufs.scene.samples == 1)
-	{
-		framebufs.dlight.tex = GL_CreateFBOAttachment (GL_RGBA16F, 1, GL_LINEAR, "dlight buffer");
-		framebufs.dlight.fbo = GL_CreateSimpleFBO (GL_TEXTURE_2D, framebufs.dlight.tex,
-			framebufs.scene.depth_stencil_tex,
-			framebufs.scene.depth_stencil_tex,
-			"dlight fbo"
-		);
-	}
-
 	/* weighted blended order-independent transparency (accum + revealage, potentially multisampled */
 	framebufs.oit.accum_tex = GL_CreateFBOAttachment (GL_RGBA16F, framebufs.scene.samples, GL_NEAREST, "oit accum");
 	framebufs.oit.revealage_tex = GL_CreateFBOAttachment (GL_R8, framebufs.scene.samples, GL_NEAREST, "oit revealage");
@@ -1332,7 +1312,6 @@ void GL_DeleteFrameBuffers (void)
 	GL_DeleteFramebuffersFunc (1, &framebufs.oit.fbo_composite);
 	GL_DeleteFramebuffersFunc (1, &framebufs.oit.fbo_scene);
 	GL_DeleteFramebuffersFunc (1, &framebufs.scene.fbo);
-	GL_DeleteFramebuffersFunc (1, &framebufs.dlight.fbo);
 	GL_DeleteFramebuffersFunc (1, &framebufs.composite.fbo);
 	GL_DeleteFramebuffersFunc (1, &framebufs.autoexposure.fbo);
 	GL_DeleteFramebuffersFunc (1, &framebufs.bloom.extract_fbo);
@@ -1364,7 +1343,6 @@ void GL_DeleteFrameBuffers (void)
 	GL_DeleteNativeTexture (framebufs.scene.depth_stencil_tex);
 	GL_DeleteNativeTexture (framebufs.scene.color_tex);
 	GL_DeleteNativeTexture (framebufs.scene.velocity_tex);
-	GL_DeleteNativeTexture (framebufs.dlight.tex);
 	GL_DeleteNativeTexture (framebufs.autoexposure.tex);
 	GL_DeleteNativeTexture (framebufs.bloom.pingpong_tex[0]);
 	GL_DeleteNativeTexture (framebufs.bloom.pingpong_tex[1]);
@@ -1590,30 +1568,6 @@ static void GL_LogSSAODepthInfo (GLuint depth_tex, GLuint ao_tex, int ssao_width
 		view_min_x, view_min_y, view_max_x, view_max_y,
 		ssao_width, ssao_height, debug_mode);
 	GL_LogErrorIfDeveloper ("GL_LogSSAODepthInfo");
-}
-
-static void R_CompositeDlightBuffer (void)
-{
-	if (!r_dlight_buffered_frame)
-		return;
-	if (!framebufs.dlight.tex || !glprogs.dlight_composite)
-		return;
-
-	float scale = (r_dlight_debug_visualize.value > 0.f) ? 1.f : q_max (0.f, r_dlight_scale.value);
-	if (scale <= 0.f)
-		return;
-
-	GL_BeginGroup ("Dlight composite");
-	GL_UseProgram (glprogs.dlight_composite);
-	if (r_dlight_debug_visualize.value > 0.f)
-		GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
-	else
-		GL_SetState (GLS_BLEND_ADD | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
-	GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, framebufs.dlight.tex);
-	GL_Uniform1fFunc (0, scale);
-	glDrawArrays (GL_TRIANGLES, 0, 3);
-	r_dlight_buffered_frame = false;
-	GL_EndGroup ();
 }
 
 static float R_SanitizeSSAOValue (float value, float fallback, float minval, float maxval)
@@ -3853,9 +3807,6 @@ qboolean GL_NeedsSceneEffects (void)
         if (framebufs.scene.samples > 1 || water_warp || r_refdef.scale != 1)
 		return true;
 
-	if (R_DlightsAdditivePassEnabled () && framebufs.dlight.fbo && r_framedata.numlights > 0)
-		return true;
-
         if (GL_ShouldApplyMotionBlur ())
 		return true;
 
@@ -4066,7 +4017,6 @@ R_SetupView -- johnfitz -- this is the stuff that needs to be done once per fram
 */
 void R_SetupView (void)
 {
-	r_dlight_buffered_frame = false;
 	framesetup.composite_ready = false;
 
 	R_AnimateLight ();
@@ -4101,7 +4051,7 @@ void R_SetupView (void)
         r_framedata.lightmap_params[2] = (r_lightingdir.value > 0.f && lightmap_dir_texture) ? 1.f : 0.f;
         r_framedata.lightmap_params[3] = r_lightstyle_framefrac;
 	R_EnvLight_BuildFrameUniforms (r_framedata.lighting_params, r_framedata.lightgrid_params);
-	r_framedata.dlight_params[0] = R_DlightsAdditivePassEnabled () ? 1.f : 0.f;
+	r_framedata.dlight_params[0] = 0.f;
 	r_framedata.dlight_params[1] = 0.f;
 	r_framedata.dlight_params[2] = 0.f;
 	r_framedata.dlight_params[3] = 1.f;
@@ -5238,98 +5188,6 @@ static void R_EndTranslucency (void)
         GL_EndGroup (); // translucent objects
 }
 
-// Quake3-style dynamic light pass rationale: render only additive dlight
-// contributions (albedo * dlight) in a separate pass to preserve contrast of
-// the baked lighting while avoiding gamma artifacts from modulating the base
-// color. Static lighting remains untouched in the base pass.
-static void R_SetDlightConfig (GLuint program, float scale)
-{
-	if (!program)
-		return;
-
-	GL_UseProgram (program);
-	GL_Uniform4fFunc (0, scale, r_dlight_radius_scale.value, 1.f, 2.f);
-	GL_Uniform4fFunc (1, 0.f, 1.f, 0.f, 0.f);
-	GL_Uniform4fFunc (2, 0.f, 0.f, 0.f, 0.f);
-}
-
-static void R_DrawDLightPass (void)
-{
-        int count = 0;
-        entity_t **ents;
-	qboolean use_buffer = false;
-
-	r_dlight_buffered_frame = false;
-
-	if (!R_DlightsAdditivePassEnabled ())
-		return;
-
-        if (r_framedata.numlights == 0 || !r_drawworld_cheatsafe)
-                return;
-
-        ents = R_GetVisEntities (mod_brush, false, &count);
-        if (count <= 0)
-                return;
-
-        GL_BeginGroup ("Dynamic lights (additive)");
-
-	if (framebufs.dlight.fbo && framebufs.scene.samples == 1)
-	{
-		use_buffer = true;
-		r_dlight_buffered_frame = true;
-		GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.dlight.fbo);
-		glDrawBuffer (GL_COLOR_ATTACHMENT0);
-		glReadBuffer (GL_COLOR_ATTACHMENT0);
-		{
-			static const float zeroes[4] = { 0.f, 0.f, 0.f, 0.f };
-			GL_ClearBufferfvFunc (GL_COLOR, 0, zeroes);
-		}
-	}
-
-
-        r_framedata.dlight_params[2] = 1.f;
-        {
-                GLuint buf;
-                GLbyte *ofs;
-                GL_Upload (GL_UNIFORM_BUFFER, &r_framedata, sizeof (r_framedata), &buf, &ofs);
-                GL_BindBufferRange (GL_UNIFORM_BUFFER, FRAME_UBO_BINDING, buf, (GLintptr)ofs, sizeof (r_framedata));
-        }
-
-		{
-		float scale = use_buffer ? 1.f : q_max (0.f, r_dlight_scale.value);
-		R_SetDlightConfig (glprogs.world_dlight[0], scale);
-		R_SetDlightConfig (glprogs.world_dlight[1], scale);
-	}
-
-	GL_SetState (GLS_BLEND_ADD | GLS_NO_ZWRITE | GLS_CULL_BACK | GLS_ATTRIBS (6));
-        R_DrawBrushModels_DLights (ents, count);
-
-        r_framedata.dlight_params[2] = 0.f;
-        {
-                GLuint buf;
-                GLbyte *ofs;
-                GL_Upload (GL_UNIFORM_BUFFER, &r_framedata, sizeof (r_framedata), &buf, &ofs);
-                GL_BindBufferRange (GL_UNIFORM_BUFFER, FRAME_UBO_BINDING, buf, (GLintptr)ofs, sizeof (r_framedata));
-        }
-
-	if (use_buffer)
-	{
-		GL_BindFramebufferFunc (GL_FRAMEBUFFER, framesetup.scene_fbo);
-		if (framesetup.scene_fbo)
-		{
-			glDrawBuffer (GL_COLOR_ATTACHMENT0);
-			glReadBuffer (GL_COLOR_ATTACHMENT0);
-		}
-		else
-		{
-			glDrawBuffer (GL_BACK);
-			glReadBuffer (GL_BACK);
-		}
-	}
-
-        GL_EndGroup ();
-}
-
 /*
 ================
 R_RenderScene
@@ -5357,8 +5215,6 @@ void R_RenderScene (void)
 	R_DrawEntitiesOnList (false); //johnfitz -- false means this is the pass for nonalpha entities
 	R_StateDebugMark ("WORLD_DLIGHT_BEGIN");
 	R_LogWorldDlightState ("WORLD_DLIGHT_BEGIN");
-	R_DrawDLightPass ();
-	R_CompositeDlightBuffer ();
 	R_LogWorldDlightState ("WORLD_DLIGHT_END");
 	R_StateDebugMark ("WORLD_DLIGHT_END");
 	R_DrawDecals (false);
@@ -5491,7 +5347,6 @@ void R_WarpScaleView (void)
 	{
 		if (fbodest == framebufs.composite.fbo)
 			framesetup.composite_ready = true;
-		R_CompositeDlightBuffer ();
 		return;
 	}
 
@@ -5517,7 +5372,6 @@ void R_WarpScaleView (void)
 
 	if (fbodest == framebufs.composite.fbo)
 		framesetup.composite_ready = true;
-	R_CompositeDlightBuffer ();
 }
 
 /*

--- a/Quake/opengl/gl_shaders.c
+++ b/Quake/opengl/gl_shaders.c
@@ -633,15 +633,9 @@ void GL_CreateShaders (void)
                         for (mode = 0; mode < 3; mode++)
                                 glprogs.world[oit][dither][mode] = GL_CreateProgram (GLSL_PATH("world.vert"), GLSL_PATH("world.frag"), "world|OIT %d; DITHER %d; MODE %d", oit, dither, mode);
 
-        for (alphatest = 0; alphatest < 2; alphatest++)
-                glprogs.world_dlight[alphatest] = GL_CreateProgram (GLSL_PATH("world_dlight.vert"), GLSL_PATH("world_dlight.frag"), "world dlight|ALPHATEST %d", alphatest);
-        for (alphatest = 0; alphatest < 2; alphatest++)
-                glprogs.world_dlight_hybrid[alphatest] = glprogs.world_dlight[alphatest];
-
         glprogs.shadow_depth = GL_CreateProgram (GLSL_PATH("shadow_depth.vert"), GLSL_PATH("shadow_depth.frag"), "shadow depth");
 	for (md5 = 0; md5 < 2; md5++)
 		glprogs.shadow_depth_alias[md5] = GL_CreateProgram (GLSL_PATH("shadow_depth_alias.vert"), GLSL_PATH("shadow_depth.frag"), "shadow depth alias|MD5 %d", md5);
-	glprogs.dlight_composite = GL_CreateProgram (GLSL_PATH("postprocess.vert"), GLSL_PATH("dlight_composite.frag"), "dlight composite");
 
 	for (dither = 0; dither < 2; dither++)
 	{

--- a/Quake/renderer/r_world.c
+++ b/Quake/renderer/r_world.c
@@ -317,9 +317,6 @@ static union {
 } bmodel_calls;
 static bmodel_gpu_call_remap_t		bmodel_call_remap[MAX_BMODEL_DRAWS];
 static int							num_bmodel_calls;
-static int							r_brush_dlight_debug_drawcalls;
-static int							r_brush_dlight_debug_instances;
-static int							r_brush_dlight_debug_batches;
 static GLuint						bmodel_batch_program;
 static int							shadow_brush_entities_input;
 static int							shadow_brush_entities_instanced;
@@ -447,9 +444,6 @@ static void R_FlushBModelCalls (void)
 
 	if (!num_bmodel_calls)
 		return;
-
-	if (bmodel_batch_program == glprogs.world_dlight[0] || bmodel_batch_program == glprogs.world_dlight[1])
-		r_brush_dlight_debug_drawcalls += num_bmodel_calls;
 
 	GL_ReserveDeviceMemory (GL_DRAW_INDIRECT_BUFFER, sizeof (bmodel_draw_indirect_t) * num_bmodel_calls, &cmdbuf, &dstcmdofs);
 
@@ -971,8 +965,6 @@ typedef enum {
         BP_SKYCUBEMAP,
         BP_SKYSTENCIL,
         BP_SHOWTRIS,
-        BP_DLIGHT_SOLID,
-        BP_DLIGHT_ALPHA,
 } brushpass_t;
 
 static void R_DrawBrushModels_MaterialStages (entity_t **ents, int count, brushpass_t pass, qboolean translucent, mat_sort_key_t sort_key)
@@ -1256,16 +1248,6 @@ static void R_DrawBrushModels_Real (entity_t **ents, int count, brushpass_t pass
                 texend = TEXTYPE_COUNT;
                 program = glprogs.world[0][0][0];
                 break;
-        case BP_DLIGHT_SOLID:
-                texbegin = 0;
-                texend = TEXTYPE_CUTOUT;
-                program = glprogs.world_dlight[0];
-                break;
-        case BP_DLIGHT_ALPHA:
-                texbegin = TEXTYPE_CUTOUT;
-                texend = TEXTYPE_CUTOUT + 1;
-                program = glprogs.world_dlight[1];
-                break;
         }
 
 	for (i = 0, totalinst = 0; i < count; i++)
@@ -1283,16 +1265,8 @@ static void R_DrawBrushModels_Real (entity_t **ents, int count, brushpass_t pass
 	if (pass == BP_SHADOW)
 		shadow_brush_entities_instanced += totalinst;
 
-	if (pass == BP_DLIGHT_SOLID || pass == BP_DLIGHT_ALPHA)
-	{
-		r_brush_dlight_debug_batches++;
-		r_brush_dlight_debug_instances += totalinst;
-	}
-
         state = GLS_CULL_BACK | GLS_ATTRIBS(6);
-        if (pass == BP_DLIGHT_SOLID || pass == BP_DLIGHT_ALPHA)
-                state |= GLS_BLEND_ADD | GLS_NO_ZWRITE;
-        else if (pass == BP_SHADOW)
+        if (pass == BP_SHADOW)
         {
                 state &= ~GLS_MASK_CULL;
                 state |= GLS_BLEND_OPAQUE | GLS_CULL_BACK;
@@ -1314,10 +1288,6 @@ R_Shadow_BindUBO ("WORLD", program, FRAME_DATA_UBO_NAME, FRAME_UBO_BINDING);
 R_Shadow_LogReceiverUniformUpload ("WORLD", program);
 R_Shadow_BindShadowMap (GL_TEXTURE5);
 R_Shadow_Log_ReceiverPassSnapshot ("WORLD", program, GL_TEXTURE5, R_Shadow_GetShadowMapTextureId (), r_shadows.value > 0.f && r_shadow_sun.value > 0.f, r_shadow_bias.value, r_shadow_normalbias.value, r_shadow_pcf.value > 0.f ? 1.f : 0.f, r_shadow_pcf_taps.value, r_framedata.shadow_viewproj);
-}
-else if (pass == BP_DLIGHT_SOLID || pass == BP_DLIGHT_ALPHA)
-{
-R_Shadow_BindDlightShadowMap (GL_TEXTURE5);
 }
 else if (pass == BP_SKYCUBEMAP)
 GL_Bind (GL_TEXTURE2, skybox->cubemap);
@@ -1671,29 +1641,6 @@ void R_DrawBrushModels (entity_t **ents, int count)
 			i = j;
 		}
 	}
-}
-
-void R_DrawBrushModels_DLights (entity_t **ents, int count)
-{
-	r_brush_dlight_debug_drawcalls = 0;
-	r_brush_dlight_debug_instances = 0;
-	r_brush_dlight_debug_batches = 0;
-
-        if (!count)
-                return;
-
-        R_DrawBrushModels_Real (ents, count, BP_DLIGHT_SOLID, false);
-        R_DrawBrushModels_Real (ents, count, BP_DLIGHT_ALPHA, false);
-}
-
-void R_GetBrushDlightPassDebugStats (int *out_drawcalls, int *out_instances, int *out_batches)
-{
-	if (out_drawcalls)
-		*out_drawcalls = r_brush_dlight_debug_drawcalls;
-	if (out_instances)
-		*out_instances = r_brush_dlight_debug_instances;
-	if (out_batches)
-		*out_batches = r_brush_dlight_debug_batches;
 }
 
 /*

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -399,7 +399,6 @@ void main()
                 return;
         }
 
-        bool additive_dlights = DLightParams.x > 0.5;
         bool dlight_debug = DLightParams.y > 0.5;
 
 	// Lightmap sampling
@@ -545,7 +544,7 @@ void main()
 	float specular_scale = 0.4 * specular_quality;
 
         // Dynamic lights (clustered lighting)
-        if (!additive_dlights && NumLights > 0u && ClusterTileSize > 0)
+        if (NumLights > 0u && ClusterTileSize > 0)
         {
                 int tileX = clamp(int(gl_FragCoord.x) / ClusterTileSize, 0, ClusterGridXY.x - 1);
                 int tileY = clamp(int(gl_FragCoord.y) / ClusterTileSize, 0, ClusterGridXY.y - 1);


### PR DESCRIPTION
### Motivation
- Remove the legacy separate additive dynamic-light pass and consolidate world dynamic lights into the clustered-in-base-pass path for simpler, modern rendering.

### Description
- Remove legacy additive dlight logic from `Quake/opengl/gl_rmain.c`, deleting `R_DlightsAdditivePassEnabled`, `R_DrawDLightPass`, `R_CompositeDlightBuffer` and associated composite/draw invocations and state handling, and set `r_framedata.dlight_params[0]` to a constant `0.f` to indicate clustered-in-base usage.
- Elide the dedicated dlight framebuffer allocation/teardown and the `framebufs.dlight` fields and their use in `gl_rmain.c`/`glquake.h` to remove unused buffer lifecycle code.
- Remove legacy world dlight shader program slots and creation (`glprogs.world_dlight*`, `glprogs.world_dlight_hybrid`, `glprogs.dlight_composite`) from `Quake/opengl/gl_shaders.c` and the corresponding program members in `Quake/glquake.h`.
- Remove additive brush-pass plumbing and debug counters from `Quake/renderer/r_world.c`, including `BP_DLIGHT_*` cases, `R_DrawBrushModels_DLights`, and `R_GetBrushDlightPassDebugStats`, and strip related shadow binding code paths so brush rendering only uses the clustered/world programs.
- Simplify the fragment shader `Quake/shaders/world.frag` by removing the additive-path branch and using the clustered path unconditionally when `NumLights` and `ClusterTileSize` indicate clustering data is available.
- Update code paths that previously considered the dlight composite when deciding whether scene effects/postprocess were needed so they no longer depend on the removed additive composite.

### Testing
- Built the tree with `make -C Quake -j4` in this environment; build failed due to missing system SDL2 development tooling (`sdl2-config` / `SDL.h`) so a full compile/test could not be completed here (environment limitation). (failure)
- Performed repository-wide searches to confirm removal of legacy symbols and references; searches show no remaining references to `R_DlightsAdditivePassEnabled`, `R_DrawDLightPass`, `R_CompositeDlightBuffer`, `R_DrawBrushModels_DLights`, `R_GetBrushDlightPassDebugStats`, `glprogs.world_dlight*`, `glprogs.dlight_composite` or `framebufs.dlight`. (success)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995089143ec832e95d815b4f491caf8)