### PR TITLE
Guard worldspawn message string offsets

### DIFF
--- a/Quake/pr_edict.c
+++ b/Quake/pr_edict.c
@@ -2373,6 +2373,13 @@ static qboolean PR_IsValidString (const char *p)
 	return d >= qcvm->maxknownstrings * sizeof (*qcvm->knownstrings);
 }
 
+qboolean PR_IsValidStringOffset (int num)
+{
+	if (num >= 0)
+		return num < qcvm->stringssize;
+	return num >= -qcvm->numknownstrings && qcvm->knownstrings[-1 - num] != NULL;
+}
+
 const char *PR_GetString (int num)
 {
 	if (num >= 0 && num < qcvm->stringssize)

--- a/Quake/progs.h
+++ b/Quake/progs.h
@@ -325,6 +325,7 @@ dfunction_t *PR_FindFunction (const char *fn_name);
 void PR_ReloadPics (qboolean purge);					//for gamedir or video changes
 
 const char *PR_GetString (int num);
+qboolean PR_IsValidStringOffset (int num);
 int PR_SetEngineString (const char *s);
 void PR_ClearEngineString (int num);
 int PR_AllocString (int bufferlength, char **ptr);

--- a/Quake/server/sv_main.c
+++ b/Quake/server/sv_main.c
@@ -426,7 +426,10 @@ void SV_SendServerinfo (client_t *client)
 	else
 		MSG_WriteByte (&client->message, GAME_COOP);
 
-	MSG_WriteString (&client->message, PR_GetString(qcvm->edicts->v.message));
+	if (PR_IsValidStringOffset ((int)qcvm->edicts->v.message))
+		MSG_WriteString (&client->message, PR_GetString((int)qcvm->edicts->v.message));
+	else
+		MSG_WriteString (&client->message, "");
 
 	//johnfitz -- only send the first 256 model and sound precaches if protocol is 15
 	for (i = 1, s = sv.model_precache+1; *s; s++,i++)
@@ -1856,7 +1859,10 @@ static void SV_PrintMapChecklist (void)
 	//
 	// map title
 	//
-	Mod_SanitizeMapDescription (buf, sizeof (buf), PR_GetString ((int)qcvm->edicts->v.message));
+	if (PR_IsValidStringOffset ((int)qcvm->edicts->v.message))
+		Mod_SanitizeMapDescription (buf, sizeof (buf), PR_GetString ((int)qcvm->edicts->v.message));
+	else
+		buf[0] = 0;
 	if (buf[0])
 		SV_PrintMapCheck (MAPCHECK_OK, "map title (%s)", buf);
 	else


### PR DESCRIPTION
### Motivation
- Prevent the server from calling `Host_Error` when `worldspawn.message` contains an invalid string offset (e.g. malformed maps or mods producing large/negative offsets).

### Description
- Add `PR_IsValidStringOffset(int)` to `Quake/pr_edict.c` and declare it in `Quake/progs.h` to validate QC string offsets safely.
- Use `PR_IsValidStringOffset` in `SV_SendServerinfo` to avoid dereferencing an invalid `qcvm->edicts->v.message` and send an empty title instead.
- Use `PR_IsValidStringOffset` in the map checklist path (`SV_PrintMapChecklist`) and treat invalid offsets as an empty map title (`buf[0] = 0`).

### Testing
- Ran a local build attempt with `make -C Quake -j4`; the build could not complete due to missing SDL2 development tools/headers (`sdl2-config` / `SDL.h`) in this environment, so compilation could not be fully validated.
- Static inspection and local edits verified the new function is declared in `progs.h` and the two call sites use it to avoid calling `PR_GetString` on invalid offsets.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998a52e4a34832e8c070c00da099774)