### PR TITLE
Optimize clustered dlight path for low-light scenes

### DIFF
--- a/Quake/opengl/gl_rlight.c
+++ b/Quake/opengl/gl_rlight.c
@@ -1144,7 +1144,6 @@ void R_Clustered_BuildLists (void)
 	params.debug_mode = (int)r_clustered_debug.value;
 
 	GL_BindBufferFunc (GL_SHADER_STORAGE_BUFFER, r_clustered.lights_ssbo);
-	GL_BufferDataFunc (GL_SHADER_STORAGE_BUFFER, (GLsizeiptr)(sizeof (clustered_light_t) * (size_t)r_clustered.max_lights), NULL, GL_STREAM_DRAW);
 	GL_BufferSubDataFunc (GL_SHADER_STORAGE_BUFFER, 0,
 		(GLsizeiptr)(sizeof (clustered_light_t) * (size_t)r_framedata.numlights), lights_local);
 	if (!clear_lists)
@@ -1152,17 +1151,11 @@ void R_Clustered_BuildLists (void)
 		R_ClusterPerf_MarkReason ("r_clustered_clearlists=0 (cluster clear/prefix clear disabled)");
 	}
 	GL_BindBufferFunc (GL_SHADER_STORAGE_BUFFER, r_clustered.headers_ssbo);
-	if (clear_lists)
-		GL_BufferDataFunc (GL_SHADER_STORAGE_BUFFER, (GLsizeiptr)(sizeof (*r_clustered_headers_cpu) * (size_t)r_clustered.cluster_count), NULL, GL_STREAM_DRAW);
 	GL_BindBufferFunc (GL_SHADER_STORAGE_BUFFER, r_clustered.temp_counts_ssbo);
-	if (clear_lists)
-		GL_BufferDataFunc (GL_SHADER_STORAGE_BUFFER, (GLsizeiptr)(sizeof (GLuint) * (size_t)r_clustered.cluster_count), NULL, GL_STREAM_DRAW);
 	counters[0] = (GLuint)r_clustered.max_indices;
 	GL_BindBufferFunc (GL_SHADER_STORAGE_BUFFER, r_clustered.counters_ssbo);
-	GL_BufferDataFunc (GL_SHADER_STORAGE_BUFFER, sizeof (counters), NULL, GL_STREAM_DRAW);
 	GL_BufferSubDataFunc (GL_SHADER_STORAGE_BUFFER, 0, sizeof (counters), counters);
 	GL_BindBufferFunc (GL_UNIFORM_BUFFER, r_clustered.params_ubo);
-	GL_BufferDataFunc (GL_UNIFORM_BUFFER, sizeof (params), NULL, GL_STREAM_DRAW);
 	GL_BufferSubDataFunc (GL_UNIFORM_BUFFER, 0, sizeof (params), &params);
 	R_ClusteredDebugDumpUpload (lights_local, r_framedata.numlights);
 
@@ -1207,16 +1200,6 @@ void R_Clustered_BuildLists (void)
 		R_ClusterPerf_EndClusterClearGPU ();
 	}
 
-	memset (&inputs, 0, sizeof (inputs));
-	inputs.pass_mode = 0;
-	inputs.num_lights = r_framedata.numlights;
-	inputs._pad0 = r_clustered.cluster_count;
-	{
-		GLuint buf;
-		GLbyte *ofs;
-		GL_Upload (GL_UNIFORM_BUFFER, &inputs, sizeof (inputs), &buf, &ofs);
-		GL_BindBufferRange (GL_UNIFORM_BUFFER, 1, buf, (GLintptr)ofs, sizeof (inputs));
-	}
 	R_ClusterPerf_BeginClusterBuildGPU ();
 	GL_DispatchComputeFunc ((GLuint)((r_framedata.numlights + 63) / 64), 1, 1);
 	R_ClusteredBarrier (barrier_bits);
@@ -1502,12 +1485,15 @@ void R_PushDlights (void)
 
 	clustered_enabled = (r_clustered_lighting.value > 0.f && r_framedata.numlights > 0);
 	use_cluster_lists = (clustered_enabled && r_clustered_buildlists.value > 0.f);
-	if (clustered_enabled && (r_framedata.numlights <= small_light_threshold || r_clustered_buildlists.value <= 0.f))
+	if (clustered_enabled && r_clustered_buildlists.value <= 0.f)
 	{
 		r_framedata.dlight_params[2] = 1.f;
 		use_cluster_lists = false;
-		if (r_framedata.numlights <= small_light_threshold)
-			R_ClusterPerf_MarkReason ("small-light fast path active (direct lightbuffer loop)");
+		R_ClusterPerf_MarkReason ("cluster build disabled (direct lightbuffer loop)");
+	}
+	else if (clustered_enabled && r_framedata.numlights <= small_light_threshold)
+	{
+		R_ClusterPerf_MarkReason ("small-light clustered path active");
 	}
 
 	if (clustered_enabled)


### PR DESCRIPTION
### Motivation
- Profiling hooks in `R_ClusterPerf_*` indicated the clustered build/upload path dominated CPU/GPU time for dynamic lights, especially when at least one light was active (heavy `upload`/`build` numbers).
- Investigation found per-frame large `glBufferData(..., NULL, ...)` re-specifications and redundant uniform uploads that can cause GPU stalls and reallocs.
- The code also forced a direct per-pixel small-light path for <=8 lights which can be more expensive than a compact clustered resolve in low-light scenes.

### Description
- Replaced per-frame buffer re-specification with in-place updates: removed `glBufferData(..., NULL, ...)` calls for lights/headers/temp/counters/params and use `glBufferSubData` to update only the active ranges in `R_Clustered_BuildLists` (`Quake/opengl/gl_rlight.c`).
- Removed a duplicated `ClusterBuildParams` (`pass_mode=0`) upload before the first build dispatch to avoid an unnecessary uniform upload and redundant buffer bind/upload sequence (`Quake/opengl/gl_rlight.c`).
- Changed low-light control logic in `R_PushDlights` so that the clustered path remains active for small numbers of lights and the direct small-light loop is only used when list-building is explicitly disabled via `r_clustered_buildlists=0` (this avoids forcing an expensive per-pixel direct loop for 1 light) (`Quake/opengl/gl_rlight.c`).
- Verified shader cluster resolve iterates over `clusterCount` and checks `NumLights` so no GLSL inner-loop fixes were required; shader code in `Quake/shaders/world.frag` was audited but left unchanged.

### Testing
- Ran configuration step `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` which completed successfully.
- Built the tree with `cmake --build build -j4` and the binary linked successfully (`ironwail` built without compile errors).
- Attempted a headless runtime profile with `xvfb-run -a ./build/ironwail ... +r_clustered_profile 1` to collect `CLPROFILE` stats for 0/1/10 lights, but execution failed in this environment because the required Quake shareware data (`id1/pak0.pak`) is not present, so in-engine profiling could not be captured here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69958636ada8832ea49921f6bc9bcf49)