### PR TITLE
Add per-block backend CVars and generic dispatcher with legacy fallback

### DIFF
--- a/Quake/backend_gl_exec.c
+++ b/Quake/backend_gl_exec.c
@@ -104,3 +104,42 @@ void RBackend_DispatchUpdateScreen (void (*legacy_fn)(void))
 
 	legacy_fn ();
 }
+
+void RBackend_DispatchBlock (const char *block_name, cvar_t *toggle, qboolean backend_path_available,
+	rbackend_block_fn_t backend_fn, void (*legacy_fn)(void), qboolean *warned_once)
+{
+	qboolean can_use_backend;
+
+	if (!legacy_fn)
+		return;
+
+	can_use_backend = ((int)r_backend.value == 1) && toggle && (toggle->value != 0.f);
+	if (!can_use_backend)
+	{
+		legacy_fn ();
+		return;
+	}
+
+	if (!backend_path_available || !backend_fn)
+	{
+		if (warned_once && !*warned_once)
+		{
+			Con_Warning ("render backend: %s backend path unavailable, falling back to legacy\n",
+				block_name ? block_name : "(unknown block)");
+			*warned_once = true;
+		}
+		legacy_fn ();
+		return;
+	}
+
+	if (!backend_fn ())
+	{
+		if (warned_once && !*warned_once)
+		{
+			Con_Warning ("render backend: %s backend block failed, falling back to legacy\n",
+				block_name ? block_name : "(unknown block)");
+			*warned_once = true;
+		}
+		legacy_fn ();
+	}
+}

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -43,6 +43,14 @@ gpuframedata_t r_framedata;
 static int r_fogvol_update_called = 0;
 static int r_fogvol_draw_called = 0;
 
+static qboolean r_backend_particles_warned = false;
+static qboolean r_backend_alias_warned = false;
+static qboolean r_backend_world_warned = false;
+static qboolean r_backend_fogvol_warned = false;
+
+static void R_DrawFogvol_Legacy (void);
+static qboolean R_DrawFogvol_Backend (void);
+
 /* BUG FIX #1 (SSAO/Fog): GL_GenerateSSAOTexture runs inside GL_PostProcess which
  * is called from SCR_UpdateScreen, AFTER Fog_DisableGFog() in R_RenderView.
  * Fog_DisableGFog clears r_framedata.fogdata[3] (density) to 0 so 2D overlays stay
@@ -231,6 +239,12 @@ static qboolean gl_srgb_capability_warned = false;
 
 cvar_t	r_norefresh = { "r_norefresh","0",CVAR_NONE };
 cvar_t	r_backend = { "r_backend", "0", CVAR_ARCHIVE };
+cvar_t	r_backend_ui = { "r_backend_ui", "1", CVAR_ARCHIVE };
+cvar_t	r_backend_postfx = { "r_backend_postfx", "1", CVAR_ARCHIVE };
+cvar_t	r_backend_particles = { "r_backend_particles", "1", CVAR_ARCHIVE };
+cvar_t	r_backend_alias = { "r_backend_alias", "1", CVAR_ARCHIVE };
+cvar_t	r_backend_world = { "r_backend_world", "1", CVAR_ARCHIVE };
+cvar_t	r_backend_fogvol = { "r_backend_fogvol", "1", CVAR_ARCHIVE };
 cvar_t	r_drawentities = { "r_drawentities","1",CVAR_NONE };
 cvar_t	r_drawviewmodel = { "r_drawviewmodel","1",CVAR_NONE };
 cvar_t	r_speeds = { "r_speeds","0",CVAR_NONE };
@@ -3586,6 +3600,21 @@ static void R_DrawWater (qboolean translucent)
 
 }
 
+
+static entity_t **r_alias_dispatch_entlist;
+static int r_alias_dispatch_count;
+
+static void R_DrawAliasBatch_Legacy (void)
+{
+	R_DrawAliasModels (r_alias_dispatch_entlist, r_alias_dispatch_count);
+}
+
+static qboolean R_DrawAliasBatch_Backend (void)
+{
+	R_DrawAliasModels (r_alias_dispatch_entlist, r_alias_dispatch_count);
+	return true;
+}
+
 /*
 =============
 R_DrawEntitiesOnList
@@ -3600,7 +3629,10 @@ void R_DrawEntitiesOnList (qboolean alphapass) //johnfitz -- added parameter
 
 	ofs = cl_modtype_ofs + (alphapass ? 1 : 0);
 	R_DrawBrushModels (entlist + ofs[2 * mod_brush], ofs[2 * mod_brush + 1] - ofs[2 * mod_brush]);
-	R_DrawAliasModels (entlist + ofs[2 * mod_alias], ofs[2 * mod_alias + 1] - ofs[2 * mod_alias]);
+	r_alias_dispatch_entlist = entlist + ofs[2 * mod_alias];
+	r_alias_dispatch_count = ofs[2 * mod_alias + 1] - ofs[2 * mod_alias];
+	RBackend_DispatchBlock ("alias", &r_backend_alias, true,
+		R_DrawAliasBatch_Backend, R_DrawAliasBatch_Legacy, &r_backend_alias_warned);
 	if (!alphapass)
 		R_DrawSpriteModels (entlist + cl_modtype_ofs[2 * mod_sprite], cl_modtype_ofs[2 * mod_sprite + 2] - cl_modtype_ofs[2 * mod_sprite]);
 
@@ -3647,7 +3679,10 @@ void R_DrawViewModel (void)
 
 	// hack the depth range to prevent view model from poking into walls
 	GL_DepthRange (ZRANGE_VIEWMODEL);
-	R_DrawAliasModels (&e, 1);
+	r_alias_dispatch_entlist = &e;
+	r_alias_dispatch_count = 1;
+	RBackend_DispatchBlock ("alias", &r_backend_alias, true,
+		R_DrawAliasBatch_Backend, R_DrawAliasBatch_Legacy, &r_backend_alias_warned);
 	GL_DepthRange (ZRANGE_FULL);
 
 	GL_EndGroup ();
@@ -4647,6 +4682,82 @@ static void R_DrawDLightPass (void)
         GL_EndGroup ();
 }
 
+
+static void R_DrawWorldOpaque_Legacy (void)
+{
+	RB_BeginPass (PASS_WORLD_OPAQUE);
+	R_DrawViewModel ();
+	RB_EndPass ();
+	S_ExtraUpdate ();
+
+	RB_BeginPass (PASS_ENTS_OPAQUE);
+	R_DrawEntitiesOnList (false);
+	RB_EndPass ();
+
+	RB_BeginPass (PASS_DLIGHT);
+	R_DrawDLightPass ();
+	RB_EndPass ();
+
+	RB_BeginPass (PASS_SKY);
+	Sky_DrawSky ();
+	RB_EndPass ();
+
+	RB_BeginPass (PASS_WATER_OPAQUE);
+	R_DrawWater (false);
+	RB_EndPass ();
+}
+
+static qboolean R_DrawWorldOpaque_Backend (void)
+{
+	R_DrawWorldOpaque_Legacy ();
+	return true;
+}
+
+static void R_DrawParticlesOpaque_Legacy (void)
+{
+	RB_BeginPass (PASS_PARTICLES);
+	R_DrawParticles (false);
+	RB_EndPass ();
+}
+
+static qboolean R_DrawParticlesOpaque_Backend (void)
+{
+	R_DrawParticlesOpaque_Legacy ();
+	return true;
+}
+
+static void R_DrawWorldAlpha_Legacy (void)
+{
+	R_BeginTranslucency ();
+	RB_BeginPass (PASS_WATER_ALPHA);
+	R_DrawWater (true);
+	RB_EndPass ();
+
+	RB_BeginPass (PASS_ENTS_ALPHA);
+	R_DrawEntitiesOnList (true);
+	RB_EndPass ();
+	R_EndTranslucency ();
+}
+
+static qboolean R_DrawWorldAlpha_Backend (void)
+{
+	R_DrawWorldAlpha_Legacy ();
+	return true;
+}
+
+static void R_DrawParticlesAlpha_Legacy (void)
+{
+	RB_BeginPass (PASS_PARTICLES);
+	R_DrawParticles (true);
+	RB_EndPass ();
+}
+
+static qboolean R_DrawParticlesAlpha_Backend (void)
+{
+	R_DrawParticlesAlpha_Legacy ();
+	return true;
+}
+
 /*
 ================
 R_RenderScene
@@ -4657,48 +4768,22 @@ void R_RenderScene (void)
 	R_SetupScene (); //johnfitz -- this does everything that should be done once per call to RenderScene
 	R_SetupGL ();
 	R_Clear ();
-	
+
 	// Upload frame data after fog has been set up to ensure fog parameters
 	// are available to all draw calls, even when light clustering is skipped.
 	R_UploadFrameData ();
-	RB_BeginPass (PASS_WORLD_OPAQUE);
-	R_DrawViewModel (); //johnfitz -- moved here from R_RenderView
-	RB_EndPass ();
-	S_ExtraUpdate (); // don't let sound get messed up if going slow
 
-	RB_BeginPass (PASS_ENTS_OPAQUE);
-	R_DrawEntitiesOnList (false); //johnfitz -- false means this is the pass for nonalpha entities
-	RB_EndPass ();
-
-	RB_BeginPass (PASS_DLIGHT);
-	R_DrawDLightPass ();
-	RB_EndPass ();
-
-	RB_BeginPass (PASS_PARTICLES);
-	R_DrawParticles (false);
-	RB_EndPass ();
-
-	RB_BeginPass (PASS_SKY);
-	Sky_DrawSky (); //johnfitz
-	RB_EndPass ();
-
-	RB_BeginPass (PASS_WATER_OPAQUE);
-	R_DrawWater (false);
-	RB_EndPass ();
-
-	R_BeginTranslucency ();
-	RB_BeginPass (PASS_WATER_ALPHA);
-	R_DrawWater (true);
-	RB_EndPass ();
-
-	RB_BeginPass (PASS_ENTS_ALPHA);
-	R_DrawEntitiesOnList (true); //johnfitz -- true means this is the pass for alpha entities
-	RB_EndPass ();
-
-	RB_BeginPass (PASS_PARTICLES);
-	R_DrawParticles (true);
-	RB_EndPass ();
-	R_EndTranslucency ();
+	/* Backend migration order (keep incremental PRs consistent):
+	 * UI/Console/2D -> Fullscreen passes -> Particles/Sprites/Beams -> Alias ->
+	 * World (Sky->Opaque->Alpha) -> PostFX graph. */
+	RBackend_DispatchBlock ("world_opaque", &r_backend_world, true,
+		R_DrawWorldOpaque_Backend, R_DrawWorldOpaque_Legacy, &r_backend_world_warned);
+	RBackend_DispatchBlock ("particles_opaque", &r_backend_particles, true,
+		R_DrawParticlesOpaque_Backend, R_DrawParticlesOpaque_Legacy, &r_backend_particles_warned);
+	RBackend_DispatchBlock ("world_alpha", &r_backend_world, true,
+		R_DrawWorldAlpha_Backend, R_DrawWorldAlpha_Legacy, &r_backend_world_warned);
+	RBackend_DispatchBlock ("particles_alpha", &r_backend_particles, true,
+		R_DrawParticlesAlpha_Backend, R_DrawParticlesAlpha_Legacy, &r_backend_particles_warned);
 	R_ShowTris (); //johnfitz
 	R_ShowBoundingBoxes (); //johnfitz
 	R_ShowPointFile ();
@@ -4891,7 +4976,8 @@ static void R_RenderView_Legacy (void)
         r_fogvol_draw_called++;
         if (r_gl_state_validate.value > 0.f)
                 Con_DPrintf ("fogvol_draw_called=%d r_fogvol=%.1f\n", r_fogvol_draw_called, r_fogvol.value);
-        R_FogVol_Render ();
+	RBackend_DispatchBlock ("fogvol", &r_backend_fogvol, true,
+		R_DrawFogvol_Backend, R_DrawFogvol_Legacy, &r_backend_fogvol_warned);
         /* BUG FIX #1: Capture fog params while r_framedata.fogdata is still valid.
          * GL_GenerateSSAOTexture (called later in GL_PostProcess) uses these for
          * fog-damped AO; after Fog_DisableGFog the density is zeroed out. */
@@ -4931,6 +5017,17 @@ static void R_RenderView_Legacy (void)
 			rs_aliaspolys,
 			rs_dynamiclightmaps);
 	//johnfitz
+}
+
+static void R_DrawFogvol_Legacy (void)
+{
+	R_FogVol_Render ();
+}
+
+static qboolean R_DrawFogvol_Backend (void)
+{
+	R_FogVol_Render ();
+	return true;
 }
 
 void R_RenderView (void)

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -78,6 +78,12 @@ extern cvar_t r_dlight_bloom_threshold;
 extern cvar_t r_dlight_ndotl;
 extern cvar_t r_dlight_satchop;
 extern cvar_t r_backend;
+extern cvar_t r_backend_ui;
+extern cvar_t r_backend_postfx;
+extern cvar_t r_backend_particles;
+extern cvar_t r_backend_alias;
+extern cvar_t r_backend_world;
+extern cvar_t r_backend_fogvol;
 //johnfitz -- new cvars
 extern cvar_t r_clearcolor;
 extern cvar_t r_flatlightstyles;
@@ -557,6 +563,12 @@ void R_Init (void)
 
 Cvar_RegisterVariable (&r_norefresh);
 Cvar_RegisterVariable (&r_backend);
+Cvar_RegisterVariable (&r_backend_ui);
+Cvar_RegisterVariable (&r_backend_postfx);
+Cvar_RegisterVariable (&r_backend_particles);
+Cvar_RegisterVariable (&r_backend_alias);
+Cvar_RegisterVariable (&r_backend_world);
+Cvar_RegisterVariable (&r_backend_fogvol);
 Cvar_RegisterVariable (&r_lightmap);
 Cvar_RegisterVariable (&r_lightmap_linear);
 Cvar_SetCallback (&r_lightmap_linear, TexMgr_LightmapLinearCompat_f);

--- a/Quake/gl_screen.c
+++ b/Quake/gl_screen.c
@@ -32,6 +32,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 extern cvar_t r_autoexposure;
 extern cvar_t r_exposure_debug;
+extern cvar_t r_backend_ui;
+extern cvar_t r_backend_postfx;
 extern float r_autoexposure_debug_exposure;
 extern float r_autoexposure_debug_luminance;
 
@@ -2102,6 +2104,86 @@ void SCR_TileClear (void)
 	}
 }
 
+static qboolean scr_backend_ui_warned = false;
+static qboolean scr_backend_postfx_warned = false;
+
+static void SCR_DrawUI2D_Legacy (void)
+{
+	RB_BeginPass (PASS_UI2D);
+	GL_BeginGroup ("2D");
+
+	GL_Set2D ();
+	R_FogVol_DrawDebug2D ();
+	SCR_TileClear ();
+
+	if (scr_drawdialog)
+	{
+		if (con_forcedup)
+			Draw_ConsoleBackground ();
+		else
+			Sbar_Draw ();
+		Draw_FadeScreen (1.f);
+		SCR_DrawNotifyString ();
+	}
+	else if (scr_drawloading)
+	{
+		SCR_DrawLoading ();
+		Sbar_Draw ();
+		M_Draw ();
+	}
+	else if (cl.intermission == 1 && key_dest == key_game)
+	{
+		Sbar_IntermissionOverlay ();
+		SCR_DrawDemoControls ();
+	}
+	else if (cl.intermission == 2 && key_dest == key_game)
+	{
+		Sbar_FinaleOverlay ();
+		SCR_CheckDrawCenterString ();
+		SCR_DrawDemoControls ();
+	}
+	else
+	{
+		SCR_DrawCrosshair ();
+		SCR_DrawNet ();
+		SCR_DrawTurtle ();
+		SCR_DrawPause ();
+		SCR_CheckDrawCenterString ();
+		Sbar_Draw ();
+		SCR_DrawDevStats ();
+		SCR_DrawExposureDebug ();
+		SCR_DrawClock ();
+		SCR_DrawDemoControls ();
+		SCR_DrawSpeed ();
+		SCR_DrawEdictInfo ();
+		SCR_DrawConsole ();
+		M_Draw ();
+		SCR_DrawFPS ();
+		SCR_DrawSaving ();
+	}
+
+	Draw_Flush ();
+	GL_EndGroup ();
+	RB_EndPass ();
+}
+
+static qboolean SCR_DrawUI2D_Backend (void)
+{
+	SCR_DrawUI2D_Legacy ();
+	return true;
+}
+
+static void SCR_PostProcess_Legacy (void)
+{
+	GL_PostProcess ();
+}
+
+static qboolean SCR_PostProcess_Backend (void)
+{
+	GL_PostProcess ();
+	return true;
+}
+
 /*
 ==================
 SCR_UpdateScreen
@@ -2150,71 +2232,15 @@ static void SCR_UpdateScreen_Legacy (void)
 
        V_RenderView ();
 
-       GL_PostProcess ();
+	RBackend_DispatchBlock ("postfx", &r_backend_postfx, true,
+		SCR_PostProcess_Backend, SCR_PostProcess_Legacy, &scr_backend_postfx_warned);
 
        V_PolyBlend ();
 
        R_StorePrevFrameState ();
 
-	RB_BeginPass (PASS_UI2D);
-	GL_BeginGroup ("2D");
-
-	GL_Set2D ();
-	R_FogVol_DrawDebug2D ();
-
-	//FIXME: only call this when needed
-	SCR_TileClear ();
-
-	if (scr_drawdialog) //new game confirm
-	{
-		if (con_forcedup)
-			Draw_ConsoleBackground ();
-		else
-			Sbar_Draw ();
-		Draw_FadeScreen (1.f);
-		SCR_DrawNotifyString ();
-	}
-	else if (scr_drawloading) //loading
-	{
-		SCR_DrawLoading ();
-		Sbar_Draw ();
-		M_Draw ();
-	}
-	else if (cl.intermission == 1 && key_dest == key_game) //end of level
-	{
-		Sbar_IntermissionOverlay ();
-		SCR_DrawDemoControls ();
-	}
-	else if (cl.intermission == 2 && key_dest == key_game) //end of episode
-	{
-		Sbar_FinaleOverlay ();
-		SCR_CheckDrawCenterString ();
-		SCR_DrawDemoControls ();
-	}
-	else
-	{
-		SCR_DrawCrosshair (); //johnfitz
-		SCR_DrawNet ();
-		SCR_DrawTurtle ();
-		SCR_DrawPause ();
-		SCR_CheckDrawCenterString ();
-		Sbar_Draw ();
-		SCR_DrawDevStats (); //johnfitz
-		SCR_DrawExposureDebug ();
-		SCR_DrawClock (); //johnfitz
-		SCR_DrawDemoControls ();
-		SCR_DrawSpeed ();
-		SCR_DrawEdictInfo ();
-		SCR_DrawConsole ();
-		M_Draw ();
-		SCR_DrawFPS (); //johnfitz
-		SCR_DrawSaving ();
-	}
-
-	Draw_Flush ();
-
-	GL_EndGroup ();
-	RB_EndPass ();
+	RBackend_DispatchBlock ("ui", &r_backend_ui, true,
+		SCR_DrawUI2D_Backend, SCR_DrawUI2D_Legacy, &scr_backend_ui_warned);
 
 	GL_EndRendering ();
 }

--- a/Quake/render_backend.h
+++ b/Quake/render_backend.h
@@ -19,9 +19,19 @@ typedef struct render_backend_vtable_s
 } render_backend_vtable_t;
 
 extern cvar_t r_backend;
+extern cvar_t r_backend_ui;
+extern cvar_t r_backend_postfx;
+extern cvar_t r_backend_particles;
+extern cvar_t r_backend_alias;
+extern cvar_t r_backend_world;
+extern cvar_t r_backend_fogvol;
+
+typedef qboolean (*rbackend_block_fn_t) (void);
 
 const render_backend_vtable_t *RBackend_GetVTable (void);
 void RBackend_DispatchRenderView (void (*legacy_fn)(void));
 void RBackend_DispatchUpdateScreen (void (*legacy_fn)(void));
+void RBackend_DispatchBlock (const char *block_name, cvar_t *toggle, qboolean backend_path_available,
+	rbackend_block_fn_t backend_fn, void (*legacy_fn)(void), qboolean *warned_once);
 
 #endif


### PR DESCRIPTION
### Motivation
- Provide per-render-block toggles so each frame-graph block can be migrated incrementally to the new render backend while keeping a safe legacy fallback. 
- Ensure runtime safety: if a backend path is unavailable or fails, automatically fall back to the legacy code and emit a one-time warning. 
- Record a stable migration ordering in code to keep incremental PRs consistent (UI/Console/2D → Fullscreen → Particles/Sprites/Beams → Alias → World (Sky→Opaque→Alpha) → PostFX). 

### Description
- Added new CVars for per-block toggles and exported them in the render backend header: `r_backend_ui`, `r_backend_postfx`, `r_backend_particles`, `r_backend_alias`, `r_backend_world`, and `r_backend_fogvol`. (files: `Quake/render_backend.h`, `Quake/gl_rmain.c`, `Quake/gl_rmisc.c`).
- Introduced a generic dispatcher API `RBackend_DispatchBlock(...)` and `rbackend_block_fn_t` type, and implemented runtime logic that: uses the backend only when global backend is enabled and the block toggle is on, falls back to legacy otherwise, and logs a one-time warning when backend path is missing or the backend block returns failure. (file: `Quake/backend_gl_exec.c`, `Quake/render_backend.h`).
- Wired the dispatcher into key frame-graph locations to enable incremental migration: PostFX and UI/2D in screen update, alias draws (entity list and viewmodel), world opaque/alpha phases, particles opaque/alpha phases, and fog volume render call. Helper wrappers and per-block `warned_once` flags were added where needed. (file: `Quake/gl_screen.c`, `Quake/gl_rmain.c`).
- Registered the new CVars during `R_Init`. (file: `Quake/gl_rmisc.c`).
- Added the requested migration-order comment in the `R_RenderScene` path to keep incremental PRs consistent. (file: `Quake/gl_rmain.c`).

### Testing
- Ran `git diff --check` and repository status checks; no whitespace errors remain and staged changes are present. (succeeded).
- Attempted an out-of-source build with `cmake` and `cmake --build`, but full compilation could not complete in this environment due to missing SDL2 CMake configuration files (`SDL2Config.cmake` / `sdl2-config.cmake`), so a complete build-and-run validation was not possible (failed due to environment). 
- Verified source edits by scanning modified files and symbol usages with `rg`/file inspections to ensure dispatcher calls and CVar registrations are present (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1755c5eb4832ea7291e033abab580)