### PR TITLE
Fix unresolved glActiveTexture linker symbol in shadow debug path

### DIFF
--- a/Quake/r_shadow.c
+++ b/Quake/r_shadow.c
@@ -218,7 +218,7 @@ void R_Shadow_DebugValidateBinding (const char *tag, GLenum texunit, GLuint expe
 
 	glGetIntegerv (GL_ACTIVE_TEXTURE, &previous_active);
 	glGetIntegerv (GL_TEXTURE_BINDING_2D, &previous_binding);
-	glActiveTexture (texunit);
+	GL_ActiveTextureFunc (texunit);
 	glGetIntegerv (GL_TEXTURE_BINDING_2D, &bound_tex);
 	if ((GLuint)bound_tex == expected_tex)
 	{
@@ -234,7 +234,7 @@ void R_Shadow_DebugValidateBinding (const char *tag, GLenum texunit, GLuint expe
 		R_Shadow_LogWrite ("WARN %s sampler validate texunit=%d expected_tex=%u bound_tex=%d\n",
 			tag, (int)(texunit - GL_TEXTURE0), expected_tex, bound_tex);
 	}
-	glActiveTexture ((GLenum)previous_active);
+	GL_ActiveTextureFunc ((GLenum)previous_active);
 	GL_BindNative ((GLenum)previous_active, GL_TEXTURE_2D, (GLuint)previous_binding);
 }
 


### PR DESCRIPTION
### Motivation
- Resolve MSVC linker failure caused by direct imports of `glActiveTexture` by switching the shadow debug path to the engine's GL dispatch wrapper instead of referencing the symbol directly.

### Description
- Replaced two direct calls to `glActiveTexture` with `GL_ActiveTextureFunc` in `Quake/r_shadow.c` inside `R_Shadow_DebugValidateBinding` to use the engine's GL function dispatch.

### Testing
- Ran `rg "\bglActiveTexture\b" -n Quake` to verify there are no remaining direct `glActiveTexture` usages in the engine sources, and the search returned no matches (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a4f72f728832e9e67a38cba1be2a4)