### PR TITLE
Refactor AsyncQueue_Drain to execute callbacks outside mutex; add AsyncQueue_TryPush

### DIFF
--- a/Quake/host.c
+++ b/Quake/host.c
@@ -777,6 +777,27 @@ static void AsyncQueue_Init (asyncqueue_t *queue, size_t capacity)
 		Sys_Error ("AsyncQueue_Init: could not create condition variable");
 }
 
+static qboolean AsyncQueue_TryPush (asyncqueue_t *queue, void (*func) (void *param), void *param)
+{
+	asyncproc_t *proc;
+	qboolean queued = false;
+
+	if (!queue->mutex)
+		return false;
+
+	SDL_LockMutex (queue->mutex);
+	if (!queue->teardown && queue->tail - queue->head < queue->capacity)
+	{
+		proc = &queue->procs[(queue->tail++) & (queue->capacity - 1)];
+		proc->func = func;
+		proc->param = param;
+		queued = true;
+	}
+	SDL_UnlockMutex (queue->mutex);
+
+	return queued;
+}
+
 static void AsyncQueue_Push (asyncqueue_t *queue, void (*func) (void *param), void *param)
 {
 	asyncproc_t *proc;
@@ -799,14 +820,30 @@ static void AsyncQueue_Push (asyncqueue_t *queue, void (*func) (void *param), vo
 
 static void AsyncQueue_Drain (asyncqueue_t *queue)
 {
-	SDL_LockMutex (queue->mutex);
-	while (queue->head != queue->tail)
+	if (!queue->mutex)
+		return;
+
+	for (;;)
 	{
-		asyncproc_t *proc = &queue->procs[(queue->head++) & (queue->capacity - 1)];
-		proc->func (proc->param);
+		asyncproc_t proc;
+
+		SDL_LockMutex (queue->mutex);
+		if (queue->head == queue->tail)
+		{
+			SDL_UnlockMutex (queue->mutex);
+			return;
+		}
+
+		proc = queue->procs[(queue->head++) & (queue->capacity - 1)];
 		SDL_CondSignal (queue->notfull);
+		SDL_UnlockMutex (queue->mutex);
+
+		/*
+		 * Never execute callbacks while holding queue->mutex.
+		 * This prevents reentrancy deadlocks when callbacks queue more work.
+		 */
+		proc.func (proc.param);
 	}
-	SDL_UnlockMutex (queue->mutex);
 }
 
 static void AsyncQueue_Destroy (asyncqueue_t *queue)
@@ -828,7 +865,8 @@ static void AsyncQueue_Destroy (asyncqueue_t *queue)
 
 void Host_InvokeOnMainThread (void (*func) (void *param), void *param)
 {
-	AsyncQueue_Push (&async_queue, func, param);
+	if (!AsyncQueue_TryPush (&async_queue, func, param))
+		AsyncQueue_Push (&async_queue, func, param);
 }
 
 //==============================================================================


### PR DESCRIPTION
### Motivation
- Avoid executing callbacks while holding the queue mutex to prevent reentrancy deadlocks and allow callbacks to queue more work safely.
- Ensure queue index mutations (`head`/`tail`) and count checks are only performed while the mutex is held to maintain concurrency correctness.
- Provide a non-blocking enqueue helper for teardown-sensitive call sites so callers can avoid blocking while holding other locks.

### Description
- Rewrote `AsyncQueue_Drain` to repeatedly: lock, check empty (unlock + return if empty), pop/copy exactly one entry, signal `notfull`, unlock, and then execute the callback outside the mutex, and added an inline comment documenting that callbacks must never run while holding `queue->mutex`.
- Added `AsyncQueue_TryPush(asyncqueue_t *queue, void (*func)(void*), void *param)` which conditionally enqueues under the mutex and returns a boolean without blocking.
- Updated `Host_InvokeOnMainThread` to try `AsyncQueue_TryPush` first and fall back to the existing blocking `AsyncQueue_Push` behavior when necessary.
- Kept `AsyncQueue_Destroy` semantics: it sets `teardown`, broadcasts waiters, and then drains using the new lock-friendly drain logic.

### Testing
- Ran `git diff --check` to ensure there are no whitespace or patch-format issues and it passed.
- No automated unit tests or builds were executed for this patch set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699904f57f30832ea6d5a7909b87b9d9)