### PR TITLE
Guard async FS search-path reads with snapshot + shared lock

### DIFF
--- a/Quake/common.c
+++ b/Quake/common.c
@@ -1746,6 +1746,20 @@ THREAD_LOCAL int	file_from_pak;		// ZOID: global indicating that file came from 
 searchpath_t	*com_searchpaths;
 searchpath_t	*com_base_searchpaths;
 
+static SDL_mutex *com_searchpaths_mutex;
+
+void COM_LockSearchPaths (void)
+{
+	if (com_searchpaths_mutex)
+		SDL_LockMutex (com_searchpaths_mutex);
+}
+
+void COM_UnlockSearchPaths (void)
+{
+	if (com_searchpaths_mutex)
+		SDL_UnlockMutex (com_searchpaths_mutex);
+}
+
 /*
 ============
 COM_Path_f
@@ -2629,7 +2643,7 @@ static void COM_AddPk3Files (const char *gamedir, unsigned int path_id, qboolean
 COM_AddGameDirectory -- johnfitz -- modified based on topaz's tutorial
 =================
 */
-void COM_AddGameDirectory (const char *dir)
+static void COM_AddGameDirectoryLocked (const char *dir)
 {
 	const char *base;
 	int i, j;
@@ -2700,10 +2714,19 @@ void COM_AddGameDirectory (const char *dir)
 
 		COM_AddPk3Files (com_gamedir, path_id, append_paths);
 	}
+
+}
+
+void COM_AddGameDirectory (const char *dir)
+{
+	COM_LockSearchPaths ();
+	COM_AddGameDirectoryLocked (dir);
+	COM_UnlockSearchPaths ();
 }
 
 void COM_ResetGameDirectories(const char *newgamedirs)
 {
+	COM_LockSearchPaths ();
 	const char *newpath, *path;
 	searchpath_t *search;
 	//Kill the extra game if it is loaded
@@ -2752,9 +2775,10 @@ void COM_ResetGameDirectories(const char *newgamedirs)
 		}
 
 		if (path == newpath)	//not already loaded
-			COM_AddGameDirectory(newpath);
+			COM_AddGameDirectoryLocked(newpath);
 		newpath = e;
 	}
+	COM_UnlockSearchPaths ();
 }
 
 //==============================================================================
@@ -3525,6 +3549,11 @@ void COM_InitFilesystem (void) //johnfitz -- modified based on topaz's tutorial
 	Cvar_RegisterVariable (&fs_integrity_report);
 	Cmd_AddCommand ("path", COM_Path_f);
 	Cmd_AddCommand ("game", COM_Game_f); //johnfitz
+
+	if (!com_searchpaths_mutex)
+		com_searchpaths_mutex = SDL_CreateMutex ();
+	if (!com_searchpaths_mutex)
+		Sys_Error ("COM_InitFilesystem: failed to create search-path mutex");
 
 	standalone_requested = (COM_CheckParm ("-standalone") != 0);
 	if (standalone_requested)

--- a/Quake/common.h
+++ b/Quake/common.h
@@ -399,6 +399,9 @@ typedef struct searchpath_s
 extern searchpath_t *com_searchpaths;
 extern searchpath_t *com_base_searchpaths;
 
+void COM_LockSearchPaths (void);
+void COM_UnlockSearchPaths (void);
+
 extern THREAD_LOCAL qfileofs_t com_filesize;
 struct cache_user_s;
 
@@ -484,4 +487,3 @@ extern qboolean		fitzmode;
 	/* if true, run in fitzquake mode disabling custom quakespasm hacks */
 
 #endif	/* _Q_COMMON_H */
-

--- a/Quake/fs_async.c
+++ b/Quake/fs_async.c
@@ -39,42 +39,142 @@ static uint64_t fs_async_enqueued;
 static uint64_t fs_async_completed_count;
 static uint64_t fs_async_completed_bytes;
 
-static qboolean FS_Async_ReadFileSync (const char *path, fs_async_result_t *result)
+typedef struct
+{
+	qboolean is_pack;
+	qboolean is_pk3;
+	char filename[MAX_OSPATH];
+	int numfiles;
+	packfile_t *files;
+} fs_async_searchpath_entry_t;
+
+typedef struct
+{
+	fs_async_searchpath_entry_t *entries;
+	size_t count;
+} fs_async_searchpath_view_t;
+
+static void FS_Async_ReleaseSearchPathView (fs_async_searchpath_view_t *view)
+{
+	size_t i;
+
+	if (!view || !view->entries)
+		return;
+
+	for (i = 0; i < view->count; ++i)
+	{
+		if (view->entries[i].files)
+			free (view->entries[i].files);
+	}
+
+	free (view->entries);
+	view->entries = NULL;
+	view->count = 0;
+}
+
+static qboolean FS_Async_CaptureSearchPathView (fs_async_searchpath_view_t *view)
 {
 	searchpath_t *search;
+	size_t count = 0;
+	size_t i = 0;
 
+	memset (view, 0, sizeof (*view));
+
+	COM_LockSearchPaths ();
 	for (search = com_searchpaths; search; search = search->next)
+		count++;
+
+	if (!count)
 	{
+		COM_UnlockSearchPaths ();
+		return true;
+	}
+
+	view->entries = (fs_async_searchpath_entry_t *) calloc (count, sizeof (*view->entries));
+	if (!view->entries)
+	{
+		COM_UnlockSearchPaths ();
+		return false;
+	}
+	view->count = count;
+
+	for (search = com_searchpaths; search; search = search->next, ++i)
+	{
+		fs_async_searchpath_entry_t *entry = &view->entries[i];
+
 		if (search->pack)
 		{
-			pack_t *pak = search->pack;
+			entry->is_pack = true;
+			entry->is_pk3 = search->pack->is_pk3;
+			q_strlcpy (entry->filename, search->pack->filename, sizeof (entry->filename));
+			entry->numfiles = search->pack->numfiles;
+			if (entry->numfiles > 0)
+			{
+				size_t n = (size_t) entry->numfiles;
+
+				entry->files = (packfile_t *) malloc (n * sizeof (*entry->files));
+				if (!entry->files)
+				{
+					COM_UnlockSearchPaths ();
+					FS_Async_ReleaseSearchPathView (view);
+					return false;
+				}
+				memcpy (entry->files, search->pack->files, n * sizeof (*entry->files));
+			}
+		}
+		else
+		{
+			q_strlcpy (entry->filename, search->filename, sizeof (entry->filename));
+		}
+	}
+	COM_UnlockSearchPaths ();
+
+	return true;
+}
+
+/*
+ * Thread-safety: this function runs on worker threads and only reads
+ * request-local arguments plus the immutable snapshot in search_view.
+ * It never dereferences com_searchpaths directly and therefore does not
+ * require holding the global filesystem search-path lock while doing IO.
+ */
+static qboolean FS_Async_ReadFileSync (const char *path, const fs_async_searchpath_view_t *search_view, fs_async_result_t *result)
+{
+	size_t search_idx;
+
+	for (search_idx = 0; search_idx < search_view->count; ++search_idx)
+	{
+		const fs_async_searchpath_entry_t *search = &search_view->entries[search_idx];
+
+		if (search->is_pack)
+		{
 			int i;
 
-			if (pak->is_pk3)
+			if (search->is_pk3)
 			{
 				mz_zip_archive zip;
 				qboolean zip_open = false;
 
 				memset (&zip, 0, sizeof (zip));
-				if (mz_zip_reader_init_file (&zip, pak->filename, 0))
+				if (mz_zip_reader_init_file (&zip, search->filename, 0))
 					zip_open = true;
 
 				if (!zip_open)
 					continue;
 
-				for (i = 0; i < pak->numfiles; i++)
+				for (i = 0; i < search->numfiles; i++)
 				{
 					size_t extracted_size;
 					void *extracted;
 
-					if (q_strcasecmp (pak->files[i].name, path) != 0)
+					if (q_strcasecmp (search->files[i].name, path) != 0)
 						continue;
 
-					extracted = mz_zip_reader_extract_to_heap (&zip, pak->files[i].filepos, &extracted_size, 0);
+					extracted = mz_zip_reader_extract_to_heap (&zip, search->files[i].filepos, &extracted_size, 0);
 					if (!extracted)
 					{
 						result->status = FS_ASYNC_STATUS_IO_ERROR;
-						result->error_code = 2;
+						result->error_code = EIO;
 						mz_zip_reader_end (&zip);
 						return false;
 					}
@@ -90,18 +190,18 @@ static qboolean FS_Async_ReadFileSync (const char *path, fs_async_result_t *resu
 			}
 			else
 			{
-				for (i = 0; i < pak->numfiles; i++)
+				for (i = 0; i < search->numfiles; i++)
 				{
 					FILE *f;
 					long nread;
 					int len;
 					byte *buf;
 
-					if (strcmp (pak->files[i].name, path) != 0)
+					if (strcmp (search->files[i].name, path) != 0)
 						continue;
 
-					len = pak->files[i].filelen;
-					buf = (byte *) malloc ((size_t)len + 1);
+					len = search->files[i].filelen;
+					buf = (byte *) malloc ((size_t) len + 1);
 					if (!buf)
 					{
 						result->status = FS_ASYNC_STATUS_IO_ERROR;
@@ -109,7 +209,7 @@ static qboolean FS_Async_ReadFileSync (const char *path, fs_async_result_t *resu
 						return false;
 					}
 
-					f = Sys_fopen (pak->filename, "rb");
+					f = Sys_fopen (search->filename, "rb");
 					if (!f)
 					{
 						free (buf);
@@ -118,7 +218,7 @@ static qboolean FS_Async_ReadFileSync (const char *path, fs_async_result_t *resu
 						return false;
 					}
 
-					if (fseek (f, pak->files[i].filepos, SEEK_SET) != 0)
+					if (fseek (f, search->files[i].filepos, SEEK_SET) != 0)
 					{
 						fclose (f);
 						free (buf);
@@ -228,9 +328,13 @@ static void FS_Async_Worker (void *job_data)
 	unsigned int idx = FS_ASYNC_HANDLE_INDEX (h);
 	unsigned int gen = FS_ASYNC_HANDLE_GEN (h);
 	fs_async_result_t result;
+	fs_async_searchpath_view_t search_view;
+	char path[MAX_QPATH];
 	qboolean ok;
 
 	memset (&result, 0, sizeof (result));
+	memset (&search_view, 0, sizeof (search_view));
+	path[0] = 0;
 
 	SDL_LockMutex (fs_async_mutex);
 	if (idx >= FS_ASYNC_MAX_REQUESTS || !fs_async_requests[idx].in_use || fs_async_requests[idx].generation != gen)
@@ -238,11 +342,22 @@ static void FS_Async_Worker (void *job_data)
 		SDL_UnlockMutex (fs_async_mutex);
 		return;
 	}
+	q_strlcpy (path, fs_async_requests[idx].path, sizeof (path));
 	SDL_UnlockMutex (fs_async_mutex);
 
-	ok = FS_Async_ReadFileSync (fs_async_requests[idx].path, &result);
-	if (!ok && result.status == FS_ASYNC_STATUS_PENDING)
+	if (!FS_Async_CaptureSearchPathView (&search_view))
+	{
 		result.status = FS_ASYNC_STATUS_IO_ERROR;
+		result.error_code = ENOMEM;
+		ok = false;
+	}
+	else
+	{
+		ok = FS_Async_ReadFileSync (path, &search_view, &result);
+		if (!ok && result.status == FS_ASYNC_STATUS_PENDING)
+			result.status = FS_ASYNC_STATUS_IO_ERROR;
+	}
+	FS_Async_ReleaseSearchPathView (&search_view);
 
 	SDL_LockMutex (fs_async_mutex);
 	if (idx < FS_ASYNC_MAX_REQUESTS && fs_async_requests[idx].in_use && fs_async_requests[idx].generation == gen)


### PR DESCRIPTION
### Motivation

- Prevent races where async worker threads traverse or read `com_searchpaths` while the main thread mutates it.  
- Ensure workers either hold the same authoritative lock or operate on an immutable view so heavy IO/decompression can run without blocking global FS metadata updates.  

### Description

- Introduce `com_searchpaths_mutex` and public helpers `COM_LockSearchPaths` / `COM_UnlockSearchPaths` in `common.c`/`common.h`, and initialize the mutex in `COM_InitFilesystem`.  
- Make search-path mutations run while holding that lock by moving the core add logic into a locked helper (`COM_AddGameDirectoryLocked`) and wrapping `COM_AddGameDirectory` and `COM_ResetGameDirectories` with `COM_LockSearchPaths`/`COM_UnlockSearchPaths`.  
- In `fs_async.c` add a snapshot type (`fs_async_searchpath_view_t`) plus `FS_Async_CaptureSearchPathView`/`FS_Async_ReleaseSearchPathView` that copies the relevant search-path metadata (pack filenames and per-pack file listings) while holding the search-path lock.  
- Change async worker flow so the worker captures a per-request immutable snapshot under the search-path lock, releases the lock, then performs heavy IO/decompression against that snapshot; `FS_Async_ReadFileSync` now accepts the snapshot and contains thread-safety documentation stating it only reads request-local state and the immutable snapshot (it never dereferences `com_searchpaths` directly).  

### Testing

- Ran `cmake -S . -B build` to exercise project configuration, which failed in this environment because the SDL2 CMake/package files are not available.  (configuration failed)  
- Performed a single-file syntax check `cc -fsyntax-only -I. -IQuake Quake/fs_async.c`, which failed due to missing SDL headers in the environment.  (syntax check could not complete)  
- No additional automated tests were executed in this environment due to unmet build dependencies; the change is limited to synchronization and snapshotting logic and was validated via local code inspection and targeted compile-time checks where possible.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995cedb4da4832e9c2ef52db3e1fc10)