### PR TITLE
Fix alias shader SSBO block name mismatch

### DIFF
--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -1,5 +1,5 @@
 
-layout(std430, binding=1) restrict readonly buffer AliasFrameBuffer
+layout(std430, binding=1) restrict readonly buffer InstanceBuffer
 {
 	mat4	ViewProj;
 	mat4	PrevViewProj;


### PR DESCRIPTION
### Motivation
- Fix a GLSL interface block name mismatch that causes shader program link errors for the alias pipeline because vertex and fragment stages used different SSBO block names for the same `binding=1` frame/instance uniform data.

### Description
- Rename the SSBO block in `Quake/shaders/alias.frag` from `AliasFrameBuffer` to `InstanceBuffer` so it matches the vertex shader's `layout(std430, binding=1) restrict readonly buffer InstanceBuffer` declaration.

### Testing
- Verified the change with `git diff` on `Quake/shaders/alias.frag`, searched for the block name with `rg -n "buffer (AliasFrameBuffer|InstanceBuffer)" Quake/shaders/alias.frag`, committed the change with `git commit`, and inspected the file head with `nl -ba Quake/shaders/alias.frag`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b3cc3a760832eb9a5fa1af253092f)