### PR TITLE
renderer: restore missing R_DrawWorld definition to fix MSVC link error

### DIFF
--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -546,6 +546,7 @@ void R_DrawBrushModels_SkyLayers (entity_t **ents, int count);
 void R_DrawBrushModels_SkyCubemap (entity_t **ents, int count);
 void R_DrawBrushModels_SkyStencil (entity_t **ents, int count);
 void R_DrawBrushModels_Shadow (entity_t **ents, int count);
+void R_DrawWorld (void);
 qboolean R_DrawWorld_Shadow (void);
 void R_Shadow_ResetBrushAuditCounters (void);
 void R_Shadow_GetBrushAuditCounters (int *out_entities_input, int *out_entities_instanced, int *out_surfaces_considered, int *out_surfaces_submitted);

--- a/Quake/renderer/r_world.c
+++ b/Quake/renderer/r_world.c
@@ -1680,6 +1680,17 @@ void R_DrawBrushModels_Shadow (entity_t **ents, int count)
 	R_DrawBrushModels_Real (ents, count, BP_SHADOW, false);
 }
 
+void R_DrawWorld (void)
+{
+	entity_t *world = &cl_entities[0];
+
+	if (!world->model || !Mod_IsKnownModel (world->model))
+		return;
+
+	R_DrawBrushModels_Real (&world, 1, BP_SOLID, false);
+	R_DrawBrushModels_Real (&world, 1, BP_ALPHATEST, false);
+}
+
 qboolean R_DrawWorld_Shadow (void)
 {
 	entity_t *world = &cl_entities[0];


### PR DESCRIPTION
### Motivation
- MSVC builds reported an unresolved external for `R_DrawWorld` because the symbol was referenced from `gl_rmain.c` but not defined in the renderer sources.

### Description
- Added an implementation of `R_DrawWorld` in `Quake/renderer/r_world.c` that validates the world entity/model and invokes the existing brush-model draw paths for `BP_SOLID` and `BP_ALPHATEST` passes using `R_DrawBrushModels_Real`.
- Added the `R_DrawWorld` declaration to `Quake/glquake.h` to expose the symbol consistently in the renderer API.
- The new function is a thin wrapper with a safety check that keeps behavior consistent with existing world-drawing logic.

### Testing
- Ran `make -C Quake -j4` to validate the change; the build could not complete in this environment due to missing SDL development tools/headers (`sdl2-config` and `SDL.h`), so full compile/link verification was not possible and the automated build failed for environmental reasons.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998a421eeb8832ea5e2d3082d305281)