### PR TITLE
Document render backend vtable contracts and DispatchBlock fallback semantics

### DIFF
--- a/Quake/backend_gl_exec.c
+++ b/Quake/backend_gl_exec.c
@@ -196,13 +196,14 @@ void RBackend_DispatchUpdateScreen (void (*legacy_fn)(void))
 void RBackend_DispatchBlock (const char *block_name, cvar_t *toggle, qboolean backend_path_available,
 	rbackend_block_fn_t backend_fn, void (*legacy_fn)(void), qboolean *warned_once)
 {
-	qboolean can_use_backend;
+	const qboolean backend_globally_enabled = ((int)r_backend.value == 1);
+	const qboolean block_toggle_enabled = toggle && (toggle->value != 0.f);
+	const qboolean can_try_backend = backend_globally_enabled && block_toggle_enabled;
 
 	if (!legacy_fn)
 		return;
 
-	can_use_backend = ((int)r_backend.value == 1) && toggle && (toggle->value != 0.f);
-	if (!can_use_backend)
+	if (!can_try_backend)
 	{
 		legacy_fn ();
 		return;

--- a/Quake/render_backend.h
+++ b/Quake/render_backend.h
@@ -6,17 +6,29 @@
 
 typedef struct render_backend_vtable_s
 {
+	/* Preconditions: active GL context on render thread; Side effects: starts backend frame bookkeeping/debug scope; Threading: single render thread only. */
 	void (*BeginFrame) (const char *label);
+	/* Preconditions: matching BeginFrame already issued for current frame; Side effects: flushes/completes backend frame scope; Threading: single render thread only. */
 	void (*EndFrame) (void);
+	/* Preconditions: inside BeginFrame/EndFrame and pass enum describes the next phase; Side effects: binds pass-local GPU state; Threading: single render thread only. */
 	void (*BeginPass) (rb_pass_t pass);
+	/* Preconditions: matching BeginPass is active; Side effects: finalizes pass-local state; Threading: single render thread only. */
 	void (*EndPass) (void);
+	/* Preconditions: required VAO/VBO/program state already bound by caller; Side effects: submits non-indexed draw call to GPU driver; Threading: single render thread only. */
 	void (*DrawArrays) (GLenum mode, GLint first, GLsizei count);
+	/* Preconditions: required indexed draw state and index buffer/pointer are valid; Side effects: submits indexed draw call to GPU driver; Threading: single render thread only. */
 	void (*DrawElements) (GLenum mode, GLsizei count, GLenum type, const GLvoid *indices);
+	/* Preconditions: compute pipeline state/resources already prepared; Side effects: dispatches compute workload to GPU queue; Threading: single render thread only. */
 	void (*DispatchCompute) (GLuint num_groups_x, GLuint num_groups_y, GLuint num_groups_z);
+	/* Preconditions: target/framebuffer are valid for current context; Side effects: mutates framebuffer binding state; Threading: single render thread only. */
 	void (*BindFramebuffer) (GLenum target, GLuint framebuffer);
+	/* Preconditions: texture unit/target/texture are valid handles; Side effects: mutates texture binding state for texunit; Threading: single render thread only. */
 	void (*BindTexture) (GLenum texunit, GLenum target, GLuint texture);
+	/* Preconditions: target/buffer are valid handles; Side effects: mutates buffer binding state; Threading: single render thread only. */
 	void (*BindBuffer) (GLenum target, GLuint buffer);
 } render_backend_vtable_t;
+
+typedef render_backend_vtable_t IRenderBackend;
 
 extern cvar_t r_backend;
 extern cvar_t r_backend_ui;
@@ -34,6 +46,14 @@ typedef qboolean (*rbackend_block_fn_t) (void);
 const render_backend_vtable_t *RBackend_GetVTable (void);
 void RBackend_DispatchRenderView (void (*legacy_fn)(void));
 void RBackend_DispatchUpdateScreen (void (*legacy_fn)(void));
+/*
+ * Fallback rule:
+ * - backend path is considered only when global backend toggle is on (r_backend == 1)
+ *   and the per-block toggle is enabled (toggle && toggle->value != 0).
+ * - otherwise legacy_fn runs immediately.
+ * - with toggles enabled, legacy_fn is still used when backend path is unavailable
+ *   (!backend_path_available or backend_fn == NULL) or when backend_fn returns false.
+ */
 void RBackend_DispatchBlock (const char *block_name, cvar_t *toggle, qboolean backend_path_available,
 	rbackend_block_fn_t backend_fn, void (*legacy_fn)(void), qboolean *warned_once);
 void RBackend_DebugCaptureEndFrameHash (void);


### PR DESCRIPTION
### Motivation
- Make the render backend API clearer by documenting preconditions, expected side-effects and threading assumptions for each vtable function. 
- Make the fallback behavior for `RBackend_DispatchBlock` explicit so callers understand when the legacy path is used. 
- Provide a non-breaking, clearer alias for the vtable type and improve readability of dispatch gating code without changing runtime behavior. 

### Description
- Added concise contract comments (preconditions, side-effects, threading) for every function in `render_backend_vtable_t` in `Quake/render_backend.h`.
- Introduced a non-breaking typedef alias `IRenderBackend` for `render_backend_vtable_t` in `Quake/render_backend.h`.
- Documented the `RBackend_DispatchBlock` fallback rule above its prototype in `Quake/render_backend.h`, covering global toggle, per-block toggle, backend-path availability, and `backend_fn` failure cases.
- Improved readability in `Quake/backend_gl_exec.c` by replacing the inline condition with named `const qboolean` variables (`backend_globally_enabled`, `block_toggle_enabled`, `can_try_backend`) while preserving existing behavior. 

### Testing
- Ran `diff --check` to ensure no whitespace or diff issues and it completed successfully. 
- Reviewed the diffs with `diff -- Quake/render_backend.h Quake/backend_gl_exec.c` to verify only documentation and readability changes were introduced. 
- Verified by inspection that the `RBackend_DispatchBlock` runtime logic is functionally equivalent after the refactor.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a18c87833c832ea6cf1955d77dae7a)