### PR TITLE
Fix MSVC build errors from removed struct fields

### DIFF
--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -520,7 +520,6 @@ void CL_ParseUpdate (int bits)
 		ent->frame = MSG_ReadByte ();
 	else if (forcelink)
 		ent->frame = ent->baseline.frame;
-	ent->oldframe = prevframe;
 
 	if (bits & U_COLORMAP)
 		i = MSG_ReadByte();
@@ -1392,4 +1391,3 @@ void CL_ParseServerMessage (void)
 		lastcmd = cmd; //johnfitz
 	}
 }
-

--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -294,15 +294,13 @@ void R_SetupAliasFrame (entity_t *e, aliashdr_t *paliashdr, lerpdata_t *lerpdata
 	if (r_debug_itemlight.value > 1.f && r_framecount != debug_frame)
 	{
 		debug_frame = r_framecount;
-		Con_Printf ("alias_anim: host_frametime=%.6f cl.time=%.6f cl.oldtime=%.6f realtime=%.6f r_refdef.time=%.6f model=%s frame=%d oldframe=%d lerpstart=%.6f lerptime=%.6f lerpfinish=%.6f lerpfrac=%.3f origin=(%.1f %.1f %.1f) pose=(%d->%d)\n",
+		Con_Printf ("alias_anim: host_frametime=%.6f cl.time=%.6f cl.oldtime=%.6f realtime=%.6f model=%s frame=%d lerpstart=%.6f lerptime=%.6f lerpfinish=%.6f lerpfrac=%.3f origin=(%.1f %.1f %.1f) pose=(%d->%d)\n",
 			host_frametime,
 			cl.time,
 			cl.oldtime,
 			realtime,
-			r_refdef.time,
 			e->model ? e->model->name : "<null>",
 			e->frame,
-			e->oldframe,
 			e->lerpstart,
 			e->lerptime,
 			e->lerpfinish,


### PR DESCRIPTION
### Motivation
- Recent changes to `render.h` removed `entity_t` and `refdef_t` members but two call sites still referenced them, causing MSVC C2039 errors during Windows builds; this PR removes those stale references to restore cross-platform build compatibility.

### Description
- Removed the stale `ent->oldframe` write in `CL_ParseUpdate` in `Quake/cl_parse.c` and removed the `r_refdef.time` and `e->oldframe` references from the debug `Con_Printf` in `R_SetupAliasFrame` in `Quake/r_alias.c` to avoid referencing non-existent struct members.

### Testing
- Verified with `rg -n "oldframe|r_refdef\.time" Quake` that no remaining references to those fields remain in the modified files, and the repository was committed after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0df68c69c832e90a397900439fe89)