### PR TITLE
Harden save-thread init/shutdown handling (SDL resource checks & cleanup)

### DIFF
--- a/Quake/host_cmd.c
+++ b/Quake/host_cmd.c
@@ -2263,17 +2263,31 @@ void Host_ShutdownSave (void)
 		SDL_CondWait (save_finished_condition, save_mutex);
 	save_pending = true;
 	save_data.file = NULL;
-	SDL_CondSignal (save_pending_condition);
+	if (save_pending_condition)
+		SDL_CondSignal (save_pending_condition);
 	SDL_UnlockMutex (save_mutex);
 
-	SDL_WaitThread (save_thread, NULL);
-	save_thread = NULL;
+	if (save_thread)
+	{
+		SDL_WaitThread (save_thread, NULL);
+		save_thread = NULL;
+	}
 
-	SDL_DestroyCond (save_finished_condition);
-	save_finished_condition = NULL;
+	if (save_finished_condition)
+	{
+		SDL_DestroyCond (save_finished_condition);
+		save_finished_condition = NULL;
+	}
 
-	SDL_DestroyCond (save_pending_condition);
-	save_pending_condition = NULL;
+	if (save_pending_condition)
+	{
+		SDL_DestroyCond (save_pending_condition);
+		save_pending_condition = NULL;
+	}
+
+	SDL_DestroyMutex (save_mutex);
+	save_mutex = NULL;
+	save_pending = false;
 
 	SaveData_Clear (&save_data);
 }
@@ -2356,11 +2370,53 @@ static int Host_BackgroundSave (void *param)
 
 static void Host_InitSaveThread (void)
 {
-	save_mutex = SDL_CreateMutex ();
-	save_finished_condition = SDL_CreateCond ();
-	save_pending_condition = SDL_CreateCond ();
-	save_thread = SDL_CreateThread (Host_BackgroundSave, "SaveThread", &save_data);
 	SaveData_Init (&save_data);
+
+	save_mutex = SDL_CreateMutex ();
+	if (!save_mutex)
+		goto fail;
+
+	save_finished_condition = SDL_CreateCond ();
+	if (!save_finished_condition)
+		goto fail;
+
+	save_pending_condition = SDL_CreateCond ();
+	if (!save_pending_condition)
+		goto fail;
+
+	save_thread = SDL_CreateThread (Host_BackgroundSave, "SaveThread", &save_data);
+	if (!save_thread)
+		goto fail;
+
+	return;
+
+fail:
+	if (save_thread)
+	{
+		SDL_WaitThread (save_thread, NULL);
+		save_thread = NULL;
+	}
+
+	if (save_pending_condition)
+	{
+		SDL_DestroyCond (save_pending_condition);
+		save_pending_condition = NULL;
+	}
+
+	if (save_finished_condition)
+	{
+		SDL_DestroyCond (save_finished_condition);
+		save_finished_condition = NULL;
+	}
+
+	if (save_mutex)
+	{
+		SDL_DestroyMutex (save_mutex);
+		save_mutex = NULL;
+	}
+
+	SaveData_Clear (&save_data);
+	Sys_Error ("Host_InitSaveThread: failed to create synchronization primitives");
 }
 
 /*
@@ -3817,4 +3873,3 @@ void Host_InitCommands (void)
 	Cmd_AddCommand ("viewnext", Host_Viewnext_f);
 	Cmd_AddCommand ("viewprev", Host_Viewprev_f);
 }
-


### PR DESCRIPTION
### Motivation

- Prevent resource leaks and double-destroys when creating or tearing down the background save thread by validating each SDL call and ensuring partial initialization is cleaned up.
- Follow the engine's existing fail-fast / error reporting conventions when initialization cannot be completed.

### Description

- Add return-value checks for `SDL_CreateMutex`, `SDL_CreateCond` (both), and `SDL_CreateThread` inside `Host_InitSaveThread` and introduce a single `fail:` path to clean up already-created resources in reverse order.
- Move `SaveData_Init` to the start of `Host_InitSaveThread` and call `SaveData_Clear` in the failure path, then call `Sys_Error` on unrecoverable init failure to match project style.
- Make `Host_ShutdownSave` robust against partial or repeated shutdowns by conditionally signaling `save_pending_condition`, conditionally joining `save_thread`, conditionally destroying both condition variables, explicitly destroying `save_mutex`, nulling all handles, and resetting `save_pending`.
- Ensure all freed handles are set to `NULL` and that the save subsystem is left in a consistent, idempotent state.

### Testing

- Verified edits and symbol locations with `rg` and inspected modified sections with `sed`/`nl` (commands succeeded and show the intended changes).
- Attempted CMake configuration with `cmake -S . -B build` to exercise basic build setup, which failed due to missing SDL2 CMake package files (`SDL2Config.cmake` / `sdl2-config.cmake`) in the environment, so a full build/test could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699905bd5684832e82dbd3b4d130d513)