### PR TITLE
Make r_dynamic=0 cost-free: skip clustered work when zero dlights + add per-pass instrumentation

### DIFF
--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -105,6 +105,8 @@ extern	cvar_t	r_telealpha;
 extern	cvar_t	r_slimealpha;
 extern	cvar_t	r_litwater;
 extern	cvar_t	r_dynamic;
+extern  cvar_t  r_dynamic_zero_cost_debug;
+extern  cvar_t  r_beam_clustered_lighting;
 extern	cvar_t	r_novis;
 extern	cvar_t	r_scale;
 
@@ -718,6 +720,16 @@ void GL_CreateShaders (void);
 void GL_DeleteShaders (void);
 void GL_ApplyFilmgrainUI (void);
 void R_Clustered_RebindForProgram (GLuint program, const char *pass_name);
+qboolean R_ClusteredShadingActive (void);
+unsigned int R_ClusteredSubmittedLightCount (void);
+
+void R_PerfStats_BeginFrame (void);
+void R_PerfStats_AddWorldDrawCalls (int count);
+void R_PerfStats_AddAliasDrawCalls (int count);
+void R_PerfStats_AddParticleDrawCalls (int count);
+void R_PerfStats_AddBeamEntities (int count);
+void R_PerfStats_SetClusterBuildRan (qboolean ran);
+void R_PerfStats_SetDlightShadowPassRan (qboolean ran);
 void R_DebugDrawWireBox (const vec3_t mins, const vec3_t maxs, const vec3_t color, qboolean ztest);
 void R_DebugFlushGeometry (void);
 

--- a/Quake/opengl/gl_rlight.c
+++ b/Quake/opengl/gl_rlight.c
@@ -624,6 +624,16 @@ static struct {
 	int num_barriers;
 } r_clustered;
 
+qboolean R_ClusteredShadingActive (void)
+{
+	return r_clustered.shading_enabled;
+}
+
+unsigned int R_ClusteredSubmittedLightCount (void)
+{
+	return (unsigned int)r_framedata.numlights;
+}
+
 static double R_ClusteredNowMS (void)
 {
 	return Sys_DoubleTime () * 1000.0;
@@ -1654,6 +1664,7 @@ void R_PushDlights (void)
 	dlight_t *submit[DLIGHT_GPU_MAX];
 
 	r_framedata.numlights = 0;
+	R_PerfStats_SetClusterBuildRan (false);
 	memset (r_dlight_sources, 0, sizeof (r_dlight_sources));
 	if (r_clustered.last_frame_built != r_framecount)
 	{
@@ -1682,6 +1693,7 @@ void R_PushDlights (void)
 	}
 
 	R_ClusterPerf_BeginLightUpload ();
+	r_framedata.clustered_light_params[2] = (r_clustered_lighting.value > 0.f && r_framedata.numlights > 0) ? 1.f : 0.f;
 	R_UploadFrameData ();
 	R_ClusterPerf_EndLightUpload ();
 
@@ -1701,9 +1713,10 @@ void R_PushDlights (void)
 		return;
 	}
 
-	if (r_clustered_lighting.value > 0.f)
+	if (r_clustered_lighting.value > 0.f && r_framedata.numlights > 0)
 	{
 		GL_BeginGroup ("Light clustering");
+		R_PerfStats_SetClusterBuildRan (true);
 		R_ClusterPerf_BeginBuild ();
 		R_Clustered_BuildLists ();
 		R_ClusterPerf_EndBuild ();

--- a/Quake/opengl/gl_rmain.c
+++ b/Quake/opengl/gl_rmain.c
@@ -480,6 +480,38 @@ static qboolean MatrixInverse4x4(const float m[16], float out[16])
 int rs_brushpolys, rs_aliaspolys, rs_skypolys;
 int rs_dynamiclightmaps, rs_brushpasses, rs_aliaspasses, rs_skypasses;
 
+typedef struct r_perf_stats_s {
+	int world_draw_calls;
+	int alias_draw_calls;
+	int particle_draw_calls;
+	int beam_entities;
+	qboolean clustered_build_ran;
+	qboolean dlight_shadow_pass_ran;
+	double frame_begin_time;
+	double world_ms;
+	double alias_ms;
+	double particles_ms;
+	double beams_ms;
+	double dlight_shadow_ms;
+	double cluster_push_ms;
+	double frame_ms;
+} r_perf_stats_t;
+
+static r_perf_stats_t r_perf_stats;
+
+void R_PerfStats_BeginFrame (void)
+{
+	memset (&r_perf_stats, 0, sizeof (r_perf_stats));
+	r_perf_stats.frame_begin_time = Sys_DoubleTime ();
+}
+
+void R_PerfStats_AddWorldDrawCalls (int count) { if (count > 0) r_perf_stats.world_draw_calls += count; }
+void R_PerfStats_AddAliasDrawCalls (int count) { if (count > 0) r_perf_stats.alias_draw_calls += count; }
+void R_PerfStats_AddParticleDrawCalls (int count) { if (count > 0) r_perf_stats.particle_draw_calls += count; }
+void R_PerfStats_AddBeamEntities (int count) { if (count > 0) r_perf_stats.beam_entities += count; }
+void R_PerfStats_SetClusterBuildRan (qboolean ran) { r_perf_stats.clustered_build_ran = ran; }
+void R_PerfStats_SetDlightShadowPassRan (qboolean ran) { r_perf_stats.dlight_shadow_pass_ran = ran; }
+
 //
 // view origin
 //
@@ -533,6 +565,8 @@ cvar_t	r_lightmap_colorspace_debug = { "r_lightmap_colorspace_debug", "0", CVAR_
 cvar_t	r_wateralpha = { "r_wateralpha","1",CVAR_ARCHIVE };
 cvar_t	r_litwater = { "r_litwater","1",CVAR_NONE };
 cvar_t	r_dynamic = { "r_dynamic","1",CVAR_ARCHIVE };
+cvar_t  r_dynamic_zero_cost_debug = { "r_dynamic_zero_cost_debug", "0", CVAR_NONE };
+cvar_t  r_beam_clustered_lighting = { "r_beam_clustered_lighting", "0", CVAR_NONE };
 /* Clustered-light controls. */
 cvar_t  r_clustered_light_enable = { "r_clustered_light_enable", "1", CVAR_ARCHIVE };
 cvar_t  r_clustered_light_radius_scale = { "r_clustered_light_radius_scale", "1.0", CVAR_ARCHIVE };
@@ -4079,7 +4113,7 @@ void R_SetupView (void)
         r_framedata.colorspace_params[3] = 0.f;
         r_framedata.shader_params[0] = r_shader_debug.value;
         r_framedata.shader_params[1] = r_tcgen_debug.value;
-        r_framedata.shader_params[2] = 0.f;
+        r_framedata.shader_params[2] = r_beam_clustered_lighting.value > 0.f ? 1.f : 0.f;
         r_framedata.shader_params[3] = 0.f;
         r_framedata.shadow_params[0] = r_shadow_bias.value;
         r_framedata.shadow_params[1] = r_shadow_normalbias.value;
@@ -5215,13 +5249,18 @@ R_RenderScene
 */
 void R_RenderScene (void)
 {
+	double t0, t1;
+	R_PerfStats_BeginFrame ();
+	R_PerfStats_AddBeamEntities (dev_stats.beams);
 	R_ClusterPerf_BeginFrame ();
 	R_StateDebugMark ("FRAME_START");
 	R_ResetViewportAndScissorFullscreen ("WORLD_RESET_BEFORE_SETUP");
 	R_SetupScene (); //johnfitz -- this does everything that should be done once per call to RenderScene
 	R_Decals_FrameBegin ();
 	R_Shadow_SunPass ();
+	t0 = Sys_DoubleTime ();
 	R_Shadow_DlightPass ();
+	r_perf_stats.dlight_shadow_ms += (Sys_DoubleTime () - t0) * 1000.0;
 	R_SetupGL ();
 	R_Clear ();
 	R_StateDebugMark ("WORLD_BEFORE_GEOMETRY");
@@ -5234,20 +5273,29 @@ void R_RenderScene (void)
 	R_StateDebugMark ("WEAPON_AFTER");
 	S_ExtraUpdate (); // don't let sound get messed up if going slow
 	R_ClusterPerf_BeginWorld ();
+	t0 = Sys_DoubleTime ();
 	R_DrawEntitiesOnList (false); //johnfitz -- false means this is the pass for nonalpha entities
+	t1 = Sys_DoubleTime ();
+	r_perf_stats.world_ms += (t1 - t0) * 1000.0;
 	R_StateDebugMark ("WORLD_CLUSTERED_LIGHTS_BEGIN");
 	R_LogWorldLightState ("WORLD_CLUSTERED_LIGHTS_BEGIN");
 	R_LogWorldLightState ("WORLD_CLUSTERED_LIGHTS_END");
 	R_StateDebugMark ("WORLD_CLUSTERED_LIGHTS_END");
 	R_ClusterPerf_EndWorld ();
 	R_DrawDecals (false);
+	t0 = Sys_DoubleTime ();
 	R_DrawParticles (false);
+	r_perf_stats.particles_ms += (Sys_DoubleTime () - t0) * 1000.0;
 	Sky_DrawSky (); //johnfitz
 	R_DrawWater (false);
 	R_BeginTranslucency ();
 	R_DrawWater (true);
+	t0 = Sys_DoubleTime ();
 	R_DrawEntitiesOnList (true); //johnfitz -- true means this is the pass for alpha entities
+	r_perf_stats.alias_ms += (Sys_DoubleTime () - t0) * 1000.0;
+	t0 = Sys_DoubleTime ();
 	R_DrawParticles (true);
+	r_perf_stats.particles_ms += (Sys_DoubleTime () - t0) * 1000.0;
 	R_EndTranslucency ();
 	R_ShowTris (); //johnfitz
 	R_ShowBoundingBoxes (); //johnfitz
@@ -5255,6 +5303,23 @@ void R_RenderScene (void)
 	R_ShowLightgridDebug ();
 	R_StateDebugMark ("WORLD_AFTER_GEOMETRY");
 	R_ClusterPerf_EndFrame ();
+	r_perf_stats.frame_ms = (Sys_DoubleTime () - r_perf_stats.frame_begin_time) * 1000.0;
+	if (r_dynamic_zero_cost_debug.value > 0.f)
+	{
+		Con_Printf ("RPERF frame_ms=%.3f world_draws=%d alias_draws=%d particles_draws=%d beams=%d cluster_build=%d dlight_shadow=%d world_ms=%.3f alias_ms=%.3f particles_ms=%.3f dlight_shadow_ms=%.3f num_dlights=%u\n",
+			r_perf_stats.frame_ms,
+			r_perf_stats.world_draw_calls,
+			r_perf_stats.alias_draw_calls,
+			r_perf_stats.particle_draw_calls,
+			r_perf_stats.beam_entities,
+			r_perf_stats.clustered_build_ran ? 1 : 0,
+			r_perf_stats.dlight_shadow_pass_ran ? 1 : 0,
+			r_perf_stats.world_ms,
+			r_perf_stats.alias_ms,
+			r_perf_stats.particles_ms,
+			r_perf_stats.dlight_shadow_ms,
+			R_ClusteredSubmittedLightCount ());
+	}
 }
 
 /*

--- a/Quake/opengl/gl_rmisc.c
+++ b/Quake/opengl/gl_rmisc.c
@@ -670,6 +670,8 @@ Cvar_RegisterVariable (&r_drawviewmodel);
         Cvar_SetCallback (&r_wateralpha, R_SetWateralpha_f);
         Cvar_RegisterVariable (&r_litwater);
         Cvar_RegisterVariable (&r_dynamic);
+        Cvar_RegisterVariable (&r_dynamic_zero_cost_debug);
+        Cvar_RegisterVariable (&r_beam_clustered_lighting);
         Cvar_RegisterVariable (&r_clustered_light_enable);
         Cvar_RegisterVariable (&r_clustered_light_radius_scale);
         Cvar_RegisterVariable (&r_clustered_light_debug_visualize);

--- a/Quake/renderer/r_alias.c
+++ b/Quake/renderer/r_alias.c
@@ -671,6 +671,7 @@ ibuf.global.rim_params2[3] = CLAMP (0.f, r_rim_debug.value, 3.f);
 		GL_BindTextures (0, 3, textures);
 
 		GL_DrawElementsInstancedFunc (GL_TRIANGLES, hdr->numindexes, GL_UNSIGNED_SHORT, (void *)hdr->eboofs, ibuf.count);
+		R_PerfStats_AddAliasDrawCalls (1);
 
 		rs_aliaspasses += hdr->numtris * ibuf.count;
 	}
@@ -769,6 +770,7 @@ static void R_FlushAliasInstances_Shadow (void)
 		GL_BindBuffersRange (GL_SHADER_STORAGE_BUFFER, 1, 2, buffers, offsets, sizes);
 
 		GL_DrawElementsInstancedFunc (GL_TRIANGLES, hdr->numindexes, GL_UNSIGNED_SHORT, (void *)hdr->eboofs, ibuf.count);
+		R_PerfStats_AddAliasDrawCalls (1);
 
 		rs_aliaspasses += hdr->numtris * ibuf.count;
 	}

--- a/Quake/renderer/r_part.c
+++ b/Quake/renderer/r_part.c
@@ -669,6 +669,7 @@ static void R_FlushParticleBatch (void)
 	GL_VertexAttribPointerFunc (1, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(partverts[0]), ofs + offsetof(particlevert_t, color));
 
 	GL_DrawArraysInstancedFunc (GL_TRIANGLE_STRIP, 0, 4, numpartverts);
+	R_PerfStats_AddParticleDrawCalls (1);
 
 	numpartverts = 0;
 }

--- a/Quake/renderer/r_shadow.c
+++ b/Quake/renderer/r_shadow.c
@@ -1809,6 +1809,7 @@ void R_Shadow_SunPass (void)
 
 void R_Shadow_DlightPass (void)
 {
+	R_PerfStats_SetDlightShadowPassRan (false);
 	qboolean shadows_enabled = r_shadows.value > 0.f;
 	qboolean dlight_shadows_enabled = (r_shadow_dlights.value > 0.f && r_clustered_shadows.value > 0.f);
 	double t0, t1;
@@ -1929,6 +1930,7 @@ void R_Shadow_DlightPass (void)
 		return;
 	}
 
+	R_PerfStats_SetDlightShadowPassRan (true);
 	memcpy (sun_viewproj, r_framedata.shadow_viewproj, sizeof (sun_viewproj));
 	R_Shadow_SaveGLState (&saved_state);
 

--- a/Quake/renderer/r_world.c
+++ b/Quake/renderer/r_world.c
@@ -472,6 +472,7 @@ static void R_FlushBModelCalls (void)
 		GL_Upload (GL_SHADER_STORAGE_BUFFER, bmodel_calls.bindless.params, sizeof (bmodel_calls.bindless.params[0]) * num_bmodel_calls, &buf, &ofs);
 		GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 1, buf, (GLintptr)ofs, sizeof (bmodel_calls.bindless.params[0]) * num_bmodel_calls);
 		GL_MultiDrawElementsIndirectFunc (GL_TRIANGLES, GL_UNSIGNED_INT, (const void *)dstcmdofs, num_bmodel_calls, sizeof (bmodel_draw_indirect_t));
+		R_PerfStats_AddWorldDrawCalls (1);
 	}
 	else
 	{
@@ -486,6 +487,7 @@ static void R_FlushBModelCalls (void)
 			GL_BindTextures (0, 2, bmodel_calls.bound.textures[i]);
 			GL_Bind (GL_TEXTURE4, bmodel_calls.bound.textures[i][2]);
 			GL_DrawElementsIndirectFunc (GL_TRIANGLES, GL_UNSIGNED_INT, (const byte *)(dstcmdofs + i * sizeof (bmodel_draw_indirect_t)));
+			R_PerfStats_AddWorldDrawCalls (1);
 		}
 	}
 

--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -237,7 +237,9 @@ void main()
 	vec3 L_amb = max(in_amb_light, vec3(0.0));
 	vec3 N_lighting = normalize_safe(gl_FrontFacing ? in_normal : -in_normal);
 	vec3 world_pos = in_pos + AliasEyePos;
-	vec3 clustered_dyn = EvaluateAliasClusteredLights(world_pos, N_lighting, gl_FragCoord.xy);
+	vec3 clustered_dyn = vec3(0.0);
+	if ((in_flags & ALIAS_FLAG_LIGHTNING) == 0 || ShaderParams.z > 0.5)
+		clustered_dyn = EvaluateAliasClusteredLights(world_pos, N_lighting, gl_FragCoord.xy);
 	vec3 L_dyn = clustered_dyn;
 	lit_color.rgb += clustered_dyn;
 


### PR DESCRIPTION
### Motivation
- Rendering collapsed when `r_dynamic=1` but there were 0 dynamic lights because clustered build/bind/upload work still ran; the intent is to make the zero-light path match `r_dynamic=0` performance by avoiding unnecessary clustered work. (investigation pointed at clustered build/upload in `R_PushDlights`).
- We also needed lightweight in-engine instrumentation to prove the zero-light fast path (no external profilers allowed).

### Description
- Gate clustered build/upload on zero lights: in `Quake/opengl/gl_rlight.c` the clustered upload/build is now forced-off when `r_framedata.numlights == 0` and `r_framedata.clustered_light_params[2]` is set accordingly before `R_UploadFrameData`; changes around `R_ClusteredSubmittedLightCount`/`R_ClusteredShadingActive` and `R_PushDlights` (see `Quake/opengl/gl_rlight.c` lines ~627-635 and ~1656-1735). 
- Add per-frame, lightweight render counters/timers and a debug cvar: a `r_perf_stats` struct plus `R_PerfStats_*` helpers were added and wired into the frame (world/alias/particles draw-call increments, beam counts, cluster-build and dlight-shadow pass flags), and the `r_dynamic_zero_cost_debug` cvar prints an `RPERF ...` line; see `Quake/opengl/gl_rmain.c` additions (`r_perf_stats` and `R_RenderScene` logging) at ~L483-L513 and ~L5249-L5321, and cvar registration in `Quake/opengl/gl_rmisc.c` ~L672-L675.
- Avoid per-entity clustered cost for beams/lightning: alias model shader path now avoids clustered lookup for beam/lightning instances by default and is opt-in via `r_beam_clustered_lighting`; the change is in the alias shader and the shader params upload (`Quake/shaders/alias.frag` ~L232-L244 and `Quake/opengl/gl_rmain.c` shader params ~L4114-L4117 and cvar ~L566-L570).
- Instrument draw counts in render backends: world bmodel indirect draws (`Quake/renderer/r_world.c` ~L466-L492), alias instanced draws (`Quake/renderer/r_alias.c` ~L671-L676 and ~L766-L774), and particle batch flush (`Quake/renderer/r_part.c` ~L669-L673) now increment counters used by the `RPERF` line; dlight shadow pass activity is flagged in `Quake/renderer/r_shadow.c` (~L1810-L1934).

### Testing
- Automated build attempt: `cmake -S . -B build && cmake --build build -j4` was run and failed due to missing SDL2 CMake package (`SDL2Config.cmake` not found), so a full compile+run smoke test could not be performed in this environment (failure of that automated step). 
- Instrumentation smoke: the new in-engine log can be exercised at runtime (when built) by enabling `r_dynamic_zero_cost_debug 1`, which prints `RPERF` lines including `cluster_build` and `num_dlights` to validate that `r_dynamic=1` + `num_dlights==0` yields `cluster_build=0` and `num_dlights=0` (manual run-time verification once the binary is built).
- No other automated tests were available in this environment; code locations to inspect for verification are listed above for targeted unit/runtime checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699650e6afbc832e8c0a0b0d0e48aa32)