### PR TITLE
Fix texunit6 unbind ordering around FRAME_BEGIN shadow logging

### DIFF
--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -595,9 +595,13 @@ ibuf.global.half_lambert = CLAMP (0.f, r_model_halflambert.value, 1.f);
 		 * Keep TEXTURE6 unbound for alias receiver draws to avoid
 		 * sampler-type conflicts (sampler2DShadow on unit 5 vs sampler2D on 6)
 		 * when both units point at the same texture object.
+		 *
+		 * Important: do not switch/bind TEXTURE6 until after
+		 * R_Shadow_Log_ReceiverPassSnapshot(), because that call may emit the
+		 * FRAME_BEGIN logging block and framebuffer attachment queries.
 		 */
-		GL_BindNative (GL_TEXTURE6, GL_TEXTURE_2D, 0);
 		R_Shadow_Log_ReceiverPassSnapshot ("ALIAS", glprogs.alias[oit][mode][alphatest][md5], (GLint)GL_GetCurrentProgram (), GL_TEXTURE5, receiver_tex, receiver_enabled, r_framedata.shadow_params[0], r_framedata.shadow_params[1], r_framedata.shadow_params[2], r_framedata.shadow_params[3], R_Shadow_GetReceiverShadowViewProj ());
+		GL_BindNative (GL_TEXTURE6, GL_TEXTURE_2D, 0);
 		R_Shadow_DebugValidateBinding ("ALIAS", GL_TEXTURE5, receiver_tex);
 	}
 

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -1524,25 +1524,29 @@ R_Shadow_BindReceiverShadowMap (GL_TEXTURE5);
 	{
 		qboolean receiver_enabled = R_Shadow_ReceiverUsesDlight ();
 		GLuint receiver_tex = receiver_enabled ? R_Shadow_GetReceiverShadowMapTextureId () : 0;
-		/*
-		 * TEXTURE6 is intentionally unbound for world receiver draws.
-		 * Binding the same depth texture on TEXTURE5 (sampler2DShadow)
-		 * and TEXTURE6 (sampler2D) can trigger GL_INVALID_OPERATION due
-		 * to incompatible sampler types on the same texture object.
-		 */
-		GL_BindNative (GL_TEXTURE6, GL_TEXTURE_2D, 0);
-		R_Shadow_Log_ReceiverPassSnapshot ("WORLD", program, (GLint)GL_GetCurrentProgram (), GL_TEXTURE5, receiver_tex, receiver_enabled, r_framedata.shadow_params[0], r_framedata.shadow_params[1], r_framedata.shadow_params[2], r_framedata.shadow_params[3], R_Shadow_GetReceiverShadowViewProj ());
-		R_Shadow_DebugValidateBinding ("WORLD", GL_TEXTURE5, receiver_tex);
-	}
+			/*
+			 * TEXTURE6 is intentionally unbound for world receiver draws.
+			 * Binding the same depth texture on TEXTURE5 (sampler2DShadow)
+			 * and TEXTURE6 (sampler2D) can trigger GL_INVALID_OPERATION due
+			 * to incompatible sampler types on the same texture object.
+			 *
+			 * Keep this bind after receiver logging. The first snapshot in a
+			 * frame can execute FRAME_BEGIN diagnostics with framebuffer queries,
+			 * and changing the active texture state beforehand can interfere.
+			 */
+			R_Shadow_Log_ReceiverPassSnapshot ("WORLD", program, (GLint)GL_GetCurrentProgram (), GL_TEXTURE5, receiver_tex, receiver_enabled, r_framedata.shadow_params[0], r_framedata.shadow_params[1], r_framedata.shadow_params[2], r_framedata.shadow_params[3], R_Shadow_GetReceiverShadowViewProj ());
+			GL_BindNative (GL_TEXTURE6, GL_TEXTURE_2D, 0);
+			R_Shadow_DebugValidateBinding ("WORLD", GL_TEXTURE5, receiver_tex);
+		}
 }
 else if (pass == BP_DLIGHT_SOLID || pass == BP_DLIGHT_ALPHA)
 {
 R_Shadow_BindDlightShadowMap (GL_TEXTURE5);
-	GL_BindNative (GL_TEXTURE6, GL_TEXTURE_2D, 0);
 	R_Shadow_BindDebugColorAtlas (GL_TEXTURE7);
 		R_Shadow_Log_ReceiverPassSnapshot ("WORLD_DLIGHT", program, (GLint)GL_GetCurrentProgram (), GL_TEXTURE5, R_Shadow_GetDlightShadowMapTextureId (),
 			R_Shadow_ReceiverUsesDlight (), r_shadow_dlight_bias.value, 0.f,
 			r_shadow_dlight_pcf_taps.value > 0.f ? 1.f : 0.f, r_shadow_dlight_pcf_taps.value, R_Shadow_GetReceiverShadowViewProj ());
+	GL_BindNative (GL_TEXTURE6, GL_TEXTURE_2D, 0);
 		R_Shadow_DebugValidateBinding ("WORLD_DLIGHT", GL_TEXTURE5, R_Shadow_GetDlightShadowMapTextureId ());
 }
 else if (pass == BP_SKYCUBEMAP)


### PR DESCRIPTION
### Motivation
- A recent `GL_BindNative(GL_TEXTURE6, GL_TEXTURE_2D, 0)` unbind could mutate the active texture state immediately before `FRAME_BEGIN` logging and framebuffer-attachment queries, causing `GL_INVALID_OPERATION` during draw-depth-attachment queries. 

### Description
- Reordered the alias receiver path so `R_Shadow_Log_ReceiverPassSnapshot(...)` runs before `GL_BindNative(GL_TEXTURE6, GL_TEXTURE_2D, 0)` in `Quake/r_alias.c` and added a comment documenting the reason. 
- Applied the same reordering and explanatory comment to the world receiver path in `Quake/r_world.c`. 
- Moved the `TEXTURE6` unbind in the world dlight receiver branch to execute after the logging snapshot to keep all receiver paths consistent.

### Testing
- Ran `git diff --check` on the working tree to validate there are no whitespace/patch issues and it passed. 
- Verified the two source files (`Quake/r_alias.c`, `Quake/r_world.c`) contain the reordered calls and added comments via repository diff inspection which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c9cc3d004832e9afeab04b31c2ac7)