### PR TITLE
Adjust dlight behavior: remove gunshot impact lights, dim torches, irregular flicker, and expand culling

### DIFF
--- a/Quake/client/cl_main.c
+++ b/Quake/client/cl_main.c
@@ -518,6 +518,11 @@ static void CL_SetDlightColorForEntity (dlight_t *dl, const entity_t *ent)
         if (name && (q_strcasestr (name, "fire") || q_strcasestr (name, "flame") || q_strcasestr (name, "torch")))
         {
                 dl->type = DLIGHT_TORCH;
+                dl->radius *= 0.5f;
+                dl->baseradius *= 0.5f;
+                dl->color[0] *= 0.5f;
+                dl->color[1] *= 0.5f;
+                dl->color[2] *= 0.5f;
                 return;
         }
 

--- a/Quake/client/cl_main.c
+++ b/Quake/client/cl_main.c
@@ -475,6 +475,17 @@ static void CL_RocketTrail (entity_t *ent, int type)
 	CL_ResetTrail (ent);
 }
 
+static qboolean CL_IsTorchFireEntity (const entity_t *ent)
+{
+	const char *name;
+
+	if (!ent || !ent->model || !ent->model->name)
+		return false;
+
+	name = ent->model->name;
+	return q_strcasestr (name, "fire") || q_strcasestr (name, "flame") || q_strcasestr (name, "torch");
+}
+
 /*
 ===============
 			CL_SetDlightColorForEntity
@@ -518,11 +529,6 @@ static void CL_SetDlightColorForEntity (dlight_t *dl, const entity_t *ent)
         if (name && (q_strcasestr (name, "fire") || q_strcasestr (name, "flame") || q_strcasestr (name, "torch")))
         {
                 dl->type = DLIGHT_TORCH;
-                dl->radius *= 0.5f;
-                dl->baseradius *= 0.5f;
-                dl->color[0] *= 0.5f;
-                dl->color[1] *= 0.5f;
-                dl->color[2] *= 0.5f;
                 return;
         }
 
@@ -707,21 +713,35 @@ void CL_RelinkEntities (void)
 		}
                 if (ent->effects & EF_BRIGHTLIGHT)
                 {
+                        const qboolean is_torchfire = CL_IsTorchFireEntity (ent);
                         dl = CL_AllocDlight (CL_DlightKeyForEntityEffect (i, 2));
                         VectorCopy (ent->origin,  dl->origin);
                         dl->origin[2] += 16;
-                        dl->radius = 400 + (rand()&31);
+                        dl->radius = is_torchfire ? (400 + (rand()&31)) * 0.5f : 400 + (rand()&31);
                         dl->baseradius = dl->radius;
                         dl->die = cl.time + 0.001;
+                        if (is_torchfire)
+                        {
+                                dl->color[0] = 0.50f;
+                                dl->color[1] = 0.36f;
+                                dl->color[2] = 0.13f;
+                        }
                         CL_SetDlightColorForEntity (dl, ent);
                 }
                 if (ent->effects & EF_DIMLIGHT)
                 {
+                        const qboolean is_torchfire = CL_IsTorchFireEntity (ent);
                         dl = CL_AllocDlight (CL_DlightKeyForEntityEffect (i, 3));
                         VectorCopy (ent->origin,  dl->origin);
-                        dl->radius = 200 + (rand()&31);
+                        dl->radius = is_torchfire ? (200 + (rand()&31)) * 0.5f : 200 + (rand()&31);
                         dl->baseradius = dl->radius;
                         dl->die = cl.time + 0.001;
+                        if (is_torchfire)
+                        {
+                                dl->color[0] = 0.50f;
+                                dl->color[1] = 0.36f;
+                                dl->color[2] = 0.13f;
+                        }
                         CL_SetDlightColorForEntity (dl, ent);
                 }
                 if (ent->effects & EF_QEX_QUADLIGHT)

--- a/Quake/client/cl_tent.c
+++ b/Quake/client/cl_tent.c
@@ -228,13 +228,6 @@ void CL_ParseTEnt (void)
 			R_RunParticleEffect (pos, vec3_origin, 0, 20);
 			CL_DecalImpactNormal (pos, nrm);
 			R_Decals_Add ("bullet_hole_default", pos, nrm, NULL, 0.f, 0);
-			dl = CL_AllocDlight (0);
-			VectorCopy (pos, dl->origin);
-			dl->radius = 96;
-			dl->baseradius = dl->radius;
-			dl->color[0] = 1.00f; dl->color[1] = 1.00f; dl->color[2] = 1.00f;
-			dl->die = cl.time + 0.75;
-			dl->decay = 96;
 		}
 		break;
 

--- a/Quake/opengl/gl_rlight.c
+++ b/Quake/opengl/gl_rlight.c
@@ -210,10 +210,11 @@ void R_ParseDlightEntities (void)
 		else if (parsed_origin && (classname_is_torchfire || R_IsTorchOrFireEntity (NULL, modelname)))
 		{
 			const int key = -(1000 + ++entity_dlight_count);
-			vec3_t torch_color = {1.0f, 0.72f, 0.26f};
+			vec3_t torch_color = {0.5f, 0.36f, 0.13f};
 
 			if (radius <= 0.f)
 				radius = 128.f;
+			radius *= 0.5f;
 			if (style <= 0)
 				style = 1; // torch-like flicker
 

--- a/Quake/renderer/r_dlight_pool.c
+++ b/Quake/renderer/r_dlight_pool.c
@@ -425,7 +425,19 @@ void DLightPool_Decay (float frametime, double time)
 			dl->baseradius = 0.f;
 
 		if (CL_DlightShouldFlicker (dl))
-			dl->radius = dl->baseradius * (1.0f + 0.1f * (float) sin (time * 9.0 + dl->flicker_seed));
+		{
+			if (dl->type == DLIGHT_TORCH)
+			{
+				float seed = dl->flicker_seed;
+				float f1 = (float) sin (time * 11.3 + seed * 0.013f);
+				float f2 = (float) sin (time * 19.7 + seed * 0.031f);
+				float f3 = (float) sin (time * 27.1 + seed * 0.071f);
+				float irregular = f1 * 0.11f + f2 * 0.07f + f3 * 0.04f;
+				dl->radius = dl->baseradius * (1.0f + irregular);
+			}
+			else
+				dl->radius = dl->baseradius * (1.0f + 0.1f * (float) sin (time * 9.0 + dl->flicker_seed));
+		}
 		else
 			dl->radius = dl->baseradius;
 		if (dl->radius < 0.f)
@@ -522,6 +534,7 @@ int DLightPool_CollectForRender (double time, const vec3_t vieworg, const mleaf_
 		float lum;
 		float dist;
 		float target_scale;
+		float cull_radius;
 		vec3_t delta;
 		vec3_t mins, maxs;
 		qboolean in_pvs = true;
@@ -584,8 +597,9 @@ int DLightPool_CollectForRender (double time, const vec3_t vieworg, const mleaf_
 		dl->lod_scale += (target_scale - dl->lod_scale) * smooth;
 		dl->lod_scale = CLAMP (0.1f, dl->lod_scale, 1.f);
 
-		VectorSet (mins, dl->origin[0] - dl->radius, dl->origin[1] - dl->radius, dl->origin[2] - dl->radius);
-		VectorSet (maxs, dl->origin[0] + dl->radius, dl->origin[1] + dl->radius, dl->origin[2] + dl->radius);
+		cull_radius = q_max (q_max (dl->radius, dl->baseradius), min_radius) + 32.f;
+		VectorSet (mins, dl->origin[0] - cull_radius, dl->origin[1] - cull_radius, dl->origin[2] - cull_radius);
+		VectorSet (maxs, dl->origin[0] + cull_radius, dl->origin[1] + cull_radius, dl->origin[2] + cull_radius);
 		if (dbg)
 		{
 			VectorCopy (mins, dbg->mins);
@@ -621,7 +635,7 @@ int DLightPool_CollectForRender (double time, const vec3_t vieworg, const mleaf_
 		for (int j = 0; j < 4; j++)
 		{
 			const mplane_t *p = &frustum[j];
-			if (DotProduct (p->normal, dl->origin) - p->dist + dl->radius < 0.f)
+			if (DotProduct (p->normal, dl->origin) - p->dist + cull_radius < 0.f)
 			{
 				in_frustum = false;
 				break;


### PR DESCRIPTION
### Motivation
- Reduce distracting transient lights from bullet impacts and make torch/fire lights less overpowering. 
- Make torch flicker feel more organic and reduce premature popping from culling.

### Description
- Remove transient impact dlight creation for `TE_GUNSHOT` so bullet impacts only spawn particles/decals (`Quake/client/cl_tent.c`).
- Scale down entity-effect torch/fire/flame lights by 50% for both radius and RGB intensity in `CL_SetDlightColorForEntity` (`Quake/client/cl_main.c`).
- Parse map entity torch/fire dlights with half radius and lower color values (`Quake/opengl/gl_rlight.c`).
- Make torch flicker less uniform by using a blend of multiple sine waves for `DLIGHT_TORCH` in the dlight decay/flicker logic (`Quake/renderer/r_dlight_pool.c`).
- Relax dlight visibility checks by computing an expanded `cull_radius` and using it for PVS/frustum box tests to reduce premature culling (`Quake/renderer/r_dlight_pool.c`).

### Testing
- Attempted an automated build with `make -C Quake -j2`, but the build could not complete because the environment is missing SDL2 tools/headers (`sdl2-config` / `SDL.h`), so a full compile/test run was not possible.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999b20c731c832ebbc6e592f22c9b4b)