### PR TITLE
Fix alias shader SSBO interface block mismatch

### DIFF
--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -1,4 +1,16 @@
 
+struct InstanceData
+{
+	vec4	WorldMatrix[3];
+	vec4	PrevWorldMatrix[3];
+	vec4	LightColor; // xyz=LightColor w=Alpha
+	vec4	DLightColor; // xyz=DLightColor
+	int		Pose1;
+	int		Pose2;
+	float	Blend;
+	int		Flags;
+};
+
 layout(std430, binding=1) restrict readonly buffer InstanceBuffer
 {
 	mat4	ViewProj;
@@ -13,6 +25,7 @@ layout(std430, binding=1) restrict readonly buffer InstanceBuffer
 	mat4	ShadowViewProj;
 	vec4	ShadowParams;
 	vec4	ShadowDebug;
+	InstanceData instances[];
 };
 // ALU-only 16x16 Bayer matrix
 float bayer01(ivec2 coord)


### PR DESCRIPTION
### Motivation
- Alias vertex and fragment stages declared different SSBO layouts which caused GLSL link-time interface/block conflicts and shader program failures; make the fragment stage match the vertex stage to restore a consistent `InstanceBuffer` layout.

### Description
- Added the `InstanceData` struct and a trailing `InstanceData instances[];` member to the `layout(std430, binding=1) ... InstanceBuffer` block in `Quake/shaders/alias.frag` so the fragment-stage SSBO matches `Quake/shaders/alias.vert`.

### Testing
- Verified the patch and formatting with `git diff --check` and confirmed matching declarations using `rg` (searching for the `InstanceBuffer` layout and `instances[]`), and committed the change with the message `Fix alias shader SSBO interface block mismatch`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b3d6b2aec832ebe2bf7ddb14da2a9)