### PR TITLE
rb_gl: track owners for framebuffer/VAO/buffer/sampler binds

### DIFF
--- a/Quake/rb_gl.c
+++ b/Quake/rb_gl.c
@@ -60,6 +60,11 @@ typedef struct rb_state_debug_s
 	const char *last_cull_owner;
 	const char *last_program_owner;
 	const char *last_texture_owner[3];
+	const char *last_fbo_owner;
+	const char *last_vao_owner;
+	const char *last_array_buffer_owner;
+	const char *last_element_array_buffer_owner;
+	const char *last_sampler_owner[3];
 } rb_state_debug_t;
 
 static rb_state_debug_t rb_state_debug;
@@ -227,9 +232,44 @@ qboolean RB_BindTexture_Owner (GLenum texunit, gltexture_t *texture, const char 
 	return GL_Bind (texunit, texture);
 }
 
-void RB_BindFramebuffer (GLenum target, GLuint framebuffer)
+void RB_BindFramebuffer_Owner (GLenum target, GLuint framebuffer, const char *owner)
 {
+	#if RB_STATE_TRACKER_ENABLED
+	rb_state_debug.last_fbo_owner = owner;
+	#endif
+
 	GL_BindFramebufferFunc (target, framebuffer);
+}
+
+void RB_BindVertexArray_Owner (GLuint array, const char *owner)
+{
+	#if RB_STATE_TRACKER_ENABLED
+	rb_state_debug.last_vao_owner = owner;
+	#endif
+
+	GL_BindVertexArrayFunc (array);
+}
+
+void RB_BindBuffer_Owner (GLenum target, GLuint buffer, const char *owner)
+{
+	#if RB_STATE_TRACKER_ENABLED
+	if (target == GL_ARRAY_BUFFER)
+		rb_state_debug.last_array_buffer_owner = owner;
+	else if (target == GL_ELEMENT_ARRAY_BUFFER)
+		rb_state_debug.last_element_array_buffer_owner = owner;
+	#endif
+
+	GL_BindBufferFunc (target, buffer);
+}
+
+void RB_BindSampler_Owner (GLuint unit, GLuint sampler, const char *owner)
+{
+	#if RB_STATE_TRACKER_ENABLED
+	if (unit < countof (rb_state_debug.last_sampler_owner))
+		rb_state_debug.last_sampler_owner[unit] = owner;
+	#endif
+
+	GL_BindSamplerFunc (unit, sampler);
 }
 
 void RB_DrawArrays (GLenum mode, GLint first, GLsizei count)
@@ -327,9 +367,9 @@ void RB_BeginPass (rb_pass_t pass)
 const char *RB_DebugStateOwnersString (void)
 {
 #if RB_STATE_TRACKER_ENABLED
-	static char info[384];
+	static char info[768];
 	q_snprintf (info, sizeof (info),
-		"pass=%s owner(blend=%s depth=%s cull=%s prog=%s tex0=%s tex1=%s tex2=%s)",
+		"pass=%s owner(blend=%s depth=%s cull=%s prog=%s tex0=%s tex1=%s tex2=%s fbo=%s vao=%s arrbuf=%s elembuf=%s samp0=%s samp1=%s samp2=%s)",
 		rb_pass_info[rb_current_pass].debug_name,
 		RB_DebugOwnerOrUnknown (rb_state_debug.last_blend_owner),
 		RB_DebugOwnerOrUnknown (rb_state_debug.last_depth_owner),
@@ -337,7 +377,14 @@ const char *RB_DebugStateOwnersString (void)
 		RB_DebugOwnerOrUnknown (rb_state_debug.last_program_owner),
 		RB_DebugOwnerOrUnknown (rb_state_debug.last_texture_owner[0]),
 		RB_DebugOwnerOrUnknown (rb_state_debug.last_texture_owner[1]),
-		RB_DebugOwnerOrUnknown (rb_state_debug.last_texture_owner[2]));
+		RB_DebugOwnerOrUnknown (rb_state_debug.last_texture_owner[2]),
+		RB_DebugOwnerOrUnknown (rb_state_debug.last_fbo_owner),
+		RB_DebugOwnerOrUnknown (rb_state_debug.last_vao_owner),
+		RB_DebugOwnerOrUnknown (rb_state_debug.last_array_buffer_owner),
+		RB_DebugOwnerOrUnknown (rb_state_debug.last_element_array_buffer_owner),
+		RB_DebugOwnerOrUnknown (rb_state_debug.last_sampler_owner[0]),
+		RB_DebugOwnerOrUnknown (rb_state_debug.last_sampler_owner[1]),
+		RB_DebugOwnerOrUnknown (rb_state_debug.last_sampler_owner[2]));
 	return info;
 #else
 	return "pass=<tracker disabled>";

--- a/Quake/rb_gl.h
+++ b/Quake/rb_gl.h
@@ -14,13 +14,24 @@
 void RB_SetState_Owner (unsigned mask, const char *owner);
 void RB_UseProgram_Owner (GLuint program, const char *owner);
 qboolean RB_BindTexture_Owner (GLenum texunit, gltexture_t *texture, const char *owner);
+void RB_BindFramebuffer_Owner (GLenum target, GLuint framebuffer, const char *owner);
+void RB_BindVertexArray_Owner (GLuint array, const char *owner);
+void RB_BindBuffer_Owner (GLenum target, GLuint buffer, const char *owner);
+void RB_BindSampler_Owner (GLuint unit, GLuint sampler, const char *owner);
 #define RB_SetState(mask) RB_SetState_Owner ((mask), __func__)
 #define RB_UseProgram(program) RB_UseProgram_Owner ((program), __func__)
 #define RB_BindTexture(texunit, texture) RB_BindTexture_Owner ((texunit), (texture), __func__)
+#define RB_BindFramebuffer(target, framebuffer) RB_BindFramebuffer_Owner ((target), (framebuffer), __func__)
+#define RB_BindVertexArray(array) RB_BindVertexArray_Owner ((array), __func__)
+#define RB_BindBuffer(target, buffer) RB_BindBuffer_Owner ((target), (buffer), __func__)
+#define RB_BindSampler(unit, sampler) RB_BindSampler_Owner ((unit), (sampler), __func__)
 #define RB_SetStateWithOwner(mask, owner) RB_SetState_Owner ((mask), (owner))
 #define RB_UseProgramWithOwner(program, owner) RB_UseProgram_Owner ((program), (owner))
 #define RB_BindTextureWithOwner(texunit, texture, owner) RB_BindTexture_Owner ((texunit), (texture), (owner))
-void RB_BindFramebuffer (GLenum target, GLuint framebuffer);
+#define RB_BindFramebufferWithOwner(target, framebuffer, owner) RB_BindFramebuffer_Owner ((target), (framebuffer), (owner))
+#define RB_BindVertexArrayWithOwner(array, owner) RB_BindVertexArray_Owner ((array), (owner))
+#define RB_BindBufferWithOwner(target, buffer, owner) RB_BindBuffer_Owner ((target), (buffer), (owner))
+#define RB_BindSamplerWithOwner(unit, sampler, owner) RB_BindSampler_Owner ((unit), (sampler), (owner))
 void RB_DrawArrays (GLenum mode, GLint first, GLsizei count);
 void RB_DrawElements (GLenum mode, GLsizei count, GLenum type, const GLvoid *indices);
 void RB_Clear (GLbitfield mask);


### PR DESCRIPTION
### Motivation
- Improve RB state debugging by recording which callsite last modified framebuffer, VAO, array/element buffer and sampler bindings so incoming-state diagnostics can report the responsible owner. 
- Keep all tracking strictly behind the existing debug guard to avoid any release-time overhead (`RB_STATE_TRACKER_ENABLED`).

### Description
- Extended `rb_state_debug_t` in `Quake/rb_gl.c` with `last_fbo_owner`, `last_vao_owner`, `last_array_buffer_owner`, `last_element_array_buffer_owner` and `last_sampler_owner[3]` to track the new channels. 
- Added owner-aware wrapper functions `RB_BindFramebuffer_Owner`, `RB_BindVertexArray_Owner`, `RB_BindBuffer_Owner` (records `GL_ARRAY_BUFFER`/`GL_ELEMENT_ARRAY_BUFFER`) and `RB_BindSampler_Owner` that update the debug fields and call the underlying `GL_*Func`. 
- Updated `Quake/rb_gl.h` to declare the new owner wrappers and adjusted macros so default calls pass `__func__` to the new wrappers while also providing explicit `WithOwner` variants. 
- Expanded `RB_DebugStateOwnersString` to include the new owner channels and increased the info buffer size accordingly, keeping all additions inside `#if RB_STATE_TRACKER_ENABLED` blocks. 

### Testing
- Performed static checks using `rg`/searches to verify the new symbols and fields are present in `Quake/rb_gl.c` and `Quake/rb_gl.h`, which succeeded. 
- Attempted a full configure/build with `cmake -S . -B build && cmake --build build -j2`, but configuration failed due to a missing SDL2 development package in the environment so a full compile could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a186d93e60832e99ee7409244ef30c)