### PR TITLE
Fix dlight shadow atlas compare-mode regression on texture cache hits

### DIFF
--- a/Quake/gl_texmgr.c
+++ b/Quake/gl_texmgr.c
@@ -2825,7 +2825,13 @@ qboolean GL_BindNative (GLenum texunit, GLenum type, GLuint handle)
 	if (index < countof (currenttexture))
 	{
 		if (currenttexture[index] == handle)
+		{
+			// Keep the active texture unit in sync even on cache hits.
+			// Callers may issue glTexParameteri/glGetTexParameter* immediately
+			// after GL_BindNative and rely on texunit being active.
+			GL_SelectTexture (texunit);
 			return false;
+		}
 		currenttexture[index] = handle;
 	}
 


### PR DESCRIPTION
### Motivation
- Restore correct GL active-texture semantics so shadow atlas compare-mode state is applied/read on the intended unit, fixing receiver warnings and missing dlight shadows.

### Description
- Modify `GL_BindNative` in `Quake/gl_texmgr.c` to call `GL_SelectTexture(texunit)` even on a per-TMU cache-hit so that immediate `glTexParameteri` / `glGetTexParameter*` calls operate on the requested unit; no new CVars, debug modes, or logging added.

### Testing
- Performed static/automated repository checks and commands: `rg` searches for shadow/compare symbols, inspected `Quake/r_shadow.c` and `Quake/gl_texmgr.c`, verified the edit with `git diff`/`nl` and committed the change; all commands completed successfully (no automated runtime tests were executed in this patch).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b8dd5b394832ea15e46a4d7a93509)