### PR TITLE
Switch to SIMD mathlib (mathlib_simd) and add `-march=native` toggle with portable fallback

### DIFF
--- a/Linux/CodeBlocks/QuakeSpasm-SDL2.cbp
+++ b/Linux/CodeBlocks/QuakeSpasm-SDL2.cbp
@@ -177,10 +177,10 @@
 		<Unit filename="../../Quake/main_sdl.c">
 			<Option compilerVar="CC" />
 		</Unit>
-		<Unit filename="../../Quake/mathlib.c">
+		<Unit filename="../../Quake/mathlib_simd.c">
 			<Option compilerVar="CC" />
 		</Unit>
-		<Unit filename="../../Quake/mathlib.h" />
+		<Unit filename="../../Quake/mathlib_simd.h" />
 		<Unit filename="../../Quake/menu.c">
 			<Option compilerVar="CC" />
 		</Unit>

--- a/Quake/Makefile
+++ b/Quake/Makefile
@@ -55,6 +55,14 @@ STRIP ?= strip
 PKG_CONFIG ?= pkg-config
 
 CPUFLAGS=
+
+# Build SIMD mathlib with host-tuned instructions by default.
+# Set MATHLIB_NATIVE=0 to build a more portable binary for older CPUs.
+MATHLIB_NATIVE ?= 1
+MATHLIB_NATIVE_FLAG :=
+ifeq ($(MATHLIB_NATIVE),1)
+MATHLIB_NATIVE_FLAG := $(call check_gcc,-march=native,)
+endif
 LDFLAGS?=
 DFLAGS ?=
 CFLAGS ?= -Wall -Wno-trigraphs
@@ -280,7 +288,7 @@ OBJS = strlcat.o \
 	cfgfile.o \
 	host.o \
 	host_cmd.o \
-	mathlib.o \
+	mathlib_simd.o \
 	pr_cmds.o \
 	pr_edict.o \
 	pr_exec.o \
@@ -298,6 +306,9 @@ OBJS += $(SYSOBJ_RES)
 bc7enc.o: bc7enc.c bc7enc.h $(MAKEFILE)
 	@echo "Compiling $<" && \
 	$(CXX) $(DFLAGS) -c $(CXXFLAGS) $(SDL_CFLAGS) -o $@ $<
+
+mathlib_simd.o: CFLAGS += $(MATHLIB_NATIVE_FLAG)
+mathlib_simd.d: CFLAGS += $(MATHLIB_NATIVE_FLAG)
 
 # ---------------------------
 # targets / rules

--- a/Quake/Makefile.w32
+++ b/Quake/Makefile.w32
@@ -52,6 +52,14 @@ WINDRES = windres
 STRIP = strip
 
 CPUFLAGS=
+
+# Build SIMD mathlib with host-tuned instructions by default.
+# Set MATHLIB_NATIVE=0 to build a more portable binary for older CPUs.
+MATHLIB_NATIVE ?= 1
+MATHLIB_NATIVE_FLAG :=
+ifeq ($(MATHLIB_NATIVE),1)
+MATHLIB_NATIVE_FLAG := $(call check_gcc,-march=native,)
+endif
 LDFLAGS?= -m32 -mwindows -static-libgcc
 DFLAGS ?=
 CFLAGS ?= -m32 -Wall -Wno-trigraphs
@@ -284,7 +292,7 @@ OBJS = strlcat.o \
 	cfgfile.o \
 	host.o \
 	host_cmd.o \
-	mathlib.o \
+	mathlib_simd.o \
 	pr_cmds.o \
 	pr_edict.o \
 	pr_exec.o \
@@ -298,6 +306,9 @@ OBJS = strlcat.o \
 
 OBJDEPS := $(OBJS:%.o=%.d)
 OBJS += $(SYSOBJ_RES)
+
+mathlib_simd.o: CFLAGS += $(MATHLIB_NATIVE_FLAG)
+mathlib_simd.d: CFLAGS += $(MATHLIB_NATIVE_FLAG)
 
 # ---------------------------
 # targets / rules

--- a/Quake/Makefile.w64
+++ b/Quake/Makefile.w64
@@ -50,6 +50,14 @@ WINDRES = windres
 STRIP = strip
 
 CPUFLAGS=
+
+# Build SIMD mathlib with host-tuned instructions by default.
+# Set MATHLIB_NATIVE=0 to build a more portable binary for older CPUs.
+MATHLIB_NATIVE ?= 1
+MATHLIB_NATIVE_FLAG :=
+ifeq ($(MATHLIB_NATIVE),1)
+MATHLIB_NATIVE_FLAG := $(call check_gcc,-march=native,)
+endif
 LDFLAGS?= -m64 -mwindows -static-libgcc
 DFLAGS ?=
 CFLAGS ?= -m64 -Wall -Wno-trigraphs
@@ -275,7 +283,7 @@ OBJS = strlcat.o \
 	cfgfile.o \
 	host.o \
 	host_cmd.o \
-	mathlib.o \
+	mathlib_simd.o \
 	pr_cmds.o \
 	pr_edict.o \
 	pr_exec.o \
@@ -289,6 +297,9 @@ OBJS = strlcat.o \
 
 OBJDEPS := $(OBJS:%.o=%.d)
 OBJS += $(SYSOBJ_RES)
+
+mathlib_simd.o: CFLAGS += $(MATHLIB_NATIVE_FLAG)
+mathlib_simd.d: CFLAGS += $(MATHLIB_NATIVE_FLAG)
 
 # ---------------------------
 # targets / rules

--- a/Quake/modelgen.h
+++ b/Quake/modelgen.h
@@ -43,7 +43,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "scriplib.h"
 #include "trilib.h"
 #include "lbmlib.h"
-#include "mathlib.h"
+#include "mathlib_simd.h"
 
 #endif
 

--- a/Quake/quakedef.h
+++ b/Quake/quakedef.h
@@ -248,7 +248,7 @@ typedef struct
 #include "common.h"
 #include "bspfile.h"
 #include "zone.h"
-#include "mathlib.h"
+#include "mathlib_simd.h"
 #include "cvar.h"
 
 #include "protocol.h"

--- a/Quake/spritegn.h
+++ b/Quake/spritegn.h
@@ -59,7 +59,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "dictlib.h"
 #include "trilib.h"
 #include "lbmlib.h"
-#include "mathlib.h"
+#include "mathlib_simd.h"
 
 #endif
 

--- a/Windows/CodeBlocks/QuakeSpasm-SDL2.cbp
+++ b/Windows/CodeBlocks/QuakeSpasm-SDL2.cbp
@@ -185,10 +185,10 @@
 		<Unit filename="..\..\Quake\main_sdl.c">
 			<Option compilerVar="CC" />
 		</Unit>
-		<Unit filename="..\..\Quake\mathlib.c">
+		<Unit filename="..\..\Quake\mathlib_simd.c">
 			<Option compilerVar="CC" />
 		</Unit>
-		<Unit filename="..\..\Quake\mathlib.h" />
+		<Unit filename="..\..\Quake\mathlib_simd.h" />
 		<Unit filename="..\..\Quake\menu.c">
 			<Option compilerVar="CC" />
 		</Unit>

--- a/Windows/CodeBlocks/QuakeSpasm.cbp
+++ b/Windows/CodeBlocks/QuakeSpasm.cbp
@@ -184,10 +184,10 @@
 		<Unit filename="..\..\Quake\main_sdl.c">
 			<Option compilerVar="CC" />
 		</Unit>
-		<Unit filename="..\..\Quake\mathlib.c">
+		<Unit filename="..\..\Quake\mathlib_simd.c">
 			<Option compilerVar="CC" />
 		</Unit>
-		<Unit filename="..\..\Quake\mathlib.h" />
+		<Unit filename="..\..\Quake\mathlib_simd.h" />
 		<Unit filename="..\..\Quake\menu.c">
 			<Option compilerVar="CC" />
 		</Unit>

--- a/Windows/VisualStudio/ironwail.vcxproj
+++ b/Windows/VisualStudio/ironwail.vcxproj
@@ -276,7 +276,7 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
     <ClCompile Include="..\..\Quake\json.c" />
     <ClCompile Include="..\..\Quake\keys.c" />
     <ClCompile Include="..\..\Quake\main_sdl.c" />
-    <ClCompile Include="..\..\Quake\mathlib.c" />
+    <ClCompile Include="..\..\Quake\mathlib_simd.c" />
     <ClCompile Include="..\..\Quake\mat_shader.c" />
     <ClCompile Include="..\..\Quake\mat_shader_parse.c" />
     <ClCompile Include="..\..\Quake\menu.c" />
@@ -401,7 +401,7 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
     <ClInclude Include="..\..\Quake\jsmn.h" />
     <ClInclude Include="..\..\Quake\json.h" />
     <ClInclude Include="..\..\Quake\keys.h" />
-    <ClInclude Include="..\..\Quake\mathlib.h" />
+    <ClInclude Include="..\..\Quake\mathlib_simd.h" />
     <ClInclude Include="..\..\Quake\mat_shader.h" />
     <ClInclude Include="..\..\Quake\mat_shader_parse.h" />
     <ClInclude Include="..\..\Quake\menu.h" />

--- a/Windows/VisualStudio/ironwail.vcxproj.filters
+++ b/Windows/VisualStudio/ironwail.vcxproj.filters
@@ -135,7 +135,7 @@
     <ClCompile Include="..\..\Quake\main_sdl.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\Quake\mathlib.c">
+    <ClCompile Include="..\..\Quake\mathlib_simd.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\Quake\mat_shader.c">
@@ -386,7 +386,7 @@
     <ClInclude Include="..\..\Quake\keys.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\Quake\mathlib.h">
+    <ClInclude Include="..\..\Quake\mathlib_simd.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Quake\mat_shader.h">


### PR DESCRIPTION
### Motivation
- Replace the legacy `mathlib` implementation with the AVX/SSE-optimized `mathlib_simd` to improve math performance on capable CPUs. 
- Compile `mathlib_simd` with host-tuned instructions by default while providing an easy portable fallback for older CPUs. 
- Update project files so IDEs and build systems use the SIMD replacement consistently.

### Description
- Switched includes from `mathlib.h` to `mathlib_simd.h` in engine/tools headers such as `Quake/quakedef.h`, `Quake/modelgen.h`, and `Quake/spritegn.h`. 
- Replaced `mathlib.o` with `mathlib_simd.o` in `Quake/Makefile`, `Quake/Makefile.w32` and `Quake/Makefile.w64`. 
- Added a `MATHLIB_NATIVE` toggle and `MATHLIB_NATIVE_FLAG` to the makefiles that defaults to `1` and appends `$(call check_gcc,-march=native,)` when enabled, and applied that flag specifically to `mathlib_simd.o` compilation. 
- Updated Visual Studio and Code::Blocks project files to reference `mathlib_simd.c` and `mathlib_simd.h` instead of the old mathlib files.

### Testing
- Ran repository-wide searches (`rg`) to verify all build and include references were updated to `mathlib_simd` (verification succeeded). 
- Attempted to build the object with `make -C Quake mathlib_simd.o MATHLIB_NATIVE=1`, but the build failed in this environment due to missing SDL development tools/headers (missing `sdl2-config` / `SDL.h`), so a full compile could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998722a85e0832ea77dc0caae6d1bb1)