### PR TITLE
Fix envlight world fill controls in world shader

### DIFF
--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -485,14 +485,13 @@ void main()
 			total_light = clamped_static;
 			if (shadow_enabled)
 				total_light *= shadow_term;
-			total_light *= ambient_lightgrid;
 		}
 
 		float static_luma = EnvLightLuma(total_light);
 		float ao_hint = clamp(EnvLightLuma(in_lightgrid), 0.0, 1.0);
 		float visibility_hint = ComputeEnvVisibilityHint(shadow_term, shadow_enabled);
 		float indoor_factor = DeriveIndoorFactor(static_luma, ao_hint, visibility_hint);
-		float env_fill_strength = clamp(LightingParams.y, 0.0, 1.0);
+		float env_fill_strength = clamp(LightgridParams.w, 0.0, 1.0);
 		env_fill = EvaluateWorldEnvFill(total_light, ambient_lightgrid, indoor_factor, env_fill_strength);
 		total_light = clamp(total_light + env_fill, 0.0, 1.0);
 	


### PR DESCRIPTION
### Motivation
- Restore correct envlight behavior by preventing an unintended global darkening and wiring world-fill to the proper parameter so `r_envlight*` cvars affect the shader as intended.

### Description
- Removed an extra `total_light *= ambient_lightgrid;` that over-darkened walls in the non-lightgrid-shadow path and changed the world-fill strength source from `LightingParams.y` to `LightgridParams.w` in `Quake/shaders/world.frag` so `r_envlight_world_fill` drives the fill.

### Testing
- Ran `make -C Quake -j4` to validate the build, which failed in this environment due to missing SDL2 development tools/headers (`sdl2-config` and `SDL.h`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998e9f53144832eb19f87d03e5ddcbf)