### PR TITLE
Fix alias dlight shadow atlas receiver data wiring

### DIFF
--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -97,6 +97,10 @@ struct ibuf_s {
 		float	shadow_viewproj[16];
 		vec4_t	shadow_params;
 		vec4_t	shadow_debug;
+		float	shadow_dlight_viewproj[SHADOW_DLIGHT_MAX][16];
+		vec4_t	shadow_dlight_atlas[SHADOW_DLIGHT_MAX];
+		vec4_t	shadow_dlight_info[SHADOW_DLIGHT_MAX];
+		vec4_t	shadow_dlight_params;
 	} global;
 	aliasinstance_t inst[MAX_ALIAS_INSTANCES];
 } ibuf;
@@ -576,6 +580,10 @@ ibuf.global.half_lambert = CLAMP (0.f, r_model_halflambert.value, 1.f);
 	ibuf.global.shadow_params[2] = r_shadow_pcf.value > 0.f ? 1.f : 0.f;
 	ibuf.global.shadow_params[3] = r_shadow_pcf_taps.value;
 	memcpy (ibuf.global.shadow_debug, r_framedata.shadow_debug, sizeof (r_framedata.shadow_debug));
+	memcpy (ibuf.global.shadow_dlight_viewproj, r_framedata.shadow_dlight_viewproj, sizeof (ibuf.global.shadow_dlight_viewproj));
+	memcpy (ibuf.global.shadow_dlight_atlas, r_framedata.shadow_dlight_atlas, sizeof (ibuf.global.shadow_dlight_atlas));
+	memcpy (ibuf.global.shadow_dlight_info, r_framedata.shadow_dlight_info, sizeof (ibuf.global.shadow_dlight_info));
+	memcpy (ibuf.global.shadow_dlight_params, r_framedata.shadow_dlight_params, sizeof (ibuf.global.shadow_dlight_params));
 
 	ibuf_size = sizeof(ibuf.global) + sizeof(ibuf.inst[0]) * ibuf.count;
 	GL_Upload (GL_SHADER_STORAGE_BUFFER, &ibuf.global, ibuf_size, &buf, &ofs);
@@ -740,6 +748,10 @@ static void R_FlushAliasInstances_Shadow (void)
 	ibuf.global.shadow_params[2] = r_shadow_pcf.value > 0.f ? 1.f : 0.f;
 	ibuf.global.shadow_params[3] = r_shadow_pcf_taps.value;
 	memcpy (ibuf.global.shadow_debug, r_framedata.shadow_debug, sizeof (r_framedata.shadow_debug));
+	memcpy (ibuf.global.shadow_dlight_viewproj, r_framedata.shadow_dlight_viewproj, sizeof (ibuf.global.shadow_dlight_viewproj));
+	memcpy (ibuf.global.shadow_dlight_atlas, r_framedata.shadow_dlight_atlas, sizeof (ibuf.global.shadow_dlight_atlas));
+	memcpy (ibuf.global.shadow_dlight_info, r_framedata.shadow_dlight_info, sizeof (ibuf.global.shadow_dlight_info));
+	memcpy (ibuf.global.shadow_dlight_params, r_framedata.shadow_dlight_params, sizeof (ibuf.global.shadow_dlight_params));
 
 	ibuf_size = sizeof(ibuf.global) + sizeof(ibuf.inst[0]) * ibuf.count;
 	GL_Upload (GL_SHADER_STORAGE_BUFFER, &ibuf.global, ibuf_size, &buf, &ofs);

--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -25,6 +25,10 @@ layout(std430, binding=1) restrict readonly buffer AliasFrameBlock
 	mat4	ShadowViewProj;
 	vec4	ShadowParams;
 	vec4	ShadowDebug;
+	mat4	ShadowDlightViewProj[4];
+	vec4	ShadowDlightAtlas[4];
+	vec4	ShadowDlightInfo[4];
+	vec4	ShadowDlightParams;
 	InstanceData instances[];
 } AliasFrameBuffer;
 // ALU-only 16x16 Bayer matrix
@@ -104,12 +108,12 @@ layout(binding=5) uniform sampler2DShadow ShadowDlightMap;
 layout(binding=7) uniform sampler2D ShadowDlightMapDebug;
 
 // alias shaders use an SSBO-backed frame block and don't include frame_uniforms.glsl.
-// Provide the dynamic-light shadow uniforms explicitly so shadow_sample.glsl compiles.
+// Mirror the same names expected by shadow_sample.glsl via AliasFrameBuffer fields.
 #define SHADOW_DLIGHT_MAX 4
-uniform mat4 ShadowDlightViewProj[SHADOW_DLIGHT_MAX];
-uniform vec4 ShadowDlightAtlas[SHADOW_DLIGHT_MAX];
-uniform vec4 ShadowDlightInfo[SHADOW_DLIGHT_MAX];
-uniform vec4 ShadowDlightParams;
+#define ShadowDlightViewProj AliasFrameBuffer.ShadowDlightViewProj
+#define ShadowDlightAtlas AliasFrameBuffer.ShadowDlightAtlas
+#define ShadowDlightInfo AliasFrameBuffer.ShadowDlightInfo
+#define ShadowDlightParams AliasFrameBuffer.ShadowDlightParams
 
 #define SHADOW_DEBUG_VALUES AliasFrameBuffer.ShadowDebug
 #define SHADOW_DLIGHT 1


### PR DESCRIPTION
### Motivation
- The ALIAS receiver path was sampling dynamic-light shadow atlas data from standalone shader uniforms that were not populated for the alias SSBO path, causing wrong tile/UV projection and visible checkerboard/mismatch artifacts. 
- World (FRAME UBO) and Alias (SSBO) receiver paths must use identical atlas packing, NDC→UV projection and reverse-Z compare semantics so shadows are stable and tile-correct.

### Description
- Extend the alias frame SSBO (`AliasFrameBlock`) with `ShadowDlightViewProj`, `ShadowDlightAtlas`, `ShadowDlightInfo` and `ShadowDlightParams` fields to mirror the `FrameDataUBO` layout. 
- Populate those new `ibuf.global.shadow_dlight_*` fields from `r_framedata` in both alias upload paths (`R_FlushAliasInstances` and `R_FlushAliasInstances_Shadow`) so the alias shader receives the same per-frame dlight atlas/viewproj data. 
- Change `alias.frag` to stop using separate `uniform` arrays and instead resolve `ShadowDlight*` to the SSBO-backed `AliasFrameBuffer` fields via `#define` macros, and add matching SSBO members to the shader struct so `shadow_sample.glsl` behavior is identical for WORLD and ALIAS. 
- Kept atlas packing semantics unchanged (`xy = scale`, `zw = offset`) and reused the shared `shadow_sample.glsl` projection / reverse-Z compare logic so both receiver programs get consistent mapping and compare behavior.

### Testing
- Verified symbol locations and references with repository searches to ensure `ShadowDlight*` names exist in CPU frame data and shader includes (`rg`/code inspection succeeded). 
- Ran `cmake -S . -B build && cmake --build build -j4` in this environment to exercise a full build, which failed due to missing external package `SDL2` (`SDL2Config.cmake` not found), so a full compile could not be completed here. 
- Confirmed via diffs and shader include wiring that alias shaders now source the same SSBO-backed fields and that the CPU now uploads the corresponding arrays, resolving the previously-observed CPU→GPU data mismatch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ce0d402a8832ead3371e523daf85c)