### PR TITLE
Fix dlight shadow view basis alignment in r_shadow.c

### DIFF
--- a/Quake/r_shadow.c
+++ b/Quake/r_shadow.c
@@ -971,6 +971,36 @@ static void R_Shadow_PerspectiveMatrix (float matrix[16], float fovx, float fovy
 	}
 }
 
+static void R_Shadow_DebugDrawBasisAxes (const vec3_t origin, const vec3_t right, const vec3_t up, const vec3_t forward)
+{
+	vec3_t axis_end;
+	vec3_t mins;
+	vec3_t maxs;
+	const float axis_len = 48.f;
+	const float half_extent = 3.f;
+	static const vec3_t axis_colors[3] = {
+		{1.f, 0.f, 0.f}, /* right   = red   */
+		{0.f, 1.f, 0.f}, /* up      = green */
+		{0.f, 0.f, 1.f}  /* forward = blue  */
+	};
+	const vec3_t *axes[3] = { &right, &up, &forward };
+
+	if (r_shadow_matrix_debug.value <= 0.f)
+		return;
+
+	for (int i = 0; i < 3; ++i)
+	{
+		VectorMA (origin, axis_len, *axes[i], axis_end);
+		mins[0] = axis_end[0] - half_extent;
+		mins[1] = axis_end[1] - half_extent;
+		mins[2] = axis_end[2] - half_extent;
+		maxs[0] = axis_end[0] + half_extent;
+		maxs[1] = axis_end[1] + half_extent;
+		maxs[2] = axis_end[2] + half_extent;
+		R_DebugDrawWireBox (mins, maxs, axis_colors[i], true);
+	}
+}
+
 static void R_Shadow_BuildDlightViewProj (float out_viewproj[16], const vec3_t origin, float radius)
 {
 	vec3_t forward;
@@ -1047,7 +1077,11 @@ static void R_Shadow_BuildDlightViewProj (float out_viewproj[16], const vec3_t o
 	}
 #endif
 
+	/* OpenGL view space looks down -Z, so row-2 uses -forward. */
+	VectorNegate (forward, forward);
+
 	R_Shadow_BuildViewMatrixColumns (view, right, light_up, forward, origin);
+	R_Shadow_DebugDrawBasisAxes (origin, right, light_up, forward);
 
 	if (!isfinite (radius) || radius < 1.f)
 		radius = 1.f;


### PR DESCRIPTION
### Motivation
- Shadows rendered from dlights were consistently spatially offset because the view matrix used a +forward basis row while OpenGL camera space expects the camera to look down -Z.  
- Add runtime debug visualization for the light basis so orientations can be validated in-world when `r_shadow_matrix_debug` is enabled.

### Description
- Negate the computed `forward` vector before building the view matrix in `R_Shadow_BuildDlightViewProj` so the view's third row maps to `-forward` for OpenGL: `VectorNegate(forward, forward)` then call `R_Shadow_BuildViewMatrixColumns(view, right, light_up, forward, origin)`.  
- Added `R_Shadow_DebugDrawBasisAxes` (gated by `r_shadow_matrix_debug`) which draws small wire-box markers at axis endpoints for `right` (red), `up` (green) and `forward` (blue) to aid visual debugging of basis orientation.  
- Kept existing right-handed basis construction (`R_Shadow_BuildOrthoBasisRH`) and only applied the sign correction at view-matrix assembly time to avoid changing culling/handedness logic.  
- The erroneous basis component was the `forward` vector sign—using `+forward` for the view third row caused the projection offset; this patch flips `forward` to `-forward` when assembling the view matrix.

### Testing
- Ran a quick diff/inspection of `Quake/r_shadow.c` to verify the inserted `VectorNegate` and `R_Shadow_DebugDrawBasisAxes` call were present and the view-matrix assembly order is correct. (succeeded)  
- Attempted to build the Quake target with `make -C Quake -j4`, but the build could not run in this environment due to missing SDL2 tooling/headers (`sdl2-config` and `SDL.h`), so runtime verification was not possible here (failed due to environment, not code).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f92a0b7c8832e9bc53eb14a5fc9bd)