### PR TITLE
Add Phase 1 safe async texture decode pipeline for loading

### DIFF
--- a/Quake/asset_decode_async.c
+++ b/Quake/asset_decode_async.c
@@ -1,0 +1,453 @@
+#include "quakedef.h"
+#include "asset_decode_async.h"
+#include "sys_jobs.h"
+#include "basisu_transcoder.h"
+#include "lodepng.h"
+
+#define ASSET_MAX_REQUESTS 512
+#define ASSET_HANDLE_INDEX_BITS 16
+#define ASSET_HANDLE_INDEX_MASK ((1u << ASSET_HANDLE_INDEX_BITS) - 1u)
+#define ASSET_MAKE_HANDLE(idx, gen) ((((uint32_t)(gen)) << ASSET_HANDLE_INDEX_BITS) | (uint32_t)(idx))
+#define ASSET_HANDLE_INDEX(h) ((unsigned int)((h) & ASSET_HANDLE_INDEX_MASK))
+#define ASSET_HANDLE_GEN(h) ((unsigned int)((h) >> ASSET_HANDLE_INDEX_BITS))
+
+typedef enum { ASSET_STAGE_EMPTY = 0, ASSET_STAGE_FS, ASSET_STAGE_DECODE, ASSET_STAGE_DONE } asset_stage_t;
+
+typedef struct {
+	qboolean in_use;
+	unsigned int generation;
+	asset_stage_t stage;
+	char path[MAX_QPATH];
+	asset_tex_params_t params;
+	char key[MAX_QPATH + 64];
+	fs_async_handle_t fs_handle;
+	void *raw_data;
+	size_t raw_size;
+	asset_result_t result;
+} asset_request_t;
+
+static asset_request_t asset_requests[ASSET_MAX_REQUESTS];
+static SDL_mutex *asset_mutex;
+static SDL_cond *asset_done_cond;
+static sys_job_queue_t *asset_decode_queue;
+static qboolean asset_initialized;
+
+static cvar_t asset_async = {"asset_async", "0", CVAR_ARCHIVE};
+static cvar_t asset_async_max_inflight_mb = {"asset_async_max_inflight_mb", "256", CVAR_ARCHIVE};
+static cvar_t asset_async_debug = {"asset_async_debug", "0", CVAR_NONE};
+
+static uint64_t asset_queued_fs;
+static uint64_t asset_completed_fs;
+static uint64_t asset_queued_decode;
+static uint64_t asset_completed_decode;
+static size_t asset_inflight_raw_bytes;
+static size_t asset_inflight_decoded_bytes;
+
+static qboolean Asset_IsKTX2(const void *data, size_t size)
+{
+	static const uint8_t magic[12] = {0xAB,0x4B,0x54,0x58,0x20,0x32,0x30,0xBB,0x0D,0x0A,0x1A,0x0A};
+	return size >= sizeof(magic) && memcmp(data, magic, sizeof(magic)) == 0;
+}
+
+static uint32_t Asset_ReadLE32(const uint8_t *p)
+{
+	return ((uint32_t)p[0]) | ((uint32_t)p[1] << 8) | ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24);
+}
+
+static uint64_t Asset_ReadLE64(const uint8_t *p)
+{
+	return ((uint64_t)p[0]) | ((uint64_t)p[1] << 8) | ((uint64_t)p[2] << 16) | ((uint64_t)p[3] << 24) |
+		((uint64_t)p[4] << 32) | ((uint64_t)p[5] << 40) | ((uint64_t)p[6] << 48) | ((uint64_t)p[7] << 56);
+}
+
+static asset_image_payload_t *Asset_DecodePNG(const void *raw_data, size_t raw_size)
+{
+	asset_image_payload_t *img;
+	unsigned char *rgba = NULL;
+	unsigned w = 0, h = 0;
+	unsigned err;
+
+	err = lodepng_decode32(&rgba, &w, &h, (const unsigned char *)raw_data, raw_size);
+	if (err || !rgba)
+		return NULL;
+
+	img = (asset_image_payload_t *)calloc(1, sizeof(*img));
+	if (!img)
+	{
+		free(rgba);
+		return NULL;
+	}
+
+	img->width = (int)w;
+	img->height = (int)h;
+	img->mip_count = 1;
+	img->format = ASSET_IMAGE_FMT_RGBA8;
+	img->has_alpha = true;
+	img->mips[0].data = rgba;
+	img->mips[0].size = (size_t)w * (size_t)h * 4u;
+	img->mips[0].pitch = (size_t)w * 4u;
+	return img;
+}
+
+static asset_image_payload_t *Asset_DecodeKTX2(const void *raw_data, size_t raw_size)
+{
+	const uint8_t *data = (const uint8_t *)raw_data;
+	uint32_t width, height, mip_count;
+	uint64_t supercompression, sgd_offset, sgd_length;
+	size_t header_size = 100;
+	size_t level_entry_size = 24;
+	size_t level_table_size;
+	asset_image_payload_t *img;
+	int i;
+
+	if (raw_size < header_size)
+		return NULL;
+	width = Asset_ReadLE32(data + 20);
+	height = Asset_ReadLE32(data + 24);
+	mip_count = Asset_ReadLE32(data + 40);
+	supercompression = Asset_ReadLE64(data + 44);
+	sgd_offset = Asset_ReadLE64(data + 84);
+	sgd_length = Asset_ReadLE64(data + 92);
+	if (!width || !height || mip_count < 1 || mip_count > 32)
+		return NULL;
+
+	level_table_size = (size_t)mip_count * level_entry_size;
+	if (header_size + level_table_size > raw_size)
+		return NULL;
+
+	img = (asset_image_payload_t *)calloc(1, sizeof(*img));
+	if (!img)
+		return NULL;
+
+	img->width = (int)width;
+	img->height = (int)height;
+	img->mip_count = (int)mip_count;
+	img->format = ASSET_IMAGE_FMT_RGBA8;
+	img->has_alpha = true;
+
+	basisu_transcoder_init();
+	for (i = 0; i < (int)mip_count; ++i)
+	{
+		const uint8_t *entry = data + header_size + (size_t)i * level_entry_size;
+		uint64_t off = Asset_ReadLE64(entry + 0);
+		uint64_t len = Asset_ReadLE64(entry + 8);
+		size_t dst_size;
+		int w = (int)q_max(1u, width >> i);
+		int h = (int)q_max(1u, height >> i);
+
+		if (off > raw_size || len > raw_size - off)
+			goto fail;
+		dst_size = (size_t)w * (size_t)h * 4u;
+		img->mips[i].data = malloc(dst_size);
+		if (!img->mips[i].data)
+			goto fail;
+		img->mips[i].size = dst_size;
+		img->mips[i].pitch = (size_t)w * 4u;
+
+		if (!basisu_transcoder_transcode_image_level(data + off, (size_t)len,
+			sgd_length ? data + sgd_offset : NULL, (size_t)sgd_length,
+			supercompression == 0, (uint8_t *)img->mips[i].data, w, h, 4, 4u, 0))
+			goto fail;
+	}
+
+	return img;
+fail:
+	for (i = 0; i < 32; ++i)
+	{
+		if (img->mips[i].data)
+			free(img->mips[i].data);
+	}
+	free(img);
+	return NULL;
+}
+
+static void Asset_DecodeWorker(void *job_data)
+{
+	asset_handle_t h = (asset_handle_t)(uintptr_t)job_data;
+	unsigned idx = ASSET_HANDLE_INDEX(h);
+	unsigned gen = ASSET_HANDLE_GEN(h);
+	void *raw_data = NULL;
+	size_t raw_size = 0;
+	asset_image_payload_t *img = NULL;
+
+	SDL_LockMutex(asset_mutex);
+	if (idx >= ASSET_MAX_REQUESTS || !asset_requests[idx].in_use || asset_requests[idx].generation != gen)
+	{
+		SDL_UnlockMutex(asset_mutex);
+		return;
+	}
+	raw_data = asset_requests[idx].raw_data;
+	raw_size = asset_requests[idx].raw_size;
+	asset_requests[idx].raw_data = NULL;
+	asset_requests[idx].raw_size = 0;
+	asset_inflight_raw_bytes -= raw_size;
+	SDL_UnlockMutex(asset_mutex);
+
+	if (Asset_IsKTX2(raw_data, raw_size))
+		img = Asset_DecodeKTX2(raw_data, raw_size);
+	else
+		img = Asset_DecodePNG(raw_data, raw_size);
+
+	free(raw_data);
+
+	SDL_LockMutex(asset_mutex);
+	if (idx < ASSET_MAX_REQUESTS && asset_requests[idx].in_use && asset_requests[idx].generation == gen)
+	{
+		asset_completed_decode++;
+		if (img)
+		{
+			asset_requests[idx].result.status = ASSET_RESULT_OK;
+			asset_requests[idx].result.image = img;
+			asset_requests[idx].stage = ASSET_STAGE_DONE;
+			{ size_t total = 0; for (int m = 0; m < img->mip_count; ++m) total += img->mips[m].size; asset_inflight_decoded_bytes += total; }
+		}
+		else
+		{
+			asset_requests[idx].result.status = ASSET_RESULT_FAILED;
+			asset_requests[idx].stage = ASSET_STAGE_DONE;
+		}
+		SDL_CondBroadcast(asset_done_cond);
+	}
+	else if (img)
+	{
+		for (int i = 0; i < img->mip_count; ++i)
+			free(img->mips[i].data);
+		free(img);
+	}
+	SDL_UnlockMutex(asset_mutex);
+}
+
+void Asset_Async_Init (void)
+{
+	if (asset_initialized)
+		return;
+	asset_mutex = SDL_CreateMutex();
+	asset_done_cond = SDL_CreateCond();
+	asset_decode_queue = Sys_Jobs_CreateQueue("Asset Decode", 256);
+	if (!asset_mutex || !asset_done_cond || !asset_decode_queue)
+		Sys_Error("Asset_Async_Init failed");
+	Cvar_RegisterVariable(&asset_async);
+	Cvar_RegisterVariable(&asset_async_max_inflight_mb);
+	Cvar_RegisterVariable(&asset_async_debug);
+	asset_initialized = true;
+}
+
+void Asset_Async_Shutdown (void)
+{
+	unsigned i;
+	if (!asset_initialized)
+		return;
+	Sys_Jobs_DestroyQueue(asset_decode_queue);
+	asset_decode_queue = NULL;
+	SDL_LockMutex(asset_mutex);
+	for (i = 0; i < ASSET_MAX_REQUESTS; ++i)
+	{
+		if (!asset_requests[i].in_use)
+			continue;
+		if (asset_requests[i].fs_handle)
+			FS_Release(asset_requests[i].fs_handle);
+		if (asset_requests[i].raw_data)
+			free(asset_requests[i].raw_data);
+		if (asset_requests[i].result.image)
+		{
+			for (int j = 0; j < asset_requests[i].result.image->mip_count; ++j)
+				free(asset_requests[i].result.image->mips[j].data);
+			free(asset_requests[i].result.image);
+		}
+		memset(&asset_requests[i], 0, sizeof(asset_requests[i]));
+	}
+	SDL_UnlockMutex(asset_mutex);
+	SDL_DestroyCond(asset_done_cond);
+	SDL_DestroyMutex(asset_mutex);
+	asset_done_cond = NULL;
+	asset_mutex = NULL;
+	asset_initialized = false;
+}
+
+asset_handle_t Asset_LoadTextureAsync (const char *path, const asset_tex_params_t *params)
+{
+	asset_handle_t h = 0;
+	unsigned i;
+	size_t budget;
+
+	if (!asset_initialized)
+		Asset_Async_Init();
+	if (!asset_async.value || !path || !*path)
+		return 0;
+
+	budget = (size_t)(q_max(16.f, asset_async_max_inflight_mb.value) * 1024.f * 1024.f);
+
+	SDL_LockMutex(asset_mutex);
+	for (i = 0; i < ASSET_MAX_REQUESTS; ++i)
+	{
+		if (!asset_requests[i].in_use)
+			continue;
+		if (params) { char key[MAX_QPATH + 64]; q_snprintf(key, sizeof(key), "%s|%u", path, params->flags); if (!strcmp(asset_requests[i].key, key))
+			{
+				h = ASSET_MAKE_HANDLE(i, asset_requests[i].generation);
+				SDL_UnlockMutex(asset_mutex);
+				return h;
+			}
+		}
+		else if (!strcmp(asset_requests[i].key, path))
+		{
+			h = ASSET_MAKE_HANDLE(i, asset_requests[i].generation);
+			SDL_UnlockMutex(asset_mutex);
+			return h;
+		}
+	}
+
+	if (asset_inflight_raw_bytes + asset_inflight_decoded_bytes >= budget)
+	{
+		SDL_UnlockMutex(asset_mutex);
+		return 0;
+	}
+
+	for (i = 0; i < ASSET_MAX_REQUESTS; ++i)
+	{
+		if (asset_requests[i].in_use)
+			continue;
+		asset_requests[i].in_use = true;
+		asset_requests[i].generation++;
+		if (!asset_requests[i].generation)
+			asset_requests[i].generation = 1;
+		q_strlcpy(asset_requests[i].path, path, sizeof(asset_requests[i].path));
+		q_snprintf(asset_requests[i].key, sizeof(asset_requests[i].key), "%s|%u", path, params ? params->flags : 0u);
+		if (params)
+			asset_requests[i].params = *params;
+		asset_requests[i].stage = ASSET_STAGE_FS;
+		asset_requests[i].result.status = ASSET_RESULT_PENDING;
+		h = ASSET_MAKE_HANDLE(i, asset_requests[i].generation);
+		break;
+	}
+	SDL_UnlockMutex(asset_mutex);
+
+	if (!h)
+		return 0;
+
+	asset_requests[ASSET_HANDLE_INDEX(h)].fs_handle = FS_ReadFileAsync(path, FS_ASYNC_FLAG_ALLOW_DECOMPRESS);
+	if (!asset_requests[ASSET_HANDLE_INDEX(h)].fs_handle)
+	{
+		Asset_Release(h);
+		return 0;
+	}
+	asset_queued_fs++;
+	return h;
+}
+
+void Asset_Async_Pump (void)
+{
+	unsigned i;
+	if (!asset_initialized)
+		return;
+
+	for (i = 0; i < ASSET_MAX_REQUESTS; ++i)
+	{
+		asset_handle_t h;
+		fs_async_result_t fs;
+		qboolean has_fs;
+		SDL_LockMutex(asset_mutex);
+		if (!asset_requests[i].in_use || asset_requests[i].stage != ASSET_STAGE_FS || !asset_requests[i].fs_handle)
+		{
+			SDL_UnlockMutex(asset_mutex);
+			continue;
+		}
+		h = ASSET_MAKE_HANDLE(i, asset_requests[i].generation);
+		SDL_UnlockMutex(asset_mutex);
+
+		has_fs = FS_Poll(asset_requests[i].fs_handle, &fs);
+		if (!has_fs)
+			continue;
+
+		SDL_LockMutex(asset_mutex);
+		if (!asset_requests[i].in_use || asset_requests[i].generation != ASSET_HANDLE_GEN(h))
+		{
+			SDL_UnlockMutex(asset_mutex);
+			continue;
+		}
+		asset_completed_fs++;
+		if (fs.status == FS_ASYNC_STATUS_OK && fs.data && fs.size)
+		{
+			asset_requests[i].raw_data = malloc(fs.size);
+			if (asset_requests[i].raw_data)
+			{
+				memcpy(asset_requests[i].raw_data, fs.data, fs.size);
+				asset_requests[i].raw_size = fs.size;
+				asset_inflight_raw_bytes += fs.size;
+				asset_requests[i].stage = ASSET_STAGE_DECODE;
+				asset_queued_decode++;
+				Sys_Jobs_Submit(asset_decode_queue, Asset_DecodeWorker, (void *)(uintptr_t)h);
+			}
+			else
+			{
+				asset_requests[i].result.status = ASSET_RESULT_FAILED;
+				asset_requests[i].stage = ASSET_STAGE_DONE;
+			}
+		}
+		else
+		{
+			asset_requests[i].result.status = (fs.status == FS_ASYNC_STATUS_NOT_FOUND) ? ASSET_RESULT_NOT_FOUND : ASSET_RESULT_FAILED;
+			asset_requests[i].stage = ASSET_STAGE_DONE;
+		}
+		FS_Release(asset_requests[i].fs_handle);
+		asset_requests[i].fs_handle = 0;
+		SDL_UnlockMutex(asset_mutex);
+	}
+
+	if (asset_async_debug.value)
+	{
+		Con_DPrintf("asset_async: fs=%" SDL_PRIu64 "/%" SDL_PRIu64 " decode=%" SDL_PRIu64 "/%" SDL_PRIu64 " inflight_raw=%zu inflight_decoded=%zu\n",
+			asset_completed_fs, asset_queued_fs, asset_completed_decode, asset_queued_decode,
+			asset_inflight_raw_bytes, asset_inflight_decoded_bytes);
+	}
+}
+
+qboolean Asset_Poll (asset_handle_t h, asset_result_t *out)
+{
+	unsigned idx = ASSET_HANDLE_INDEX(h), gen = ASSET_HANDLE_GEN(h);
+	if (out)
+		memset(out, 0, sizeof(*out));
+	if (!h || idx >= ASSET_MAX_REQUESTS || !asset_initialized)
+		return false;
+	Asset_Async_Pump();
+	SDL_LockMutex(asset_mutex);
+	if (!asset_requests[idx].in_use || asset_requests[idx].generation != gen || asset_requests[idx].stage != ASSET_STAGE_DONE)
+	{
+		SDL_UnlockMutex(asset_mutex);
+		return false;
+	}
+	if (out)
+		*out = asset_requests[idx].result;
+	SDL_UnlockMutex(asset_mutex);
+	return true;
+}
+
+void Asset_Wait (asset_handle_t h, asset_result_t *out)
+{
+	while (!Asset_Poll(h, out))
+	{
+		Asset_Async_Pump();
+		SDL_Delay(1);
+	}
+}
+
+void Asset_Release (asset_handle_t h)
+{
+	unsigned idx = ASSET_HANDLE_INDEX(h), gen = ASSET_HANDLE_GEN(h);
+	if (!h || idx >= ASSET_MAX_REQUESTS || !asset_initialized)
+		return;
+	Asset_Wait(h, NULL);
+	SDL_LockMutex(asset_mutex);
+	if (asset_requests[idx].in_use && asset_requests[idx].generation == gen)
+	{
+		if (asset_requests[idx].result.image)
+		{
+			for (int i = 0; i < asset_requests[idx].result.image->mip_count; ++i)
+				free(asset_requests[idx].result.image->mips[i].data);
+			{ size_t total = 0; for (int m = 0; m < asset_requests[idx].result.image->mip_count; ++m) total += asset_requests[idx].result.image->mips[m].size; if (asset_inflight_decoded_bytes >= total) asset_inflight_decoded_bytes -= total; else asset_inflight_decoded_bytes = 0; }
+			free(asset_requests[idx].result.image);
+		}
+		memset(&asset_requests[idx], 0, sizeof(asset_requests[idx]));
+	}
+	SDL_UnlockMutex(asset_mutex);
+}

--- a/Quake/asset_decode_async.h
+++ b/Quake/asset_decode_async.h
@@ -1,0 +1,63 @@
+#ifndef _ASSET_DECODE_ASYNC_H_
+#define _ASSET_DECODE_ASYNC_H_
+
+#include "q_stdinc.h"
+#include "fs_async.h"
+
+typedef struct model_s qmodel_t;
+
+typedef uint32_t asset_handle_t;
+
+typedef enum
+{
+	ASSET_IMAGE_FMT_RGBA8 = 0
+} asset_image_format_t;
+
+typedef struct
+{
+	void *data;
+	size_t size;
+	size_t pitch;
+} asset_mip_blob_t;
+
+typedef struct
+{
+	int width;
+	int height;
+	int mip_count;
+	asset_image_format_t format;
+	qboolean srgb;
+	qboolean has_alpha;
+	asset_mip_blob_t mips[32];
+} asset_image_payload_t;
+
+typedef struct
+{
+	const char *name;
+	unsigned flags;
+	qmodel_t *owner;
+} asset_tex_params_t;
+
+typedef enum
+{
+	ASSET_RESULT_PENDING = 0,
+	ASSET_RESULT_OK,
+	ASSET_RESULT_FAILED,
+	ASSET_RESULT_NOT_FOUND
+} asset_result_status_t;
+
+typedef struct
+{
+	asset_result_status_t status;
+	asset_image_payload_t *image;
+} asset_result_t;
+
+void Asset_Async_Init (void);
+void Asset_Async_Shutdown (void);
+asset_handle_t Asset_LoadTextureAsync (const char *path, const asset_tex_params_t *params);
+qboolean Asset_Poll (asset_handle_t h, asset_result_t *out);
+void Asset_Wait (asset_handle_t h, asset_result_t *out);
+void Asset_Release (asset_handle_t h);
+void Asset_Async_Pump (void);
+
+#endif

--- a/Quake/host.c
+++ b/Quake/host.c
@@ -24,6 +24,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "quakedef.h"
 #include "fs_async.h"
+#include "asset_decode_async.h"
 #include "simd_caps.h"
 #include "bgmusic.h"
 #include "steam.h"
@@ -1281,6 +1282,7 @@ void _Host_Frame (double time)
 // run async procs
 	AsyncQueue_Drain (&async_queue);
 	FS_Async_Pump ();
+	Asset_Async_Pump ();
 
 // get new key events
 	Key_UpdateForDest ();
@@ -1465,6 +1467,7 @@ void Host_Init (void)
 	COM_Init ();
 	COM_InitFilesystem ();
 	FS_Async_Init ();
+	Asset_Async_Init ();
 	Host_InitLocal ();
 	W_LoadWadFile (); //johnfitz -- filename is now hard-coded for honesty
 	if (cls.state != ca_dedicated)
@@ -1569,6 +1572,7 @@ void Host_Shutdown(void)
 
 	AsyncQueue_Destroy (&async_queue);
 	FS_Async_Shutdown ();
+	Asset_Async_Shutdown ();
 
 	Host_ShutdownSave ();
 	Host_WriteConfiguration ();

--- a/Quake/opengl/gl_model.c
+++ b/Quake/opengl/gl_model.c
@@ -28,6 +28,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "opengl/gl_lightgrid.h"
 #include "opengl/gl_ktx2.h"
 #include "mat_shader.h"
+#include "asset_decode_async.h"
 #include "../common/lightgrid.h"
 
 #define INVALID_LIGHTSTYLE_OLD 255
@@ -1132,6 +1133,43 @@ static gltexture_t *Mod_LoadEmissiveMap (qmodel_t *mod, const char *basename, in
         return tex;
 }
 
+
+static gltexture_t *Mod_LoadTextureAsyncDuringLoad(qmodel_t *owner, const char *basepath, unsigned texflags)
+{
+	asset_tex_params_t params;
+	asset_result_t result;
+	asset_handle_t h;
+	char path[MAX_OSPATH];
+	int i;
+	static const char *const exts[] = {"ktx2", "png", NULL};
+
+	if (!Host_IsAssetLoading ())
+		return NULL;
+
+	memset(&params, 0, sizeof(params));
+	params.owner = owner;
+	params.name = basepath;
+	params.flags = texflags;
+
+	for (i = 0; exts[i]; ++i)
+	{
+		q_snprintf(path, sizeof(path), "%s.%s", basepath, exts[i]);
+		h = Asset_LoadTextureAsync(path, &params);
+		if (!h)
+			continue;
+		Asset_Wait(h, &result);
+		if (result.status == ASSET_RESULT_OK && result.image)
+		{
+			gltexture_t *tex = R_CommitDecodedTexture(result.image, &params);
+			Asset_Release(h);
+			return tex;
+		}
+		Asset_Release(h);
+	}
+
+	return NULL;
+}
+
 static gltexture_t *Mod_LoadKTX2Texture(const char *name)
 {
         byte *rawbuf;
@@ -1295,7 +1333,9 @@ static void Mod_LoadTextures (lump_t *l)
                                 if (tx->shader_map && tx->shader_map[0])
                                 {
                                         COM_StripExtension (tx->shader_map, filename, sizeof (filename));
-                                        ktx2tex = Mod_LoadKTX2Texture (filename);
+                                        ktx2tex = Mod_LoadTextureAsyncDuringLoad (loadmodel, filename, TEXPREF_MIPMAP | TEXPREF_BINDLESS);
+                                        if (!ktx2tex)
+                                                ktx2tex = Mod_LoadKTX2Texture (filename);
                                         data = ktx2tex ? NULL : Image_LoadImage (filename, &fwidth, &fheight, &fmt);
                                 }
                                 else
@@ -1304,12 +1344,16 @@ static void Mod_LoadTextures (lump_t *l)
                                                 q_snprintf (filename, sizeof(filename), "textures/%s/#%s", mapname, tx->name+1); //this also replaces the '*' with a '#'
                                         else
                                                 q_snprintf (filename, sizeof(filename), "textures/#%s", tx->name+1);
-                                        ktx2tex = Mod_LoadKTX2Texture (filename);
+                                        ktx2tex = Mod_LoadTextureAsyncDuringLoad (loadmodel, filename, TEXPREF_MIPMAP | TEXPREF_BINDLESS);
+                                        if (!ktx2tex)
+                                                ktx2tex = Mod_LoadKTX2Texture (filename);
                                         data = ktx2tex ? NULL : Image_LoadImage (filename, &fwidth, &fheight, &fmt);
                                         if (!ktx2tex && !data && mapname[0])
                                         {
                                                 q_snprintf (filename, sizeof(filename), "textures/#%s", tx->name+1);
-                                                ktx2tex = Mod_LoadKTX2Texture (filename);
+                                                ktx2tex = Mod_LoadTextureAsyncDuringLoad (loadmodel, filename, TEXPREF_MIPMAP | TEXPREF_BINDLESS);
+                                                if (!ktx2tex)
+                                                        ktx2tex = Mod_LoadKTX2Texture (filename);
                                                 if (!ktx2tex)
                                                         data = Image_LoadImage (filename, &fwidth, &fheight, &fmt);
                                         }
@@ -1351,7 +1395,7 @@ static void Mod_LoadTextures (lump_t *l)
                                         }
                                 }
                                 tx->emissive = Mod_LoadEmissiveMap (loadmodel, filename, TEXPREF_MIPMAP | TEXPREF_BINDLESS);
-                                if (malloced)
+                                if (malloced && data)
                                         free(data);
                                 Hunk_FreeToLowMark (mark);
                         }
@@ -1367,7 +1411,9 @@ static void Mod_LoadTextures (lump_t *l)
                                 if (tx->shader_map && tx->shader_map[0])
                                 {
                                         COM_StripExtension (tx->shader_map, filename, sizeof (filename));
-                                        ktx2tex = Mod_LoadKTX2Texture (filename);
+                                        ktx2tex = Mod_LoadTextureAsyncDuringLoad (loadmodel, filename, TEXPREF_MIPMAP | TEXPREF_BINDLESS);
+                                        if (!ktx2tex)
+                                                ktx2tex = Mod_LoadKTX2Texture (filename);
                                         data = ktx2tex ? NULL : Image_LoadImage (filename, &fwidth, &fheight, &fmt);
                                 }
                                 else
@@ -1376,12 +1422,16 @@ static void Mod_LoadTextures (lump_t *l)
                                                 q_snprintf (filename, sizeof(filename), "textures/%s/%s", mapname, tx->name);
                                         else
                                                 q_snprintf (filename, sizeof(filename), "textures/%s", tx->name);
-                                        ktx2tex = Mod_LoadKTX2Texture (filename);
+                                        ktx2tex = Mod_LoadTextureAsyncDuringLoad (loadmodel, filename, TEXPREF_MIPMAP | extraflags);
+                                        if (!ktx2tex)
+                                                ktx2tex = Mod_LoadKTX2Texture (filename);
                                         data = ktx2tex ? NULL : Image_LoadImage (filename, &fwidth, &fheight, &fmt);
                                         if (!ktx2tex && !data && mapname[0])
                                         {
                                                 q_snprintf (filename, sizeof(filename), "textures/%s", tx->name);
-                                                ktx2tex = Mod_LoadKTX2Texture (filename);
+                                                ktx2tex = Mod_LoadTextureAsyncDuringLoad (loadmodel, filename, TEXPREF_MIPMAP | extraflags);
+                                                if (!ktx2tex)
+                                                        ktx2tex = Mod_LoadKTX2Texture (filename);
                                                 if (!ktx2tex)
                                                         data = Image_LoadImage (filename, &fwidth, &fheight, &fmt);
                                         }

--- a/Quake/opengl/gl_texmgr.c
+++ b/Quake/opengl/gl_texmgr.c
@@ -3090,3 +3090,14 @@ Returns index of palette buffer to use:
 
 	return 1;
 }
+
+
+gltexture_t *R_CommitDecodedTexture (const asset_image_payload_t *img, const asset_tex_params_t *params)
+{
+	if (!img || !params || img->format != ASSET_IMAGE_FMT_RGBA8 || img->mip_count < 1 || !img->mips[0].data)
+		return NULL;
+
+	return TexMgr_LoadImage (params->owner, params->name ? params->name : "",
+		img->width, img->height, SRC_RGBA, (byte *)img->mips[0].data,
+		params->name ? params->name : "", 0, params->flags);
+}

--- a/Quake/opengl/gl_texmgr.h
+++ b/Quake/opengl/gl_texmgr.h
@@ -164,6 +164,8 @@ void TexMgr_DeleteTextureObjects (void);
 void TexMgr_ApplySettings (void);
 qboolean TexMgr_UsesFilterOverride (void);
 
+#include "asset_decode_async.h"
+
 // IMAGE LOADING
 gltexture_t *TexMgr_LoadImage (qmodel_t *owner, const char *name, int width, int height, enum srcformat format,
                                byte *data, const char *source_file, src_offset_t source_offset, unsigned flags);
@@ -173,6 +175,7 @@ GLuint TexMgr_LoadDDS (const char *path);
 void TexMgr_ReloadImage (gltexture_t *glt, int shirt, int pants);
 void TexMgr_ReloadImages (void);
 void TexMgr_ReloadNobrightImages (void);
+gltexture_t *R_CommitDecodedTexture (const asset_image_payload_t *img, const asset_tex_params_t *params);
 void TexMgr_SRGBTextures_f (cvar_t *var);
 qboolean TexMgr_ShouldUseSRGB (const char *name, enum srcformat format, unsigned flags, const char *source_file);
 


### PR DESCRIPTION
### Motivation
- Implement a safe, loading-screen-only id Tech 7 “light” asset streaming pipeline that chains existing asynchronous filesystem reads into a worker decode stage and a main-thread GL commit step. 
- Provide a minimal, extensible Phase 1 implementation that handles PNG and KTX2, enforces strict thread-safety rules, and avoids changing existing FS async behavior.
- Integrate the pipeline only into the blocking map/load precache path so runtime behavior is unchanged when `asset_async` is disabled.

### Description
- New async decode module: added `Quake/asset_decode_async.h` and `Quake/asset_decode_async.c` which expose `Asset_LoadTextureAsync`, `Asset_Poll`, `Asset_Wait`, `Asset_Release`, and `Asset_Async_Pump`, plus the result/payload types such as `asset_image_payload_t` and `asset_tex_params_t`.
- Worker decode implementations: PNG decoding is done in workers via `lodepng_decode32` producing an RGBA8 `asset_image_payload_t`, and KTX2 parsing/transcode uses the repo's `basisu_transcoder`-based path to produce upload-ready RGBA8 mip blobs (worker-only, no GL calls).
- Chaining & safety/backpressure: the module reuses the existing FS async API (`FS_ReadFileAsync`, `FS_Poll`, `FS_Release`) to schedule reads, then schedules decode jobs on a new `Sys_Jobs` queue; it implements in-flight dedup keyed by `path|flags`, tracks `inflight_raw_bytes` and `inflight_decoded_bytes`, and enforces a configurable budget via `asset_async_max_inflight_mb` with `asset_async` and `asset_async_debug` cvars.
- Main-thread commit and integration: added `R_CommitDecodedTexture(const asset_image_payload_t *img, const asset_tex_params_t *params)` in `gl_texmgr.c` which calls `TexMgr_LoadImage` (all GL/caches remain main-thread only), and integrated loading-screen-only usage via `Mod_LoadTextureAsyncDuringLoad()` called from `Mod_LoadTextures()` guarded by `Host_IsAssetLoading()` so synchronous fallback remains.
- Lifecycle and pump: `Asset_Async_Init` and `Asset_Async_Shutdown` are hooked into `Host_Init` / `Host_Shutdown`, and `Asset_Async_Pump()` is invoked from `Host_Frame` alongside `FS_Async_Pump()` to move completed decode results to main-thread state.
- Summary of inspected existing code (how integration reuses it): `FS async` is in `Quake/fs_async.h/.c` with API `FS_ReadFileAsync` / `FS_Poll` / `FS_Wait` / `FS_Release` and a worker queue created via `Sys_Jobs_CreateQueue`; FS read work uses `FS_Async_ReadFileSync` which already reads from `com_searchpaths` and PK3s and returns `malloc`-owned buffers; PNG is currently decoded synchronously in `Image_LoadImage()` (via `stb_image`/`lodepng` in repo) and KTX2 CPU-side parse/transcode lives in `Quake/opengl/gl_ktx2.c`; the safest loading integration point chosen is `Mod_LoadTextures()` (map precache/load path) where the engine is already in a blocking load phase.

### Testing
- Attempted an out-of-tree configuration and build with `cmake -S . -B build && cmake --build build -j4`, which failed at CMake configure due to missing system `SDL2` package files in this environment (no SDL2 CMake config available), so a full compile/test could not be completed here.
- Ran repository checks and lightweight validations: `rg`/file inspections to locate `fs_async`, PNG (`lodepng`/`stb_image`), and KTX2 (`gl_ktx2.c`) code paths, plus `git` operations to confirm the new sources were added and the working tree is clean; these checks succeeded.
- Notes for reviewers: functional validation to perform locally or in CI should include: map load / precache with `asset_async 1` and default `asset_async_max_inflight_mb`, a build-and-run to verify no GL calls are made from workers, load of PNG and KTX2 assets to ensure they come through the async path and commit correctly, missing-file behavior, and clean shutdown during loads (no hangs).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995c706af5c832ea9d1b8c4d205ce89)