### PR TITLE
Remove shadow subsystem hooks and unused shadow functions

### DIFF
--- a/Quake/gl_vidsdl.c
+++ b/Quake/gl_vidsdl.c
@@ -654,7 +654,6 @@ static void VID_FSAA_f (cvar_t *cvar)
                 return;
         GL_DeleteFrameBuffers ();
         GL_CreateFrameBuffers ();
-        R_ResizeShadowMapIfNeeded ();
         gl_lodbias.callback (&gl_lodbias);
 }
 
@@ -1356,7 +1355,6 @@ static void GL_Init (void)
 
         GL_CreateShaders ();
         GL_CreateFrameBuffers ();
-        R_InitShadow ();
         GLLight_CreateResources ();
 	GLPalette_CreateResources ();
 
@@ -1387,8 +1385,7 @@ void GL_BeginRendering (int *x, int *y, int *width, int *height)
                 VID_RecalcInterfaceSize ();
                 GL_DeleteFrameBuffers ();
                 GL_CreateFrameBuffers ();
-                R_ResizeShadowMapIfNeeded ();
-        }
+                }
 
 	*x = *y = 0;
 	*width = vid.width;
@@ -1435,7 +1432,6 @@ void	VID_Shutdown (void)
 	if (vid_initialized)
 	{
 		Lightgrid_Shutdown ();
-		R_ShutdownShadow ();
 		VID_FreeMouseCursors();
 		SDL_GL_DeleteContext(gl_context);
 		gl_context = NULL;

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -486,10 +486,6 @@ void R_TranslateNewPlayerSkin (int playernum); //johnfitz -- this handles cases 
 void R_UploadFrameData (void);
 void R_StorePrevFrameState (void);
 qboolean R_PrevFrameValid (void);
-void R_InitShadow (void);
-void R_ShutdownShadow (void);
-void R_ResizeShadowMapIfNeeded (void);
-void R_EnsureShadowSamplerState (GLuint texture);
 
 void R_DrawBrushModels (entity_t **ents, int count);
 void R_DrawBrushModels_Water (entity_t **ents, int count, qboolean translucent);
@@ -498,9 +494,7 @@ void R_DrawBrushModels_Godrays (entity_t **ents, int count);
 void R_DrawBrushModels_SkyLayers (entity_t **ents, int count);
 void R_DrawBrushModels_SkyCubemap (entity_t **ents, int count);
 void R_DrawBrushModels_SkyStencil (entity_t **ents, int count);
-void R_DrawBrushModels_Shadow (entity_t **ents, int count);
 void R_DrawAliasModels (entity_t **ents, int count);
-void R_DrawAliasModels_Shadow (entity_t **ents, int count);
 void R_DrawSpriteModels (entity_t **ents, int count);
 void R_DrawBrushModels_ShowTris (entity_t **ents, int count);
 void R_DrawAliasModels_ShowTris (entity_t **ents, int count);

--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -865,17 +865,6 @@ void R_DrawAliasModels (entity_t **ents, int count)
 
 /*
 =================
-R_DrawAliasModels_Shadow
-=================
-*/
-void R_DrawAliasModels_Shadow (entity_t **ents, int count)
-{
-	(void) ents;
-	(void) count;
-}
-
-/*
-=================
 R_DrawAliasModels_ShowTris
 =================
 */


### PR DESCRIPTION
### Motivation

- Remove legacy/unused shadow-related hooks and empty stubs from the renderer to simplify init/shutdown and resize flows.
- Prevent unnecessary shadow-map adjustments during framebuffer recreation (FSAA, resize) when the shadow subsystem is not present.

### Description

- Deleted calls to `R_InitShadow`, `R_ShutdownShadow`, and `R_ResizeShadowMapIfNeeded` from initialization, shutdown, FSAA handling, and resize code paths in `gl_vidsdl.c` and `GL_Init`/`VID_Shutdown` flows. 
- Removed shadow-related function declarations (`R_InitShadow`, `R_ShutdownShadow`, `R_ResizeShadowMapIfNeeded`, `R_EnsureShadowSamplerState`) and shadow-draw prototypes (`R_DrawBrushModels_Shadow`, `R_DrawAliasModels_Shadow`) from `glquake.h`.
- Removed the empty `R_DrawAliasModels_Shadow` implementation from `r_alias.c` since it was a no-op.
- Minor brace/formatting adjustment in `GL_BeginRendering` where the resize handling block was reindented after removing the shadow resize call.

### Testing

- Built the project with `make` and the build completed successfully.
- Ran the repository's automated test target (`make test`) and observed no test failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699faa084c30832ebf8722dbddf02b88)