### PR TITLE
Fix decal placement/prevent floating decals and add flickering torch dlights for fire models

### DIFF
--- a/Quake/client/cl_main.c
+++ b/Quake/client/cl_main.c
@@ -547,6 +547,20 @@ static int CL_DlightKeyForEntityEffect (int entnum, int effect_channel)
 	return (entnum << 4) | (effect_channel & 0xF);
 }
 
+static qboolean CL_EntityModelLooksLikeFire (const entity_t *ent)
+{
+	const char *name;
+
+	if (!ent || !ent->model)
+		return false;
+
+	name = ent->model->name;
+	if (!name || !name[0])
+		return false;
+
+	return q_strcasestr (name, "fire") || q_strcasestr (name, "flame") || q_strcasestr (name, "torch");
+}
+
 /*
 ===============
 CL_RelinkEntities
@@ -666,6 +680,23 @@ void CL_RelinkEntities (void)
 
 		if (ent->effects & EF_BRIGHTFIELD)
 			R_EntityParticles (ent);
+
+		if (CL_EntityModelLooksLikeFire (ent))
+		{
+			float flicker;
+			dl = CL_AllocDlight (CL_DlightKeyForEntityEffect (i, 7));
+			VectorCopy (ent->origin, dl->origin);
+			dl->origin[2] += 8;
+			dl->type = DLIGHT_TORCH;
+			flicker = (float)sin (cl.time * 13.0 + (double)i * 0.73);
+			dl->radius = 185.f + 45.f * flicker + (float)(rand () & 7);
+			dl->baseradius = dl->radius;
+			dl->die = cl.time + 0.1;
+			dl->minlight = 24;
+			dl->color[0] = 1.00f;
+			dl->color[1] = 0.65f;
+			dl->color[2] = 0.18f;
+		}
 
 		if (ent->effects & EF_MUZZLEFLASH)
 		{

--- a/Quake/renderer/r_decals.c
+++ b/Quake/renderer/r_decals.c
@@ -89,7 +89,7 @@ static cvar_t r_decals_max = { "r_decals_max", "512", CVAR_ARCHIVE };
 static cvar_t r_decals_drawdist = { "r_decals_drawdist", "1536", CVAR_ARCHIVE };
 static cvar_t r_decals_lifetime = { "r_decals_lifetime", "30", CVAR_ARCHIVE };
 static cvar_t r_decals_fade = { "r_decals_fade", "6", CVAR_ARCHIVE };
-static cvar_t r_decals_bias = { "r_decals_bias", "0.25", CVAR_ARCHIVE };
+static cvar_t r_decals_bias = { "r_decals_bias", "0.03", CVAR_ARCHIVE };
 static cvar_t r_decals_spawn_budget = { "r_decals_spawn_budget", "8", CVAR_ARCHIVE };
 static cvar_t r_decals_render_budget_decals = { "r_decals_render_budget_decals", "256", CVAR_ARCHIVE };
 static cvar_t r_decals_debug = { "r_decals_debug", "0", CVAR_NONE };
@@ -631,9 +631,10 @@ void R_Decals_Add (const char *name, const vec3_t org, const vec3_t normal, cons
 	decal_spawned_this_frame++;
 }
 
-static qboolean R_Decals_FindImpact (const vec3_t point, const vec3_t prefer_dir_opt, vec3_t out_pos, vec3_t out_normal)
+static qboolean R_Decals_FindImpact (const vec3_t point, const vec3_t prefer_dir_opt, float max_dist, vec3_t out_pos, vec3_t out_normal)
 {
 	const float trace_dist = 32.f;
+	const float max_dist_sq = (max_dist > 0.f) ? (max_dist * max_dist) : FLT_MAX;
 	float best_dist_sq = FLT_MAX;
 	qboolean found = false;
 	vec3_t dirs[10];
@@ -682,6 +683,8 @@ static qboolean R_Decals_FindImpact (const vec3_t point, const vec3_t prefer_dir
 			VectorSubtract (trace.endpos, point, delta);
 			dist_sq = DotProduct (delta, delta);
 		}
+		if (dist_sq > max_dist_sq)
+			continue;
 		if (!found || dist_sq < best_dist_sq)
 		{
 			best_dist_sq = dist_sq;
@@ -702,7 +705,7 @@ static qboolean R_Decals_FindImpact (const vec3_t point, const vec3_t prefer_dir
 void R_AddBulletDecal (const vec3_t point)
 {
 	vec3_t hit, n;
-	if (!R_Decals_FindImpact (point, NULL, hit, n))
+	if (!R_Decals_FindImpact (point, NULL, 24.f, hit, n))
 		return;
 	R_Decals_Add ("bullet_hole_default", hit, n, NULL, 0.f, 0);
 }
@@ -711,7 +714,7 @@ void R_AddBloodDecal (const vec3_t point, const vec3_t dir)
 {
 	vec3_t hit, n, prefer;
 	VectorScale (dir, -1.f, prefer);
-	if (!R_Decals_FindImpact (point, prefer, hit, n))
+	if (!R_Decals_FindImpact (point, prefer, 4.f, hit, n))
 		return;
 	R_Decals_Add ((rand() & 1) ? "blood_splat_small" : "blood_splat_large", hit, n, NULL, 0.f, 0);
 }
@@ -719,7 +722,7 @@ void R_AddBloodDecal (const vec3_t point, const vec3_t dir)
 void R_AddScorchDecal (const vec3_t point)
 {
 	vec3_t hit, n;
-	if (!R_Decals_FindImpact (point, NULL, hit, n))
+	if (!R_Decals_FindImpact (point, NULL, 24.f, hit, n))
 		return;
 	R_Decals_Add ((rand() & 1) ? "scorch_small" : "scorch_large", hit, n, NULL, 0.f, 0);
 }


### PR DESCRIPTION
### Motivation
- Decals were spawning offset too far from surfaces (and sometimes in mid-air), causing visible separation and z-fighting; this needs to be corrected so decals sit on surfaces but remain z-fight-safe.
- Gibs and impact effects were producing decals when no nearby surface existed, so tighten impact acceptance to avoid decals floating in open space.
- Models representing fire should emit a persistent, warm flickering dynamic light to better simulate flames.

### Description
- Lower `r_decals_bias` from `0.25` to `0.03` so decal quads are placed much closer to the surface while keeping a small anti-z-fighting offset (`Quake/renderer/r_decals.c`).
- Add a `max_dist` parameter to `R_Decals_FindImpact` and reject trace hits farther than that distance by checking `max_dist_sq`, preventing distant fallback hits from being used (`Quake/renderer/r_decals.c`).
- Use per-decal-type max distances when calling `R_Decals_FindImpact`: bullets & scorch use `24.f`, blood uses `4.f` (prevents blood decals from appearing in air) (`Quake/renderer/r_decals.c`).
- Add helper `CL_EntityModelLooksLikeFire` and, in `CL_RelinkEntities`, allocate a persistent torch-style dlight for entities whose model name contains `fire`, `flame`, or `torch`; the light has warm tint, flickering radius, `DLIGHT_TORCH` type, and a small vertical offset (`Quake/client/cl_main.c`).

### Testing
- Attempted an automated build with `cmake -S . -B build && cmake --build build -j2`, which failed during configuration because the SDL2 CMake package was not available in this environment (`SDL2Config.cmake` not found), so a full build/test run could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69990e077a54832eb7bcfa7589742571)