### PR TITLE
Rename alias shader SSBO block to avoid interface-block name conflict

### DIFF
--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -11,7 +11,7 @@ struct InstanceData
 	int		Flags;
 };
 
-layout(std430, binding=1) restrict readonly buffer InstanceBuffer
+layout(std430, binding=1) restrict readonly buffer AliasFrameBlock
 {
 	mat4	ViewProj;
 	mat4	PrevViewProj;

--- a/Quake/shaders/alias.vert
+++ b/Quake/shaders/alias.vert
@@ -10,7 +10,7 @@ struct InstanceData
 	int		Flags;
 };
 
-layout(std430, binding=1) restrict readonly buffer InstanceBuffer
+layout(std430, binding=1) restrict readonly buffer AliasFrameBlock
 {
 	mat4	ViewProj;
 	mat4	PrevViewProj;


### PR DESCRIPTION
### Motivation
- Prevent GLSL link-time/compiler errors caused by a generic SSBO interface-block name collision between alias shaders and other blocks by giving the alias stage its own block name.

### Description
- Renamed the `std430` SSBO interface block in `Quake/shaders/alias.vert` and `Quake/shaders/alias.frag` from `InstanceBuffer` to `AliasFrameBlock` while preserving `layout(binding=1)`, the instance name `AliasFrameBuffer`, and the buffer contents/structure.

### Testing
- Verified the edits with code searches (`rg`) and file diffs to ensure both vertex and fragment shaders were updated consistently, and attempted a local `cmake` configure/build which failed in this environment due to missing SDL2 CMake package files (`SDL2Config.cmake` / `sdl2-config.cmake`), so a full build/run could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b4fd0d268832ebac1a38248f07fcc)