### PR TITLE
Async queues: submit policies and backpressure/overflow counters

### DIFF
--- a/Quake/asset_decode_async.c
+++ b/Quake/asset_decode_async.c
@@ -50,10 +50,20 @@ static uint64_t asset_completed_fs;
 static uint64_t asset_queued_decode;
 static uint64_t asset_completed_decode;
 static uint64_t asset_failed_decode;
+static uint64_t asset_decode_submit_backpressure;
 static uint64_t asset_decode_us_png;
 static uint64_t asset_decode_us_ktx2;
 static size_t asset_inflight_raw_bytes;
 static size_t asset_inflight_decoded_bytes;
+
+typedef enum
+{
+	ASSET_DECODE_SUBMIT_POLICY_BLOCKING = 0,
+	ASSET_DECODE_SUBMIT_POLICY_NONBLOCKING
+} asset_decode_submit_policy_t;
+
+/* Pump runs in the frame loop; keep decode queue submission explicitly non-blocking. */
+static const asset_decode_submit_policy_t asset_decode_submit_policy = ASSET_DECODE_SUBMIT_POLICY_NONBLOCKING;
 
 static const char *Asset_StageName(asset_stage_t stage)
 {
@@ -431,7 +441,9 @@ void Asset_Async_Pump (void)
 
 		if (submit_decode)
 		{
-			if (Sys_Jobs_TrySubmit(asset_decode_queue, Asset_DecodeWorker, (void *)(uintptr_t)h))
+			if ((asset_decode_submit_policy == ASSET_DECODE_SUBMIT_POLICY_BLOCKING
+				? Sys_Jobs_Submit(asset_decode_queue, Asset_DecodeWorker, (void *)(uintptr_t)h)
+				: Sys_Jobs_TrySubmit(asset_decode_queue, Asset_DecodeWorker, (void *)(uintptr_t)h)))
 			{
 				SDL_LockMutex(asset_mutex);
 				asset_queued_decode++;
@@ -440,6 +452,7 @@ void Asset_Async_Pump (void)
 			else
 			{
 				SDL_LockMutex(asset_mutex);
+				asset_decode_submit_backpressure++;
 				if (asset_requests[i].in_use && asset_requests[i].generation == ASSET_HANDLE_GEN(h) && asset_requests[i].stage == ASSET_STAGE_DECODE_PENDING)
 					asset_requests[i].decode_queued = false;
 				SDL_UnlockMutex(asset_mutex);
@@ -499,8 +512,10 @@ void Asset_Async_Pump (void)
 
 	if (asset_async_debug.value)
 	{
-		Con_DPrintf("asset_async: fs=%" SDL_PRIu64 "/%" SDL_PRIu64 " decode=%" SDL_PRIu64 "/%" SDL_PRIu64 " failed=%" SDL_PRIu64 " inflight_raw=%zu inflight_decoded=%zu decode_ms[png]=%.3f decode_ms[ktx2]=%.3f\n",
+		Con_DPrintf("asset_async: fs=%" SDL_PRIu64 "/%" SDL_PRIu64 " decode=%" SDL_PRIu64 "/%" SDL_PRIu64 " failed=%" SDL_PRIu64 " decode_backpressure=%" SDL_PRIu64 " decode_policy=%s inflight_raw=%zu inflight_decoded=%zu decode_ms[png]=%.3f decode_ms[ktx2]=%.3f\n",
 			asset_completed_fs, asset_queued_fs, asset_completed_decode, asset_queued_decode, asset_failed_decode,
+			asset_decode_submit_backpressure,
+			asset_decode_submit_policy == ASSET_DECODE_SUBMIT_POLICY_BLOCKING ? "block" : "nonblock",
 			asset_inflight_raw_bytes, asset_inflight_decoded_bytes,
 			(double)asset_decode_us_png / 1000.0, (double)asset_decode_us_ktx2 / 1000.0);
 	}

--- a/Quake/fs_async.c
+++ b/Quake/fs_async.c
@@ -40,6 +40,17 @@ static cvar_t fs_async_debug = {"fs_async_debug", "0", CVAR_NONE};
 static uint64_t fs_async_enqueued;
 static uint64_t fs_async_completed_count;
 static uint64_t fs_async_completed_bytes;
+static uint64_t fs_async_completed_overflow_count;
+static uint64_t fs_async_submit_backpressure_count;
+
+typedef enum
+{
+	FS_ASYNC_SUBMIT_POLICY_BLOCKING = 0,
+	FS_ASYNC_SUBMIT_POLICY_NONBLOCKING
+} fs_async_submit_policy_t;
+
+/* Request submission can be called from frame-critical paths: avoid blocking by default. */
+static const fs_async_submit_policy_t fs_async_submit_policy = FS_ASYNC_SUBMIT_POLICY_NONBLOCKING;
 
 extern qfileofs_t COM_filelength (FILE *f);
 
@@ -320,7 +331,10 @@ static void FS_Async_Complete (fs_async_handle_t h)
 
 	count = fs_async_completed_tail - fs_async_completed_head;
 	if (count >= FS_ASYNC_COMPLETED_CAPACITY)
+	{
+		fs_async_completed_overflow_count++;
 		return;
+	}
 
 	fs_async_completed[fs_async_completed_tail & (FS_ASYNC_COMPLETED_CAPACITY - 1)] = h;
 	fs_async_completed_tail++;
@@ -388,6 +402,8 @@ void FS_Async_Init (void)
 	fs_async_enqueued = 0;
 	fs_async_completed_count = 0;
 	fs_async_completed_bytes = 0;
+	fs_async_completed_overflow_count = 0;
+	fs_async_submit_backpressure_count = 0;
 
 	fs_async_mutex = SDL_CreateMutex ();
 	fs_async_done_cond = SDL_CreateCond ();
@@ -465,8 +481,11 @@ fs_async_handle_t FS_ReadFileAsync (const char *path, int flags)
 	if (!h)
 		return 0;
 
-	if (!Sys_Jobs_Submit (fs_async_queue, FS_Async_Worker, (void *) (uintptr_t) h))
+	if ((fs_async_submit_policy == FS_ASYNC_SUBMIT_POLICY_BLOCKING
+		? !Sys_Jobs_Submit (fs_async_queue, FS_Async_Worker, (void *) (uintptr_t) h)
+		: !Sys_Jobs_TrySubmit (fs_async_queue, FS_Async_Worker, (void *) (uintptr_t) h)))
 	{
+		fs_async_submit_backpressure_count++;
 		FS_Release (h);
 		return 0;
 	}
@@ -587,7 +606,10 @@ void FS_Async_Pump (void)
 	if (fs_async_debug.value && pumped)
 	{
 		double avg = (double) fs_async_completed_bytes / (double) (fs_async_completed_count ? fs_async_completed_count : 1);
-		Con_Printf ("fs_async: enqueued=%" SDL_PRIu64 " completed=%" SDL_PRIu64 " avg_bytes=%.1f\n",
-			fs_async_enqueued, fs_async_completed_count, avg);
+		Con_Printf ("fs_async: enqueued=%" SDL_PRIu64 " completed=%" SDL_PRIu64 " avg_bytes=%.1f complete_overflow=%" SDL_PRIu64 " submit_backpressure=%" SDL_PRIu64 " policy=%s\n",
+			fs_async_enqueued, fs_async_completed_count, avg,
+			fs_async_completed_overflow_count,
+			fs_async_submit_backpressure_count,
+			fs_async_submit_policy == FS_ASYNC_SUBMIT_POLICY_BLOCKING ? "block" : "nonblock");
 	}
 }


### PR DESCRIPTION
### Motivation
- Prevent silent loss of FS async completions when the completion ring is full and make submission failures visible for diagnostics. 
- Avoid blocking frame-critical code paths when job queues are under backpressure by preferring non-blocking enqueue with a clear degradation path. 
- Surface queue health in existing debug/stat outputs to aid runtime troubleshooting.

### Description
- Add `fs_async_completed_overflow_count` and `fs_async_submit_backpressure_count` counters to `Quake/fs_async.c` and increment the overflow counter when the completion ring is saturated instead of silently returning. 
- Introduce an explicit submit policy enum (`FS_ASYNC_SUBMIT_POLICY_{BLOCKING,NONBLOCKING}`) and route `FS_ReadFileAsync` submission through policy-controlled `Sys_Jobs_Submit`/`Sys_Jobs_TrySubmit`, incrementing a backpressure counter on failure. 
- Add an analogous submit policy enum and `asset_decode_submit_backpressure` counter to `Quake/asset_decode_async.c`, keep decode submissions non-blocking by default, and implement the decode-path degradation (clearing `decode_queued`) when `TrySubmit` fails. 
- Extend existing debug/stat prints to include `complete_overflow`, `submit_backpressure` (or `decode_backpressure`) and the active policy string for both subsystems.

### Testing
- Performed targeted code inspection and search (`rg`/`sed`) to identify `FS_Async_Complete`, `FS_ReadFileAsync`, and the asset decode pump call sites and verified they now use policy-controlled submission. 
- Applied the source patches and committed the changes locally with no patch/merge conflicts. 
- Attempted a full CMake configure/build with `cmake -S . -B build && cmake --build build -j2`, which failed in this environment due to a missing SDL2 CMake package (`SDL2Config.cmake`/`sdl2-config.cmake`), so a full build/test run could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69990840fa4c832eb2d698221d795d0f)