### PR TITLE
renderer: ensure shadow atlas depth texture compare state before sampling

### DIFF
--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -499,6 +499,7 @@ void R_Shadow_DrawDebug (void);
 void R_Shadow_BindShadowMap (GLenum texunit);
 void R_Shadow_BindDlightShadowMap (GLenum texunit);
 void R_Shadow_BindReceiverShadowMap (GLenum texunit);
+void R_EnsureShadowSamplerState (GLuint texture);
 void R_Shadow_DebugValidateBinding (const char *tag, GLenum texunit, GLuint expected_tex);
 void R_Shadow_Log_BeginFrame (void);
 void R_Shadow_Log_DlightEarlyOut (const char *reason);

--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -592,6 +592,7 @@ ibuf.global.half_lambert = CLAMP (0.f, r_model_halflambert.value, 1.f);
 		{
 		qboolean receiver_enabled = R_Shadow_ReceiverUsesDlight ();
 		GLuint receiver_tex = receiver_enabled ? R_Shadow_GetReceiverShadowMapTextureId () : 0;
+		R_EnsureShadowSamplerState (receiver_tex);
 		GL_BindNative (GL_TEXTURE6, GL_TEXTURE_2D, receiver_tex);
 		R_Shadow_Log_ReceiverPassSnapshot ("ALIAS", glprogs.alias[oit][mode][alphatest][md5], (GLint)GL_GetCurrentProgram (), GL_TEXTURE5, receiver_tex, receiver_enabled, r_framedata.shadow_params[0], r_framedata.shadow_params[1], r_framedata.shadow_params[2], r_framedata.shadow_params[3], R_Shadow_GetReceiverShadowViewProj ());
 		R_Shadow_DebugValidateBinding ("ALIAS", GL_TEXTURE5, receiver_tex);

--- a/Quake/r_shadow.c
+++ b/Quake/r_shadow.c
@@ -239,6 +239,23 @@ static void R_Shadow_SetTextureCompareState (void)
 	R_Shadow_SetTextureCompareStateForMode (GL_COMPARE_REF_TO_TEXTURE);
 }
 
+void R_EnsureShadowSamplerState (GLuint texture)
+{
+	GLint previous_active;
+	GLint previous_binding;
+
+	if (!texture)
+		return;
+
+	glGetIntegerv (GL_ACTIVE_TEXTURE, &previous_active);
+	GL_ActiveTextureFunc (GL_TEXTURE0);
+	glGetIntegerv (GL_TEXTURE_BINDING_2D, &previous_binding);
+	glBindTexture (GL_TEXTURE_2D, texture);
+	R_Shadow_SetTextureCompareStateForMode (r_shadow_debug.value >= 3.f ? GL_NONE : GL_COMPARE_REF_TO_TEXTURE);
+	glBindTexture (GL_TEXTURE_2D, (GLuint)previous_binding);
+	GL_ActiveTextureFunc ((GLenum)previous_active);
+}
+
 static void R_Shadow_DebugValidateProgramSampler (const char *tag, const char *uniform_name, GLint expected_unit)
 {
 	GLint prog = 0;
@@ -755,7 +772,7 @@ void R_Shadow_BindDlightShadowMap (GLenum texunit)
 	{
 		GL_ActiveTextureFunc (texunit);
 		GL_BindNative (texunit, GL_TEXTURE_2D, shadow_dlight_depth_tex);
-		R_Shadow_SetTextureCompareStateForMode (r_shadow_debug.value >= 3.f ? GL_NONE : GL_COMPARE_REF_TO_TEXTURE);
+		R_EnsureShadowSamplerState (shadow_dlight_depth_tex);
 	}
 	else
 		GL_BindNative (texunit, GL_TEXTURE_2D, 0);

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -1530,6 +1530,7 @@ R_Shadow_BindReceiverShadowMap (GL_TEXTURE5);
 		{
 		qboolean receiver_enabled = R_Shadow_ReceiverUsesDlight ();
 		GLuint receiver_tex = receiver_enabled ? R_Shadow_GetReceiverShadowMapTextureId () : 0;
+		R_EnsureShadowSamplerState (receiver_tex);
 		GL_BindNative (GL_TEXTURE6, GL_TEXTURE_2D, receiver_tex);
 		R_Shadow_Log_ReceiverPassSnapshot ("WORLD", program, (GLint)GL_GetCurrentProgram (), GL_TEXTURE5, receiver_tex, receiver_enabled, r_framedata.shadow_params[0], r_framedata.shadow_params[1], r_framedata.shadow_params[2], r_framedata.shadow_params[3], R_Shadow_GetReceiverShadowViewProj ());
 		R_Shadow_DebugValidateBinding ("WORLD", GL_TEXTURE5, receiver_tex);


### PR DESCRIPTION
### Motivation
- Fix intermittent dynamic dlight shadow corruption and sampler validation warnings caused by the shadow atlas losing its depth-compare state at use time.
- Root cause: atlas is created correctly but later pipeline activity can leave `GL_TEXTURE_COMPARE_MODE` as `GL_NONE`, breaking `sampler2DShadow` sampling.
- Preserve existing behavior (no new CVars/debug modes) and keep Reverse-Z semantics intact.

### Description
- Added `R_EnsureShadowSamplerState(GLuint texture)` in `Quake/r_shadow.c` and declared it in `Quake/glquake.h`; the helper preserves/restores active texture and binding, binds the provided texture on `GL_TEXTURE0`, and reapplies `GL_TEXTURE_COMPARE_MODE` and `GL_TEXTURE_COMPARE_FUNC` using the existing reverse-Z aware mapping (`GL_GEQUAL` when `gl_clipcontrol_able`).
- Replaced the inline compare-state call in `R_Shadow_BindDlightShadowMap` with a call to `R_EnsureShadowSamplerState(shadow_dlight_depth_tex)` so the atlas compare state is enforced whenever the shadow atlas is bound for sampling.
- Before receiver sampling, call `R_EnsureShadowSamplerState(receiver_tex)` in both WORLD and ALIAS receiver code paths (`Quake/r_world.c`, `Quake/r_alias.c`) to reapply the compare state prior to binding the raw receiver texture on `GL_TEXTURE6` and before logging/validation.
- Verified the atlas creation and FBO setup already use a depth internal format (`GL_DEPTH_COMPONENT24`) and set compare state at creation, and that the shadow pass remains depth-only with `glDrawBuffer(GL_NONE)` / `glReadBuffer(GL_NONE)` and unchanged Reverse-Z `glClearDepth` / `glDepthFunc` handling.
- Files changed: `Quake/r_shadow.c`, `Quake/r_world.c`, `Quake/r_alias.c`, `Quake/glquake.h`.

### Testing
- Ran source grep audits to validate changes and references to the new helper: `rg` searches for `R_EnsureShadowSamplerState` and related compare-state symbols succeeded and show the added calls in `r_shadow.c`, `r_world.c`, and `r_alias.c` (success).
- Attempted to build with `make -C Quake -j4` in this environment; the build attempt failed due to missing SDL development tooling/headers (`sdl2-config` / `SDL.h`), so runtime/integration validation on a real GL context could not be performed here (expected environment limitation).
- No new CVars or debug modes were added and Reverse-Z clear/compare behavior was preserved by the helper logic (manual code review).

If you want, I can run runtime validation (check `SHDLOG` warnings, shadow debug views, WORLD/ALIAS receiver shadows) on a machine with SDL/OpenGL available and report the results.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b7ad5ac10832e92484a638515d48c)