### PR TITLE
Fix unresolved lodepng_decode32 linker error on Windows

### DIFF
--- a/Quake/image.c
+++ b/Quake/image.c
@@ -53,7 +53,6 @@ static byte *Image_LoadLMP (FILE *f, int *width, int *height);
 #define STB_IMAGE_WRITE_STATIC
 #include "stb_image_write.h"
 
-#define LODEPNG_NO_COMPILE_DECODER
 #define LODEPNG_NO_COMPILE_CPP
 #define LODEPNG_NO_COMPILE_ANCILLARY_CHUNKS
 #define LODEPNG_NO_COMPILE_ERROR_TEXT


### PR DESCRIPTION
### Motivation
- Windows link failed with an unresolved external `lodepng_decode32` because the lodepng decoder was disabled in the translation unit that includes `lodepng.c`.

### Description
- Remove `#define LODEPNG_NO_COMPILE_DECODER` from `Quake/image.c` so the lodepng decoder implementation (including `lodepng_decode32`) is compiled into the translation unit that includes `lodepng.c`.

### Testing
- Verified with `rg` that `LODEPNG_NO_COMPILE_DECODER` was removed and inspected `Quake/image.c` to confirm `lodepng.c` is still included, and committed the change; the verification commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995fb9021e0832ea9a87cde2f38d556)