### PR TITLE
fogvol: add depth/transmittance debug modes and clamp extinction

### DIFF
--- a/Quake/r_fogvol.c
+++ b/Quake/r_fogvol.c
@@ -55,6 +55,9 @@ cvar_t r_fogvol_physblend = { "r_fogvol_physblend", "1", CVAR_ARCHIVE };
 cvar_t r_fogvol_temporal_alpha = { "r_fogvol_temporal_alpha", "0.9", CVAR_ARCHIVE };
 cvar_t r_fogvol_temporal_depth_reject = { "r_fogvol_temporal_depth_reject", "0.01", CVAR_ARCHIVE };
 cvar_t r_fogvol_jitter = { "r_fogvol_jitter", "1", CVAR_ARCHIVE };
+cvar_t r_fogvol_debug = { "r_fogvol_debug", "0", CVAR_ARCHIVE };
+cvar_t r_fogvol_density_scale = { "r_fogvol_density_scale", "1", CVAR_ARCHIVE };
+cvar_t r_fogvol_sigma_max = { "r_fogvol_sigma_max", "2", CVAR_ARCHIVE };
 
 static int r_fogvol_history_index = 0;
 static int r_fogvol_history_width = 0;
@@ -555,6 +558,9 @@ void R_FogVol_Init (void)
 	Cvar_RegisterVariable (&r_fogvol_temporal_alpha);
 	Cvar_RegisterVariable (&r_fogvol_temporal_depth_reject);
 	Cvar_RegisterVariable (&r_fogvol_jitter);
+	Cvar_RegisterVariable (&r_fogvol_debug);
+	Cvar_RegisterVariable (&r_fogvol_density_scale);
+	Cvar_RegisterVariable (&r_fogvol_sigma_max);
 }
 
 void R_FogVol_Clear (void)
@@ -932,7 +938,7 @@ void R_FogVol_Render (void)
 	GLuint buf;
 	GLbyte *ofs;
 	fog_volume_gpu_t gpu_volumes[MAX_FOGVOLUMES];
-	const int mode = 0;
+	const int mode = CLAMP (0, (int)Q_rint (r_fogvol_debug.value), 7);
 	float inv_viewproj[16];
 	GLuint src_tex;
 	GLuint dst_tex;
@@ -952,6 +958,9 @@ void R_FogVol_Render (void)
 	float view_y;
 	float view_w;
 	float view_h;
+	float depth_near;
+	float depth_far;
+	float depth_sky_cutoff;
 	int fog_src = 0;
 	int fog_dst = 0;
 	GLuint final_tex = 0;
@@ -997,6 +1006,9 @@ void R_FogVol_Render (void)
 	view_y = (float)(gly + glheight - r_refdef.vrect.y - r_refdef.vrect.height);
 	view_w = (float)r_refdef.vrect.width;
 	view_h = (float)r_refdef.vrect.height;
+	depth_near = 0.5f;
+	depth_far = gl_farclip.value > depth_near ? gl_farclip.value : depth_near + 1.f;
+	depth_sky_cutoff = gl_clipcontrol_able ? 0.001f : 0.999f;
 
 	if (use_halfres && r_fogvol_steps_scale_halfres.value > 0.f)
 		steps = (int)Q_rint (r_fogvol_steps.value * r_fogvol_steps_scale_halfres.value);
@@ -1059,6 +1071,8 @@ void R_FogVol_Render (void)
 	GL_Uniform4fFunc (9, (float)glwidth, (float)glheight, 1.f / (float)glwidth, 1.f / (float)glheight);
 	GL_Uniform2fFunc (10, depth_scale_x, depth_scale_y);
 	GL_Uniform4fFunc (11, view_x, view_y, 1.f / view_w, 1.f / view_h);
+	GL_Uniform4fFunc (12, depth_near, depth_far, gl_clipcontrol_able ? 1.f : 0.f, depth_sky_cutoff);
+	GL_Uniform2fFunc (13, q_max (0.f, r_fogvol_density_scale.value), q_max (0.001f, r_fogvol_sigma_max.value));
 
 	if (use_halfres)
 		glViewport (0, 0, fog_width, fog_height);
@@ -1149,6 +1163,9 @@ void R_FogVol_Render (void)
 		R_FogVol_SetReadBufferDebug (GL_COLOR_ATTACHMENT0, "ITER read=COLOR_ATTACHMENT0");
 		R_FogVol_SetDrawBufferDebug (GL_COLOR_ATTACHMENT0, "ITER draw=COLOR_ATTACHMENT0");
 		R_FogVol_LogHazardPass ("ITER", src_tex, 0, src_tex);
+		if (mode == 1)
+			Con_DPrintf ("FOGVOL debug ITER idx=%d src_tex=%u depth_tex=%u dst_tex=%u src_fbo=%u dst_fbo=%u scissor=(%d %d %d %d)\n",
+				i, src_tex, depth_tex, dst_tex, src_fbo, dst_fbo, x0, y0, x1 - x0, y1 - y0);
 		R_FogVol_AssertNoFeedbackHazard ("ITER", dst_tex, src_tex);
 		R_FogVol_AssertNoBoundFeedbackHazard ("ITER");
 		GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, src_tex);
@@ -1219,6 +1236,9 @@ void R_FogVol_Render (void)
 		GL_Uniform2fFunc (5, depth_scale_x, depth_scale_y);
 		GL_Uniform1iFunc (6, history_valid ? 1 : 0);
 		GL_Uniform4fFunc (7, view_x, view_y, 1.f / view_w, 1.f / view_h);
+		if (mode == 1)
+			Con_DPrintf ("FOGVOL debug COMPOSITE final_tex=%u history_tex=%u depth_tex=%u dst_tex=%u\n",
+				final_tex, history_tex[history_src], depth_tex, framebufs.fogvol.composite_tex[composite_dst]);
 		glDrawArrays (GL_TRIANGLES, 0, 3);
 
 		R_FogVol_BindFramebuffer (GL_READ_FRAMEBUFFER, framebufs.fogvol.composite_fbo[composite_dst]);

--- a/Quake/shaders/fogvol.frag
+++ b/Quake/shaders/fogvol.frag
@@ -33,6 +33,8 @@ layout(location=8) uniform vec3 FogCameraPosWS;
 layout(location=9) uniform vec4 FogViewportParams; // xy: screen size, zw: inv screen size
 layout(location=10) uniform vec2 FogDepthScale;
 layout(location=11) uniform vec4 FogViewParams; // xy: view origin in screen px, zw: inv view size
+layout(location=12) uniform vec4 FogDepthParams; // x: near, y: far, z: reverse-Z flag, w: sky cutoff
+layout(location=13) uniform vec2 FogDensityParams; // x: density scale, y: sigma clamp
 
 layout(location=0) out vec4 FragColor;
 
@@ -116,20 +118,29 @@ float FogNoise(vec3 p)
 
 float DepthToNdcZ(float depth)
 {
-#if REVERSED_Z
-	return depth;
-#else
+	if (FogDepthParams.z > 0.5)
+		return depth;
 	return depth * 2.0 - 1.0;
-#endif
 }
 
 bool IsSkyDepth(float depth)
 {
-#if REVERSED_Z
-	return depth <= 0.0001;
-#else
-	return depth >= 0.9999;
-#endif
+	if (FogDepthParams.z > 0.5)
+		return depth <= FogDepthParams.w;
+	return depth >= FogDepthParams.w;
+}
+
+float LinearEyeDepth(float depth)
+{
+	float ndcDepth = DepthToNdcZ(depth);
+	vec4 clip = vec4(0.0, 0.0, ndcDepth, 1.0);
+	vec4 world = FogInvViewProj * clip;
+	if (abs(world.w) < 1e-6)
+		return FogDepthParams.y;
+	float dist = length(world.xyz / world.w - FogCameraPosWS);
+	if (!isfinite(dist))
+		return FogDepthParams.y;
+	return clamp(dist, FogDepthParams.x, FogDepthParams.y);
 }
 
 bool RayAABB(vec3 ro, vec3 rd, vec3 bmin, vec3 bmax, out float tEnter, out float tExit)
@@ -190,6 +201,7 @@ void main()
 
 	ivec2 depthCoord = ivec2(screenPos);
 	float depth = texelFetch(SceneDepth, depthCoord, 0).r;
+	float linearDepth = LinearEyeDepth(depth);
 	float ndcDepth = DepthToNdcZ(depth);
 	vec4 clip = vec4(viewUv * 2.0 - 1.0, ndcDepth, 1.0);
 	vec4 world = FogInvViewProj * clip;
@@ -204,7 +216,7 @@ void main()
 	vec3 rd = normalize(worldPos - ro);
 	float tScene = length(worldPos - ro);
 	if (IsSkyDepth(depth))
-		tScene = 1e6;
+		tScene = FogDepthParams.y;
 
 	float tEnter;
 	float tExit;
@@ -237,7 +249,7 @@ void main()
 	}
 
 	vec3 scatterColor = volume.color_density.rgb;
-	float density = max(volume.color_density.a, 0.0);
+	float density = max(volume.color_density.a * FogDensityParams.x, 0.0);
 	float falloff = volume.misc.z;
 
 	vec3 accum = vec3(0.0);
@@ -270,7 +282,9 @@ void main()
 			noiseFactor = mix(1.0, n, amt);
 		}
 
-		float sigma = density * noiseFactor * edgeFade;
+		float sigma = min(density * noiseFactor * edgeFade, FogDensityParams.y);
+		if (!isfinite(sigma))
+			sigma = 0.0;
 		float att = exp(-sigma * stepLen);
 		vec3 stepScatter = (1.0 - att) * scatterColor;
 		accum += transmittance * stepScatter;
@@ -285,29 +299,39 @@ void main()
 		}
 	}
 
-	if (FogDebugMode == 5)
+	if (FogDebugMode == 2)
 	{
-		vec3 debugColor = DebugVolumeColor(float(FogVolumeIndex), volume.misc.x);
-		FragColor = vec4(debugColor, 1.0);
+		FragColor = vec4(vec3(depth), 1.0);
 		return;
 	}
 	if (FogDebugMode == 3)
 	{
-		float tauViz = tau / (1.0 + tau);
-		FragColor = vec4(vec3(tauViz), 1.0);
+		float depthViz = linearDepth / max(FogDepthParams.y, 1e-6);
+		FragColor = vec4(vec3(clamp(depthViz, 0.0, 1.0)), 1.0);
 		return;
 	}
 	if (FogDebugMode == 4)
 	{
-		float fadeViz = (edgeFadeSamples > 0.0) ? (edgeFadeSum / edgeFadeSamples) : 0.0;
-		FragColor = vec4(vec3(fadeViz), 1.0);
+		float maskViz = clamp((tExit - tEnter) / max(FogDepthParams.y, 1e-6), 0.0, 1.0);
+		FragColor = vec4(vec3(maskViz), 1.0);
 		return;
 	}
-	if (FogDebugMode == 8)
+	if (FogDebugMode == 5)
 	{
-		float stepViz = stepsTaken / max(stepCount, 1.0);
-		float earlyViz = earlyTerminated ? 1.0 : 0.0;
-		FragColor = vec4(stepViz, earlyViz, 0.0, 1.0);
+		float sigmaViz = 1.0 - exp(-tau);
+		FragColor = vec4(vec3(clamp(sigmaViz, 0.0, 1.0)), 1.0);
+		return;
+	}
+	if (FogDebugMode == 6)
+	{
+		FragColor = vec4(vec3(clamp(transmittance, 0.0, 1.0)), 1.0);
+		return;
+	}
+
+	if (FogDebugMode == 1)
+	{
+		vec3 debugColor = DebugVolumeColor(float(FogVolumeIndex), volume.misc.x);
+		FragColor = vec4(debugColor, 1.0);
 		return;
 	}
 

--- a/Quake/shaders/fogvol_temporal.frag
+++ b/Quake/shaders/fogvol_temporal.frag
@@ -48,7 +48,7 @@ void main()
 	vec2 viewSize = 1.0 / max(FogViewParams.zw, vec2(1e-6));
 	vec4 current = texture(FogCurrent, screenUv);
 
-	if (FogHistoryValid == 0 || PrevFrameValid == 0u || FogTemporalAlpha <= 0.0 || FogDebugMode == 5 || FogDebugMode == 8)
+	if (FogHistoryValid == 0 || PrevFrameValid == 0u || FogTemporalAlpha <= 0.0 || (FogDebugMode >= 2 && FogDebugMode <= 6))
 	{
 		OutColor = current;
 		return;
@@ -80,12 +80,6 @@ void main()
 	if (valid)
 		history = texture(FogHistory, prevScreenUv);
 
-	if (FogDebugMode == 6)
-	{
-		OutColor = vec4(vec3(valid ? 1.0 : 0.0), 1.0);
-		return;
-	}
-
 	vec3 minColor = current.rgb;
 	vec3 maxColor = current.rgb;
 	for (int j = -1; j <= 1; ++j)
@@ -107,7 +101,7 @@ void main()
 
 	if (FogDebugMode == 7)
 	{
-		OutColor = vec4(vec3(alpha), 1.0);
+		OutColor = vec4(alpha, valid ? 1.0 : 0.0, motionFactor, 1.0);
 		return;
 	}
 

--- a/docs/fogvol_debug_notes.md
+++ b/docs/fogvol_debug_notes.md
@@ -1,0 +1,29 @@
+# FogVol milky/white-screen debug notes
+
+## Likely root cause
+The dominant issue was **A + C combined**:
+
+1. Fog depth handling used only compile-time `REVERSED_Z` assumptions and an effectively infinite sky distance (`1e6`), which can drive integration distances far beyond sane scene ranges in some camera/depth setups.
+2. Extinction had no runtime scale/upper guard, so wrong distances quickly forced `transmittance -> 0` (white/milky overlay depending on blend path).
+
+## Added debug modes (`r_fogvol_debug`)
+- `0`: off (normal rendering)
+- `1`: legacy volume debug coloring + verbose pass logs
+- `2`: raw depth sample
+- `3`: linear eye depth visualization (normalized)
+- `4`: fog mask/path-length visualization
+- `5`: integrated extinction (sigma/tau-like visualization)
+- `6`: transmittance visualization
+- `7`: temporal history contribution (`R=alpha, G=history valid, B=motion factor`)
+
+## Added guardrails
+- Runtime depth conventions are now passed explicitly (`near/far/reverseZ/skyCutoff`) to fog shader.
+- Linear depth reconstruction is clamped and NaN/Inf-safe.
+- Fog sigma uses runtime density scaling and max clamp (`r_fogvol_density_scale`, `r_fogvol_sigma_max`).
+- Sky integration distance now uses camera far range instead of hardcoded `1e6`.
+
+## Useful cvars
+- `r_fogvol_debug`
+- `r_fogvol_density_scale`
+- `r_fogvol_sigma_max`
+- Existing diagnostics retained: `r_fogvol_testvolumes`, `r_fogvol_testvolumes_dumpstate`


### PR DESCRIPTION
### Motivation
- Fix full-screen milky/white fog caused by incorrect depth interpretation with Reverse-Z and runaway extinction (sigma) that drove transmittance to ~0.
- Provide per-pixel debug visualizations to quickly distinguish issues in depth reconstruction, bindings/history, and density scaling.

### Description
- Add runtime controls `r_fogvol_debug`, `r_fogvol_density_scale`, and `r_fogvol_sigma_max` and register them in `R_FogVol_Init` to enable debug modes and density guardrails.
- Pass explicit depth parameters and density clamps from `Quake/r_fogvol.c` into shaders (`FogDepthParams`, `FogDensityParams`) and log per-pass state in debug mode 1.
- Update `Quake/shaders/fogvol.frag` to be reverse‑Z aware, add `LinearEyeDepth()` (clamped and NaN/Inf-safe), replace hardcoded huge sky distance with camera farclip, clamp sigma with `FogDensityParams.y`, and implement debug outputs for raw depth (2), linear depth (3), mask/path-length (4), integrated extinction (5), transmittance (6), and history debug (7); keep mode 1 as legacy debug color.
- Update `Quake/shaders/fogvol_temporal.frag` so modes 2..6 bypass temporal blending and mode 7 reports `R=alpha, G=history valid, B=motionFactor` for temporal diagnostics; add `docs/fogvol_debug_notes.md` describing root cause, modes and guardrails.

### Testing
- Searched codepaths and validated uniform/flag wiring with `rg` for `fogvol`, reverse‑Z and depth helpers, and inspected modified shader/C files (succeeded).
- Ran `make -j4` in `Quake/` to attempt a full build but it failed due to missing system dependencies (`sdl2-config` / `SDL.h`), so a full compile/runtime validation could not be performed in this environment (failed).
- Verified changed files were staged and committed and diff reviewed (`git show` / `git status`) (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a08a5977c4832ebb20b277f68d1ac2)