### PR TITLE
Fix MSVC C4047/C4013 in Quake/r_shadow.c

### DIFF
--- a/Quake/r_shadow.c
+++ b/Quake/r_shadow.c
@@ -983,7 +983,7 @@ static void R_Shadow_DebugDrawBasisAxes (const vec3_t origin, const vec3_t right
 		{0.f, 1.f, 0.f}, /* up      = green */
 		{0.f, 0.f, 1.f}  /* forward = blue  */
 	};
-	const vec3_t *axes[3] = { &right, &up, &forward };
+	const vec_t *axes[3] = { right, up, forward };
 
 	if (r_shadow_matrix_debug.value <= 0.f)
 		return;
@@ -1078,7 +1078,7 @@ static void R_Shadow_BuildDlightViewProj (float out_viewproj[16], const vec3_t o
 #endif
 
 	/* OpenGL view space looks down -Z, so row-2 uses -forward. */
-	VectorNegate (forward, forward);
+	VectorScale (forward, -1.f, forward);
 
 	R_Shadow_BuildViewMatrixColumns (view, right, light_up, forward, origin);
 	R_Shadow_DebugDrawBasisAxes (origin, right, light_up, forward);


### PR DESCRIPTION
### Motivation
- Resolve MSVC warnings treated as errors reported during Windows build by fixing a pointer-type mismatch and removing a call to an undeclared helper.

### Description
- Change `const vec3_t *axes[3] = { &right, &up, &forward };` to `const vec_t *axes[3] = { right, up, forward };` to fix the indirection/type mismatch (C4047).
- Replace `VectorNegate(forward, forward);` with `VectorScale(forward, -1.f, forward);` to avoid the implicit undeclared-function warning (C4013) while preserving behavior.

### Testing
- Inspected the diffs with `git diff` and verified the two targeted changes in `Quake/r_shadow.c` and committed the patch successfully.`git show` confirmed the commit.
- MSVC/project build was not executed in this environment, but the changes address the specific compiler warnings reported and should unblock builds using `/WX`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f94b5f86c832e8eeb20b2bd559e7a)