### PR TITLE
Add persistent torch/fire dlights and attach dynamic lights for projectiles and impacts

### DIFF
--- a/Quake/client/cl_main.c
+++ b/Quake/client/cl_main.c
@@ -747,9 +747,25 @@ void CL_RelinkEntities (void)
 		else if (ent->model->flags & EF_ZOMGIB)
 			CL_RocketTrail (ent, 4);
 		else if (ent->model->flags & EF_TRACER)
+		{
 			CL_RocketTrail (ent, 3);
+			dl = CL_AllocDlight (CL_DlightKeyForEntityEffect (i, 7));
+			VectorCopy (ent->origin, dl->origin);
+			dl->radius = 96;
+			dl->baseradius = dl->radius;
+			dl->die = cl.time + 0.01;
+			dl->color[0] = 1.00f; dl->color[1] = 0.84f; dl->color[2] = 0.38f;
+		}
 		else if (ent->model->flags & EF_TRACER2)
+		{
 			CL_RocketTrail (ent, 5);
+			dl = CL_AllocDlight (CL_DlightKeyForEntityEffect (i, 8));
+			VectorCopy (ent->origin, dl->origin);
+			dl->radius = 96;
+			dl->baseradius = dl->radius;
+			dl->die = cl.time + 0.01;
+			dl->color[0] = 0.45f; dl->color[1] = 0.90f; dl->color[2] = 0.30f;
+		}
                 else if (ent->model->flags & EF_ROCKET)
                 {
                         CL_RocketTrail (ent, 0);
@@ -761,10 +777,26 @@ void CL_RelinkEntities (void)
                         dl->type = DLIGHT_ROCKET;
                         CL_SetDlightColorForEntity (dl, ent);
                 }
-                else if (ent->model->flags & EF_GRENADE)
+		else if (ent->model->flags & EF_GRENADE)
+		{
 			CL_RocketTrail (ent, 1);
+			dl = CL_AllocDlight (CL_DlightKeyForEntityEffect (i, 9));
+			VectorCopy (ent->origin, dl->origin);
+			dl->radius = 144;
+			dl->baseradius = dl->radius;
+			dl->die = cl.time + 0.01;
+			dl->color[0] = 1.00f; dl->color[1] = 0.62f; dl->color[2] = 0.24f;
+		}
 		else if (ent->model->flags & EF_TRACER3)
+		{
 			CL_RocketTrail (ent, 6);
+			dl = CL_AllocDlight (CL_DlightKeyForEntityEffect (i, 10));
+			VectorCopy (ent->origin, dl->origin);
+			dl->radius = 104;
+			dl->baseradius = dl->radius;
+			dl->die = cl.time + 0.01;
+			dl->color[0] = 0.80f; dl->color[1] = 0.45f; dl->color[2] = 1.00f;
+		}
 		else
 			CL_ResetTrail (ent);
 

--- a/Quake/client/cl_tent.c
+++ b/Quake/client/cl_tent.c
@@ -228,6 +228,13 @@ void CL_ParseTEnt (void)
 			R_RunParticleEffect (pos, vec3_origin, 0, 20);
 			CL_DecalImpactNormal (pos, nrm);
 			R_Decals_Add ("bullet_hole_default", pos, nrm, NULL, 0.f, 0);
+			dl = CL_AllocDlight (0);
+			VectorCopy (pos, dl->origin);
+			dl->radius = 96;
+			dl->baseradius = dl->radius;
+			dl->color[0] = 1.00f; dl->color[1] = 1.00f; dl->color[2] = 1.00f;
+			dl->die = cl.time + 0.75;
+			dl->decay = 96;
 		}
 		break;
 

--- a/Quake/opengl/gl_rlight.c
+++ b/Quake/opengl/gl_rlight.c
@@ -101,6 +101,12 @@ static qboolean R_ParseDlightOrigin (const char *value, vec3_t origin)
 	return value && sscanf (value, "%f %f %f", &origin[0], &origin[1], &origin[2]) == 3;
 }
 
+static qboolean R_IsTorchOrFireEntity (const char *classname, const char *modelname)
+{
+	return (classname && (q_strcasestr (classname, "torch") || q_strcasestr (classname, "fire") || q_strcasestr (classname, "flame")))
+		|| (modelname && (q_strcasestr (modelname, "torch") || q_strcasestr (modelname, "fire") || q_strcasestr (modelname, "flame")));
+}
+
 static void R_AddEntityDlight (const vec3_t origin, float radius, const vec3_t color, int style, int key)
 {
 	dlight_t *dl = DLightPool_GetOrCreatePersistent (key, cl.time);
@@ -151,8 +157,10 @@ void R_ParseDlightEntities (void)
 		int style = 0;
 		qboolean classname_is_dlight = false;
 		qboolean classname_is_light = false;
+		qboolean classname_is_torchfire = false;
 		qboolean marked_dynamic = false;
 		qboolean parsed_origin = false;
+		char modelname[1024] = "";
 
 		if (com_token[0] != '{')
 			break;
@@ -176,9 +184,12 @@ void R_ParseDlightEntities (void)
 			{
 				classname_is_dlight = !strcmp (value, "dlight");
 				classname_is_light = !strcmp (value, "light");
+				classname_is_torchfire = R_IsTorchOrFireEntity (value, NULL);
 			}
 			else if (!strcmp (key, "origin"))
 				parsed_origin = R_ParseDlightOrigin (value, origin);
+			else if (!strcmp (key, "model"))
+				q_strlcpy (modelname, value, sizeof (modelname));
 			else if (!strcmp (key, "_color") || !strcmp (key, "color"))
 				R_ParseDlightColor (value, color);
 			else if (!strcmp (key, "radius"))
@@ -195,6 +206,20 @@ void R_ParseDlightEntities (void)
 		{
 			const int key = -(1000 + ++entity_dlight_count);
 			R_AddEntityDlight (origin, radius, color, style, key);
+		}
+		else if (parsed_origin && (classname_is_torchfire || R_IsTorchOrFireEntity (NULL, modelname)))
+		{
+			const int key = -(1000 + ++entity_dlight_count);
+			vec3_t torch_color = {1.0f, 0.72f, 0.26f};
+
+			if (radius <= 0.f)
+				radius = 128.f;
+			if (style <= 0)
+				style = 1; // torch-like flicker
+
+			R_AddEntityDlight (origin, radius, torch_color, style, key);
+			dlight_t *dl = DLightPool_GetOrCreatePersistent (key, cl.time);
+			dl->type = DLIGHT_TORCH;
 		}
 
 		data = COM_Parse (data);


### PR DESCRIPTION
### Motivation
- Provide persistent map lights for torch/fire entities so torches and flames produce warm, flickering dlights on map load. 
- Attach small dynamic lights to non-hitscan projectiles so moving projectiles (tracers, grenades, rockets) carry a light like rockets do. 
- Spawn a short, bright impact dlight for bullet/shot impacts to visually emphasize shotgun/bullet hits.

### Description
- Parse BSP entity entries and auto-create persistent dlights for entities whose `classname` or `model` contains `torch`, `fire`, or `flame`, with a warm reddish-yellow color, default radius fallback (128) and a flicker `style` set; the dlight `type` is set to `DLIGHT_TORCH`. (edited `Quake/opengl/gl_rlight.c`)
- For moving projectiles, attach short-lived transient dlights during entity relinking for `EF_TRACER`, `EF_TRACER2`, `EF_TRACER3`, and `EF_GRENADE` with tuned colors, radii and very short lifetimes so they follow the projectile. (edited `Quake/client/cl_main.c`)
- Spawn a short-lived bright white dlight at `TE_GUNSHOT` impact points with radius 96, lifetime ~0.75s and decay to simulate a quick bright impact flash. (edited `Quake/client/cl_tent.c`)

### Testing
- Attempted a full build with `make --directory=Quake -j4`, which exercised dependency generation and compilation; the build could not complete in this environment because `sdl2-config` / `SDL.h` are missing, so compilation failed early with missing SDL2 headers (no successful binary test).
- Verified the diffs and committed the three modified files: `Quake/opengl/gl_rlight.c`, `Quake/client/cl_main.c`, and `Quake/client/cl_tent.c`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999a55abe78832eb1b458bd46af6bef)