### PR TITLE
Add missing sys_jobs.h include to gl_rlight.c

### DIFF
--- a/Quake/opengl/gl_rlight.c
+++ b/Quake/opengl/gl_rlight.c
@@ -22,6 +22,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // r_light.c
 
 #include "quakedef.h"
+#include "sys_jobs.h"
 #include "opengl/gl_lightgrid.h"
 #include "renderer/r_dlight_pool.h"
 #include "renderer/r_envlight.h"


### PR DESCRIPTION
### Motivation
- Ensure `sys_job_queue_t` and `Sys_Jobs_*` symbols are declared in `Quake/opengl/gl_rlight.c` to fix the undeclared-identifier compilation errors reported for clustered async lighting.

### Description
- Inserted `#include "sys_jobs.h"` at the top of `Quake/opengl/gl_rlight.c` so the job-queue types and APIs are visible to the clustered lighting code.

### Testing
- Ran `make -C Quake gl_rlight.o USE_SDL2=1` to validate compilation, which exercised the build but could not complete in this environment due to missing `sdl2-config`/`SDL.h`, and the change addresses the previously reported `sys_job_queue_t`/`Sys_Jobs_*` undeclared errors when built in a correctly provisioned environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699656ce96d4832eb7bb6cb79eecdb8a)