### PR TITLE
Fix VectorMA argument type in shadow debug axis drawing

### DIFF
--- a/Quake/r_shadow.c
+++ b/Quake/r_shadow.c
@@ -990,7 +990,7 @@ static void R_Shadow_DebugDrawBasisAxes (const vec3_t origin, const vec3_t right
 
 	for (int i = 0; i < 3; ++i)
 	{
-		VectorMA (origin, axis_len, *axes[i], axis_end);
+		VectorMA (origin, axis_len, axes[i], axis_end);
 		mins[0] = axis_end[0] - half_extent;
 		mins[1] = axis_end[1] - half_extent;
 		mins[2] = axis_end[2] - half_extent;


### PR DESCRIPTION
### Motivation
- Fix a type mismatch that caused MSVC errors (`C2440`/`C4024`) by ensuring the `VectorMA` call in `R_Shadow_DebugDrawBasisAxes` receives a `const vec_t *` pointer rather than a scalar.

### Description
- Replace the incorrect dereference in `Quake/r_shadow.c` so the call is `VectorMA(origin, axis_len, axes[i], axis_end);` instead of `VectorMA(origin, axis_len, *axes[i], axis_end);`.

### Testing
- Verified the source change with `rg -n "VectorMA \(origin, axis_len" Quake/r_shadow.c` which shows the updated call and inspected the diff with `git show --stat --oneline -1`; both succeeded.  
- Checked for Windows build tooling with `which msbuild || true` but MSVC/Visual Studio tools are not available in this environment so a full Visual Studio build could not be run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f954bc394832eb8b94a640fc37dbb)