### PR TITLE
Fix MSVC compile errors in clustered lighting paths

### DIFF
--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -198,6 +198,7 @@ extern	const char	*gl_version;
 	x(void,			BlitFramebuffer, (GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0, GLint dstX1, GLint dstY1, GLbitfield mask, GLenum filter))\
 	x(void,			DrawBuffers, (GLsizei n, const GLenum *bufs))\
 	x(void,			ClearBufferfv, (GLenum buffer, GLint drawbuffer, const GLfloat *value))\
+	x(void,			ClearBufferData, (GLenum target, GLenum internalformat, GLenum format, GLenum type, const void *data))\
 	x(void,			BlendEquation, (GLenum mode))\
 	x(void,			BlendFuncSeparate, (GLenum srcRGB, GLenum dstRGB, GLenum srcAlpha, GLenum dstAlpha))\
 	x(void,			BlendFunci, (GLuint buf, GLenum sfactor, GLenum dfactor))\

--- a/Quake/opengl/gl_rmisc.c
+++ b/Quake/opengl/gl_rmisc.c
@@ -392,7 +392,6 @@ extern cvar_t r_filmgrain_debug;
 #if defined(USE_SIMD)
 extern cvar_t r_simd;
 #endif
-	Cvar_RegisterVariable (&r_clustered_force_empty);
 qboolean use_simd;
 
 extern gltexture_t *playertextures[MAX_SCOREBOARD]; //johnfitz
@@ -546,10 +545,8 @@ static void R_SIMD_f (cvar_t *var)
 #else
 	use_simd = false;
 #endif
-	Cvar_RegisterVariable (&r_clustered_force_empty);
 }
 #endif
-	Cvar_RegisterVariable (&r_clustered_force_empty);
 
 /*
 ====================
@@ -747,7 +744,6 @@ Cvar_RegisterVariable (&r_drawviewmodel);
         Cvar_SetCallback (&r_simd, R_SIMD_f);
 	R_SIMD_f(&r_simd);
 #endif
-	Cvar_RegisterVariable (&r_clustered_force_empty);
 	Cvar_RegisterVariable (&r_speeds);
 	Cvar_RegisterVariable (&r_pos);
 	Cvar_RegisterVariable (&r_alphasort);


### PR DESCRIPTION
### Motivation
- MSVC reported syntax errors when compiling clustered lighting code because stray `Cvar_RegisterVariable(&r_clustered_force_empty)` invocations appeared at file/global scope and in the wrong places, causing invalid tokens at parse time. 
- `GL_ClearBufferDataFunc` was used before being declared, producing an undeclared identifier error in the clustered lighting path.

### Description
- Removed accidental `Cvar_RegisterVariable(&r_clustered_force_empty)` statements inserted at file/global scope and around the SIMD callback inside `Quake/opengl/gl_rmisc.c` while preserving the legitimate registration in the renderer initialization code. 
- Added `ClearBufferData` to the OpenGL function pointer macro list in `Quake/glquake.h` so the `GL_ClearBufferDataFunc` symbol is declared and available to `gl_rlight.c`.

### Testing
- Searched repository for occurrences of the stray registration and `ClearBufferData` with `rg` and confirmed the stray registrations were removed and a single intended `r_clustered_force_empty` registration remains (command succeeded). 
- Inspected the modified regions with `nl -ba`/`sed` to verify the changes were applied at the expected line ranges (command succeeded). 
- Ran `git diff --check` to validate no whitespace/style issues were introduced (command succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699637e88060832ea1b19598d437d415)