### PR TITLE
Add async asset/fs sources to Visual Studio project to resolve linker errors

### DIFF
--- a/Windows/VisualStudio/ironwail.vcxproj
+++ b/Windows/VisualStudio/ironwail.vcxproj
@@ -223,6 +223,7 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\Quake\asset_decode_async.c" />
     <ClCompile Include="..\..\Quake\bgmusic.c" />
     <ClCompile Include="..\..\Quake\bc7enc.c">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
@@ -248,6 +249,7 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
     <ClCompile Include="..\..\Quake\console.c" />
     <ClCompile Include="..\..\Quake\crc.c" />
     <ClCompile Include="..\..\Quake\cvar.c" />
+    <ClCompile Include="..\..\Quake\fs_async.c" />
     <ClCompile Include="..\..\Quake\opengl\gl_draw.c" />
     <ClCompile Include="..\..\Quake\opengl\gl_fog.c" />
     <ClCompile Include="..\..\Quake\opengl\gl_lightgrid.c" />

--- a/Windows/VisualStudio/ironwail.vcxproj.filters
+++ b/Windows/VisualStudio/ironwail.vcxproj.filters
@@ -15,6 +15,9 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\Quake\asset_decode_async.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\Quake\bgmusic.c">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -55,6 +58,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\Quake\cvar.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Quake\fs_async.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\Quake\opengl\gl_draw.c">


### PR DESCRIPTION
### Motivation
- The Windows build produced unresolved externals for async filesystem/asset functions (e.g. `FS_ReadFileAsync`, `Asset_LoadTextureAsync`, `Asset_Wait`) because their implementation files were not included in the Visual Studio project.

### Description
- Added `Quake/asset_decode_async.c` to `Windows/VisualStudio/ironwail.vcxproj` so async asset symbols are compiled into the Windows binary.
- Added `Quake/fs_async.c` to `Windows/VisualStudio/ironwail.vcxproj` so async filesystem symbols are compiled into the Windows binary.
- Added both files to `Windows/VisualStudio/ironwail.vcxproj.filters` so they appear under `Source Files` in Solution Explorer.

### Testing
- Verified the new entries are present by searching the project files with `rg` which returned the added `asset_decode_async.c` and `fs_async.c` lines and locations.
- Parsed both XML files with `python -c 'import xml.etree.ElementTree as ET; ET.parse("...")'` to confirm the project/filter XML remains well-formed and valid after edits.
- Inspected the project diff with `git diff` to confirm only the intended insertions were made and no unrelated changes occurred.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995f816ab28832e985fc329afa6b5b8)