### PR TITLE
Remove automatic CLEARDBG console logging

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -3109,31 +3109,6 @@ void R_SetupGL (void)
 R_Clear -- johnfitz -- rewritten and gutted
 =============
 */
-static void R_LogClearDebug (const char *tag, GLbitfield clearbits)
-{
-	GLint draw_fbo, read_fbo;
-	GLint viewport[4], scissor_box[4];
-	GLboolean scissor_test;
-	GLfloat clear_color[4];
-
-	glGetIntegerv (GL_DRAW_FRAMEBUFFER_BINDING, &draw_fbo);
-	glGetIntegerv (GL_READ_FRAMEBUFFER_BINDING, &read_fbo);
-	glGetIntegerv (GL_VIEWPORT, viewport);
-	scissor_test = glIsEnabled (GL_SCISSOR_TEST);
-	glGetIntegerv (GL_SCISSOR_BOX, scissor_box);
-	glGetFloatv (GL_COLOR_CLEAR_VALUE, clear_color);
-
-	Con_Printf (
-		"CLEARDBG %s draw_fbo=%d read_fbo=%d viewport=(%d %d %d %d) scissor_test=%d scissor_box=(%d %d %d %d) clear_color=(%.3f %.3f %.3f %.3f) clear_mask=0x%08x\n",
-		tag,
-		draw_fbo,
-		read_fbo,
-		viewport[0], viewport[1], viewport[2], viewport[3],
-		scissor_test,
-		scissor_box[0], scissor_box[1], scissor_box[2], scissor_box[3],
-		clear_color[0], clear_color[1], clear_color[2], clear_color[3],
-		(unsigned int)clearbits);
-}
 
 void R_Clear (void)
 {
@@ -3143,7 +3118,6 @@ void R_Clear (void)
 
 	GL_SetState (glstate & ~GLS_NO_ZWRITE); // make sure depth writes are enabled
 	glStencilMask (~0u);
-	R_LogClearDebug ("R_Clear", clearbits);
 	glClear (clearbits);
 }
 

--- a/Quake/r_shadow.c
+++ b/Quake/r_shadow.c
@@ -11,32 +11,6 @@ of the License, or (at your option) any later version.
 #include <float.h>
 #include <time.h>
 
-static void R_Shadow_LogClearDebug (const char *tag, GLbitfield clearbits)
-{
-	GLint draw_fbo, read_fbo;
-	GLint viewport[4], scissor_box[4];
-	GLboolean scissor_test;
-	GLfloat clear_color[4];
-
-	glGetIntegerv (GL_DRAW_FRAMEBUFFER_BINDING, &draw_fbo);
-	glGetIntegerv (GL_READ_FRAMEBUFFER_BINDING, &read_fbo);
-	glGetIntegerv (GL_VIEWPORT, viewport);
-	scissor_test = glIsEnabled (GL_SCISSOR_TEST);
-	glGetIntegerv (GL_SCISSOR_BOX, scissor_box);
-	glGetFloatv (GL_COLOR_CLEAR_VALUE, clear_color);
-
-	Con_Printf (
-		"CLEARDBG %s draw_fbo=%d read_fbo=%d viewport=(%d %d %d %d) scissor_test=%d scissor_box=(%d %d %d %d) clear_color=(%.3f %.3f %.3f %.3f) clear_mask=0x%08x\n",
-		tag,
-		draw_fbo,
-		read_fbo,
-		viewport[0], viewport[1], viewport[2], viewport[3],
-		scissor_test,
-		scissor_box[0], scissor_box[1], scissor_box[2], scissor_box[3],
-		clear_color[0], clear_color[1], clear_color[2], clear_color[3],
-		(unsigned int)clearbits);
-}
-
 extern cvar_t gl_farclip;
 extern cvar_t r_shadows;
 extern cvar_t r_shadow_sun;
@@ -897,7 +871,6 @@ void R_Shadow_SunPass (void)
 
 	GL_UseProgram (glprogs.shadow_depth);
 	GL_SetState (GLS_BLEND_OPAQUE | GLS_CULL_FRONT | GLS_ATTRIBS (6));
-	R_Shadow_LogClearDebug ("R_Shadow_Sun", GL_DEPTH_BUFFER_BIT);
 	glClear (GL_DEPTH_BUFFER_BIT);
 
 	{
@@ -1075,7 +1048,6 @@ void R_Shadow_DlightPass (void)
 			shadow_dlight_tile_size, shadow_dlight_tile_size);
 		glScissor (tile_x * shadow_dlight_tile_size, tile_y * shadow_dlight_tile_size,
 			shadow_dlight_tile_size, shadow_dlight_tile_size);
-		R_Shadow_LogClearDebug ("R_Shadow_Dlight", GL_DEPTH_BUFFER_BIT);
 		glClear (GL_DEPTH_BUFFER_BIT);
 
 		GL_UseProgram (glprogs.shadow_depth);


### PR DESCRIPTION
### Motivation
- Prevent the renderer from emitting repetitive `CLEARDBG ...` lines to the in-game console during normal rendering and shadow passes to reduce log spam.

### Description
- Remove the automatic clear-debug helper `R_LogClearDebug` and its unconditional call from `R_Clear` in `Quake/gl_rmain.c` so `glClear` is no longer preceded by a console dump.
- Remove the equivalent `R_Shadow_LogClearDebug` helper and its unconditional calls in `Quake/r_shadow.c` (sun and dlight shadow clear paths) so shadow clears no longer print `CLEARDBG` lines.
- Preserve existing clear behavior by leaving the `glClear` calls intact and only removing the debug printing.

### Testing
- Ran `rg -n "CLEARDBG|R_LogClearDebug|R_Shadow_LogClearDebug" /workspace/ironwail/Quake` to confirm there are no remaining automatic `CLEARDBG` callsites and it returned no matches.
- Attempted a build with `cmake -S /workspace/ironwail -B /workspace/ironwail/build && cmake --build /workspace/ironwail/build -j2`, which failed in this environment due to a missing `SDL2` development package, so a full build/test could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a327eabb4832e83c0c7c149d4b037)