### PR TITLE
Fix undefined GL_TexImage2DFunc usage in shadow texture setup

### DIFF
--- a/Quake/r_shadow.c
+++ b/Quake/r_shadow.c
@@ -258,7 +258,7 @@ static void R_Shadow_CreateDummyTexture (void)
 	glGenTextures (1, &shadow_dlight_dummy_tex);
 	GL_ActiveTextureFunc (GL_TEXTURE0);
 	GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, shadow_dlight_dummy_tex);
-	GL_TexImage2DFunc (GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT24, 8, 8, 0, GL_DEPTH_COMPONENT, GL_FLOAT, depth_data);
+	glTexImage2D (GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT24, 8, 8, 0, GL_DEPTH_COMPONENT, GL_FLOAT, depth_data);
 	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);


### PR DESCRIPTION
### Motivation
- MSVC builds treated an undeclared `GL_TexImage2DFunc` as an error (C4013 → C2220), so the shadow dummy texture upload must use the proper OpenGL function to avoid the build break.

### Description
- Replace `GL_TexImage2DFunc(...)` with `glTexImage2D(...)` in `R_Shadow_CreateDummyTexture` in `Quake/r_shadow.c`.

### Testing
- Ran `rg "GL_TexImage2DFunc" -n Quake` to confirm there are no remaining references, which returned no matches (success).
- Inspected the modified source region with `nl -ba Quake/r_shadow.c | sed -n '248,272p'` to verify the replacement (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c8fdff078832ebe4f00c61664f709)