### PR TITLE
Add debug owner tracking and baseline assertions to RB state layer

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -256,6 +256,7 @@ cvar_t  r_dlight_debug = { "r_dlight_debug", "0", CVAR_NONE };
 cvar_t  r_dlight_debug_spawn = { "r_dlight_debug_spawn", "0", CVAR_NONE };
 cvar_t  r_dlight_debug_models = { "r_dlight_debug_models", "0", CVAR_NONE };
 cvar_t  r_gl_state_validate = { "r_gl_state_validate", "0", CVAR_NONE };
+cvar_t  r_rb_assert_state = { "r_rb_assert_state", "0", CVAR_NONE };
 cvar_t	r_dlight_entities = { "r_dlight_entities", "1", CVAR_ARCHIVE };
 cvar_t  r_dlight_mode = { "r_dlight_mode", "0", CVAR_ARCHIVE };
 cvar_t  r_dlight_scale = { "r_dlight_scale", "1.0", CVAR_ARCHIVE };
@@ -3309,8 +3310,9 @@ void R_GLStateDump (const char *tag)
 	glGetIntegerv (GL_TEXTURE_BINDING_2D, &tex2d_2);
 	GL_ActiveTextureFunc (prev_active_texture);
 
-	Con_Printf ("GL_STATE[%s] prog=%d acttex=%d fbo(draw/read)=%d/%d vp=(%d %d %d %d) sci=%d box=(%d %d %d %d) blend=%d depth=%d depthmask=%d cull=%d srgb=%d ubo(0/1/2)=%d/%d/%d tex2d(0/1/2)=%d/%d/%d\n",
+	Con_Printf ("GL_STATE[%s] %s prog=%d acttex=%d fbo(draw/read)=%d/%d vp=(%d %d %d %d) sci=%d box=(%d %d %d %d) blend=%d depth=%d depthmask=%d cull=%d srgb=%d ubo(0/1/2)=%d/%d/%d tex2d(0/1/2)=%d/%d/%d\n",
 		tag,
+		RB_DebugStateOwnersString (),
 		program,
 		active_texture - GL_TEXTURE0,
 		draw_fbo,

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -805,6 +805,7 @@ Cvar_RegisterVariable (&r_vignette);
 	Cvar_RegisterVariable (&gl_overbright_models);
 	Cvar_RegisterVariable (&r_model_halflambert);
 	Cvar_RegisterVariable (&r_gl_state_validate);
+	Cvar_RegisterVariable (&r_rb_assert_state);
 	Cvar_RegisterVariable (&r_lerpmodels);
 	Cvar_RegisterVariable (&r_lerpmove);
 	Cvar_RegisterVariable (&r_nolerp_list);

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -96,6 +96,7 @@ extern	cvar_t	r_drawworld;
 extern	cvar_t	r_drawviewmodel;
 extern	cvar_t	r_dlight_debug_models;
 extern	cvar_t	r_gl_state_validate;
+extern	cvar_t	r_rb_assert_state;
 extern	cvar_t	r_speeds;
 extern	cvar_t	r_pos;
 extern	cvar_t	r_waterwarp;

--- a/Quake/rb_gl.c
+++ b/Quake/rb_gl.c
@@ -44,6 +44,137 @@ static const rb_pass_info_t rb_pass_info[PASS_COUNT] = {
 
 static rb_pass_setup_hook_t rb_pass_setup_hook;
 static qboolean rb_pass_active;
+static rb_pass_t rb_current_pass = PASS_WORLD_OPAQUE;
+
+#if !defined(NDEBUG) || defined(_DEBUG) || defined(DEBUG)
+#define RB_STATE_TRACKER_ENABLED 1
+#else
+#define RB_STATE_TRACKER_ENABLED 0
+#endif
+
+#if RB_STATE_TRACKER_ENABLED
+typedef struct rb_state_debug_s
+{
+	const char *last_blend_owner;
+	const char *last_depth_owner;
+	const char *last_cull_owner;
+	const char *last_program_owner;
+	const char *last_texture_owner[3];
+} rb_state_debug_t;
+
+static rb_state_debug_t rb_state_debug;
+
+static const char *RB_DebugOwnerOrUnknown (const char *owner)
+{
+	return owner ? owner : "<unknown>";
+}
+
+static const char *RB_BlendName (unsigned state)
+{
+	switch (state & GLS_MASK_BLEND)
+	{
+	case GLS_BLEND_OPAQUE: return "opaque";
+	case GLS_BLEND_ALPHA: return "alpha";
+	case GLS_BLEND_ALPHA_OIT: return "alpha_oit";
+	case GLS_BLEND_MULTIPLY: return "multiply";
+	case GLS_BLEND_ADD: return "add";
+	default: return "invalid";
+	}
+}
+
+static const char *RB_CullName (unsigned state)
+{
+	switch (state & GLS_MASK_CULL)
+	{
+	case GLS_CULL_BACK: return "back";
+	case GLS_CULL_NONE: return "none";
+	case GLS_CULL_FRONT: return "front";
+	default: return "invalid";
+	}
+}
+
+static void RB_LogIncomingStateDiff (rb_pass_t pass, unsigned expected_state, unsigned current_state,
+	GLint current_program, GLint tex2d_0, GLint tex2d_1, GLint tex2d_2)
+{
+	qboolean mismatch = false;
+
+	if ((current_state & GLS_MASK_BLEND) != (expected_state & GLS_MASK_BLEND))
+	{
+		if (!mismatch)
+			Con_Warning ("RB_BeginPass(%s): incoming state mismatch\n", rb_pass_info[pass].debug_name);
+		Con_Warning ("  blend: expected=%s actual=%s last_owner=%s\n",
+			RB_BlendName (expected_state),
+			RB_BlendName (current_state),
+			RB_DebugOwnerOrUnknown (rb_state_debug.last_blend_owner));
+		mismatch = true;
+	}
+
+	if ((current_state & (GLS_NO_ZTEST | GLS_NO_ZWRITE)) != (expected_state & (GLS_NO_ZTEST | GLS_NO_ZWRITE)))
+	{
+		if (!mismatch)
+			Con_Warning ("RB_BeginPass(%s): incoming state mismatch\n", rb_pass_info[pass].debug_name);
+		Con_Warning ("  depth: expected=(ztest:%d zwrite:%d) actual=(ztest:%d zwrite:%d) last_owner=%s\n",
+			(expected_state & GLS_NO_ZTEST) == 0,
+			(expected_state & GLS_NO_ZWRITE) == 0,
+			(current_state & GLS_NO_ZTEST) == 0,
+			(current_state & GLS_NO_ZWRITE) == 0,
+			RB_DebugOwnerOrUnknown (rb_state_debug.last_depth_owner));
+		mismatch = true;
+	}
+
+	if ((current_state & GLS_MASK_CULL) != (expected_state & GLS_MASK_CULL))
+	{
+		if (!mismatch)
+			Con_Warning ("RB_BeginPass(%s): incoming state mismatch\n", rb_pass_info[pass].debug_name);
+		Con_Warning ("  cull: expected=%s actual=%s last_owner=%s\n",
+			RB_CullName (expected_state),
+			RB_CullName (current_state),
+			RB_DebugOwnerOrUnknown (rb_state_debug.last_cull_owner));
+		mismatch = true;
+	}
+
+	if (current_program != 0)
+	{
+		if (!mismatch)
+			Con_Warning ("RB_BeginPass(%s): incoming state mismatch\n", rb_pass_info[pass].debug_name);
+		Con_Warning ("  program: expected=0 actual=%d last_owner=%s\n",
+			(int)current_program,
+			RB_DebugOwnerOrUnknown (rb_state_debug.last_program_owner));
+		mismatch = true;
+	}
+
+	if (tex2d_0 != 0)
+	{
+		if (!mismatch)
+			Con_Warning ("RB_BeginPass(%s): incoming state mismatch\n", rb_pass_info[pass].debug_name);
+		Con_Warning ("  texture[0]: expected=0 actual=%d last_owner=%s\n",
+			(int)tex2d_0,
+			RB_DebugOwnerOrUnknown (rb_state_debug.last_texture_owner[0]));
+		mismatch = true;
+	}
+	if (tex2d_1 != 0)
+	{
+		if (!mismatch)
+			Con_Warning ("RB_BeginPass(%s): incoming state mismatch\n", rb_pass_info[pass].debug_name);
+		Con_Warning ("  texture[1]: expected=0 actual=%d last_owner=%s\n",
+			(int)tex2d_1,
+			RB_DebugOwnerOrUnknown (rb_state_debug.last_texture_owner[1]));
+		mismatch = true;
+	}
+	if (tex2d_2 != 0)
+	{
+		if (!mismatch)
+			Con_Warning ("RB_BeginPass(%s): incoming state mismatch\n", rb_pass_info[pass].debug_name);
+		Con_Warning ("  texture[2]: expected=0 actual=%d last_owner=%s\n",
+			(int)tex2d_2,
+			RB_DebugOwnerOrUnknown (rb_state_debug.last_texture_owner[2]));
+		mismatch = true;
+	}
+
+	if (mismatch && r_rb_assert_state.value > 0.f)
+		Sys_Error ("RB_BeginPass(%s): incoming state mismatch", rb_pass_info[pass].debug_name);
+}
+#endif
 
 static void RB_ResetMinimalTextureBindings (void)
 {
@@ -60,18 +191,39 @@ static void RB_ResetMinimalTextureBindings (void)
 	GL_ActiveTextureFunc (previous_active_tex);
 }
 
-void RB_SetState (unsigned mask)
+void RB_SetState_Owner (unsigned mask, const char *owner)
 {
+	#if RB_STATE_TRACKER_ENABLED
+	unsigned changed = glstate ^ mask;
+
+	if ((changed & GLS_MASK_BLEND) != 0)
+		rb_state_debug.last_blend_owner = owner;
+	if ((changed & (GLS_NO_ZTEST | GLS_NO_ZWRITE)) != 0)
+		rb_state_debug.last_depth_owner = owner;
+	if ((changed & GLS_MASK_CULL) != 0)
+		rb_state_debug.last_cull_owner = owner;
+	#endif
+
 	GL_SetState (mask);
 }
 
-void RB_UseProgram (GLuint program)
+void RB_UseProgram_Owner (GLuint program, const char *owner)
 {
+	#if RB_STATE_TRACKER_ENABLED
+	rb_state_debug.last_program_owner = owner;
+	#endif
+
 	GL_UseProgram (program);
 }
 
-qboolean RB_BindTexture (GLenum texunit, gltexture_t *texture)
+qboolean RB_BindTexture_Owner (GLenum texunit, gltexture_t *texture, const char *owner)
 {
+	#if RB_STATE_TRACKER_ENABLED
+	int texindex = (int)(texunit - GL_TEXTURE0);
+	if (texindex >= 0 && texindex < (int)countof (rb_state_debug.last_texture_owner))
+		rb_state_debug.last_texture_owner[texindex] = owner;
+	#endif
+
 	return GL_Bind (texunit, texture);
 }
 
@@ -102,11 +254,33 @@ void RB_SetPassSetupHook (rb_pass_setup_hook_t hook)
 
 void RB_BeginPass (rb_pass_t pass)
 {
+	GLint current_program = 0;
+	GLint previous_active_tex = 0;
+	GLint tex2d_0 = 0, tex2d_1 = 0, tex2d_2 = 0;
+
 	if (pass < 0 || pass >= PASS_COUNT)
 		pass = PASS_WORLD_OPAQUE;
 
 	if (rb_pass_active)
 		RB_EndPass ();
+
+	#if RB_STATE_TRACKER_ENABLED
+	if (r_gl_state_validate.value > 0.f)
+	{
+		glGetIntegerv (GL_CURRENT_PROGRAM, &current_program);
+		glGetIntegerv (GL_ACTIVE_TEXTURE, &previous_active_tex);
+
+		GL_ActiveTextureFunc (GL_TEXTURE0);
+		glGetIntegerv (GL_TEXTURE_BINDING_2D, &tex2d_0);
+		GL_ActiveTextureFunc (GL_TEXTURE1);
+		glGetIntegerv (GL_TEXTURE_BINDING_2D, &tex2d_1);
+		GL_ActiveTextureFunc (GL_TEXTURE2);
+		glGetIntegerv (GL_TEXTURE_BINDING_2D, &tex2d_2);
+		GL_ActiveTextureFunc (previous_active_tex);
+
+		RB_LogIncomingStateDiff (pass, rb_pass_info[pass].baseline_state, glstate, current_program, tex2d_0, tex2d_1, tex2d_2);
+	}
+	#endif
 
 	GL_BeginGroup (rb_pass_info[pass].debug_name);
 	RB_SetState (rb_pass_info[pass].baseline_state);
@@ -116,7 +290,28 @@ void RB_BeginPass (rb_pass_t pass)
 	if (rb_pass_setup_hook)
 		rb_pass_setup_hook (pass);
 
+	rb_current_pass = pass;
 	rb_pass_active = true;
+}
+
+const char *RB_DebugStateOwnersString (void)
+{
+#if RB_STATE_TRACKER_ENABLED
+	static char info[384];
+	q_snprintf (info, sizeof (info),
+		"pass=%s owner(blend=%s depth=%s cull=%s prog=%s tex0=%s tex1=%s tex2=%s)",
+		rb_pass_info[rb_current_pass].debug_name,
+		RB_DebugOwnerOrUnknown (rb_state_debug.last_blend_owner),
+		RB_DebugOwnerOrUnknown (rb_state_debug.last_depth_owner),
+		RB_DebugOwnerOrUnknown (rb_state_debug.last_cull_owner),
+		RB_DebugOwnerOrUnknown (rb_state_debug.last_program_owner),
+		RB_DebugOwnerOrUnknown (rb_state_debug.last_texture_owner[0]),
+		RB_DebugOwnerOrUnknown (rb_state_debug.last_texture_owner[1]),
+		RB_DebugOwnerOrUnknown (rb_state_debug.last_texture_owner[2]));
+	return info;
+#else
+	return "pass=<tracker disabled>";
+#endif
 }
 
 void RB_EndPass (void)

--- a/Quake/rb_gl.h
+++ b/Quake/rb_gl.h
@@ -11,9 +11,15 @@
  */
 #define RB_GL_PASSTHROUGH_ONLY 1
 
-void RB_SetState (unsigned mask);
-void RB_UseProgram (GLuint program);
-qboolean RB_BindTexture (GLenum texunit, gltexture_t *texture);
+void RB_SetState_Owner (unsigned mask, const char *owner);
+void RB_UseProgram_Owner (GLuint program, const char *owner);
+qboolean RB_BindTexture_Owner (GLenum texunit, gltexture_t *texture, const char *owner);
+#define RB_SetState(mask) RB_SetState_Owner ((mask), __func__)
+#define RB_UseProgram(program) RB_UseProgram_Owner ((program), __func__)
+#define RB_BindTexture(texunit, texture) RB_BindTexture_Owner ((texunit), (texture), __func__)
+#define RB_SetStateWithOwner(mask, owner) RB_SetState_Owner ((mask), (owner))
+#define RB_UseProgramWithOwner(program, owner) RB_UseProgram_Owner ((program), (owner))
+#define RB_BindTextureWithOwner(texunit, texture, owner) RB_BindTexture_Owner ((texunit), (texture), (owner))
 void RB_BindFramebuffer (GLenum target, GLuint framebuffer);
 void RB_DrawArrays (GLenum mode, GLint first, GLsizei count);
 void RB_Clear (GLbitfield mask);
@@ -23,5 +29,6 @@ typedef void (*rb_pass_setup_hook_t) (rb_pass_t pass);
 void RB_SetPassSetupHook (rb_pass_setup_hook_t hook);
 void RB_BeginPass (rb_pass_t pass);
 void RB_EndPass (void);
+const char *RB_DebugStateOwnersString (void);
 
 #endif


### PR DESCRIPTION
### Motivation

- Provide developer-only diagnostics for the new RB_* render-backend wrappers so render-state changes can be traced to the last caller.
- Detect and report unexpected GL state at RB pass boundaries by comparing incoming GL state to per-pass baselines.
- Allow tests to optionally hard-fail on state mismatches via a cvar to catch regressions early during development.

### Description

- Added owner-aware entry points and convenience macros in `Quake/rb_gl.h`: `RB_SetState_Owner`, `RB_UseProgram_Owner`, `RB_BindTexture_Owner` and `RB_*` macros that pass `__func__` as default owner. (Also added `WithOwner` variants.)
- Implemented a debug-only state tracker in `Quake/rb_gl.c` that records `last_blend_owner`, `last_depth_owner`, `last_cull_owner`, `last_program_owner` and `last_texture_owner[0..2]`, and exposes `RB_DebugStateOwnersString()` for diagnostic output.
- Added baseline validation to `RB_BeginPass` which, when `r_gl_state_validate > 0`, snapshots relevant GL state, compares it with the pass baseline and logs any diffs plus the recorded last-owner for each changed category; when `r_rb_assert_state` is set the mismatch triggers `Sys_Error`.
- Hooked the tracker into the existing diagnostics by appending `RB_DebugStateOwnersString()` to `R_GLStateDump` output and wired the new cvar `r_rb_assert_state` into `gl_rmain.c`, `glquake.h` and registration in `gl_rmisc.c`.

### Testing

- Ran `git diff --check` to ensure no trailing whitespace / index issues (passed).
- Attempted a full build with `make -C Quake -j4`, which could not complete in the container due to missing external build dependencies (`sdl2-config` / `SDL.h`), so compile-time verification inside this environment was partial (configuration and edits applied, but no full binary produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a171e26fc0832eb043bea3a00dbf28)