### PR TITLE
Fix unresolved externals in Windows build by adding lodepng.c and sys_jobs.c to VS project

### DIFF
--- a/Windows/VisualStudio/ironwail.vcxproj
+++ b/Windows/VisualStudio/ironwail.vcxproj
@@ -275,6 +275,7 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
     <ClCompile Include="..\..\Quake\in_sdl.c" />
     <ClCompile Include="..\..\Quake\json.c" />
     <ClCompile Include="..\..\Quake\keys.c" />
+    <ClCompile Include="..\..\Quake\lodepng.c" />
     <ClCompile Include="..\..\Quake\main_sdl.c" />
     <ClCompile Include="..\..\Quake\mathlib.c" />
     <ClCompile Include="..\..\Quake\mat_shader.c" />
@@ -368,6 +369,7 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\Quake\sys_sdl_win.c" />
+    <ClCompile Include="..\..\Quake\sys_jobs.c" />
     <ClCompile Include="..\..\Quake\view.c" />
     <ClCompile Include="..\..\Quake\wad.c" />
     <ClCompile Include="..\..\Quake\world.c" />

--- a/Windows/VisualStudio/ironwail.vcxproj.filters
+++ b/Windows/VisualStudio/ironwail.vcxproj.filters
@@ -132,6 +132,9 @@
     <ClCompile Include="..\..\Quake\keys.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Quake\lodepng.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\Quake\main_sdl.c">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -271,6 +274,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\Quake\sys_sdl_win.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Quake\sys_jobs.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\Quake\view.c">


### PR DESCRIPTION
### Motivation

- The Windows Visual Studio project was missing the C sources that provide `lodepng_decode32` and `Sys_Jobs_*` symbols, causing LNK2001/LNK1120 unresolved external errors for async asset/fs code.

### Description

- Add `..\..\Quake\lodepng.c` to `Windows/VisualStudio/ironwail.vcxproj` so `lodepng_decode32` is compiled into the Windows binary.
- Add `..\..\Quake\sys_jobs.c` to `Windows/VisualStudio/ironwail.vcxproj` so the `Sys_Jobs_CreateQueue/DestroyQueue/Submit/TrySubmit` implementations are linked.
- Add matching `ClCompile` entries for both `lodepng.c` and `sys_jobs.c` to `Windows/VisualStudio/ironwail.vcxproj.filters` so Solution Explorer reflects the new sources.
- No changes to the implementation code were made; only project and filter files were updated.

### Testing

- Verified both `lodepng.c` and `sys_jobs.c` are present in `Windows/VisualStudio/ironwail.vcxproj` and `Windows/VisualStudio/ironwail.vcxproj.filters` by searching the project files (`rg`/file inspection) and confirmed the new `ClCompile` entries exist.
- Confirmed the solution filters were updated so the files appear under `Source Files` in the filters file (`.vcxproj.filters`).
- Windows build with `MSBuild` was not executed in this environment because the Windows MSBuild toolchain is unavailable here, so link-time verification on Windows was not run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995f94c6f24832e8b80487acca16703)