### PR TITLE
Bind WORLD program before shadow receiver uniform uploads

### DIFF
--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -1492,6 +1492,7 @@ static void R_DrawBrushModels_Real (entity_t **ents, int count, brushpass_t pass
 
         R_ResetBModelCalls (program);
         GL_SetState (state);
+        GL_UseProgram (program);
 if (pass <= BP_ALPHATEST)
 {
 GL_Bind (GL_TEXTURE2, r_fullbright_cheatsafe ? greytexture : lightmap_texture);


### PR DESCRIPTION
### Motivation
- Fix incorrect shadow debug output caused when WORLD receiver uniforms were uploaded while a different GLSL program was still bound, which made `R_Shadow_Log_ReceiverPassSnapshot` report mismatched `program`/`current_program` and produced unstable debug modes.

### Description
- Add `GL_UseProgram(program);` in `R_DrawBrushModels_Real` (file `Quake/r_world.c`) immediately after `GL_SetState(state)` so WORLD receiver texture/state setup and `R_Shadow_Log_ReceiverPassSnapshot` execute with the intended WORLD program bound; the ALIAS path already binds its program beforehand so no ALIAS-side changes were required.

### Testing
- No automated tests were run for this tiny, surgical change; the patch was validated by code inspection and basic static checks (`rg`/`git diff`) and committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a5d569cbc832ea3d08e628788944d)