### PR TITLE
Fix missing glGetIntegeri_v declaration on MSVC

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -3285,9 +3285,9 @@ void R_GLStateDump (const char *tag)
 	glGetBooleanv (GL_DEPTH_WRITEMASK, &depth_mask);
 	prev_active_texture = active_texture;
 
-	glGetIntegeri_v (GL_UNIFORM_BUFFER_BINDING, 0, &ubo0);
-	glGetIntegeri_v (GL_UNIFORM_BUFFER_BINDING, 1, &ubo1);
-	glGetIntegeri_v (GL_UNIFORM_BUFFER_BINDING, 2, &ubo2);
+	GL_GetIntegeri_vFunc (GL_UNIFORM_BUFFER_BINDING, 0, &ubo0);
+	GL_GetIntegeri_vFunc (GL_UNIFORM_BUFFER_BINDING, 1, &ubo1);
+	GL_GetIntegeri_vFunc (GL_UNIFORM_BUFFER_BINDING, 2, &ubo2);
 
 	GL_ActiveTextureFunc (GL_TEXTURE0);
 	glGetIntegerv (GL_TEXTURE_BINDING_2D, &tex2d_0);

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -176,6 +176,7 @@ extern	const char	*gl_version;
 	x(void,			VertexAttribIPointer, (GLuint index, GLint size, GLenum type, GLsizei stride, const GLvoid *pointer))\
 	x(GLint,		GetUniformLocation, (GLuint program, const GLchar *name))\
 	x(void,			GetUniformiv, (GLuint program, GLint location, GLint *params))\
+	x(void,			GetIntegeri_v, (GLenum target, GLuint index, GLint *data))\
 	x(void,			GetActiveUniform, (GLuint program, GLuint index, GLsizei bufSize, GLsizei *length, GLint *size, GLenum *type, GLchar *name))\
 	x(void,			Uniform1i, (GLint location, GLint v0))\
 	x(void,			Uniform1f, (GLint location, GLfloat v0))\


### PR DESCRIPTION
### Motivation
- MSVC treated the implicit declaration of `glGetIntegeri_v` as an error (warning C4013 promoted to error C2220) because the symbol wasn't exposed via the project's GL loader abstraction.
- Ensure the engine uses the loader function pointer so the code compiles cleanly across platforms, including Windows.

### Description
- Add `GetIntegeri_v` to the core QGL function table in `Quake/glquake.h` so `GL_GetIntegeri_vFunc` is declared and can be loaded.
- Replace direct calls to `glGetIntegeri_v` with `GL_GetIntegeri_vFunc` in `Quake/gl_rmain.c` (`R_GLStateDump`) to use the project's GL loader.

### Testing
- Verified the symbol is declared in `Quake/glquake.h` and the call sites now use `GL_GetIntegeri_vFunc` via `rg` and `nl` inspection (`rg "glGetIntegeri_v|GL_GetIntegeri_vFunc" Quake -n`).
- Reviewed the resulting diff with `git diff` to confirm only the intended lines were changed.
- Committed the changes successfully with `git commit` (commit message: "Fix missing glGetIntegeri_v declaration on MSVC").

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0cd1fca9c832ebf913d3dbd039377)