### PR TITLE
Replace undefined Vector4Set with explicit component assignments in r_alias.c

### DIFF
--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -122,7 +122,10 @@ static void R_Alias_SelectDominantShadowDlight (const vec3_t entity_origin, alia
 	dlight_t *best_light = NULL;
 
 	instance->shadow_light_index = UINT32_MAX;
-	Vector4Set (instance->shadow_light_pos_range, 0.f, 0.f, 0.f, 0.f);
+	instance->shadow_light_pos_range[0] = 0.f;
+	instance->shadow_light_pos_range[1] = 0.f;
+	instance->shadow_light_pos_range[2] = 0.f;
+	instance->shadow_light_pos_range[3] = 0.f;
 
 	if (!R_Shadow_DlightShadowsActiveThisFrame ())
 		return;
@@ -1104,7 +1107,10 @@ static void R_DrawAliasModel_Shadow_Real (entity_t *e)
 
 	VectorClear (instance->lightcolor);
 	VectorClear (instance->dlightcolor);
-	Vector4Set (instance->shadow_light_pos_range, 0.f, 0.f, 0.f, 0.f);
+	instance->shadow_light_pos_range[0] = 0.f;
+	instance->shadow_light_pos_range[1] = 0.f;
+	instance->shadow_light_pos_range[2] = 0.f;
+	instance->shadow_light_pos_range[3] = 0.f;
 	instance->shadow_light_index = UINT32_MAX;
 	instance->alpha = entalpha;
 	instance->pose1 = lerpdata.pose1;


### PR DESCRIPTION
### Motivation
- Resolve MSVC build failure (C4013 treated as error C2220) caused by an undeclared `Vector4Set` helper used to zero a vec4 in the alias renderer.

### Description
- Replace the two `Vector4Set(instance->shadow_light_pos_range, 0.f, 0.f, 0.f, 0.f)` calls with explicit assignments to `instance->shadow_light_pos_range[0..3] = 0.f` in `Quake/r_alias.c` so the 4D shadow light vector is initialized without relying on an external helper.

### Testing
- Ran `rg "Vector4Set\s*\(" Quake/r_alias.c -n` to verify the usages were removed and inspected the modified regions with `nl -ba Quake/r_alias.c | sed -n '116,136p'` and `sed -n '1098,1118p'`, and those checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e50e70844832ea93b201644b2c689)