### PR TITLE
Fix alias OIT shader compile error for missing ShadowParams macro

### DIFF
--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -115,6 +115,7 @@ layout(binding=7) uniform sampler2D ShadowDlightMapDebug;
 // alias shaders use an SSBO-backed frame block and don't include frame_uniforms.glsl.
 // Mirror the same names expected by shadow_sample.glsl via AliasFrameBuffer fields.
 #define SHADOW_DLIGHT_MAX 4
+#define ShadowParams AliasFrameBuffer.ShadowParams
 #define ShadowDlightViewProj AliasFrameBuffer.ShadowDlightViewProj
 #define ShadowDlightAtlas AliasFrameBuffer.ShadowDlightAtlas
 #define ShadowDlightInfo AliasFrameBuffer.ShadowDlightInfo


### PR DESCRIPTION
### Motivation
- The alias fragment shader's OIT permutation failed GLSL compilation with `undefined variable "ShadowParams"` because the SSBO-backed alias frame block didn't expose `ShadowParams` under the name expected by `shadow_sample.glsl` helpers.

### Description
- Add `#define ShadowParams AliasFrameBuffer.ShadowParams` to `Quake/shaders/alias.frag` alongside the other `AliasFrameBuffer` macro mappings so `shadow_sample.glsl` can reference `ShadowParams` correctly.

### Testing
- Verified references with `rg -n "ShadowParams|alias\|OIT|OIT" -S .` and attempted a local configure with `cmake -S . -B build`, but full build validation could not be completed because the environment lacks the SDL2 development package (`SDL2Config.cmake` / `sdl2-config.cmake`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f81ccf1dc832e9b49ea9711e9ae52)