### PR TITLE
Add missing max_dist argument to R_Decals_FindImpact call in R_Decals_Test_f

### DIFF
--- a/Quake/renderer/r_decals.c
+++ b/Quake/renderer/r_decals.c
@@ -973,7 +973,7 @@ static void R_Decals_Test_f (void)
 	const char *name = (Cmd_Argc () > 1) ? Cmd_Argv (1) : "bullet_hole_default";
 	VectorMA (r_refdef.vieworg, 256.f, vpn, end);
 	TraceLine (r_refdef.vieworg, end, point);
-	if (!R_Decals_FindImpact (point, NULL, hit, nrm))
+	if (!R_Decals_FindImpact (point, NULL, 24.f, hit, nrm))
 		return;
 	R_Decals_Add (name, hit, nrm, NULL, 0.f, 0);
 }


### PR DESCRIPTION
### Motivation
- Fix a compile-time error where `R_Decals_Test_f` called `R_Decals_FindImpact` without the required `float max_dist` argument, causing type/argument mismatch on MSVC.

### Description
- Update `Quake/renderer/r_decals.c` so `R_Decals_Test_f` calls `R_Decals_FindImpact(point, NULL, 24.f, hit, nrm)`, using `24.f` to match nearby impact-search calls.

### Testing
- Applied the patch to `Quake/renderer/r_decals.c` and verified with a code search that all `R_Decals_FindImpact` call sites now pass five arguments and the change was applied cleanly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69990f3c721c832ebd261f6b0cdd27ee)