### PR TITLE
Enforce forward+-only clustered dynamic lighting; remove legacy lightgrid dynlights

### DIFF
--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -603,7 +603,6 @@ qboolean R_SampleLightmapAtPoint(const vec3_t pos, vec3_t out_rgb);
 qboolean R_SampleLightmapAndDeluxemapAtPoint(const vec3_t pos, vec3_t out_rgb, vec3_t out_dir);
 qboolean R_LightgridEnabled (void);
 void R_LightgridLighting (const vec3_t pos, vec3_t out_color, float *out_ao);
-void R_AddDynamicLights_Lightgrid (const vec3_t pos, vec3_t lightcolor);
 void R_GetClusterDlightDebugStats (int *out_clusters, int *out_indices, const int **out_light_hits, int *out_max_hits);
 void R_ClusterPerf_BeginFrame (void);
 void R_ClusterPerf_EndFrame (void);

--- a/Quake/opengl/gl_rlight.c
+++ b/Quake/opengl/gl_rlight.c
@@ -947,13 +947,7 @@ static void R_Clustered_Shutdown (void);
 
 static qboolean R_ClusteredEnabled (void)
 {
-	if (!r_clustered.available)
-		return false;
-	if (r_clustered_lighting.value <= 0.f)
-		return false;
-	if (r_framedata.numlights <= 0)
-		return false;
-	return true;
+	return r_clustered.available;
 }
 
 void R_Clustered_Init (void)
@@ -977,7 +971,7 @@ void R_Clustered_Init (void)
 
 	if (!r_clustered.available)
 	{
-		Con_Printf ("Clustered lighting init failed, falling back to legacy dynlights.\n");
+		Con_Printf ("Clustered lighting init failed; clustered shading disabled.\n");
 		R_Clustered_Shutdown ();
 		return;
 	}
@@ -1072,11 +1066,6 @@ void R_Clustered_BuildLists (void)
 	if (!R_ClusteredEnabled () || !glprogs.cluster_lights || !glprogs.cluster_prefix)
 		return;
 
-	if (r_framedata.numlights == 0)
-	{
-		R_ClusterPerf_MarkReason ("buildlists called with numlights=0");
-		return;
-	}
 
 	tile_size = (int)r_clustered_tilesize.value;
 	if (tile_size <= 8)
@@ -1138,8 +1127,11 @@ void R_Clustered_BuildLists (void)
 	params.debug_mode = (int)r_clustered_debug.value;
 
 	GL_BindBufferFunc (GL_SHADER_STORAGE_BUFFER, r_clustered.lights_ssbo);
-	GL_BufferSubDataFunc (GL_SHADER_STORAGE_BUFFER, 0,
-		(GLsizeiptr)(sizeof (clustered_light_t) * (size_t)r_framedata.numlights), lights_local);
+	if (r_framedata.numlights > 0)
+	{
+		GL_BufferSubDataFunc (GL_SHADER_STORAGE_BUFFER, 0,
+			(GLsizeiptr)(sizeof (clustered_light_t) * (size_t)r_framedata.numlights), lights_local);
+	}
 	if (r_clustered_clearlists.value <= 0.f && developer.value > 0.f && R_ClusteredShouldLog ())
 	{
 		R_ClusterPerf_MarkReason ("r_clustered_clearlists=0 ignored (cluster clear/prefix clear always enabled)");
@@ -1192,7 +1184,7 @@ void R_Clustered_BuildLists (void)
 	R_ClusterPerf_EndClusterClearGPU ();
 
 	R_ClusterPerf_BeginClusterBuildGPU ();
-	GL_DispatchComputeFunc ((GLuint)((r_framedata.numlights + 63) / 64), 1, 1);
+	GL_DispatchComputeFunc ((GLuint)q_max (1, (r_framedata.numlights + 63) / 64), 1, 1);
 	R_ClusteredBarrier (barrier_bits);
 
 	inputs.pass_mode = 1;
@@ -1216,7 +1208,7 @@ void R_Clustered_BuildLists (void)
 		GL_Upload (GL_UNIFORM_BUFFER, &inputs, sizeof (inputs), &buf, &ofs);
 		GL_BindBufferRange (GL_UNIFORM_BUFFER, 1, buf, (GLintptr)ofs, sizeof (inputs));
 	}
-	GL_DispatchComputeFunc ((GLuint)((r_framedata.numlights + 63) / 64), 1, 1);
+	GL_DispatchComputeFunc ((GLuint)q_max (1, (r_framedata.numlights + 63) / 64), 1, 1);
 	R_ClusteredBarrier (barrier_bits);
 	R_ClusterPerf_EndClusterBuildGPU ();
 
@@ -1297,11 +1289,6 @@ void R_Clustered_BindForShading (void)
 {
 	if (!R_ClusteredEnabled ())
 		return;
-	if (r_framedata.numlights == 0)
-	{
-		R_ClusterPerf_MarkReason ("bind for shading called with numlights=0");
-		return;
-	}
 	R_ClusterPerf_BeginClusterBindBarrier ();
 
 	GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 3, r_clustered.lights_ssbo, 0,
@@ -1327,6 +1314,17 @@ void R_Clustered_RebindForProgram (GLuint program, const char *pass_name)
 
 	R_Clustered_BindForShading ();
 
+	if (R_ClusteredShouldLog ())
+	{
+		Con_Printf ("CLUSTERDBG bind pass=%s program=%u buffers=ok lights=%u grid=(%d %d %d) tile=%d\n",
+			pass_name ? pass_name : "<unknown>",
+			(unsigned)program,
+			r_framedata.numlights,
+			r_clustered.grid_x,
+			r_clustered.grid_y,
+			r_clustered.z_slices,
+			(int)r_clustered_tilesize.value);
+	}
 }
 
 void R_GetClusterDlightDebugStats (int *out_clusters, int *out_indices, const int **out_light_hits, int *out_max_hits)
@@ -1451,54 +1449,46 @@ void R_PushDlights (void)
 	memset (r_dlight_sources, 0, sizeof (r_dlight_sources));
 	R_ClusterPerf_BeginPush ();
 
-	if (r_dlight_enable.value <= 0.f || r_dynamic.value <= 0.f)
+	if (r_dlight_enable.value > 0.f && r_dynamic.value > 0.f)
 	{
-		R_ClusterPerf_EndPush ();
-		return;
+		R_ClusterPerf_BeginLightFilter ();
+		const int budget = q_min (q_max (1, DLightPool_GetBudget ()), DLIGHT_GPU_MAX);
+		DLightPool_NewFrame (cl.time, r_framecount);
+		const int num_submit = DLightPool_CollectForRender (cl.time, r_refdef.vieworg, r_viewleaf, submit, budget);
+		R_ClusterPerf_EndLightFilter ();
+		if (num_submit > 0)
+			R_PushDlightArray (submit, num_submit);
+		DLightPool_DebugPrint ();
 	}
 
-	R_ClusterPerf_BeginLightFilter ();
-	const int budget = q_min (q_max (1, DLightPool_GetBudget ()), DLIGHT_GPU_MAX);
-	DLightPool_NewFrame (cl.time, r_framecount);
-	const int num_submit = DLightPool_CollectForRender (cl.time, r_refdef.vieworg, r_viewleaf, submit, budget);
-	R_ClusterPerf_EndLightFilter ();
-	if (num_submit > 0)
-		R_PushDlightArray (submit, num_submit);
-	DLightPool_DebugPrint ();
+	if (r_clustered_lighting.value <= 0.f)
+		r_framedata.numlights = 0;
 
 	R_ClusterPerf_BeginLightUpload ();
 	R_UploadFrameData ();
 	R_ClusterPerf_EndLightUpload ();
 
-	clustered_enabled = (r_clustered_lighting.value > 0.f && r_framedata.numlights > 0);
-
-	if (clustered_enabled)
-	{
-		if (r_clustered_buildlists.value <= 0.f && developer.value > 0.f && R_ClusteredShouldLog ())
-			R_ClusterPerf_MarkReason ("r_clustered_buildlists=0 ignored (cluster list build always enabled)");
-		if (!r_clustered.available)
-		{
-			Con_Printf ("CLUSTERDBG ERROR numlights=%u but clustered buffers unavailable\n", r_framedata.numlights);
-			R_ClusterPerf_EndPush ();
-			return;
-		}
-		GL_BeginGroup ("Light clustering");
-		R_ClusterPerf_BeginBuild ();
-		R_Clustered_BuildLists ();
-		R_ClusterPerf_EndBuild ();
-		R_Clustered_BindForShading ();
-		GL_EndGroup ();
-	}
-	else
+	clustered_enabled = (r_clustered.available != 0);
+	if (!clustered_enabled)
 	{
 		if (r_clustered_lighting.value > 0.f)
-			R_ClusterPerf_MarkReason ("cluster path skipped: numlights=0");
+			R_ClusterPerf_MarkReason ("clustered resources unavailable");
+		R_ClusterPerf_EndPush ();
+		return;
 	}
+
+	if (r_clustered_buildlists.value <= 0.f && developer.value > 0.f && R_ClusteredShouldLog ())
+		R_ClusterPerf_MarkReason ("r_clustered_buildlists=0 ignored (cluster list build always enabled)");
+
+	GL_BeginGroup ("Light clustering");
+	R_ClusterPerf_BeginBuild ();
+	R_Clustered_BuildLists ();
+	R_ClusterPerf_EndBuild ();
+	R_Clustered_BindForShading ();
+	GL_EndGroup ();
 	R_ClusterPerf_EndPush ();
 
 }
-
-
 
 /*
 =============================================================================
@@ -1542,42 +1532,6 @@ void R_LightgridLighting (const vec3_t pos, vec3_t out_color, float *out_ao)
         VectorScale (out_color, ao, out_color);
         if (out_ao)
                 *out_ao = ao;
-}
-
-/*
-==================
-R_AddDynamicLights_Lightgrid
-==================
-*/
-static void R_AddDynamicLights_LightgridArray (const dlight_t *const *lights, int count, const vec3_t pos, vec3_t lightcolor)
-{
-	for (int i = 0; i < count; i++)
-	{
-		const dlight_t *l = lights[i];
-		vec3_t dist;
-		float add;
-
-
-		if (!CL_DlightIsActive (l))
-			continue;
-
-		VectorSubtract (pos, l->origin, dist);
-		add = l->radius - VectorLength (dist);
-
-		if (add <= l->minlight)
-			continue;
-
-		add -= l->minlight;
-		VectorMA (lightcolor, add, l->color, lightcolor);
-	}
-}
-
-void R_AddDynamicLights_Lightgrid (const vec3_t pos, vec3_t lightcolor)
-{
-	int count = 0;
-	const dlight_t *const *active = DLightPool_GetActiveList (&count);
-	if (active && count > 0)
-		R_AddDynamicLights_LightgridArray (active, count, pos, lightcolor);
 }
 
 
@@ -2157,7 +2111,6 @@ int R_LightPoint (qmodel_t *model, vec3_t p, float ofs, lightcache_t *cache)
                 VectorScale (lg_color, 255.f, lg_color255);
 
                 VectorCopy (lg_color255, lightcolor);
-                R_AddDynamicLights_Lightgrid (p, lightcolor);
 
                 cache->surfidx = 0;
                 VectorCopy (p, cache->pos);

--- a/Quake/render.h
+++ b/Quake/render.h
@@ -42,7 +42,6 @@ typedef struct lightcache_s {
 	short				ds;
 	short				dt;
 	vec3_t				ambientcolor;
-	vec3_t				dlightcolor;
 	vec3_t				lightgrid_color;
 	float				lightgrid_ao;
 	qboolean		lightgrid_has_sample;

--- a/Quake/renderer/r_alias.c
+++ b/Quake/renderer/r_alias.c
@@ -86,10 +86,10 @@ typedef struct aliasinstance_s {
 	float		prev_worldmatrix[12];
 	vec3_t		lightcolor;
 	float		alpha;
-	vec3_t		dlightcolor;
-	float		_pad0;
 	vec3_t		ambientcolor;
-	float		_pad1;
+	float		_pad0;
+	vec3_t		_pad1;
+	float		_pad2;
 	vec4_t		envmap_params;
 	int32_t		pose1;
 	int32_t		pose2;
@@ -177,7 +177,7 @@ static void R_DebugLightgridSample (const entity_t *e, const vec3_t ambient_add)
                 ambient_add[0], ambient_add[1], ambient_add[2]);
 }
 
-static void R_ApplyLightgridLighting (const entity_t *e, vec3_t ambientcolor, vec3_t dlightcolor)
+static void R_ApplyLightgridLighting (const entity_t *e, vec3_t ambientcolor)
 {
         vec3_t          gridcolor;
 
@@ -421,26 +421,16 @@ void R_SetupAliasLighting (entity_t     *e)
 {
         float           add;
         unsigned int    i;
-        vec3_t          dlightcolor = {0.f, 0.f, 0.f};
         vec3_t          ambientcolor;
-        vec3_t          static_color;
         entity_lightinfo_t lightinfo;
         entity_lightinfo_t *lightinfo_ptr = r_debug_itemlight.value > 0.f ? &lightinfo : NULL;
 
-        R_EntityStaticLight (e, static_color, lightinfo_ptr);
-        VectorCopy (static_color, lightcolor);
-        VectorCopy (static_color, ambientcolor);
+        R_EntityStaticLight (e, ambientcolor, lightinfo_ptr);
 
         if (lightinfo_ptr && R_DebugItemLightEnabled (e))
                 R_LogItemLight (e, lightinfo_ptr);
 
-        if (lightinfo_ptr ? lightinfo_ptr->used_lightgrid : e->lightcache.lightgrid_has_sample)
-        {
-                R_AddDynamicLights_Lightgrid (e->origin, lightcolor);
-                VectorSubtract (lightcolor, ambientcolor, dlightcolor);
-        }
-
-        R_ApplyLightgridLighting (e, ambientcolor, dlightcolor);
+        R_ApplyLightgridLighting (e, ambientcolor);
 
         // viewmodel lighting is typically darker because world lights aren't placed for a free camera
 	if (e == &cl.viewent)
@@ -483,37 +473,19 @@ void R_SetupAliasLighting (entity_t     *e)
 	//hack up the brightness when fullbrights but no overbrights (256)
 	if (!gl_overbright_models.value && (e->model->flags & MOD_FBRIGHTHACK) && gl_fullbrights.value)
 	{
-		lightcolor[0] = 256.0f;
-		lightcolor[1] = 256.0f;
-		lightcolor[2] = 256.0f;
-		VectorCopy (lightcolor, ambientcolor);
-		VectorClear (dlightcolor);
+		ambientcolor[0] = 256.0f;
+		ambientcolor[1] = 256.0f;
+		ambientcolor[2] = 256.0f;
 	}
 
+	for (i = 0; i < 3; i++)
 	{
-		vec3_t pre_total;
-		vec3_t linear_total;
-		VectorAdd (ambientcolor, dlightcolor, pre_total);
-		for (i = 0; i < 3; i++)
-		{
-			float L = pre_total[i] * (1.0f / 256.0f);
-			L = fminf(L, 1.0f);
-			linear_total[i] = L;
-		}
-
-		for (i = 0; i < 3; i++)
-		{
-			const float total = pre_total[i];
-			const float ambient_ratio = total > 0.0f ? ambientcolor[i] / total : 0.0f;
-			const float dlight_ratio = total > 0.0f ? dlightcolor[i] / total : 0.0f;
-			ambientcolor[i] = linear_total[i] * ambient_ratio;
-			dlightcolor[i] = linear_total[i] * dlight_ratio;
-			lightcolor[i] = linear_total[i];
-		}
+		float L = ambientcolor[i] * (1.0f / 256.0f);
+		ambientcolor[i] = fminf (L, 1.0f);
 	}
 
+	VectorCopy (ambientcolor, lightcolor);
 	VectorCopy (ambientcolor, e->lightcache.ambientcolor);
-	VectorCopy (dlightcolor, e->lightcache.dlightcolor);
 }
 
 /*
@@ -910,7 +882,6 @@ static void R_DrawAliasModel_Real (entity_t *e, qboolean showtris)
         {
                 lightcolor[0] = lightcolor[1] = lightcolor[2] = 0.5f;
                 VectorCopy (lightcolor, e->lightcache.ambientcolor);
-                VectorClear (e->lightcache.dlightcolor);
                 e->lightcache.lightgrid_has_sample = false;
                 e->lightcache.lightgrid_ao = 0.f;
                 VectorClear (e->lightcache.lightgrid_color);
@@ -968,7 +939,7 @@ static void R_DrawAliasModel_Real (entity_t *e, qboolean showtris)
 	e->motion_blur_prev_valid = true;
 
 	VectorCopy (lightcolor, instance->lightcolor);
-	VectorCopy (e->lightcache.dlightcolor, instance->dlightcolor);
+	VectorClear (instance->_pad1);
 	VectorCopy (e->lightcache.ambientcolor, instance->ambientcolor);
 	instance->alpha = entalpha;
 	if (e == &cl.viewent)
@@ -1061,7 +1032,7 @@ static void R_DrawAliasModel_Shadow_Real (entity_t *e)
 	MatrixTranspose4x3 (model_matrix, instance->prev_worldmatrix);
 
 	VectorClear (instance->lightcolor);
-	VectorClear (instance->dlightcolor);
+	VectorClear (instance->_pad1);
 	VectorClear (instance->ambientcolor);
 	instance->alpha = entalpha;
 	instance->envmap_params[0] = 0.f;

--- a/Quake/renderer/r_envlight.h
+++ b/Quake/renderer/r_envlight.h
@@ -4,7 +4,7 @@
 
 /*
  * Envlight/entity ambient probes are expressed in linear RGB intensity.
- * Callers must keep entity lighting data (ambientcolor/dlightcolor/lightcolor)
+ * Callers must keep entity lighting data (ambientcolor/lightcolor)
  * in linear space and rely on the renderer's global postprocess / framebuffer
  * sRGB path for the final transfer conversion.
  *

--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -5,8 +5,8 @@ struct InstanceData
 	vec4	WorldMatrix[3];
 	vec4	PrevWorldMatrix[3];
 	vec4	LightColor; // xyz=LightColor w=Alpha
-	vec4	DLightColor; // xyz=DLightColor
 	vec4	AmbientColor; // xyz=AmbientColor
+	vec4	UnusedDynLightPad;
 	vec4	EnvMapParams; // x=enable y=glossMask z=indoorHint w=intensity
 	int		Pose1;
 	int		Pose2;
@@ -172,9 +172,8 @@ layout(location=6) in vec3 in_normal;
 // Do not apply per-material gamma here; final transfer is handled globally
 // by postprocess / framebuffer-sRGB selection.
 layout(location=7) in vec3 in_static_light;
-layout(location=8) in vec3 in_dyn_light;
-layout(location=9) in vec3 in_amb_light;
-layout(location=10) flat in vec4 in_env_params;
+layout(location=8) in vec3 in_amb_light;
+layout(location=9) flat in vec4 in_env_params;
 
 #define OUT_COLOR out_fragcolor
 #if OIT
@@ -279,12 +278,10 @@ void main()
         float shadow_term = 1.0;
 	vec4 lit_color = in_color;
 	vec3 L_static = max(in_static_light, vec3(0.0));
-	vec3 L_dyn = max(in_dyn_light, vec3(0.0));
 	vec3 L_amb = max(in_amb_light, vec3(0.0));
 	vec3 N_lighting = normalize_safe(gl_FrontFacing ? in_normal : -in_normal);
 	vec3 world_pos = in_pos + AliasEyePos;
 	vec3 clustered_dyn = EvaluateAliasClusteredLights(world_pos, N_lighting, gl_FragCoord.xy);
-	L_dyn += clustered_dyn;
 	lit_color.rgb += clustered_dyn;
 
 	if (ShadowDebug.x > 0.5 && (in_flags & ALIAS_FLAG_VIEWMODEL) == 0)

--- a/Quake/shaders/alias.vert
+++ b/Quake/shaders/alias.vert
@@ -5,8 +5,8 @@ struct InstanceData
 	vec4	WorldMatrix[3];
 	vec4	PrevWorldMatrix[3];
 	vec4	LightColor; // xyz=LightColor w=Alpha
-	vec4	DLightColor; // xyz=DLightColor
 	vec4	AmbientColor; // xyz=AmbientColor
+	vec4	UnusedDynLightPad;
 	vec4	EnvMapParams; // x=enable y=glossMask z=indoorHint w=intensity
 	int		Pose1;
 	int		Pose2;
@@ -104,9 +104,8 @@ layout(location=4) noperspective out vec4 out_prev_clip;
 layout(location=5) flat out int out_flags;
 layout(location=6) out vec3 out_normal;
 layout(location=7) out vec3 out_static_light;
-layout(location=8) out vec3 out_dyn_light;
-layout(location=9) out vec3 out_amb_light;
-layout(location=10) flat out vec4 out_env_params;
+layout(location=8) out vec3 out_amb_light;
+layout(location=9) flat out vec4 out_env_params;
 
 
 void main()
@@ -141,12 +140,10 @@ void main()
         float static_mix = mix(0.35, 1.0, lighting) * AliasOverbright;
         vec3 litAmbient = ambient * 0.35 * AliasOverbright;
         vec3 litStatic = ambient * max(static_mix - (0.35 * AliasOverbright), 0.0);
-        vec3 litDlight = inst.DLightColor.rgb * lighting;
-        vec3 base_color = litAmbient + litStatic + litDlight;
+        vec3 base_color = litAmbient + litStatic;
         out_color = clamp(vec4(base_color, inst.LightColor.a), 0.0, AliasOverbright);
 	out_normal = world_normal;
 	out_static_light = litStatic;
-	out_dyn_light = litDlight;
 	out_amb_light = litAmbient;
 	out_env_params = inst.EnvMapParams;
 }

--- a/Quake/shaders/shadow_depth_alias.vert
+++ b/Quake/shaders/shadow_depth_alias.vert
@@ -3,8 +3,9 @@ struct InstanceData
 	vec4	WorldMatrix[3];
 	vec4	PrevWorldMatrix[3];
 	vec4	LightColor; // xyz=LightColor w=Alpha
-	vec4	DLightColor; // xyz=DLightColor
 	vec4	AmbientColor; // xyz=AmbientColor
+	vec4	UnusedDynLightPad;
+	vec4	EnvMapParams;
 	int		Pose1;
 	int		Pose2;
 	float	Blend;


### PR DESCRIPTION
### Motivation
- Provide a single, forward+-only dynamic lighting model so legacy CPU lightgrid dynlights never contribute in parallel with clustered lighting.
- Make clustered resources the authoritative backend contract: always-allocated and bound for shading passes even when there are zero lights.
- Remove stale/duplicated state and shader inputs that caused double-additive or inconsistent dynamic-light contributions.

### Description
- Remove legacy lightgrid dynamic-light accumulation: deleted the `R_AddDynamicLights_Lightgrid` callsites and prototype and stopped adding CPU dynlights into lighting paths so alias/world lighting is clustered-only for dynamic lights; updated `R_LightPoint` to stop invoking the legacy add. (files: `Quake/opengl/gl_rlight.c`, `Quake/glquake.h`)
- Simplify alias/entity lighting state: removed `dlightcolor` from `lightcache_t` and the alias instance payload, refactored `R_SetupAliasLighting` to compute ambient/static only, and clear legacy per-instance dynlight slots so shaders do not receive CPU dynlight colors. (files: `Quake/render.h`, `Quake/renderer/r_alias.c`)
- Make clustered backend authoritative and robust: `R_ClusteredEnabled()` now reflects resource availability only, cluster buffers/UBO/SSBO allocations and bind ranges are established regardless of `numlights`, `GL_BufferSubData` is guarded when `numlights==0`, and compute dispatch group counts are clamped so dispatches use at least one workgroup. (file: `Quake/opengl/gl_rlight.c`)
- Change `R_PushDlights` behavior so `r_clustered_lighting` controls whether light data is populated (it may force `r_framedata.numlights=0`), but clustered resources are still built/bound and used as the single path; this unifies runtime ownership and prevents split backends. (file: `Quake/opengl/gl_rlight.c`)
- Update shaders and instance layout: removed legacy `DLightColor` inputs and added a padding field to keep layout compatible; alias vertex/fragment and shadow-depth alias shaders no longer mix legacy + clustered contributions and expect clustered reads only. (files: `Quake/shaders/alias.vert`, `Quake/shaders/alias.frag`, `Quake/shaders/shadow_depth_alias.vert`)
- Documentation and header updates: removed legacy dlight expectations from envlight docs and cleaned up prototypes. (files: `Quake/renderer/r_envlight.h`, `Quake/glquake.h`)
- Added debug bind logging in `R_Clustered_RebindForProgram` to print `CLUSTERDBG bind pass=... program=... lights=... grid=... tile=...` for per-pass ownership auditing. (file: `Quake/opengl/gl_rlight.c`)

### Testing
- Symbol audit: ran repository-wide searches for legacy symbols (`R_AddDynamicLights_Lightgrid`, `lightcache.dlightcolor`, shader `DLightColor`) and confirmed removal (automation returned "legacy symbols removed"). — succeeded.
- Sanity checks: ran `git diff --check` to ensure no whitespace/errors in diffs — succeeded.
- Build attempt: ran `cmake -S . -B build` to validate project config; configuration failed in this environment due to a missing external dependency (`SDL2` dev package), which is unrelated to the patch logic (no compile-time validation possible here). — config failed (external dependency missing).
- Runtime/trace validations: performed targeted source inspections and grep checks to verify clustered bind/build paths are always invoked and shaders no longer reference legacy per-instance dynlight fields — manual/automated scans succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995932b42d4832ebb7b5ee492f0ad2d)