### PR TITLE
Fix stale GL program cache during palette LUT update

### DIFF
--- a/Quake/gl_texmgr.c
+++ b/Quake/gl_texmgr.c
@@ -3004,7 +3004,12 @@ void GLPalette_UpdateLookupTable (void)
 	memcpy (cached_palette, d_8to24table, sizeof (cached_palette));
 	GLPalette_InvalidateRemapped ();
 
-	GL_UseProgramFunc (glprogs.palette_init[metric]);
+	/*
+	 * Keep GL's tracked current program in sync with the actual binding.
+	 * Bypassing GL_UseProgram() here can leave gl_current_program stale,
+	 * which later causes render passes to skip required rebinding.
+	 */
+	GL_UseProgram (glprogs.palette_init[metric]);
 	GL_BindImageTextureFunc (0, gl_palette_lut, 0, GL_TRUE, 0, GL_WRITE_ONLY, GL_R8UI);
 	GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 0, gl_palette_buffer[0], 0, 256 * sizeof (GLuint));
 	GL_BufferSubDataFunc (GL_SHADER_STORAGE_BUFFER, 0, 256 * sizeof (GLuint), d_8to24table);


### PR DESCRIPTION
### Motivation
- Shadow receiver uniforms/logging could be corrupted because the palette LUT update path called the raw GL entrypoint and bypassed the renderer's `gl_current_program` cache, allowing later passes to incorrectly skip `GL_UseProgram()` and leave the wrong program bound (e.g. the WORLD receiver logging showed `program=63 current_program=194`).

### Description
- Replace `GL_UseProgramFunc(glprogs.palette_init[metric])` with `GL_UseProgram(glprogs.palette_init[metric])` in `Quake/gl_texmgr.c` and add a short comment explaining that the wrapper keeps the tracked `gl_current_program` in sync with the real GL binding.

### Testing
- Ran ripgrep to confirm the change is present in `Quake/gl_texmgr.c` and inspected the related `GL_UseProgram` wrapper in `Quake/gl_shaders.c` to ensure it updates `gl_current_program` as intended; these checks passed. 
- Attempted an automated configure/build but CMake configuration failed in this environment due to missing SDL2 development package, so a full compile/run test could not be performed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a617a5a1c832e9e3c4cdad16dc3b8)