### PR TITLE
Fix world clustered dlights being clamped out

### DIFF
--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -596,7 +596,10 @@ void main()
 				}
 			}
 
-			total_light += max(min(dynamic_light, 1.0 - total_light), 0.0);
+			// Keep dynamic lights additive. Clamping against (1 - total_light)
+			// suppresses dlight contribution on already-lit surfaces, which makes
+			// clustered dlights appear to vanish in normal gameplay.
+			total_light += max(dynamic_light, 0.0);
 		}
 	}
 


### PR DESCRIPTION
### Motivation
- Clustered dlights were being spawned, filtered, uploaded and bound correctly but often produced no visible effect on world geometry because the world fragment shader clamped dynamic light contribution against remaining headroom (`1.0 - total_light`).
- Alias/viewmodel lights still showed (glitches on the weapon) because that shader path did not apply the same headroom clamp, matching the reported symptom.

### Description
- Changed world clustered-light accumulation in `Quake/shaders/world.frag` to use additive accumulation instead of clamping against remaining headroom by replacing `total_light += max(min(dynamic_light, 1.0 - total_light), 0.0);` with `total_light += max(dynamic_light, 0.0);` and added a short comment explaining the rationale.
- Kept the rest of the clustered pipeline (collection, clustering, SSBO/UBO uploads and bindings in `Quake/opengl/gl_rlight.c`) unchanged and documented the investigation that verified clustered data is populated and uploaded prior to shading.

### Testing
- Ran `git diff --check` and `git diff` to verify the patch and that there are no whitespace/check errors, which succeeded.
- Inspected the clustered runtime/upload/bind flow (`R_PushDlights`, `R_Clustered_CommitLists`, `R_Clustered_BindForShading`) and shader fetch/evaluation paths to validate the change addresses the visibility bottleneck, which confirmed the fix conceptually.
- Committed the change (`Fix world clustered dlights being clamped out`) and created the PR; automated checks listed above passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69988e9cef10832eb8656324836c984e)