### PR TITLE
Route frequent per-frame GL calls through RB wrappers

### DIFF
--- a/Quake/gl_draw.c
+++ b/Quake/gl_draw.c
@@ -24,6 +24,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // draw.c -- 2d drawing
 
 #include "quakedef.h"
+#include "rb_gl.h"
 
 const vec3_t	rgb_black = {0.f, 0.f, 0.f};
 const vec3_t	rgb_white = {1.f, 1.f, 1.f};
@@ -604,7 +605,7 @@ void Draw_Flush (void)
 
 	GL_Upload (GL_ELEMENT_ARRAY_BUFFER, batchindices, sizeof(batchindices[0]) * 6 * numbatchquads, &buf, &ofs);
 	GL_BindBuffer (GL_ELEMENT_ARRAY_BUFFER, buf);
-	glDrawElements (GL_TRIANGLES, numbatchquads * 6, GL_UNSIGNED_SHORT, ofs);
+	RB_DrawElements (GL_TRIANGLES, numbatchquads * 6, GL_UNSIGNED_SHORT, ofs);
 
 	numbatchquads = 0;
 }
@@ -1140,7 +1141,7 @@ void Draw_SetClipRect (float x, float y, float width, float height)
 
 	Draw_Flush ();
 	GL_SetScissorEnabled (true);
-	glScissor (x, y2, x2 - x, y - y2);
+	RB_Scissor (x, y2, x2 - x, y - y2);
 }
 
 /*
@@ -1301,7 +1302,7 @@ void GL_Set2D (void)
 	glcanvas.texture = NULL;
 	glcanvas.blendmode = GLS_BLEND_ALPHA;
 	glcanvas.colorstacktop = 0;
-	glViewport (glx, gly, glwidth, glheight);
+	RB_Viewport (glx, gly, glwidth, glheight);
 	GL_SetCanvas (CANVAS_DEFAULT);
 	GL_SetCanvasColor (1.f, 1.f, 1.f, 1.f);
 }

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -1860,11 +1860,11 @@ static void GL_PostProcessFallback (void)
 		return;
 
 	RB_BindFramebuffer (GL_FRAMEBUFFER, framebufs.composite.fbo);
-	glReadBuffer (GL_COLOR_ATTACHMENT0);
+	RB_ReadBuffer (GL_COLOR_ATTACHMENT0);
 	glPixelStorei (GL_PACK_ALIGNMENT, 1);
 	glReadPixels (0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
 	RB_BindFramebuffer (GL_FRAMEBUFFER, 0);
-	glReadBuffer (GL_BACK);
+	RB_ReadBuffer (GL_BACK);
 	glPixelStorei (GL_UNPACK_ALIGNMENT, 1);
 	{
 		qboolean srgb_output = GL_UseSRGBFramebuffer ();
@@ -2016,7 +2016,7 @@ static qboolean GL_SampleAutoExposureLuminance (float *out_luminance)
 	GL_BlitFramebufferFunc (0, 0, vid.width, vid.height, 0, 0, width, height, GL_COLOR_BUFFER_BIT, GL_LINEAR);
 
 	RB_BindFramebuffer (GL_READ_FRAMEBUFFER, framebufs.autoexposure.fbo);
-	glReadBuffer (GL_COLOR_ATTACHMENT0);
+	RB_ReadBuffer (GL_COLOR_ATTACHMENT0);
 	glGetIntegerv (GL_PACK_ALIGNMENT, &prev_pack_alignment);
 	glPixelStorei (GL_PACK_ALIGNMENT, 1);
 
@@ -2049,7 +2049,7 @@ static qboolean GL_SampleAutoExposureLuminance (float *out_luminance)
 		if (!got_data)
 		{
 			RB_BindFramebuffer (GL_FRAMEBUFFER, 0);
-			glReadBuffer (GL_BACK);
+			RB_ReadBuffer (GL_BACK);
 			return false;
 		}
 	}
@@ -2064,7 +2064,7 @@ static qboolean GL_SampleAutoExposureLuminance (float *out_luminance)
 		glPixelStorei (GL_PACK_ALIGNMENT, prev_pack_alignment);
 	}
 	RB_BindFramebuffer (GL_FRAMEBUFFER, 0);
-	glReadBuffer (GL_BACK);
+	RB_ReadBuffer (GL_BACK);
 
 	for (int i = 0; i < pixel_count; ++i)
 	{
@@ -2241,12 +2241,12 @@ void GL_PostProcess (void)
 		GL_BeginGroup ("Postprocess backbuffer copy");
 		RB_BindFramebuffer (GL_READ_FRAMEBUFFER, 0);
 		RB_BindFramebuffer (GL_DRAW_FRAMEBUFFER, framebufs.composite.fbo);
-		glReadBuffer (GL_BACK);
-		glDrawBuffer (GL_COLOR_ATTACHMENT0);
+		RB_ReadBuffer (GL_BACK);
+		RB_DrawBuffer (GL_COLOR_ATTACHMENT0);
 		GL_BlitFramebufferFunc (0, 0, vid.width, vid.height, 0, 0, vid.width, vid.height, GL_COLOR_BUFFER_BIT, GL_NEAREST);
 		RB_BindFramebuffer (GL_FRAMEBUFFER, 0);
-		glDrawBuffer (GL_BACK);
-		glReadBuffer (GL_BACK);
+		RB_DrawBuffer (GL_BACK);
+		RB_ReadBuffer (GL_BACK);
 		framesetup.composite_ready = true;
 		GL_EndGroup ();
 		RB_EndPass ();
@@ -3206,13 +3206,13 @@ void R_SetupGL (void)
 		framesetup.composite_ready = (target == framebufs.composite.fbo);
 		if (target)
 		{
-			glDrawBuffer (GL_COLOR_ATTACHMENT0);
-			glReadBuffer (GL_COLOR_ATTACHMENT0);
+			RB_DrawBuffer (GL_COLOR_ATTACHMENT0);
+			RB_ReadBuffer (GL_COLOR_ATTACHMENT0);
 		}
 		else
 		{
-			glDrawBuffer (GL_BACK);
-			glReadBuffer (GL_BACK);
+			RB_DrawBuffer (GL_BACK);
+			RB_ReadBuffer (GL_BACK);
 		}
 		RB_Viewport (glx + r_refdef.vrect.x, gly + glheight - r_refdef.vrect.y - r_refdef.vrect.height, r_refdef.vrect.width, r_refdef.vrect.height);
 	}
@@ -3227,12 +3227,12 @@ void R_SetupGL (void)
 		{
 			GLuint buffers[2] = { GL_COLOR_ATTACHMENT0, GL_COLOR_ATTACHMENT1 };
 			GL_DrawBuffersFunc (2, buffers);
-			glReadBuffer (GL_COLOR_ATTACHMENT0);
+			RB_ReadBuffer (GL_COLOR_ATTACHMENT0);
 		}
 		else
 		{
-			glDrawBuffer (GL_COLOR_ATTACHMENT0);
-			glReadBuffer (GL_COLOR_ATTACHMENT0);
+			RB_DrawBuffer (GL_COLOR_ATTACHMENT0);
+			RB_ReadBuffer (GL_COLOR_ATTACHMENT0);
 		}
 		RB_Viewport (0, 0, r_refdef.vrect.width / r_refdef.scale, r_refdef.vrect.height / r_refdef.scale);
 	}
@@ -3730,7 +3730,7 @@ static void R_FlushDebugGeometry (void)
 
 		GL_Upload (GL_ELEMENT_ARRAY_BUFFER, debugidx, sizeof (debugidx[0]) * numdebugidx, &buf, &ofs);
 		GL_BindBuffer (GL_ELEMENT_ARRAY_BUFFER, buf);
-		glDrawElements (GL_LINES, numdebugidx, GL_UNSIGNED_SHORT, ofs);
+		RB_DrawElements (GL_LINES, numdebugidx, GL_UNSIGNED_SHORT, ofs);
 	}
 
 	numdebugverts = 0;
@@ -4622,8 +4622,8 @@ static void R_DrawDLightPass (void)
 		use_buffer = true;
 		r_dlight_buffered_frame = true;
 		RB_BindFramebuffer (GL_FRAMEBUFFER, framebufs.dlight.fbo);
-		glDrawBuffer (GL_COLOR_ATTACHMENT0);
-		glReadBuffer (GL_COLOR_ATTACHMENT0);
+		RB_DrawBuffer (GL_COLOR_ATTACHMENT0);
+		RB_ReadBuffer (GL_COLOR_ATTACHMENT0);
 		{
 			static const float zeroes[4] = { 0.f, 0.f, 0.f, 0.f };
 			GL_ClearBufferfvFunc (GL_COLOR, 0, zeroes);
@@ -4669,13 +4669,13 @@ static void R_DrawDLightPass (void)
 		RB_BindFramebuffer (GL_FRAMEBUFFER, framesetup.scene_fbo);
 		if (framesetup.scene_fbo)
 		{
-			glDrawBuffer (GL_COLOR_ATTACHMENT0);
-			glReadBuffer (GL_COLOR_ATTACHMENT0);
+			RB_DrawBuffer (GL_COLOR_ATTACHMENT0);
+			RB_ReadBuffer (GL_COLOR_ATTACHMENT0);
 		}
 		else
 		{
-			glDrawBuffer (GL_BACK);
-			glReadBuffer (GL_BACK);
+			RB_DrawBuffer (GL_BACK);
+			RB_ReadBuffer (GL_BACK);
 		}
 	}
 
@@ -4831,14 +4831,14 @@ void R_WarpScaleView (void)
 		RB_BindFramebuffer (GL_READ_FRAMEBUFFER, framebufs.scene.fbo);
 		RB_BindFramebuffer (GL_DRAW_FRAMEBUFFER, framebufs.resolved_scene.fbo);
 
-		glReadBuffer (GL_COLOR_ATTACHMENT0);
-		glDrawBuffer (GL_COLOR_ATTACHMENT0);
+		RB_ReadBuffer (GL_COLOR_ATTACHMENT0);
+		RB_DrawBuffer (GL_COLOR_ATTACHMENT0);
 		GL_BlitFramebufferFunc (0, 0, srcw, srch, 0, 0, srcw, srch, GL_COLOR_BUFFER_BIT, GL_NEAREST);
 
 		if (framebufs.scene.velocity_tex && framebufs.resolved_scene.velocity_tex)
 		{
-			glReadBuffer (GL_COLOR_ATTACHMENT1);
-			glDrawBuffer (GL_COLOR_ATTACHMENT1);
+			RB_ReadBuffer (GL_COLOR_ATTACHMENT1);
+			RB_DrawBuffer (GL_COLOR_ATTACHMENT1);
 			GL_BlitFramebufferFunc (0, 0, srcw, srch, 0, 0, srcw, srch, GL_COLOR_BUFFER_BIT, GL_NEAREST);
 		}
 
@@ -4848,12 +4848,12 @@ void R_WarpScaleView (void)
 		if (!needwarpscale)
 		{
 			RB_BindFramebuffer (GL_READ_FRAMEBUFFER, framebufs.resolved_scene.fbo);
-			glReadBuffer (GL_COLOR_ATTACHMENT0);
+			RB_ReadBuffer (GL_COLOR_ATTACHMENT0);
 			RB_BindFramebuffer (GL_DRAW_FRAMEBUFFER, fbodest);
 			if (fbodest)
-				glDrawBuffer (GL_COLOR_ATTACHMENT0);
+				RB_DrawBuffer (GL_COLOR_ATTACHMENT0);
 			else
-				glDrawBuffer (GL_BACK);
+				RB_DrawBuffer (GL_BACK);
 			{
 				GLbitfield mask = GL_COLOR_BUFFER_BIT;
 				if (need_depth_resolve)
@@ -4869,21 +4869,21 @@ void R_WarpScaleView (void)
 		int dsth = (r_refdef.scale != 1) ? r_refdef.vrect.height : srch;
 
 		RB_BindFramebuffer (GL_READ_FRAMEBUFFER, framebufs.scene.fbo);
-		glReadBuffer (GL_COLOR_ATTACHMENT0);
+		RB_ReadBuffer (GL_COLOR_ATTACHMENT0);
 		RB_BindFramebuffer (GL_DRAW_FRAMEBUFFER, framebufs.composite.fbo);
-		glDrawBuffer (GL_COLOR_ATTACHMENT0);
+		RB_DrawBuffer (GL_COLOR_ATTACHMENT0);
 		GL_BlitFramebufferFunc (0, 0, srcw, srch, srcx, srcy, srcx + dstw, srcy + dsth, GL_DEPTH_BUFFER_BIT, GL_NEAREST);
 	}
 
 	if (!msaa && !needwarpscale)
 	{
 		RB_BindFramebuffer (GL_READ_FRAMEBUFFER, framebufs.scene.fbo);
-		glReadBuffer (GL_COLOR_ATTACHMENT0);
+		RB_ReadBuffer (GL_COLOR_ATTACHMENT0);
 		RB_BindFramebuffer (GL_DRAW_FRAMEBUFFER, fbodest);
 		if (fbodest)
-			glDrawBuffer (GL_COLOR_ATTACHMENT0);
+			RB_DrawBuffer (GL_COLOR_ATTACHMENT0);
 		else
-			glDrawBuffer (GL_BACK);
+			RB_DrawBuffer (GL_BACK);
 		GL_BlitFramebufferFunc (0, 0, srcw, srch,
 			srcx, srcy, srcx + srcw, srcy + srch,
 			GL_COLOR_BUFFER_BIT, GL_NEAREST);
@@ -4892,13 +4892,13 @@ void R_WarpScaleView (void)
 	RB_BindFramebuffer (GL_FRAMEBUFFER, fbodest);
 	if (fbodest)
 	{
-		glDrawBuffer (GL_COLOR_ATTACHMENT0);
-		glReadBuffer (GL_COLOR_ATTACHMENT0);
+		RB_DrawBuffer (GL_COLOR_ATTACHMENT0);
+		RB_ReadBuffer (GL_COLOR_ATTACHMENT0);
 	}
 	else
 	{
-		glDrawBuffer (GL_BACK);
-		glReadBuffer (GL_BACK);
+		RB_DrawBuffer (GL_BACK);
+		RB_ReadBuffer (GL_BACK);
 	}
 	RB_Viewport (srcx, srcy, r_refdef.vrect.width, r_refdef.vrect.height);
 

--- a/Quake/r_sprite.c
+++ b/Quake/r_sprite.c
@@ -170,7 +170,7 @@ static void R_FlushSpriteInstances (void)
 
 	GL_Upload (GL_ELEMENT_ARRAY_BUFFER, batchindices, sizeof(batchindices[0]) * 6 * numbatchquads, &buf, &ofs);
 	GL_BindBuffer (GL_ELEMENT_ARRAY_BUFFER, buf);
-	glDrawElements (GL_TRIANGLES, 6 * numbatchquads, GL_UNSIGNED_SHORT, ofs);
+	RB_DrawElements (GL_TRIANGLES, 6 * numbatchquads, GL_UNSIGNED_SHORT, ofs);
 
 	//johnfitz: offset decals
 	if (psprite->type == SPR_ORIENTED)

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -1164,13 +1164,13 @@ static void R_DrawBrushModels_MaterialStages (entity_t **ents, int count, brushp
 					R_ResetBModelCalls (program);
 					RB_SetState (stage_state);
 					current_state = stage_state;
-					glDepthFunc (depth_func);
+					RB_DepthFunc (depth_func);
 					current_depth = depth_func;
 
 					if (stage->blend_mode == MAT_BLEND_PREMULT)
-						glBlendFunc (GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
+						RB_BlendFunc (GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
 					else if (stage->blend_mode == MAT_BLEND_CUSTOM)
-						glBlendFunc (stage->blend_src, stage->blend_dst);
+						RB_BlendFunc (stage->blend_src, stage->blend_dst);
 					current_blend_mode = stage->blend_mode;
 					current_blend_src = stage->blend_src;
 					current_blend_dst = stage->blend_dst;
@@ -1195,7 +1195,7 @@ static void R_DrawBrushModels_MaterialStages (entity_t **ents, int count, brushp
 	if (num_bmodel_calls)
 		R_FlushBModelCalls ();
 
-	glDepthFunc (R_MapDepthFunc (MAT_DEPTHFUNC_LEQUAL));
+	RB_DepthFunc (R_MapDepthFunc (MAT_DEPTHFUNC_LEQUAL));
 }
 
 static void R_DrawBrushModels_GodrayStages (entity_t **ents, int count)
@@ -1367,7 +1367,7 @@ static void R_DrawBrushModels_GodrayStages (entity_t **ents, int count)
 	if (num_bmodel_calls)
 		R_FlushBModelCalls ();
 
-	glDepthFunc (R_MapDepthFunc (MAT_DEPTHFUNC_LEQUAL));
+	RB_DepthFunc (R_MapDepthFunc (MAT_DEPTHFUNC_LEQUAL));
 }
 
 /*

--- a/Quake/rb_gl.c
+++ b/Quake/rb_gl.c
@@ -237,6 +237,11 @@ void RB_DrawArrays (GLenum mode, GLint first, GLsizei count)
 	glDrawArrays (mode, first, count);
 }
 
+void RB_DrawElements (GLenum mode, GLsizei count, GLenum type, const GLvoid *indices)
+{
+	glDrawElements (mode, count, type, indices);
+}
+
 void RB_Clear (GLbitfield mask)
 {
 	glClear (mask);
@@ -245,6 +250,31 @@ void RB_Clear (GLbitfield mask)
 void RB_Viewport (GLint x, GLint y, GLsizei width, GLsizei height)
 {
 	glViewport (x, y, width, height);
+}
+
+void RB_Scissor (GLint x, GLint y, GLsizei width, GLsizei height)
+{
+	glScissor (x, y, width, height);
+}
+
+void RB_DepthFunc (GLenum func)
+{
+	glDepthFunc (func);
+}
+
+void RB_BlendFunc (GLenum sfactor, GLenum dfactor)
+{
+	glBlendFunc (sfactor, dfactor);
+}
+
+void RB_DrawBuffer (GLenum buf)
+{
+	glDrawBuffer (buf);
+}
+
+void RB_ReadBuffer (GLenum src)
+{
+	glReadBuffer (src);
 }
 
 void RB_SetPassSetupHook (rb_pass_setup_hook_t hook)

--- a/Quake/rb_gl.h
+++ b/Quake/rb_gl.h
@@ -22,8 +22,14 @@ qboolean RB_BindTexture_Owner (GLenum texunit, gltexture_t *texture, const char 
 #define RB_BindTextureWithOwner(texunit, texture, owner) RB_BindTexture_Owner ((texunit), (texture), (owner))
 void RB_BindFramebuffer (GLenum target, GLuint framebuffer);
 void RB_DrawArrays (GLenum mode, GLint first, GLsizei count);
+void RB_DrawElements (GLenum mode, GLsizei count, GLenum type, const GLvoid *indices);
 void RB_Clear (GLbitfield mask);
 void RB_Viewport (GLint x, GLint y, GLsizei width, GLsizei height);
+void RB_Scissor (GLint x, GLint y, GLsizei width, GLsizei height);
+void RB_DepthFunc (GLenum func);
+void RB_BlendFunc (GLenum sfactor, GLenum dfactor);
+void RB_DrawBuffer (GLenum buf);
+void RB_ReadBuffer (GLenum src);
 
 typedef void (*rb_pass_setup_hook_t) (rb_pass_t pass);
 void RB_SetPassSetupHook (rb_pass_setup_hook_t hook);


### PR DESCRIPTION
### Motivation
- Reduce direct per-frame OpenGL calls in the render path by routing frequently used draw/state calls through a small render-backend (RB) API to allow centralized tracking and future backend changes. 
- Prioritize Draw- and state-calls that are executed every frame (draw, depth/blend, viewport/scissor, draw/read buffer) while leaving upload/init GL calls untouched to minimize migration risk. 
- Provide minimal 1:1 passthrough wrappers initially so behavior is unchanged during the migration stage guarded by `RB_GL_PASSTHROUGH_ONLY`.

### Description
- Added RB API declarations in `Quake/rb_gl.h` and implemented 1:1 passthroughs in `Quake/rb_gl.c` for: `RB_DrawElements`, `RB_Scissor`, `RB_DepthFunc`, `RB_BlendFunc`, `RB_DrawBuffer`, and `RB_ReadBuffer`.
- Replaced prioritized direct GL calls in the per-frame flow with the new RB wrappers in the render-path sources: `Quake/gl_draw.c`, `Quake/gl_rmain.c`, `Quake/r_world.c`, and `Quake/r_sprite.c` (also added `#include "rb_gl.h"` to `gl_draw.c`).
- Kept upload/init-style GL calls (texture uploads, buffer uploads, shader setup, etc.) unchanged to keep the migration risk low; wrappers are plain passthroughs while `RB_GL_PASSTHROUGH_ONLY` is set.

### Testing
- Ran `git diff --check` and it passed with no whitespace/errors detected.
- Attempted a full CMake configure/build (`cmake -S . -B build && cmake --build build -j4`) but configuration failed in this environment due to missing SDL2 CMake config (`SDL2Config.cmake` / `sdl2-config.cmake` not found), so a full build could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a185427110832e9603e049114261a8)