### PR TITLE
Fix build break: use `cl.time` for water shader time in r_world

### DIFF
--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -1674,7 +1674,7 @@ void R_DrawBrushModels_Water (entity_t **ents, int count, qboolean translucent)
 		water_program = glprogs.water[oit][softemu == SOFTEMU_COARSE];
 	teleport_program = glprogs.teleport[oit][softemu == SOFTEMU_COARSE];
 	program = water_program;
-	shader_time = r_refdef.time;
+	shader_time = cl.time;
 
 	R_ResetBModelCalls (program);
 	GL_UseProgram (program);


### PR DESCRIPTION
### Motivation
- Fix MSVC compile error `C2039` caused by accessing non-existent `time` member on `refdef_t` when setting the water shader time in world rendering.

### Description
- Replace `shader_time = r_refdef.time;` with `shader_time = cl.time;` in `R_DrawBrushModels_Water` (`Quake/r_world.c`).

### Testing
- Verified the change is present with `rg -n "shader_time = cl\.time;" Quake/r_world.c`, inspected the `git diff` for `Quake/r_world.c`, and committed the update; all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0f716a0a4832eafab159182cd970f)