### PR TITLE
Restore ShadowViewProj and ShadowParams in frame UBO

### DIFF
--- a/Quake/shaders/frame_uniforms.glsl
+++ b/Quake/shaders/frame_uniforms.glsl
@@ -48,16 +48,13 @@ layout(std140, binding=0) uniform FrameDataUBO
     vec4    ColorSpaceParams;   // 352
     vec4    ShaderParams;       // 368
 
-    // ── DLight shadow atlas ───────────────────────────── offset 384
-    // NOTE: ShadowViewProj (globale Sonne) entfernt — Sonne ist keine Lichtquelle mehr.
-    // NOTE: ShadowParams entfernt — war nur für Sun-Shadow-Pass, nirgends im Shader gelesen.
-    // NOTE: ShadowDebug entfernt — war nur für Sun-Shadow-Visualisierung (world.frag) genutzt,
-    //       die ebenfalls entfernt wurde.
-    // Die 96 Byte (mat4 + vec4 + vec4) werden durch explizites Padding ersetzt damit
-    // die CPU-seitige Struct-Grösse und alle nachfolgenden Offsets stabil bleiben,
-    // bis die CPU-Seite ebenfalls bereinigt ist. Danach kann _ShadowSunReserved entfernt werden.
-    vec4    ShadowDebug;             // 384 (x: enabled, y: debug mode, z: dummy tex, w: source)
-    vec4    _ShadowSunReserved[5];    // 400..479
+    // ── Global shadow params (kept for world shadow-depth pass) ── offset 384
+    // NOTE: These members must stay layout-compatible with gpuframedata_t
+    // (shadow_viewproj/shadow_params/shadow_debug) so later dlight uniforms keep
+    // their expected offsets.
+    mat4    ShadowViewProj;          // 384
+    vec4    ShadowParams;            // 448
+    vec4    ShadowDebug;             // 464 (x: enabled, y: debug mode, z: dummy tex, w: source)
 
     mat4    ShadowDlightViewProj[SHADOW_DLIGHT_MAX];  // 480
     vec4    ShadowDlightAtlas[SHADOW_DLIGHT_MAX];     // 736


### PR DESCRIPTION
### Motivation
- Recent edits removed the global shadow fields from the GLSL frame uniform block while the shadow depth vertex shader still reads `ShadowViewProj`, causing shader compile failures (`undefined variable "ShadowViewProj"`).
- The goal is to restore layout-compatibility with the CPU `gpuframedata_t` so downstream dlight uniforms keep their expected offsets and existing shaders keep working.

### Description
- Reintroduced `mat4 ShadowViewProj`, `vec4 ShadowParams`, and retained `vec4 ShadowDebug` in `Quake/shaders/frame_uniforms.glsl` at offsets matching the CPU layout so later members remain at the same offsets. 
- Replaced the previous reserved-padding block with explicit fields and updated comments documenting the layout-compatibility requirement with `gpuframedata_t`.
- This change ensures `shadow_depth.vert` and other shaders that reference `ShadowViewProj` resolve the symbol again without moving later dlight uniforms.

### Testing
- Ran `make -C Quake -j4` to validate the build, but the build could not complete in this environment due to missing SDL2 tooling/headers (`sdl2-config` / `SDL.h`).
- Verified the `frame_uniforms.glsl` file now contains `ShadowViewProj`, `ShadowParams`, and `ShadowDebug` at the expected offsets.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c90c23588832e9f75a1fc7856bf88)