### PR TITLE
Print CPU brand, SIMD extensions, and core count at startup

### DIFF
--- a/Quake/simd_caps.c
+++ b/Quake/simd_caps.c
@@ -4,11 +4,14 @@
 #if defined(_MSC_VER)
 #include <intrin.h>
 #endif
-
 #if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
 #define SIMD_X86_FAMILY 1
 #else
 #define SIMD_X86_FAMILY 0
+#endif
+
+#if SIMD_X86_FAMILY && (defined(__GNUC__) || defined(__clang__))
+#include <cpuid.h>
 #endif
 
 #if SIMD_X86_FAMILY
@@ -25,11 +28,127 @@ cvar_t simd_force = {"simd_force", "0", CVAR_ARCHIVE};
 
 static simd_caps_t simd_caps;
 static qboolean simd_caps_initialized;
+static qboolean cpu_info_initialized;
 
 static int simd_mode_cache = -1;
 static int simd_force_cache = -999;
 static int simd_enable_cache = -999;
 
+
+static char cpu_brand_string[64] = "Unknown";
+static void CPU_NormalizeWhitespace (const char *src, char *dst, size_t dst_size)
+{
+	qboolean in_space = false;
+	size_t out = 0;
+
+	while (*src && q_isspace ((unsigned char)*src))
+		++src;
+
+	for (; *src && out + 1 < dst_size; ++src)
+	{
+		if (q_isspace ((unsigned char)*src))
+		{
+			in_space = true;
+			continue;
+		}
+
+		if (in_space && out > 0 && out + 1 < dst_size)
+			dst[out++] = ' ';
+		in_space = false;
+		dst[out++] = *src;
+	}
+
+	if (out > 0 && dst[out - 1] == ' ')
+		--out;
+
+	dst[out] = '\0';
+}
+
+static char simd_extensions_string[64] = "none";
+
+static void CPU_BuildSIMDExtensionsString (simd_caps_t caps)
+{
+	q_strlcpy (simd_extensions_string, "none", sizeof (simd_extensions_string));
+
+	if (caps.sse2)
+		q_strlcpy (simd_extensions_string, "SSE2", sizeof (simd_extensions_string));
+	if (caps.ssse3)
+		q_strlcpy (simd_extensions_string, "SSE2 SSSE3", sizeof (simd_extensions_string));
+	if (caps.sse41)
+		q_strlcpy (simd_extensions_string, "SSE2 SSSE3 SSE4.1", sizeof (simd_extensions_string));
+	if (caps.avx2)
+		q_strlcpy (simd_extensions_string, "SSE2 SSSE3 SSE4.1 AVX2", sizeof (simd_extensions_string));
+}
+
+#if SIMD_X86_FAMILY
+static void CPU_DetectBrandString (void)
+{
+	int regs[4] = {0, 0, 0, 0};
+	int max_extended = 0;
+	char raw[49];
+
+#if defined(_MSC_VER)
+	__cpuidex (regs, 0x80000000, 0);
+	max_extended = regs[0];
+#elif defined(__GNUC__) || defined(__clang__)
+	__cpuid_count (0x80000000, 0, regs[0], regs[1], regs[2], regs[3]);
+	max_extended = regs[0];
+#endif
+
+	if (max_extended < 0x80000004)
+		return;
+
+	memset (raw, 0, sizeof (raw));
+
+#if defined(_MSC_VER)
+	__cpuidex (&regs[0], 0x80000002, 0);
+	memcpy (raw + 0, regs, 16);
+	__cpuidex (&regs[0], 0x80000003, 0);
+	memcpy (raw + 16, regs, 16);
+	__cpuidex (&regs[0], 0x80000004, 0);
+	memcpy (raw + 32, regs, 16);
+#elif defined(__GNUC__) || defined(__clang__)
+	__cpuid_count (0x80000002, 0, regs[0], regs[1], regs[2], regs[3]);
+	memcpy (raw + 0, regs, 16);
+	__cpuid_count (0x80000003, 0, regs[0], regs[1], regs[2], regs[3]);
+	memcpy (raw + 16, regs, 16);
+	__cpuid_count (0x80000004, 0, regs[0], regs[1], regs[2], regs[3]);
+	memcpy (raw + 32, regs, 16);
+#endif
+
+	CPU_NormalizeWhitespace (raw, cpu_brand_string, sizeof (cpu_brand_string));
+	if (!cpu_brand_string[0])
+		q_strlcpy (cpu_brand_string, "Unknown", sizeof (cpu_brand_string));
+}
+#else
+static void CPU_DetectBrandString (void)
+{
+	/* Best effort on non-x86: leave as Unknown when no portable brand source exists. */
+}
+#endif
+
+static void CPU_InitInfo (void)
+{
+	if (cpu_info_initialized)
+		return;
+
+	simd_caps = SIMD_GetCaps ();
+	CPU_DetectBrandString ();
+	CPU_BuildSIMDExtensionsString (simd_caps);
+	cpu_info_initialized = true;
+}
+
+const char *CPU_GetBrandString (void)
+{
+	CPU_InitInfo ();
+	return cpu_brand_string;
+}
+
+const char *CPU_GetSIMDExtensionsString (void)
+{
+	CPU_InitInfo ();
+	return simd_extensions_string;
+}
 
 int CPU_GetCoreCount (void)
 {
@@ -121,7 +240,7 @@ void SIMD_Init (void)
 	Cvar_RegisterVariable (&simd_enable);
 	Cvar_RegisterVariable (&simd_force);
 
-	simd_caps = SIMD_GetCaps ();
+	CPU_InitInfo ();
 	simd_caps_initialized = true;
 }
 

--- a/Quake/simd_caps.h
+++ b/Quake/simd_caps.h
@@ -30,6 +30,8 @@ qboolean SIMD_SupportsMode (int mode);
 /* Shared CPU helpers for non-SIMD systems code. */
 int CPU_GetCoreCount (void);
 qboolean CPU_HasSSE2 (void);
+const char *CPU_GetBrandString (void);
+const char *CPU_GetSIMDExtensionsString (void);
 
 /* RGBA/BGRA channel swap helpers used by upload/conversion loops. */
 void swizzle_rgba_bgra_scalar (uint8_t *dst, const uint8_t *src, size_t n_pixels);

--- a/Quake/sys_sdl_unix.c
+++ b/Quake/sys_sdl_unix.c
@@ -767,7 +767,8 @@ void Sys_Init (void)
 	host_parms->userdir = userdir;
 #endif
 	host_parms->numcpus = Sys_NumCPUs ();
-	Sys_Printf("Detected %d CPUs.\n", host_parms->numcpus);
+	Sys_Printf("Detected %d CPUs (%s).\n", host_parms->numcpus, CPU_GetBrandString ());
+	Sys_Printf("SIMD extensions: %s.\n", CPU_GetSIMDExtensionsString ());
 
 	rcp_counter_freq = 1.0 / SDL_GetPerformanceFrequency();
 }

--- a/Quake/sys_sdl_win.c
+++ b/Quake/sys_sdl_win.c
@@ -1031,7 +1031,8 @@ void Sys_Init (void)
 		Sys_Error ("This engine requires Windows XP or newer");
 
 	host_parms->numcpus = CPU_GetCoreCount ();
-	Sys_Printf("Detected %d CPUs.\n", host_parms->numcpus);
+	Sys_Printf("Detected %d CPUs (%s).\n", host_parms->numcpus, CPU_GetBrandString ());
+	Sys_Printf("SIMD extensions: %s.\n", CPU_GetSIMDExtensionsString ());
 
 	if (isDedicated)
 	{


### PR DESCRIPTION
### Motivation

- Improve engine startup diagnostics by reporting CPU identity (brand string), available SIMD extensions, and core count in the existing startup console messages.
- Reuse and extend the existing CPU/SIMD detection code so other subsystems can query a cached CPU identity and SIMD summary.

### Description

- Added public helpers in `Quake/simd_caps.h`: `CPU_GetBrandString()` and `CPU_GetSIMDExtensionsString()` and kept existing `CPU_GetCoreCount()` and `CPU_HasSSE2()` available.
- Implemented CPU info detection and caching in `Quake/simd_caps.c`: CPUID-based brand string extraction for x86 (extended brand leaves), whitespace normalization (`CPU_NormalizeWhitespace`), runtime SIMD-capabilities -> readable string builder (`CPU_BuildSIMDExtensionsString`), and a one-time `CPU_InitInfo()` to populate/caches results.
- Made `SIMD_Init()` delegate CPU probing into the new cached init so queries are safe before cvar timing differences, and added compiler-guarded `#include <cpuid.h>` where appropriate.
- Extended startup logging in `Quake/sys_sdl_unix.c` and `Quake/sys_sdl_win.c` to print core count with brand and a separate line listing SIMD extensions (calls `CPU_GetBrandString()` and `CPU_GetSIMDExtensionsString()`).
- Files changed: `Quake/simd_caps.h`, `Quake/simd_caps.c`, `Quake/sys_sdl_unix.c`, `Quake/sys_sdl_win.c`.

### Testing

- Attempted to build the engine with `make -C Quake -j4`; the build could not proceed in this environment due to missing SDL development tooling/headers (`sdl2-config` not found and `SDL.h` not found), so compilation could not be validated here (failure).
- Code changes were staged and committed locally (no runtime test possible in this environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699641af9c10832eaebfc3daa799b77c)