### PR TITLE
Harden save-thread SDL resource lifecycle handling

### DIFF
--- a/Quake/host_cmd.c
+++ b/Quake/host_cmd.c
@@ -2255,17 +2255,17 @@ static void Host_InvalidateSave (const char *relname)
 
 void Host_ShutdownSave (void)
 {
-	if (!save_mutex)
-		return; // not initialized yet
-
-	SDL_LockMutex (save_mutex);
-	while (save_pending)
-		SDL_CondWait (save_finished_condition, save_mutex);
-	save_pending = true;
-	save_data.file = NULL;
-	if (save_pending_condition)
-		SDL_CondSignal (save_pending_condition);
-	SDL_UnlockMutex (save_mutex);
+	if (save_mutex)
+	{
+		SDL_LockMutex (save_mutex);
+		while (save_pending && save_finished_condition)
+			SDL_CondWait (save_finished_condition, save_mutex);
+		save_pending = true;
+		save_data.file = NULL;
+		if (save_pending_condition)
+			SDL_CondSignal (save_pending_condition);
+		SDL_UnlockMutex (save_mutex);
+	}
 
 	if (save_thread)
 	{
@@ -2285,8 +2285,11 @@ void Host_ShutdownSave (void)
 		save_pending_condition = NULL;
 	}
 
-	SDL_DestroyMutex (save_mutex);
-	save_mutex = NULL;
+	if (save_mutex)
+	{
+		SDL_DestroyMutex (save_mutex);
+		save_mutex = NULL;
+	}
 	save_pending = false;
 
 	SaveData_Clear (&save_data);
@@ -2370,23 +2373,42 @@ static int Host_BackgroundSave (void *param)
 
 static void Host_InitSaveThread (void)
 {
+	const char *error_step = NULL;
+	const char *sdl_error = NULL;
+
 	SaveData_Init (&save_data);
 
 	save_mutex = SDL_CreateMutex ();
 	if (!save_mutex)
+	{
+		error_step = "create save mutex";
+		sdl_error = SDL_GetError ();
 		goto fail;
+	}
 
 	save_finished_condition = SDL_CreateCond ();
 	if (!save_finished_condition)
+	{
+		error_step = "create save finished condition";
+		sdl_error = SDL_GetError ();
 		goto fail;
+	}
 
 	save_pending_condition = SDL_CreateCond ();
 	if (!save_pending_condition)
+	{
+		error_step = "create save pending condition";
+		sdl_error = SDL_GetError ();
 		goto fail;
+	}
 
 	save_thread = SDL_CreateThread (Host_BackgroundSave, "SaveThread", &save_data);
 	if (!save_thread)
+	{
+		error_step = "create save worker thread";
+		sdl_error = SDL_GetError ();
 		goto fail;
+	}
 
 	return;
 
@@ -2416,7 +2438,7 @@ fail:
 	}
 
 	SaveData_Clear (&save_data);
-	Sys_Error ("Host_InitSaveThread: failed to create synchronization primitives");
+	Sys_Error ("Host_InitSaveThread: failed to %s (%s)", error_step ? error_step : "initialize save thread", (sdl_error && *sdl_error) ? sdl_error : "unknown SDL error");
 }
 
 /*


### PR DESCRIPTION
### Motivation
- Improve robustness of save-thread initialization by validating each SDL resource creation and providing clearer diagnostics on failure.
- Ensure shutdown can be called repeatedly or partially without causing double-destroy or using NULL resources.

### Description
- In `Host_InitSaveThread` added per-step failure tracking (`error_step`) and `SDL_GetError()` capture and included them in the `Sys_Error` message for clearer diagnostics.
- Added explicit checks after each SDL call (`SDL_CreateMutex`, `SDL_CreateCond`, `SDL_CreateThread`) and preserved reverse-order cleanup for partially-initialized resources while resetting pointers to `NULL`.
- Hardened `Host_ShutdownSave` to only lock/wait/signal when `save_mutex` is initialized and to destroy condition variables and the mutex only when non-NULL, setting them to `NULL` after destroy to avoid double-destroy.
- Kept existing fail-fast behavior but improved error messages to indicate the failing step and SDL error text.

### Testing
- Performed static inspection of the updated `Quake/host_cmd.c` to verify the new guards, cleanup order, and error reporting were applied correctly and no dangling pointer uses remain. (succeeded)
- Attempted a local build check but no `build/` directory exists in this environment, so compilation was not executed here (skipped).
- Reviewed diff to confirm only the intended save-thread init/shutdown paths were modified (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69990827f6ec832e811dddad4dd8c141)