### PR TITLE
Add RB_* OpenGL passthrough wrappers and migrate render orchestration to RB_*

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -22,6 +22,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // r_main.c
 
 #include "quakedef.h"
+#include "rb_gl.h"
 #include "cl_postfx.h"
 #include "r_postfx.h"
 #include "r_fogvol.h"
@@ -704,7 +705,7 @@ static GLuint GL_CreateFBO (GLenum target, const GLuint* colors, int numcolors, 
 		Sys_Error ("GL_CreateFBO: too many color buffers (%d)", numcolors);
 
 	GL_GenFramebuffersFunc (1, &fbo);
-	GL_BindFramebufferFunc (GL_FRAMEBUFFER, fbo);
+	RB_BindFramebuffer (GL_FRAMEBUFFER, fbo);
 	GL_ObjectLabelFunc (GL_FRAMEBUFFER, fbo, -1, name);
 	GL_LogErrorIfDeveloper ("GL_CreateFBO bind");
 
@@ -914,7 +915,7 @@ void GL_CreateFrameBuffers (void)
 		);
 	}
 
-        GL_BindFramebufferFunc (GL_FRAMEBUFFER, 0);
+        RB_BindFramebuffer (GL_FRAMEBUFFER, 0);
         GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, 0);
 }
 
@@ -948,7 +949,7 @@ void GL_DeleteFrameBuffers (void)
 		GL_DeleteFramebuffersFunc (1, &framebufs.ssao.ao_fbo[i]);
 		GL_DeleteFramebuffersFunc (1, &framebufs.ssao.blur_fbo[i]);
 	}
-	GL_BindFramebufferFunc (GL_FRAMEBUFFER, 0);
+	RB_BindFramebuffer (GL_FRAMEBUFFER, 0);
 
 	GL_DeleteNativeTexture (framebufs.resolved_scene.color_tex);
 	GL_DeleteNativeTexture (framebufs.resolved_scene.velocity_tex);
@@ -1040,17 +1041,17 @@ static GLuint GL_GenerateBloomTexture (void)
 	float mask_enabled = velocity_texture ? 1.f : 0.f;
 
 	GL_BeginGroup ("Bloom extract");
-	GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.bloom.extract_fbo);
-	glViewport (0, 0, width, height);
-	GL_UseProgram (glprogs.bloom_extract);
-	GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
+	RB_BindFramebuffer (GL_FRAMEBUFFER, framebufs.bloom.extract_fbo);
+	RB_Viewport (0, 0, width, height);
+	RB_UseProgram (glprogs.bloom_extract);
+	RB_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
 	GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, framebufs.composite.color_tex);
 	GL_BindNative (GL_TEXTURE1, GL_TEXTURE_2D, velocity_texture);
 	GL_Uniform4fFunc (0, threshold, mask_enabled, 0.f, 0.f);
 	GL_Uniform4fFunc (1, (float)vid.width, (float)vid.height,
 		(float)vid.width / (float)width,
 		(float)vid.height / (float)height);
-	glDrawArrays (GL_TRIANGLES, 0, 3);
+	RB_DrawArrays (GL_TRIANGLES, 0, 3);
 	GL_EndGroup ();
 
 	GLuint input_tex = framebufs.bloom.extract_tex;
@@ -1059,15 +1060,15 @@ static GLuint GL_GenerateBloomTexture (void)
 	for (int pass = 0; pass < passes; ++pass)
 	{
 		int target_index = pass & 1;
-		GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.bloom.pingpong_fbo[target_index]);
-		glViewport (0, 0, width, height);
-		GL_UseProgram (glprogs.bloom_blur);
-		GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
+		RB_BindFramebuffer (GL_FRAMEBUFFER, framebufs.bloom.pingpong_fbo[target_index]);
+		RB_Viewport (0, 0, width, height);
+		RB_UseProgram (glprogs.bloom_blur);
+		RB_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
 		GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, input_tex);
 		float dirx = (pass & 1) ? 0.f : 1.f;
 		float diry = (pass & 1) ? 1.f : 0.f;
 		GL_Uniform4fFunc (0, 1.f / (float)width, 1.f / (float)height, dirx, diry);
-		glDrawArrays (GL_TRIANGLES, 0, 3);
+		RB_DrawArrays (GL_TRIANGLES, 0, 3);
 		input_tex = framebufs.bloom.pingpong_tex[target_index];
 	}
 	GL_EndGroup ();
@@ -1094,17 +1095,17 @@ static GLuint GL_GenerateBloomTextureFrom (GLuint source_tex, float threshold, f
 		radius = 1.f;
 
 	GL_BeginGroup ("Dlight bloom extract");
-	GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.bloom.extract_fbo);
-	glViewport (0, 0, width, height);
-	GL_UseProgram (glprogs.bloom_extract);
-	GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
+	RB_BindFramebuffer (GL_FRAMEBUFFER, framebufs.bloom.extract_fbo);
+	RB_Viewport (0, 0, width, height);
+	RB_UseProgram (glprogs.bloom_extract);
+	RB_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
 	GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, source_tex);
 	GL_BindNative (GL_TEXTURE1, GL_TEXTURE_2D, 0);
 	GL_Uniform4fFunc (0, threshold, 0.f, 0.f, 0.f);
 	GL_Uniform4fFunc (1, (float)vid.width, (float)vid.height,
 		(float)vid.width / (float)width,
 		(float)vid.height / (float)height);
-	glDrawArrays (GL_TRIANGLES, 0, 3);
+	RB_DrawArrays (GL_TRIANGLES, 0, 3);
 	GL_EndGroup ();
 
 	GLuint input_tex = framebufs.bloom.extract_tex;
@@ -1113,15 +1114,15 @@ static GLuint GL_GenerateBloomTextureFrom (GLuint source_tex, float threshold, f
 	for (int pass = 0; pass < passes; ++pass)
 	{
 		int target_index = pass & 1;
-		GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.bloom.pingpong_fbo[target_index]);
-		glViewport (0, 0, width, height);
-		GL_UseProgram (glprogs.bloom_blur);
-		GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
+		RB_BindFramebuffer (GL_FRAMEBUFFER, framebufs.bloom.pingpong_fbo[target_index]);
+		RB_Viewport (0, 0, width, height);
+		RB_UseProgram (glprogs.bloom_blur);
+		RB_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
 		GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, input_tex);
 		float dirx = (pass & 1) ? 0.f : 1.f;
 		float diry = (pass & 1) ? 1.f : 0.f;
 		GL_Uniform4fFunc (0, radius / (float)width, radius / (float)height, dirx, diry);
-		glDrawArrays (GL_TRIANGLES, 0, 3);
+		RB_DrawArrays (GL_TRIANGLES, 0, 3);
 		input_tex = framebufs.bloom.pingpong_tex[target_index];
 	}
 	GL_EndGroup ();
@@ -1237,11 +1238,11 @@ static void R_CompositeDlightBuffer (void)
 		return;
 
 	GL_BeginGroup ("Dlight composite");
-	GL_UseProgram (glprogs.dlight_composite);
-	GL_SetState (GLS_BLEND_ADD | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
+	RB_UseProgram (glprogs.dlight_composite);
+	RB_SetState (GLS_BLEND_ADD | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
 	GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, framebufs.dlight.tex);
 	GL_Uniform1fFunc (0, scale);
-	glDrawArrays (GL_TRIANGLES, 0, 3);
+	RB_DrawArrays (GL_TRIANGLES, 0, 3);
 	GL_EndGroup ();
 
 	if (bloom_enabled > 0.f && bloom_scale > 0.f)
@@ -1250,11 +1251,11 @@ static void R_CompositeDlightBuffer (void)
 		if (bloom_tex)
 		{
 			GL_BeginGroup ("Dlight bloom composite");
-			GL_UseProgram (glprogs.dlight_composite);
-			GL_SetState (GLS_BLEND_ADD | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
+			RB_UseProgram (glprogs.dlight_composite);
+			RB_SetState (GLS_BLEND_ADD | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
 			GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, bloom_tex);
 			GL_Uniform1fFunc (0, bloom_scale);
-			glDrawArrays (GL_TRIANGLES, 0, 3);
+			RB_DrawArrays (GL_TRIANGLES, 0, 3);
 			GL_EndGroup ();
 		}
 	}
@@ -1334,7 +1335,7 @@ static GLuint GL_GenerateSSAOTexture (float view_min_x, float view_min_y, float 
 	}
 
 	GL_BeginGroup ("SSAO");
-	GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.ssao.ao_fbo[index]);
+	RB_BindFramebuffer (GL_FRAMEBUFFER, framebufs.ssao.ao_fbo[index]);
 	GL_LogErrorIfDeveloper ("SSAO bind FBO");
 	{
 		GLenum status = GL_CheckFramebufferStatusFunc (GL_FRAMEBUFFER);
@@ -1348,7 +1349,7 @@ static GLuint GL_GenerateSSAOTexture (float view_min_x, float view_min_y, float 
 	// SSAO FIX: Reset viewport/scissor/color mask per pass to avoid banding from stale state.
 	GL_SetScissorEnabled (false);
 	glColorMask (GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
-	glViewport (0, 0, width, height);
+	RB_Viewport (0, 0, width, height);
 	{
 		const float clear[4] = { 1.f, 1.f, 1.f, 1.f };
 		GL_ClearBufferfvFunc (GL_COLOR, 0, clear);
@@ -1356,8 +1357,8 @@ static GLuint GL_GenerateSSAOTexture (float view_min_x, float view_min_y, float 
 
 	GL_LogSSAODepthInfo (framebufs.composite.depth_stencil_tex, framebufs.ssao.ao_tex[index], width, height, view_min_x, view_min_y, view_max_x, view_max_y);
 
-	GL_UseProgram (glprogs.ssao);
-	GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
+	RB_UseProgram (glprogs.ssao);
+	RB_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
 	GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, framebufs.composite.depth_stencil_tex);
 	GL_BindNative (GL_TEXTURE1, GL_TEXTURE_2D, framebufs.ssao.noise_tex);
 	GL_UniformMatrix4fvFunc (0, 1, GL_FALSE, r_matproj);
@@ -1394,7 +1395,7 @@ static GLuint GL_GenerateSSAOTexture (float view_min_x, float view_min_y, float 
 	GL_Uniform4fFunc (14, max_distance, r_ssao_saved_fog[3],
 		r_ssao_saved_fog[0] * 0.299f + r_ssao_saved_fog[1] * 0.587f + r_ssao_saved_fog[2] * 0.114f,
 		0.f);
-	glDrawArrays (GL_TRIANGLES, 0, 3);
+	RB_DrawArrays (GL_TRIANGLES, 0, 3);
 	GL_LogErrorIfDeveloper ("SSAO draw");
 
 	qboolean allow_blur = (r_ssao_blur.value > 0.f) && (debug_mode_i < 0);
@@ -1407,7 +1408,7 @@ static GLuint GL_GenerateSSAOTexture (float view_min_x, float view_min_y, float 
 		float depth_threshold_scale = 0.02f;
 		float blur_bilateral = (r_ssao_blur_bilateral.value > 0.f) ? 1.f : 0.f;
 
-		GL_UseProgram (glprogs.ssao_blur);
+		RB_UseProgram (glprogs.ssao_blur);
 		GL_BindNative (GL_TEXTURE1, GL_TEXTURE_2D, framebufs.composite.depth_stencil_tex);
 		GL_Uniform4fFunc (0,
 			1.f / (float)vid.width,
@@ -1426,22 +1427,22 @@ static GLuint GL_GenerateSSAOTexture (float view_min_x, float view_min_y, float 
 		GL_Uniform1iFunc (7, 0);
 		GL_UniformMatrix4fvFunc (8, 1, GL_FALSE, r_matinvproj);
 
-		GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.ssao.blur_fbo[index]);
+		RB_BindFramebuffer (GL_FRAMEBUFFER, framebufs.ssao.blur_fbo[index]);
 		GL_LogErrorIfDeveloper ("SSAO blur bind FBO");
 		GL_SetScissorEnabled (false);
 		glColorMask (GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
-		glViewport (0, 0, width, height);
+		RB_Viewport (0, 0, width, height);
 		GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, framebufs.ssao.ao_tex[index]);
 		GL_Uniform4fFunc (2, 1.f, 0.f, 0.f, 0.f);
-		glDrawArrays (GL_TRIANGLES, 0, 3);
+		RB_DrawArrays (GL_TRIANGLES, 0, 3);
 		GL_LogErrorIfDeveloper ("SSAO blur horizontal draw");
 
-		GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.ssao.ao_fbo[index]);
+		RB_BindFramebuffer (GL_FRAMEBUFFER, framebufs.ssao.ao_fbo[index]);
 		GL_SetScissorEnabled (false);
 		glColorMask (GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
 		GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, framebufs.ssao.blur_tex[index]);
 		GL_Uniform4fFunc (2, 0.f, 1.f, 0.f, 0.f);
-		glDrawArrays (GL_TRIANGLES, 0, 3);
+		RB_DrawArrays (GL_TRIANGLES, 0, 3);
 		GL_LogErrorIfDeveloper ("SSAO blur vertical draw");
 	}
 
@@ -1603,8 +1604,8 @@ static void GL_GenerateGodraysSource (qboolean draw_sky, qboolean draw_brush)
 	float mask_knee = q_max (0.f, r_godrays_mask_knee.value);
 
 	GL_BeginGroup ("Godrays source");
-	GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.godrays.source_fbo);
-	glViewport (0, 0, width, height);
+	RB_BindFramebuffer (GL_FRAMEBUFFER, framebufs.godrays.source_fbo);
+	RB_Viewport (0, 0, width, height);
 	{
 		const float zero[4] = { 0.f, 0.f, 0.f, 0.f };
 		GL_ClearBufferfvFunc (GL_COLOR, 0, zero);
@@ -1620,13 +1621,13 @@ static void GL_GenerateGodraysSource (qboolean draw_sky, qboolean draw_brush)
 			float reversed_z = gl_clipcontrol_able ? 1.f : 0.f;
 			float sky_depth_cutoff = gl_clipcontrol_able ? 0.001f : 0.999f;
 			R_ParseGodraysSkyTint (tint);
-			GL_UseProgram (glprogs.godrays_source_sky);
-			GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
+			RB_UseProgram (glprogs.godrays_source_sky);
+			RB_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
 			GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, framebufs.composite.depth_stencil_tex);
 			GL_Uniform4fFunc (0, sky_depth_cutoff, sky_intensity, reversed_z, sky_threshold);
 			GL_Uniform4fFunc (1, tint[0], tint[1], tint[2], 0.f);
 			GL_Uniform4fFunc (2, mask_knee, 0.f, 0.f, 0.f);
-			glDrawArrays (GL_TRIANGLES, 0, 3);
+			RB_DrawArrays (GL_TRIANGLES, 0, 3);
 		}
 	}
 
@@ -1636,8 +1637,8 @@ static void GL_GenerateGodraysSource (qboolean draw_sky, qboolean draw_brush)
 		entity_t **ents = R_GetVisEntities (mod_brush, false, &count);
 		if (count > 0)
 		{
-			GL_UseProgram (glprogs.godrays_source);
-			GL_SetState (GLS_BLEND_ADD | GLS_NO_ZWRITE | GLS_CULL_BACK | GLS_ATTRIBS (6));
+			RB_UseProgram (glprogs.godrays_source);
+			RB_SetState (GLS_BLEND_ADD | GLS_NO_ZWRITE | GLS_CULL_BACK | GLS_ATTRIBS (6));
 			GL_Uniform4fFunc (0,
 				q_max (0.f, r_godrays_emissive_intensity.value),
 				q_max (0.f, r_godrays_lighttex_intensity.value),
@@ -1694,8 +1695,8 @@ static GLuint GL_GenerateGodraysTexture (GLuint *out_mask)
 	GL_GetGodraysLightPos (width, height, light_x, light_y, &stabilized_x, &stabilized_y);
 
 	GL_BeginGroup ("Godrays scatter");
-	GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.godrays.shafts_fbo);
-	glViewport (0, 0, width, height);
+	RB_BindFramebuffer (GL_FRAMEBUFFER, framebufs.godrays.shafts_fbo);
+	RB_Viewport (0, 0, width, height);
 	{
 		const float zero[4] = { 0.f, 0.f, 0.f, 0.f };
 		GL_ClearBufferfvFunc (GL_COLOR, 0, zero);
@@ -1713,31 +1714,31 @@ static GLuint GL_GenerateGodraysTexture (GLuint *out_mask)
 			GL_GenerateGodraysSource (true, false);
 
 			GL_BeginGroup ("Godrays mask (sky)");
-			GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.godrays.mask_fbo);
-			glViewport (0, 0, width, height);
+			RB_BindFramebuffer (GL_FRAMEBUFFER, framebufs.godrays.mask_fbo);
+			RB_Viewport (0, 0, width, height);
 			{
 				const float zero[4] = { 0.f, 0.f, 0.f, 0.f };
 				GL_ClearBufferfvFunc (GL_COLOR, 0, zero);
 			}
-			GL_UseProgram (glprogs.godrays_mask);
-			GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
+			RB_UseProgram (glprogs.godrays_mask);
+			RB_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
 			GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, framebufs.godrays.source_tex);
 			GL_Uniform4fFunc (0, threshold, sky_softness, 1.f, 0.f);
 			GL_Uniform4fFunc (1, (float)vid.width, (float)vid.height,
 				(float)vid.width / (float)width,
 				(float)vid.height / (float)height);
-			glDrawArrays (GL_TRIANGLES, 0, 3);
+			RB_DrawArrays (GL_TRIANGLES, 0, 3);
 			GL_EndGroup ();
 
 			GL_BeginGroup ("Godrays scatter (sky)");
-			GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.godrays.shafts_fbo);
-			glViewport (0, 0, width, height);
-			GL_UseProgram (glprogs.godrays);
-			GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
+			RB_BindFramebuffer (GL_FRAMEBUFFER, framebufs.godrays.shafts_fbo);
+			RB_Viewport (0, 0, width, height);
+			RB_UseProgram (glprogs.godrays);
+			RB_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
 			GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, framebufs.godrays.mask_tex);
 			GL_Uniform4fFunc (0, stabilized_x, stabilized_y, density, weight);
 			GL_Uniform4fFunc (1, decay, exposure, max_radius, (float)samples);
-			glDrawArrays (GL_TRIANGLES, 0, 3);
+			RB_DrawArrays (GL_TRIANGLES, 0, 3);
 			GL_EndGroup ();
 			first_pass = false;
 		}
@@ -1747,31 +1748,31 @@ static GLuint GL_GenerateGodraysTexture (GLuint *out_mask)
 			GL_GenerateGodraysSource (false, true);
 
 			GL_BeginGroup ("Godrays mask (brush)");
-			GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.godrays.mask_fbo);
-			glViewport (0, 0, width, height);
+			RB_BindFramebuffer (GL_FRAMEBUFFER, framebufs.godrays.mask_fbo);
+			RB_Viewport (0, 0, width, height);
 			{
 				const float zero[4] = { 0.f, 0.f, 0.f, 0.f };
 				GL_ClearBufferfvFunc (GL_COLOR, 0, zero);
 			}
-			GL_UseProgram (glprogs.godrays_mask);
-			GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
+			RB_UseProgram (glprogs.godrays_mask);
+			RB_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
 			GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, framebufs.godrays.source_tex);
 			GL_Uniform4fFunc (0, threshold, softness, sharpness, 0.f);
 			GL_Uniform4fFunc (1, (float)vid.width, (float)vid.height,
 				(float)vid.width / (float)width,
 				(float)vid.height / (float)height);
-			glDrawArrays (GL_TRIANGLES, 0, 3);
+			RB_DrawArrays (GL_TRIANGLES, 0, 3);
 			GL_EndGroup ();
 
 			GL_BeginGroup ("Godrays scatter (brush)");
-			GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.godrays.shafts_fbo);
-			glViewport (0, 0, width, height);
-			GL_UseProgram (glprogs.godrays);
-			GL_SetState ((first_pass ? GLS_BLEND_OPAQUE : GLS_BLEND_ADD) | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
+			RB_BindFramebuffer (GL_FRAMEBUFFER, framebufs.godrays.shafts_fbo);
+			RB_Viewport (0, 0, width, height);
+			RB_UseProgram (glprogs.godrays);
+			RB_SetState ((first_pass ? GLS_BLEND_OPAQUE : GLS_BLEND_ADD) | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
 			GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, framebufs.godrays.mask_tex);
 			GL_Uniform4fFunc (0, stabilized_x, stabilized_y, density, weight);
 			GL_Uniform4fFunc (1, decay, exposure, max_radius, (float)samples);
-			glDrawArrays (GL_TRIANGLES, 0, 3);
+			RB_DrawArrays (GL_TRIANGLES, 0, 3);
 			GL_EndGroup ();
 		}
 	}
@@ -1841,11 +1842,11 @@ static void GL_PostProcessFallback (void)
 	if (!pixels)
 		return;
 
-	GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.composite.fbo);
+	RB_BindFramebuffer (GL_FRAMEBUFFER, framebufs.composite.fbo);
 	glReadBuffer (GL_COLOR_ATTACHMENT0);
 	glPixelStorei (GL_PACK_ALIGNMENT, 1);
 	glReadPixels (0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
-	GL_BindFramebufferFunc (GL_FRAMEBUFFER, 0);
+	RB_BindFramebuffer (GL_FRAMEBUFFER, 0);
 	glReadBuffer (GL_BACK);
 	glPixelStorei (GL_UNPACK_ALIGNMENT, 1);
 	{
@@ -1903,7 +1904,7 @@ static void GL_PostProcessFallback (void)
 
 	glDisable (GL_DEPTH_TEST);
 	glDisable (GL_BLEND);
-        GL_UseProgram (0);
+        RB_UseProgram (0);
 	glMatrixMode (GL_PROJECTION);
 	glPushMatrix ();
 	glLoadIdentity ();
@@ -1993,11 +1994,11 @@ static qboolean GL_SampleAutoExposureLuminance (float *out_luminance)
 	if (width <= 0 || height <= 0 || pixel_count > (int)countof (luminance_samples))
 		return false;
 
-	GL_BindFramebufferFunc (GL_READ_FRAMEBUFFER, framebufs.composite.fbo);
-	GL_BindFramebufferFunc (GL_DRAW_FRAMEBUFFER, framebufs.autoexposure.fbo);
+	RB_BindFramebuffer (GL_READ_FRAMEBUFFER, framebufs.composite.fbo);
+	RB_BindFramebuffer (GL_DRAW_FRAMEBUFFER, framebufs.autoexposure.fbo);
 	GL_BlitFramebufferFunc (0, 0, vid.width, vid.height, 0, 0, width, height, GL_COLOR_BUFFER_BIT, GL_LINEAR);
 
-	GL_BindFramebufferFunc (GL_READ_FRAMEBUFFER, framebufs.autoexposure.fbo);
+	RB_BindFramebuffer (GL_READ_FRAMEBUFFER, framebufs.autoexposure.fbo);
 	glReadBuffer (GL_COLOR_ATTACHMENT0);
 	glGetIntegerv (GL_PACK_ALIGNMENT, &prev_pack_alignment);
 	glPixelStorei (GL_PACK_ALIGNMENT, 1);
@@ -2030,7 +2031,7 @@ static qboolean GL_SampleAutoExposureLuminance (float *out_luminance)
 
 		if (!got_data)
 		{
-			GL_BindFramebufferFunc (GL_FRAMEBUFFER, 0);
+			RB_BindFramebuffer (GL_FRAMEBUFFER, 0);
 			glReadBuffer (GL_BACK);
 			return false;
 		}
@@ -2045,7 +2046,7 @@ static qboolean GL_SampleAutoExposureLuminance (float *out_luminance)
 		glReadPixels (0, 0, width, height, GL_RGBA, GL_FLOAT, pixels);
 		glPixelStorei (GL_PACK_ALIGNMENT, prev_pack_alignment);
 	}
-	GL_BindFramebufferFunc (GL_FRAMEBUFFER, 0);
+	RB_BindFramebuffer (GL_FRAMEBUFFER, 0);
 	glReadBuffer (GL_BACK);
 
 	for (int i = 0; i < pixel_count; ++i)
@@ -2220,12 +2221,12 @@ void GL_PostProcess (void)
 	if (!framesetup.composite_ready)
 	{
 		GL_BeginGroup ("Postprocess backbuffer copy");
-		GL_BindFramebufferFunc (GL_READ_FRAMEBUFFER, 0);
-		GL_BindFramebufferFunc (GL_DRAW_FRAMEBUFFER, framebufs.composite.fbo);
+		RB_BindFramebuffer (GL_READ_FRAMEBUFFER, 0);
+		RB_BindFramebuffer (GL_DRAW_FRAMEBUFFER, framebufs.composite.fbo);
 		glReadBuffer (GL_BACK);
 		glDrawBuffer (GL_COLOR_ATTACHMENT0);
 		GL_BlitFramebufferFunc (0, 0, vid.width, vid.height, 0, 0, vid.width, vid.height, GL_COLOR_BUFFER_BIT, GL_NEAREST);
-		GL_BindFramebufferFunc (GL_FRAMEBUFFER, 0);
+		RB_BindFramebuffer (GL_FRAMEBUFFER, 0);
 		glDrawBuffer (GL_BACK);
 		glReadBuffer (GL_BACK);
 		framesetup.composite_ready = true;
@@ -2382,8 +2383,8 @@ void GL_PostProcess (void)
 	}
 	motion_enabled = (motion_effective_shutter > 0.f && motion_max_samples > 0 && velocity_texture != 0);
 
-	GL_BindFramebufferFunc (GL_FRAMEBUFFER, 0);
-	glViewport (glx, gly, glwidth, glheight);
+	RB_BindFramebuffer (GL_FRAMEBUFFER, 0);
+	RB_Viewport (glx, gly, glwidth, glheight);
 	{
 		int debug_mode = (int)Q_rint (CLAMP (0.f, r_debug_colorspace.value, 4.f));
 		qboolean linear_debug = (debug_mode == 2);
@@ -2398,8 +2399,8 @@ void GL_PostProcess (void)
 		GL_EndGroup ();
 		return;
 	}
-	GL_UseProgram (glprogs.postprocess[variant]);
-	GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
+	RB_UseProgram (glprogs.postprocess[variant]);
+	RB_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
 	GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, framebufs.composite.color_tex);
 	GL_BindNative (GL_TEXTURE1, GL_TEXTURE_3D, gl_palette_lut);
 	GL_BindNative (GL_TEXTURE3, GL_TEXTURE_2D, bloom_texture);
@@ -2519,7 +2520,7 @@ void GL_PostProcess (void)
 		GL_Uniform4fFunc (2, dof_znear, dof_zfar, gl_clipcontrol_able ? 1.f : 0.f, 0.f);
 	}
 
-	glDrawArrays (GL_TRIANGLES, 0, 3);
+	RB_DrawArrays (GL_TRIANGLES, 0, 3);
 
 	GL_EndGroup ();
 }
@@ -3176,7 +3177,7 @@ void R_SetupGL (void)
 		GLuint target = GL_NeedsPostprocess () ? framebufs.composite.fbo : 0u;
 		qboolean srgb_output = (target == 0u) && GL_UseSRGBFramebuffer ();
 
-		GL_BindFramebufferFunc (GL_FRAMEBUFFER, target);
+		RB_BindFramebuffer (GL_FRAMEBUFFER, target);
 		GL_SetFramebufferSRGB (srgb_output);
 		framesetup.scene_fbo = framebufs.composite.fbo;
 		framesetup.oit_fbo = framebufs.oit.fbo_composite;
@@ -3191,11 +3192,11 @@ void R_SetupGL (void)
 			glDrawBuffer (GL_BACK);
 			glReadBuffer (GL_BACK);
 		}
-		glViewport (glx + r_refdef.vrect.x, gly + glheight - r_refdef.vrect.y - r_refdef.vrect.height, r_refdef.vrect.width, r_refdef.vrect.height);
+		RB_Viewport (glx + r_refdef.vrect.x, gly + glheight - r_refdef.vrect.y - r_refdef.vrect.height, r_refdef.vrect.width, r_refdef.vrect.height);
 	}
 	else
 	{
-		GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.scene.fbo);
+		RB_BindFramebuffer (GL_FRAMEBUFFER, framebufs.scene.fbo);
 		GL_SetFramebufferSRGB (false);
 		framesetup.scene_fbo = framebufs.scene.fbo;
 		framesetup.oit_fbo = framebufs.oit.fbo_scene;
@@ -3211,7 +3212,7 @@ void R_SetupGL (void)
 			glDrawBuffer (GL_COLOR_ATTACHMENT0);
 			glReadBuffer (GL_COLOR_ATTACHMENT0);
 		}
-		glViewport (0, 0, r_refdef.vrect.width / r_refdef.scale, r_refdef.vrect.height / r_refdef.scale);
+		RB_Viewport (0, 0, r_refdef.vrect.width / r_refdef.scale, r_refdef.vrect.height / r_refdef.scale);
 	}
 }
 
@@ -3227,9 +3228,9 @@ void R_Clear (void)
 	if (gl_clear.value)
 		clearbits |= GL_COLOR_BUFFER_BIT;
 
-	GL_SetState (glstate & ~GLS_NO_ZWRITE); // make sure depth writes are enabled
+	RB_SetState (glstate & ~GLS_NO_ZWRITE); // make sure depth writes are enabled
 	glStencilMask (~0u);
-	glClear (clearbits);
+	RB_Clear (clearbits);
 }
 
 /*
@@ -3672,11 +3673,11 @@ static void R_FlushDebugGeometry (void)
 		GLbyte* ofs;
 		unsigned int state;
 
-		GL_UseProgram (glprogs.debug3d);
+		RB_UseProgram (glprogs.debug3d);
 		state = GLS_BLEND_ALPHA | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (2);
 		if (!debugztest)
 			state |= GLS_NO_ZTEST;
-		GL_SetState (state);
+		RB_SetState (state);
 
 		GL_Upload (GL_ARRAY_BUFFER, debugverts, sizeof (debugverts[0]) * numdebugverts, &buf, &ofs);
 		GL_BindBuffer (GL_ARRAY_BUFFER, buf);
@@ -4493,7 +4494,7 @@ static void R_BeginTranslucency (void)
 
 	if (R_GetEffectiveAlphaMode () == ALPHAMODE_OIT)
 	{
-		GL_BindFramebufferFunc (GL_FRAMEBUFFER, framesetup.oit_fbo);
+		RB_BindFramebuffer (GL_FRAMEBUFFER, framesetup.oit_fbo);
 		GL_ClearBufferfvFunc (GL_COLOR, 0, zeroes);
 		GL_ClearBufferfvFunc (GL_COLOR, 1, ones);
 
@@ -4515,17 +4516,17 @@ static void R_EndTranslucency (void)
 	{
 		GL_BeginGroup ("OIT resolve");
 
-		GL_BindFramebufferFunc (GL_FRAMEBUFFER, framesetup.scene_fbo);
+		RB_BindFramebuffer (GL_FRAMEBUFFER, framesetup.scene_fbo);
 
 		glStencilFunc (GL_EQUAL, 2, 2);
 		glStencilOp (GL_KEEP, GL_KEEP, GL_KEEP);
 
-		GL_UseProgram (glprogs.oit_resolve[framebufs.scene.samples > 1]);
-		GL_SetState (GLS_BLEND_ALPHA | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
+		RB_UseProgram (glprogs.oit_resolve[framebufs.scene.samples > 1]);
+		RB_SetState (GLS_BLEND_ALPHA | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
 		GL_BindNative (GL_TEXTURE0, framebufs.scene.samples > 1 ? GL_TEXTURE_2D_MULTISAMPLE : GL_TEXTURE_2D, framebufs.oit.accum_tex);
 		GL_BindNative (GL_TEXTURE1, framebufs.scene.samples > 1 ? GL_TEXTURE_2D_MULTISAMPLE : GL_TEXTURE_2D, framebufs.oit.revealage_tex);
 
-		glDrawArrays (GL_TRIANGLES, 0, 3);
+		RB_DrawArrays (GL_TRIANGLES, 0, 3);
 
 		glDisable (GL_STENCIL_TEST);
 
@@ -4546,7 +4547,7 @@ static void R_SetDlightConfig (GLuint program, float scale, float falloff, float
 	if (!program)
 		return;
 
-	GL_UseProgram (program);
+	RB_UseProgram (program);
 	GL_Uniform4fFunc (0, scale, r_dlight_radius_scale.value, falloff, expval);
 	GL_Uniform4fFunc (1, core_boost, core_exp, knee, ndotl);
 	GL_Uniform4fFunc (2, satchop, 0.f, 0.f, 0.f);
@@ -4576,7 +4577,7 @@ static void R_DrawDLightPass (void)
 	{
 		use_buffer = true;
 		r_dlight_buffered_frame = true;
-		GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.dlight.fbo);
+		RB_BindFramebuffer (GL_FRAMEBUFFER, framebufs.dlight.fbo);
 		glDrawBuffer (GL_COLOR_ATTACHMENT0);
 		glReadBuffer (GL_COLOR_ATTACHMENT0);
 		{
@@ -4621,7 +4622,7 @@ static void R_DrawDLightPass (void)
 
 	if (use_buffer)
 	{
-		GL_BindFramebufferFunc (GL_FRAMEBUFFER, framesetup.scene_fbo);
+		RB_BindFramebuffer (GL_FRAMEBUFFER, framesetup.scene_fbo);
 		if (framesetup.scene_fbo)
 		{
 			glDrawBuffer (GL_COLOR_ATTACHMENT0);
@@ -4706,8 +4707,8 @@ void R_WarpScaleView (void)
 	{
 		GL_BeginGroup ("MSAA resolve");
 
-		GL_BindFramebufferFunc (GL_READ_FRAMEBUFFER, framebufs.scene.fbo);
-		GL_BindFramebufferFunc (GL_DRAW_FRAMEBUFFER, framebufs.resolved_scene.fbo);
+		RB_BindFramebuffer (GL_READ_FRAMEBUFFER, framebufs.scene.fbo);
+		RB_BindFramebuffer (GL_DRAW_FRAMEBUFFER, framebufs.resolved_scene.fbo);
 
 		glReadBuffer (GL_COLOR_ATTACHMENT0);
 		glDrawBuffer (GL_COLOR_ATTACHMENT0);
@@ -4724,9 +4725,9 @@ void R_WarpScaleView (void)
 
 		if (!needwarpscale)
 		{
-			GL_BindFramebufferFunc (GL_READ_FRAMEBUFFER, framebufs.resolved_scene.fbo);
+			RB_BindFramebuffer (GL_READ_FRAMEBUFFER, framebufs.resolved_scene.fbo);
 			glReadBuffer (GL_COLOR_ATTACHMENT0);
-			GL_BindFramebufferFunc (GL_DRAW_FRAMEBUFFER, fbodest);
+			RB_BindFramebuffer (GL_DRAW_FRAMEBUFFER, fbodest);
 			if (fbodest)
 				glDrawBuffer (GL_COLOR_ATTACHMENT0);
 			else
@@ -4745,18 +4746,18 @@ void R_WarpScaleView (void)
 		int dstw = (r_refdef.scale != 1) ? r_refdef.vrect.width : srcw;
 		int dsth = (r_refdef.scale != 1) ? r_refdef.vrect.height : srch;
 
-		GL_BindFramebufferFunc (GL_READ_FRAMEBUFFER, framebufs.scene.fbo);
+		RB_BindFramebuffer (GL_READ_FRAMEBUFFER, framebufs.scene.fbo);
 		glReadBuffer (GL_COLOR_ATTACHMENT0);
-		GL_BindFramebufferFunc (GL_DRAW_FRAMEBUFFER, framebufs.composite.fbo);
+		RB_BindFramebuffer (GL_DRAW_FRAMEBUFFER, framebufs.composite.fbo);
 		glDrawBuffer (GL_COLOR_ATTACHMENT0);
 		GL_BlitFramebufferFunc (0, 0, srcw, srch, srcx, srcy, srcx + dstw, srcy + dsth, GL_DEPTH_BUFFER_BIT, GL_NEAREST);
 	}
 
 	if (!msaa && !needwarpscale)
 	{
-		GL_BindFramebufferFunc (GL_READ_FRAMEBUFFER, framebufs.scene.fbo);
+		RB_BindFramebuffer (GL_READ_FRAMEBUFFER, framebufs.scene.fbo);
 		glReadBuffer (GL_COLOR_ATTACHMENT0);
-		GL_BindFramebufferFunc (GL_DRAW_FRAMEBUFFER, fbodest);
+		RB_BindFramebuffer (GL_DRAW_FRAMEBUFFER, fbodest);
 		if (fbodest)
 			glDrawBuffer (GL_COLOR_ATTACHMENT0);
 		else
@@ -4766,7 +4767,7 @@ void R_WarpScaleView (void)
 			GL_COLOR_BUFFER_BIT, GL_NEAREST);
 	}
 
-	GL_BindFramebufferFunc (GL_FRAMEBUFFER, fbodest);
+	RB_BindFramebuffer (GL_FRAMEBUFFER, fbodest);
 	if (fbodest)
 	{
 		glDrawBuffer (GL_COLOR_ATTACHMENT0);
@@ -4777,7 +4778,7 @@ void R_WarpScaleView (void)
 		glDrawBuffer (GL_BACK);
 		glReadBuffer (GL_BACK);
 	}
-	glViewport (srcx, srcy, r_refdef.vrect.width, r_refdef.vrect.height);
+	RB_Viewport (srcx, srcy, r_refdef.vrect.width, r_refdef.vrect.height);
 
 	if (!needwarpscale)
 	{
@@ -4792,8 +4793,8 @@ void R_WarpScaleView (void)
 	smax = srcw / (float)vid.width;
 	tmax = srch / (float)vid.height;
 
-	GL_UseProgram (glprogs.warpscale[water_warp]);
-	GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
+	RB_UseProgram (glprogs.warpscale[water_warp]);
+	RB_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
 
 	t = M_ForcedUnderwater () ? realtime : cl.time;
 	GL_Uniform4fFunc (0, smax, tmax, water_warp ? 1.f / 256.f : 0.f, (float)t);
@@ -4803,7 +4804,7 @@ void R_WarpScaleView (void)
 	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, water_warp && msaa ? GL_LINEAR : GL_NEAREST);
 	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, water_warp && msaa ? GL_LINEAR : GL_NEAREST);
 
-	glDrawArrays (GL_TRIANGLES, 0, 3);
+	RB_DrawArrays (GL_TRIANGLES, 0, 3);
 
 	GL_EndGroup ();
 

--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -23,6 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 //r_alias.c -- alias model rendering
 
 #include "quakedef.h"
+#include "rb_gl.h"
 #include "../common/lightgrid.h"
 
 extern cvar_t gl_overbright_models, gl_fullbrights, r_lerpmodels, r_lerpmove, r_model_halflambert; //johnfitz
@@ -559,7 +560,7 @@ void R_FlushAliasInstances (qboolean showtris)
 		mode = r_softemu_mdl_warp.value > 0.f ? ALIASSHADER_NOPERSP : ALIASSHADER_STANDARD;
 		break;
 	}
-	GL_UseProgram (glprogs.alias[oit][mode][alphatest][md5]);
+	RB_UseProgram (glprogs.alias[oit][mode][alphatest][md5]);
 
 	if (md5)
 		state = GLS_CULL_BACK | GLS_ATTRIBS(5);
@@ -570,7 +571,7 @@ void R_FlushAliasInstances (qboolean showtris)
 		state |= GLS_BLEND_OPAQUE;
 	else
 		state |= GLS_BLEND_ALPHA_OIT | GLS_NO_ZWRITE;
-	GL_SetState (state);
+	RB_SetState (state);
 
 memcpy (ibuf.global.matviewproj, r_matviewproj, sizeof (r_matviewproj));
 memcpy (ibuf.global.prev_matviewproj, r_framedata.prev_viewproj, sizeof (r_framedata.prev_viewproj));

--- a/Quake/r_fogvol.c
+++ b/Quake/r_fogvol.c
@@ -21,6 +21,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 */
 
 #include "quakedef.h"
+#include "rb_gl.h"
 #include "draw.h"
 #include "r_fogvol.h"
 #include <math.h>
@@ -75,17 +76,17 @@ void R_FogVol_ClearHistory (void)
 	if (!framebufs.fogvol.history_fbo[0] || !framebufs.fogvol.history_fbo[1])
 		return;
 
-	GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.fogvol.history_fbo[0]);
+	RB_BindFramebuffer (GL_FRAMEBUFFER, framebufs.fogvol.history_fbo[0]);
 	{
 		const float zero[4] = {0.f, 0.f, 0.f, 0.f};
 		GL_ClearBufferfvFunc (GL_COLOR, 0, zero);
 	}
-	GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.fogvol.history_fbo[1]);
+	RB_BindFramebuffer (GL_FRAMEBUFFER, framebufs.fogvol.history_fbo[1]);
 	{
 		const float zero[4] = {0.f, 0.f, 0.f, 0.f};
 		GL_ClearBufferfvFunc (GL_COLOR, 0, zero);
 	}
-	GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.composite.fbo);
+	RB_BindFramebuffer (GL_FRAMEBUFFER, framebufs.composite.fbo);
 }
 
 typedef struct fogvol_test_state_s
@@ -160,7 +161,7 @@ static fogvol_state_cache_t r_fogvol_state_cache = { 0, 0, 0, 0 };
 
 static void R_FogVol_BindFramebuffer (GLenum target, GLuint fbo)
 {
-	GL_BindFramebufferFunc (target, fbo);
+	RB_BindFramebuffer (target, fbo);
 	/* BEST PRACTICE #10: GL_FRAMEBUFFER is an alias that binds both draw and
 	 * read targets simultaneously (GL 3.0+).  Reflect that in the cache so
 	 * that subsequent GL_DRAW/READ_FRAMEBUFFER queries against the cache are
@@ -178,7 +179,7 @@ static void R_FogVol_BindFramebuffer (GLenum target, GLuint fbo)
 
 static void R_FogVol_UseProgram (GLuint prog)
 {
-	GL_UseProgram (prog);
+	RB_UseProgram (prog);
 	r_fogvol_state_cache.program = (GLint)prog;
 }
 
@@ -191,9 +192,9 @@ static void R_FogVol_BindVertexArray (GLuint vao)
 static void R_FogVol_SetDepthMask (qboolean enabled)
 {
 	if (enabled)
-		GL_SetState (glstate & ~GLS_NO_ZWRITE);
+		RB_SetState (glstate & ~GLS_NO_ZWRITE);
 	else
-		GL_SetState (glstate | GLS_NO_ZWRITE);
+		RB_SetState (glstate | GLS_NO_ZWRITE);
 }
 
 static qboolean R_FogVol_TestDebugEnabled (void)
@@ -502,7 +503,7 @@ static void R_FogVol_Restore3DRenderState (const fogvol_restore_state_t *state)
 	R_FogVol_BindFramebuffer (GL_READ_FRAMEBUFFER, state->read_fbo);
 	glDrawBuffer ((GLenum)state->draw_buffer);
 	glReadBuffer ((GLenum)state->read_buffer);
-	glViewport (state->viewport[0], state->viewport[1], state->viewport[2], state->viewport[3]);
+	RB_Viewport (state->viewport[0], state->viewport[1], state->viewport[2], state->viewport[3]);
 	if (state->scissor_test)
 		GL_SetScissorEnabled (true);
 	else
@@ -515,7 +516,7 @@ static void R_FogVol_Restore3DRenderState (const fogvol_restore_state_t *state)
 	glColorMask (GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
 	R_FogVol_SetDepthMask (true);
 	glPolygonMode (GL_FRONT_AND_BACK, GL_FILL);
-	GL_SetState (state->glstate_bits);
+	RB_SetState (state->glstate_bits);
 	if (state->framebuffer_srgb)
 		glEnable (GL_FRAMEBUFFER_SRGB);
 	else
@@ -1128,7 +1129,7 @@ void R_FogVol_Render (void)
 
 	GL_BeginGroup ("Fog volumes");
 	R_FogVol_UseProgram (glprogs.fogvol);
-	GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
+	RB_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
 	GL_SetScissorEnabled (false);
 	glColorMask (GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
 	GL_Uniform1iFunc (0, steps);
@@ -1146,9 +1147,9 @@ void R_FogVol_Render (void)
 	GL_Uniform2fFunc (13, q_max (0.f, r_fogvol_density_scale.value), q_max (0.001f, r_fogvol_sigma_max.value));
 
 	if (use_halfres)
-		glViewport (0, 0, fog_width, fog_height);
+		RB_Viewport (0, 0, fog_width, fog_height);
 	else
-		glViewport ((int)view_x, (int)view_y, (int)view_w, (int)view_h);
+		RB_Viewport ((int)view_x, (int)view_y, (int)view_w, (int)view_h);
 	depth_tex = framebufs.composite.depth_stencil_tex;
 	fog_tex[0] = framebufs.fogvol.color_tex[0];
 	fog_tex[1] = framebufs.fogvol.color_tex[1];
@@ -1252,7 +1253,7 @@ void R_FogVol_Render (void)
 		GL_SetScissorEnabled (true);
 		glScissor (x0, y0, x1 - x0, y1 - y0);
 		GL_Uniform1iFunc (3, i);
-		glDrawArrays (GL_TRIANGLES, 0, 3);
+		RB_DrawArrays (GL_TRIANGLES, 0, 3);
 		GL_SetScissorEnabled (false);
 
 		fog_src = fog_dst;
@@ -1267,7 +1268,7 @@ void R_FogVol_Render (void)
 		R_FogVol_BindFramebuffer (GL_FRAMEBUFFER, framebufs.composite.fbo);
 		R_FogVol_SetDrawBufferDebug (GL_COLOR_ATTACHMENT0, "temporal draw=COLOR_ATTACHMENT0");
 		R_FogVol_SetReadBufferDebug (GL_COLOR_ATTACHMENT0, "temporal read=COLOR_ATTACHMENT0");
-		glViewport (glx, gly, glwidth, glheight);
+		RB_Viewport (glx, gly, glwidth, glheight);
 		goto done;
 	}
 
@@ -1294,7 +1295,7 @@ void R_FogVol_Render (void)
 		}
 
 		R_FogVol_UseProgram (glprogs.fogvol_temporal);
-		GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
+		RB_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
 		/* BUG FIX #5: Removed unreachable same-index guards.  history_src and
 		 * history_dst are always opposite values after the init block above, so
 		 * the guards `if (history_src == history_dst)` were dead code that
@@ -1303,7 +1304,7 @@ void R_FogVol_Render (void)
 		R_FogVol_BindFramebuffer (GL_DRAW_FRAMEBUFFER, framebufs.fogvol.composite_fbo[composite_dst]);
 		R_FogVol_SetReadBufferDebug (GL_COLOR_ATTACHMENT0, "COMPOSITE read=COLOR_ATTACHMENT0");
 		R_FogVol_SetDrawBufferDebug (GL_COLOR_ATTACHMENT0, "COMPOSITE draw=COLOR_ATTACHMENT0");
-		glViewport (0, 0, fog_width, fog_height);
+		RB_Viewport (0, 0, fog_width, fog_height);
 		R_FogVol_AssertNoFeedbackHazard ("COMPOSITE", framebufs.fogvol.composite_tex[composite_dst], final_tex);
 		R_FogVol_AssertNoFeedbackHazard ("COMPOSITE", framebufs.fogvol.composite_tex[composite_dst], history_tex[history_src]);
 		R_FogVol_AssertNoBoundFeedbackHazard ("COMPOSITE");
@@ -1322,7 +1323,7 @@ void R_FogVol_Render (void)
 		if (mode == 1)
 			Con_DPrintf ("FOGVOL debug COMPOSITE final_tex=%u history_tex=%u depth_tex=%u dst_tex=%u\n",
 				final_tex, history_tex[history_src], depth_tex, framebufs.fogvol.composite_tex[composite_dst]);
-		glDrawArrays (GL_TRIANGLES, 0, 3);
+		RB_DrawArrays (GL_TRIANGLES, 0, 3);
 
 		R_FogVol_BindFramebuffer (GL_READ_FRAMEBUFFER, framebufs.fogvol.composite_fbo[composite_dst]);
 		R_FogVol_BindFramebuffer (GL_DRAW_FRAMEBUFFER, history_fbo[history_dst]);
@@ -1346,7 +1347,7 @@ void R_FogVol_Render (void)
 	{
 		R_FogVol_BindFramebuffer (GL_FRAMEBUFFER, framebufs.composite.fbo);
 		R_FogVol_SetDrawBufferDebug (GL_COLOR_ATTACHMENT0, "HISTORY draw=COLOR_ATTACHMENT0");
-		glViewport (glx, gly, glwidth, glheight);
+		RB_Viewport (glx, gly, glwidth, glheight);
 		if (use_halfres)
 		{
 			if (composite_src_tex)
@@ -1359,7 +1360,7 @@ void R_FogVol_Render (void)
 				int taps = (int)Q_rint (r_fogvol_upsample_taps.value);
 				taps = (taps == 9) ? 9 : 4;
 				R_FogVol_UseProgram (glprogs.fogvol_upsample);
-				GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
+				RB_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
 				R_FogVol_AssertNoFeedbackHazard ("HISTORY", framebufs.composite.color_tex, final_tex);
 				GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, final_tex);
 				GL_BindNative (GL_TEXTURE1, GL_TEXTURE_2D, depth_tex);
@@ -1367,7 +1368,7 @@ void R_FogVol_Render (void)
 				GL_Uniform4fFunc (0, (float)glwidth, (float)glheight, (float)fog_width, (float)fog_height);
 				GL_Uniform1fFunc (1, r_fogvol_upsample_k.value);
 				GL_Uniform1iFunc (2, taps);
-				glDrawArrays (GL_TRIANGLES, 0, 3);
+				RB_DrawArrays (GL_TRIANGLES, 0, 3);
 			}
 			else
 			{

--- a/Quake/r_part.c
+++ b/Quake/r_part.c
@@ -22,6 +22,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 */
 
 #include "quakedef.h"
+#include "rb_gl.h"
 
 #define MAX_PARTICLES			16384	// default max # of particles at one
 										//  time
@@ -700,7 +701,7 @@ static void R_DrawParticles_Real (qboolean alpha, qboolean showtris)
 
 	dither = (softemu == SOFTEMU_COARSE && !showtris);
 	oit = (alpha && R_GetEffectiveAlphaMode () == ALPHAMODE_OIT);
-	GL_UseProgram (glprogs.particles[oit][dither]);
+	RB_UseProgram (glprogs.particles[oit][dither]);
 
 	// compensate for apparent size of different particle textures
 	// this bakes in the additional scaling of vup and vright by 1.5f for billboarding,
@@ -712,9 +713,9 @@ static void R_DrawParticles_Real (qboolean alpha, qboolean showtris)
 	GL_Uniform3fFunc (0, scalex, scaley, uvscale);
 
 	if (alpha)
-		GL_SetState (GLS_BLEND_ALPHA_OIT | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (2) | GLS_INSTANCED_ATTRIBS (2));
+		RB_SetState (GLS_BLEND_ALPHA_OIT | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (2) | GLS_INSTANCED_ATTRIBS (2));
 	else
-		GL_SetState (GLS_BLEND_OPAQUE | GLS_CULL_NONE | GLS_ATTRIBS (2) | GLS_INSTANCED_ATTRIBS (2));
+		RB_SetState (GLS_BLEND_OPAQUE | GLS_CULL_NONE | GLS_ATTRIBS (2) | GLS_INSTANCED_ATTRIBS (2));
 
 	numpartverts = 0;
 	for (i = 0, p = particles; i < r_numactiveparticles; i++, p++)

--- a/Quake/r_postfx.c
+++ b/Quake/r_postfx.c
@@ -20,6 +20,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 */
 
 #include "quakedef.h"
+#include "rb_gl.h"
 #include "r_postfx.h"
 #include "cl_postfx.h"
 #include "gl_texmgr.h"

--- a/Quake/r_sprite.c
+++ b/Quake/r_sprite.c
@@ -22,6 +22,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 //r_sprite.c -- sprite model rendering
 
 #include "quakedef.h"
+#include "rb_gl.h"
 
 typedef struct spritevert_t {
 	vec3_t		pos;
@@ -153,14 +154,14 @@ static void R_FlushSpriteInstances (void)
 		GL_PolygonOffset (OFFSET_DECAL);
 
 	dither = (softemu == SOFTEMU_COARSE && !showtris);
-	GL_UseProgram (glprogs.sprites[dither]);
+	RB_UseProgram (glprogs.sprites[dither]);
 
 	if (showtris)
-		GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZWRITE | GLS_CULL_BACK | GLS_ATTRIBS(2));
+		RB_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZWRITE | GLS_CULL_BACK | GLS_ATTRIBS(2));
 	else
-		GL_SetState (GLS_BLEND_OPAQUE | GLS_CULL_BACK | GLS_ATTRIBS(2));
+		RB_SetState (GLS_BLEND_OPAQUE | GLS_CULL_BACK | GLS_ATTRIBS(2));
 
-	GL_Bind (GL_TEXTURE0, showtris ? whitetexture : batchtexture);
+	RB_BindTexture (GL_TEXTURE0, showtris ? whitetexture : batchtexture);
 
 	GL_Upload (GL_ARRAY_BUFFER, batchverts, sizeof(batchverts[0]) * 4 * numbatchquads, &buf, &ofs);
 	GL_BindBuffer (GL_ARRAY_BUFFER, buf);

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -23,6 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // r_world.c: world model rendering
 
 #include "quakedef.h"
+#include "rb_gl.h"
 #include "mat_shader.h"
 
 extern cvar_t gl_fullbrights, r_oldskyleaf, r_showtris; //johnfitz
@@ -206,12 +207,12 @@ static void R_MarkVisSurfaces (byte* vis)
 	COMPILE_TIME_ASSERT (vis_alignment_must_be_multiple_of_uint, (VIS_ALIGN & 3) == 0);
 	vissize = (vissize + VIS_ALIGN_MASK) & ~VIS_ALIGN_MASK; // round up
 
-	GL_UseProgram (glprogs.clear_indirect);
+	RB_UseProgram (glprogs.clear_indirect);
 	GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 1, gl_bmodel_indirect_buffer, 0, cl.worldmodel->texofs[TEXTYPE_COUNT] * sizeof(bmodel_draw_indirect_t));
 	GL_DispatchComputeFunc ((cl.worldmodel->texofs[TEXTYPE_COUNT] + 63) / 64, 1, 1);
 	GL_MemoryBarrierFunc (GL_SHADER_STORAGE_BARRIER_BIT);
 
-	GL_UseProgram (glprogs.cull_mark);
+	RB_UseProgram (glprogs.cull_mark);
 	GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 2, gl_bmodel_ibo, 0, gl_bmodel_ibo_size);
 	GL_Upload (GL_SHADER_STORAGE_BUFFER, vis, vissize, &buf, &ofs);
 	GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 3, buf, (GLintptr)ofs, vissize);
@@ -430,7 +431,7 @@ static void R_FlushBModelCalls (void)
 
 	GL_ReserveDeviceMemory (GL_DRAW_INDIRECT_BUFFER, sizeof (bmodel_draw_indirect_t) * num_bmodel_calls, &cmdbuf, &dstcmdofs);
 
-	GL_UseProgram (glprogs.gather_indirect);
+	RB_UseProgram (glprogs.gather_indirect);
 	GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 5, gl_bmodel_indirect_buffer, 0, gl_bmodel_indirect_buffer_size);
 	GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 6, cmdbuf, dstcmdofs, sizeof (bmodel_draw_indirect_t) * num_bmodel_calls);
 	GL_Upload (GL_SHADER_STORAGE_BUFFER, bmodel_call_remap, sizeof (bmodel_call_remap[0]) * num_bmodel_calls, &buf, &ofs);
@@ -438,7 +439,7 @@ static void R_FlushBModelCalls (void)
 	GL_DispatchComputeFunc ((num_bmodel_calls + 63) / 64, 1, 1);
 	GL_MemoryBarrierFunc (GL_COMMAND_BARRIER_BIT);
 
-	GL_UseProgram (bmodel_batch_program);
+	RB_UseProgram (bmodel_batch_program);
 	GL_BindBuffer (GL_ELEMENT_ARRAY_BUFFER, gl_bmodel_ibo);
 	GL_BindBuffer (GL_ARRAY_BUFFER, gl_bmodel_vbo);
 	GL_BindBuffer (GL_DRAW_INDIRECT_BUFFER, cmdbuf);
@@ -466,7 +467,7 @@ static void R_FlushBModelCalls (void)
 		{
 			GL_Uniform1iFunc (0, i);
 			GL_BindTextures (0, 2, bmodel_calls.bound.textures[i]);
-			GL_Bind (GL_TEXTURE4, bmodel_calls.bound.textures[i][2]);
+			RB_BindTexture (GL_TEXTURE4, bmodel_calls.bound.textures[i][2]);
 			GL_DrawElementsIndirectFunc (GL_TRIANGLES, GL_UNSIGNED_INT, (const byte *)(dstcmdofs + i * sizeof (bmodel_draw_indirect_t)));
 		}
 	}
@@ -1030,8 +1031,8 @@ static void R_DrawBrushModels_MaterialStages (entity_t **ents, int count, brushp
 		return;
 
 	R_ResetBModelCalls (program);
-	GL_Bind (GL_TEXTURE2, r_fullbright_cheatsafe ? greytexture : lightmap_texture);
-	GL_Bind (GL_TEXTURE3, (r_lightingdir.value > 0.f && lightmap_dir_texture) ? lightmap_dir_texture : greytexture);
+	RB_BindTexture (GL_TEXTURE2, r_fullbright_cheatsafe ? greytexture : lightmap_texture);
+	RB_BindTexture (GL_TEXTURE3, (r_lightingdir.value > 0.f && lightmap_dir_texture) ? lightmap_dir_texture : greytexture);
 
 	GL_Upload (GL_SHADER_STORAGE_BUFFER, bmodel_instances, sizeof (bmodel_instances[0]) * totalinst, &buf, &ofs);
 	GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 2, buf, (GLintptr)ofs, sizeof (bmodel_instances[0]) * totalinst);
@@ -1161,7 +1162,7 @@ static void R_DrawBrushModels_MaterialStages (entity_t **ents, int count, brushp
 					if (num_bmodel_calls)
 						R_FlushBModelCalls ();
 					R_ResetBModelCalls (program);
-					GL_SetState (stage_state);
+					RB_SetState (stage_state);
 					current_state = stage_state;
 					glDepthFunc (depth_func);
 					current_depth = depth_func;
@@ -1232,9 +1233,9 @@ static void R_DrawBrushModels_GodrayStages (entity_t **ents, int count)
 		return;
 
 	R_ResetBModelCalls (glprogs.godrays_source);
-	GL_SetState (GLS_CULL_BACK | GLS_BLEND_ADD | GLS_NO_ZWRITE | GLS_ATTRIBS (6));
-	GL_Bind (GL_TEXTURE2, r_fullbright_cheatsafe ? greytexture : lightmap_texture);
-	GL_Bind (GL_TEXTURE3, (r_lightingdir.value > 0.f && lightmap_dir_texture) ? lightmap_dir_texture : greytexture);
+	RB_SetState (GLS_CULL_BACK | GLS_BLEND_ADD | GLS_NO_ZWRITE | GLS_ATTRIBS (6));
+	RB_BindTexture (GL_TEXTURE2, r_fullbright_cheatsafe ? greytexture : lightmap_texture);
+	RB_BindTexture (GL_TEXTURE3, (r_lightingdir.value > 0.f && lightmap_dir_texture) ? lightmap_dir_texture : greytexture);
 
 	GL_Upload (GL_SHADER_STORAGE_BUFFER, bmodel_instances, sizeof (bmodel_instances[0]) * totalinst, &buf, &ofs);
 	GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 2, buf, (GLintptr)ofs, sizeof (bmodel_instances[0]) * totalinst);
@@ -1470,19 +1471,19 @@ static void R_DrawBrushModels_Real (entity_t **ents, int count, brushpass_t pass
                 state |= GLS_BLEND_ALPHA_OIT | GLS_NO_ZWRITE;
 
         R_ResetBModelCalls (program);
-        GL_SetState (state);
-        GL_UseProgram (program);
+        RB_SetState (state);
+        RB_UseProgram (program);
 if (pass <= BP_ALPHATEST)
 {
-GL_UseProgram (program);
-	GL_Bind (GL_TEXTURE2, r_fullbright_cheatsafe ? greytexture : lightmap_texture);
-	GL_Bind (GL_TEXTURE3, (r_lightingdir.value > 0.f && lightmap_dir_texture) ? lightmap_dir_texture : greytexture);
+RB_UseProgram (program);
+	RB_BindTexture (GL_TEXTURE2, r_fullbright_cheatsafe ? greytexture : lightmap_texture);
+	RB_BindTexture (GL_TEXTURE3, (r_lightingdir.value > 0.f && lightmap_dir_texture) ? lightmap_dir_texture : greytexture);
 }
 else if (pass == BP_DLIGHT_SOLID || pass == BP_DLIGHT_ALPHA)
 {
 }
 else if (pass == BP_SKYCUBEMAP)
-	GL_Bind (GL_TEXTURE2, skybox->cubemap);
+	RB_BindTexture (GL_TEXTURE2, skybox->cubemap);
 
         GL_Upload (GL_SHADER_STORAGE_BUFFER, bmodel_instances, sizeof(bmodel_instances[0]) * totalinst, &buf, &ofs);
         GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 2, buf, (GLintptr)ofs, sizeof(bmodel_instances[0]) * totalinst);
@@ -1584,7 +1585,7 @@ else if (pass == BP_SKYCUBEMAP)
 		baseinst += numinst;
         }
 
-	GL_UseProgram (program);
+	RB_UseProgram (program);
 	R_FlushBModelCalls ();
 
 	if (pass == BP_SOLID || pass == BP_ALPHATEST)
@@ -1677,11 +1678,11 @@ void R_DrawBrushModels_Water (entity_t **ents, int count, qboolean translucent)
 	shader_time = cl.time;
 
 	R_ResetBModelCalls (program);
-	GL_UseProgram (program);
+	RB_UseProgram (program);
 	GL_Uniform1fFunc (12, shader_time);
-	GL_SetState (state);
-	GL_Bind (GL_TEXTURE2, r_fullbright_cheatsafe ? greytexture : lightmap_texture);
-	GL_Bind (GL_TEXTURE3, (r_lightingdir.value > 0.f && lightmap_dir_texture) ? lightmap_dir_texture : greytexture);
+	RB_SetState (state);
+	RB_BindTexture (GL_TEXTURE2, r_fullbright_cheatsafe ? greytexture : lightmap_texture);
+	RB_BindTexture (GL_TEXTURE3, (r_lightingdir.value > 0.f && lightmap_dir_texture) ? lightmap_dir_texture : greytexture);
 
 	GL_Upload (GL_SHADER_STORAGE_BUFFER, bmodel_instances, sizeof(bmodel_instances[0]) * totalinst, &buf, &ofs);
 	GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 2, buf, (GLintptr)ofs, sizeof(bmodel_instances[0]) * totalinst);
@@ -1735,7 +1736,7 @@ void R_DrawBrushModels_Water (entity_t **ents, int count, qboolean translucent)
 				R_FlushBModelCalls ();
 				program = target_program;
 				R_ResetBModelCalls (program);
-				GL_UseProgram (program);
+				RB_UseProgram (program);
 				GL_Uniform1fFunc (12, shader_time);
 			}
 			{

--- a/Quake/rb_gl.c
+++ b/Quake/rb_gl.c
@@ -1,0 +1,41 @@
+#include "quakedef.h"
+#include "rb_gl.h"
+
+#if !RB_GL_PASSTHROUGH_ONLY
+#error "RB wrappers must remain pass-through during this migration stage"
+#endif
+
+void RB_SetState (unsigned mask)
+{
+	GL_SetState (mask);
+}
+
+void RB_UseProgram (GLuint program)
+{
+	GL_UseProgram (program);
+}
+
+qboolean RB_BindTexture (GLenum texunit, gltexture_t *texture)
+{
+	return GL_Bind (texunit, texture);
+}
+
+void RB_BindFramebuffer (GLenum target, GLuint framebuffer)
+{
+	GL_BindFramebufferFunc (target, framebuffer);
+}
+
+void RB_DrawArrays (GLenum mode, GLint first, GLsizei count)
+{
+	glDrawArrays (mode, first, count);
+}
+
+void RB_Clear (GLbitfield mask)
+{
+	glClear (mask);
+}
+
+void RB_Viewport (GLint x, GLint y, GLsizei width, GLsizei height)
+{
+	glViewport (x, y, width, height);
+}

--- a/Quake/rb_gl.h
+++ b/Quake/rb_gl.h
@@ -1,0 +1,21 @@
+#ifndef RB_GL_H
+#define RB_GL_H
+
+#include "glquake.h"
+#include "gl_texmgr.h"
+
+/*
+ * Build guard: wrappers are pass-through only during the initial migration.
+ * Keep this set to 1 until backend behavior intentionally diverges.
+ */
+#define RB_GL_PASSTHROUGH_ONLY 1
+
+void RB_SetState (unsigned mask);
+void RB_UseProgram (GLuint program);
+qboolean RB_BindTexture (GLenum texunit, gltexture_t *texture);
+void RB_BindFramebuffer (GLenum target, GLuint framebuffer);
+void RB_DrawArrays (GLenum mode, GLint first, GLsizei count);
+void RB_Clear (GLbitfield mask);
+void RB_Viewport (GLint x, GLint y, GLsizei width, GLsizei height);
+
+#endif


### PR DESCRIPTION
### Motivation

- Introduce a render-backend abstraction layer so GL orchestration calls can be migrated incrementally without changing rendering behavior. 
- Enable future backend changes by routing high-level orchestration through `RB_*` wrappers while keeping existing `GL_*` utilities intact. 
- Ensure each migration step is compileable and pixel-identical by making the new wrappers pure pass-throughs under a build guard.

### Description

- Added a new wrapper module `Quake/rb_gl.h` and `Quake/rb_gl.c` that expose `RB_SetState`, `RB_UseProgram`, `RB_BindTexture`, `RB_BindFramebuffer`, `RB_DrawArrays`, `RB_Clear` and `RB_Viewport`, guarded by `RB_GL_PASSTHROUGH_ONLY` and implemented as 1:1 forwards to existing `GL_*`/OpenGL calls. 
- Replaced orchestration-level callsites in `Quake/gl_rmain.c` to use `RB_*` for FBO binds, viewport changes, program binds, fullscreen draws, clears and related state changes without altering logic. 
- Applied the same thin-forwarding migration to the render modules `Quake/r_fogvol.c`, `Quake/r_postfx.c`, `Quake/r_world.c`, `Quake/r_alias.c`, `Quake/r_part.c`, and `Quake/r_sprite.c` so orchestration paths route through `RB_*`. 
- Kept all existing `GL_*` helpers and lower-level calls unchanged and invoked them from `RB_*` so the refactor can continue in small, compileable steps.

### Testing

- Attempted a local CMake configure/build with `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build -j4` to validate compileability. 
- Configure/build aborted in this environment due to missing `SDL2Config.cmake` / `sdl2-config.cmake` (external dependency/environment limitation); no further automated tests were run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a16ef3dbd0832eba16728acf814001)