### PR TITLE
Replace VectorNegate with VectorScale in r_decals to fix MSVC build error

### DIFF
--- a/Quake/renderer/r_decals.c
+++ b/Quake/renderer/r_decals.c
@@ -649,7 +649,7 @@ static qboolean R_Decals_FindImpact (const vec3_t point, const vec3_t prefer_dir
 		VectorCopy (prefer_dir_opt, dirs[dir_count]);
 		VectorNormalizeFast (dirs[dir_count]);
 		dir_count++;
-		VectorNegate (dirs[0], dirs[dir_count]);
+		VectorScale (dirs[0], -1.f, dirs[dir_count]);
 		dir_count++;
 	}
 
@@ -660,7 +660,7 @@ static qboolean R_Decals_FindImpact (const vec3_t point, const vec3_t prefer_dir
 	VectorSet (dirs[dir_count++], 0.f, 0.f, 1.f);
 	VectorSet (dirs[dir_count++], 0.f, 0.f, -1.f);
 	VectorCopy (vpn, dirs[dir_count++]);
-	VectorNegate (vpn, dirs[dir_count++]);
+	VectorScale (vpn, -1.f, dirs[dir_count++]);
 
 	for (i = 0; i < dir_count; ++i)
 	{


### PR DESCRIPTION
### Motivation
- Replace undefined `VectorNegate` usage that caused MSVC warning C4013 (promoted to error C2220) in `R_Decals_FindImpact` so the project can build cleanly under MSVC.

### Description
- Replaced two calls to `VectorNegate` with `VectorScale(..., -1.f, ...)` in `Quake/renderer/r_decals.c`, preserving the inverse-vector semantics while using an existing declared math helper.

### Testing
- Verified the change and commit with `git show --oneline --stat -1`, confirmed `Quake/renderer/r_decals.c` no longer contains `VectorNegate` using `rg -n "VectorNegate"`, and confirmed a clean working tree with `git status --short`; the commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998fe1af25c832e83debe95759c3600)