### PR TITLE
Fix dlight shadow radial offset by using symmetric ortho depth range

### DIFF
--- a/Quake/r_shadow.c
+++ b/Quake/r_shadow.c
@@ -1015,7 +1015,6 @@ static void R_Shadow_BuildDlightViewProj (float out_viewproj[16], const vec3_t o
 	float viewproj_view_first[16];
 	float znear;
 	float zfar;
-	float fov_deg;
 	int aim_mode;
 	qboolean matrix_debug;
 
@@ -1085,12 +1084,9 @@ static void R_Shadow_BuildDlightViewProj (float out_viewproj[16], const vec3_t o
 
 	if (!isfinite (radius) || radius < 1.f)
 		radius = 1.f;
-	znear = 4.f;
-	zfar = q_max (radius, znear + 1.f);
-	if (zfar - znear < 1.f)
-		zfar = znear + 1.f;
-	fov_deg = CLAMP (45.f, r_shadow_dlight_fov.value, 140.f);
-	R_Shadow_PerspectiveMatrix (proj, DEG2RAD (fov_deg), DEG2RAD (fov_deg), znear, zfar);
+	znear = -radius;
+	zfar = radius;
+	R_Shadow_OrthoMatrix (proj, -radius, radius, -radius, radius, znear, zfar);
 
 	/* MatrixMultiply(left,right) uses column-major multiplication with left = left * right.
 	 * For shader usage clip = viewproj * world_pos we must build viewproj = proj * view.
@@ -1102,8 +1098,8 @@ static void R_Shadow_BuildDlightViewProj (float out_viewproj[16], const vec3_t o
 	{
 		memcpy (viewproj_view_first, view, sizeof (view));
 		MatrixMultiply (viewproj_view_first, proj);
-		Con_DPrintf ("r_shadow_matrix_debug: aim=%d fov=%.1f origin=(%.1f %.1f %.1f) fwd=(%.3f %.3f %.3f) right=(%.3f %.3f %.3f) up=(%.3f %.3f %.3f) det=%.6g hash(pv)=%08X hash(vp)=%08X\n",
-			aim_mode, fov_deg,
+		Con_DPrintf ("r_shadow_matrix_debug: aim=%d ortho_radius=%.1f origin=(%.1f %.1f %.1f) fwd=(%.3f %.3f %.3f) right=(%.3f %.3f %.3f) up=(%.3f %.3f %.3f) det=%.6g hash(pv)=%08X hash(vp)=%08X\n",
+			aim_mode, radius,
 			origin[0], origin[1], origin[2],
 			forward[0], forward[1], forward[2],
 			right[0], right[1], right[2],


### PR DESCRIPTION
### Motivation
- Dlight-projected shadows were radially offset because the light-space near plane was set to a positive constant (`4.0f`), which asymmetrically clipped the light frustum and biased the depth distribution. 
- The intended light-space projection is symmetric around the light so the depth range must span `[-radius, +radius]` to avoid a radial shift in shadow projection.

### Description
- Replaced the perspective projection in `R_Shadow_BuildDlightViewProj` with an orthographic projection by calling `R_Shadow_OrthoMatrix` and using XY extents `-radius`..`+radius`. 
- Changed the light-space depth range to `znear = -radius` and `zfar = radius` so the orthographic light volume is symmetric about the light. 
- Removed the now-unused perspective `fov_deg` usage for this codepath and updated the matrix debug log to report `ortho_radius` instead of `fov`.

### Testing
- Attempted to build the engine with `make -C Quake -j4`, but the build could not complete in this environment because `sdl2-config` / `SDL.h` are missing, preventing a full compile and runtime verification. 
- Source-level verification and static checks were performed and the changed code now calls `R_Shadow_OrthoMatrix(..., znear=-radius, zfar=radius)`, matching the intended fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f96bfca6c832e82642994c654e60d)