### PR TITLE
Fix alias shadow shader SSBO instance reference

### DIFF
--- a/Quake/shaders/shadow_depth_alias.vert
+++ b/Quake/shaders/shadow_depth_alias.vert
@@ -68,7 +68,7 @@ layout(std430, binding = 1) restrict readonly buffer InstanceBuffer
     vec4        ShadowParams;
     vec4        ShadowDebug;
     InstanceData instances[];
-};
+} AliasFrameBuffer;
 
 // ---------------------------------------------------------------------------
 // Pose vertex
@@ -147,7 +147,7 @@ void main()
     // FIX 3: clamp instance index — gl_InstanceID is 0-based per the spec but
     // baseInstance variants may shift it; keep non-negative for array safety.
     int inst_id = max(0, gl_InstanceID);
-    InstanceData inst = instances[inst_id];
+    InstanceData inst = AliasFrameBuffer.instances[inst_id];
 
     PoseVertex pose1 = GetPoseVertex(uint(inst.Pose1));
     PoseVertex pose2 = GetPoseVertex(uint(inst.Pose2));
@@ -164,5 +164,5 @@ void main()
 
     vec3 world_vert = (worldmatrix * vec4(local_vert, 1.0)).xyz;
 
-    gl_Position = ShadowViewProj * vec4(world_vert, 1.0);
+    gl_Position = AliasFrameBuffer.ShadowViewProj * vec4(world_vert, 1.0);
 }


### PR DESCRIPTION
### Motivation
- Prevent GLSL link-time SSBO/interface-block ownership conflicts on stricter drivers by giving the alias shadow shader the same named SSBO instance used elsewhere and qualifying member access.

### Description
- Add an SSBO instance name `AliasFrameBuffer` to `Quake/shaders/shadow_depth_alias.vert` and update per-instance access to `AliasFrameBuffer.instances[...]` and the shadow matrix usage to `AliasFrameBuffer.ShadowViewProj`.

### Testing
- Attempted a local build with `cmake -S . -B build && cmake --build build -j2`, which failed in this environment due to missing SDL2 CMake package files (`SDL2Config.cmake`), so a full build could not be performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b51df057c832ea556e2dec4cc662a)