### PR TITLE
Replace glActiveTexture with GL_ActiveTextureFunc in GL_DumpRenderState to fix Windows linker error

### DIFF
--- a/Quake/opengl/gl_rmain.c
+++ b/Quake/opengl/gl_rmain.c
@@ -249,11 +249,11 @@ static void GL_DumpRenderState (const char *label)
 	glGetBooleanv (GL_COLOR_WRITEMASK, color_mask);
 	for (i = 0; i < 4; ++i)
 	{
-		glActiveTexture (GL_TEXTURE0 + i);
+		GL_ActiveTextureFunc (GL_TEXTURE0 + i);
 		glGetIntegerv (GL_TEXTURE_BINDING_2D, &tex2d[i]);
 		glGetIntegerv (GL_SAMPLER_BINDING, &samplers[i]);
 	}
-	glActiveTexture (active_tex);
+	GL_ActiveTextureFunc (active_tex);
 
 	Con_Printf (
 		"STATEDBG frame=%d pass=%s vp=(%d %d %d %d) scissor=%d box=(%d %d %d %d) "


### PR DESCRIPTION
### Motivation
- The Windows build produced `LNK2001: unresolved external symbol __imp_glActiveTexture` because `GL_DumpRenderState` used the direct `glActiveTexture` symbol instead of the engine's dynamically loaded function pointer.

### Description
- In `Quake/opengl/gl_rmain.c` replace the two `glActiveTexture(...)` calls with `GL_ActiveTextureFunc(...)` (loop iteration and restore), keeping GL calls consistent with the project's dynamic loader.
- The change is limited to `GL_DumpRenderState` and is a 2-line substitution (2 insertions, 2 deletions) that avoids importing the direct `opengl32` symbol.
- Changes were committed to the repository.

### Testing
- Ran `rg -n "\bglActiveTexture\s*\("` to verify no direct `glActiveTexture` calls remain and it returned no matches (success).
- Used `git diff -- Quake/opengl/gl_rmain.c` to confirm the diff shows the two expected replacements (success).
- Performed `git commit` which completed successfully (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998e222fe04832eb9c4c1c9f4e3143f)