### PR TITLE
Fix DoF depth reconstruction using inverse projection

### DIFF
--- a/Quake/opengl/gl_rmain.c
+++ b/Quake/opengl/gl_rmain.c
@@ -3120,6 +3120,7 @@ void GL_PostProcess (void)
 	GL_Uniform4fFunc (22, postfx_lut_strength, postfx_state.underwater_grade_strength, postfx_state.underwater_fog_strength, postfx_vignette_softness);
 	GL_Uniform4fFunc (23, (float)postfx_lut_size, (float)postfx_lut_id, 0.f, 0.f);
 	GL_Uniform4fFunc (24, fog_r, fog_g, fog_b, 0.f);
+	GL_UniformMatrix4fvFunc (31, 1, GL_FALSE, r_matinvproj);
 	{
 		int quality = (int)Q_rint (r_post_damage_dv_quality.value);
 		dv_quality = (float)CLAMP (0, quality, 2);

--- a/Quake/shaders/postprocess.frag
+++ b/Quake/shaders/postprocess.frag
@@ -15,6 +15,7 @@ layout(std430, binding=0) restrict readonly buffer PaletteBuffer
 	uint Palette[256];
 };
 #include "frame_uniforms.glsl"
+#include "depth_common.glsl"
 
 uvec3 UnpackRGB8(uint c)
 {
@@ -153,6 +154,7 @@ layout(location=27) uniform vec4 TonemapBlackLiftParams; // x: lift, y: strength
 layout(location=28) uniform vec4 AtmosFroxelParams0; // x: enabled, yzw: dimensions
 layout(location=29) uniform vec4 AtmosFroxelParams1; // x: downsample, y: z slices, z: z far, w: reserved
 layout(location=30) uniform vec4 FogDebugViews; // x density, y transmittance, z scattering, w light/step
+layout(location=31) uniform mat4 DoFInvProj;
 
 const int MOTION_MAX_SAMPLES = 64;
 const float OPAQUE_ALPHA_THRESHOLD = 0.999;
@@ -208,20 +210,12 @@ float SampleLinearDepth(vec2 fragPx, DepthSamplingInfo info)
         if (depthUV.x < 0.0 || depthUV.y < 0.0)
                 return 0.0;
         float rawDepth = texture(DepthTexture, depthUV).r;
-        float nearPlane = DoFParams1.x;
-        float farPlane = DoFParams1.y;
-        float reversed = DoFParams1.z;
-        if (reversed > 0.5)
-        {
-                float denom = nearPlane + rawDepth * (farPlane - nearPlane);
-                return (nearPlane * farPlane) / max(denom, 1e-6);
-        }
-        else
-        {
-                float ndcDepth = rawDepth * 2.0 - 1.0;
-                float denom = farPlane + nearPlane - ndcDepth * (farPlane - nearPlane);
-                return (2.0 * nearPlane * farPlane) / max(denom, 1e-6);
-        }
+        float ndcDepth = DepthRawToNdc(rawDepth, DoFParams1.z);
+        vec4 clip = vec4(depthUV * 2.0 - 1.0, ndcDepth, 1.0);
+        vec4 view = DoFInvProj * clip;
+        float invW = (abs(view.w) > 1e-6) ? (1.0 / view.w) : 0.0;
+        float viewDepth = view.x * invW;
+        return max(viewDepth, 0.0);
 }
 
 float FogTransmittanceFromDepth(float depth, float fogStrength)


### PR DESCRIPTION
### Motivation
- Depth-of-field produced incorrect results (everything sharp or everything blurred) because the postprocess shader used ad-hoc depth math that could diverge from the active projection/depth mode. 
- The change aligns DoF depth conversion with other effects (SSAO/etc.) by reconstructing view-space depth from the inverse projection to handle normal-Z and reversed-Z consistently.

### Description
- Use shared helper `DepthRawToNdc` by `#include "depth_common.glsl"` in `Quake/shaders/postprocess.frag` so depth mode handling is unified.
- Replace the old analytic depth formula in `SampleLinearDepth` with full NDC->clip->view reconstruction using a new `DoFInvProj` `mat4` and return view-space X depth.
- Upload the inverse projection matrix from the renderer each frame with `GL_UniformMatrix4fvFunc (31, 1, GL_FALSE, r_matinvproj);` in `Quake/opengl/gl_rmain.c` and bind it to the new shader uniform slot.

### Testing
- Attempted an automated build with `cmake -S . -B build && cmake --build build -j2`, which failed during configuration due to a missing SDL2 development package, so runtime validation of the shader change could not be performed in this environment.  
- Changes were verified via diffs and committed to the repository (`git commit` succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999d664d06c832eb2145ddca84c22fb)