### PR TITLE
Make asset decode queue submission non-blocking

### DIFF
--- a/Quake/asset_decode_async.c
+++ b/Quake/asset_decode_async.c
@@ -23,6 +23,7 @@ typedef struct {
 	fs_async_handle_t fs_handle;
 	void *raw_data;
 	size_t raw_size;
+	qboolean decode_queued;
 	asset_result_t result;
 } asset_request_t;
 
@@ -316,6 +317,7 @@ asset_handle_t Asset_LoadTextureAsync (const char *path, const asset_tex_params_
 		if (params)
 			asset_requests[i].params = *params;
 		asset_requests[i].stage = ASSET_STAGE_FS;
+		asset_requests[i].decode_queued = false;
 		asset_requests[i].result.status = ASSET_RESULT_PENDING;
 		h = ASSET_MAKE_HANDLE(i, asset_requests[i].generation);
 		break;
@@ -335,6 +337,7 @@ asset_handle_t Asset_LoadTextureAsync (const char *path, const asset_tex_params_
 	return h;
 }
 
+/* Main thread only: this pump must never block on worker queue backpressure. */
 void Asset_Async_Pump (void)
 {
 	unsigned i;
@@ -343,24 +346,59 @@ void Asset_Async_Pump (void)
 
 	for (i = 0; i < ASSET_MAX_REQUESTS; ++i)
 	{
-		asset_handle_t h;
+		asset_handle_t h = 0;
+		fs_async_handle_t fs_handle = 0;
 		fs_async_result_t fs;
 		qboolean has_fs;
+		qboolean submit_decode = false;
+
 		SDL_LockMutex(asset_mutex);
-		if (!asset_requests[i].in_use || asset_requests[i].stage != ASSET_STAGE_FS || !asset_requests[i].fs_handle)
+		if (!asset_requests[i].in_use)
 		{
 			SDL_UnlockMutex(asset_mutex);
 			continue;
 		}
-		h = ASSET_MAKE_HANDLE(i, asset_requests[i].generation);
+
+		if (asset_requests[i].stage == ASSET_STAGE_FS && asset_requests[i].fs_handle)
+		{
+			h = ASSET_MAKE_HANDLE(i, asset_requests[i].generation);
+			fs_handle = asset_requests[i].fs_handle;
+		}
+		else if (asset_requests[i].stage == ASSET_STAGE_DECODE && !asset_requests[i].decode_queued && asset_requests[i].raw_data && asset_requests[i].raw_size)
+		{
+			h = ASSET_MAKE_HANDLE(i, asset_requests[i].generation);
+			asset_requests[i].decode_queued = true;
+			submit_decode = true;
+		}
 		SDL_UnlockMutex(asset_mutex);
 
-		has_fs = FS_Poll(asset_requests[i].fs_handle, &fs);
+		if (submit_decode)
+		{
+			if (Sys_Jobs_TrySubmit(asset_decode_queue, Asset_DecodeWorker, (void *)(uintptr_t)h))
+			{
+				SDL_LockMutex(asset_mutex);
+				asset_queued_decode++;
+				SDL_UnlockMutex(asset_mutex);
+			}
+			else
+			{
+				SDL_LockMutex(asset_mutex);
+				if (asset_requests[i].in_use && asset_requests[i].generation == ASSET_HANDLE_GEN(h) && asset_requests[i].stage == ASSET_STAGE_DECODE)
+					asset_requests[i].decode_queued = false;
+				SDL_UnlockMutex(asset_mutex);
+			}
+			continue;
+		}
+
+		if (!fs_handle)
+			continue;
+
+		has_fs = FS_Poll(fs_handle, &fs);
 		if (!has_fs)
 			continue;
 
 		SDL_LockMutex(asset_mutex);
-		if (!asset_requests[i].in_use || asset_requests[i].generation != ASSET_HANDLE_GEN(h))
+		if (!asset_requests[i].in_use || asset_requests[i].generation != ASSET_HANDLE_GEN(h) || asset_requests[i].stage != ASSET_STAGE_FS)
 		{
 			SDL_UnlockMutex(asset_mutex);
 			continue;
@@ -373,10 +411,9 @@ void Asset_Async_Pump (void)
 			{
 				memcpy(asset_requests[i].raw_data, fs.data, fs.size);
 				asset_requests[i].raw_size = fs.size;
+				asset_requests[i].decode_queued = false;
 				asset_inflight_raw_bytes += fs.size;
 				asset_requests[i].stage = ASSET_STAGE_DECODE;
-				asset_queued_decode++;
-				Sys_Jobs_Submit(asset_decode_queue, Asset_DecodeWorker, (void *)(uintptr_t)h);
 			}
 			else
 			{

--- a/Quake/sys_jobs.c
+++ b/Quake/sys_jobs.c
@@ -125,3 +125,22 @@ qboolean Sys_Jobs_Submit (sys_job_queue_t *queue, sys_job_execute_fn execute, vo
 	SDL_UnlockMutex (queue->mutex);
 	return true;
 }
+
+qboolean Sys_Jobs_TrySubmit (sys_job_queue_t *queue, sys_job_execute_fn execute, void *job_data)
+{
+	qboolean submitted = false;
+
+	if (!queue || !execute)
+		return false;
+
+	SDL_LockMutex (queue->mutex);
+	if (!queue->teardown && queue->tail - queue->head < queue->capacity)
+	{
+		queue->entries[(queue->tail++) & (queue->capacity - 1)] = (sys_job_entry_t) { execute, job_data };
+		SDL_CondSignal (queue->notempty);
+		submitted = true;
+	}
+	SDL_UnlockMutex (queue->mutex);
+
+	return submitted;
+}

--- a/Quake/sys_jobs.h
+++ b/Quake/sys_jobs.h
@@ -10,5 +10,6 @@ typedef void (*sys_job_execute_fn)(void *job_data);
 sys_job_queue_t *Sys_Jobs_CreateQueue (const char *name, size_t capacity);
 void Sys_Jobs_DestroyQueue (sys_job_queue_t *queue);
 qboolean Sys_Jobs_Submit (sys_job_queue_t *queue, sys_job_execute_fn execute, void *job_data);
+qboolean Sys_Jobs_TrySubmit (sys_job_queue_t *queue, sys_job_execute_fn execute, void *job_data);
 
 #endif


### PR DESCRIPTION
### Motivation

- Prevent the main thread from blocking when worker job queues are full or tearing down by providing a non-blocking enqueue path. 
- Ensure asset decode requests are prepared under the `asset_mutex` and retried safely without losing state or double-submitting when the worker queue is backpressured. 

### Description

- Add a non-blocking queue API `Sys_Jobs_TrySubmit` in `Quake/sys_jobs.h`/`.c` that returns immediately `false` when the queue is full or tearing down. 
- Add `decode_queued` to `asset_request_t` and initialize it on request creation and when raw data is staged. 
- Rewrite `Asset_Async_Pump` in `Quake/asset_decode_async.c` to prepare decode submission state while holding `asset_mutex`, release the lock before calling `Sys_Jobs_TrySubmit`, and retry later if enqueue fails instead of blocking. 
- Only increment `asset_queued_decode` when `Sys_Jobs_TrySubmit` succeeds, and keep requests in `ASSET_STAGE_DECODE` when enqueue fails so they are retried on the next pump iteration. 
- Document the main-thread requirement with a comment above `Asset_Async_Pump` that the pump must never block on worker queue backpressure.

### Testing

- Attempted to build the Quake target with `make -C Quake -j4` to validate the changes, but the build failed in this environment due to missing `sdl2-config` / `SDL.h` headers so full compile verification could not complete. 
- No unit tests were present or run; changes were limited to thread- and queue-handling code and validated by local code inspection and a repository build attempt which encountered the environment dependency failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995ccac8a7c832e8ce5d26626f67449)