### PR TITLE
Fix decal spawning: require valid surface hits and stable placement

### DIFF
--- a/Quake/renderer/r_decals.c
+++ b/Quake/renderer/r_decals.c
@@ -89,7 +89,7 @@ static cvar_t r_decals_max = { "r_decals_max", "512", CVAR_ARCHIVE };
 static cvar_t r_decals_drawdist = { "r_decals_drawdist", "1536", CVAR_ARCHIVE };
 static cvar_t r_decals_lifetime = { "r_decals_lifetime", "30", CVAR_ARCHIVE };
 static cvar_t r_decals_fade = { "r_decals_fade", "6", CVAR_ARCHIVE };
-static cvar_t r_decals_bias = { "r_decals_bias", "0.6", CVAR_ARCHIVE };
+static cvar_t r_decals_bias = { "r_decals_bias", "0.25", CVAR_ARCHIVE };
 static cvar_t r_decals_spawn_budget = { "r_decals_spawn_budget", "8", CVAR_ARCHIVE };
 static cvar_t r_decals_render_budget_decals = { "r_decals_render_budget_decals", "256", CVAR_ARCHIVE };
 static cvar_t r_decals_debug = { "r_decals_debug", "0", CVAR_NONE };
@@ -106,9 +106,23 @@ static int decal_spawned_this_frame;
 static int decal_next_spawn_id;
 static int decal_frame;
 static decal_stats_t decal_stats;
+static int decal_debug_next_log_frame;
 
 static void R_Decals_ComputeLighting (decal_instance_t *d);
 static void R_Decals_DebugState (void);
+
+static qboolean R_Decals_IsFiniteVec3 (const vec3_t v)
+{
+	return isfinite (v[0]) && isfinite (v[1]) && isfinite (v[2]);
+}
+
+static void R_Decals_DebugReject (const char *name, const char *reason)
+{
+	if (r_decals_debug.value < 1.f || decal_frame < decal_debug_next_log_frame)
+		return;
+	decal_debug_next_log_frame = decal_frame + 30;
+	Con_DPrintf ("decal reject: name=%s reason=%s\n", name ? name : "<null>", reason ? reason : "unknown");
+}
 
 #define DECAL_BATCH_MAX 256
 
@@ -572,6 +586,16 @@ void R_Decals_Add (const char *name, const vec3_t org, const vec3_t normal, cons
 
 	if (!r_decals.value || !name || !name[0] || !decal_pool || !decal_capacity)
 		return;
+	if (!R_Decals_IsFiniteVec3 (org))
+	{
+		R_Decals_DebugReject (name, "invalid origin");
+		return;
+	}
+	if (!R_Decals_IsFiniteVec3 (normal) || VectorLengthSquared (normal) < 0.0001f)
+	{
+		R_Decals_DebugReject (name, "invalid normal");
+		return;
+	}
 	if (decal_spawned_this_frame >= (int)r_decals_spawn_budget.value)
 	{
 		decal_stats.dropped_spawn_budget++;
@@ -600,56 +624,104 @@ void R_Decals_Add (const char *name, const vec3_t org, const vec3_t normal, cons
 	if (!d->texture)
 	{
 		d->active = false;
+		R_Decals_DebugReject (name, "missing texture");
 		return;
 	}
 	decal_stats.spawned++;
 	decal_spawned_this_frame++;
 }
 
-static qboolean R_Decals_TraceNormal (const vec3_t point, vec3_t out_normal)
+static qboolean R_Decals_FindImpact (const vec3_t point, const vec3_t prefer_dir_opt, vec3_t out_pos, vec3_t out_normal)
 {
-	trace_t trace;
-	vec3_t end;
-	vec3_t start;
+	const float trace_dist = 32.f;
+	float best_dist_sq = FLT_MAX;
+	qboolean found = false;
+	vec3_t dirs[10];
+	int dir_count = 0;
+	int i;
 	if (!cl.worldmodel)
 		return false;
-	VectorCopy (point, start);
-	VectorMA (point, 32.f, vpn, end);
-	memset (&trace, 0, sizeof (trace));
-	trace.fraction = 1.f;
-	SV_RecursiveHullCheck (cl.worldmodel->hulls, 0, 0.f, 1.f, end, start, &trace);
-	if (trace.fraction < 1.f && VectorLengthSquared (trace.plane.normal) > 0.001f)
+	if (!R_Decals_IsFiniteVec3 (point))
+		return false;
+
+	if (prefer_dir_opt && VectorLengthSquared (prefer_dir_opt) > 0.0001f)
 	{
-		VectorCopy (trace.plane.normal, out_normal);
+		VectorCopy (prefer_dir_opt, dirs[dir_count]);
+		VectorNormalizeFast (dirs[dir_count]);
+		dir_count++;
+		VectorNegate (dirs[0], dirs[dir_count]);
+		dir_count++;
+	}
+
+	VectorSet (dirs[dir_count++], 1.f, 0.f, 0.f);
+	VectorSet (dirs[dir_count++], -1.f, 0.f, 0.f);
+	VectorSet (dirs[dir_count++], 0.f, 1.f, 0.f);
+	VectorSet (dirs[dir_count++], 0.f, -1.f, 0.f);
+	VectorSet (dirs[dir_count++], 0.f, 0.f, 1.f);
+	VectorSet (dirs[dir_count++], 0.f, 0.f, -1.f);
+	VectorCopy (vpn, dirs[dir_count++]);
+	VectorNegate (vpn, dirs[dir_count++]);
+
+	for (i = 0; i < dir_count; ++i)
+	{
+		trace_t trace;
+		vec3_t start, end;
+		float dist_sq;
+
+		VectorMA (point, trace_dist, dirs[i], start);
+		VectorMA (point, -trace_dist, dirs[i], end);
+		memset (&trace, 0, sizeof (trace));
+		trace.fraction = 1.f;
+		SV_RecursiveHullCheck (cl.worldmodel->hulls, 0, 0.f, 1.f, start, end, &trace);
+		if (trace.fraction >= 1.f)
+			continue;
+		if (VectorLengthSquared (trace.plane.normal) <= 0.001f || !R_Decals_IsFiniteVec3 (trace.endpos))
+			continue;
+		{
+			vec3_t delta;
+			VectorSubtract (trace.endpos, point, delta);
+			dist_sq = DotProduct (delta, delta);
+		}
+		if (!found || dist_sq < best_dist_sq)
+		{
+			best_dist_sq = dist_sq;
+			VectorCopy (trace.endpos, out_pos);
+			VectorCopy (trace.plane.normal, out_normal);
+			found = true;
+		}
+	}
+
+	if (found)
+	{
+		VectorNormalizeFast (out_normal);
 		return true;
 	}
-	VectorSet (out_normal, 0.f, 0.f, 1.f);
 	return false;
 }
 
 void R_AddBulletDecal (const vec3_t point)
 {
-	vec3_t n;
-	R_Decals_TraceNormal (point, n);
-	R_Decals_Add ("bullet_hole_default", point, n, NULL, 0.f, 0);
+	vec3_t hit, n;
+	if (!R_Decals_FindImpact (point, NULL, hit, n))
+		return;
+	R_Decals_Add ("bullet_hole_default", hit, n, NULL, 0.f, 0);
 }
 
 void R_AddBloodDecal (const vec3_t point, const vec3_t dir)
 {
-	vec3_t n;
-	if ((rand () & 3) != 0)
+	vec3_t hit, n, prefer;
+	VectorScale (dir, -1.f, prefer);
+	if (!R_Decals_FindImpact (point, prefer, hit, n))
 		return;
-	VectorScale (dir, -1.f, n);
-	if (VectorLengthSquared (n) < 0.01f)
-		R_Decals_TraceNormal (point, n);
-	R_Decals_Add ((rand() & 1) ? "blood_splat_small" : "blood_splat_large", point, n, NULL, 0.f, 0);
+	R_Decals_Add ((rand() & 1) ? "blood_splat_small" : "blood_splat_large", hit, n, NULL, 0.f, 0);
 }
 
 void R_AddScorchDecal (const vec3_t point)
 {
-	vec3_t n;
-	R_Decals_TraceNormal (point, n);
-	R_Decals_Add ((rand() & 1) ? "scorch_small" : "scorch_large", point, n, NULL, 0.f, 0);
+	vec3_t hit, n;
+	if (!R_Decals_FindImpact (point, NULL, hit, n))
+		return;
+	R_Decals_Add ((rand() & 1) ? "scorch_small" : "scorch_large", hit, n, NULL, 0.f, 0);
 }
 
 static int R_Decal_CompareRender (const void *a, const void *b)
@@ -894,11 +966,12 @@ static void R_Decals_ReloadCmd_f (void)
 
 static void R_Decals_Test_f (void)
 {
-	vec3_t end, hit, nrm;
+	vec3_t end, point, hit, nrm;
 	const char *name = (Cmd_Argc () > 1) ? Cmd_Argv (1) : "bullet_hole_default";
 	VectorMA (r_refdef.vieworg, 256.f, vpn, end);
-	TraceLine (r_refdef.vieworg, end, hit);
-	R_Decals_TraceNormal (hit, nrm);
+	TraceLine (r_refdef.vieworg, end, point);
+	if (!R_Decals_FindImpact (point, NULL, hit, nrm))
+		return;
 	R_Decals_Add (name, hit, nrm, NULL, 0.f, 0);
 }
 
@@ -927,6 +1000,7 @@ void R_Decals_Init (void)
 	R_Decals_EnsurePool ();
 	R_Decals_LoadScripts ();
 	R_Decals_ResetFrameStats ();
+	decal_debug_next_log_frame = 0;
 }
 
 void R_Decals_Shutdown (void)


### PR DESCRIPTION
### Motivation
- Decals were spawning in air, too far from surfaces, or with unstable orientation because impact normals/positions were sometimes taken from view-direction fallbacks or invalid traces; the goal is to make all decal spawns require a real surface hit and use a stable tangent basis. (observed in spawn paths: `TE_EXPLOSION`/`R_AddScorchDecal`, bullet/blood spawns).【Quake/client/cl_tent.c: `CL_ParseTEnt` / `TE_EXPLOSION` (lines ~234-241)】【Quake/renderer/r_part.c: `R_RocketTrail` blood cases (lines ~510-516, ~542-548)】
- Blood decals were frequently missing due to probabilistic suppression and/or invalid impact data; RL-explosion scorch decals used the raw event position instead of a validated hull hit.【Quake/renderer/r_decals.c: original trace path (~lines 606-626)】

### Description
- Added robust input validation and throttled debug logging to the renderer: `R_Decals_Add` now rejects non-finite origins and zero/invalid normals and emits a logged reject when `r_decals_debug` >= 1; this change is in `Quake/renderer/r_decals.c` at `R_Decals_Add` (lines ~577-632) and new helpers `R_Decals_IsFiniteVec3` / `R_Decals_DebugReject` (lines ~114-125).【Quake/renderer/r_decals.c: `R_Decals_Add` (L577-L632); `R_Decals_IsFiniteVec3` / `R_Decals_DebugReject` (L114-L125)】
- Replaced the single-direction normal probe with a multi-direction impact search: implemented `R_Decals_FindImpact` which fires short hull-traces in several directions, picks the nearest valid world hit (position + plane normal), and normalizes the plane normal for stable basis construction; see `R_Decals_FindImpact` (lines ~634-700).【Quake/renderer/r_decals.c: `R_Decals_FindImpact` (L634-L700)】
- Updated all decal spawners to use the validated impact result instead of raw event points or view-dependent normals: `R_AddBulletDecal`, `R_AddBloodDecal`, `R_AddScorchDecal`, and `R_Decals_Test_f` now call `R_Decals_FindImpact` and pass the returned hit+normal into `R_Decals_Add` (lines ~702-725 and test helper at ~967-976).【Quake/renderer/r_decals.c: `R_AddBulletDecal` (L702-L708), `R_AddBloodDecal` (L710-L717), `R_AddScorchDecal` (L719-L725), `R_Decals_Test_f` (L967-L976)】
- Restored reliable blood decal spawning by removing the previous probabilistic early-drop and by preferring the negated particle direction when searching impacts; the blood path is now deterministic subject to valid surface hit.【Quake/renderer/r_part.c: blood spawn points call `R_AddBloodDecal` (L510-L516, L542-L548); Quake/renderer/r_decals.c: `R_AddBloodDecal` (L710-L717)】
- Tuned the CPU-side decal push-bias to a small, constant value by changing `r_decals_bias` default from `0.6` to `0.25` and ensuring the single bias application remains in `R_Decals_BuildOrthonormalQuad` (`VectorMA(... r_decals_bias ...)`) so decals sit close to the surface without z-fighting.【Quake/renderer/r_decals.c: `r_decals_bias` (L92) and `R_Decals_BuildOrthonormalQuad` (L545-L567)】

### Testing
- Sanity checks: searched/correlated decal call sites and updated usage with `rg`/inspection to ensure spawners now call the validated path (automated grep/inspection commands executed successfully). (verification of code paths and symbol references).【repo search outputs used to map: `Quake/client/cl_tent.c`, `Quake/renderer/r_part.c`, `Quake/renderer/r_decals.c`】
- Build attempt: ran `make -j4` in `Quake/` to compile and validate the change, but the build failed due to missing SDL2 development tools/headers (`sdl2-config` / `SDL.h`), so a full compile verification could not complete in this environment. (automated `make` run failed).【attempted: `make -j4` in `/workspace/ironwail/Quake` — failed due to missing `sdl2-config` and `SDL.h`} 
- Automated tests: no unit tests existed for decals in-tree; the change includes a safer `decals_test` command path (`R_Decals_Test_f`) which now uses `R_Decals_FindImpact` for manual in-engine testing (see `Quake/renderer/r_decals.c` `R_Decals_Test_f` lines ~967-976).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998fc1922c4832e8026cebd2c716a7d)