### PR TITLE
Remove direct dlight shader path and always build clustered lists

### DIFF
--- a/Quake/opengl/gl_rlight.c
+++ b/Quake/opengl/gl_rlight.c
@@ -1078,12 +1078,6 @@ void R_Clustered_BuildLists (void)
 		return;
 	}
 
-	if (r_clustered_buildlists.value <= 0.f)
-	{
-		R_ClusterPerf_MarkReason ("buildlists skipped by r_clustered_buildlists=0");
-		return;
-	}
-
 	tile_size = (int)r_clustered_tilesize.value;
 	if (tile_size <= 8)
 		tile_size = 8;
@@ -1454,9 +1448,7 @@ R_PushDlights
 void R_PushDlights (void)
 {
 	qboolean clustered_enabled;
-	qboolean use_cluster_lists;
 	dlight_t *submit[DLIGHT_GPU_MAX];
-	const unsigned int small_light_threshold = 8;
 
 	r_framedata.numlights = 0;
 	memset (r_dlight_sources, 0, sizeof (r_dlight_sources));
@@ -1481,20 +1473,7 @@ void R_PushDlights (void)
 	R_UploadFrameData ();
 	R_ClusterPerf_EndLightUpload ();
 
-	r_framedata.dlight_params[2] = 0.f;
-
 	clustered_enabled = (r_clustered_lighting.value > 0.f && r_framedata.numlights > 0);
-	use_cluster_lists = (clustered_enabled && r_clustered_buildlists.value > 0.f);
-	if (clustered_enabled && r_clustered_buildlists.value <= 0.f)
-	{
-		r_framedata.dlight_params[2] = 1.f;
-		use_cluster_lists = false;
-		R_ClusterPerf_MarkReason ("cluster build disabled (direct lightbuffer loop)");
-	}
-	else if (clustered_enabled && r_framedata.numlights <= small_light_threshold)
-	{
-		R_ClusterPerf_MarkReason ("small-light clustered path active");
-	}
 
 	if (clustered_enabled)
 	{
@@ -1504,20 +1483,12 @@ void R_PushDlights (void)
 			R_ClusterPerf_EndPush ();
 			return;
 		}
-		if (use_cluster_lists)
-		{
-			GL_BeginGroup ("Light clustering");
-			R_ClusterPerf_BeginBuild ();
-			R_Clustered_BuildLists ();
-			R_ClusterPerf_EndBuild ();
-		}
-		else
-		{
-			R_ClusterPerf_MarkReason ("cluster build skipped");
-		}
+		GL_BeginGroup ("Light clustering");
+		R_ClusterPerf_BeginBuild ();
+		R_Clustered_BuildLists ();
+		R_ClusterPerf_EndBuild ();
 		R_Clustered_BindForShading ();
-		if (use_cluster_lists)
-			GL_EndGroup ();
+		GL_EndGroup ();
 	}
 	else
 	{

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -548,8 +548,7 @@ void main()
 	int zSlice = 0;
 	int clusterIdx = 0;
 	uint clusterCount = 0u;
-	bool directSmallPath = (DLightParams.z > 0.5);
-	bool clusterActive = (!directSmallPath && NumLights > 0u && ClusterTileSize > 0 && ClusterGridXY.x > 0 && ClusterGridXY.y > 0 && ClusterZSlices > 0);
+	bool clusterActive = (NumLights > 0u && ClusterTileSize > 0 && ClusterGridXY.x > 0 && ClusterGridXY.y > 0 && ClusterZSlices > 0);
 
 	if (clusterActive)
 	{
@@ -598,24 +597,30 @@ void main()
 		return;
 	}
 
-        // Dynamic lights (clustered lighting)
-	if (directSmallPath)
+	// Dynamic lights (clustered lighting)
+	if (clusterActive)
 	{
+		ClusterHeader header = headers[clusterIdx];
+		uint clusterCount = min(header.count, NumLights);
 		vec3 dynamic_light = vec3(0.0);
 		float dynamic_light_noise = 1.0 - whitenoise01(in_pos.xy) * 0.15;
 		vec4 plane = vec4(surface_normal, dot(in_pos, surface_normal));
-		uint directCount = min(NumLights, 8u);
 
-		for (uint i = 0u; i < directCount; ++i)
+		for (uint i = 0u; i < clusterCount; ++i)
 		{
-			PackedLight pl = packedLights[i];
+			uint lightId = lightIndices[header.offset + i];
+			if (lightId >= NumLights)
+				continue;
+			PackedLight pl = packedLights[lightId];
 			vec3 lightOrigin = pl.posRadius.xyz;
 			float radius = pl.posRadius.w;
 			vec3 lightColor = pl.colorIntensity.rgb;
+
 			float dist = dot(lightOrigin, plane.xyz) - plane.w;
 			float rad = radius - abs(dist);
 			if (rad <= 0.0)
 				continue;
+
 			vec3 local_pos = lightOrigin - plane.xyz * dist;
 			vec3 light_vec = local_pos - in_pos;
 			float surface_dist = length(light_vec);
@@ -624,58 +629,24 @@ void main()
 			float falloff = pow(1.0 - clamp(normalized_dist, 0.0, 1.0), 1.5);
 			vec3 light_contrib = attenuation * falloff * lightColor * dynamic_light_noise;
 			dynamic_light += light_contrib;
+
+			if (attenuation > 0.0 && falloff > 0.0 && surface_dist > 0.0)
+			{
+				vec3 light_dir = light_vec / surface_dist;
+				float ndotl = max(dot(surface_normal, light_dir), 0.0);
+				if (ndotl > 0.0)
+				{
+					vec3 half_vec = normalize(light_dir + view_dir);
+					float ndoth = max(dot(surface_normal, half_vec), 0.0);
+					float spec = pow(ndoth, SPECULAR_POWER) * ndotl;
+					float energy = min(1.0, max(light_contrib.r, max(light_contrib.g, light_contrib.b)));
+					specular_light += light_contrib * (spec * specular_scale * energy);
+				}
+			}
 		}
+
 		total_light += max(min(dynamic_light, 1.0 - total_light), 0.0);
 	}
-	else if (clusterActive)
-	{
-		ClusterHeader header = headers[clusterIdx];
-		uint clusterCount = min(header.count, NumLights);
-		vec3 dynamic_light = vec3(0.0);
-                float dynamic_light_noise = 1.0 - whitenoise01(in_pos.xy) * 0.15;
-                vec4 plane = vec4(surface_normal, dot(in_pos, surface_normal));
-
-		for (uint i = 0u; i < clusterCount; ++i)
-		{
-			uint lightId = lightIndices[header.offset + i];
-			if (lightId >= NumLights)
-                                continue;
-                        PackedLight pl = packedLights[lightId];
-                        vec3 lightOrigin = pl.posRadius.xyz;
-                        float radius = pl.posRadius.w;
-                        vec3 lightColor = pl.colorIntensity.rgb;
-
-                        float dist = dot(lightOrigin, plane.xyz) - plane.w;
-                        float rad = radius - abs(dist);
-                        if (rad <= 0.0)
-                                continue;
-
-                        vec3 local_pos = lightOrigin - plane.xyz * dist;
-                        vec3 light_vec = local_pos - in_pos;
-                        float surface_dist = length(light_vec);
-                        float attenuation = clamp((rad - surface_dist) / 16.0, 0.0, 1.0);
-                        float normalized_dist = surface_dist / max(rad, 1e-4);
-                        float falloff = pow(1.0 - clamp(normalized_dist, 0.0, 1.0), 1.5);
-                        vec3 light_contrib = attenuation * falloff * lightColor * dynamic_light_noise;
-                        dynamic_light += light_contrib;
-
-                        if (attenuation > 0.0 && falloff > 0.0 && surface_dist > 0.0)
-                        {
-                                vec3 light_dir = light_vec / surface_dist;
-                                float ndotl = max(dot(surface_normal, light_dir), 0.0);
-                                if (ndotl > 0.0)
-                                {
-                                        vec3 half_vec = normalize(light_dir + view_dir);
-                                        float ndoth = max(dot(surface_normal, half_vec), 0.0);
-                                        float spec = pow(ndoth, SPECULAR_POWER) * ndotl;
-                                        float energy = min(1.0, max(light_contrib.r, max(light_contrib.g, light_contrib.b)));
-                                        specular_light += light_contrib * (spec * specular_scale * energy);
-                                }
-                        }
-                }
-
-                total_light += max(min(dynamic_light, 1.0 - total_light), 0.0);
-        }
 
 	// Sun light
         vec3 sun_light = dlight_debug ? vec3(0.0) : ComputeSunLight(in_pos, surface_normal);


### PR DESCRIPTION
### Motivation
- Move dynamic light evaluation entirely to the clustered lighting path to simplify backend switching and make clustered list construction the single source of truth for dlights during rendering.
- Remove a legacy backend switch that signalled a direct small-light shader path via `r_framedata.dlight_params[2]` so the runtime no longer toggles shader logic via that field.
- Ensure the engine always builds cluster lists when clustered lighting is enabled and there are lights so the GPU-side clustering data is consistently prepared.

### Description
- In `Quake/shaders/world.frag` removed the `directSmallPath` boolean and deleted the direct small-light loop (`for i < min(NumLights,8)`), and made `clusterActive` depend only on clustered capability, using the `headers/lightIndices` iteration exclusively for dynamic lights.
- In `Quake/opengl/gl_rlight.c` (`R_PushDlights`) removed writes to `r_framedata.dlight_params[2]`, removed the `use_cluster_lists`/`small_light_threshold` branch, and now always call `R_Clustered_BuildLists()` and bind clustered buffers when clustered lighting is enabled and `r_framedata.numlights > 0`.
- Removed the early-return guard for `r_clustered_buildlists` inside `R_Clustered_BuildLists()` so list construction is not skipped by that cvar in the production cluster path.

### Testing
- Searched the tree to validate removals with `rg` for `directSmallPath`, `dlight_params[2]` and `r_clustered_buildlists` references which confirmed the direct shader path and backend switch writes were removed (searches executed during the change process).
- Ran `git diff --check` which returned no whitespace or diff-check issues.
- Attempted a full build via `make -j2` but the workspace root has no Makefile so a build could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69958e034098832e9e7124a490a809ff)