### PR TITLE
Provide missing dlight shadow uniforms in alias.frag to fix GLSL compile errors

### DIFF
--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -100,6 +100,14 @@ layout(binding=1) uniform sampler2D FullbrightTex;
 layout(binding=2) uniform sampler2D EmissiveTex;
 layout(binding=5) uniform sampler2D ShadowDlightMap;
 
+// alias shaders use an SSBO-backed frame block and don't include frame_uniforms.glsl.
+// Provide the dynamic-light shadow uniforms explicitly so shadow_sample.glsl compiles.
+#define SHADOW_DLIGHT_MAX 4
+uniform mat4 ShadowDlightViewProj[SHADOW_DLIGHT_MAX];
+uniform vec4 ShadowDlightAtlas[SHADOW_DLIGHT_MAX];
+uniform vec4 ShadowDlightInfo[SHADOW_DLIGHT_MAX];
+uniform vec4 ShadowDlightParams;
+
 #define SHADOW_DLIGHT 1
 #include "shadow_sample.glsl"
 


### PR DESCRIPTION
### Motivation
- The alias fragment shader included `shadow_sample.glsl` but did not provide the dynamic-light shadow uniforms and `SHADOW_DLIGHT_MAX` that the included file references, causing GLSL compile-time undefined-variable errors for `ShadowDlightParams`, `ShadowDlightInfo`, and `SHADOW_DLIGHT_MAX` during startup (e.g. `alias|OIT ... fragment shader` errors). 

### Description
- Added explicit declarations for `SHADOW_DLIGHT_MAX`, `ShadowDlightViewProj`, `ShadowDlightAtlas`, `ShadowDlightInfo`, and `ShadowDlightParams` at the top of `Quake/shaders/alias.frag` before `#include "shadow_sample.glsl"` so the included shader has the symbols it expects. 
- Left `#define SHADOW_DLIGHT 1` in place to enable the dynamic-light shadow code path in `shadow_sample.glsl`.

### Testing
- Ran a configure/build attempt with `cmake -S . -B build && cmake --build build -j2` and the build configuration failed due to missing system dependency `SDL2` (no `SDL2Config.cmake`), which is unrelated to the shader change and prevented a full compile in this environment. 
- Verified the shader source file `Quake/shaders/alias.frag` was updated and committed successfully; no GLSL compilation was performed here due to the missing SDL2 development files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b2bdae178832eb8c9cda59c64c175)