### PR TITLE
Deprecate legacy dlight toggles; add clustered-light cvars and rename frame UBO fields

### DIFF
--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -450,7 +450,7 @@ typedef struct gpuframedata_s {
         vec4_t          zparams;        // x: zlogscale, y: zlogbias, zw: padding
         float           lightmap_params[4];
         vec4_t          lightgrid_params; // x: enabled, y: debug, z: shadow mode, w: world fill
-        vec4_t          dlight_params;  // x: style, y: debug view, z: pass selector, w: padding
+        vec4_t          clustered_light_params;  // x: debug visualize, y: clustered debug mode, z: clustered enabled, w: dynamic light quality scale
         vec4_t          colorspace_params; // x: debug mode, y: manual gamma, z: output sRGB, w: unused
         vec4_t          shader_params;  // x: shader debug, y: tcgen debug, zw: unused
         vec4_t          lighting_params; // x: envmap enabled, y: reflection debug, z: sky SH enabled, w: lighting debug view
@@ -458,10 +458,10 @@ typedef struct gpuframedata_s {
         vec4_t          shadow_params; // x: bias, y: normal bias, z: pcf enabled, w: pcf taps
         vec4_t          shadow_debug;  // x: enabled, y: debug mode, zw: unused
         vec4_t          shadow_sun_dir; // xyz: direction, w: unused
-        float           shadow_dlight_viewproj[SHADOW_DLIGHT_MAX][16];
-        vec4_t          shadow_dlight_atlas[SHADOW_DLIGHT_MAX]; // xy: scale, zw: offset
-        vec4_t          shadow_dlight_info[SHADOW_DLIGHT_MAX]; // x: light index, yzw: unused
-        vec4_t          shadow_dlight_params; // x: bias, y: pcf taps, z: enabled, w: unused
+        float           shadow_clustered_light_viewproj[SHADOW_DLIGHT_MAX][16];
+        vec4_t          shadow_clustered_light_atlas[SHADOW_DLIGHT_MAX]; // xy: scale, zw: offset
+        vec4_t          shadow_clustered_light_info[SHADOW_DLIGHT_MAX]; // x: light index, yzw: unused
+        vec4_t          shadow_clustered_light_params; // x: bias, y: pcf taps, z: enabled, w: unused
         unsigned int    numlights;
         unsigned int    prev_frame_valid;
         unsigned int    _padding1;

--- a/Quake/opengl/gl_rlight.c
+++ b/Quake/opengl/gl_rlight.c
@@ -31,8 +31,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 extern cvar_t r_flatlightstyles; //johnfitz
 extern cvar_t r_lerplightstyles;
 extern cvar_t r_dynamic;
-extern cvar_t r_dlight_enable;
-extern cvar_t r_dlight_radius_scale;
+extern cvar_t r_clustered_light_enable;
+extern cvar_t r_clustered_light_radius_scale;
 extern cvar_t r_clustered_lighting;
 extern cvar_t r_clustered_tilesize;
 extern cvar_t r_clustered_zslices;
@@ -1399,7 +1399,7 @@ static void R_PushDlightArray (dlight_t *const *lights, int count)
 			radius = l->baseradius * (1.f + 0.1f * (float) sin (cl.time * 9.0 + l->flicker_seed));
 		else
 			radius = l->baseradius;
-		radius *= q_max (0.f, r_dlight_radius_scale.value);
+		radius *= q_max (0.f, r_clustered_light_radius_scale.value);
 		radius = q_max (radius, 0.f);
 		l->radius = radius;
 
@@ -1449,7 +1449,7 @@ void R_PushDlights (void)
 	memset (r_dlight_sources, 0, sizeof (r_dlight_sources));
 	R_ClusterPerf_BeginPush ();
 
-	if (r_dlight_enable.value > 0.f && r_dynamic.value > 0.f)
+	if (r_clustered_light_enable.value > 0.f && r_dynamic.value > 0.f)
 	{
 		R_ClusterPerf_BeginLightFilter ();
 		const int budget = q_min (q_max (1, DLightPool_GetBudget ()), DLIGHT_GPU_MAX);

--- a/Quake/opengl/gl_rmain.c
+++ b/Quake/opengl/gl_rmain.c
@@ -192,7 +192,7 @@ static const float r_identity_mat4[16] = {
 
 extern cvar_t r_state_debug;
 extern cvar_t r_state_debug_filter;
-extern cvar_t r_dlight_debug_visualize;
+extern cvar_t r_clustered_light_debug_visualize;
 extern cvar_t r_gl_verify_program;
 
 static void GL_LogErrorIfDeveloper (const char *label)
@@ -275,7 +275,7 @@ static void R_LogWorldLightState (const char *marker)
 
 	if (r_state_debug.value <= 0.f)
 	{
-		if (q_strcasecmp (marker, "WORLD_LIGHTS_BEGIN") || r_dlight_debug_visualize.value < 2.f)
+		if (q_strcasecmp (marker, "WORLD_CLUSTERED_LIGHTS_BEGIN") || r_clustered_light_debug_visualize.value < 2.f)
 			return;
 	}
 	else if (!GL_StateDebugMatchesFilter (marker))
@@ -322,12 +322,12 @@ static void R_LogWorldLightState (const char *marker)
 		program, GL_GetProgramDebugName ((GLuint)program),
 		r_framedata.numlights);
 
-	if (!q_strcasecmp (marker, "WORLD_LIGHTS_BEGIN"))
+	if (!q_strcasecmp (marker, "WORLD_CLUSTERED_LIGHTS_BEGIN"))
 	{
 		dlight_filter_debug_t filter_stats;
 		dlight_debug_entry_t entries[4];
 		DLightPool_GetFilterDebug (&filter_stats, entries);
-		Con_Printf ("STATEDBG dlight_filter total_active=%d lifetime_radius=%d world=%d pvs=%d frustum=%d budget=%d reject_lifetime=%d reject_world=%d reject_pvs=%d reject_frustum=%d reject_budget=%d\n",
+		Con_Printf ("STATEDBG clustered_light_filter total_active=%d lifetime_radius=%d world=%d pvs=%d frustum=%d budget=%d reject_lifetime=%d reject_world=%d reject_pvs=%d reject_frustum=%d reject_budget=%d\n",
 			filter_stats.total_active,
 			filter_stats.pass_lifetime_radius,
 			filter_stats.pass_world_flag,
@@ -344,7 +344,7 @@ static void R_LogWorldLightState (const char *marker)
 			const dlight_debug_entry_t *entry = &entries[i];
 			if (!entry->captured)
 				continue;
-			Con_Printf ("STATEDBG dlight[%d] id=%d org=(%.1f %.1f %.1f) radius=%.1f base=%.1f color=(%.2f %.2f %.2f) die=%.3f flags=0x%X bbox=(%.1f %.1f %.1f)-(%.1f %.1f %.1f) leaf=%d has_leaf=%d in_pvs=%d in_frustum=%d reason=%s\n",
+			Con_Printf ("STATEDBG clustered_light[%d] id=%d org=(%.1f %.1f %.1f) radius=%.1f base=%.1f color=(%.2f %.2f %.2f) die=%.3f flags=0x%X bbox=(%.1f %.1f %.1f)-(%.1f %.1f %.1f) leaf=%d has_leaf=%d in_pvs=%d in_frustum=%d reason=%s\n",
 				i,
 				entry->id,
 				entry->origin[0], entry->origin[1], entry->origin[2],
@@ -533,8 +533,12 @@ cvar_t	r_lightmap_colorspace_debug = { "r_lightmap_colorspace_debug", "0", CVAR_
 cvar_t	r_wateralpha = { "r_wateralpha","1",CVAR_ARCHIVE };
 cvar_t	r_litwater = { "r_litwater","1",CVAR_NONE };
 cvar_t	r_dynamic = { "r_dynamic","1",CVAR_ARCHIVE };
+/* Clustered-light controls. */
+cvar_t  r_clustered_light_enable = { "r_clustered_light_enable", "1", CVAR_ARCHIVE };
+cvar_t  r_clustered_light_radius_scale = { "r_clustered_light_radius_scale", "1.0", CVAR_ARCHIVE };
+cvar_t  r_clustered_light_debug_visualize = { "r_clustered_light_debug_visualize", "0", CVAR_NONE };
+/* Deprecated compatibility aliases for legacy dynamic light controls. */
 cvar_t  r_dlight_enable = { "r_dlight_enable", "1", CVAR_ARCHIVE };
-cvar_t  r_dlight_scale = { "r_dlight_scale", "1.0", CVAR_ARCHIVE };
 cvar_t  r_dlight_radius_scale = { "r_dlight_radius_scale", "1.0", CVAR_ARCHIVE };
 cvar_t  r_dlight_debug_visualize = { "r_dlight_debug_visualize", "0", CVAR_NONE };
 cvar_t  r_clustered_lighting = { "r_clustered_lighting", "0", CVAR_ARCHIVE };
@@ -4063,10 +4067,10 @@ void R_SetupView (void)
         r_framedata.lightmap_params[2] = (r_lightingdir.value > 0.f && lightmap_dir_texture) ? 1.f : 0.f;
         r_framedata.lightmap_params[3] = r_lightstyle_framefrac;
 	R_EnvLight_BuildFrameUniforms (r_framedata.lighting_params, r_framedata.lightgrid_params);
-	r_framedata.dlight_params[0] = 0.f;
-	r_framedata.dlight_params[1] = 0.f;
-	r_framedata.dlight_params[2] = 0.f;
-	r_framedata.dlight_params[3] = 1.f;
+	r_framedata.clustered_light_params[0] = CLAMP (0.f, r_clustered_light_debug_visualize.value, 1.f);
+	r_framedata.clustered_light_params[1] = CLAMP (0.f, r_clustered_debug.value, 2.f);
+	r_framedata.clustered_light_params[2] = (r_clustered_lighting.value > 0.f) ? 1.f : 0.f;
+	r_framedata.clustered_light_params[3] = CLAMP (0.f, r_clustered_light_radius_scale.value, 3.f);
         r_framedata.colorspace_params[0] = CLAMP (0.f, r_debug_colorspace.value, 4.f);
         r_framedata.colorspace_params[1] = 0.f;
         r_framedata.colorspace_params[2] = 0.f;
@@ -4083,10 +4087,10 @@ void R_SetupView (void)
         r_framedata.shadow_debug[1] = r_shadow_debug.value;
         r_framedata.shadow_debug[2] = gl_clipcontrol_able ? 2.f : 1.f;
         r_framedata.shadow_debug[3] = 0.f;
-        r_framedata.shadow_dlight_params[0] = r_shadow_dlight_bias.value;
-        r_framedata.shadow_dlight_params[1] = r_shadow_dlight_pcf_taps.value;
-        r_framedata.shadow_dlight_params[2] = (r_shadows.value > 0.f && r_shadow_dlights.value > 0.f && r_clustered_shadows.value > 0.f) ? 1.f : 0.f;
-        r_framedata.shadow_dlight_params[3] = 0.f;
+        r_framedata.shadow_clustered_light_params[0] = r_shadow_dlight_bias.value;
+        r_framedata.shadow_clustered_light_params[1] = r_shadow_dlight_pcf_taps.value;
+        r_framedata.shadow_clustered_light_params[2] = (r_shadows.value > 0.f && r_shadow_dlights.value > 0.f && r_clustered_shadows.value > 0.f) ? 1.f : 0.f;
+        r_framedata.shadow_clustered_light_params[3] = 0.f;
 
 	double prev_delta = cl.time - r_prev_frame_time;
 	qboolean prev_valid = r_prev_frame_valid && prev_delta > 0.0;
@@ -5227,10 +5231,10 @@ void R_RenderScene (void)
 	S_ExtraUpdate (); // don't let sound get messed up if going slow
 	R_ClusterPerf_BeginWorld ();
 	R_DrawEntitiesOnList (false); //johnfitz -- false means this is the pass for nonalpha entities
-	R_StateDebugMark ("WORLD_LIGHTS_BEGIN");
-	R_LogWorldLightState ("WORLD_LIGHTS_BEGIN");
-	R_LogWorldLightState ("WORLD_LIGHTS_END");
-	R_StateDebugMark ("WORLD_LIGHTS_END");
+	R_StateDebugMark ("WORLD_CLUSTERED_LIGHTS_BEGIN");
+	R_LogWorldLightState ("WORLD_CLUSTERED_LIGHTS_BEGIN");
+	R_LogWorldLightState ("WORLD_CLUSTERED_LIGHTS_END");
+	R_StateDebugMark ("WORLD_CLUSTERED_LIGHTS_END");
 	R_ClusterPerf_EndWorld ();
 	R_DrawDecals (false);
 	R_DrawParticles (false);

--- a/Quake/opengl/gl_rmisc.c
+++ b/Quake/opengl/gl_rmisc.c
@@ -73,8 +73,10 @@ extern cvar_t r_lightmap_linear;
 extern cvar_t r_lightmap_mipmaps;
 extern cvar_t r_lightmap16f;
 extern cvar_t r_lightingdir;
+extern cvar_t r_clustered_light_enable;
+extern cvar_t r_clustered_light_radius_scale;
+extern cvar_t r_clustered_light_debug_visualize;
 extern cvar_t r_dlight_enable;
-extern cvar_t r_dlight_scale;
 extern cvar_t r_dlight_radius_scale;
 extern cvar_t r_dlight_debug_visualize;
 extern cvar_t r_clustered_lighting;
@@ -127,6 +129,49 @@ extern cvar_t r_shadow_validate;
 extern cvar_t r_shadow_coord_debug;
 extern cvar_t r_shadow_comparefunc;
 extern cvar_t r_gl_verify_program;
+
+static qboolean r_clustered_light_compat_busy;
+static qboolean r_clustered_light_deprecated_warned;
+
+static void R_ClusteredLight_PrintDeprecatedWarning (const cvar_t *var)
+{
+	if (r_clustered_light_deprecated_warned)
+		return;
+
+	Con_Printf ("%s is deprecated; use r_clustered_light_enable/r_clustered_light_radius_scale/r_clustered_light_debug_visualize.\n", var->name);
+	r_clustered_light_deprecated_warned = true;
+}
+
+static void R_ClusteredLight_MasterCallback (cvar_t *var)
+{
+	(void)var;
+	if (r_clustered_light_compat_busy)
+		return;
+
+	r_clustered_light_compat_busy = true;
+	Cvar_SetValueQuick (&r_dlight_enable, r_clustered_light_enable.value > 0.f ? 1.f : 0.f);
+	Cvar_SetValueQuick (&r_dlight_radius_scale, r_clustered_light_radius_scale.value);
+	Cvar_SetValueQuick (&r_dlight_debug_visualize, r_clustered_light_debug_visualize.value);
+	r_clustered_light_compat_busy = false;
+}
+
+static void R_ClusteredLight_LegacyCallback (cvar_t *var)
+{
+	if (r_clustered_light_compat_busy)
+		return;
+
+	R_ClusteredLight_PrintDeprecatedWarning (var);
+	r_clustered_light_compat_busy = true;
+	if (var == &r_dlight_enable)
+		Cvar_SetValueQuick (&r_clustered_light_enable, var->value > 0.f ? 1.f : 0.f);
+	else if (var == &r_dlight_radius_scale)
+		Cvar_SetValueQuick (&r_clustered_light_radius_scale, var->value);
+	else if (var == &r_dlight_debug_visualize)
+		Cvar_SetValueQuick (&r_clustered_light_debug_visualize, var->value);
+	r_clustered_light_compat_busy = false;
+	R_ClusteredLight_MasterCallback (NULL);
+}
+
 //johnfitz
 extern cvar_t gl_zfix; // QuakeSpasm z-fighting fix
 extern cvar_t r_alphasort;
@@ -622,10 +667,19 @@ Cvar_RegisterVariable (&r_drawviewmodel);
         Cvar_SetCallback (&r_wateralpha, R_SetWateralpha_f);
         Cvar_RegisterVariable (&r_litwater);
         Cvar_RegisterVariable (&r_dynamic);
+        Cvar_RegisterVariable (&r_clustered_light_enable);
+        Cvar_RegisterVariable (&r_clustered_light_radius_scale);
+        Cvar_RegisterVariable (&r_clustered_light_debug_visualize);
         Cvar_RegisterVariable (&r_dlight_enable);
-        Cvar_RegisterVariable (&r_dlight_scale);
         Cvar_RegisterVariable (&r_dlight_radius_scale);
         Cvar_RegisterVariable (&r_dlight_debug_visualize);
+        Cvar_SetCallback (&r_clustered_light_enable, R_ClusteredLight_MasterCallback);
+        Cvar_SetCallback (&r_clustered_light_radius_scale, R_ClusteredLight_MasterCallback);
+        Cvar_SetCallback (&r_clustered_light_debug_visualize, R_ClusteredLight_MasterCallback);
+        Cvar_SetCallback (&r_dlight_enable, R_ClusteredLight_LegacyCallback);
+        Cvar_SetCallback (&r_dlight_radius_scale, R_ClusteredLight_LegacyCallback);
+        Cvar_SetCallback (&r_dlight_debug_visualize, R_ClusteredLight_LegacyCallback);
+        R_ClusteredLight_MasterCallback (NULL);
         Cvar_RegisterVariable (&r_clustered_lighting);
         Cvar_RegisterVariable (&r_clustered_tilesize);
         Cvar_RegisterVariable (&r_clustered_zslices);

--- a/Quake/renderer/r_shadow.c
+++ b/Quake/renderer/r_shadow.c
@@ -62,7 +62,7 @@ static GLuint shadow_depth_tex;
 static int shadowmap_size;
 static GLuint shadow_dlight_fbo;
 static GLuint shadow_dlight_depth_tex;
-static int shadow_dlight_atlas_size;
+static int shadow_clustered_light_atlas_size;
 static int shadow_dlight_tile_size;
 static int shadow_dlight_tile_count;
 static int shadow_dlight_selected_count;
@@ -1190,7 +1190,7 @@ static void R_Shadow_DestroyDlightResources (void)
 		GL_DeleteNativeTexture (shadow_dlight_depth_tex);
 		shadow_dlight_depth_tex = 0;
 	}
-	shadow_dlight_atlas_size = 0;
+	shadow_clustered_light_atlas_size = 0;
 	shadow_dlight_tile_size = 0;
 	shadow_dlight_tile_count = 0;
 	shadow_dlight_validated_once = false;
@@ -1562,7 +1562,7 @@ static void R_Shadow_ResizeDlightAtlasIfNeeded (void)
 	}
 
 	if (shadow_dlight_depth_tex && shadow_dlight_fbo &&
-		shadow_dlight_atlas_size == atlas_size &&
+		shadow_clustered_light_atlas_size == atlas_size &&
 		shadow_dlight_tile_size == tile_size &&
 		shadow_dlight_tile_count == grid * grid)
 		return;
@@ -1589,7 +1589,7 @@ static void R_Shadow_ResizeDlightAtlasIfNeeded (void)
 			Sys_Error ("Failed to create dlight shadowmap FBO (status code 0x%X)", status);
 	}
 
-	shadow_dlight_atlas_size = atlas_size;
+	shadow_clustered_light_atlas_size = atlas_size;
 	shadow_dlight_tile_size = tile_size;
 	shadow_dlight_tile_count = grid * grid;
 }
@@ -1601,7 +1601,7 @@ void R_InitShadow (void)
 	shadowmap_size = 0;
 	shadow_dlight_fbo = 0;
 	shadow_dlight_depth_tex = 0;
-	shadow_dlight_atlas_size = 0;
+	shadow_clustered_light_atlas_size = 0;
 	shadow_dlight_tile_size = 0;
 	shadow_dlight_tile_count = 0;
 	shadow_dlight_selected_count = 0;
@@ -1824,15 +1824,15 @@ void R_Shadow_DlightPass (void)
 
 	for (int i = 0; i < SHADOW_DLIGHT_MAX; ++i)
 	{
-		IdentityMatrix (r_framedata.shadow_dlight_viewproj[i]);
-		r_framedata.shadow_dlight_atlas[i][0] = 0.f;
-		r_framedata.shadow_dlight_atlas[i][1] = 0.f;
-		r_framedata.shadow_dlight_atlas[i][2] = 0.f;
-		r_framedata.shadow_dlight_atlas[i][3] = 0.f;
-		r_framedata.shadow_dlight_info[i][0] = -1.f;
-		r_framedata.shadow_dlight_info[i][1] = 0.f;
-		r_framedata.shadow_dlight_info[i][2] = 0.f;
-		r_framedata.shadow_dlight_info[i][3] = 0.f;
+		IdentityMatrix (r_framedata.shadow_clustered_light_viewproj[i]);
+		r_framedata.shadow_clustered_light_atlas[i][0] = 0.f;
+		r_framedata.shadow_clustered_light_atlas[i][1] = 0.f;
+		r_framedata.shadow_clustered_light_atlas[i][2] = 0.f;
+		r_framedata.shadow_clustered_light_atlas[i][3] = 0.f;
+		r_framedata.shadow_clustered_light_info[i][0] = -1.f;
+		r_framedata.shadow_clustered_light_info[i][1] = 0.f;
+		r_framedata.shadow_clustered_light_info[i][2] = 0.f;
+		r_framedata.shadow_clustered_light_info[i][3] = 0.f;
 		shadow_dlight_light_indices[i] = -1;
 	}
 
@@ -1944,12 +1944,12 @@ void R_Shadow_DlightPass (void)
 	GL_DepthRange (ZRANGE_FULL);
 	if (!shadow_dlight_validated_once || r_shadow_validate.value > 1.f)
 	{
-		R_Shadow_ValidateDepthResources ("dlight", shadow_dlight_fbo, shadow_dlight_depth_tex, shadow_dlight_atlas_size, shadow_dlight_atlas_size, GL_NONE, R_Shadow_SelectCompareFunc ());
+		R_Shadow_ValidateDepthResources ("dlight", shadow_dlight_fbo, shadow_dlight_depth_tex, shadow_clustered_light_atlas_size, shadow_clustered_light_atlas_size, GL_NONE, R_Shadow_SelectCompareFunc ());
 		shadow_dlight_validated_once = true;
 	}
 	GL_SetScissorEnabled (true);
 
-	grid = shadow_dlight_atlas_size / shadow_dlight_tile_size;
+	grid = shadow_clustered_light_atlas_size / shadow_dlight_tile_size;
 	if (grid < 1)
 		grid = 1;
 
@@ -1982,17 +1982,17 @@ void R_Shadow_DlightPass (void)
 		else if (coverage < 0.45f)
 			lod_mul = 0.75f;
 
-		scale = ((float)shadow_dlight_tile_size * lod_mul) / (float)shadow_dlight_atlas_size;
-		offset_x = tile_x * ((float)shadow_dlight_tile_size / (float)shadow_dlight_atlas_size);
-		offset_y = tile_y * ((float)shadow_dlight_tile_size / (float)shadow_dlight_atlas_size);
+		scale = ((float)shadow_dlight_tile_size * lod_mul) / (float)shadow_clustered_light_atlas_size;
+		offset_x = tile_x * ((float)shadow_dlight_tile_size / (float)shadow_clustered_light_atlas_size);
+		offset_y = tile_y * ((float)shadow_dlight_tile_size / (float)shadow_clustered_light_atlas_size);
 
 		R_Shadow_BuildDlightViewProj (viewproj, glight->pos, glight->radius);
-		memcpy (r_framedata.shadow_dlight_viewproj[i], viewproj, sizeof (viewproj));
-		r_framedata.shadow_dlight_atlas[i][0] = scale;
-		r_framedata.shadow_dlight_atlas[i][1] = scale;
-		r_framedata.shadow_dlight_atlas[i][2] = offset_x;
-		r_framedata.shadow_dlight_atlas[i][3] = offset_y;
-		r_framedata.shadow_dlight_info[i][0] = (float)light_index;
+		memcpy (r_framedata.shadow_clustered_light_viewproj[i], viewproj, sizeof (viewproj));
+		r_framedata.shadow_clustered_light_atlas[i][0] = scale;
+		r_framedata.shadow_clustered_light_atlas[i][1] = scale;
+		r_framedata.shadow_clustered_light_atlas[i][2] = offset_x;
+		r_framedata.shadow_clustered_light_atlas[i][3] = offset_y;
+		r_framedata.shadow_clustered_light_info[i][0] = (float)light_index;
 
 		memcpy (r_framedata.shadow_viewproj, viewproj, sizeof (viewproj));
 		R_UploadFrameData ();
@@ -2027,9 +2027,9 @@ void R_Shadow_DlightPass (void)
 
 	GL_SetScissorEnabled (false);
 	t1 = Sys_DoubleTime ();
-	R_Shadow_Log_ShadowPassSnapshot ("DLIGHTPASS", shadow_dlight_fbo, shadow_dlight_depth_tex, shadow_dlight_atlas_size, shadow_dlight_atlas_size,
+	R_Shadow_Log_ShadowPassSnapshot ("DLIGHTPASS", shadow_dlight_fbo, shadow_dlight_depth_tex, shadow_clustered_light_atlas_size, shadow_clustered_light_atlas_size,
 		(rs_brushpasses + rs_aliaspasses) - draws0, (rs_brushpasses + rs_aliaspasses) - tris0, (t1 - t0) * 1000.0);
-	R_Shadow_LogWrite ("DLIGHTPASS selected=%d atlas=%d tile=%d tile_count=%d cvar_max=%d\n", shadow_dlight_selected_count, shadow_dlight_atlas_size, shadow_dlight_tile_size, shadow_dlight_tile_count, max_tiles);
+	R_Shadow_LogWrite ("DLIGHTPASS selected=%d atlas=%d tile=%d tile_count=%d cvar_max=%d\n", shadow_dlight_selected_count, shadow_clustered_light_atlas_size, shadow_dlight_tile_size, shadow_dlight_tile_count, max_tiles);
 	R_Shadow_LogStateSnapshot ("DLIGHTPASS_BEFORE_RESTORE");
 
 	memcpy (r_framedata.shadow_viewproj, sun_viewproj, sizeof (sun_viewproj));

--- a/Quake/shaders/atmos_froxel_integrate.comp
+++ b/Quake/shaders/atmos_froxel_integrate.comp
@@ -154,7 +154,7 @@ void main()
 
     vec2 screenPos = uv * vec2(ClusterScreenSize);
     float viewDepth = max(z0 + 0.5 * stepLen, 1e-4);
-    vec3 LiDyn = EvaluateDynamicLights(worldPos, screenPos, viewDepth, sigma_t) * clamp(DLightParams.w / 3.0, 0.0, 1.0);
+    vec3 LiDyn = EvaluateDynamicLights(worldPos, screenPos, viewDepth, sigma_t) * clamp(ClusteredLightParams.w / 3.0, 0.0, 1.0);
 
     vec3 LiTotal = LiSun + LiDyn;
     vec3 scatter = sigma_s * LiTotal * phase * stepLen;

--- a/Quake/shaders/fogvol.frag
+++ b/Quake/shaders/fogvol.frag
@@ -382,7 +382,7 @@ void main()
 		float sigma_s = sigma_t * clamp(max(scatterColor.r, max(scatterColor.g, scatterColor.b)), 0.0, 1.0);
 		vec3 pView = (View * vec4(p, 1.0)).xyz;
 		float viewDepth = max(-pView.z, 1e-4);
-		vec3 LiDyn = EvaluateDynamicLights(p, screenPos, viewDepth) * clamp(DLightParams.w / 3.0, 0.0, 1.0);
+		vec3 LiDyn = EvaluateDynamicLights(p, screenPos, viewDepth) * clamp(ClusteredLightParams.w / 3.0, 0.0, 1.0);
 		float cosTheta = dot(viewDir, sunDir);
 		float phase = HGPhase(cosTheta, anisotropy);
 		vec3 LiSun = sunColor * max(dot(rd, sunDir), 0.0);

--- a/Quake/shaders/frame_uniforms.glsl
+++ b/Quake/shaders/frame_uniforms.glsl
@@ -24,7 +24,7 @@ layout(std140, binding=0) uniform FrameDataUBO
         float   ZLogBias;
         vec4    LightmapParams;
         vec4    LightgridParams;
-        vec4    DLightParams;
+        vec4    ClusteredLightParams;
         vec4    ColorSpaceParams;
         vec4    ShaderParams;
         vec4    LightingParams;
@@ -32,10 +32,10 @@ layout(std140, binding=0) uniform FrameDataUBO
         vec4    ShadowParams;
         vec4    ShadowDebug;
         vec4    ShadowSunDir;
-        mat4    ShadowDlightViewProj[SHADOW_DLIGHT_MAX];
-        vec4    ShadowDlightAtlas[SHADOW_DLIGHT_MAX];
-        vec4    ShadowDlightInfo[SHADOW_DLIGHT_MAX];
-        vec4    ShadowDlightParams;
+        mat4    ShadowClusteredLightViewProj[SHADOW_DLIGHT_MAX];
+        vec4    ShadowClusteredLightAtlas[SHADOW_DLIGHT_MAX];
+        vec4    ShadowClusteredLightInfo[SHADOW_DLIGHT_MAX];
+        vec4    ShadowClusteredLightParams;
         uint    NumLights;
         uint    PrevFrameValid;
         uint    _Pad1;

--- a/Quake/shaders/legacy_debug/world_dlight.frag
+++ b/Quake/shaders/legacy_debug/world_dlight.frag
@@ -119,7 +119,7 @@ void main()
 
         vec3 dynamic_light = vec3(0.0);
         vec3 specular_light = vec3(0.0);
-        float quality = clamp(DLightParams.w / 3.0, 0.25, 1.0);
+        float quality = clamp(ClusteredLightParams.w / 3.0, 0.25, 1.0);
         vec3 view_dir = normalize(EyePos - in_pos);
         if (NumLights > 0u)
         {

--- a/Quake/shaders/legacy_debug/world_dlight_hybrid.frag
+++ b/Quake/shaders/legacy_debug/world_dlight_hybrid.frag
@@ -119,7 +119,7 @@ void main()
 
         vec3 dynamic_light = vec3(0.0);
         vec3 specular_light = vec3(0.0);
-        float quality = clamp(DLightParams.w / 3.0, 0.25, 1.0);
+        float quality = clamp(ClusteredLightParams.w / 3.0, 0.25, 1.0);
         vec3 view_dir = normalize(EyePos - in_pos);
         if (NumLights > 0u)
         {

--- a/Quake/shaders/shadow_sample.glsl
+++ b/Quake/shaders/shadow_sample.glsl
@@ -279,7 +279,7 @@ float ShadowSamplePCFDlight(vec2 uv, float reference, float bias, int taps)
 
 float ShadowVisibilityDlight(vec3 world_pos, vec3 normal, vec3 light_pos, uint light_index, out float in_range)
 {
-	if (ShadowDlightParams.z < 0.5)
+	if (ShadowClusteredLightParams.z < 0.5)
 	{
 		in_range = 1.0;
 		return 1.0;
@@ -288,9 +288,9 @@ float ShadowVisibilityDlight(vec3 world_pos, vec3 normal, vec3 light_pos, uint l
 	int shadow_index = -1;
 	for (int i = 0; i < SHADOW_DLIGHT_MAX; ++i)
 	{
-		if (ShadowDlightInfo[i].x < 0.0)
+		if (ShadowClusteredLightInfo[i].x < 0.0)
 			continue;
-		int idx = int(ShadowDlightInfo[i].x + 0.5);
+		int idx = int(ShadowClusteredLightInfo[i].x + 0.5);
 		if (idx == int(light_index))
 		{
 			shadow_index = i;
@@ -304,7 +304,7 @@ float ShadowVisibilityDlight(vec3 world_pos, vec3 normal, vec3 light_pos, uint l
 		return 1.0;
 	}
 
-	vec4 clip = ShadowMul(ShadowDlightViewProj[shadow_index], vec4(world_pos, 1.0));
+	vec4 clip = ShadowMul(ShadowClusteredLightViewProj[shadow_index], vec4(world_pos, 1.0));
 	if (clip.w <= 0.0)
 	{
 		in_range = 0.0;
@@ -321,18 +321,18 @@ float ShadowVisibilityDlight(vec3 world_pos, vec3 normal, vec3 light_pos, uint l
 	if (!inside_local)
 		return 1.0;
 
-	vec4 atlas = ShadowDlightAtlas[shadow_index];
+	vec4 atlas = ShadowClusteredLightAtlas[shadow_index];
 	uv = uv * atlas.xy + atlas.zw;
 
 	vec3 light_dir = normalize(light_pos - world_pos);
 	float ndotl = clamp(dot(normal, light_dir), 0.0, 1.0);
-	// FIX: Added constant bias term (ShadowDlightParams.x) to prevent shadow acne
+	// FIX: Added constant bias term (ShadowClusteredLightParams.x) to prevent shadow acne
 	// at near-perpendicular angles (ndotl ≈ 1 made old bias ≈ 0).
-	// ShadowDlightParams.x = constant bias, ShadowDlightParams.y = slope bias,
+	// ShadowClusteredLightParams.x = constant bias, ShadowClusteredLightParams.y = slope bias,
 	// matching the convention used in the sun shadow path.
-	float bias = ShadowDlightParams.x + ShadowDlightParams.y * (1.0 - ndotl);
+	float bias = ShadowClusteredLightParams.x + ShadowClusteredLightParams.y * (1.0 - ndotl);
 
-	int taps = int(ShadowDlightParams.w + 0.5);
+	int taps = int(ShadowClusteredLightParams.w + 0.5);
 	if (taps > 0)
 		return ShadowSamplePCFDlight(uv, reference, bias, taps);
 

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -399,7 +399,7 @@ void main()
                 return;
         }
 
-        bool dlight_debug = DLightParams.y > 0.5;
+        bool clustered_light_debug = ClusteredLightParams.y > 0.5;
 
 	// Lightmap sampling
 	vec2 lmuv = in_lmuv;
@@ -473,7 +473,7 @@ void main()
 			return;
 		}
 
-		if (dlight_debug)
+		if (clustered_light_debug)
 		{
 			static_light = vec3(0.0);
 			fullbright = vec3(0.0);
@@ -540,7 +540,7 @@ void main()
 		total_light = clamp(total_light + env_fill, 0.0, 1.0);
 	
 	const float SPECULAR_POWER = 16.0;
-	float specular_quality = clamp(DLightParams.w / 3.0, 0.25, 1.0);
+	float specular_quality = clamp(ClusteredLightParams.w / 3.0, 0.25, 1.0);
 	float specular_scale = 0.4 * specular_quality;
 
 	int tileX = 0;
@@ -649,7 +649,7 @@ void main()
 	}
 
 	// Sun light
-        vec3 sun_light = dlight_debug ? vec3(0.0) : ComputeSunLight(in_pos, surface_normal);
+        vec3 sun_light = clustered_light_debug ? vec3(0.0) : ComputeSunLight(in_pos, surface_normal);
 	total_light += max(min(sun_light, 1.0 - total_light), 0.0);
 
 		// Apply lighting


### PR DESCRIPTION
### Motivation
- Consolidate dynamic-light controls under clustered-light scope and reduce confusion from legacy `dlight` naming while preserving backward compatibility. 
- Ensure frame UBO fields and CPU-side fills explicitly reflect clustered-light semantics used by the shaders and clustering code. 

### Description
- Added clustered-scoped cvars: `r_clustered_light_enable`, `r_clustered_light_radius_scale`, and `r_clustered_light_debug_visualize`, and removed unused `r_dlight_scale` registration/definition wiring. 
- Kept legacy `r_dlight_*` cvars as deprecated compatibility aliases and wired bidirectional callbacks in `gl_rmisc.c` that forward values between legacy and clustered controls and print a one-time deprecation warning. 
- Switched runtime dynamic-light submission and radius scaling to use the clustered-scoped controls (`R_PushDlights` and `R_PushDlightArray` changes in `gl_rlight.c`). 
- Renamed frame UBO and CPU fields from dlight-centric names to clustered-focused names: `dlight_params` -> `clustered_light_params`, `shadow_dlight_*` -> `shadow_clustered_light_*` (updated in `glquake.h`, `gl_rmain.c`, `frame_uniforms.glsl` and propagated to shaders). 
- Updated renderer debug/state markers and filtering wording from `WORLD_LIGHTS_*`/`dlight` to `WORLD_CLUSTERED_LIGHTS_*`/`clustered_light` and updated all shader consumers to use the new `ClusteredLightParams`/`ShadowClusteredLight*` uniforms. 

### Testing
- Searched repository for removed/renamed identifiers with `rg` (e.g. `rg -n "r_dlight_scale|\bDLightParams\b|\bShadowDlightParams\b" Quake`) and confirmed there are no remaining matches for the old names. (succeeded) 
- Ran `cmake -S . -B build` to validate build integration in this environment; configuration failed due to missing SDL2 development package (`SDL2Config.cmake` not found) in the environment, so a full build could not be completed here. (failed due to environment, not code)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699598556a88832ea3cf689fe493032c)