### PR TITLE
Render teleport brush surfaces with procedural FBM shader

### DIFF
--- a/Quake/gl_shaders.c
+++ b/Quake/gl_shaders.c
@@ -678,6 +678,7 @@ void GL_CreateShaders (void)
 		for (oit = 0; oit < 2; oit++)
 		{
                         glprogs.water[oit][dither] = GL_CreateProgram (GLSL_PATH("water.vert"), GLSL_PATH("water.frag"), "water|OIT %d; DITHER %d", oit, dither);
+                        glprogs.teleport[oit][dither] = GL_CreateProgram (GLSL_PATH("water.vert"), GLSL_PATH("glsl/teleport_fbm.frag"), "teleport fbm|OIT %d; DITHER %d", oit, dither);
                         glprogs.particles[oit][dither] = GL_CreateProgram (GLSL_PATH("particles.vert"), GLSL_PATH("particles.frag"), "particles|OIT %d; DITHER %d", oit, dither);
 		}
                 for (mode = 0; mode < 2; mode++)

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -589,6 +589,7 @@ typedef struct glprogs_s {
 	GLuint		world[2][3][3];		// [OIT][standard/dithered/banded][solid/alpha test/water]
 	GLuint		world_dlight[2];		// [alpha test]
 	GLuint		water[2][2];		// [OIT][dither]
+	GLuint		teleport[2][2];		// [OIT][dither]
 	GLuint		skystencil;
 	GLuint		skylayers[2];		// [dither]
 	GLuint		skycubemap[2][2];	// [anim][dither]

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -1475,14 +1475,14 @@ static void R_DrawBrushModels_Real (entity_t **ents, int count, brushpass_t pass
 if (pass <= BP_ALPHATEST)
 {
 GL_UseProgram (program);
-GL_Bind (GL_TEXTURE2, r_fullbright_cheatsafe ? greytexture : lightmap_texture);
-GL_Bind (GL_TEXTURE3, (r_lightingdir.value > 0.f && lightmap_dir_texture) ? lightmap_dir_texture : greytexture);
+	GL_Bind (GL_TEXTURE2, r_fullbright_cheatsafe ? greytexture : lightmap_texture);
+	GL_Bind (GL_TEXTURE3, (r_lightingdir.value > 0.f && lightmap_dir_texture) ? lightmap_dir_texture : greytexture);
 }
 else if (pass == BP_DLIGHT_SOLID || pass == BP_DLIGHT_ALPHA)
 {
 }
 else if (pass == BP_SKYCUBEMAP)
-GL_Bind (GL_TEXTURE2, skybox->cubemap);
+	GL_Bind (GL_TEXTURE2, skybox->cubemap);
 
         GL_Upload (GL_SHADER_STORAGE_BUFFER, bmodel_instances, sizeof(bmodel_instances[0]) * totalinst, &buf, &ofs);
         GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 2, buf, (GLintptr)ofs, sizeof(bmodel_instances[0]) * totalinst);
@@ -1639,9 +1639,10 @@ void R_DrawBrushModels_Water (entity_t **ents, int count, qboolean translucent)
 	int i, j;
 	int totalinst, baseinst;
 	unsigned state;
-	GLuint buf, program;
+	GLuint buf, program, water_program, teleport_program;
 	GLbyte *ofs;
 	qboolean oit;
+	double shader_time;
 
 	if (count > countof(bmodel_instances))
 	{
@@ -1668,16 +1669,21 @@ void R_DrawBrushModels_Water (entity_t **ents, int count, qboolean translucent)
 
 	oit = translucent && R_GetEffectiveAlphaMode () == ALPHAMODE_OIT;
 	if (cl.worldmodel->haslitwater && r_litwater.value)
-		program = glprogs.world[oit][q_max(0, (int)softemu - 1)][WORLDSHADER_WATER];
+		water_program = glprogs.world[oit][q_max(0, (int)softemu - 1)][WORLDSHADER_WATER];
 	else
-		program = glprogs.water[oit][softemu == SOFTEMU_COARSE];
+		water_program = glprogs.water[oit][softemu == SOFTEMU_COARSE];
+	teleport_program = glprogs.teleport[oit][softemu == SOFTEMU_COARSE];
+	program = water_program;
+	shader_time = r_refdef.time;
 
-R_ResetBModelCalls (program);
-GL_SetState (state);
-GL_Bind (GL_TEXTURE2, r_fullbright_cheatsafe ? greytexture : lightmap_texture);
-GL_Bind (GL_TEXTURE3, (r_lightingdir.value > 0.f && lightmap_dir_texture) ? lightmap_dir_texture : greytexture);
+	R_ResetBModelCalls (program);
+	GL_UseProgram (program);
+	GL_Uniform1fFunc (12, shader_time);
+	GL_SetState (state);
+	GL_Bind (GL_TEXTURE2, r_fullbright_cheatsafe ? greytexture : lightmap_texture);
+	GL_Bind (GL_TEXTURE3, (r_lightingdir.value > 0.f && lightmap_dir_texture) ? lightmap_dir_texture : greytexture);
 
-GL_Upload (GL_SHADER_STORAGE_BUFFER, bmodel_instances, sizeof(bmodel_instances[0]) * totalinst, &buf, &ofs);
+	GL_Upload (GL_SHADER_STORAGE_BUFFER, bmodel_instances, sizeof(bmodel_instances[0]) * totalinst, &buf, &ofs);
 	GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 2, buf, (GLintptr)ofs, sizeof(bmodel_instances[0]) * totalinst);
 
 	// generate drawcalls
@@ -1702,6 +1708,7 @@ GL_Upload (GL_SHADER_STORAGE_BUFFER, bmodel_instances, sizeof(bmodel_instances[0
 			texture_t *t = R_GetUsedTexture (model, j, NULL);
 			unsigned extra_flags = 0u;
 			unsigned mat_flags = 0u;
+			GLuint target_program;
 
 			if (!t)
 				continue;
@@ -1721,6 +1728,16 @@ GL_Upload (GL_SHADER_STORAGE_BUFFER, bmodel_instances, sizeof(bmodel_instances[0
 			float alpha = GL_WaterAlphaForEntityTextureType (e, t->type);
 			if ((alpha < 1.f) != translucent)
 				continue;
+
+			target_program = (t->type == TEXTYPE_TELE) ? teleport_program : water_program;
+			if (target_program != program)
+			{
+				R_FlushBModelCalls ();
+				program = target_program;
+				R_ResetBModelCalls (program);
+				GL_UseProgram (program);
+				GL_Uniform1fFunc (12, shader_time);
+			}
 			{
 				float polygon_offset_factor;
 				float polygon_offset_units;

--- a/Quake/shaders/glsl/teleport_fbm.frag
+++ b/Quake/shaders/glsl/teleport_fbm.frag
@@ -1,0 +1,90 @@
+layout(location=12) uniform float u_time;
+layout(location=2) in vec2 v_texcoord;
+
+float colormap_red(float x)
+{
+	return clamp(1.5 - abs(4.0 * (x - 0.75)), 0.0, 1.0);
+}
+
+float colormap_green(float x)
+{
+	return clamp(1.5 - abs(4.0 * (x - 0.5)), 0.0, 1.0);
+}
+
+float colormap_blue(float x)
+{
+	return clamp(1.5 - abs(4.0 * (x - 0.25)), 0.0, 1.0);
+}
+
+vec3 colormap(float x)
+{
+	return vec3(colormap_red(x), colormap_green(x), colormap_blue(x));
+}
+
+float rand(vec2 co)
+{
+	return fract(sin(dot(co, vec2(12.9898, 78.233))) * 43758.5453);
+}
+
+float noise(vec2 p)
+{
+	vec2 i = floor(p);
+	vec2 f = fract(p);
+	float a = rand(i);
+	float b = rand(i + vec2(1.0, 0.0));
+	float c = rand(i + vec2(0.0, 1.0));
+	float d = rand(i + vec2(1.0, 1.0));
+	vec2 u = f * f * (3.0 - 2.0 * f);
+	return mix(a, b, u.x) + (c - a) * u.y * (1.0 - u.x) + (d - b) * u.x * u.y;
+}
+
+float fbm(vec2 p)
+{
+	float value = 0.0;
+	float amplitude = 0.5;
+	for (int i = 0; i < 5; ++i)
+	{
+		value += amplitude * noise(p);
+		p *= 2.0;
+		amplitude *= 0.5;
+	}
+	return value;
+}
+
+float pattern(vec2 p)
+{
+	vec2 q = vec2(fbm(p + vec2(0.0, 0.0)), fbm(p + vec2(5.2, 1.3)));
+	vec2 r = vec2(
+		fbm(p + 4.0 * q + vec2(1.7, 9.2)),
+		fbm(p + 4.0 * q + vec2(8.3, 2.8))
+	);
+	return clamp(fbm(p + 4.0 * r), 0.0, 1.0);
+}
+
+#if OIT
+layout(location=0) out vec4 out_accum;
+layout(location=1) out float out_reveal;
+#else
+layout(location=0) out vec4 fragColor;
+layout(location=1) out vec4 out_velocity;
+#endif
+
+void main()
+{
+	vec2 uv = v_texcoord * 2.0;
+	float t = u_time * 0.6;
+	float shade = pattern(uv + t);
+	vec3 color = colormap(shade).rgb;
+	vec4 outColor = vec4(color, shade);
+
+#if OIT
+	float z = 1.0 / gl_FragCoord.w;
+	float weight = clamp(outColor.a * outColor.a * 0.03 / (1e-5 + pow(z / 1e7, 1.0)), 1e-2, 3e3);
+	out_accum = vec4(outColor.rgb, outColor.a * weight);
+	out_accum.rgb *= out_accum.a;
+	out_reveal = outColor.a;
+#else
+	fragColor = outColor;
+	out_velocity = vec4(0.0);
+#endif
+}


### PR DESCRIPTION
### Motivation
- Ersetze ausschließlich die warpende Teleport-Brush-Oberfläche (die `*tele` Brush-Texture) durch einen prozeduralen GLSL-Fragment-Shader ohne neue CVars, Debug-Flags, Fallbacks, Screen-space- oder Partikel-Mechanik. 
- Ziel ist minimale Eingriffe: nur das Fragment-Shader-Programm für Teleporter-Flächen tauschen, Renderstates und Wasser/Slime/Lava unverändert lassen.

### Description
- Neue Datei: `Quake/shaders/glsl/teleport_fbm.frag` implementiert rein prozedurale FBM-/Noise-/Colormap-Funktionen (`colormap_*`, `rand`, `noise`, `fbm`, `pattern`) und verwendet `in vec2 v_texcoord` sowie die Uniform `u_time` (keine `texture()`-Aufrufe). 
- `glprogs` erweitert um `teleport[2][2]` und `GL_CreateShaders` registriert `glprogs.teleport[oit][dither]` als `water.vert` + `glsl/teleport_fbm.frag`. 
- Erkennung: Texturen mit Namen `*tele...` werden zu `TEXTYPE_TELE` klassifiziert und im Draw-Pfad wird per `t->type == TEXTYPE_TELE` auf den neuen Teleport-Fragment-Shader umgeschaltet (Wasser/Slime/Lava bleiben im bestehenden Wasser-Programm). 
- Shader-Bind: In `R_DrawBrushModels_Water` wird pro Surface zwischen `water_program` und `teleport_program` gewechselt; bei Programmwechsel wird der Batching-Call geflusht, das neue Programm via `GL_UseProgram` gesetzt und `u_time` an Uniform-Location `12` mit `r_refdef.time` übergeben (lokale Variable `shader_time`). 
- Diff-Style Änderungsliste: `+` `Quake/shaders/glsl/teleport_fbm.frag` (neu); `~` `Quake/glquake.h` (`teleport[2][2]` hinzugefügt); `~` `Quake/gl_shaders.c` (Teleport-Programm erzeugt); `~` `Quake/r_world.c` (Draw-Pfad: Auswahl `TEXTYPE_TELE` → Teleport-Programm und `u_time` Bind).

### Testing
- `make -j4` im Repo-Root schlug fehl (kein Makefile), daher kein Full-Build dort möglich. 
- `make -C Quake -j4` wurde ausgeführt und die Build-Generierung startete, scheiterte jedoch an fehlenden System-Dependencies (`sdl2-config` / `SDL.h`), weshalb ein vollständiger Build/Link nicht abgeschlossen werden konnte.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0f1cae6fc832ea52434bdf81b5a4a)