### PR TITLE
Clear fog volume temporal history on FBO/resolution changes and guard temporal pass

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -3127,6 +3127,9 @@ GL_NeedsPostprocess
 */
 qboolean GL_NeedsPostprocess (void)
 {
+	if (r_postfx.value <= 0.f)
+		return false;
+
         float saturation = CLAMP (0.9f, r_color_saturation.value, 1.2f);
 	r_color_saturation.value = saturation;
 	if (softemu || R_GetEffectiveAlphaMode () == ALPHAMODE_OIT || R_DoFEnabled ())

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -985,6 +985,7 @@ void R_NewMap (void)
 	VEC_CLEAR (r_pointfile);
 
 	R_ResetGodraysStabilization ();
+	R_FogVol_ClearHistory ();
 
 	GL_BuildLightmaps ();
         GL_BuildBModelVertexBuffer ();

--- a/Quake/gl_vidsdl.c
+++ b/Quake/gl_vidsdl.c
@@ -654,6 +654,7 @@ static void VID_FSAA_f (cvar_t *cvar)
                 return;
         GL_DeleteFrameBuffers ();
         GL_CreateFrameBuffers ();
+	R_FogVol_ClearHistory ();
         gl_lodbias.callback (&gl_lodbias);
 }
 
@@ -751,6 +752,7 @@ static void VID_Restart (void)
 	VID_RecalcInterfaceSize ();
 
 	GL_CreateFrameBuffers ();
+	R_FogVol_ClearHistory ();
 //
 // keep cvars in line with actual mode
 //
@@ -1355,6 +1357,7 @@ static void GL_Init (void)
 
         GL_CreateShaders ();
         GL_CreateFrameBuffers ();
+	R_FogVol_ClearHistory ();
         GLLight_CreateResources ();
 	GLPalette_CreateResources ();
 
@@ -1385,6 +1388,7 @@ void GL_BeginRendering (int *x, int *y, int *width, int *height)
                 VID_RecalcInterfaceSize ();
                 GL_DeleteFrameBuffers ();
                 GL_CreateFrameBuffers ();
+	R_FogVol_ClearHistory ();
                 }
 
 	*x = *y = 0;

--- a/Quake/r_fogvol.c
+++ b/Quake/r_fogvol.c
@@ -65,6 +65,29 @@ static int r_fogvol_history_index = 0;
 static int r_fogvol_history_width = 0;
 static int r_fogvol_history_height = 0;
 
+
+void R_FogVol_ClearHistory (void)
+{
+	r_fogvol_history_index = 0;
+	r_fogvol_history_width = 0;
+	r_fogvol_history_height = 0;
+
+	if (!framebufs.fogvol.history_fbo[0] || !framebufs.fogvol.history_fbo[1])
+		return;
+
+	GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.fogvol.history_fbo[0]);
+	{
+		const float zero[4] = {0.f, 0.f, 0.f, 0.f};
+		GL_ClearBufferfvFunc (GL_COLOR, 0, zero);
+	}
+	GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.fogvol.history_fbo[1]);
+	{
+		const float zero[4] = {0.f, 0.f, 0.f, 0.f};
+		GL_ClearBufferfvFunc (GL_COLOR, 0, zero);
+	}
+	GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.composite.fbo);
+}
+
 typedef struct fogvol_test_state_s
 {
 	unsigned statebits;
@@ -1248,7 +1271,7 @@ void R_FogVol_Render (void)
 		goto done;
 	}
 
-	if (has_drawn && glprogs.fogvol_temporal && final_tex)
+	if (has_drawn && r_fogvol_temporal_alpha.value > 0.f && glprogs.fogvol_temporal && final_tex)
 	{
 		int history_valid = (r_fogvol_history_width == fog_width && r_fogvol_history_height == fog_height);
 		int history_src = r_fogvol_history_index;

--- a/Quake/r_fogvol.h
+++ b/Quake/r_fogvol.h
@@ -50,6 +50,7 @@ void R_FogVol_BuildList (void);
 void R_FogVol_AddTestVolumes (void);
 void R_FogVol_Render (void);
 void R_FogVol_DrawDebug2D (void);
+void R_FogVol_ClearHistory (void);
 void R_FogVol_LogEndFrameState (void);
 void R_FogVol_InjectIntoGrid (froxel_grid_t *grid, const fog_volume_t *vols, int num);
 qboolean R_FogVol_ProjectAABBToScreenRect (const fog_volume_t *v, int *x0, int *y0, int *x1, int *y1, qboolean fullres);


### PR DESCRIPTION
### Motivation

- Ensure fog volume temporal history is reset when framebuffers, resolution, or maps change to avoid stale history artifacts and invalid history indexing.

### Description

- Add `R_FogVol_ClearHistory` to reset history indices/sizes and clear fog volume history FBOs and bind the composite FBO after clearing.  
- Call `R_FogVol_ClearHistory` from `R_NewMap`, after framebuffer recreation in `VID_FSAA_f`, `VID_Restart`, `GL_Init`, and when handling window resize in `GL_BeginRendering` so history is cleared on map load and FBO/resolution changes.  
- Add declaration for `R_FogVol_ClearHistory` to `r_fogvol.h`.  
- Guard the temporal fog-volume pass with `r_fogvol_temporal_alpha.value > 0.f` so the temporal shader is only used when alpha blending is enabled.  
- Reset `r_fogvol_history_index` to `0` when the history buffer size is invalidated to ensure a known-clean starting slot after resolution changes.  
- Minor related tweak: short-circuit `GL_NeedsPostprocess` early when `r_postfx.value <= 0.f` (skip postprocess when disabled).

### Testing

- Compiled the project with `make` on Linux and the build completed successfully.  
- No automated unit tests were modified; no project unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0eb1eb750832e9e7248233e11d75c)