### PR TITLE
Fix alias SSBO layout mismatch and add fogvol/animation debug instrumentation

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -38,6 +38,9 @@ qboolean	r_cache_thrash;		// compatability
 
 gpuframedata_t r_framedata;
 
+static int r_fogvol_update_called = 0;
+static int r_fogvol_draw_called = 0;
+
 /* BUG FIX #1 (SSAO/Fog): GL_GenerateSSAOTexture runs inside GL_PostProcess which
  * is called from SCR_UpdateScreen, AFTER Fog_DisableGFog() in R_RenderView.
  * Fog_DisableGFog clears r_framedata.fogdata[3] (density) to 0 so 2D overlays stay
@@ -3322,8 +3325,21 @@ R_SetupView -- johnfitz -- this is the stuff that needs to be done once per fram
 */
 void R_SetupView (void)
 {
+	static qboolean gpuframedata_layout_logged = false;
 	r_dlight_buffered_frame = false;
 	framesetup.composite_ready = false;
+
+	if (r_gl_state_validate.value > 0.f && !gpuframedata_layout_logged)
+	{
+		gpuframedata_layout_logged = true;
+		Con_Printf ("gpuframedata layout: sizeof=%u vieworg=%u viewproj=%u time=%u dlight_params=%u fog=%u\n",
+			(unsigned)sizeof (gpuframedata_t),
+			(unsigned)offsetof (gpuframedata_t, eye),
+			(unsigned)offsetof (gpuframedata_t, viewproj),
+			(unsigned)(offsetof (gpuframedata_t, eye) + 3 * sizeof (float)),
+			(unsigned)offsetof (gpuframedata_t, dlight_params),
+			(unsigned)offsetof (gpuframedata_t, fogdata));
+	}
 
 	R_AnimateLight ();
 
@@ -4821,11 +4837,17 @@ void R_RenderView (void)
         else if (gl_finish.value)
                 glFinish ();
 
-        R_SetupView (); //johnfitz -- this does everything that should be done once per frame
+	R_SetupView (); //johnfitz -- this does everything that should be done once per frame
         Fog_EnableGFog ();
         R_RenderScene ();
         R_WarpScaleView ();
+        r_fogvol_update_called++;
+        if (r_gl_state_validate.value > 0.f)
+                Con_DPrintf ("fogvol_update_called=%d r_fogvol=%.1f\n", r_fogvol_update_called, r_fogvol.value);
         R_FogVol_BuildList ();
+        r_fogvol_draw_called++;
+        if (r_gl_state_validate.value > 0.f)
+                Con_DPrintf ("fogvol_draw_called=%d r_fogvol=%.1f\n", r_fogvol_draw_called, r_fogvol.value);
         R_FogVol_Render ();
         /* BUG FIX #1: Capture fog params while r_framedata.fogdata is still valid.
          * GL_GenerateSSAOTexture (called later in GL_PostProcess) uses these for

--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -62,9 +62,6 @@ typedef struct aliasinstance_s {
 	float		alpha;
 	vec3_t		dlightcolor;
 	float		_pad0;
-	uint32_t	_pad1;
-	uint32_t	_pad2;
-	uint32_t	_pad3;
 	int32_t		pose1;
 	int32_t		pose2;
 	float		blend;
@@ -95,7 +92,7 @@ struct ibuf_s {
 } ibuf;
 
 COMPILE_TIME_ASSERT (alias_global_size_matches_std430, sizeof (ibuf.global) % 16 == 0);
-COMPILE_TIME_ASSERT (alias_instance_size_matches_std430, sizeof (aliasinstance_t) == 156);
+COMPILE_TIME_ASSERT (alias_instance_size_matches_std430, sizeof (aliasinstance_t) == 144);
 
 static qboolean r_lightgrid_debug_sample_reported = false;
 static const qmodel_t *r_lightgrid_debug_last_world = NULL;
@@ -229,6 +226,7 @@ R_SetupAliasFrame -- johnfitz -- rewritten to support lerping
 */
 void R_SetupAliasFrame (entity_t *e, aliashdr_t *paliashdr, lerpdata_t *lerpdata)
 {
+	static int debug_frame = -1;
 	int posenum, numposes;
 	int frame = e->frame;
 
@@ -291,6 +289,24 @@ void R_SetupAliasFrame (entity_t *e, aliashdr_t *paliashdr, lerpdata_t *lerpdata
 		lerpdata->blend = 1;
 		lerpdata->pose1 = posenum;
 		lerpdata->pose2 = posenum;
+	}
+
+	if (r_debug_itemlight.value > 1.f && r_framecount != debug_frame)
+	{
+		debug_frame = r_framecount;
+		Con_Printf ("alias_anim: host_frametime=%.6f cl.time=%.6f cl.oldtime=%.6f r_refdef.time=%.6f model=%s frame=%d oldframe=%d lerpstart=%.6f lerpfinish=%.6f lerpfrac=%.3f pose=(%d->%d)\n",
+			host_frametime,
+			cl.time,
+			cl.oldtime,
+			r_refdef.time,
+			e->model ? e->model->name : "<null>",
+			e->frame,
+			e->oldframe,
+			e->lerpstart,
+			e->lerpfinish,
+			lerpdata->blend,
+			lerpdata->pose1,
+			lerpdata->pose2);
 	}
 }
 
@@ -566,7 +582,7 @@ gl_overbright_models.value ?
 ibuf.global.overbright = gl_overbright_models.value > 0.f ? r_framedata.dither[2] : 1.f;
 ibuf.global.dither = r_framedata.dither[0];
 ibuf.global.half_lambert = CLAMP (0.f, r_model_halflambert.value, 1.f);
-ibuf.global.dlight_debug_models = r_dlight_debug_models.value > 0.f ? 1.f : 0.f;
+ibuf.global.dlight_debug_models = r_dlight_debug_models.value;
 
 	ibuf_size = sizeof(ibuf.global) + sizeof(ibuf.inst[0]) * ibuf.count;
 	GL_Upload (GL_SHADER_STORAGE_BUFFER, &ibuf.global, ibuf_size, &buf, &ofs);

--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -198,7 +198,36 @@ void main()
 	result.rgb = ApplyFog(result.rgb, in_pos);
 	if (AliasFrameBuffer.DLightDebugModels > 0.5)
 	{
-		result.rgb = vec3(in_dlight_vis);
+		float mode = AliasFrameBuffer.DLightDebugModels;
+		vec3 world_pos = in_pos + AliasFrameBuffer.EyePos;
+		vec3 world_nor = normalize(in_normal);
+		if (mode > 4.5)
+		{
+			result.rgb = vec3(fract(AliasFrameBuffer.EyePos.x * 0.01), fract(AliasFrameBuffer.EyePos.y * 0.01), fract(AliasFrameBuffer.EyePos.z * 0.01));
+		}
+		else if (mode > 3.5)
+		{
+			float attenuation = clamp(in_dlight_vis, 0.0, 1.0);
+			result.rgb = vec3(attenuation);
+		}
+		else if (mode > 2.5)
+		{
+			vec3 L = normalize(vec3(0.3, 0.5, 0.8));
+			float ndotl = max(dot(world_nor, L), 0.0);
+			result.rgb = vec3(ndotl);
+		}
+		else if (mode > 1.5)
+		{
+			result.rgb = world_nor * 0.5 + 0.5;
+		}
+		else if (mode > 0.75)
+		{
+			result.rgb = fract(world_pos * 0.01);
+		}
+		else
+		{
+			result.rgb = vec3(in_dlight_vis);
+		}
 	}
         OUT_COLOR = result;
 #if !OIT


### PR DESCRIPTION
### Motivation
- Track down regression where viewmodel/alias lighting and frozen alias animations appeared after the FogVol refactor by inspecting UBO/SSBO layout, animation lerp timing, and model shader inputs.
- Ensure CPU-side `aliasinstance_t` packing matches the GPU `std430` instance layout so SSBO uploads don't corrupt pose/lighting data.
- Add lightweight runtime markers and shader debug modes to validate fogvol call paths and per-frame animation/time flow without assuming `r_fogvol` is the cause.

### Description
- Fixed CPU/GLSL instance layout mismatch by removing extra CPU-only padding from `aliasinstance_t` and updating the compile-time assert to `144` bytes in `Quake/r_alias.c` so SSBO data aligns with the shader view. (`Quake/r_alias.c`)
- Made the alias SSBO global `dlight_debug_models` pass the raw `r_dlight_debug_models` numeric value (instead of boolean) so the shader can select multiple debug visualizations. (`Quake/r_alias.c`)
- Extended alias fragment shader debug output to multiple visualization modes (world position, world normal, NdotL proxy, attenuation proxy, camera-space checks) gated by the numeric `dlight_debug_models` value. (`Quake/shaders/alias.frag`)
- Added one-shot runtime UBO/std140 layout logging for `gpuframedata_t` (size and selected offsets) behind `r_gl_state_validate` to detect CPU/GL layout mismatches. (`Quake/gl_rmain.c`)
- Added fog-vol pipeline markers `r_fogvol_update_called` / `r_fogvol_draw_called` and guarded debug prints so the fogvol build/render calls can be observed even when `r_fogvol` is `0`. (`Quake/gl_rmain.c`)
- Added per-frame alias animation timing diagnostics (host frametime, `cl.time`/`cl.oldtime`, `r_refdef.time`, `lerpstart`/`lerpfinish`/`lerpfrac`, poses) gated by `r_debug_itemlight > 1` to help pinpoint why lerp fractions may be reset. (`Quake/r_alias.c`)

### Testing
- Attempted an automated local build with `make -C Quake -j2`; the build could not complete in this environment due to missing `sdl2-config` / `SDL.h` (external dependency), so a full compile/run test was not possible here (build aborted). 
- Verified diffs and compile-time asserts were updated and the new debug prints and shader branches are controlled by existing cvars, so they are safely gated at runtime.
- Committed changes and inspected the repository diff to confirm files modified: `Quake/r_alias.c`, `Quake/gl_rmain.c`, and `Quake/shaders/alias.frag`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0d0b77944832eaa5f712124c6e220)