### PR TITLE
Fix dlight atlas receiver sampling, reverse‑Z compare and add shader debug

### DIFF
--- a/Quake/r_shadow.c
+++ b/Quake/r_shadow.c
@@ -829,28 +829,25 @@ static void R_Shadow_SelectReceiverSource (GLuint tex, const float viewproj[16])
 	else
 		IdentityMatrix (shadow_receiver_viewproj);
 
+#if defined(SHDLOG)
+	if (r_shadow_debug.value > 0.f)
+	{
+		R_Shadow_LogWrite ("receiver_upload path=UBO/std140 matrix_layout=column_major transpose=GL_FALSE(implicit) matrix_hash=%08X\n",
+			R_Shadow_MatrixHash (shadow_receiver_viewproj));
+		R_Shadow_LogWrite ("receiver_upload m=[%.6f %.6f %.6f %.6f | %.6f %.6f %.6f %.6f | %.6f %.6f %.6f %.6f | %.6f %.6f %.6f %.6f]\n",
+			shadow_receiver_viewproj[0], shadow_receiver_viewproj[1], shadow_receiver_viewproj[2], shadow_receiver_viewproj[3],
+			shadow_receiver_viewproj[4], shadow_receiver_viewproj[5], shadow_receiver_viewproj[6], shadow_receiver_viewproj[7],
+			shadow_receiver_viewproj[8], shadow_receiver_viewproj[9], shadow_receiver_viewproj[10], shadow_receiver_viewproj[11],
+			shadow_receiver_viewproj[12], shadow_receiver_viewproj[13], shadow_receiver_viewproj[14], shadow_receiver_viewproj[15]);
+	}
+#endif
+
 	r_framedata.shadow_debug[0] = tex ? 1.f : 0.f;
 	r_framedata.shadow_params[0] = r_shadow_dlight_bias.value;
 	r_framedata.shadow_params[1] = 0.f;
 	r_framedata.shadow_params[2] = r_shadow_dlight_pcf_taps.value > 0.f ? 1.f : 0.f;
 	r_framedata.shadow_params[3] = r_shadow_dlight_pcf_taps.value;
 	r_framedata.shadow_dlight_params[2] = tex ? 1.f : 0.f;
-}
-
-static void R_Shadow_BuildReceiverAtlasViewProj (float out_viewproj[16], const float viewproj[16], const vec4_t atlas)
-{
-	float atlas_transform[16];
-	float viewproj_copy[16];
-
-	IdentityMatrix (atlas_transform);
-	atlas_transform[0] = atlas[0];
-	atlas_transform[5] = atlas[1];
-	atlas_transform[12] = atlas[2];
-	atlas_transform[13] = atlas[3];
-
-	memcpy (viewproj_copy, viewproj, sizeof (viewproj_copy));
-	memcpy (out_viewproj, atlas_transform, sizeof (atlas_transform));
-	MatrixMultiply (out_viewproj, viewproj_copy);
 }
 
 void R_Shadow_BindReceiverShadowMap (GLenum texunit)
@@ -1082,7 +1079,7 @@ void R_Shadow_DlightPass (void)
 	{
 		float receiver_viewproj[16];
 		int selected_light_index = shadow_dlight_light_indices[shadow_dlight_selected_slot];
-		R_Shadow_BuildReceiverAtlasViewProj (receiver_viewproj, r_framedata.shadow_dlight_viewproj[shadow_dlight_selected_slot], r_framedata.shadow_dlight_atlas[shadow_dlight_selected_slot]);
+		memcpy (receiver_viewproj, r_framedata.shadow_dlight_viewproj[shadow_dlight_selected_slot], sizeof (receiver_viewproj));
 		R_Shadow_SelectReceiverSource (shadow_dlight_depth_tex, receiver_viewproj);
 		memcpy (r_framedata.shadow_viewproj, receiver_viewproj, sizeof (r_framedata.shadow_viewproj));
 		shadow_dlight_atlas_valid_frame_id = r_framecount;

--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -99,7 +99,8 @@ const int ALIAS_FLAG_LIGHTNING = 4;
 layout(binding=0) uniform sampler2D Tex;
 layout(binding=1) uniform sampler2D FullbrightTex;
 layout(binding=2) uniform sampler2D EmissiveTex;
-layout(binding=5) uniform sampler2D ShadowDlightMap;
+layout(binding=5) uniform sampler2DShadow ShadowDlightMap;
+layout(binding=6) uniform sampler2D ShadowDlightMapRaw;
 
 // alias shaders use an SSBO-backed frame block and don't include frame_uniforms.glsl.
 // Provide the dynamic-light shadow uniforms explicitly so shadow_sample.glsl compiles.
@@ -183,20 +184,14 @@ void main()
 			if (AliasFrameBuffer.ShadowDebug.y < 1.5)
 				OUT_COLOR = vec4(vec3(shadow_term), 1.0);
 			else if (AliasFrameBuffer.ShadowDebug.y < 2.5)
-			{
-				vec4 shadow_clip = AliasFrameBuffer.ShadowViewProj * vec4(world_pos, 1.0);
-				vec3 proj = shadow_clip.xyz / max(shadow_clip.w, 1e-6);
-				vec2 uv = proj.xy * 0.5 + 0.5;
-				float reference = ShadowReference01(proj.z);
-				OUT_COLOR = vec4(uv, reference, 1.0);
-			}
+				OUT_COLOR = ShadowDebugDlight(world_pos, shadow_light_index);
 			else
 			{
 				vec4 shadow_clip = AliasFrameBuffer.ShadowViewProj * vec4(world_pos, 1.0);
 				vec3 proj = shadow_clip.xyz / max(shadow_clip.w, 1e-6);
 				vec2 uv = proj.xy * 0.5 + 0.5;
 				float reference = ShadowReference01(proj.z);
-				float raw_depth = texture(ShadowDlightMap, uv).r;
+				float raw_depth = texture(ShadowDlightMapRaw, uv).r;
 				OUT_COLOR = vec4(raw_depth, reference, shadow_term, 1.0);
 			}
 #if !OIT

--- a/Quake/shaders/shadow_sample.glsl
+++ b/Quake/shaders/shadow_sample.glsl
@@ -93,8 +93,13 @@ float ShadowCompare(float depth, float reference, float bias)
 
 float ShadowSampleRawDlight(vec2 uv, float reference, float bias)
 {
-    float depth = texture(ShadowDlightMap, uv).r;
-    return ShadowCompare(depth, reference, bias);
+    float ref = reference;
+#if REVERSED_Z
+    ref += bias;
+#else
+    ref -= bias;
+#endif
+    return texture(ShadowDlightMap, vec3(uv, clamp(ref, 0.0, 1.0)));
 }
 
 // Gleiche Tap-Semantik wie ShadowSamplePCF (s.o.)
@@ -207,6 +212,45 @@ float ShadowVisibilityDlight(vec3 world_pos, vec3 normal, vec3 light_pos,
         return ShadowSamplePCFDlight(uv, reference, bias, taps);
 
     return ShadowSampleRawDlight(uv, reference, bias);
+}
+
+vec4 ShadowDebugDlight(vec3 world_pos, uint light_index)
+{
+    int shadow_index = -1;
+    for (int i = 0; i < SHADOW_DLIGHT_MAX; ++i)
+    {
+        if (ShadowDlightInfo[i].x < 0.0)
+            continue;
+        if (int(round(ShadowDlightInfo[i].x)) == int(light_index))
+        {
+            shadow_index = i;
+            break;
+        }
+    }
+
+    if (shadow_index < 0)
+        return vec4(1.0, 0.0, 1.0, 1.0);
+
+    vec4 clip = ShadowMul(ShadowDlightViewProj[shadow_index], vec4(world_pos, 1.0));
+    if (abs(clip.w) <= 1e-6)
+        return vec4(1.0, 0.0, 1.0, 1.0);
+
+    vec3 ndc = clip.xyz / clip.w;
+    vec2 uv_local = ndc.xy * 0.5 + 0.5;
+    float reference = ShadowReference01(ndc.z);
+
+    vec4 atlas = ShadowDlightAtlas[shadow_index];
+    vec2 uv = uv_local * atlas.xy + atlas.zw;
+
+    vec2 atlas_min = atlas.zw;
+    vec2 atlas_max = atlas.zw + atlas.xy;
+    bool inside = all(greaterThanEqual(uv, atlas_min)) &&
+                  all(lessThanEqual(uv, atlas_max));
+
+    if (!inside)
+        return vec4(1.0, 0.0, 0.0, 1.0);
+
+    return vec4(uv, reference, 1.0);
 }
 
 #endif // SHADOW_DLIGHT

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -7,7 +7,8 @@
 #endif
 layout(binding=2) uniform sampler2D LMTex;
 layout(binding=3) uniform sampler2D LMTexDir;
-layout(binding=5) uniform sampler2D ShadowDlightMap;
+layout(binding=5) uniform sampler2DShadow ShadowDlightMap;
+layout(binding=6) uniform sampler2D ShadowDlightMapRaw;
 #include "frame_uniforms.glsl"
 #define SHADOW_DLIGHT 1
 #include "shadow_sample.glsl"
@@ -457,11 +458,7 @@ void main()
 				OUT_COLOR = vec4(vec3(shadow_term), 1.0);
 			else if (ShadowDebug.y < 2.5)
 			{
-				vec4 shadow_clip = ShadowViewProj * vec4(in_pos, 1.0);
-				vec3 proj = shadow_clip.xyz / max(shadow_clip.w, 1e-6);
-				vec2 uv = proj.xy * 0.5 + 0.5;
-				float reference = ShadowReference01(proj.z);
-				OUT_COLOR = vec4(uv, reference, 1.0);
+				OUT_COLOR = ShadowDebugDlight(in_pos, 0u);
 			}
 			else
 			{
@@ -469,7 +466,7 @@ void main()
 				vec3 proj = shadow_clip.xyz / max(shadow_clip.w, 1e-6);
 				vec2 uv = proj.xy * 0.5 + 0.5;
 				float reference = ShadowReference01(proj.z);
-				float raw_depth = texture(ShadowDlightMap, uv).r;
+				float raw_depth = texture(ShadowDlightMapRaw, uv).r;
 				OUT_COLOR = vec4(raw_depth, reference, shadow_term, 1.0);
 			}
 #if !OIT

--- a/Quake/shaders/world_dlight.frag
+++ b/Quake/shaders/world_dlight.frag
@@ -5,7 +5,7 @@ layout(binding=0) uniform sampler2D Tex;
 #endif
 layout(binding=2) uniform sampler2D LMTex; // unused, kept for binding slot consistency
 layout(binding=3) uniform sampler2D LMTexDir; // unused
-layout(binding=5) uniform sampler2D ShadowDlightMap;
+layout(binding=5) uniform sampler2DShadow ShadowDlightMap;
 
 #include "frame_uniforms.glsl"
 #define SHADOW_DLIGHT 1


### PR DESCRIPTION
### Motivation

- Receiver-side shadow sampling from the dlight atlas produced incorrect UV/reference values (after SUN removal and with Reverse‑Z), causing broken dlight shadows in world and alias passes. 
- Root causes identified: CPU-side atlas bake + shader atlas remap duplication, inconsistent compare/reference handling for reverse‑Z, and lack of decisive debug output to isolate matrix/tile/reference issues.

### Description

- Stop baking the atlas transform into the CPU receiver matrix and instead upload the selected per-light `viewproj` directly; the atlas remap is applied once in the shader after the projection divide (removed `R_Shadow_BuildReceiverAtlasViewProj` usage and `memcpy` the `shadow_dlight_viewproj`).
- Add SHDLOG diagnostics in `R_Shadow_SelectReceiverSource` to log the receiver matrix upload path, assumed column-major layout, implicit `transpose=GL_FALSE`, matrix hash and the exact 4x4 values written into the frame UBO (visible when `r_shadow_debug > 0`).
- Switch the dlight receiver sampling to hardware depth-compare sampling: use `sampler2DShadow` at binding 5 and pass a reverse‑Z aware reference (`vec3(uv, ref)`) to let the GPU do the compare; compute `ref` with bias adjusted for `REVERSED_Z` semantics in `ShadowSampleRawDlight`.
- Keep a separate `sampler2D` bound at binding 6 (`ShadowDlightMapRaw`) for raw-depth debug visualization and use that for raw-depth debug reads.
- Add a decisive shader debug helper `ShadowDebugDlight()` that returns magenta when no slot/invalid `w`, red when UV is outside the atlas tile, or `(uv.x, uv.y, reference)` otherwise, and wire world/alias debug paths to use it for quick diagnosis.
- Files modified: `Quake/r_shadow.c`, `Quake/shaders/shadow_sample.glsl`, `Quake/shaders/world.frag`, `Quake/shaders/alias.frag`, `Quake/shaders/world_dlight.frag`.

### Testing

- Ran repository searches to validate touchpoints and that shader/CPU code was updated: `rg -n "DLIGHTPASS|dlight_atlas|shadow_vp|tile_count|receiver_select|matrix_hash|glUniformMatrix4fv" Quake/` (succeeded).
- Verified shader references and updated sampler declarations with `rg -n "sampler2DShadow|texture\(|Shadow|pcf|taps|bias|normalbias|tile" Quake/shaders` (succeeded).
- Attempted a full build in `Quake/` with `make -j4` to smoke-test compilation, but the build failed in this environment due to missing SDL development tools/headers (`sdl2-config` / `SDL.h`), so a full compile/test could not be completed here (failure unrelated to the patch logic).
- Code-level checks performed by printing updated sources and diffs (inspected with `sed`/`nl`) to ensure the matrix upload logging, removal of CPU atlas bake, shader compare sampling, and debug helper were added and wired into world/alias debug paths (succeeded).

How to validate in a runtime build (manual test instructions):

- Run a build with the platform toolchain present and start the engine with one dlight caster present, then enable shader debug modes:
  - `r_shadow_debug 2` to see UV+reference visualization from `ShadowDebugDlight()` where a sane gradient inside [0,1] indicates correct matrix/tile mapping and red pixels show out-of-tile samples. 
  - `r_shadow_debug 3` to inspect raw depth / reference / shadow-term overlays using the raw sampler bound at texture unit 6.
- Confirm `DLIGHTPASS` logging shows `receiver_upload path=UBO/std140 matrix_layout=column_major transpose=GL_FALSE(implicit)` and a matrix dump matching the expected `viewproj` and that shadows follow the camera and are consistent across world + alias passes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b699fcd18832ea8382132e1df8f2a)