### PR TITLE
Fix alias shader SSBO block naming conflicts

### DIFF
--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -26,7 +26,7 @@ layout(std430, binding=1) restrict readonly buffer InstanceBuffer
 	vec4	ShadowParams;
 	vec4	ShadowDebug;
 	InstanceData instances[];
-};
+} AliasFrameBuffer;
 // ALU-only 16x16 Bayer matrix
 float bayer01(ivec2 coord)
 {
@@ -47,9 +47,9 @@ float bayer(ivec2 coord)
 
 vec3 ApplyFog(vec3 clr, vec3 p)
 {
-        float fog = exp2(-abs(Fog.w) * dot(p, p));
+        float fog = exp2(-abs(AliasFrameBuffer.Fog.w) * dot(p, p));
         fog = clamp(fog, 0.0, 1.0);
-        return mix(Fog.rgb, clr, fog);
+        return mix(AliasFrameBuffer.Fog.rgb, clr, fog);
 }
 
 // Hash without Sine
@@ -170,21 +170,21 @@ void main()
         float shadow_range = 1.0;
         float shadow_term = 1.0;
         uint shadow_light_index = 0u;
-        vec3 shadow_light_pos = EyePos;
+        vec3 shadow_light_pos = AliasFrameBuffer.EyePos;
 	vec4 lit_color = in_color;
 
-	if (ShadowDebug.x > 0.5 && (in_flags & ALIAS_FLAG_VIEWMODEL) == 0)
+	if (AliasFrameBuffer.ShadowDebug.x > 0.5 && (in_flags & ALIAS_FLAG_VIEWMODEL) == 0)
 	{
-		vec3 world_pos = in_pos + EyePos;
+		vec3 world_pos = in_pos + AliasFrameBuffer.EyePos;
 		vec3 shadow_normal = gl_FrontFacing ? in_normal : -in_normal;
 		shadow_term = ShadowVisibilityDlight(world_pos, shadow_normal, shadow_light_pos, shadow_light_index, shadow_range);
-		if (ShadowDebug.y > 0.5)
+		if (AliasFrameBuffer.ShadowDebug.y > 0.5)
 		{
-			if (ShadowDebug.y < 1.5)
+			if (AliasFrameBuffer.ShadowDebug.y < 1.5)
 				OUT_COLOR = vec4(vec3(shadow_term), 1.0);
-			else if (ShadowDebug.y < 2.5)
+			else if (AliasFrameBuffer.ShadowDebug.y < 2.5)
 			{
-				vec4 shadow_clip = ShadowViewProj * vec4(world_pos, 1.0);
+				vec4 shadow_clip = AliasFrameBuffer.ShadowViewProj * vec4(world_pos, 1.0);
 				vec3 proj = shadow_clip.xyz / max(shadow_clip.w, 1e-6);
 				vec2 uv = proj.xy * 0.5 + 0.5;
 				float reference = ShadowReference01(proj.z);
@@ -192,7 +192,7 @@ void main()
 			}
 			else
 			{
-				vec4 shadow_clip = ShadowViewProj * vec4(world_pos, 1.0);
+				vec4 shadow_clip = AliasFrameBuffer.ShadowViewProj * vec4(world_pos, 1.0);
 				vec3 proj = shadow_clip.xyz / max(shadow_clip.w, 1e-6);
 				vec2 uv = proj.xy * 0.5 + 0.5;
 				float reference = ShadowReference01(proj.z);
@@ -251,13 +251,13 @@ void main()
 #endif
 #if MODE == 1 || MODE == 2
 	// Note: sign bit is used as overbright flag
-	if (abs(Fog.w) > 0.)
+	if (abs(AliasFrameBuffer.Fog.w) > 0.)
 	{
 		OUT_COLOR.rgb = sqrt(OUT_COLOR.rgb);
-		OUT_COLOR.rgb += SCREEN_SPACE_NOISE() * ScreenDither;
+		OUT_COLOR.rgb += SCREEN_SPACE_NOISE() * AliasFrameBuffer.ScreenDither;
 		OUT_COLOR.rgb *= OUT_COLOR.rgb;
 	}
 #else
-	OUT_COLOR.rgb += SUPPRESS_BANDING() * ScreenDither;
+	OUT_COLOR.rgb += SUPPRESS_BANDING() * AliasFrameBuffer.ScreenDither;
 #endif
 }

--- a/Quake/shaders/alias.vert
+++ b/Quake/shaders/alias.vert
@@ -25,7 +25,7 @@ layout(std430, binding=1) restrict readonly buffer InstanceBuffer
 	vec4	ShadowParams;
 	vec4	ShadowDebug;
 	InstanceData instances[];
-};
+} AliasFrameBuffer;
 
 struct PoseVertex
 {
@@ -80,7 +80,7 @@ float r_avertexnormal_dot(vec3 vertexnormal, vec3 dir) // from MH, blended with 
         float halfLambert = max(d, 0.0) * 0.5 + 0.5;
         // wtf - this reproduces anorm_dots within as reasonable a degree of tolerance as the >= 0 case
         float quakeShade = d < 0.0 ? 1.0 + d * (13.0 / 44.0) : 1.0 + d;
-        float halfLambertMix = clamp(ModelHalfLambert, 0.0, 1.0);
+        float halfLambertMix = clamp(AliasFrameBuffer.ModelHalfLambert, 0.0, 1.0);
         return mix(quakeShade, halfLambert, halfLambertMix);
 }
 
@@ -100,7 +100,7 @@ const int ALIAS_FLAG_VIEWMODEL = 2;
 
 void main()
 {
-	InstanceData inst = instances[gl_InstanceID];
+	InstanceData inst = AliasFrameBuffer.instances[gl_InstanceID];
 	out_texcoord = in_uv;
 	PoseVertex pose1 = GetPoseVertex(inst.Pose1);
 	PoseVertex pose2 = GetPoseVertex(inst.Pose2);
@@ -109,13 +109,13 @@ void main()
 	mat4x3 prev_worldmatrix = transpose(mat3x4(inst.PrevWorldMatrix[0], inst.PrevWorldMatrix[1], inst.PrevWorldMatrix[2]));
 	vec3 world_vert = (worldmatrix * vec4(local_vert, 1.0)).xyz;
 	vec3 prev_world_vert = (prev_worldmatrix * vec4(local_vert, 1.0)).xyz;
-	vec4 curr_clip = ViewProj * vec4(world_vert, 1.0);
-	vec4 prev_clip = PrevViewProj * vec4(prev_world_vert, 1.0);
+	vec4 curr_clip = AliasFrameBuffer.ViewProj * vec4(world_vert, 1.0);
+	vec4 prev_clip = AliasFrameBuffer.PrevViewProj * vec4(prev_world_vert, 1.0);
 	gl_Position = curr_clip;
 	out_curr_clip = curr_clip;
 	out_prev_clip = prev_clip;
 	out_flags = inst.Flags;
-	out_pos = world_vert - EyePos;
+	out_pos = world_vert - AliasFrameBuffer.EyePos;
 	// transform world X and Z axes to local space
         mat3 orientation = mat3(normalize(worldmatrix[0].xyz), normalize(worldmatrix[1].xyz), normalize(worldmatrix[2].xyz));
         orientation = transpose(orientation);
@@ -129,11 +129,11 @@ void main()
         vec3 view_dir = normalize(-out_pos);
         float rim = pow(max(1.0 - dot(world_normal, view_dir), 0.0), 3.0) * 0.3;
         vec3 ambient = max(inst.LightColor.rgb - inst.DLightColor.rgb, vec3(0.0));
-        vec3 litAmbient = ambient * (mix(0.35, 1.0, lighting) * Overbright);
+        vec3 litAmbient = ambient * (mix(0.35, 1.0, lighting) * AliasFrameBuffer.Overbright);
         vec3 litDlight = inst.DLightColor.rgb * lighting;
         vec3 base_color = litAmbient + litDlight;
         bool is_viewmodel = (inst.Flags & ALIAS_FLAG_VIEWMODEL) != 0;
         vec3 final_color = is_viewmodel ? base_color + vec3(rim) : base_color;
-        out_color = clamp(vec4(final_color, inst.LightColor.a), 0.0, Overbright);
+        out_color = clamp(vec4(final_color, inst.LightColor.a), 0.0, AliasFrameBuffer.Overbright);
 	out_normal = world_normal;
 }


### PR DESCRIPTION
### Motivation
- Alias vertex/fragment shaders used an anonymous `std430` SSBO which injected members into the global scope and caused GLSL interface/name collisions during program linking for certain shader variants.

### Description
- Name the SSBO block `AliasFrameBuffer` in both `Quake/shaders/alias.vert` and `Quake/shaders/alias.frag` to create a scoped interface block.
- Qualify all frame and instance accesses through the new block (for example `ViewProj` → `AliasFrameBuffer.ViewProj`, `instances` → `AliasFrameBuffer.instances`, `Fog` → `AliasFrameBuffer.Fog`, etc.).
- This change is a namespace/qualification fix only and does not alter the underlying SSBO layout or intended runtime data.

### Testing
- Ran `git diff --check` to validate there are no whitespace/conflict issues, which succeeded.
- Committed the changes and verified the diff shows the intended replacements for both `Quake/shaders/alias.vert` and `Quake/shaders/alias.frag`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b45e4c254832eb3da11ebd848069f)