### PR TITLE
Refactor postprocess.frag: extract Motion Blur and DoF into separate shader includes

### DIFF
--- a/Quake/shaders/postprocess.frag
+++ b/Quake/shaders/postprocess.frag
@@ -339,23 +339,8 @@ vec3 LinearToSRGB(vec3 color)
         return mix(lower, higher, cutoff);
 }
 
-void AccumulateMotionSample(inout vec3 accum, inout float weight, vec2 sampleUV, vec2 sampleCoordPx, vec2 viewMin, vec2 viewMax, DepthSamplingInfo info, bool useDepth, float centerDepth, float depthThresholdRatio)
-{
-        if (!all(greaterThanEqual(sampleUV, viewMin)) || !all(lessThanEqual(sampleUV, viewMax)))
-                return;
-        if (useDepth)
-        {
-                float sampleDepth = SampleLinearDepth(sampleCoordPx, info);
-                float tolerance = depthThresholdRatio * max(centerDepth, 1e-6);
-                if (abs(sampleDepth - centerDepth) > tolerance)
-                        return;
-        }
-        vec4 sampleColor = texture(GammaTexture, sampleUV);
-        if (sampleColor.a < OPAQUE_ALPHA_THRESHOLD)
-                return;
-        accum += sampleColor.rgb;
-        weight += 1.0;
-}
+#include "postprocess_motion.glsl"
+#include "postprocess_dof.glsl"
 
 layout(location=0) out vec4 out_fragcolor;
 
@@ -411,97 +396,9 @@ void main()
                 materialMask = int(floor(velocitySample.w + 0.5));
         }
 
-        if (MotionParams0.x > 0.5 && inView && hasVelocityTexture && viewModelMask < 0.5 && centerOpaque)
-        {
-                float effectiveShutter = MotionParams0.y;
-                if (effectiveShutter > 0.0)
-                {
-                        vec2 velocityPx = velocity * effectiveShutter * texSize;
-                        float speed = length(velocityPx);
-                        float minVelocity = max(MotionParams0.z, 0.0);
-                        float maxRadius = MotionParams1.x;
-                        int maxSamples = int(MotionParams1.y + 0.5);
-                        maxSamples = clamp(maxSamples, 1, MOTION_MAX_SAMPLES);
-                        if (maxRadius <= 0.0)
-                                maxRadius = speed;
-                        float radius = clamp(speed, 0.0, maxRadius);
-                        if (radius > minVelocity && maxSamples > 0)
-                        {
-                                float radiusNormDenom = max(maxRadius, 1e-3);
-                                float sampleCountF = clamp(radius / radiusNormDenom, 0.0, 1.0) * float(maxSamples);
-                                int sampleCount = clamp(int(floor(sampleCountF + 0.5)), 1, maxSamples);
-                                vec2 direction = speed > 1e-4 ? (velocityPx / speed) : vec2(0.0);
-                                bool useDepth = MotionParams0.w > 0.0 && depthInfo.valid;
-                                float centerDepth = 0.0;
-                                float depthThresholdRatio = max(MotionParams0.w, 0.0);
-                                if (useDepth)
-                                        centerDepth = SampleLinearDepth(gl_FragCoord.xy, depthInfo);
-                                vec3 accum = color.rgb;
-                                float weight = 1.0;
-                                float jitter = SCREEN_SPACE_NOISE();
-                                for (int i = 1; i <= MOTION_MAX_SAMPLES; ++i)
-                                {
-                                        if (i > sampleCount)
-                                                break;
-                                        float t = (float(i) - 0.5 + jitter) / float(sampleCount);
-                                        t = clamp(t, 0.0, 1.0);
-                                        vec2 offsetPx = direction * (t * radius);
-                                        if (length(offsetPx) < 1e-6)
-                                                continue;
-                                        vec2 offsetUV = offsetPx * invTexSize;
-                                        vec2 sampleUVPos = uv + offsetUV;
-                                        vec2 sampleUVNeg = uv - offsetUV;
-                                        vec2 fragCoordPos = gl_FragCoord.xy + offsetPx;
-                                        vec2 fragCoordNeg = gl_FragCoord.xy - offsetPx;
-                                        AccumulateMotionSample(accum, weight, sampleUVPos, fragCoordPos, viewMin, viewMax, depthInfo, useDepth, centerDepth, depthThresholdRatio);
-                                        AccumulateMotionSample(accum, weight, sampleUVNeg, fragCoordNeg, viewMin, viewMax, depthInfo, useDepth, centerDepth, depthThresholdRatio);
-                                }
-                                if (weight > 0.0)
-                                        color.rgb = accum / weight;
-                        }
-                }
-        }
+        ApplyMotionBlur(color, uv, viewMin, viewMax, texSize, invTexSize, inView, centerOpaque, hasVelocityTexture, velocity, depthInfo, viewModelMask);
 
-        if (DoFParams0.x > 0.5 && inView && depthInfo.valid && viewModelMask < 0.5 && centerOpaque)
-        {
-                float linearDepth = SampleLinearDepth(gl_FragCoord.xy, depthInfo);
-                float focusDistance = DoFParams0.y;
-                float focusRange = max(DoFParams0.z, 0.0001);
-                float maxBlur = max(DoFParams0.w, 0.0);
-                float coc = abs(linearDepth - focusDistance);
-                float blurFactor = clamp((coc - focusRange) / focusRange, 0.0, 1.0);
-                float blurRadius = blurFactor * maxBlur;
-                if (blurRadius > 0.0001)
-                {
-                        const vec2 kernel[8] = vec2[](
-                                vec2(1.0, 0.0),
-                                vec2(-1.0, 0.0),
-                                vec2(0.0, 1.0),
-                                vec2(0.0, -1.0),
-                                vec2(0.70710678, 0.70710678),
-                                vec2(-0.70710678, 0.70710678),
-                                vec2(0.70710678, -0.70710678),
-                                vec2(-0.70710678, -0.70710678)
-                        );
-                        float noise = SCREEN_SPACE_NOISE();
-                        float angle = noise * 6.28318530718;
-                        float sine = sin(angle);
-                        float cosine = cos(angle);
-                        mat2 rotation = mat2(cosine, -sine, sine, cosine);
-                        vec3 accum = color.rgb;
-                        float weight = 1.0;
-                        for (int i = 0; i < 8; ++i)
-                        {
-                                vec2 offset = rotation * kernel[i] * blurRadius * invTexSize;
-                                vec4 sampleColor = texture(GammaTexture, uv + offset);
-                                if (sampleColor.a < OPAQUE_ALPHA_THRESHOLD)
-                                        continue;
-                                accum += sampleColor.rgb;
-                                weight += 1.0;
-                        }
-                        color.rgb = accum / weight;
-                }
-        }
+        ApplyDepthOfField(color, uv, invTexSize, inView, centerOpaque, depthInfo, viewModelMask);
 
         if (inView)
         {

--- a/Quake/shaders/postprocess_dof.glsl
+++ b/Quake/shaders/postprocess_dof.glsl
@@ -1,0 +1,43 @@
+void ApplyDepthOfField(inout vec4 color, vec2 uv, vec2 invTexSize, bool inView, bool centerOpaque, DepthSamplingInfo depthInfo, float viewModelMask)
+{
+        if (!(DoFParams0.x > 0.5 && inView && depthInfo.valid && viewModelMask < 0.5 && centerOpaque))
+                return;
+
+        float linearDepth = SampleLinearDepth(gl_FragCoord.xy, depthInfo);
+        float focusDistance = DoFParams0.y;
+        float focusRange = max(DoFParams0.z, 0.0001);
+        float maxBlur = max(DoFParams0.w, 0.0);
+        float coc = abs(linearDepth - focusDistance);
+        float blurFactor = clamp((coc - focusRange) / focusRange, 0.0, 1.0);
+        float blurRadius = blurFactor * maxBlur;
+        if (blurRadius <= 0.0001)
+                return;
+
+        const vec2 kernel[8] = vec2[](
+                vec2(1.0, 0.0),
+                vec2(-1.0, 0.0),
+                vec2(0.0, 1.0),
+                vec2(0.0, -1.0),
+                vec2(0.70710678, 0.70710678),
+                vec2(-0.70710678, 0.70710678),
+                vec2(0.70710678, -0.70710678),
+                vec2(-0.70710678, -0.70710678)
+        );
+        float noise = SCREEN_SPACE_NOISE();
+        float angle = noise * 6.28318530718;
+        float sine = sin(angle);
+        float cosine = cos(angle);
+        mat2 rotation = mat2(cosine, -sine, sine, cosine);
+        vec3 accum = color.rgb;
+        float weight = 1.0;
+        for (int i = 0; i < 8; ++i)
+        {
+                vec2 offset = rotation * kernel[i] * blurRadius * invTexSize;
+                vec4 sampleColor = texture(GammaTexture, uv + offset);
+                if (sampleColor.a < OPAQUE_ALPHA_THRESHOLD)
+                        continue;
+                accum += sampleColor.rgb;
+                weight += 1.0;
+        }
+        color.rgb = accum / weight;
+}

--- a/Quake/shaders/postprocess_motion.glsl
+++ b/Quake/shaders/postprocess_motion.glsl
@@ -1,0 +1,72 @@
+void AccumulateMotionSample(inout vec3 accum, inout float weight, vec2 sampleUV, vec2 sampleCoordPx, vec2 viewMin, vec2 viewMax, DepthSamplingInfo info, bool useDepth, float centerDepth, float depthThresholdRatio)
+{
+        if (!all(greaterThanEqual(sampleUV, viewMin)) || !all(lessThanEqual(sampleUV, viewMax)))
+                return;
+        if (useDepth)
+        {
+                float sampleDepth = SampleLinearDepth(sampleCoordPx, info);
+                float tolerance = depthThresholdRatio * max(centerDepth, 1e-6);
+                if (abs(sampleDepth - centerDepth) > tolerance)
+                        return;
+        }
+        vec4 sampleColor = texture(GammaTexture, sampleUV);
+        if (sampleColor.a < OPAQUE_ALPHA_THRESHOLD)
+                return;
+        accum += sampleColor.rgb;
+        weight += 1.0;
+}
+
+void ApplyMotionBlur(inout vec4 color, vec2 uv, vec2 viewMin, vec2 viewMax, vec2 texSize, vec2 invTexSize, bool inView, bool centerOpaque, bool hasVelocityTexture, vec2 velocity, DepthSamplingInfo depthInfo, float viewModelMask)
+{
+        if (!(MotionParams0.x > 0.5 && inView && hasVelocityTexture && viewModelMask < 0.5 && centerOpaque))
+                return;
+
+        float effectiveShutter = MotionParams0.y;
+        if (effectiveShutter <= 0.0)
+                return;
+
+        vec2 velocityPx = velocity * effectiveShutter * texSize;
+        float speed = length(velocityPx);
+        float minVelocity = max(MotionParams0.z, 0.0);
+        float maxRadius = MotionParams1.x;
+        int maxSamples = int(MotionParams1.y + 0.5);
+        maxSamples = clamp(maxSamples, 1, MOTION_MAX_SAMPLES);
+        if (maxRadius <= 0.0)
+                maxRadius = speed;
+        float radius = clamp(speed, 0.0, maxRadius);
+        if (!(radius > minVelocity && maxSamples > 0))
+                return;
+
+        float radiusNormDenom = max(maxRadius, 1e-3);
+        float sampleCountF = clamp(radius / radiusNormDenom, 0.0, 1.0) * float(maxSamples);
+        int sampleCount = clamp(int(floor(sampleCountF + 0.5)), 1, maxSamples);
+        vec2 direction = speed > 1e-4 ? (velocityPx / speed) : vec2(0.0);
+        bool useDepth = MotionParams0.w > 0.0 && depthInfo.valid;
+        float centerDepth = 0.0;
+        float depthThresholdRatio = max(MotionParams0.w, 0.0);
+        if (useDepth)
+                centerDepth = SampleLinearDepth(gl_FragCoord.xy, depthInfo);
+
+        vec3 accum = color.rgb;
+        float weight = 1.0;
+        float jitter = SCREEN_SPACE_NOISE();
+        for (int i = 1; i <= MOTION_MAX_SAMPLES; ++i)
+        {
+                if (i > sampleCount)
+                        break;
+                float t = (float(i) - 0.5 + jitter) / float(sampleCount);
+                t = clamp(t, 0.0, 1.0);
+                vec2 offsetPx = direction * (t * radius);
+                if (length(offsetPx) < 1e-6)
+                        continue;
+                vec2 offsetUV = offsetPx * invTexSize;
+                vec2 sampleUVPos = uv + offsetUV;
+                vec2 sampleUVNeg = uv - offsetUV;
+                vec2 fragCoordPos = gl_FragCoord.xy + offsetPx;
+                vec2 fragCoordNeg = gl_FragCoord.xy - offsetPx;
+                AccumulateMotionSample(accum, weight, sampleUVPos, fragCoordPos, viewMin, viewMax, depthInfo, useDepth, centerDepth, depthThresholdRatio);
+                AccumulateMotionSample(accum, weight, sampleUVNeg, fragCoordNeg, viewMin, viewMax, depthInfo, useDepth, centerDepth, depthThresholdRatio);
+        }
+        if (weight > 0.0)
+                color.rgb = accum / weight;
+}


### PR DESCRIPTION
### Motivation
- Reduce complexity of the monolithic postprocess shader by separating per-effect logic into dedicated, reusable include files for easier maintenance and future extension.
- Keep a single common `postprocess.frag` entrypoint that orchestrates per-effect steps while letting each effect implement its own helper functions.

### Description
- Extracted motion-blur sampling and application into `Quake/shaders/postprocess_motion.glsl`, including `AccumulateMotionSample` and `ApplyMotionBlur` helpers.
- Extracted depth-of-field blur into `Quake/shaders/postprocess_dof.glsl` as `ApplyDepthOfField` containing the CoC and blur kernel logic.
- Replaced the inlined motion blur and DoF code in `Quake/shaders/postprocess.frag` with `#include "postprocess_motion.glsl"` and `#include "postprocess_dof.glsl"`, and invoke `ApplyMotionBlur(...)` and `ApplyDepthOfField(...)` at the same points the original code executed.
- Preserved existing interfaces and uniforms (e.g. `DepthSamplingInfo`, `MotionParams*`, `DoFParams*`, `GammaTexture`) so runtime usage remains unchanged.

### Testing
- Ran a repository inspection with `rg` and `nl` to verify the new files (`postprocess_motion.glsl`, `postprocess_dof.glsl`) exist and that `postprocess.frag` now includes and calls the new helpers, which succeeded.
- Attempted an automated build with `make -j4`, which failed because the repository root does not provide a Makefile target (expected for this tree), so no shader compilation was performed in this environment.
- Performed automated textual validation by diffing the modified shader and checking that the original blocks were removed and replaced by includes and calls, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a2ef702b4832e884d765d6d47f3e1)