### PR TITLE
Use SDL_GL_GetDrawableSize for VID_GetCurrentWidth/Height to fix edge artifact

### DIFF
--- a/Quake/opengl/gl_vidsdl.c
+++ b/Quake/opengl/gl_vidsdl.c
@@ -261,7 +261,9 @@ VID_GetCurrentWidth
 static int VID_GetCurrentWidth (void)
 {
 	int w = 0, h = 0;
-	SDL_GetWindowSize(draw_context, &w, &h);
+	SDL_GL_GetDrawableSize (draw_context, &w, &h);
+	if (w <= 0)
+		SDL_GetWindowSize (draw_context, &w, &h);
 	return w;
 }
 
@@ -273,7 +275,9 @@ VID_GetCurrentHeight
 static int VID_GetCurrentHeight (void)
 {
 	int w = 0, h = 0;
-	SDL_GetWindowSize(draw_context, &w, &h);
+	SDL_GL_GetDrawableSize (draw_context, &w, &h);
+	if (h <= 0)
+		SDL_GetWindowSize (draw_context, &w, &h);
 	return h;
 }
 


### PR DESCRIPTION
### Motivation
- On HiDPI/scaled displays the logical window size can differ from the OpenGL drawable size, which can leave unrendered pixels at the top/right edges when the renderer uses `vid.width`/`vid.height` for `glViewport`/framebuffer setup.

### Description
- Replace `SDL_GetWindowSize` with `SDL_GL_GetDrawableSize` in `VID_GetCurrentWidth` and `VID_GetCurrentHeight` in `Quake/opengl/gl_vidsdl.c` and add a fallback to `SDL_GetWindowSize` when the drawable size is unavailable (<= 0), ensuring the engine uses the real GL drawable dimensions for viewport/framebuffer calculations.

### Testing
- Attempted an automated build with `cmake -S . -B build && cmake --build build -j4`, which failed during configuration due to a missing SDL2 CMake package (`SDL2Config.cmake` not found), so no runtime binary tests were performed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998fbd11240832e95145121d9450784)