### PR TITLE
Fix dlight shadow receiver stability under Reverse-Z

### DIFF
--- a/Quake/r_shadow.c
+++ b/Quake/r_shadow.c
@@ -227,9 +227,11 @@ static void R_Shadow_LogTextureParams (const char *tag, GLuint tex)
 
 static void R_Shadow_SetTextureCompareStateForMode (GLenum compare_mode)
 {
+	const GLenum compare_func = gl_clipcontrol_able ? GL_GEQUAL : GL_LEQUAL;
+
 	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE, compare_mode);
 	if (compare_mode == GL_COMPARE_REF_TO_TEXTURE)
-		glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_FUNC, gl_clipcontrol_able ? GL_GEQUAL : GL_LEQUAL);
+		glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_FUNC, compare_func);
 }
 
 static void R_Shadow_SetTextureCompareState (void)
@@ -872,9 +874,7 @@ const float *R_Shadow_GetReceiverShadowViewProj (void)
 
 qboolean R_Shadow_ReceiverUsesDlight (void)
 {
-	return shadow_dlight_shadows_active_this_frame &&
-		shadow_dlight_atlas_valid_frame_id == r_framecount &&
-		shadow_receiver_tex != 0;
+	return shadow_dlight_shadow_caster_count > 0 && shadow_receiver_tex != 0;
 }
 
 void R_Shadow_DlightPass (void)
@@ -892,9 +892,6 @@ void R_Shadow_DlightPass (void)
 	shadow_dlight_selected_slot = -1;
 	shadow_dlight_shadow_caster_count = 0;
 	shadow_dlight_shadows_active_this_frame = false;
-	shadow_dlight_atlas_valid_frame_id = -1;
-
-	R_Shadow_SelectReceiverSource (0, NULL);
 
 	for (int i = 0; i < SHADOW_DLIGHT_MAX; ++i)
 	{
@@ -939,6 +936,8 @@ void R_Shadow_DlightPass (void)
 
 	if (r_framedata.numlights == 0)
 	{
+		shadow_dlight_atlas_valid_frame_id = -1;
+		R_Shadow_SelectReceiverSource (0, NULL);
 		R_Shadow_Log_DlightEarlyOut ("DLIGHTPASS no gpu lights");
 		return;
 	}
@@ -984,6 +983,8 @@ void R_Shadow_DlightPass (void)
 
 	if (!shadow_dlight_shadows_active_this_frame || !tiles_used)
 	{
+		R_Shadow_SelectReceiverSource (0, NULL);
+		shadow_dlight_atlas_valid_frame_id = -1;
 		R_Shadow_Log_DlightEarlyOut (shadow_dlight_shadows_active_this_frame ? "DLIGHTPASS no selected lights" : "DLIGHTPASS no shadow casters");
 		return;
 	}


### PR DESCRIPTION
### Motivation

- Address receiver flicker and disabled shadow branches when Reverse-Z (clip control) is active by removing frame-based invalidation and ensuring texture compare conventions match the engine's depth mode.
- Ensure shadow sampler/compare state and dlight receiver enablement follow the same Reverse-Z convention used elsewhere in the renderer so debug visualisations and compares are not inverted.

### Description

- Use a single, explicit compare function selection in `R_Shadow_SetTextureCompareStateForMode` by computing `compare_func = gl_clipcontrol_able ? GL_GEQUAL : GL_LEQUAL` and applying it to `GL_TEXTURE_COMPARE_FUNC` so sampler compare agrees with Reverse-Z mode.
- Change `R_Shadow_ReceiverUsesDlight` to return `shadow_dlight_shadow_caster_count > 0 && shadow_receiver_tex != 0`, removing the previous frame-id gating (`shadow_dlight_atlas_valid_frame_id == r_framecount`) to avoid disabling a still-valid receiver due to frame churn.
- Stop unconditionally clearing receiver/atlas state at the start of `R_Shadow_DlightPass`; instead only clear the receiver source and mark the atlas invalid in genuine no-shadow cases (when there are no GPU lights or when no selected/casting dlights remain).
- Preserve existing Reverse-Z depth clear and `glDepthFunc` behavior in the dlight render pass (no projection/depth-scheme logic changes were required in this patch).

### Testing

- Ran repository searches and audits (`rg`) to locate shadow, Reverse-Z and compare usage for consistency; these succeeded and informed the changes.
- Attempted build with `make -C /workspace/ironwail/Quake -j4`, but the compile could not complete in this environment due to missing system dependencies (`sdl2-config` / `SDL.h`), so full compile verification could not be performed here (build step failed).
- Verified repository changes with `git` commands: `git status`, `git diff` and `git commit` succeeded and the patch is committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b6d3963d8832ebbf7dbed5f92a8e8)