### PR TITLE
Declare extern gl_farclip in r_fogvol.c to fix MSVC build

### DIFF
--- a/Quake/r_fogvol.c
+++ b/Quake/r_fogvol.c
@@ -59,6 +59,8 @@ cvar_t r_fogvol_debug = { "r_fogvol_debug", "0", CVAR_ARCHIVE };
 cvar_t r_fogvol_density_scale = { "r_fogvol_density_scale", "1", CVAR_ARCHIVE };
 cvar_t r_fogvol_sigma_max = { "r_fogvol_sigma_max", "2", CVAR_ARCHIVE };
 
+extern cvar_t gl_farclip;
+
 static int r_fogvol_history_index = 0;
 static int r_fogvol_history_width = 0;
 static int r_fogvol_history_height = 0;


### PR DESCRIPTION
### Motivation
- `R_FogVol_Draw` references `gl_farclip.value` but `gl_farclip` was not declared in `Quake/r_fogvol.c`, causing MSVC compile errors about an undeclared identifier and invalid `.value` access.

### Description
- Add `extern cvar_t gl_farclip;` to `Quake/r_fogvol.c` so the fog volume renderer can reference the global `gl_farclip` cvar.

### Testing
- Attempted an automated build with `cmake --build build`, which failed because the `build/` directory is not present in this environment (no successful build run performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a08de95b74832eaf20d270eb592587)