### PR TITLE
Fix world shader compile error from undefined SHADOW_DLIGHT_ATLAS_SIZE

### DIFF
--- a/Quake/shaders/shadow_sample.glsl
+++ b/Quake/shaders/shadow_sample.glsl
@@ -186,8 +186,10 @@ bool ShadowProjectToAtlasUV(vec4 clip, vec4 atlas, out vec2 uv_local, out vec2 u
     vec2 atlas_max = atlas.zw + atlas.xy;
 
     // Inset/clamp in atlas space to reduce cross-tile filtering bleed.
-    // SHADOW_DLIGHT_ATLAS_SIZE is the full atlas dimension in texels.
-    float eps = 0.5 / max(SHADOW_DLIGHT_ATLAS_SIZE, 1.0);
+    // Derive full atlas dimension from the actual shadow texture to avoid
+    // relying on an externally-defined compile-time macro.
+    float atlas_size = float(textureSize(ShadowDlightMap, 0).x);
+    float eps = 0.5 / max(atlas_size, 1.0);
     uv_atlas = clamp(uv_atlas, atlas_min + vec2(eps), atlas_max - vec2(eps));
 
     return all(greaterThanEqual(uv_atlas, atlas_min)) &&


### PR DESCRIPTION
### Motivation
- Fix a GLSL compiler error triggered when `world` shader variants referenced the undefined `SHADOW_DLIGHT_ATLAS_SIZE` macro during OpenGL initialization.

### Description
- Stop relying on the compile-time `SHADOW_DLIGHT_ATLAS_SIZE` macro and instead derive the atlas texel dimension at runtime with `float atlas_size = float(textureSize(ShadowDlightMap, 0).x);` and compute the inset `eps` from that in `Quake/shaders/shadow_sample.glsl`.

### Testing
- Ran `rg -n "SHADOW_DLIGHT_ATLAS_SIZE" Quake/shaders` to confirm no remaining references and inspected the change with `git diff -- Quake/shaders/shadow_sample.glsl` and `git show --stat --oneline -1`, all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f7a40fa48832eb985c0b1e3290c08)