### PR TITLE
Fix duplicate LodePNG symbols in Visual Studio build

### DIFF
--- a/Windows/VisualStudio/ironwail.vcxproj
+++ b/Windows/VisualStudio/ironwail.vcxproj
@@ -275,7 +275,6 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
     <ClCompile Include="..\..\Quake\in_sdl.c" />
     <ClCompile Include="..\..\Quake\json.c" />
     <ClCompile Include="..\..\Quake\keys.c" />
-    <ClCompile Include="..\..\Quake\lodepng.c" />
     <ClCompile Include="..\..\Quake\main_sdl.c" />
     <ClCompile Include="..\..\Quake\mathlib.c" />
     <ClCompile Include="..\..\Quake\mat_shader.c" />

--- a/Windows/VisualStudio/ironwail.vcxproj.filters
+++ b/Windows/VisualStudio/ironwail.vcxproj.filters
@@ -132,9 +132,6 @@
     <ClCompile Include="..\..\Quake\keys.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\Quake\lodepng.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\Quake\main_sdl.c">
       <Filter>Source Files</Filter>
     </ClCompile>


### PR DESCRIPTION
### Motivation
- Prevent linker errors (`LNK2005`/`LNK1169`) caused by `lodepng.c` being compiled twice: once as a separate translation unit in the Visual Studio project and once via `#include "lodepng.c"` in `Quake/image.c`.

### Description
- Removed the `ClCompile` entry for `..\..\Quake\lodepng.c` from `Windows/VisualStudio/ironwail.vcxproj` and removed the matching entry from `Windows/VisualStudio/ironwail.vcxproj.filters` so `lodepng.c` is only included via `Quake/image.c`.

### Testing
- Ran `rg -n "lodepng.c" Windows/VisualStudio/ironwail.vcxproj Windows/VisualStudio/ironwail.vcxproj.filters Quake/image.c` and verified `lodepng.c` is referenced only in `Quake/image.c` (check succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995fb140ab4832ead353b991630914b)