### PR TITLE
Fix async asset/fs compile errors (basisu call, miniz include, COM_filelength)

### DIFF
--- a/Quake/asset_decode_async.c
+++ b/Quake/asset_decode_async.c
@@ -147,8 +147,10 @@ static asset_image_payload_t *Asset_DecodeKTX2(const void *raw_data, size_t raw_
 		img->mips[i].pitch = (size_t)w * 4u;
 
 		if (!basisu_transcoder_transcode_image_level(data + off, (size_t)len,
+			supercompression == 0,
 			sgd_length ? data + sgd_offset : NULL, (size_t)sgd_length,
-			supercompression == 0, (uint8_t *)img->mips[i].data, w, h, 4, 4u, 0))
+			(uint32_t)i, (uint32_t)w, (uint32_t)h,
+			(uint8_t *)img->mips[i].data, dst_size))
 			goto fail;
 	}
 

--- a/Quake/fs_async.c
+++ b/Quake/fs_async.c
@@ -1,6 +1,7 @@
 #include "quakedef.h"
 #include "fs_async.h"
 #include "sys_jobs.h"
+#include "miniz.h"
 
 #define FS_ASYNC_MAX_REQUESTS 1024
 #define FS_ASYNC_COMPLETED_CAPACITY 1024
@@ -39,6 +40,8 @@ static cvar_t fs_async_debug = {"fs_async_debug", "0", CVAR_NONE};
 static uint64_t fs_async_enqueued;
 static uint64_t fs_async_completed_count;
 static uint64_t fs_async_completed_bytes;
+
+extern qfileofs_t COM_filelength (FILE *f);
 
 typedef struct
 {


### PR DESCRIPTION
### Motivation
- Address MSVC build errors reporting a parameter type mismatch and "too many arguments" for `basisu_transcoder_transcode_image_level` in the KTX2 async decoder. 
- Fix undeclared `mz_zip_archive`/miniz APIs causing errors in the async filesystem worker. 
- Eliminate implicit declaration/usage of `COM_filelength` in `fs_async.c` which triggers warnings/errors on stricter compilers.

### Description
- Adjusted the call in `Quake/asset_decode_async.c` to `basisu_transcoder_transcode_image_level` so arguments match the stub/API signature, reordering parameters to pass `is_uastc` before global data, supplying the mip `level_index`, explicit `width`/`height`, and the destination buffer size (`dst_size`).
- Added `#include "miniz.h"` to `Quake/fs_async.c` so `mz_zip_archive` and related zip reader functions are declared in that translation unit.
- Added an explicit `extern qfileofs_t COM_filelength (FILE *f);` declaration to `Quake/fs_async.c` to avoid implicit-declaration issues when calling `COM_filelength`.

### Testing
- Ran a CMake configure attempt with `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`, which executed but failed to complete due to missing SDL2 CMake package files (`SDL2Config.cmake` / `sdl2-config.cmake`) in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995f8b6f5f8832eb26c9415f0dc6364)