### PR TITLE
Unbind GL_TEXTURE6 to avoid GL_INVALID_OPERATION from shadow-sampler type conflict

### DIFF
--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -588,13 +588,15 @@ ibuf.global.half_lambert = CLAMP (0.f, r_model_halflambert.value, 1.f);
 	GL_BindBuffer (GL_ELEMENT_ARRAY_BUFFER, model->meshindexesvbo);
 	R_Shadow_BindReceiverShadowMap (GL_TEXTURE5);
 	R_Shadow_BindDebugColorAtlas (GL_TEXTURE7);
-	// FIX: Always bind raw shadow depth on TEXTURE6 for ShadowMapRaw (sampler2D).
-	// See matching fix in r_world.c R_DrawBrushModels_Real BP_SHADOW block.
-		{
+	{
 		qboolean receiver_enabled = R_Shadow_ReceiverUsesDlight ();
 		GLuint receiver_tex = receiver_enabled ? R_Shadow_GetReceiverShadowMapTextureId () : 0;
-		R_EnsureShadowSamplerState (receiver_tex);
-		GL_BindNative (GL_TEXTURE6, GL_TEXTURE_2D, receiver_tex);
+		/*
+		 * Keep TEXTURE6 unbound for alias receiver draws to avoid
+		 * sampler-type conflicts (sampler2DShadow on unit 5 vs sampler2D on 6)
+		 * when both units point at the same texture object.
+		 */
+		GL_BindNative (GL_TEXTURE6, GL_TEXTURE_2D, 0);
 		R_Shadow_Log_ReceiverPassSnapshot ("ALIAS", glprogs.alias[oit][mode][alphatest][md5], (GLint)GL_GetCurrentProgram (), GL_TEXTURE5, receiver_tex, receiver_enabled, r_framedata.shadow_params[0], r_framedata.shadow_params[1], r_framedata.shadow_params[2], r_framedata.shadow_params[3], R_Shadow_GetReceiverShadowViewProj ());
 		R_Shadow_DebugValidateBinding ("ALIAS", GL_TEXTURE5, receiver_tex);
 	}

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -1521,18 +1521,16 @@ GL_Bind (GL_TEXTURE2, r_fullbright_cheatsafe ? greytexture : lightmap_texture);
 GL_Bind (GL_TEXTURE3, (r_lightingdir.value > 0.f && lightmap_dir_texture) ? lightmap_dir_texture : greytexture);
 R_Shadow_BindReceiverShadowMap (GL_TEXTURE5);
 	R_Shadow_BindDebugColorAtlas (GL_TEXTURE7);
-	// FIX: Always bind the raw shadow depth texture on TEXTURE6 so that
-	// ShadowMapRaw (sampler2D, no hardware compare) works correctly in ALL
-	// debug modes (ShadowDebug.y > 2.5 path in shadow_sample.glsl).
-	// Previously this was only done for r_shadow_debug >= 3, leaving
-	// ShadowMapRaw unbound (reading 0) for intermediate debug modes 2.5..3.
-	// Note: TEXTURE6 must stay GL_NONE compare mode – only TEXTURE5 uses
-	// GL_COMPARE_REF_TO_TEXTURE (set inside R_Shadow_BindShadowMap).
-		{
+	{
 		qboolean receiver_enabled = R_Shadow_ReceiverUsesDlight ();
 		GLuint receiver_tex = receiver_enabled ? R_Shadow_GetReceiverShadowMapTextureId () : 0;
-		R_EnsureShadowSamplerState (receiver_tex);
-		GL_BindNative (GL_TEXTURE6, GL_TEXTURE_2D, receiver_tex);
+		/*
+		 * TEXTURE6 is intentionally unbound for world receiver draws.
+		 * Binding the same depth texture on TEXTURE5 (sampler2DShadow)
+		 * and TEXTURE6 (sampler2D) can trigger GL_INVALID_OPERATION due
+		 * to incompatible sampler types on the same texture object.
+		 */
+		GL_BindNative (GL_TEXTURE6, GL_TEXTURE_2D, 0);
 		R_Shadow_Log_ReceiverPassSnapshot ("WORLD", program, (GLint)GL_GetCurrentProgram (), GL_TEXTURE5, receiver_tex, receiver_enabled, r_framedata.shadow_params[0], r_framedata.shadow_params[1], r_framedata.shadow_params[2], r_framedata.shadow_params[3], R_Shadow_GetReceiverShadowViewProj ());
 		R_Shadow_DebugValidateBinding ("WORLD", GL_TEXTURE5, receiver_tex);
 	}
@@ -1540,6 +1538,7 @@ R_Shadow_BindReceiverShadowMap (GL_TEXTURE5);
 else if (pass == BP_DLIGHT_SOLID || pass == BP_DLIGHT_ALPHA)
 {
 R_Shadow_BindDlightShadowMap (GL_TEXTURE5);
+	GL_BindNative (GL_TEXTURE6, GL_TEXTURE_2D, 0);
 	R_Shadow_BindDebugColorAtlas (GL_TEXTURE7);
 		R_Shadow_Log_ReceiverPassSnapshot ("WORLD_DLIGHT", program, (GLint)GL_GetCurrentProgram (), GL_TEXTURE5, R_Shadow_GetDlightShadowMapTextureId (),
 			R_Shadow_ReceiverUsesDlight (), r_shadow_dlight_bias.value, 0.f,


### PR DESCRIPTION
### Motivation
- OpenGL can generate `GL_INVALID_OPERATION` when the same texture object is bound to two texture units with incompatible sampler types (e.g. `sampler2DShadow` on unit 5 and `sampler2D` on unit 6), which happened after shader-side removal of `ShadowDlightMapRaw` while the CPU still bound the texture to unit 6.
- The change aims to avoid these illegal bindings by ensuring texunit 6 is cleared for receiver draw paths where unit 5 is used for shadow compare sampling.

### Description
- Explicitly unbinds `GL_TEXTURE6` (`GL_BindNative(GL_TEXTURE6, GL_TEXTURE_2D, 0)`) in the world receiver draw path in `Quake/r_world.c` so the depth texture is not bound on both unit 5 and unit 6 simultaneously.
- Adds an explicit unbind of `GL_TEXTURE6` in the world dlight pass in `Quake/r_world.c` to prevent stale state carrying over between passes.
- Applies the same protection to alias model receiver draws in `Quake/r_alias.c` by unbinding unit 6 before the draw and adding a comment explaining the sampler-type conflict.
- Adds explanatory comments where the unbind is applied and removes the previous behavior of binding the raw shadow depth to unit 6 in these receiver paths.

### Testing
- Ran repository search with `rg` to locate remaining `GL_TEXTURE6`/binding patterns, which confirmed the updated unbinds (succeeded).
- Ran `cmake -S . -B build -G Ninja` to validate configure, which failed in this environment due to a missing SDL2 development package/config (failed).
- No automated unit tests were present for this codepath in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c94d20fd4832e9be702c27bb9674f)