### PR TITLE
Include q_ctype.h in simd_caps.c to fix MSVC C4013/C2220 build error

### DIFF
--- a/Quake/simd_caps.c
+++ b/Quake/simd_caps.c
@@ -1,4 +1,5 @@
 #include "quakedef.h"
+#include "q_ctype.h"
 #include "simd_caps.h"
 
 #if defined(_MSC_VER)


### PR DESCRIPTION
### Motivation
- MSVC treated the implicit declaration of `q_isspace` in `Quake/simd_caps.c` as an error (warning C4013 promoted to error C2220), so the file needs to see the `q_isspace` declaration.

### Description
- Add `#include "q_ctype.h"` at the top of `Quake/simd_caps.c` so the inline `q_isspace` declaration is visible to that translation unit.

### Testing
- Ran `rg` to locate the `q_isspace` definition and confirm it lives in `Quake/q_ctype.h`, which is now included; the search returned the expected file and locations.
- Ran `git diff --check` which returned no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699647838a50832eab73a46b9d47624b)