### PR TITLE
Guard server PVS/leaf logic when worldmodel is not initialized

### DIFF
--- a/Quake/world.c
+++ b/Quake/world.c
@@ -393,6 +393,9 @@ void SV_FindTouchedLeafs (edict_t *ent, mnode_t *node)
 	int			sides;
 	int			leafnum;
 
+	if (!sv.worldmodel)
+		return;
+
 	if (node->contents == CONTENTS_SOLID)
 		return;
 
@@ -435,6 +438,9 @@ qboolean SV_BoxInPVS (vec3_t mins, vec3_t maxs, byte *pvs, mnode_t *node)
 	mleaf_t		*leaf;
 	int			sides;
 	int			leafnum;
+
+	if (!sv.worldmodel)
+		return false;
 
 	if (node->contents == CONTENTS_SOLID)
 		return false;
@@ -503,9 +509,9 @@ void SV_LinkEdict (edict_t *ent, qboolean touch_triggers)
 		ent->v.absmax[2] += 1;
 	}
 
-// link to PVS leafs
+	// link to PVS leafs
 	ent->num_leafs = 0;
-	if (ent->v.modelindex)
+	if (ent->v.modelindex && sv.worldmodel)
 		SV_FindTouchedLeafs (ent, sv.worldmodel->nodes);
 
 	if (ent->v.solid == SOLID_NOT)
@@ -969,4 +975,3 @@ trace_t SV_Move (vec3_t start, vec3_t mins, vec3_t maxs, vec3_t end, int type, e
 
 	return clip.trace;
 }
-


### PR DESCRIPTION
### Motivation
- Avoid crashes caused by dereferencing `sv.worldmodel->leafs` when `sv.worldmodel` is NULL during map/model load or unload order windows. 
- Ensure area/leaf/PVS-related functions called from entity/area link paths do nothing if the world model is not yet available.

### Description
- Add an early-return guard at the start of `SV_FindTouchedLeafs` to exit immediately if `sv.worldmodel` is NULL. 
- Add the same null check to `SV_BoxInPVS`, returning `false` when no world model is available. 
- Gate the call in `SV_LinkEdict` so `SV_FindTouchedLeafs` is only invoked when `ent->v.modelindex` and `sv.worldmodel` are both valid (change made in `Quake/world.c`).

### Testing
- Ran `git diff --check` to validate the working tree for whitespace/patch issues and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999ac08c938832e95b2a7a6f5cac05e)