### PR TITLE
Fix dlight shadow atlas projection path and add UV debug visualization

### DIFF
--- a/Quake/shaders/shadow_sample.glsl
+++ b/Quake/shaders/shadow_sample.glsl
@@ -163,6 +163,31 @@ float ShadowSampleDlightSource(vec2 uv, float reference, float bias, int taps)
     return ShadowSampleRawDlight(uv, reference, bias);
 }
 
+bool ShadowProjectToAtlasUV(vec4 clip, vec4 atlas, out vec2 uv_local, out vec2 uv_atlas, out float reference)
+{
+    if (clip.w <= 0.0)
+        return false;
+
+    vec3 proj = clip.xyz / clip.w;
+
+#if REVERSED_Z
+    if (proj.z < 0.0 || proj.z > 1.0)
+        return false;
+#else
+    if (proj.z < -1.0 || proj.z > 1.0)
+        return false;
+#endif
+
+    uv_local = proj.xy * 0.5 + 0.5;
+    uv_atlas = uv_local * atlas.xy + atlas.zw;
+    reference = ShadowReference01(proj.z);
+
+    vec2 atlas_min = atlas.zw;
+    vec2 atlas_max = atlas.zw + atlas.xy;
+    return all(greaterThanEqual(uv_atlas, atlas_min)) &&
+           all(lessThanEqual(uv_atlas, atlas_max));
+}
+
 float ShadowVisibilityDlight(vec3 world_pos, vec3 normal, vec3 light_pos,
                               uint light_index, out float in_range)
 {
@@ -193,50 +218,11 @@ float ShadowVisibilityDlight(vec3 world_pos, vec3 normal, vec3 light_pos,
         return 1.0;
     }
 
-    vec4 clip = ShadowMul(ShadowDlightViewProj[shadow_index], vec4(world_pos, 1.0));
-    if (clip.w <= 0.0)
-    {
-        in_range = 0.0;
-        return 1.0;
-    }
-
-    vec3  proj      = clip.xyz / clip.w;
-
-    // FIX: Frustum-Tiefenbereichscheck vor ShadowReference01.
-    // proj.z (NDC-Tiefe nach w-Division) liegt fuer Punkte HINTER der Far-Ebene
-    // ausserhalb des gueltigen Bereichs. ShadowReference01 wuerde solche Werte
-    // auf 0.0 clampen, was mit GL_GEQUAL (Reverse-Z) als "im Schatten" bewertet
-    // wird -- das erzeugt das dunkle Artefakt an Geometrie jenseits des Lichtradius.
-    // Korrekt: Punkte ausserhalb des Shadow-Frustum-Tiefenbereichs sind BELEUCHTET.
-#if REVERSED_Z
-    // Reverse-Z: gueltiger NDC-Z-Bereich [0,1] (0=fern, 1=nah)
-    if (proj.z < 0.0 || proj.z > 1.0)
-    {
-        in_range = 0.0;
-        return 1.0;
-    }
-#else
-    // Standard-Z: gueltiger NDC-Z-Bereich [-1,1]
-    if (proj.z < -1.0 || proj.z > 1.0)
-    {
-        in_range = 0.0;
-        return 1.0;
-    }
-#endif
-
-    vec2  uv_local  = proj.xy * 0.5 + 0.5;
-    float reference = ShadowReference01(proj.z);
-
-    // Atlas-Remapping: uv_local → atlas UV
     vec4 atlas = ShadowDlightAtlas[shadow_index];
-    // atlas.xy = scale, atlas.zw = offset
-    vec2 uv = uv_local * atlas.xy + atlas.zw;
-
-    // Bounds-Check gegen Atlas-Kachel (nicht gegen Textur-Rand)
-    vec2 atlas_min = atlas.zw;
-    vec2 atlas_max = atlas.zw + atlas.xy;
-    bool inside = all(greaterThanEqual(uv, atlas_min)) &&
-                  all(lessThanEqual   (uv, atlas_max));
+    vec2 uv_local, uv;
+    float reference;
+    vec4 clip = ShadowMul(ShadowDlightViewProj[shadow_index], vec4(world_pos, 1.0));
+    bool inside = ShadowProjectToAtlasUV(clip, atlas, uv_local, uv, reference);
     in_range = inside ? 1.0 : 0.0;
     if (!inside)
         return 1.0;
@@ -262,6 +248,10 @@ float ShadowVisibilityDlight(vec3 world_pos, vec3 normal, vec3 light_pos,
         return ShadowDebugChecker(uv * 32.0);
     if (SHADOW_DEBUG_VALUES.y >= 2.5 && SHADOW_DEBUG_VALUES.y < 3.5)
         return reference;
+    if (SHADOW_DEBUG_VALUES.y >= 3.5 && SHADOW_DEBUG_VALUES.y < 4.5)
+        return uv.x;
+    if (SHADOW_DEBUG_VALUES.y >= 4.5 && SHADOW_DEBUG_VALUES.y < 5.5)
+        return uv.y;
 
     return shadow_term;
 }
@@ -283,21 +273,11 @@ vec4 ShadowDebugDlight(vec3 world_pos, uint light_index)
     if (shadow_index < 0)
         return vec4(1.0, 0.0, 1.0, 1.0);
 
-    vec4 clip = ShadowMul(ShadowDlightViewProj[shadow_index], vec4(world_pos, 1.0));
-    if (abs(clip.w) <= 1e-6)
-        return vec4(1.0, 0.0, 1.0, 1.0);
-
-    vec3 ndc = clip.xyz / clip.w;
-    vec2 uv_local = ndc.xy * 0.5 + 0.5;
-    float reference = ShadowReference01(ndc.z);
-
     vec4 atlas = ShadowDlightAtlas[shadow_index];
-    vec2 uv = uv_local * atlas.xy + atlas.zw;
-
-    vec2 atlas_min = atlas.zw;
-    vec2 atlas_max = atlas.zw + atlas.xy;
-    bool inside = all(greaterThanEqual(uv, atlas_min)) &&
-                  all(lessThanEqual(uv, atlas_max));
+    vec2 uv_local, uv;
+    float reference;
+    vec4 clip = ShadowMul(ShadowDlightViewProj[shadow_index], vec4(world_pos, 1.0));
+    bool inside = ShadowProjectToAtlasUV(clip, atlas, uv_local, uv, reference);
 
     if (!inside)
         return vec4(1.0, 0.0, 0.0, 1.0);


### PR DESCRIPTION
### Motivation
- Eliminate incorrect/unstable DLight receiver sampling caused by duplicated/diverging clip→NDC→UV→atlas remap logic that produced checkerboard/tile-mismatch artifacts. 
- Make atlas projection deterministic and add direct UV debug visualizations so tile/UV issues can be diagnosed in-frame.

### Description
- Add a shared helper `ShadowProjectToAtlasUV(vec4 clip, vec4 atlas, out vec2 uv_local, out vec2 uv_atlas, out float reference)` in `Quake/shaders/shadow_sample.glsl` to centralize clip-space divide, Reverse-Z-aware depth-range checking, NDC→UV bias, atlas remap, and tile bounds tests. 
- Update `ShadowVisibilityDlight()` and `ShadowDebugDlight()` to call the new helper and remove the duplicated clip/NDC/atlas mapping code so WORLD and ALIAS receiver paths use identical projection math. 
- Add two debug bands that expose computed atlas UV channels (return `uv.x` for `ShadowDebug.y ∈ [3.5,4.5)` and `uv.y` for `ShadowDebug.y ∈ [4.5,5.5)`) to aid visual validation of tile mapping. 
- No CPU packing changes: `r_framedata.shadow_dlight_atlas[i]` remains `{ scale, scale, offset_x, offset_y }`, and existing Reverse-Z compare-state handling is preserved.

### Testing
- Attempted an automated CMake configure + build (`cmake -S . -B build && cmake --build build`) in this environment, but it failed due to a missing SDL2 CMake package, so no compiled-run validation was possible.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cde14aa54832ebfeebbdaad3cdc42)