### PR TITLE
Adjust autoexposure curve for low-luma range

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -300,7 +300,7 @@ cvar_t	r_motionblur_depththreshold = { "r_motionblur_depththreshold", "0.1", CVA
 cvar_t	r_tonemap = { "r_tonemap", "2", CVAR_ARCHIVE };
 cvar_t	r_tonemap_exposure = { "r_tonemap_exposure", "1.0", CVAR_ARCHIVE };
 cvar_t	r_autoexposure = { "r_autoexposure", "1", CVAR_ARCHIVE };
-cvar_t	r_ae_min_scene_luma = { "r_ae_min_scene_luma", "0.02", CVAR_ARCHIVE };
+cvar_t	r_ae_min_scene_luma = { "r_ae_min_scene_luma", "0.001", CVAR_ARCHIVE };
 cvar_t	r_ae_min_exposure = { "r_ae_min_exposure", "0.25", CVAR_ARCHIVE };
 cvar_t	r_ae_max_exposure = { "r_ae_max_exposure", "8.0", CVAR_ARCHIVE };
 cvar_t	r_exposure_bias = { "r_exposure_bias", "1.0", CVAR_ARCHIVE };
@@ -2014,13 +2014,18 @@ static float GL_UpdateAutoExposure (void)
 		return current_exposure;
 
 	{
-		const float exposure_middle_gray = 0.18f;
+		const float min_scene_luma = 0.001f;
+		const float max_scene_luma = 0.01f;
+		const float min_scene_log = log10f (min_scene_luma);
+		const float max_scene_log = log10f (max_scene_luma);
+		const float scene_log = log10f (q_max (scene_luminance, min_scene_luma));
 		const float bias = q_max (0.f, r_exposure_bias.value);
 		const float min_exposure = q_min (r_exposure_min.value, r_exposure_max.value);
 		const float max_exposure = q_max (r_exposure_min.value, r_exposure_max.value);
 		const float hard_min_exposure = q_max (0.f, q_min (r_ae_min_exposure.value, r_ae_max_exposure.value));
 		const float hard_max_exposure = q_max (hard_min_exposure, q_max (r_ae_min_exposure.value, r_ae_max_exposure.value));
-		float target = exposure_middle_gray * bias / scene_luminance;
+		float interpolation = (scene_log - min_scene_log) / (max_scene_log - min_scene_log);
+		float target = LERP (hard_max_exposure, hard_min_exposure, interpolation) * bias;
 		float speed_up = q_max (0.f, r_exposure_speed_up.value);
 		float speed_down = q_max (0.f, r_exposure_speed_down.value);
 		float adaptation_speed = (target > current_exposure) ? speed_up : speed_down;
@@ -2033,6 +2038,7 @@ static float GL_UpdateAutoExposure (void)
 
 		last_time = cl.time;
 
+		target = CLAMP (hard_min_exposure, target, hard_max_exposure);
 		target = CLAMP (min_exposure, target, max_exposure);
 		target = CLAMP (hard_min_exposure, target, hard_max_exposure);
 		change = (target - current_exposure) * delta * adaptation_speed;


### PR DESCRIPTION
### Motivation
- Make the autoexposure mapping follow the requested anchors so very dark scenes drive exposure to the maximum and slightly brighter low-luma scenes drive it to the minimum.
- Align the default minimum scene luminance with the new low-luma behavior so sampling and clamping floor match the mapping range.

### Description
- Replaced the previous middle-gray division target in `GL_UpdateAutoExposure` with a log-space interpolation between scene luminance 0.001 and 0.01 so that `luma = 0.001` maps to max exposure and `luma = 0.01` maps to min exposure.
- Added local constants and computations (`min_scene_luma`, `max_scene_luma`, `min_scene_log`, `max_scene_log`, `scene_log`, `interpolation`) and compute `target` via `LERP(hard_max_exposure, hard_min_exposure, interpolation) * bias` in `Quake/gl_rmain.c`.
- Updated the default `r_ae_min_scene_luma` cvar from `0.02` to `0.001` to match the new mapping floor.
- Adjusted clamp ordering to ensure `target` is constrained to hard exposure limits and the general exposure min/max.

### Testing
- Ran `make -C Quake -j2` to validate the change, but the build failed in this container because `sdl2-config` / `SDL.h` are missing so a full compile could not be completed (failure).
- Performed local static inspection and `git diff` of `Quake/gl_rmain.c` to verify the intended code changes were applied (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b621a3f98832eb52585e9709d1621)