### PR TITLE
Enable clustered lighting by default and gate fallback on capability/debug cvar

### DIFF
--- a/Quake/opengl/gl_rlight.c
+++ b/Quake/opengl/gl_rlight.c
@@ -33,7 +33,6 @@ extern cvar_t r_lerplightstyles;
 extern cvar_t r_dynamic;
 extern cvar_t r_dlight_enable;
 extern cvar_t r_dlight_radius_scale;
-extern cvar_t r_clustered_lighting;
 extern cvar_t r_clustered_tilesize;
 extern cvar_t r_clustered_zslices;
 extern cvar_t r_clustered_maxindices;
@@ -42,7 +41,7 @@ extern cvar_t r_clustered_log;
 extern cvar_t r_clustered_profile;
 extern cvar_t r_clustered_profile_dumpinterval;
 extern cvar_t r_clustered_validate;
-extern cvar_t r_clustered_buildlists;
+extern cvar_t r_dbg_clustered_force_fallback;
 extern cvar_t r_clustered_clearlists;
 extern cvar_t r_clustered_barriers;
 extern cvar_t r_lightgrid;
@@ -1461,9 +1460,6 @@ void R_PushDlights (void)
 		DLightPool_DebugPrint ();
 	}
 
-	if (r_clustered_lighting.value <= 0.f)
-		r_framedata.numlights = 0;
-
 	R_ClusterPerf_BeginLightUpload ();
 	R_UploadFrameData ();
 	R_ClusterPerf_EndLightUpload ();
@@ -1471,14 +1467,18 @@ void R_PushDlights (void)
 	clustered_enabled = (r_clustered.available != 0);
 	if (!clustered_enabled)
 	{
-		if (r_clustered_lighting.value > 0.f)
-			R_ClusterPerf_MarkReason ("clustered resources unavailable");
+		R_ClusterPerf_MarkReason ("clustered resources unavailable");
 		R_ClusterPerf_EndPush ();
 		return;
 	}
 
-	if (r_clustered_buildlists.value <= 0.f && developer.value > 0.f && R_ClusteredShouldLog ())
-		R_ClusterPerf_MarkReason ("r_clustered_buildlists=0 ignored (cluster list build always enabled)");
+	if (r_dbg_clustered_force_fallback.value > 0.f)
+	{
+		if (developer.value > 0.f && R_ClusteredShouldLog ())
+			R_ClusterPerf_MarkReason ("r_dbg_clustered_force_fallback=1 (developer fallback)");
+		R_ClusterPerf_EndPush ();
+		return;
+	}
 
 	GL_BeginGroup ("Light clustering");
 	R_ClusterPerf_BeginBuild ();

--- a/Quake/opengl/gl_rmain.c
+++ b/Quake/opengl/gl_rmain.c
@@ -537,7 +537,7 @@ cvar_t  r_dlight_enable = { "r_dlight_enable", "1", CVAR_ARCHIVE };
 cvar_t  r_dlight_scale = { "r_dlight_scale", "1.0", CVAR_ARCHIVE };
 cvar_t  r_dlight_radius_scale = { "r_dlight_radius_scale", "1.0", CVAR_ARCHIVE };
 cvar_t  r_dlight_debug_visualize = { "r_dlight_debug_visualize", "0", CVAR_NONE };
-cvar_t  r_clustered_lighting = { "r_clustered_lighting", "0", CVAR_ARCHIVE };
+cvar_t  r_clustered_lighting = { "r_clustered_lighting", "1", CVAR_ARCHIVE };
 cvar_t  r_clustered_tilesize = { "r_clustered_tilesize", "16", CVAR_ARCHIVE };
 cvar_t  r_clustered_zslices = { "r_clustered_zslices", "24", CVAR_ARCHIVE };
 cvar_t  r_clustered_maxindices = { "r_clustered_maxindices", "262144", CVAR_ARCHIVE };
@@ -546,9 +546,8 @@ cvar_t  r_clustered_log = { "r_clustered_log", "0", CVAR_NONE };
 cvar_t  r_clustered_profile = { "r_clustered_profile", "0", CVAR_NONE };
 cvar_t  r_clustered_profile_dumpinterval = { "r_clustered_profile_dumpinterval", "60", CVAR_NONE };
 cvar_t  r_clustered_validate = { "r_clustered_validate", "0", CVAR_NONE };
-// Debug-only instrumentation toggles. Production clustered list build always
-// runs regardless of these values.
-cvar_t  r_clustered_buildlists = { "r_clustered_buildlists", "1", CVAR_NONE };
+// Debug-only instrumentation toggles.
+cvar_t  r_dbg_clustered_force_fallback = { "r_dbg_clustered_force_fallback", "0", CVAR_NONE };
 cvar_t  r_clustered_clearlists = { "r_clustered_clearlists", "1", CVAR_NONE };
 cvar_t  r_clustered_barriers = { "r_clustered_barriers", "1", CVAR_NONE };
 cvar_t  r_clustered_shadows = { "r_clustered_shadows", "1", CVAR_ARCHIVE };

--- a/Quake/opengl/gl_rmisc.c
+++ b/Quake/opengl/gl_rmisc.c
@@ -86,7 +86,7 @@ extern cvar_t r_clustered_log;
 extern cvar_t r_clustered_profile;
 extern cvar_t r_clustered_profile_dumpinterval;
 extern cvar_t r_clustered_validate;
-extern cvar_t r_clustered_buildlists;
+extern cvar_t r_dbg_clustered_force_fallback;
 extern cvar_t r_clustered_clearlists;
 extern cvar_t r_clustered_barriers;
 extern cvar_t r_clustered_shadows;
@@ -636,7 +636,7 @@ Cvar_RegisterVariable (&r_drawviewmodel);
 	Cvar_RegisterVariable (&r_clustered_profile_dumpinterval);
 	Cvar_RegisterVariable (&r_clustered_validate);
 #ifdef _DEBUG
-	Cvar_RegisterVariable (&r_clustered_buildlists);
+	Cvar_RegisterVariable (&r_dbg_clustered_force_fallback);
 	Cvar_RegisterVariable (&r_clustered_clearlists);
 	Cvar_RegisterVariable (&r_clustered_barriers);
 #endif


### PR DESCRIPTION
### Motivation
- Enable clustered lighting by default so the renderer attempts clustered list build when the GPU/resources support it. 
- Prevent a user-facing cvar from disabling clustered list build at runtime and instead base operation on resource capability. 
- Preserve startup logging that warns when clustered resources are unavailable. 
- Keep a developer-only override for forcing fallback, but expose it under a clearly debug-scoped name.

### Description
- Change the default of `r_clustered_lighting` from `"0"` to `"1"` in `Quake/opengl/gl_rmain.c`. 
- Remove the user-toggle suppression path in `R_PushDlights` (`Quake/opengl/gl_rlight.c`) so clustered operation is attempted when `r_clustered.available` is true, and retain the perf/logging call when clustered resources are unavailable. 
- Introduce a debug-only cvar `r_dbg_clustered_force_fallback` in `Quake/opengl/gl_rmain.c` and use it in `R_PushDlights` as a developer-scoped fallback; replace references to the old `r_clustered_buildlists` with this new cvar. 
- Update `Quake/opengl/gl_rlight.c` and `Quake/opengl/gl_rmisc.c` to declare/register the new debug cvar (registration gated by `#ifdef _DEBUG`) and remove the previous `r_clustered_buildlists` usage.

### Testing
- Ran `git diff --check` with no issues reported. 
- Attempted `cmake --build build`, which failed in this environment because `/workspace/ironwail/build` does not exist. 
- Confirmed repository changes were committed successfully (commit created on branch `work`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995983de7e4832e9e814fef383ebeb3)