### PR TITLE
Fix WORLD shadow receiver program binding/cache validation

### DIFF
--- a/Quake/gl_shaders.c
+++ b/Quake/gl_shaders.c
@@ -484,6 +484,11 @@ void GL_UseProgram (GLuint program)
 	GL_UseProgramFunc (program);
 }
 
+GLuint GL_GetCurrentProgram (void)
+{
+	return gl_current_program;
+}
+
 /*
 ====================
 GL_ClearCachedProgram

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -504,7 +504,7 @@ void R_Shadow_DebugValidateBinding (const char *tag, GLenum texunit, GLuint expe
 void R_Shadow_Log_BeginFrame (void);
 void R_Shadow_Log_SunPassEarlyOut (const char *reason);
 void R_Shadow_Log_ShadowPassSnapshot (const char *tag, GLuint fbo, GLuint depth_tex, int vpw, int vph, int drawcalls, int tris, double msec);
-void R_Shadow_Log_ReceiverPassSnapshot (const char *tag, int program, GLenum texunit, GLuint expected_tex, qboolean shadows_enabled, float bias, float normalbias, float pcf, float taps, const float *shadow_viewproj);
+void R_Shadow_Log_ReceiverPassSnapshot (const char *tag, int program, GLint cached_current_program, GLenum texunit, GLuint expected_tex, qboolean shadows_enabled, float bias, float normalbias, float pcf, float taps, const float *shadow_viewproj);
 GLuint R_Shadow_GetShadowMapTextureId (void);
 GLuint R_Shadow_GetDlightShadowMapTextureId (void);
 
@@ -632,6 +632,7 @@ typedef struct glprogs_s {
 extern glprogs_t glprogs;
 
 void GL_UseProgram (GLuint program);
+GLuint GL_GetCurrentProgram (void);
 void GL_ClearCachedProgram (void);
 void GL_CreateShaders (void);
 void GL_DeleteShaders (void);

--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -592,7 +592,7 @@ ibuf.global.half_lambert = CLAMP (0.f, r_model_halflambert.value, 1.f);
 	R_Shadow_BindShadowMap (GL_TEXTURE5);
 	if (r_shadow_debug.value >= 3.f)
 		GL_BindNative (GL_TEXTURE6, GL_TEXTURE_2D, R_Shadow_GetShadowMapTextureId ());
-	R_Shadow_Log_ReceiverPassSnapshot ("ALIAS", glprogs.alias[oit][mode][alphatest][md5], GL_TEXTURE5, R_Shadow_GetShadowMapTextureId (), r_shadows.value > 0.f && r_shadow_sun.value > 0.f, r_shadow_bias_mdl.value, r_shadow_normalbias_mdl.value, r_shadow_pcf.value > 0.f ? 1.f : 0.f, r_shadow_pcf_taps.value, r_framedata.shadow_viewproj);
+	R_Shadow_Log_ReceiverPassSnapshot ("ALIAS", glprogs.alias[oit][mode][alphatest][md5], (GLint)GL_GetCurrentProgram (), GL_TEXTURE5, R_Shadow_GetShadowMapTextureId (), r_shadows.value > 0.f && r_shadow_sun.value > 0.f, r_shadow_bias_mdl.value, r_shadow_normalbias_mdl.value, r_shadow_pcf.value > 0.f ? 1.f : 0.f, r_shadow_pcf_taps.value, r_framedata.shadow_viewproj);
 	R_Shadow_DebugValidateBinding ("ALIAS", GL_TEXTURE5, R_Shadow_GetShadowMapTextureId ());
 
 	for (hdr = mainhdr; hdr; hdr = hdr->nextsurface ? (aliashdr_t *) ((byte *)hdr + hdr->nextsurface) : NULL)

--- a/Quake/r_shadow.c
+++ b/Quake/r_shadow.c
@@ -377,7 +377,7 @@ void R_Shadow_Log_ShadowPassSnapshot (const char *tag, GLuint fbo, GLuint depth_
 	R_Shadow_LogGLStage (tag);
 }
 
-void R_Shadow_Log_ReceiverPassSnapshot (const char *tag, int program, GLenum texunit, GLuint expected_tex, qboolean shadows_enabled, float bias, float normalbias, float pcf, float taps, const float *shadow_viewproj)
+void R_Shadow_Log_ReceiverPassSnapshot (const char *tag, int program, GLint cached_current_program, GLenum texunit, GLuint expected_tex, qboolean shadows_enabled, float bias, float normalbias, float pcf, float taps, const float *shadow_viewproj)
 {
 	GLint active_tex, bound_tex, draw_fbo, read_fbo, current_program;
 	GLint vp[4], sc[4];
@@ -390,7 +390,13 @@ void R_Shadow_Log_ReceiverPassSnapshot (const char *tag, int program, GLenum tex
 	GL_ActiveTextureFunc (texunit);
 	glGetIntegerv (GL_TEXTURE_BINDING_2D, &bound_tex);
 	GL_ActiveTextureFunc (active_tex);
+#if defined(SHDLOG)
 	glGetIntegerv (GL_CURRENT_PROGRAM, &current_program);
+#else
+	current_program = cached_current_program;
+	if (r_shadow_debug.value > 0.f)
+		glGetIntegerv (GL_CURRENT_PROGRAM, &current_program);
+#endif
 	glGetIntegerv (GL_DRAW_FRAMEBUFFER_BINDING, &draw_fbo);
 	glGetIntegerv (GL_READ_FRAMEBUFFER_BINDING, &read_fbo);
 	glGetIntegerv (GL_VIEWPORT, vp);
@@ -404,8 +410,8 @@ void R_Shadow_Log_ReceiverPassSnapshot (const char *tag, int program, GLenum tex
 	shdlog.last_program = program;
 	shdlog.last_shadow_sampler_unit = (GLint)(texunit - GL_TEXTURE0);
 	shdlog.last_shadow_tex = expected_tex;
-	R_Shadow_LogWrite ("%s receiver program=%d current_program=%d enable=%d texunit=%d expected_tex=%u bound_tex=%d draw_fbo=%d read_fbo=%d viewport=(%d %d %d %d) scissor=(%d %d %d %d)\n",
-		tag, program, current_program, shadows_enabled, (int)(texunit - GL_TEXTURE0), expected_tex, bound_tex, draw_fbo, read_fbo, vp[0], vp[1], vp[2], vp[3], sc[0], sc[1], sc[2], sc[3]);
+	R_Shadow_LogWrite ("%s receiver program=%d cached_current=%d gl_current=%d enable=%d texunit=%d expected_tex=%u bound_tex=%d draw_fbo=%d read_fbo=%d viewport=(%d %d %d %d) scissor=(%d %d %d %d)\n",
+		tag, program, cached_current_program, current_program, shadows_enabled, (int)(texunit - GL_TEXTURE0), expected_tex, bound_tex, draw_fbo, read_fbo, vp[0], vp[1], vp[2], vp[3], sc[0], sc[1], sc[2], sc[3]);
 	R_Shadow_LogWrite ("%s params bias=%.6f normalbias=%.6f pcf=%.1f taps=%.1f matrix_col0=(%g %g %g %g) matrix_col1=(%g %g %g %g) matrix_col2=(%g %g %g %g) matrix_col3=(%g %g %g %g) det3x3=%.6g\n",
 		tag, bias, normalbias, pcf, taps,
 		shadow_viewproj ? shadow_viewproj[0] : 0.f,

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -1493,20 +1493,43 @@ static void R_DrawBrushModels_Real (entity_t **ents, int count, brushpass_t pass
         R_ResetBModelCalls (program);
         GL_SetState (state);
         GL_UseProgram (program);
+#if defined(SHDLOG)
+        {
+                GLint gl_current_program = 0;
+                glGetIntegerv (GL_CURRENT_PROGRAM, &gl_current_program);
+                if ((GLuint)gl_current_program != program)
+                {
+                        GL_ClearCachedProgram ();
+                        GL_UseProgram (program);
+                }
+        }
+#endif
 if (pass <= BP_ALPHATEST)
 {
+GL_UseProgram (program);
+#if defined(SHDLOG)
+{
+GLint gl_current_program = 0;
+glGetIntegerv (GL_CURRENT_PROGRAM, &gl_current_program);
+if ((GLuint)gl_current_program != program)
+{
+        GL_ClearCachedProgram ();
+        GL_UseProgram (program);
+}
+}
+#endif
 GL_Bind (GL_TEXTURE2, r_fullbright_cheatsafe ? greytexture : lightmap_texture);
 GL_Bind (GL_TEXTURE3, (r_lightingdir.value > 0.f && lightmap_dir_texture) ? lightmap_dir_texture : greytexture);
 R_Shadow_BindShadowMap (GL_TEXTURE5);
 	if (r_shadow_debug.value >= 3.f)
 		GL_BindNative (GL_TEXTURE6, GL_TEXTURE_2D, R_Shadow_GetShadowMapTextureId ());
-R_Shadow_Log_ReceiverPassSnapshot ("WORLD", program, GL_TEXTURE5, R_Shadow_GetShadowMapTextureId (), r_shadows.value > 0.f && r_shadow_sun.value > 0.f, r_shadow_bias.value, r_shadow_normalbias.value, r_shadow_pcf.value > 0.f ? 1.f : 0.f, r_shadow_pcf_taps.value, r_framedata.shadow_viewproj);
+R_Shadow_Log_ReceiverPassSnapshot ("WORLD", program, (GLint)GL_GetCurrentProgram (), GL_TEXTURE5, R_Shadow_GetShadowMapTextureId (), r_shadows.value > 0.f && r_shadow_sun.value > 0.f, r_shadow_bias.value, r_shadow_normalbias.value, r_shadow_pcf.value > 0.f ? 1.f : 0.f, r_shadow_pcf_taps.value, r_framedata.shadow_viewproj);
 		R_Shadow_DebugValidateBinding ("WORLD", GL_TEXTURE5, R_Shadow_GetShadowMapTextureId ());
 }
 else if (pass == BP_DLIGHT_SOLID || pass == BP_DLIGHT_ALPHA)
 {
 R_Shadow_BindDlightShadowMap (GL_TEXTURE5);
-		R_Shadow_Log_ReceiverPassSnapshot ("WORLD_DLIGHT", program, GL_TEXTURE5, R_Shadow_GetDlightShadowMapTextureId (),
+		R_Shadow_Log_ReceiverPassSnapshot ("WORLD_DLIGHT", program, (GLint)GL_GetCurrentProgram (), GL_TEXTURE5, R_Shadow_GetDlightShadowMapTextureId (),
 			r_shadows.value > 0.f && r_shadow_dlights.value > 0.f, r_shadow_dlight_bias.value, 0.f,
 			r_shadow_dlight_pcf_taps.value > 0.f ? 1.f : 0.f, r_shadow_dlight_pcf_taps.value, r_framedata.shadow_viewproj);
 		R_Shadow_DebugValidateBinding ("WORLD_DLIGHT", GL_TEXTURE5, R_Shadow_GetDlightShadowMapTextureId ());
@@ -1614,6 +1637,18 @@ GL_Bind (GL_TEXTURE2, skybox->cubemap);
 		baseinst += numinst;
         }
 
+	GL_UseProgram (program);
+#if defined(SHDLOG)
+	{
+		GLint gl_current_program = 0;
+		glGetIntegerv (GL_CURRENT_PROGRAM, &gl_current_program);
+		if ((GLuint)gl_current_program != program)
+		{
+			GL_ClearCachedProgram ();
+			GL_UseProgram (program);
+		}
+	}
+#endif
 	R_FlushBModelCalls ();
 
 	if (pass == BP_SOLID || pass == BP_ALPHATEST)


### PR DESCRIPTION
### Motivation
- The WORLD shadow receiver was observed running with the ALIAS GL program active (logs showed `WORLD program=63 current_program=194`), indicating a program bind/cache mismatch at the receiver uniform/upload or draw site.
- The patch must ensure the WORLD program is bound when uniforms/samplers are set and at draw time and must add debug-only verification of the real GL `GL_CURRENT_PROGRAM` to detect stale cache vs driver state.

### Description
- Repaired the WORLD receiver path in `R_DrawBrushModels_Real` (`Quake/r_world.c`) to re-bind the WORLD program immediately before receiver uniform/sampler setup and again immediately before `R_FlushBModelCalls()` (draw submission), and added debug-only verification using `glGetIntegerv(GL_CURRENT_PROGRAM, ...)` with fallback to call `GL_ClearCachedProgram()` + `GL_UseProgram(program)` when mismatch detected (changes near `R_DrawBrushModels_Real` around lines ~1493-1527 and ~1640-1652). 
- Extended `R_Shadow_Log_ReceiverPassSnapshot` in `Quake/r_shadow.c` to accept the cached program value and to log both cached and real GL program values as `cached_current` and `gl_current`, while gating `glGetIntegerv(GL_CURRENT_PROGRAM, ...)` behind debug-only macros/runtime checks (function header and logging changes around lines ~380-415).
- Added `GLuint GL_GetCurrentProgram(void)` to `Quake/gl_shaders.c` and declared it in `Quake/glquake.h` so callers can obtain the cached program id for logging (added at `gl_shaders.c` ~L487-L490 and `glquake.h` declarations ~L507 and ~L634-L636).
- Updated receiver snapshot call sites to pass the cached program: `R_Shadow_Log_ReceiverPassSnapshot` calls in `Quake/r_world.c` and `Quake/r_alias.c` now pass `(GLint)GL_GetCurrentProgram()` (call-site changes around `r_world.c` ~L1526-L1534 and `r_alias.c` ~L592-L596).
- Kept all GL queries and extra `glGetIntegerv(GL_CURRENT_PROGRAM, ...)` in debug-only paths (`#if defined(SHDLOG)` or guarded by `r_shadow_debug`), per constraints.

Touched files/functions (high-level):
- `R_DrawBrushModels_Real` in `Quake/r_world.c` (rebind before receiver setup and before flush) — ~L1493-L1527, ~L1640-L1652.
- `R_Shadow_Log_ReceiverPassSnapshot` in `Quake/r_shadow.c` (signature + logging + debug gl state read) — ~L380-L415.
- `GL_UseProgram` area plus new `GL_GetCurrentProgram` in `Quake/gl_shaders.c` — ~L479-L490.
- Declarations in `Quake/glquake.h` (changed prototype for `R_Shadow_Log_ReceiverPassSnapshot`, added `GL_GetCurrentProgram`) — prototypes around ~L507 and ~L634-L636.
- Call-site updates in `Quake/r_alias.c` and `Quake/r_world.c` to pass cached program into the logging helper — ~L592-L596 and ~L1526-L1534.

### Testing
- Attempted build: `make -j4` at repository root; no top-level Makefile, so no targets found (automated build not possible in root). This run returned an error (no targets).
- Attempted build: `make -j4` in `Quake/` to compile modified code; build failed due to missing system dependency `sdl2-config` / header `SDL.h`, so full compile-time/run-time verification was blocked by environment; no runtime GL validation could be executed.
- Static verification performed via code inspection and searching to confirm modified call sites, new function declaration/definition, and inserted debug-only GL checks were applied as intended; these checks succeeded (files updated and local diffs produced as shown).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a63245cfc832ebdd6fe107546d214)