### PR TITLE
Fix net header include path in quakedef.h

### DIFF
--- a/Quake/quakedef.h
+++ b/Quake/quakedef.h
@@ -252,7 +252,7 @@ typedef struct
 #include "cvar.h"
 
 #include "protocol.h"
-#include "net.h"
+#include "net/net.h"
 
 #include "cmd.h"
 #include "crc.h"


### PR DESCRIPTION
### Motivation
- Resolve the Visual Studio C1083 build error where `quakedef.c` could not open the include file `net.h` by using the correct relative path to the networking headers.

### Description
- Replace `#include "net.h"` with `#include "net/net.h"` in `Quake/quakedef.h` to match the repository layout.

### Testing
- Ran `rg -n '#include "net\.h"' Quake` which returned no matches and inspected `git diff -- Quake/quakedef.h` to confirm the change, and both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999a03f7d94832e9280e9e52551f339)