### PR TITLE
Fix undeclared SSAO index in GL_GenerateSSAOTexture

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -1428,6 +1428,8 @@ static GLuint GL_GenerateSSAOTexture (float view_min_x, float view_min_y, float 
 		return 0;
 
 	int samples = (int)Q_rint (r_ssao_samples.value);
+	qboolean use_halfres = R_SSAOUseHalfRes ();
+	int index = use_halfres ? 1 : 0;
 	if (index == 1)
 		samples = q_min (samples, 8);
 	samples = CLAMP (4, samples, SSAO_MAX_SAMPLES);
@@ -1435,8 +1437,6 @@ static GLuint GL_GenerateSSAOTexture (float view_min_x, float view_min_y, float 
 	float bias = R_SanitizeSSAOValue (r_ssao_bias.value, 0.02f, 0.f, 1.f) * radius;
 	float power = R_SanitizeSSAOValue (r_ssao_power.value, 1.f, 0.01f, 8.f);
 	float min_ao = CLAMP (0.f, r_ssao_min.value, 1.f);
-	qboolean use_halfres = R_SSAOUseHalfRes ();
-	int index = use_halfres ? 1 : 0;
 	int width = framebufs.ssao.width[index];
 	int height = framebufs.ssao.height[index];
 	if (width <= 0 || height <= 0)


### PR DESCRIPTION
### Motivation
- Fix MSVC build error caused by `index` being used before its declaration in `GL_GenerateSSAOTexture`.

### Description
- Move `qboolean use_halfres = R_SSAOUseHalfRes();` and `int index = use_halfres ? 1 : 0;` to immediately follow the `samples` declaration so `index` is defined before its first use and remove the duplicate later.

### Testing
- Verified the updated declaration order in `Quake/gl_rmain.c` by inspecting the modified source file; Windows/MSVC build was not run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f31997b40832eafd1ac7d095cd5b8)