### PR TITLE
Use runtime near/far planes for clustered keys (fix build error)

### DIFF
--- a/Quake/opengl/gl_rlight.c
+++ b/Quake/opengl/gl_rlight.c
@@ -795,14 +795,14 @@ static unsigned int R_ClusteredComputeDirtyReasons (const cluster_runtime_params
 	view_key.vup_q[0] = R_ClusteredQuantizeFloat (vup[0], 8192.f);
 	view_key.vup_q[1] = R_ClusteredQuantizeFloat (vup[1], 8192.f);
 	view_key.vup_q[2] = R_ClusteredQuantizeFloat (vup[2], 8192.f);
-	view_key.znear_q = R_ClusteredQuantizeFloat (view_znear, 1024.f);
-	view_key.zfar_q = R_ClusteredQuantizeFloat (view_zfar, 128.f);
+	view_key.znear_q = R_ClusteredQuantizeFloat (runtime->near_plane, 1024.f);
+	view_key.zfar_q = R_ClusteredQuantizeFloat (runtime->far_plane, 128.f);
 	view_key.reverse_z = gl_clipcontrol_able ? 1 : 0;
 
 	proj_key.fov_x_q = R_ClusteredQuantizeFloat (r_fovx, 4096.f);
 	proj_key.fov_y_q = R_ClusteredQuantizeFloat (r_fovy, 4096.f);
-	proj_key.znear_q = R_ClusteredQuantizeFloat (view_znear, 1024.f);
-	proj_key.zfar_q = R_ClusteredQuantizeFloat (view_zfar, 128.f);
+	proj_key.znear_q = R_ClusteredQuantizeFloat (runtime->near_plane, 1024.f);
+	proj_key.zfar_q = R_ClusteredQuantizeFloat (runtime->far_plane, 128.f);
 	proj_key.reverse_z = gl_clipcontrol_able ? 1 : 0;
 
 	viewport_key.screen_w = runtime->screen_w;


### PR DESCRIPTION
### Motivation
- Fix MSVC C2065 compile failures in `R_ClusteredComputeDirtyReasons` caused by out-of-scope `view_znear` / `view_zfar` references by using the runtime-provided near/far planes.

### Description
- Replace `view_key.znear_q`/`view_key.zfar_q` and `proj_key.znear_q`/`proj_key.zfar_q` quantization inputs to use `runtime->near_plane` and `runtime->far_plane` in `Quake/opengl/gl_rlight.c` inside `R_ClusteredComputeDirtyReasons`.

### Testing
- Ran `rg "view_znear|view_zfar" -n Quake/opengl/gl_rlight.c` to confirm no remaining references in the file, which succeeded; `git diff -- Quake/opengl/gl_rlight.c` and `git status --short` show only the intended changes, which also succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69979ae685ac832eb80c63289eddc5ef)