### PR TITLE
Remove duplicate R_Shadow_GetShadowMapTextureId definition

### DIFF
--- a/Quake/r_shadow.c
+++ b/Quake/r_shadow.c
@@ -742,11 +742,6 @@ void R_Shadow_BindDlightShadowMap (GLenum texunit)
 		GL_BindNative (texunit, GL_TEXTURE_2D, 0);
 }
 
-GLuint R_Shadow_GetShadowMapTextureId (void)
-{
-	return shadow_dlight_depth_tex;
-}
-
 GLuint R_Shadow_GetDlightShadowMapTextureId (void)
 {
 	return shadow_dlight_depth_tex;


### PR DESCRIPTION
### Motivation
- Remove a duplicate definition of `R_Shadow_GetShadowMapTextureId` in `Quake/r_shadow.c` to resolve MSVC error C2084 caused by multiple function bodies for the same symbol during compilation.

### Description
- Deleted the redundant `R_Shadow_GetShadowMapTextureId` implementation in `Quake/r_shadow.c` while keeping the single remaining `R_Shadow_GetShadowMapTextureId` and `R_Shadow_GetDlightShadowMapTextureId` accessors intact.

### Testing
- Ran `rg -n "R_Shadow_GetShadowMapTextureId (void)" Quake/r_shadow.c` to confirm only one definition remains and committed the change with `git commit`, both commands succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b2a12fda0832e94d0c008f62273ac)