### PR TITLE
Fix sun shadow compare path and add shadow receiver debug visualizations

### DIFF
--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -589,6 +589,8 @@ ibuf.global.half_lambert = CLAMP (0.f, r_model_halflambert.value, 1.f);
 	GL_BindBuffer (GL_ARRAY_BUFFER, model->meshvbo);
 	GL_BindBuffer (GL_ELEMENT_ARRAY_BUFFER, model->meshindexesvbo);
 	R_Shadow_BindShadowMap (GL_TEXTURE5);
+	if (r_shadow_debug.value >= 3.f)
+		GL_BindNative (GL_TEXTURE6, GL_TEXTURE_2D, R_Shadow_GetShadowMapTextureId ());
 	R_Shadow_Log_ReceiverPassSnapshot ("ALIAS", glprogs.alias[oit][mode][alphatest][md5], GL_TEXTURE5, R_Shadow_GetShadowMapTextureId (), r_shadows.value > 0.f && r_shadow_sun.value > 0.f, r_shadow_bias_mdl.value, r_shadow_normalbias_mdl.value, r_shadow_pcf.value > 0.f ? 1.f : 0.f, r_shadow_pcf_taps.value, r_framedata.shadow_viewproj);
 	R_Shadow_DebugValidateBinding ("ALIAS", GL_TEXTURE5, R_Shadow_GetShadowMapTextureId ());
 

--- a/Quake/r_shadow.c
+++ b/Quake/r_shadow.c
@@ -203,10 +203,34 @@ static void R_Shadow_LogTextureParams (const char *tag, GLuint tex)
 	shdlog.last_shadow_compare_mode = (GLenum)cmode;
 }
 
+static void R_Shadow_SetTextureCompareStateForMode (GLenum compare_mode)
+{
+	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE, compare_mode);
+	if (compare_mode == GL_COMPARE_REF_TO_TEXTURE)
+		glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_FUNC, gl_clipcontrol_able ? GL_GEQUAL : GL_LEQUAL);
+}
+
 static void R_Shadow_SetTextureCompareState (void)
 {
-	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE, GL_COMPARE_REF_TO_TEXTURE);
-	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_FUNC, gl_clipcontrol_able ? GL_GEQUAL : GL_LEQUAL);
+	R_Shadow_SetTextureCompareStateForMode (GL_COMPARE_REF_TO_TEXTURE);
+}
+
+static void R_Shadow_DebugValidateProgramSampler (const char *tag, const char *uniform_name, GLint expected_unit)
+{
+	GLint prog = 0;
+	GLint loc;
+	GLint value = -1;
+	if ((r_shadow_log.value <= 0.f && r_shadow_log_dump.value <= 0.f))
+		return;
+	glGetIntegerv (GL_CURRENT_PROGRAM, &prog);
+	if (prog <= 0)
+		return;
+	loc = glGetUniformLocation ((GLuint)prog, uniform_name);
+	if (loc < 0)
+		return;
+	glGetUniformiv ((GLuint)prog, loc, &value);
+	if (value != expected_unit)
+		R_Shadow_LogWrite ("WARN %s sampler uniform %s=%d expected=%d (prog=%d)\n", tag, uniform_name, value, expected_unit, prog);
 }
 
 void R_Shadow_DebugValidateBinding (const char *tag, GLenum texunit, GLuint expected_tex)
@@ -220,6 +244,7 @@ void R_Shadow_DebugValidateBinding (const char *tag, GLenum texunit, GLuint expe
 	glGetIntegerv (GL_TEXTURE_BINDING_2D, &previous_binding);
 	GL_ActiveTextureFunc (texunit);
 	glGetIntegerv (GL_TEXTURE_BINDING_2D, &bound_tex);
+	R_Shadow_DebugValidateProgramSampler (tag, "ShadowMap", 5);
 	if ((GLuint)bound_tex == expected_tex)
 	{
 		glGetTexParameteriv (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE, &cmode);
@@ -381,12 +406,24 @@ void R_Shadow_Log_ReceiverPassSnapshot (const char *tag, int program, GLenum tex
 	shdlog.last_shadow_tex = expected_tex;
 	R_Shadow_LogWrite ("%s receiver program=%d current_program=%d enable=%d texunit=%d expected_tex=%u bound_tex=%d draw_fbo=%d read_fbo=%d viewport=(%d %d %d %d) scissor=(%d %d %d %d)\n",
 		tag, program, current_program, shadows_enabled, (int)(texunit - GL_TEXTURE0), expected_tex, bound_tex, draw_fbo, read_fbo, vp[0], vp[1], vp[2], vp[3], sc[0], sc[1], sc[2], sc[3]);
-	R_Shadow_LogWrite ("%s params bias=%.6f normalbias=%.6f pcf=%.1f taps=%.1f matrix_col0=(%g %g %g %g) det3x3=%.6g\n",
+	R_Shadow_LogWrite ("%s params bias=%.6f normalbias=%.6f pcf=%.1f taps=%.1f matrix_col0=(%g %g %g %g) matrix_col1=(%g %g %g %g) matrix_col2=(%g %g %g %g) matrix_col3=(%g %g %g %g) det3x3=%.6g\n",
 		tag, bias, normalbias, pcf, taps,
 		shadow_viewproj ? shadow_viewproj[0] : 0.f,
 		shadow_viewproj ? shadow_viewproj[1] : 0.f,
 		shadow_viewproj ? shadow_viewproj[2] : 0.f,
 		shadow_viewproj ? shadow_viewproj[3] : 0.f,
+		shadow_viewproj ? shadow_viewproj[4] : 0.f,
+		shadow_viewproj ? shadow_viewproj[5] : 0.f,
+		shadow_viewproj ? shadow_viewproj[6] : 0.f,
+		shadow_viewproj ? shadow_viewproj[7] : 0.f,
+		shadow_viewproj ? shadow_viewproj[8] : 0.f,
+		shadow_viewproj ? shadow_viewproj[9] : 0.f,
+		shadow_viewproj ? shadow_viewproj[10] : 0.f,
+		shadow_viewproj ? shadow_viewproj[11] : 0.f,
+		shadow_viewproj ? shadow_viewproj[12] : 0.f,
+		shadow_viewproj ? shadow_viewproj[13] : 0.f,
+		shadow_viewproj ? shadow_viewproj[14] : 0.f,
+		shadow_viewproj ? shadow_viewproj[15] : 0.f,
 		det);
 	if (!shadows_enabled)
 		R_Shadow_LogWrite ("WARN receiver shadow branch disabled\n");
@@ -633,10 +670,14 @@ static void R_Shadow_BuildViewProj (float out_viewproj[16], vec4_t out_sun_dir)
 	view[14] = -DotProduct (sun_dir, origin_world);
 
 	{
-		// FIX: Extend depth range backward to include shadow casters behind the camera.
 		float z_extend = zfar;
 		float min_z = -extents[2] - z_extend;
 		float max_z =  extents[2];
+		if (shdlog.active)
+		{
+			R_Shadow_LogWrite ("SUNPASS lightdir=(%.5f %.5f %.5f) ortho_lrtb=(%.3f %.3f %.3f %.3f) near=%.3f far=%.3f extents=(%.3f %.3f %.3f)\n",
+				sun_dir[0], sun_dir[1], sun_dir[2], -extents[0], extents[0], -extents[1], extents[1], min_z, max_z, extents[0], extents[1], extents[2]);
+		}
 		R_Shadow_OrthoMatrix (ortho, -extents[0], extents[0], -extents[1], extents[1], min_z, max_z);
 	}
 
@@ -882,7 +923,15 @@ void R_ResizeShadowMapIfNeeded (void)
 
 void R_Shadow_BindShadowMap (GLenum texunit)
 {
-	GL_BindNative (texunit, GL_TEXTURE_2D, shadow_depth_tex);
+	if (shadow_depth_tex)
+	{
+		GL_BindNative (texunit, GL_TEXTURE_2D, shadow_depth_tex);
+		R_Shadow_SetTextureCompareStateForMode (r_shadow_debug.value >= 3.f ? GL_NONE : GL_COMPARE_REF_TO_TEXTURE);
+	}
+	else
+	{
+		GL_BindNative (texunit, GL_TEXTURE_2D, 0);
+	}
 }
 
 void R_Shadow_BindDlightShadowMap (GLenum texunit)
@@ -1231,20 +1280,20 @@ void R_Shadow_DlightPass (void)
 void R_Shadow_DrawDebug (void)
 {
 	int mode = (int)r_shadow_debug.value;
-	if (mode != 1 && mode != 4)
+	if (mode != 4 && mode != 5)
 		return;
 	if (!glprogs.shadow_debug)
 		return;
-	if (mode == 1 && !shadow_depth_tex)
+	if (mode == 4 && !shadow_depth_tex)
 		return;
-	if (mode == 4 && !shadow_dlight_depth_tex)
+	if (mode == 5 && !shadow_dlight_depth_tex)
 		return;
 
 	GL_BeginGroup ("Shadow map debug");
 
 	GL_UseProgram (glprogs.shadow_debug);
 	GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
-	if (mode == 1)
+	if (mode == 4)
 		GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, shadow_depth_tex);
 	else
 		GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, shadow_dlight_depth_tex);

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -1496,6 +1496,8 @@ if (pass <= BP_ALPHATEST)
 GL_Bind (GL_TEXTURE2, r_fullbright_cheatsafe ? greytexture : lightmap_texture);
 GL_Bind (GL_TEXTURE3, (r_lightingdir.value > 0.f && lightmap_dir_texture) ? lightmap_dir_texture : greytexture);
 R_Shadow_BindShadowMap (GL_TEXTURE5);
+	if (r_shadow_debug.value >= 3.f)
+		GL_BindNative (GL_TEXTURE6, GL_TEXTURE_2D, R_Shadow_GetShadowMapTextureId ());
 R_Shadow_Log_ReceiverPassSnapshot ("WORLD", program, GL_TEXTURE5, R_Shadow_GetShadowMapTextureId (), r_shadows.value > 0.f && r_shadow_sun.value > 0.f, r_shadow_bias.value, r_shadow_normalbias.value, r_shadow_pcf.value > 0.f ? 1.f : 0.f, r_shadow_pcf_taps.value, r_framedata.shadow_viewproj);
 		R_Shadow_DebugValidateBinding ("WORLD", GL_TEXTURE5, R_Shadow_GetShadowMapTextureId ());
 }

--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -99,7 +99,8 @@ const int ALIAS_FLAG_LIGHTNING = 4;
 layout(binding=0) uniform sampler2D Tex;
 layout(binding=1) uniform sampler2D FullbrightTex;
 layout(binding=2) uniform sampler2D EmissiveTex;
-layout(binding=5) uniform sampler2D ShadowMap;
+layout(binding=5) uniform sampler2DShadow ShadowMap;
+layout(binding=6) uniform sampler2D ShadowMapRaw;
 
 #define SHADOW_SUN 1
 #include "shadow_sample.glsl"
@@ -168,10 +169,27 @@ void main()
 		vec3 world_pos = in_pos + EyePos;
 		vec3 shadow_normal = gl_FrontFacing ? in_normal : -in_normal;
 		shadow_term = ShadowVisibility(world_pos, shadow_normal, shadow_range);
-		if (ShadowDebug.y > 1.5)
+		if (ShadowDebug.y > 0.5)
 		{
-			float debug_value = (ShadowDebug.y > 2.5) ? shadow_range : shadow_term;
-			out_fragcolor = vec4(vec3(debug_value), 1.0);
+			if (ShadowDebug.y < 1.5)
+				OUT_COLOR = vec4(vec3(shadow_term), 1.0);
+			else if (ShadowDebug.y < 2.5)
+			{
+				vec4 shadow_clip = ShadowViewProj * vec4(world_pos, 1.0);
+				vec3 proj = shadow_clip.xyz / max(shadow_clip.w, 1e-6);
+				vec2 uv = proj.xy * 0.5 + 0.5;
+				float reference = ShadowReference01(proj.z);
+				OUT_COLOR = vec4(uv, reference, 1.0);
+			}
+			else
+			{
+				vec4 shadow_clip = ShadowViewProj * vec4(world_pos, 1.0);
+				vec3 proj = shadow_clip.xyz / max(shadow_clip.w, 1e-6);
+				vec2 uv = proj.xy * 0.5 + 0.5;
+				float reference = ShadowReference01(proj.z);
+				float raw_depth = texture(ShadowMapRaw, uv).r;
+				OUT_COLOR = vec4(raw_depth, reference, shadow_term, 1.0);
+			}
 #if !OIT
 			out_velocity = vec4(0.0);
 #endif
@@ -213,7 +231,7 @@ void main()
         result.rgb = clamp(result.rgb, 0.0, 1.0);
 
         result.rgb = ApplyFog(result.rgb, in_pos);
-        out_fragcolor = result;
+        OUT_COLOR = result;
 #if !OIT
         vec2 velocity = ComputeVelocity(in_curr_clip, in_prev_clip);
         float viewModelMask = ((in_flags & ALIAS_FLAG_NO_MOTION_BLUR) != 0) ? 1.0 : 0.0;
@@ -226,11 +244,11 @@ void main()
 	// Note: sign bit is used as overbright flag
 	if (abs(Fog.w) > 0.)
 	{
-		out_fragcolor.rgb = sqrt(out_fragcolor.rgb);
-		out_fragcolor.rgb += SCREEN_SPACE_NOISE() * ScreenDither;
-		out_fragcolor.rgb *= out_fragcolor.rgb;
+		OUT_COLOR.rgb = sqrt(OUT_COLOR.rgb);
+		OUT_COLOR.rgb += SCREEN_SPACE_NOISE() * ScreenDither;
+		OUT_COLOR.rgb *= OUT_COLOR.rgb;
 	}
 #else
-	out_fragcolor.rgb += SUPPRESS_BANDING() * ScreenDither;
+	OUT_COLOR.rgb += SUPPRESS_BANDING() * ScreenDither;
 #endif
 }

--- a/Quake/shaders/shadow_sample.glsl
+++ b/Quake/shaders/shadow_sample.glsl
@@ -91,10 +91,33 @@ float ShadowCompare(float depth, float reference, float bias)
 // ===========================================================================
 #ifdef SHADOW_SUN
 
+float ShadowSampleRawDepth(vec2 uv)
+{
+    return texture(ShadowMapRaw, uv).r;
+}
+
+float ShadowSampleRawCompare(vec2 uv, float reference)
+{
+    return texture(ShadowMap, vec3(uv, reference));
+}
+
+float ShadowApplyBias(float reference, float bias)
+{
+#if REVERSED_Z
+    return clamp(reference - bias, 0.0, 1.0);
+#else
+    return clamp(reference + bias, 0.0, 1.0);
+#endif
+}
+
 float ShadowSampleRaw(vec2 uv, float reference, float bias)
 {
-    float depth = texture(ShadowMap, uv).r;
-    return ShadowCompare(depth, reference, bias);
+    if (ShadowDebug.y > 2.5)
+    {
+        float depth = ShadowSampleRawDepth(uv);
+        return ShadowCompare(depth, reference, bias);
+    }
+    return ShadowSampleRawCompare(uv, ShadowApplyBias(reference, bias));
 }
 
 // FIX 5: taps-Wert-Semantik dokumentiert:
@@ -167,12 +190,15 @@ float ShadowVisibility(vec3 world_pos, vec3 normal, out float in_range)
     vec2 uv        = proj.xy * 0.5 + 0.5;
     float reference = ShadowReference01(proj.z);
 
-    // inside-Test: UV in [0,1]² und reference immer in [0,1] durch clamp
     bool inside = all(greaterThanEqual(uv, vec2(0.0))) &&
-                  all(lessThanEqual   (uv, vec2(1.0)));
+                  all(lessThanEqual   (uv, vec2(1.0))) &&
+                  reference >= 0.0 && reference <= 1.0;
     in_range = inside ? 1.0 : 0.0;
     if (!inside)
         return 1.0;
+
+    if (ShadowDebug.y > 3.5)
+        return ShadowSampleRawCompare(uv, reference);
 
     float ndotl = clamp(dot(normal, -ShadowSunDir.xyz), 0.0, 1.0);
     float bias  = ShadowParams.x + ShadowParams.y * (1.0 - ndotl);

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -7,7 +7,8 @@
 #endif
 layout(binding=2) uniform sampler2D LMTex;
 layout(binding=3) uniform sampler2D LMTexDir;
-layout(binding=5) uniform sampler2D ShadowMap;
+layout(binding=5) uniform sampler2DShadow ShadowMap;
+layout(binding=6) uniform sampler2D ShadowMapRaw;
 #include "frame_uniforms.glsl"
 #define SHADOW_SUN 1
 #include "shadow_sample.glsl"
@@ -456,11 +457,27 @@ void main()
 		bool shadow_enabled  = ShadowDebug.x > 0.5;
 		bool lightgrid_shadow = LightgridParams.z > 0.5 && LightgridParams.x > 0.5;
 
-		if (shadow_enabled && ShadowDebug.y > 1.5)
+		if (shadow_enabled && ShadowDebug.y > 0.5)
 		{
-			float debug_value = (ShadowDebug.y > 2.5) ? shadow_range : shadow_term;
-			// BUG FIX: same out_fragcolor alias issue
-			OUT_COLOR = vec4(vec3(debug_value), 1.0);
+			if (ShadowDebug.y < 1.5)
+				OUT_COLOR = vec4(vec3(shadow_term), 1.0);
+			else if (ShadowDebug.y < 2.5)
+			{
+				vec4 shadow_clip = ShadowViewProj * vec4(in_pos, 1.0);
+				vec3 proj = shadow_clip.xyz / max(shadow_clip.w, 1e-6);
+				vec2 uv = proj.xy * 0.5 + 0.5;
+				float reference = ShadowReference01(proj.z);
+				OUT_COLOR = vec4(uv, reference, 1.0);
+			}
+			else
+			{
+				vec4 shadow_clip = ShadowViewProj * vec4(in_pos, 1.0);
+				vec3 proj = shadow_clip.xyz / max(shadow_clip.w, 1e-6);
+				vec2 uv = proj.xy * 0.5 + 0.5;
+				float reference = ShadowReference01(proj.z);
+				float raw_depth = texture(ShadowMapRaw, uv).r;
+				OUT_COLOR = vec4(raw_depth, reference, shadow_term, 1.0);
+			}
 #if !OIT
 			out_velocity = vec4(0.0);
 #endif


### PR DESCRIPTION
### Motivation
- Sun shadows were rendering incorrectly because the receiver sampling path and reference-depth mapping did not unambiguously match the depth texture sampling path under Reverse-Z and hardware compare modes. 
- Addable shader debug visualizations were needed to prove whether compares return always 0/1, to inspect UVs and the raw depth values, and to diagnose matrix / bias mismatches.

### Description
- Shader changes: switched receiver shaders to use a hardware compare sampler (`sampler2DShadow ShadowMap`) and added a second `sampler2D ShadowMapRaw` for raw-depth debug reads, and implemented receiver debug modes (`r_shadow_debug` semantics implemented in world/alias shaders) to show shadow factor, UV+reference, and raw-depth diagnostics; updated `shadow_sample.glsl` to provide `ShadowSampleRawDepth`, `ShadowSampleRawCompare`, `ShadowApplyBias`, and to apply bias to the reference for Reverse-Z before `sampler2DShadow` lookups.
- Compare / Reverse-Z handling: made the compare semantics explicit (compile-time path via `REVERSED_Z`) and applied bias to the reference for the `sampler2DShadow` path so `GL_COMPARE_REF_TO_TEXTURE` with `GL_GEQUAL` (Reverse-Z) matches the manual-compare logic.
- Debug plumbing (CPU): when `r_shadow_debug >= 3` the code now binds the shadow depth texture also to texture unit 6 for `ShadowMapRaw` reads, and `R_Shadow_BindShadowMap` toggles the texture compare mode to `GL_NONE` in that debug mode so raw sampling works without affecting normal behavior.
- Logging & validation: added `R_Shadow_DebugValidateProgramSampler` to verify the sampler uniform points to unit 5, expanded `R_Shadow_Log_ReceiverPassSnapshot` to print all 4 matrix columns for the shadow viewproj, and added a one-shot SUNPASS log of `lightdir` + ortho bounds/near/far/extents to aid diagnosis.

### Testing
- Ran static checks: `git diff --check` returned no whitespace/patch issues and the modified files were committed successfully.
- Build attempt: `make` in `/workspace/ironwail/Quake` was run but failed due to missing system dependencies (`sdl2-config` / `SDL.h`) in the container, so a full compile/run test could not be performed in this environment.
- Smoke diagnostics: code-level validation hooks were added (sampler uniform verification, full matrix logging, and toggled compare-mode) to enable fast runtime debugging once a build/run is possible; those paths are gated by `r_shadow_log`/`r_shadow_debug` and do not change normal runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a52ae8538832eb2792c3c13c796a1)