### PR TITLE
Refactor clustered lighting shader plumbing into shared include

### DIFF
--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -109,50 +109,7 @@ layout(binding=2) uniform sampler2D EmissiveTex;
 layout(binding=5) uniform sampler2D ShadowMap;
 layout(binding=6) uniform samplerCube ReflectionTex;
 
-struct ClusterHeader
-{
-	uint offset;
-	uint count;
-};
-
-struct PackedLight
-{
-	vec4 posRadius;
-	vec4 colorIntensity;
-	ivec4 flags;
-};
-
-layout(std430, binding=4) readonly buffer ClusterHeaderBuffer
-{
-	ClusterHeader headers[];
-};
-
-layout(std430, binding=5) readonly buffer ClusterIndexBuffer
-{
-	uint lightIndices[];
-};
-
-layout(std430, binding=3) readonly buffer PackedLightsBuffer
-{
-	PackedLight packedLights[];
-};
-
-layout(std140, binding=2) uniform ClusterParams
-{
-	ivec2 ClusterScreenSize;
-	ivec2 ClusterGridXY;
-	int ClusterZSlices;
-	float ClusterNearPlane;
-	float ClusterFarPlane;
-	float ClusterZLogScale;
-	float ClusterZLogBias;
-	mat4 ClusterViewMatrix;
-	mat4 ClusterProjMatrix;
-	mat4 ClusterInvProj;
-	int ClusterTileSize;
-	int ClusterDebugMode;
-};
-
+#include "clustered_lighting.glsl"
 #include "envlight.glsl"
 #define SHADOW_SUN 1
 #include "shadow_sample.glsl"
@@ -235,25 +192,22 @@ vec3 normalize_safe(vec3 v)
 
 vec3 EvaluateAliasClusteredLights(vec3 world_pos, vec3 normal, vec2 screen_pos)
 {
-	if (NumLights == 0u || ClusterTileSize <= 0 || ClusterGridXY.x <= 0 || ClusterGridXY.y <= 0 || ClusterZSlices <= 0)
+	float view_depth = abs((ClusterViewMatrix * vec4(world_pos, 1.0)).z);
+	ClusterHeader header;
+	uint cluster_count;
+	int cluster_idx;
+	if (!ClusterResolve(screen_pos, view_depth, cluster_idx, header, cluster_count))
 		return vec3(0.0);
 
-	float view_depth = abs((ClusterViewMatrix * vec4(world_pos, 1.0)).z);
-	int tile_x = clamp(int(screen_pos.x) / ClusterTileSize, 0, ClusterGridXY.x - 1);
-	int tile_y = clamp(int(screen_pos.y) / ClusterTileSize, 0, ClusterGridXY.y - 1);
-	int z_slice = clamp(int(floor(log2(max(view_depth, 1e-4)) * ClusterZLogScale + ClusterZLogBias)), 0, ClusterZSlices - 1);
-	int cluster_idx = (z_slice * ClusterGridXY.y + tile_y) * ClusterGridXY.x + tile_x;
-	ClusterHeader header = headers[cluster_idx];
-	uint cluster_count = min(header.count, NumLights);
 	vec3 dynamic_light = vec3(0.0);
 
 	for (uint i = 0u; i < cluster_count; ++i)
 	{
-		uint light_id = lightIndices[header.offset + i];
-		if (light_id >= NumLights)
+		uint light_id;
+		PackedLight pl;
+		if (!ClusterFetchLight(header, i, light_id, pl))
 			continue;
 
-		PackedLight pl = packedLights[light_id];
 		vec3 light_vec = pl.posRadius.xyz - world_pos;
 		float dist = length(light_vec);
 		float radius = pl.posRadius.w;
@@ -282,6 +236,7 @@ void main()
 	vec3 N_lighting = normalize_safe(gl_FrontFacing ? in_normal : -in_normal);
 	vec3 world_pos = in_pos + AliasEyePos;
 	vec3 clustered_dyn = EvaluateAliasClusteredLights(world_pos, N_lighting, gl_FragCoord.xy);
+	vec3 L_dyn = clustered_dyn;
 	lit_color.rgb += clustered_dyn;
 
 	if (ShadowDebug.x > 0.5 && (in_flags & ALIAS_FLAG_VIEWMODEL) == 0)

--- a/Quake/shaders/atmos_froxel_integrate.comp
+++ b/Quake/shaders/atmos_froxel_integrate.comp
@@ -6,49 +6,7 @@ layout(binding=6) uniform sampler2D ShadowMap;
 #define SHADOW_SUN 1
 #include "shadow_sample.glsl"
 
-struct ClusterHeader
-{
-    uint offset;
-    uint count;
-};
-
-struct PackedLight
-{
-    vec4 posRadius;
-    vec4 colorIntensity;
-    ivec4 flags;
-};
-
-layout(std430, binding=4) readonly buffer ClusterHeaderBuffer
-{
-    ClusterHeader headers[];
-};
-
-layout(std430, binding=5) readonly buffer ClusterIndexBuffer
-{
-    uint lightIndices[];
-};
-
-layout(std430, binding=3) readonly buffer PackedLightsBuffer
-{
-    PackedLight packedLights[];
-};
-
-layout(std140, binding=2) uniform ClusterParams
-{
-    ivec2 ClusterScreenSize;
-    ivec2 ClusterGridXY;
-    int ClusterZSlices;
-    float ClusterNearPlane;
-    float ClusterFarPlane;
-    float ClusterZLogScale;
-    float ClusterZLogBias;
-    mat4 ClusterViewMatrix;
-    mat4 ClusterProjMatrix;
-    mat4 ClusterInvProj;
-    int ClusterTileSize;
-    int ClusterDebugMode;
-};
+#include "clustered_lighting.glsl"
 
 layout(location=0) uniform vec4 FroxelParams0; // xyz dims, w steps
 layout(location=1) uniform vec4 LightParams0; // x g, y intensity, z shadow enable
@@ -87,22 +45,21 @@ vec3 Atmosphere_ViewToWorld(vec3 viewPos)
 
 vec3 EvaluateDynamicLights(vec3 worldPos, vec2 screenPos, float viewDepth, float sigma_t)
 {
-    if (NumLights == 0u || ClusterTileSize <= 0)
+    ClusterHeader header;
+    uint clusterCount;
+    int clusterIdx;
+    if (!ClusterResolve(screenPos, viewDepth, clusterIdx, header, clusterCount))
         return vec3(0.0);
 
-    int tileX = clamp(int(screenPos.x) / ClusterTileSize, 0, ClusterGridXY.x - 1);
-    int tileY = clamp(int(screenPos.y) / ClusterTileSize, 0, ClusterGridXY.y - 1);
-    int zSlice = clamp(int(floor(log2(max(viewDepth, 1e-4)) * ClusterZLogScale + ClusterZLogBias)), 0, ClusterZSlices - 1);
-    int clusterIdx = (zSlice * ClusterGridXY.y + tileY) * ClusterGridXY.x + tileX;
-    ClusterHeader header = headers[clusterIdx];
     vec3 dynamicLight = vec3(0.0);
 
-    for (uint i = 0u; i < header.count; ++i)
+    for (uint i = 0u; i < clusterCount; ++i)
     {
-        uint lightId = lightIndices[header.offset + i];
-        if (lightId >= NumLights)
+        uint lightId;
+        PackedLight pl;
+        if (!ClusterFetchLight(header, i, lightId, pl))
             continue;
-        PackedLight pl = packedLights[lightId];
+
         vec3 lightVec = pl.posRadius.xyz - worldPos;
         float dist = length(lightVec);
         float radius = max(pl.posRadius.w, 1e-4);

--- a/Quake/shaders/clustered_lighting.glsl
+++ b/Quake/shaders/clustered_lighting.glsl
@@ -1,0 +1,96 @@
+struct ClusterHeader
+{
+	uint offset;
+	uint count;
+};
+
+struct PackedLight
+{
+	vec4 posRadius;
+	vec4 colorIntensity;
+	ivec4 flags;
+};
+
+layout(std430, binding=4) readonly buffer ClusterHeaderBuffer
+{
+	ClusterHeader headers[];
+};
+
+layout(std430, binding=5) readonly buffer ClusterIndexBuffer
+{
+	uint lightIndices[];
+};
+
+layout(std430, binding=3) readonly buffer PackedLightsBuffer
+{
+	PackedLight packedLights[];
+};
+
+layout(std140, binding=2) uniform ClusterParams
+{
+	ivec2 ClusterScreenSize;
+	ivec2 ClusterGridXY;
+	int ClusterZSlices;
+	float ClusterNearPlane;
+	float ClusterFarPlane;
+	float ClusterZLogScale;
+	float ClusterZLogBias;
+	mat4 ClusterViewMatrix;
+	mat4 ClusterProjMatrix;
+	mat4 ClusterInvProj;
+	int ClusterTileSize;
+	int ClusterDebugMode;
+};
+
+bool ClusterLightingEnabled()
+{
+	return NumLights > 0u
+		&& ClusterTileSize > 0
+		&& ClusterGridXY.x > 0
+		&& ClusterGridXY.y > 0
+		&& ClusterZSlices > 0;
+}
+
+int ClusterComputeZSlice(float viewDepth)
+{
+	float depth = max(viewDepth, 1e-4);
+	float z = floor(log2(depth) * ClusterZLogScale + ClusterZLogBias);
+	return clamp(int(z), 0, ClusterZSlices - 1);
+}
+
+int ClusterComputeIndex(vec2 screenPos, float viewDepth)
+{
+	int tileX = clamp(int(screenPos.x) / ClusterTileSize, 0, ClusterGridXY.x - 1);
+	int tileY = clamp(int(screenPos.y) / ClusterTileSize, 0, ClusterGridXY.y - 1);
+	int zSlice = ClusterComputeZSlice(viewDepth);
+	return (zSlice * ClusterGridXY.y + tileY) * ClusterGridXY.x + tileX;
+}
+
+bool ClusterResolve(vec2 screenPos, float viewDepth, out int clusterIdx, out ClusterHeader header, out uint clusterCount)
+{
+	clusterIdx = 0;
+	header = ClusterHeader(0u, 0u);
+	clusterCount = 0u;
+	if (!ClusterLightingEnabled())
+		return false;
+
+	clusterIdx = ClusterComputeIndex(screenPos, viewDepth);
+	header = headers[clusterIdx];
+	clusterCount = min(header.count, NumLights);
+	return clusterCount > 0u;
+}
+
+bool ClusterFetchLight(ClusterHeader header, uint localIndex, out uint lightId, out PackedLight light)
+{
+	lightId = 0u;
+	light = PackedLight(vec4(0.0), vec4(0.0), ivec4(0));
+	if (localIndex >= header.count)
+		return false;
+
+	lightId = lightIndices[header.offset + localIndex];
+	if (lightId >= NumLights)
+		return false;
+
+	light = packedLights[lightId];
+	return true;
+}

--- a/Quake/shaders/fogvol.frag
+++ b/Quake/shaders/fogvol.frag
@@ -21,49 +21,7 @@ layout(std140, binding=12) uniform FogVolumeUBO
 	FogVolume FogVolumes[MAX_FOGVOLUMES];
 };
 
-struct ClusterHeader
-{
-	uint offset;
-	uint count;
-};
-
-struct PackedLight
-{
-	vec4 posRadius;
-	vec4 colorIntensity;
-	ivec4 flags;
-};
-
-layout(std430, binding=4) readonly buffer ClusterHeaderBuffer
-{
-	ClusterHeader headers[];
-};
-
-layout(std430, binding=5) readonly buffer ClusterIndexBuffer
-{
-	uint lightIndices[];
-};
-
-layout(std430, binding=3) readonly buffer PackedLightsBuffer
-{
-	PackedLight packedLights[];
-};
-
-layout(std140, binding=2) uniform ClusterParams
-{
-	ivec2 ClusterScreenSize;
-	ivec2 ClusterGridXY;
-	int ClusterZSlices;
-	float ClusterNearPlane;
-	float ClusterFarPlane;
-	float ClusterZLogScale;
-	float ClusterZLogBias;
-	mat4 ClusterViewMatrix;
-	mat4 ClusterProjMatrix;
-	mat4 ClusterInvProj;
-	int ClusterTileSize;
-	int ClusterDebugMode;
-};
+#include "clustered_lighting.glsl"
 
 layout(location=0) uniform int FogSteps;
 layout(location=1) uniform int FogNoiseEnabled;
@@ -222,22 +180,21 @@ float HGPhase(float cosTheta, float g)
 
 vec3 EvaluateDynamicLights(vec3 worldPos, vec2 screenPos, float viewDepth)
 {
-	if (NumLights == 0u || ClusterTileSize <= 0)
+	ClusterHeader header;
+	uint clusterCount;
+	int clusterIdx;
+	if (!ClusterResolve(screenPos, viewDepth, clusterIdx, header, clusterCount))
 		return vec3(0.0);
 
-	int tileX = clamp(int(screenPos.x) / ClusterTileSize, 0, ClusterGridXY.x - 1);
-	int tileY = clamp(int(screenPos.y) / ClusterTileSize, 0, ClusterGridXY.y - 1);
-	int zSlice = clamp(int(floor(log2(max(viewDepth, 1e-4)) * ClusterZLogScale + ClusterZLogBias)), 0, ClusterZSlices - 1);
-	int clusterIdx = (zSlice * ClusterGridXY.y + tileY) * ClusterGridXY.x + tileX;
-	ClusterHeader header = headers[clusterIdx];
 	vec3 dynamicLight = vec3(0.0);
 
-	for (uint i = 0u; i < header.count; ++i)
+	for (uint i = 0u; i < clusterCount; ++i)
 	{
-		uint lightId = lightIndices[header.offset + i];
-		if (lightId >= NumLights)
+		uint lightId;
+		PackedLight pl;
+		if (!ClusterFetchLight(header, i, lightId, pl))
 			continue;
-		PackedLight pl = packedLights[lightId];
+
 		vec3 lightVec = pl.posRadius.xyz - worldPos;
 		float dist = length(lightVec);
 		float radius = pl.posRadius.w;

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -12,6 +12,7 @@ layout(binding=6) uniform samplerCube ReflectionTex;
 #include "frame_uniforms.glsl"
 #include "depth_common.glsl"
 #include "envlight.glsl"
+#include "clustered_lighting.glsl"
 #define SHADOW_SUN 1
 #include "shadow_sample.glsl"
 
@@ -42,50 +43,6 @@ float GetLightStyle(int index)
 {
 	return (index < 64) ? mix(LightStyles[index].x, LightStyles[index].y, LightmapParams.w) : 1.0;
 }
-
-struct ClusterHeader
-{
-	uint offset;
-	uint count;
-};
-
-struct PackedLight
-{
-	vec4 posRadius;
-	vec4 colorIntensity;
-	ivec4 flags;
-};
-
-layout(std430, binding=4) readonly buffer ClusterHeaderBuffer
-{
-	ClusterHeader headers[];
-};
-
-layout(std430, binding=5) readonly buffer ClusterIndexBuffer
-{
-	uint lightIndices[];
-};
-
-layout(std430, binding=3) readonly buffer PackedLightsBuffer
-{
-	PackedLight packedLights[];
-};
-
-layout(std140, binding=2) uniform ClusterParams
-{
-	ivec2 ClusterScreenSize;
-	ivec2 ClusterGridXY;
-	int ClusterZSlices;
-	float ClusterNearPlane;
-	float ClusterFarPlane;
-	float ClusterZLogScale;
-	float ClusterZLogBias;
-	mat4 ClusterViewMatrix;
-	mat4 ClusterProjMatrix;
-	mat4 ClusterInvProj;
-	int ClusterTileSize;
-	int ClusterDebugMode;
-};
 
 struct Call
 {
@@ -548,13 +505,13 @@ void main()
 	int zSlice = 0;
 	int clusterIdx = 0;
 	uint clusterCount = 0u;
-	bool clusterActive = (NumLights > 0u && ClusterTileSize > 0 && ClusterGridXY.x > 0 && ClusterGridXY.y > 0 && ClusterZSlices > 0);
+	bool clusterActive = ClusterLightingEnabled();
 
 	if (clusterActive)
 	{
 		tileX = clamp(int(gl_FragCoord.x) / ClusterTileSize, 0, ClusterGridXY.x - 1);
 		tileY = clamp(int(gl_FragCoord.y) / ClusterTileSize, 0, ClusterGridXY.y - 1);
-		zSlice = clamp(int(floor(log2(max(in_depth, 1e-4)) * ClusterZLogScale + ClusterZLogBias)), 0, ClusterZSlices - 1);
+		zSlice = ClusterComputeZSlice(in_depth);
 		clusterIdx = (zSlice * ClusterGridXY.y + tileY) * ClusterGridXY.x + tileX;
 		clusterCount = headers[clusterIdx].count;
 	}
@@ -600,18 +557,21 @@ void main()
 	// Dynamic lights (clustered lighting)
 	if (clusterActive)
 	{
-		ClusterHeader header = headers[clusterIdx];
-		uint clusterCount = min(header.count, NumLights);
+		ClusterHeader header;
+		uint clusterCount;
+		int resolvedClusterIdx;
+		if (!ClusterResolve(gl_FragCoord.xy, in_depth, resolvedClusterIdx, header, clusterCount))
+			clusterCount = 0u;
 		vec3 dynamic_light = vec3(0.0);
 		float dynamic_light_noise = 1.0 - whitenoise01(in_pos.xy) * 0.15;
 		vec4 plane = vec4(surface_normal, dot(in_pos, surface_normal));
 
 		for (uint i = 0u; i < clusterCount; ++i)
 		{
-			uint lightId = lightIndices[header.offset + i];
-			if (lightId >= NumLights)
+			uint lightId;
+			PackedLight pl;
+			if (!ClusterFetchLight(header, i, lightId, pl))
 				continue;
-			PackedLight pl = packedLights[lightId];
 			vec3 lightOrigin = pl.posRadius.xyz;
 			float radius = pl.posRadius.w;
 			vec3 lightColor = pl.colorIntensity.rgb;


### PR DESCRIPTION
### Motivation
- Reduce duplicated clustered-lighting declarations and iteration plumbing across multiple shader stages by centralizing common data and helper functions.
- Keep per-shader light math (attenuation, BRDF, scattering) local so each stage preserves its existing lighting behavior and debug paths.

### Description
- Add `Quake/shaders/clustered_lighting.glsl` containing `ClusterHeader`, `PackedLight`, SSBO/UBO binding declarations, and helpers: `ClusterLightingEnabled`, `ClusterComputeZSlice`, `ClusterComputeIndex`, `ClusterResolve`, and `ClusterFetchLight`.
- Replace duplicated cluster data blocks and per-shader index logic in `world.frag`, `alias.frag`, `fogvol.frag`, and `atmos_froxel_integrate.comp` with `#include "clustered_lighting.glsl"` and calls to the new helpers.
- Keep each shader's per-light contribution math (attenuation, specular, scattering, etc.) unchanged and only use the shared helpers for cluster lookup and safe light fetching.
- Preserve no-light early-outs and per-material BRDF/behavior by returning zero contribution when cluster resolve fails and letting shaders perform their own light accumulation.

### Testing
- Ran `rg -n "struct ClusterHeader|struct PackedLight|clustered_lighting.glsl|ClusterResolve|ClusterFetchLight"` against the modified shaders to confirm old declarations were removed and helpers are referenced, and the search returned expected references (success).
- Reviewed diffs with `git diff`/`git show --stat --oneline` to verify the new include and removal of duplicated blocks across `world.frag`, `alias.frag`, `fogvol.frag`, and `atmos_froxel_integrate.comp` (success).
- Ran `git status --short` to confirm the new include and updated shader files are present in the working tree (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699598462044832e9c34191ae3901356)