### PR TITLE
Prevent startup command buffer overflow in Cmd_StuffCmds_f

### DIFF
--- a/Quake/cmd.c
+++ b/Quake/cmd.c
@@ -260,14 +260,22 @@ void Cmd_StuffCmds_f (void)
 			if (j > 0)
 			{
 				cmds[j-1] = ';';
-				cmds[j++] = ' ';
+				if (j < (int)sizeof (cmds) - 1)
+					cmds[j++] = ' ';
 			}
 		}
 		else if (cmdline.string[i] == '-' &&
 			(i==0 || cmdline.string[i-1] == ' ')) //johnfitz -- allow hypenated map names with +map
 				plus = false;
 		else if (plus)
+		{
+			if (j >= (int)sizeof (cmds) - 1)
+			{
+				Con_Warning ("Command line script is too long, truncating startup commands\n");
+				break;
+			}
 			cmds[j++] = cmdline.string[i];
+		}
 	}
 	cmds[j] = 0;
 
@@ -980,4 +988,3 @@ int Cmd_CheckParm (const char *parm)
 
 	return 0;
 }
-


### PR DESCRIPTION
### Motivation
- Prevent a hard crash at startup caused by overflowing the fixed `cmds[CMDLINE_LENGTH]` buffer when parsing long `+` command-line scripts (e.g. long `+map` / `+playdemo` sequences). The change makes startup parsing safe and avoids memory corruption.

### Description
- Add bounds checks in `Cmd_StuffCmds_f` (`Quake/cmd.c`) to guard the appended space and each character written into the local `cmds` buffer, and emit a warning and stop appending when the buffer capacity is reached so the startup script is safely truncated instead of overflowing.

### Testing
- Attempted an automated build with `make -j4 --directory=Quake`, which exercised the code paths but the build was blocked in this environment due to missing SDL2 headers/tools (`sdl2-config`/`SDL.h`), so no full binary was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999a9becda0832ea61abb489da0fe82)