### PR TITLE
Fix sampler state debug query on MSVC

### DIFF
--- a/Quake/opengl/gl_rmain.c
+++ b/Quake/opengl/gl_rmain.c
@@ -251,7 +251,7 @@ static void GL_DumpRenderState (const char *label)
 	{
 		glActiveTexture (GL_TEXTURE0 + i);
 		glGetIntegerv (GL_TEXTURE_BINDING_2D, &tex2d[i]);
-		GL_GetIntegeri_vFunc (GL_SAMPLER_BINDING, i, &samplers[i]);
+		glGetIntegerv (GL_SAMPLER_BINDING, &samplers[i]);
 	}
 	glActiveTexture (active_tex);
 


### PR DESCRIPTION
### Motivation
- MSVC treated the implicit declaration of `GL_GetIntegeri_vFunc` as an error (C4013 -> C2220), so the debug code querying sampler bindings needed a portable call that is available without the function pointer.

### Description
- Replace `GL_GetIntegeri_vFunc(GL_SAMPLER_BINDING, i, &samplers[i])` with `glGetIntegerv(GL_SAMPLER_BINDING, &samplers[i])` inside `GL_DumpRenderState` in `Quake/opengl/gl_rmain.c` to query the sampler per active texture unit.

### Testing
- Confirmed the undefined symbol was removed with `rg "GL_GetIntegeri_vFunc" -n Quake` and it returned no matches (success). 
- Verified the change via `git diff -- Quake/opengl/gl_rmain.c` and committed the patch with `git commit` (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998dfb68b6c832e93b717dc3c7b4462)