### PR TITLE
Fix alias shader SSBO layout mismatch causing program link errors

### DIFF
--- a/Quake/shaders/alias.vert
+++ b/Quake/shaders/alias.vert
@@ -24,6 +24,10 @@ layout(std430, binding=1) restrict readonly buffer AliasFrameBlock
 	mat4	ShadowViewProj;
 	vec4	ShadowParams;
 	vec4	ShadowDebug;
+	mat4	ShadowDlightViewProj[4];
+	vec4	ShadowDlightAtlas[4];
+	vec4	ShadowDlightInfo[4];
+	vec4	ShadowDlightParams;
 	InstanceData instances[];
 } AliasFrameBuffer;
 


### PR DESCRIPTION
### Motivation
- Vertex and fragment alias shaders declared different `std430` layouts for the same SSBO binding, which can produce cross-stage offset/link errors (e.g. `instances[0].WorldMatrix` / `PrevWorldMatrix` mismatches) and cause shader link failures or rendering glitches.

### Description
- Added the missing dynamic-light shadow fields to the `AliasFrameBlock` SSBO in `Quake/shaders/alias.vert`: `ShadowDlightViewProj[4]`, `ShadowDlightAtlas[4]`, `ShadowDlightInfo[4]`, and `ShadowDlightParams`, so its layout matches `Quake/shaders/alias.frag` and `shadow_depth_alias.vert`.
- This change aligns vertex-stage buffer offsets with the fragment stage and the CPU-side packing expectations to prevent stride/offset mismatches.

### Testing
- Ran a small Python check that extracts and compares the `AliasFrameBlock` declaration from `Quake/shaders/alias.vert` and `Quake/shaders/alias.frag`, which reported matching layouts after the change (success).
- Inspected the file diff for `Quake/shaders/alias.vert` to confirm only the intended SSBO fields were added (success).
- Verified workspace status showed the modified shader file present and ready for further validation; no shader compile/link run was performed in this change (status check passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ce610deb8832e9a6096db029181c9)