### PR TITLE
Add render backend vtable & dispatcher with `r_backend` switch (GL exec backend)

### DIFF
--- a/Quake/backend_gl_exec.c
+++ b/Quake/backend_gl_exec.c
@@ -1,0 +1,106 @@
+#include "quakedef.h"
+#include "rb_gl.h"
+#include "render_backend.h"
+
+static void BackendGL_BeginFrame (const char *label)
+{
+	if (label)
+		Con_DPrintf ("render backend: BeginFrame (%s)\n", label);
+	else
+		Con_DPrintf ("render backend: BeginFrame\n");
+}
+
+static void BackendGL_EndFrame (void)
+{
+	Con_DPrintf ("render backend: EndFrame\n");
+}
+
+static void BackendGL_BeginPass (rb_pass_t pass)
+{
+	RB_BeginPass (pass);
+}
+
+static void BackendGL_EndPass (void)
+{
+	RB_EndPass ();
+}
+
+static void BackendGL_DrawArrays (GLenum mode, GLint first, GLsizei count)
+{
+	RB_DrawArrays (mode, first, count);
+}
+
+static void BackendGL_DrawElements (GLenum mode, GLsizei count, GLenum type, const GLvoid *indices)
+{
+	glDrawElements (mode, count, type, indices);
+}
+
+static void BackendGL_DispatchCompute (GLuint num_groups_x, GLuint num_groups_y, GLuint num_groups_z)
+{
+	GL_DispatchComputeFunc (num_groups_x, num_groups_y, num_groups_z);
+}
+
+static void BackendGL_BindFramebuffer (GLenum target, GLuint framebuffer)
+{
+	RB_BindFramebuffer (target, framebuffer);
+}
+
+static void BackendGL_BindTexture (GLenum texunit, GLenum target, GLuint texture)
+{
+	GL_BindNative (texunit, target, texture);
+}
+
+static void BackendGL_BindBuffer (GLenum target, GLuint buffer)
+{
+	GL_BindBuffer (target, buffer);
+}
+
+static const render_backend_vtable_t backend_gl_vtable = {
+	BackendGL_BeginFrame,
+	BackendGL_EndFrame,
+	BackendGL_BeginPass,
+	BackendGL_EndPass,
+	BackendGL_DrawArrays,
+	BackendGL_DrawElements,
+	BackendGL_DispatchCompute,
+	BackendGL_BindFramebuffer,
+	BackendGL_BindTexture,
+	BackendGL_BindBuffer
+};
+
+const render_backend_vtable_t *RBackend_GetVTable (void)
+{
+	return &backend_gl_vtable;
+}
+
+void RBackend_DispatchRenderView (void (*legacy_fn)(void))
+{
+	if (!legacy_fn)
+		return;
+
+	if ((int)r_backend.value == 1)
+	{
+		backend_gl_vtable.BeginFrame ("R_RenderView");
+		legacy_fn ();
+		backend_gl_vtable.EndFrame ();
+		return;
+	}
+
+	legacy_fn ();
+}
+
+void RBackend_DispatchUpdateScreen (void (*legacy_fn)(void))
+{
+	if (!legacy_fn)
+		return;
+
+	if ((int)r_backend.value == 1)
+	{
+		backend_gl_vtable.BeginFrame ("SCR_UpdateScreen");
+		legacy_fn ();
+		backend_gl_vtable.EndFrame ();
+		return;
+	}
+
+	legacy_fn ();
+}

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -28,6 +28,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "r_fogvol.h"
 #include "gl_lightgrid.h"
 #include "mat_shader.h"
+#include "render_backend.h"
 #include <float.h>
 #include <math.h>
 
@@ -229,6 +230,7 @@ static qboolean gl_srgb_capability_warned = false;
 
 
 cvar_t	r_norefresh = { "r_norefresh","0",CVAR_NONE };
+cvar_t	r_backend = { "r_backend", "0", CVAR_ARCHIVE };
 cvar_t	r_drawentities = { "r_drawentities","1",CVAR_NONE };
 cvar_t	r_drawviewmodel = { "r_drawviewmodel","1",CVAR_NONE };
 cvar_t	r_speeds = { "r_speeds","0",CVAR_NONE };
@@ -4855,7 +4857,7 @@ void R_WarpScaleView (void)
 R_RenderView
 ================
 */
-void R_RenderView (void)
+static void R_RenderView_Legacy (void)
 {
 	double	time1, time2;
 
@@ -4929,4 +4931,9 @@ void R_RenderView (void)
 			rs_aliaspolys,
 			rs_dynamiclightmaps);
 	//johnfitz
+}
+
+void R_RenderView (void)
+{
+	RBackend_DispatchRenderView (R_RenderView_Legacy);
 }

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -77,6 +77,7 @@ extern cvar_t r_dlight_bloom_radius;
 extern cvar_t r_dlight_bloom_threshold;
 extern cvar_t r_dlight_ndotl;
 extern cvar_t r_dlight_satchop;
+extern cvar_t r_backend;
 //johnfitz -- new cvars
 extern cvar_t r_clearcolor;
 extern cvar_t r_flatlightstyles;
@@ -555,6 +556,7 @@ void R_Init (void)
         R_MapTex_ExportInit ();
 
 Cvar_RegisterVariable (&r_norefresh);
+Cvar_RegisterVariable (&r_backend);
 Cvar_RegisterVariable (&r_lightmap);
 Cvar_RegisterVariable (&r_lightmap_linear);
 Cvar_SetCallback (&r_lightmap_linear, TexMgr_LightmapLinearCompat_f);

--- a/Quake/gl_screen.c
+++ b/Quake/gl_screen.c
@@ -26,6 +26,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "quakedef.h"
 #include "rb_gl.h"
 #include "r_fogvol.h"
+#include "render_backend.h"
 #include "steam.h"
 #include <time.h>
 
@@ -2112,7 +2113,7 @@ WARNING: be very careful calling this from elsewhere, because the refresh
 needs almost the entire 256k of stack space!
 ==================
 */
-void SCR_UpdateScreen (void)
+static void SCR_UpdateScreen_Legacy (void)
 {
 	vid.numpages = (gl_triplebuffer.value) ? 3 : 2;
 
@@ -2216,4 +2217,9 @@ void SCR_UpdateScreen (void)
 	RB_EndPass ();
 
 	GL_EndRendering ();
+}
+
+void SCR_UpdateScreen (void)
+{
+	RBackend_DispatchUpdateScreen (SCR_UpdateScreen_Legacy);
 }

--- a/Quake/render_backend.h
+++ b/Quake/render_backend.h
@@ -1,0 +1,27 @@
+#ifndef RENDER_BACKEND_H
+#define RENDER_BACKEND_H
+
+#include "quakedef.h"
+#include "rb_pass.h"
+
+typedef struct render_backend_vtable_s
+{
+	void (*BeginFrame) (const char *label);
+	void (*EndFrame) (void);
+	void (*BeginPass) (rb_pass_t pass);
+	void (*EndPass) (void);
+	void (*DrawArrays) (GLenum mode, GLint first, GLsizei count);
+	void (*DrawElements) (GLenum mode, GLsizei count, GLenum type, const GLvoid *indices);
+	void (*DispatchCompute) (GLuint num_groups_x, GLuint num_groups_y, GLuint num_groups_z);
+	void (*BindFramebuffer) (GLenum target, GLuint framebuffer);
+	void (*BindTexture) (GLenum texunit, GLenum target, GLuint texture);
+	void (*BindBuffer) (GLenum target, GLuint buffer);
+} render_backend_vtable_t;
+
+extern cvar_t r_backend;
+
+const render_backend_vtable_t *RBackend_GetVTable (void);
+void RBackend_DispatchRenderView (void (*legacy_fn)(void));
+void RBackend_DispatchUpdateScreen (void (*legacy_fn)(void));
+
+#endif


### PR DESCRIPTION
### Motivation

- Provide a central place to route frame entry to pluggable render backends and enable runtime switching via a CVar while keeping existing rendering behavior.
- Introduce a minimal backend interface to allow future backends to implement frame/pass/draw/dispatch/bind operations without changing high-level call sites.

### Description

- Add `Quake/render_backend.h` which defines a small vtable (`BeginFrame`, `EndFrame`, `BeginPass`, `EndPass`, `DrawArrays`, `DrawElements`, `DispatchCompute`, `BindFramebuffer`, `BindTexture`, `BindBuffer`) and dispatcher prototypes `RBackend_DispatchRenderView` / `RBackend_DispatchUpdateScreen` and exposes the `r_backend` CVar.
- Implement `Quake/backend_gl_exec.c` as the initial backend that forwards vtable calls to the current `RB_*`/`GL_*` code paths and emits lightweight `Con_DPrintf` logging in `BeginFrame`/`EndFrame` (no change to actual rendering logic).
- Introduce `cvar_t r_backend` (`0` = legacy, `1` = backend route), register it in `R_Init`, and move the original `R_RenderView` and `SCR_UpdateScreen` bodies to `R_RenderView_Legacy` and `SCR_UpdateScreen_Legacy` respectively.
- Route the public entry points `R_RenderView` and `SCR_UpdateScreen` through the central dispatchers so that when `r_backend` is `1` the backend vtable is used to bracket the legacy call (the legacy call executes unchanged); any differences are limited to logging/debug framing.

### Testing

- Attempted automated configure/build with `cmake -S . -B build && cmake --build build` to validate integration and compile-time issues, but configuration failed due to missing SDL2 package files (`SDL2Config.cmake` / `sdl2-config.cmake`), so no successful build was produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1742b21a4832ebffc0ce27c7fb6fe)