### PR TITLE
Synchronize fs_handle publication in Asset_LoadTextureAsync

### DIFF
--- a/Quake/asset_decode_async.c
+++ b/Quake/asset_decode_async.c
@@ -268,6 +268,7 @@ void Asset_Async_Shutdown (void)
 asset_handle_t Asset_LoadTextureAsync (const char *path, const asset_tex_params_t *params)
 {
 	asset_handle_t h = 0;
+	fs_async_handle_t fs_handle = 0;
 	unsigned i;
 	size_t budget;
 
@@ -327,13 +328,36 @@ asset_handle_t Asset_LoadTextureAsync (const char *path, const asset_tex_params_
 	if (!h)
 		return 0;
 
-	asset_requests[ASSET_HANDLE_INDEX(h)].fs_handle = FS_ReadFileAsync(path, FS_ASYNC_FLAG_ALLOW_DECOMPRESS);
-	if (!asset_requests[ASSET_HANDLE_INDEX(h)].fs_handle)
+	fs_handle = FS_ReadFileAsync(path, FS_ASYNC_FLAG_ALLOW_DECOMPRESS);
+	if (!fs_handle)
 	{
-		Asset_Release(h);
+		const unsigned idx = ASSET_HANDLE_INDEX(h);
+		const unsigned gen = ASSET_HANDLE_GEN(h);
+
+		SDL_LockMutex(asset_mutex);
+		if (asset_requests[idx].in_use && asset_requests[idx].generation == gen)
+			memset(&asset_requests[idx], 0, sizeof(asset_requests[idx]));
+		SDL_UnlockMutex(asset_mutex);
 		return 0;
 	}
-	asset_queued_fs++;
+
+	SDL_LockMutex(asset_mutex);
+	{
+		const unsigned idx = ASSET_HANDLE_INDEX(h);
+		const unsigned gen = ASSET_HANDLE_GEN(h);
+
+		if (!asset_requests[idx].in_use || asset_requests[idx].generation != gen)
+		{
+			SDL_UnlockMutex(asset_mutex);
+			FS_Release(fs_handle);
+			return 0;
+		}
+
+		/* asset_requests[idx].fs_handle is protected by asset_mutex for all reads/writes. */
+		asset_requests[idx].fs_handle = fs_handle;
+		asset_queued_fs++;
+	}
+	SDL_UnlockMutex(asset_mutex);
 	return h;
 }
 


### PR DESCRIPTION
### Motivation

- Prevent a race where a newly created async FS handle could be published to `asset_requests[].fs_handle` without holding `asset_mutex`, causing other threads to observe it prematurely.
- Ensure slot ownership (reservation + generation) is re-validated after calling `FS_ReadFileAsync()` so dropped or recycled slots do not retain or leak file handles.

### Description

- Introduced a local `fs_handle` variable and call `FS_ReadFileAsync()` into it while not holding `asset_mutex` to avoid blocking other operations.
- After `FS_ReadFileAsync()` returns, reacquire `asset_mutex` and re-check the reserved slot by validating both `in_use` and the request `generation` before storing the handle into `asset_requests[idx].fs_handle`.
- If the slot/generation changed while unlocked, release the newly created `fs_handle` with `FS_Release()` and return failure to avoid leaking handles or corrupting another request.
- On `FS_ReadFileAsync()` failure, clear the reserved slot under `asset_mutex` and return failure to leave data structures consistent.
- Moved the `asset_queued_fs` increment into the locked section and added a short comment noting that `asset_requests[idx].fs_handle` must only be accessed while holding `asset_mutex`.

### Testing

- Attempted `cmake --build build -j2` which reported there was no `build` directory in this environment so no build was performed.
- Ran `make -C Quake -j2` to compile the project; the build failed in this environment due to missing SDL2 tooling/headers (`sdl2-config` / `SDL.h`), so a full compile/test could not be completed here.}

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995ce0a2e5c832ebf1bc513cc1c1954)