### PR TITLE
Restore dlight FBO draw buffer after shadow pass

### DIFF
--- a/Quake/r_shadow.c
+++ b/Quake/r_shadow.c
@@ -1342,6 +1342,10 @@ void R_Shadow_DlightPass (void)
 	}
 	R_UploadFrameData ();
 
+	// Restore a color draw buffer before handing this FBO into the next frame.
+	// Some drivers reject depth-attachment framebuffer queries while GL_DRAW_BUFFER is GL_NONE.
+	glDrawBuffer (GL_COLOR_ATTACHMENT0);
+
 	GL_EndGroup ();
 }
 


### PR DESCRIPTION
### Motivation
- Fix `GL_INVALID_OPERATION` seen in `FRAME_BEGIN` framebuffer attachment queries when the dlight shadow pass leaves the FBO with `GL_DRAW_BUFFER = GL_NONE` by restoring a valid color draw buffer before the FBO is used in the next frame.

### Description
- Add `glDrawBuffer(GL_COLOR_ATTACHMENT0)` (with a short explanatory comment) after `R_UploadFrameData()` at the end of the dlight shadow pass in `Quake/r_shadow.c` so the FBO is not handed to the next frame with `GL_NONE` while preserving the depth-only behavior during the pass.

### Testing
- Ran `git diff --check` to validate the patch formatting and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cc22d2904832ead1810bb285fdada)