### PR TITLE
Replace GLSL `isfinite()` usage in fog volume shader with portable helper

### DIFF
--- a/Quake/shaders/fogvol.frag
+++ b/Quake/shaders/fogvol.frag
@@ -123,6 +123,13 @@ float DepthToNdcZ(float depth)
 	return depth * 2.0 - 1.0;
 }
 
+bool IsFiniteFloat(float v)
+{
+	// GLSL does not guarantee an isfinite() builtin across all versions/drivers.
+	// This catches infinities while also rejecting NaN (comparison with NaN is false).
+	return abs(v) <= 3.402823466e+38;
+}
+
 bool IsSkyDepth(float depth)
 {
 	if (FogDepthParams.z > 0.5)
@@ -138,7 +145,7 @@ float LinearEyeDepth(float depth)
 	if (abs(world.w) < 1e-6)
 		return FogDepthParams.y;
 	float dist = length(world.xyz / world.w - FogCameraPosWS);
-	if (!isfinite(dist))
+	if (!IsFiniteFloat(dist))
 		return FogDepthParams.y;
 	return clamp(dist, FogDepthParams.x, FogDepthParams.y);
 }
@@ -283,7 +290,7 @@ void main()
 		}
 
 		float sigma = min(density * noiseFactor * edgeFade, FogDensityParams.y);
-		if (!isfinite(sigma))
+		if (!IsFiniteFloat(sigma))
 			sigma = 0.0;
 		float att = exp(-sigma * stepLen);
 		vec3 stepScatter = (1.0 - att) * scatterColor;


### PR DESCRIPTION
### Motivation
- Some OpenGL drivers/GLSL compilers do not provide the global `isfinite()` function, causing the fog volume fragment shader to fail compilation with errors like `isfinite` undefined and preventing fog initialization.

### Description
- Add a local helper `IsFiniteFloat(float v)` that checks `abs(v) <= 3.402823466e+38` to detect non-finite values in a portable way.
- Replace direct `isfinite(...)` calls in `Quake/shaders/fogvol.frag` with `IsFiniteFloat(...)` in `LinearEyeDepth()` and the per-step sigma validation to preserve the original guards without depending on the builtin.

### Testing
- Ran `rg -n "isfinite|IsFiniteFloat" Quake/shaders/fogvol.frag` to confirm `isfinite` usages were removed and `IsFiniteFloat` is present (succeeded).
- Reviewed the file diff with `git diff -- Quake/shaders/fogvol.frag` to ensure the patch is limited to the intended portability changes (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a08eaaf148832e910de581b68d4656)