### PR TITLE
Use box-based PVS for clustered dlight visibility

### DIFF
--- a/Quake/renderer/r_dlight_pool.c
+++ b/Quake/renderer/r_dlight_pool.c
@@ -5,6 +5,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+extern qboolean SV_BoxInPVS (vec3_t mins, vec3_t maxs, byte *pvs, mnode_t *node);
+
 typedef struct dlight_pool_s
 {
 	dlight_t *items;
@@ -590,7 +592,7 @@ int DLightPool_CollectForRender (double time, const vec3_t vieworg, const mleaf_
 			VectorCopy (maxs, dbg->maxs);
 		}
 
-		if (have_world && viewleaf && view_pvs)
+		if (have_world && viewleaf && view_pvs && cl.worldmodel->nodes)
 		{
 			mleaf_t *lightleaf = Mod_PointInLeaf (dl->origin, cl.worldmodel);
 			if (dbg)
@@ -598,14 +600,13 @@ int DLightPool_CollectForRender (double time, const vec3_t vieworg, const mleaf_
 				dbg->has_leaf = (lightleaf != NULL);
 				dbg->leaf_index = lightleaf ? (int)(lightleaf - cl.worldmodel->leafs) : -1;
 			}
-			if (!lightleaf)
-				in_pvs = false;
-			else
-			{
-				int leafnum = (int)(lightleaf - cl.worldmodel->leafs) - 1;
-				if (leafnum >= 0)
-					in_pvs = ((view_pvs[leafnum >> 3] & (1 << (leafnum & 7))) != 0);
-			}
+
+			/*
+			 * Use the light bounds for visibility tests rather than only its origin leaf.
+			 * Cluster lights can straddle multiple leaves, and origin-only PVS checks
+			 * can cause lights to pop on/off too aggressively when crossing portals.
+			 */
+			in_pvs = SV_BoxInPVS (mins, maxs, view_pvs, cl.worldmodel->nodes);
 		}
 		if (dbg)
 			dbg->in_pvs = in_pvs;


### PR DESCRIPTION
### Motivation
- Clustered dynamic lights were being rejected by origin-only PVS tests causing them to abruptly pop on when you got very close and disappear a few steps away near portals/leaf boundaries.
- The change aims to make visibility filtering more robust for lights that span multiple BSP leaves so they remain active while any part of their volume is visible.

### Description
- Added an `extern` declaration for `SV_BoxInPVS` and computed per-light bounds (`mins`/`maxs`) for visibility testing instead of relying solely on the light origin.
- Replaced the origin-leaf PVS acceptance path with a box-in-PVS test via `SV_BoxInPVS(mins, maxs, view_pvs, cl.worldmodel->nodes)` and guarded the call with `cl.worldmodel->nodes` availability.
- Preserved existing debug metadata by still capturing `has_leaf` and `leaf_index` for diagnostics while changing the actual acceptance check to the box-based test.
- Kept the rest of the dlight filtering logic (frustum checks, scoring, budget sorting) unchanged.

### Testing
- Ran `make -j4` at the repository root which reported no top-level Makefile/targets and did not build (no targets present). (failed)
- Attempted to build in `Quake/` with `make -j4` which progressed to dependency generation but failed due to missing SDL2 development tooling (`sdl2-config` and missing `SDL.h`), so a full compile/test could not be completed in this environment. (blocked)
- No automated unit tests exist for this code path in the tree, so runtime validation should be performed in an environment with SDL2 and a full build to confirm reduced dlight pop-in.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999a87e4d64832e914d7dadcb6e8970)