### PR TITLE
Ensure dlight atlas compare mode is set on the correct texture unit

### DIFF
--- a/Quake/r_shadow.c
+++ b/Quake/r_shadow.c
@@ -687,6 +687,7 @@ static void R_Shadow_ResizeDlightAtlasIfNeeded (void)
 		R_Shadow_DestroyDlightResources ();
 
 	glGenTextures (1, &shadow_dlight_depth_tex);
+	GL_ActiveTextureFunc (GL_TEXTURE0);
 	GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, shadow_dlight_depth_tex);
 	GL_ObjectLabelFunc (GL_TEXTURE, shadow_dlight_depth_tex, -1, "shadowmap dlight depth");
 	GL_TexStorage2DFunc (GL_TEXTURE_2D, 1, GL_DEPTH_COMPONENT24, atlas_size, atlas_size);
@@ -752,9 +753,8 @@ void R_Shadow_BindDlightShadowMap (GLenum texunit)
 {
 	if (shadow_dlight_depth_tex)
 	{
-		GL_BindNative (texunit, GL_TEXTURE_2D, shadow_dlight_depth_tex);
 		GL_ActiveTextureFunc (texunit);
-		// FIX Bug 2: War immer GL_NONE - korrekt: wie R_Shadow_BindShadowMap.
+		GL_BindNative (texunit, GL_TEXTURE_2D, shadow_dlight_depth_tex);
 		R_Shadow_SetTextureCompareStateForMode (r_shadow_debug.value >= 3.f ? GL_NONE : GL_COMPARE_REF_TO_TEXTURE);
 	}
 	else


### PR DESCRIPTION
### Motivation
- Fix the case where the dlight atlas depth texture ended up with `GL_TEXTURE_COMPARE_MODE = GL_NONE` (SHDLOG showed `compare=0x0`), which caused receiver shadow sampling to be wrong or disabled. 

### Description
- Modified file: `Quake/r_shadow.c`.
- Key functions changed: `R_Shadow_ResizeDlightAtlasIfNeeded` and `R_Shadow_BindDlightShadowMap`.
- Change: explicitly activate the intended texture unit before binding/configuring the atlas texture by calling `GL_ActiveTextureFunc(GL_TEXTURE0)` during atlas creation and `GL_ActiveTextureFunc(texunit)` in the bind path, then bind the texture and call `R_Shadow_SetTextureCompareStateForMode(...)` so `glTexParameteri` applies to the correct unit.
- Reasoning: `glTexParameteri` operates on the currently active texture unit; stale active-unit state could leave the atlas with `GL_NONE` (or a non-shadow sampler) even though the code attempted to set shadow compare state. Activating the correct unit before bind/parameter updates makes the ownership deterministic and avoids adding new cvars or debug modes.

### Testing
- Performed a code inspection and `git diff` to verify the two-line, behavior-preserving change in `Quake/r_shadow.c` (success).
- Attempted an automated build with `cmake -S . -B build && cmake --build build -j2`, which failed due to missing `SDL2` CMake package in the environment (failure unrelated to the change itself).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b702a9a1c832ebef5ceb1d67f4d08)