### PR TITLE
Add defensive pass baseline guards for high-churn draw leaf functions

### DIFF
--- a/Quake/gl_draw.c
+++ b/Quake/gl_draw.c
@@ -590,6 +590,14 @@ void Draw_Flush (void)
 	if (!numbatchquads)
 		return;
 
+	/*
+	 * Leaf baseline: PASS_UI2D.
+	 * Expected baseline when pass is active: opaque blend, no z-test/write,
+	 * no culling, program 0, and texture units 0..2 unbound.
+	 */
+	if (RB_PassActive () && RB_CurrentPass () != PASS_UI2D)
+		Con_DWarning ("Draw_Flush invoked outside PASS_UI2D (owners: %s)\n", RB_DebugStateOwnersString ());
+
 	if (scrap_dirty && glcanvas.texture == scrap_texture)
 		Scrap_Upload ();
 

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -1046,6 +1046,14 @@ static GLuint GL_GenerateBloomTexture (void)
 	if (!glprogs.bloom_extract || !glprogs.bloom_blur)
 		return fallback;
 
+	/*
+	 * Leaf baseline: PASS_POSTFX.
+	 * Expected baseline when pass is active: opaque blend, no z-test/write,
+	 * no culling, program 0, and texture units 0..2 unbound.
+	 */
+	if (RB_PassActive () && RB_CurrentPass () != PASS_POSTFX)
+		Con_DWarning ("GL_GenerateBloomTexture invoked outside PASS_POSTFX (owners: %s)\n", RB_DebugStateOwnersString ());
+
 	float threshold = q_max (0.f, r_bloom_threshold.value);
 	qboolean msaa = framebufs.scene.samples > 1;
 	GLuint velocity_texture = 0;
@@ -1106,6 +1114,20 @@ static GLuint GL_GenerateBloomTextureFrom (GLuint source_tex, float threshold, f
 	if (!glprogs.bloom_extract || !glprogs.bloom_blur)
 		return fallback;
 
+	/*
+	 * Leaf baseline: PASS_POSTFX (or local standalone fallback path, e.g. dlight composite).
+	 * Expected baseline when pass is active: opaque blend, no z-test/write,
+	 * no culling, program 0, and texture units 0..2 unbound.
+	 */
+	qboolean local_pass = false;
+	if (!RB_PassActive ())
+	{
+		RB_BeginPass (PASS_POSTFX);
+		local_pass = true;
+	}
+	else if (RB_CurrentPass () != PASS_POSTFX)
+		Con_DWarning ("GL_GenerateBloomTextureFrom invoked outside PASS_POSTFX (owners: %s)\n", RB_DebugStateOwnersString ());
+
 	threshold = q_max (0.f, threshold);
 	float radius = q_max (0.f, radius_scale);
 	if (radius <= 0.f)
@@ -1143,6 +1165,9 @@ static GLuint GL_GenerateBloomTextureFrom (GLuint source_tex, float threshold, f
 		input_tex = framebufs.bloom.pingpong_tex[target_index];
 	}
 	GL_EndGroup ();
+
+	if (local_pass)
+		RB_EndPass ();
 
 	return input_tex;
 }
@@ -1303,6 +1328,14 @@ static GLuint GL_GenerateSSAOTexture (float view_min_x, float view_min_y, float 
 		return 0;
 	if (framebufs.ssao.ao_fbo[0] == 0 || framebufs.ssao.ao_fbo[1] == 0)
 		return 0;
+
+	/*
+	 * Leaf baseline: PASS_POSTFX.
+	 * Expected baseline when pass is active: opaque blend, no z-test/write,
+	 * no culling, program 0, and texture units 0..2 unbound.
+	 */
+	if (RB_PassActive () && RB_CurrentPass () != PASS_POSTFX)
+		Con_DWarning ("GL_GenerateSSAOTexture invoked outside PASS_POSTFX (owners: %s)\n", RB_DebugStateOwnersString ());
 
 	int samples = (int)Q_rint (r_ssao_samples.value);
 	samples = CLAMP (4, samples, SSAO_MAX_SAMPLES);
@@ -1686,6 +1719,14 @@ static GLuint GL_GenerateGodraysTexture (GLuint *out_mask)
 		return fallback;
 	if (!R_GodraysReady ())
 		return fallback;
+
+	/*
+	 * Leaf baseline: PASS_POSTFX.
+	 * Expected baseline when pass is active: opaque blend, no z-test/write,
+	 * no culling, program 0, and texture units 0..2 unbound.
+	 */
+	if (RB_PassActive () && RB_CurrentPass () != PASS_POSTFX)
+		Con_DWarning ("GL_GenerateGodraysTexture invoked outside PASS_POSTFX (owners: %s)\n", RB_DebugStateOwnersString ());
 
 	qboolean emit_sky = (r_godrays_emit_sky.value > 0.f && r_godray_sky_enable.value > 0.f && glprogs.godrays_source_sky);
 	qboolean emit_brush = ((r_godrays_emit_emissive.value > 0.f || r_godrays_emit_lighttex.value > 0.f) && glprogs.godrays_source);

--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -535,6 +535,14 @@ void R_FlushAliasInstances (qboolean showtris)
 	if (!ibuf.count)
 		return;
 
+	/*
+	 * Leaf baseline: PASS_ENTS_OPAQUE/PASS_ENTS_ALPHA (or show-tris overlay path
+	 * without a pass). Expected baseline when pass is active: opaque blend,
+	 * depth test/write on, back-face cull, program 0, and textures 0..2 unbound.
+	 */
+	if (RB_PassActive () && RB_CurrentPass () != PASS_ENTS_OPAQUE && RB_CurrentPass () != PASS_ENTS_ALPHA)
+		Con_DWarning ("R_FlushAliasInstances invoked outside entity passes (owners: %s)\n", RB_DebugStateOwnersString ());
+
 	R_GLStateDump (ibuf.ent == &cl.viewent ? "before-viewmodel" : "before-alias");
 
 	model = ibuf.ent->model;

--- a/Quake/r_part.c
+++ b/Quake/r_part.c
@@ -685,6 +685,7 @@ static void R_DrawParticles_Real (qboolean alpha, qboolean showtris)
 	//float			alpha; //johnfitz -- particle transparency
 	float			scalex, scaley;
 	qboolean		dither, oit;
+	qboolean		local_pass = false;
 	int				i;
 
 	if (!r_particles.value)
@@ -696,6 +697,19 @@ static void R_DrawParticles_Real (qboolean alpha, qboolean showtris)
 	// square particles are drawn opaque (avoiding alpha sorting issues)
 	if (!showtris && alpha != ((int)r_particles.value != 2))
 		return;
+
+	/*
+	 * Leaf baseline: PASS_PARTICLES (or show-tris overlay path without a pass).
+	 * Expected baseline when pass is active: opaque blend, depth test/write on,
+	 * back-face cull, program 0, and texture units 0..2 unbound.
+	 */
+	if (!RB_PassActive ())
+	{
+		RB_BeginPass (PASS_PARTICLES);
+		local_pass = true;
+	}
+	else if (RB_CurrentPass () != PASS_PARTICLES)
+		Con_DWarning ("R_DrawParticles_Real invoked outside PASS_PARTICLES (owners: %s)\n", RB_DebugStateOwnersString ());
 
 	GL_BeginGroup ("Particles");
 
@@ -740,6 +754,9 @@ static void R_DrawParticles_Real (qboolean alpha, qboolean showtris)
 	R_FlushParticleBatch ();
 
 	GL_EndGroup ();
+
+	if (local_pass)
+		RB_EndPass ();
 }
 
 /*
@@ -760,4 +777,3 @@ void R_DrawParticles_ShowTris (void)
 {
 	R_DrawParticles_Real (false, true);
 }
-

--- a/Quake/rb_gl.c
+++ b/Quake/rb_gl.c
@@ -399,3 +399,13 @@ void RB_EndPass (void)
 	GL_EndGroup ();
 	rb_pass_active = false;
 }
+
+qboolean RB_PassActive (void)
+{
+	return rb_pass_active;
+}
+
+rb_pass_t RB_CurrentPass (void)
+{
+	return rb_current_pass;
+}

--- a/Quake/rb_gl.h
+++ b/Quake/rb_gl.h
@@ -46,6 +46,8 @@ typedef void (*rb_pass_setup_hook_t) (rb_pass_t pass);
 void RB_SetPassSetupHook (rb_pass_setup_hook_t hook);
 void RB_BeginPass (rb_pass_t pass);
 void RB_EndPass (void);
+qboolean RB_PassActive (void);
+rb_pass_t RB_CurrentPass (void);
 const char *RB_DebugStateOwnersString (void);
 
 #endif


### PR DESCRIPTION
### Motivation
- Harte GL-/Pass-Fehler treten an Leaf-Funktionen mit vielen State-Wechseln auf; diese Änderung dokumentiert erwartete Pass-Baselines und fügt defensive Konsistenzchecks hinzu, ohne Architektur zu ändern. 
- Ziel ist, unbemerkte Cross-pass-Aufrufe früh zu erkennen und nur dort lokale Scope-Absicherungen zu öffnen, wo Callsites ohne aktiven Pass plausibel sind.

### Description
- Exponiere leichte Pass-Introspection-APIs: `RB_PassActive()` und `RB_CurrentPass()` in `rb_gl` zur passiven Abfrage des aktuellen Pass-Kontexts (`Quake/rb_gl.h`, `Quake/rb_gl.c`).
- Dokumentiere erwartete Eingangs-Baseline und füge Warnungen bei Abweichung ein für `Draw_Flush` (`PASS_UI2D`), `R_FlushAliasInstances` (`PASS_ENTS_OPAQUE`/`PASS_ENTS_ALPHA`) und PostFX-Subpass-Helpers (`GL_GenerateBloomTexture`, `GL_GenerateBloomTextureFrom`, `GL_GenerateSSAOTexture`, `GL_GenerateGodraysTexture`) in `Quake/gl_draw.c` und `Quake/gl_rmain.c`.
- Ergänze lokale Scope-Absicherungen nur dort, wo ein Aufruf ohne aktiven Pass plausibel ist: `R_DrawParticles_Real` startet/schliesst `PASS_PARTICLES` bei Bedarf, und `GL_GenerateBloomTextureFrom` startet/schliesst `PASS_POSTFX` wenn kein Pass aktiv ist (z.B. Dlight-Composite-Pfad). Änderungen in `Quake/r_part.c` und `Quake/gl_rmain.c`.
- Kleine, nicht-invasive Checks rufen `Con_DWarning(...)` mit `RB_DebugStateOwnersString()` auf, anstatt Laufzeit-Fehler oder architektonische Änderungen zu erzwingen; nur lokale begin/end eingefügt, kein Rework des Rendering-Designs.

### Testing
- Versucht: `cmake -S . -B build && cmake --build build -j4` (automatischer Build) — Fehlschlag in dieser Umgebung, da das `SDL2` CMake-Paket nicht vorhanden ist; Änderung ist jedoch rein quellcode-beschreibend und kompiliert in einer vollständigen Entwickler-Umgebung erwartet ohne weitere Quelländerungen.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a187b35208832ea8be8cd0c79d6cf4)