### PR TITLE
Fix MSVC shadow debug compile errors

### DIFF
--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -173,6 +173,7 @@ extern	const char	*gl_version;
 	x(void,			VertexAttribPointer, (GLuint index, GLint size, GLenum type, GLboolean normalized, GLsizei stride, const GLvoid *pointer))\
 	x(void,			VertexAttribIPointer, (GLuint index, GLint size, GLenum type, GLsizei stride, const GLvoid *pointer))\
 	x(GLint,		GetUniformLocation, (GLuint program, const GLchar *name))\
+	x(void,			GetUniformiv, (GLuint program, GLint location, GLint *params))\
 	x(void,			GetActiveUniform, (GLuint program, GLuint index, GLsizei bufSize, GLsizei *length, GLint *size, GLenum *type, GLchar *name))\
 	x(void,			Uniform1i, (GLint location, GLint v0))\
 	x(void,			Uniform1f, (GLint location, GLfloat v0))\

--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -37,6 +37,7 @@ extern cvar_t r_shadows;
 extern cvar_t r_shadow_sun;
 extern cvar_t r_shadow_pcf;
 extern cvar_t r_shadow_pcf_taps;
+extern cvar_t r_shadow_debug;
 extern cvar_t r_shadow_twosided_mdl;
 
 //up to 16 color translated skins

--- a/Quake/r_shadow.c
+++ b/Quake/r_shadow.c
@@ -225,10 +225,10 @@ static void R_Shadow_DebugValidateProgramSampler (const char *tag, const char *u
 	glGetIntegerv (GL_CURRENT_PROGRAM, &prog);
 	if (prog <= 0)
 		return;
-	loc = glGetUniformLocation ((GLuint)prog, uniform_name);
+	loc = GL_GetUniformLocationFunc ((GLuint)prog, uniform_name);
 	if (loc < 0)
 		return;
-	glGetUniformiv ((GLuint)prog, loc, &value);
+	GL_GetUniformivFunc ((GLuint)prog, loc, &value);
 	if (value != expected_unit)
 		R_Shadow_LogWrite ("WARN %s sampler uniform %s=%d expected=%d (prog=%d)\n", tag, uniform_name, value, expected_unit, prog);
 }

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -45,6 +45,7 @@ extern cvar_t r_shadow_bias;
 extern cvar_t r_shadow_normalbias;
 extern cvar_t r_shadow_pcf;
 extern cvar_t r_shadow_pcf_taps;
+extern cvar_t r_shadow_debug;
 extern cvar_t r_shadow_dlights;
 extern cvar_t r_shadow_dlight_bias;
 extern cvar_t r_shadow_dlight_pcf_taps;


### PR DESCRIPTION
### Motivation
- MSVC builds failed due to an undeclared `r_shadow_debug` variable referenced in rendering modules and direct `glGetUniformLocation`/`glGetUniformiv` calls that are not available as direct symbols in the engine's GL loader approach. 
- The change ensures shadow debug checks compile cleanly and uses the engine's GL function-pointer abstraction for portability.

### Description
- Register `GetUniformiv` in the core GL function table by adding `x(void, GetUniformiv, (GLuint program, GLint location, GLint *params))` in `Quake/glquake.h`. 
- Add missing `extern cvar_t r_shadow_debug;` declarations to `Quake/r_alias.c` and `Quake/r_world.c` so references to `r_shadow_debug.value` compile. 
- Replace direct OpenGL calls in `Quake/r_shadow.c` with the engine function-pointer wrappers: `GL_GetUniformLocationFunc` and `GL_GetUniformivFunc` for sampler debug validation.

### Testing
- Ran `git diff --check` which produced no whitespace or diff errors and returned successfully. 
- Ran project-wide searches (`rg`) to verify the new `GetUniformiv` entry and that `r_shadow_debug` and the `GL_GetUniform*Func` replacements appear in the expected files and locations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a54aa5784832e9f8e7d14d465a81b)