### PR TITLE
Fix dlight shadow receiver selection and harden shadow UBO/SSBO + sampler state

### DIFF
--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -460,6 +460,13 @@ typedef struct gpuframedata_s {
         unsigned int    _padding2;
 } gpuframedata_t;
 
+COMPILE_TIME_ASSERT (gpuframedata_std140_size, sizeof (gpuframedata_t) == 896);
+COMPILE_TIME_ASSERT (gpuframedata_shadow_viewproj_offset, offsetof (gpuframedata_t, shadow_viewproj) == 384);
+COMPILE_TIME_ASSERT (gpuframedata_shadow_dlight_viewproj_offset, offsetof (gpuframedata_t, shadow_dlight_viewproj) == 480);
+COMPILE_TIME_ASSERT (gpuframedata_shadow_dlight_atlas_offset, offsetof (gpuframedata_t, shadow_dlight_atlas) == 736);
+COMPILE_TIME_ASSERT (gpuframedata_shadow_dlight_info_offset, offsetof (gpuframedata_t, shadow_dlight_info) == 800);
+COMPILE_TIME_ASSERT (gpuframedata_shadow_dlight_params_offset, offsetof (gpuframedata_t, shadow_dlight_params) == 864);
+
 typedef enum
 {
 	TCGEN_BASE = 0,

--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -69,6 +69,11 @@ typedef struct aliasinstance_s {
 	float		alpha;
 	vec3_t		dlightcolor;
 	float		_pad0;
+	vec4_t		shadow_light_pos_range; // xyz: dlight position, w: range
+	uint32_t	shadow_light_index;
+	uint32_t	_pad_shadow1;
+	uint32_t	_pad_shadow2;
+	uint32_t	_pad_shadow3;
 	int32_t		pose1;
 	int32_t		pose2;
 	float		blend;
@@ -106,6 +111,67 @@ struct ibuf_s {
 } ibuf;
 
 COMPILE_TIME_ASSERT (alias_global_size_matches_std430, sizeof (ibuf.global) % 16 == 0);
+COMPILE_TIME_ASSERT (alias_instance_size_matches_std430, sizeof (aliasinstance_t) == 176);
+COMPILE_TIME_ASSERT (alias_instance_shadow_pos_offset, offsetof (aliasinstance_t, shadow_light_pos_range) == 128);
+COMPILE_TIME_ASSERT (alias_instance_shadow_index_offset, offsetof (aliasinstance_t, shadow_light_index) == 144);
+
+static void R_Alias_SelectDominantShadowDlight (const vec3_t entity_origin, aliasinstance_t *instance)
+{
+	float best_score = -FLT_MAX;
+	int best_light_index = -1;
+	dlight_t *best_light = NULL;
+
+	instance->shadow_light_index = UINT32_MAX;
+	Vector4Set (instance->shadow_light_pos_range, 0.f, 0.f, 0.f, 0.f);
+
+	if (!R_Shadow_DlightShadowsActiveThisFrame ())
+		return;
+
+	for (int slot = 0; slot < SHADOW_DLIGHT_MAX; ++slot)
+	{
+		int light_index;
+		dlight_t *dl;
+		float radius;
+		float dist;
+		float score;
+
+		if (r_framedata.shadow_dlight_info[slot][0] < 0.f)
+			continue;
+
+		light_index = (int)Q_rint (r_framedata.shadow_dlight_info[slot][0]);
+		if (light_index < 0 || light_index >= DLIGHT_GPU_MAX)
+			continue;
+
+		dl = r_dlight_sources[light_index];
+		if (!dl || !dl->active)
+			continue;
+
+		radius = dl->radius;
+		if (radius <= 0.f)
+			continue;
+
+		dist = Distance (entity_origin, dl->origin);
+		if (dist > radius)
+			continue;
+
+		score = radius - dist;
+		if (score > best_score)
+		{
+			best_score = score;
+			best_light_index = light_index;
+			best_light = dl;
+		}
+	}
+
+	if (!best_light)
+		return;
+
+	instance->shadow_light_index = (uint32_t)best_light_index;
+	instance->shadow_light_pos_range[0] = best_light->origin[0];
+	instance->shadow_light_pos_range[1] = best_light->origin[1];
+	instance->shadow_light_pos_range[2] = best_light->origin[2];
+	instance->shadow_light_pos_range[3] = best_light->radius;
+}
 
 static qboolean r_lightgrid_debug_sample_reported = false;
 static const qmodel_t *r_lightgrid_debug_last_world = NULL;
@@ -969,6 +1035,7 @@ if (!Q_strncmp (e->model->name, "progs/bolt", 10))
         instance->pose1 = lerpdata.pose1;
         instance->pose2 = lerpdata.pose2;
         instance->blend = lerpdata.blend;
+	R_Alias_SelectDominantShadowDlight (lerpdata.origin, instance);
 
 	if (paliashdr->poseverttype == PV_QUAKE1)
 	{
@@ -1037,6 +1104,8 @@ static void R_DrawAliasModel_Shadow_Real (entity_t *e)
 
 	VectorClear (instance->lightcolor);
 	VectorClear (instance->dlightcolor);
+	Vector4Set (instance->shadow_light_pos_range, 0.f, 0.f, 0.f, 0.f);
+	instance->shadow_light_index = UINT32_MAX;
 	instance->alpha = entalpha;
 	instance->pose1 = lerpdata.pose1;
 	instance->pose2 = lerpdata.pose2;

--- a/Quake/r_shadow.c
+++ b/Quake/r_shadow.c
@@ -44,6 +44,7 @@ static qboolean shadow_dlight_shadows_active_this_frame;
 static int shadow_dlight_shadow_caster_count;
 static int shadow_dlight_atlas_valid_frame_id = -1;
 static int shadow_dlight_selected_slot = -1;
+static int shadow_dlight_slottable_last_frame = -9999;
 
 extern cvar_t r_shadow_log;
 extern cvar_t r_shadow_log_rate;
@@ -239,6 +240,20 @@ static void R_Shadow_SetTextureCompareStateForMode (GLenum compare_mode)
 		glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_FUNC, compare_func);
 }
 
+static void R_Shadow_ApplyDepthSamplerState (GLenum compare_mode)
+{
+	const float border_val = gl_clipcontrol_able ? 0.f : 1.f;
+	const float border[4] = { border_val, border_val, border_val, border_val };
+
+	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
+	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
+	glTexParameterfv (GL_TEXTURE_2D, GL_TEXTURE_BORDER_COLOR, border);
+	R_Shadow_SetTextureCompareStateForMode (compare_mode);
+	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0);
+}
+
 static void R_Shadow_SetTextureCompareState (void)
 {
 	R_Shadow_SetTextureCompareStateForMode (GL_COMPARE_REF_TO_TEXTURE);
@@ -280,7 +295,9 @@ void R_EnsureShadowSamplerState (GLuint texture)
 	GL_ActiveTextureFunc (GL_TEXTURE0);
 	glGetIntegerv (GL_TEXTURE_BINDING_2D, &previous_binding);
 	glBindTexture (GL_TEXTURE_2D, texture);
-	R_Shadow_SetTextureCompareStateForMode (r_shadow_debug.value >= 3.f ? GL_NONE : GL_COMPARE_REF_TO_TEXTURE);
+	R_Shadow_ApplyDepthSamplerState (r_shadow_debug.value >= 3.f ? GL_NONE : GL_COMPARE_REF_TO_TEXTURE);
+	if (r_shadow_debug.value >= 2.f && (r_framecount & 63) == 0)
+		R_Shadow_LogTextureParams ("receiver_sampler_validate", texture);
 	glBindTexture (GL_TEXTURE_2D, (GLuint)previous_binding);
 	GL_ActiveTextureFunc ((GLenum)previous_active);
 }
@@ -985,23 +1002,7 @@ static void R_Shadow_ResizeDlightAtlasIfNeeded (void)
 	GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, shadow_dlight_depth_tex);
 	GL_ObjectLabelFunc (GL_TEXTURE, shadow_dlight_depth_tex, -1, "shadowmap dlight depth");
 	GL_TexStorage2DFunc (GL_TEXTURE_2D, 1, GL_DEPTH_COMPONENT24, atlas_size, atlas_size);
-	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
-	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
-	{
-		/* FIX Border-Farbe fuer Reverse-Z:
-		 * Mit Reverse-Z bedeutet depth=1.0 "ganz nah" (= im Schatten).
-		 * border=1.0 wuerde dann alles ausserhalb des Shadow-Frustums als
-		 * "im Schatten" werten -> dunkles Artefakt am Bildrand/Wand.
-		 * Korrekt: border=1.0 fuer Standard-Z (weit weg = kein Schatten),
-		 *          border=0.0 fuer Reverse-Z  (weit weg = kein Schatten). */
-		const float border_val = gl_clipcontrol_able ? 0.f : 1.f;
-		const float border[4] = { border_val, border_val, border_val, border_val };
-		glTexParameterfv (GL_TEXTURE_2D, GL_TEXTURE_BORDER_COLOR, border);
-	}
-	R_Shadow_SetTextureCompareState ();
-	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0);
+	R_Shadow_ApplyDepthSamplerState (GL_COMPARE_REF_TO_TEXTURE);
 
 	glGenTextures (1, &shadow_dlight_debug_color_tex);
 	GL_ActiveTextureFunc (GL_TEXTURE0);
@@ -1191,6 +1192,12 @@ static void R_Shadow_SelectReceiverSource (GLuint tex, const float viewproj[16])
 
 void R_Shadow_BindReceiverShadowMap (GLenum texunit)
 {
+	if (R_Shadow_DlightShadowsActiveThisFrame () && shadow_dlight_atlas_valid_frame_id != r_framecount)
+	{
+		Con_DPrintf ("r_shadow: receiver bind before current-frame dlight pass (atlas=%d frame=%d)\n",
+			shadow_dlight_atlas_valid_frame_id, r_framecount);
+	}
+
 	if (!R_Shadow_ReceiverUsesDlight ())
 	{
 		GL_BindNative (texunit, GL_TEXTURE_2D, 0);
@@ -1442,6 +1449,21 @@ void R_Shadow_DlightPass (void)
 		(rs_brushpolys  + rs_aliaspolys)  - tris0,
 		(t1 - t0) * 1000.0);
 	R_Shadow_LogWrite ("DLIGHTPASS selected=%d casters=%d atlas=%d tile=%d tile_count=%d cvar_max=%d\n", shadow_dlight_selected_count, shadow_dlight_shadow_caster_count, shadow_dlight_atlas_size, shadow_dlight_tile_size, shadow_dlight_tile_count, max_tiles);
+
+	if (r_shadow_debug.value > 0.f && r_framecount - shadow_dlight_slottable_last_frame >= 60)
+	{
+		shadow_dlight_slottable_last_frame = r_framecount;
+		for (int i = 0; i < shadow_dlight_selected_count; ++i)
+		{
+			const int li = shadow_dlight_light_indices[i];
+			dlight_t *dl = (li >= 0 && li < DLIGHT_GPU_MAX) ? r_dlight_sources[li] : NULL;
+			R_Shadow_LogWrite ("slot[%d] light=%d rect=(%.3f %.3f %.3f %.3f) range=%.1f\n",
+				i, li,
+				r_framedata.shadow_dlight_atlas[i][0], r_framedata.shadow_dlight_atlas[i][1],
+				r_framedata.shadow_dlight_atlas[i][2], r_framedata.shadow_dlight_atlas[i][3],
+				dl ? dl->radius : 0.f);
+		}
+	}
 
 	memcpy (r_framedata.shadow_viewproj, saved_viewproj, sizeof (saved_viewproj));
 	if (shadow_dlight_selected_slot >= 0)

--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -5,6 +5,11 @@ struct InstanceData
 	vec4	PrevWorldMatrix[3];
 	vec4	LightColor; // xyz=LightColor w=Alpha
 	vec4	DLightColor; // xyz=DLightColor
+	vec4	ShadowLightPosRange; // xyz=dlight pos, w=range
+	uint	ShadowLightIndex;
+	uint	_PadShadow1;
+	uint	_PadShadow2;
+	uint	_PadShadow3;
 	int		Pose1;
 	int		Pose2;
 	float	Blend;
@@ -130,6 +135,8 @@ layout(location=3) noperspective in vec4 in_curr_clip;
 layout(location=4) noperspective in vec4 in_prev_clip;
 layout(location=5) flat in int in_flags;
 layout(location=6) in vec3 in_normal;
+layout(location=7) flat in uint in_shadow_light_index;
+layout(location=8) flat in vec4 in_shadow_light_pos_range;
 
 #define OUT_COLOR out_fragcolor
 #if OIT
@@ -174,13 +181,11 @@ void main()
 {
         vec2 uv = in_texcoord;
         vec3 emissive = vec3(0.0);
-        float shadow_range = 1.0;
+        float shadow_range = 0.0;
         float shadow_term = 1.0;
-        uint shadow_light_index = 0u;  // Slot 0: erster DLight-Caster
-        // NOTE: shadow_light_pos wird nur fuer ndotl-Bias in ShadowVisibilityDlight
-        // genutzt. Alias-Shader hat keinen Zugriff auf die echte Lichtposition.
-        // EyePos als Fallback liefert konservativen (leicht zu hohen) Bias.
-        vec3 shadow_light_pos = AliasFrameBuffer.EyePos;
+	uint shadow_light_index = in_shadow_light_index;
+	vec3 shadow_light_pos = in_shadow_light_pos_range.xyz;
+	shadow_range = in_shadow_light_pos_range.w;
 	vec4 lit_color = in_color;
 
 	// FIX: Shadow-Berechnung laeuft immer (nicht nur wenn ShadowDebug.x > 0.5).
@@ -191,7 +196,8 @@ void main()
 	{
 		vec3 world_pos = in_pos + AliasFrameBuffer.EyePos;
 		vec3 shadow_normal = gl_FrontFacing ? in_normal : -in_normal;
-		shadow_term = ShadowVisibilityDlight(world_pos, shadow_normal, shadow_light_pos, shadow_light_index, shadow_range);
+		if (shadow_light_index != 0xFFFFFFFFu && shadow_range > 0.0)
+			shadow_term = ShadowVisibilityDlight(world_pos, shadow_normal, shadow_light_pos, shadow_light_index, shadow_range);
 
 		// Debug-Visualisierung (nur wenn ShadowDebug.x > 0.5)
 		if (AliasFrameBuffer.ShadowDebug.x > 0.5 && AliasFrameBuffer.ShadowDebug.y > 0.5)
@@ -200,6 +206,12 @@ void main()
 				OUT_COLOR = vec4(vec3(shadow_term), 1.0);
 			else if (AliasFrameBuffer.ShadowDebug.y < 2.5)
 				OUT_COLOR = ShadowDebugDlight(world_pos, shadow_light_index);
+			else if (AliasFrameBuffer.ShadowDebug.y < 3.5)
+			{
+				float idx = (shadow_light_index == 0xFFFFFFFFu) ? -1.0 : float(shadow_light_index);
+				vec3 idx_color = fract(vec3(idx * 0.1031, idx * 0.11369, idx * 0.13787));
+				OUT_COLOR = vec4(idx_color, 1.0);
+			}
 			else
 			{
 				vec4 shadow_clip = AliasFrameBuffer.ShadowViewProj * vec4(world_pos, 1.0);

--- a/Quake/shaders/alias.vert
+++ b/Quake/shaders/alias.vert
@@ -4,6 +4,11 @@ struct InstanceData
 	vec4	PrevWorldMatrix[3];
 	vec4	LightColor; // xyz=LightColor w=Alpha
 	vec4	DLightColor; // xyz=DLightColor
+	vec4	ShadowLightPosRange; // xyz=dlight pos, w=range
+	uint	ShadowLightIndex;
+	uint	_PadShadow1;
+	uint	_PadShadow2;
+	uint	_PadShadow3;
 	int		Pose1;
 	int		Pose2;
 	float	Blend;
@@ -99,12 +104,16 @@ layout(location=3) noperspective out vec4 out_curr_clip;
 layout(location=4) noperspective out vec4 out_prev_clip;
 layout(location=5) flat out int out_flags;
 layout(location=6) out vec3 out_normal;
+layout(location=7) flat out uint out_shadow_light_index;
+layout(location=8) out vec4 out_shadow_light_pos_range;
 
 const int ALIAS_FLAG_VIEWMODEL = 2;
 
 void main()
 {
 	InstanceData inst = AliasFrameBuffer.instances[gl_InstanceID];
+	out_shadow_light_index = inst.ShadowLightIndex;
+	out_shadow_light_pos_range = inst.ShadowLightPosRange;
 	out_texcoord = in_uv;
 	PoseVertex pose1 = GetPoseVertex(inst.Pose1);
 	PoseVertex pose2 = GetPoseVertex(inst.Pose2);

--- a/Quake/shaders/shadow_depth_alias.vert
+++ b/Quake/shaders/shadow_depth_alias.vert
@@ -48,11 +48,16 @@ struct InstanceData
     vec4  PrevWorldMatrix[3];  // 48B
     vec4  LightColor;          // xyz=color w=alpha
     vec4  DLightColor;         // xyz=color
+    vec4  ShadowLightPosRange; // xyz=dlight pos, w=range
+    uint  ShadowLightIndex;
+    uint  _PadShadow1;
+    uint  _PadShadow2;
+    uint  _PadShadow3;
     int   Pose1;               // 4B
     int   Pose2;               // 4B
     float Blend;               // 4B  — clamp before use!
     int   Flags;               // 4B
-    // std430 stride = 48+48+16+16+16 = 144B (verify on CPU side)
+    // std430 stride = 176B (verify on CPU side)
 };
 
 layout(std430, binding = 1) restrict readonly buffer InstanceBuffer

--- a/Quake/shaders/shadow_sample.glsl
+++ b/Quake/shaders/shadow_sample.glsl
@@ -234,10 +234,9 @@ float ShadowVisibilityDlight(vec3 world_pos, vec3 normal, vec3 light_pos,
     vec3  light_dir  = (light_dist > 1e-6) ? light_delta / light_dist : vec3(0.0, 0.0, 1.0);
 
     float ndotl = clamp(dot(normal, light_dir), 0.0, 1.0);
-    // FIX: bias = slope_scale * (1 - ndotl) wird 0 wenn ndotl=1 (Fläche direkt zum Licht),
-    // was Floating-Point-Acne bei gut beleuchteten Flächen verursacht (schwarze Wände).
-    // max(0.15, ...) garantiert minimalen Bias von 0.0025*0.15=0.000375.
-    float bias  = ShadowDlightParams.x * max(0.15, 1.0 - ndotl);
+    float base_bias = ShadowDlightParams.x * 0.15;
+    float slope_bias = ShadowDlightParams.x * (1.0 - ndotl);
+    float bias  = base_bias + slope_bias;
 
     int taps = int(ShadowDlightParams.y + 0.5);
     float shadow_term = ShadowSampleDlightSource(uv, reference, bias, taps);


### PR DESCRIPTION
### Motivation
- Alias instances were sampling the wrong dlight slot (hardcoded slot 0 / `EyePos` fallback) causing incorrect shadows and flicker.  
- std140/std430 layout mismatches between CPU structs and GLSL risk silent corruption of shadow matrices/params.  
- Depth texture compare/sampler state could be left in undefined configurations across drivers leading to all-lit/all-dark artifacts.  
- Bias formula produced unstable acne/peter-panning under some view/light angles and needs a robust base+slope formulation.

### Description
- Extended alias instance SSBO (`aliasinstance_t` + GLSL `InstanceData`) with `ShadowLightPosRange` (vec4) and `ShadowLightIndex` plus explicit padding, and added `static_assert` checks for size/offset (`COMPILE_TIME_ASSERT`).  
- Added `R_Alias_SelectDominantShadowDlight` to choose a per-entity dominant dlight from active atlas slots (score = `radius - distance`) and store index/pos/range in the instance buffer; shaders now read the per-instance shadow metadata instead of using slot 0 / `EyePos`.  
- Hardened frame UBO mapping by adding compile-time assertions for `gpuframedata_t` size and critical offsets to match `frame_uniforms.glsl` (`COMPILE_TIME_ASSERT sizeof(...) == 896` and offsets for `shadow_viewproj`, `shadow_dlight_viewproj`, atlas/info/params).  
- Centralized and enforced depth-sampler setup in `R_Shadow_ApplyDepthSamplerState` (compare mode/func, linear filters for hardware PCF, `GL_CLAMP_TO_BORDER` with a driver-aware border color, `GL_TEXTURE_MAX_LEVEL = 0`) and used it during atlas creation and defensive receiver binding; added periodic `R_Shadow_LogTextureParams` checks when debug is enabled.  
- Replaced the old bias expression in `shadow_sample.glsl` with a stable `base_bias + slope_bias` formulation while preserving the existing tuning parameter (`ShadowDlightParams.x`).  
- Added diagnostics: a warning when receivers bind before the same-frame dlight pass, per-interval slot-table logging of `(slot, light, rect, range)`, and a shader debug color view for per-fragment chosen light index.

### Testing
- Attempted to configure/build with `cmake -S . -B build && cmake --build build -j4`, but CMake configure failed in this environment due to missing SDL2 development package (config error: missing `SDL2Config.cmake`), so full compile-time validation could not be completed.  
- Verified source changes by running repository inspections and commits; changes were staged and committed (`git commit`) successfully.  
- Ran targeted runtime/static validations available in-tree: grepped and printed modified GLSL/C struct layouts and ensured the new `COMPILE_TIME_ASSERT` and instance-field additions are present; runtime shader/GL validation requires a build and runtime GPU environment to confirm (recommended to run locally with `r_shadow_debug >= 2` to see sampler logs and slot table prints).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e4f3b333c832eb66a0a26c1e2fb4a)