### PR TITLE
rb_gl: enforce deterministic full-pass GL baseline

### DIFF
--- a/Quake/rb_gl.c
+++ b/Quake/rb_gl.c
@@ -5,11 +5,78 @@
 #error "RB wrappers must remain pass-through during this migration stage"
 #endif
 
+typedef struct rb_pass_baseline_gl_s
+{
+	GLint draw_fbo;
+	GLint read_fbo;
+	GLint viewport[4];
+	qboolean scissor_enable;
+	GLint scissor_box[4];
+	GLenum depth_func;
+	GLboolean depth_mask;
+	GLenum blend_src;
+	GLenum blend_dst;
+	GLenum blend_equation;
+	GLenum cull_mode;
+	GLboolean color_mask[4];
+	qboolean stencil_enable;
+	GLenum stencil_func;
+	GLint stencil_ref;
+	GLuint stencil_value_mask;
+	GLenum stencil_sfail;
+	GLenum stencil_dpfail;
+	GLenum stencil_dppass;
+	GLuint stencil_writemask;
+	GLuint program;
+	GLuint vao;
+	GLuint array_buffer;
+	GLuint element_array_buffer;
+	GLenum active_texture;
+	GLuint sampler_bindings[3];
+	qboolean framebuffer_srgb;
+	GLenum polygon_mode;
+} rb_pass_baseline_gl_t;
+
 typedef struct rb_pass_info_s
 {
 	const char *debug_name;
 	unsigned baseline_state;
+	rb_pass_baseline_gl_t baseline_gl;
 } rb_pass_info_t;
+
+typedef struct rb_gl_state_snapshot_s
+{
+	GLint draw_fbo;
+	GLint read_fbo;
+	GLint viewport[4];
+	GLboolean scissor_enable;
+	GLint scissor_box[4];
+	GLint depth_func;
+	GLboolean depth_mask;
+	GLint blend_src;
+	GLint blend_dst;
+	GLint blend_equation;
+	GLboolean cull_enable;
+	GLint cull_mode;
+	GLboolean color_mask[4];
+	GLboolean stencil_enable;
+	GLint stencil_func;
+	GLint stencil_ref;
+	GLint stencil_value_mask;
+	GLint stencil_sfail;
+	GLint stencil_dpfail;
+	GLint stencil_dppass;
+	GLint stencil_writemask;
+	GLint program;
+	GLint vao;
+	GLint array_buffer;
+	GLint element_array_buffer;
+	GLint active_texture;
+	GLint sampler_bindings[3];
+	GLboolean framebuffer_srgb;
+	GLint polygon_mode[2];
+	GLint tex2d[3];
+} rb_gl_state_snapshot_t;
 
 /*
  * Render-backend pass baseline matrix (pass -> expected start state).
@@ -29,17 +96,17 @@ typedef struct rb_pass_info_s
  * | PASS_UI2D          | Opaque | Off        | Off         | None | 0       | Unbound            |
  */
 static const rb_pass_info_t rb_pass_info[PASS_COUNT] = {
-	[PASS_WORLD_OPAQUE] = {"PASS_WORLD_OPAQUE", GLS_BLEND_OPAQUE | GLS_CULL_BACK | GLS_ATTRIBS (0)},
-	[PASS_DLIGHT] = {"PASS_DLIGHT", GLS_BLEND_OPAQUE | GLS_CULL_BACK | GLS_ATTRIBS (0)},
-	[PASS_SKY] = {"PASS_SKY", GLS_BLEND_OPAQUE | GLS_CULL_BACK | GLS_ATTRIBS (0)},
-	[PASS_WATER_OPAQUE] = {"PASS_WATER_OPAQUE", GLS_BLEND_OPAQUE | GLS_CULL_BACK | GLS_ATTRIBS (0)},
-	[PASS_WATER_ALPHA] = {"PASS_WATER_ALPHA", GLS_BLEND_OPAQUE | GLS_CULL_BACK | GLS_ATTRIBS (0)},
-	[PASS_ENTS_OPAQUE] = {"PASS_ENTS_OPAQUE", GLS_BLEND_OPAQUE | GLS_CULL_BACK | GLS_ATTRIBS (0)},
-	[PASS_ENTS_ALPHA] = {"PASS_ENTS_ALPHA", GLS_BLEND_OPAQUE | GLS_CULL_BACK | GLS_ATTRIBS (0)},
-	[PASS_PARTICLES] = {"PASS_PARTICLES", GLS_BLEND_OPAQUE | GLS_CULL_BACK | GLS_ATTRIBS (0)},
-	[PASS_POSTFX] = {"PASS_POSTFX", GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0)},
-	[PASS_FOGVOL] = {"PASS_FOGVOL", GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0)},
-	[PASS_UI2D] = {"PASS_UI2D", GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0)},
+	[PASS_WORLD_OPAQUE] = {"PASS_WORLD_OPAQUE", GLS_BLEND_OPAQUE | GLS_CULL_BACK | GLS_ATTRIBS (0), {{0, 0, {0, 0, 0, 0}, false, {0, 0, 0, 0}, GL_LEQUAL, GL_TRUE, GL_ONE, GL_ZERO, GL_FUNC_ADD, GL_BACK, {GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE}, false, GL_ALWAYS, 0, ~0u, GL_KEEP, GL_KEEP, GL_KEEP, ~0u, 0, 0, 0, 0, GL_TEXTURE0, {0, 0, 0}, false, GL_FILL}}},
+	[PASS_DLIGHT] = {"PASS_DLIGHT", GLS_BLEND_OPAQUE | GLS_CULL_BACK | GLS_ATTRIBS (0), {{0, 0, {0, 0, 0, 0}, false, {0, 0, 0, 0}, GL_LEQUAL, GL_TRUE, GL_ONE, GL_ZERO, GL_FUNC_ADD, GL_BACK, {GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE}, false, GL_ALWAYS, 0, ~0u, GL_KEEP, GL_KEEP, GL_KEEP, ~0u, 0, 0, 0, 0, GL_TEXTURE0, {0, 0, 0}, false, GL_FILL}}},
+	[PASS_SKY] = {"PASS_SKY", GLS_BLEND_OPAQUE | GLS_CULL_BACK | GLS_ATTRIBS (0), {{0, 0, {0, 0, 0, 0}, false, {0, 0, 0, 0}, GL_LEQUAL, GL_TRUE, GL_ONE, GL_ZERO, GL_FUNC_ADD, GL_BACK, {GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE}, false, GL_ALWAYS, 0, ~0u, GL_KEEP, GL_KEEP, GL_KEEP, ~0u, 0, 0, 0, 0, GL_TEXTURE0, {0, 0, 0}, false, GL_FILL}}},
+	[PASS_WATER_OPAQUE] = {"PASS_WATER_OPAQUE", GLS_BLEND_OPAQUE | GLS_CULL_BACK | GLS_ATTRIBS (0), {{0, 0, {0, 0, 0, 0}, false, {0, 0, 0, 0}, GL_LEQUAL, GL_TRUE, GL_ONE, GL_ZERO, GL_FUNC_ADD, GL_BACK, {GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE}, false, GL_ALWAYS, 0, ~0u, GL_KEEP, GL_KEEP, GL_KEEP, ~0u, 0, 0, 0, 0, GL_TEXTURE0, {0, 0, 0}, false, GL_FILL}}},
+	[PASS_WATER_ALPHA] = {"PASS_WATER_ALPHA", GLS_BLEND_OPAQUE | GLS_CULL_BACK | GLS_ATTRIBS (0), {{0, 0, {0, 0, 0, 0}, false, {0, 0, 0, 0}, GL_LEQUAL, GL_TRUE, GL_ONE, GL_ZERO, GL_FUNC_ADD, GL_BACK, {GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE}, false, GL_ALWAYS, 0, ~0u, GL_KEEP, GL_KEEP, GL_KEEP, ~0u, 0, 0, 0, 0, GL_TEXTURE0, {0, 0, 0}, false, GL_FILL}}},
+	[PASS_ENTS_OPAQUE] = {"PASS_ENTS_OPAQUE", GLS_BLEND_OPAQUE | GLS_CULL_BACK | GLS_ATTRIBS (0), {{0, 0, {0, 0, 0, 0}, false, {0, 0, 0, 0}, GL_LEQUAL, GL_TRUE, GL_ONE, GL_ZERO, GL_FUNC_ADD, GL_BACK, {GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE}, false, GL_ALWAYS, 0, ~0u, GL_KEEP, GL_KEEP, GL_KEEP, ~0u, 0, 0, 0, 0, GL_TEXTURE0, {0, 0, 0}, false, GL_FILL}}},
+	[PASS_ENTS_ALPHA] = {"PASS_ENTS_ALPHA", GLS_BLEND_OPAQUE | GLS_CULL_BACK | GLS_ATTRIBS (0), {{0, 0, {0, 0, 0, 0}, false, {0, 0, 0, 0}, GL_LEQUAL, GL_TRUE, GL_ONE, GL_ZERO, GL_FUNC_ADD, GL_BACK, {GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE}, false, GL_ALWAYS, 0, ~0u, GL_KEEP, GL_KEEP, GL_KEEP, ~0u, 0, 0, 0, 0, GL_TEXTURE0, {0, 0, 0}, false, GL_FILL}}},
+	[PASS_PARTICLES] = {"PASS_PARTICLES", GLS_BLEND_OPAQUE | GLS_CULL_BACK | GLS_ATTRIBS (0), {{0, 0, {0, 0, 0, 0}, false, {0, 0, 0, 0}, GL_LEQUAL, GL_TRUE, GL_ONE, GL_ZERO, GL_FUNC_ADD, GL_BACK, {GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE}, false, GL_ALWAYS, 0, ~0u, GL_KEEP, GL_KEEP, GL_KEEP, ~0u, 0, 0, 0, 0, GL_TEXTURE0, {0, 0, 0}, false, GL_FILL}}},
+	[PASS_POSTFX] = {"PASS_POSTFX", GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0), {{0, 0, {0, 0, 0, 0}, false, {0, 0, 0, 0}, GL_LEQUAL, GL_FALSE, GL_ONE, GL_ZERO, GL_FUNC_ADD, 0, {GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE}, false, GL_ALWAYS, 0, ~0u, GL_KEEP, GL_KEEP, GL_KEEP, ~0u, 0, 0, 0, 0, GL_TEXTURE0, {0, 0, 0}, false, GL_FILL}}},
+	[PASS_FOGVOL] = {"PASS_FOGVOL", GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0), {{0, 0, {0, 0, 0, 0}, false, {0, 0, 0, 0}, GL_LEQUAL, GL_FALSE, GL_ONE, GL_ZERO, GL_FUNC_ADD, 0, {GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE}, false, GL_ALWAYS, 0, ~0u, GL_KEEP, GL_KEEP, GL_KEEP, ~0u, 0, 0, 0, 0, GL_TEXTURE0, {0, 0, 0}, false, GL_FILL}}},
+	[PASS_UI2D] = {"PASS_UI2D", GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0), {{0, 0, {0, 0, 0, 0}, false, {0, 0, 0, 0}, GL_LEQUAL, GL_FALSE, GL_ONE, GL_ZERO, GL_FUNC_ADD, 0, {GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE}, false, GL_ALWAYS, 0, ~0u, GL_KEEP, GL_KEEP, GL_KEEP, ~0u, 0, 0, 0, 0, GL_TEXTURE0, {0, 0, 0}, false, GL_FILL}}},
 };
 
 static rb_pass_setup_hook_t rb_pass_setup_hook;
@@ -76,126 +143,186 @@ static const char *RB_DebugOwnerOrUnknown (const char *owner)
 	return owner ? owner : "<unknown>";
 }
 
-static const char *RB_BlendName (unsigned state)
+static const char *RB_BoolName (int value)
 {
-	switch (state & GLS_MASK_BLEND)
-	{
-	case GLS_BLEND_OPAQUE: return "opaque";
-	case GLS_BLEND_ALPHA: return "alpha";
-	case GLS_BLEND_ALPHA_OIT: return "alpha_oit";
-	case GLS_BLEND_MULTIPLY: return "multiply";
-	case GLS_BLEND_ADD: return "add";
-	default: return "invalid";
-	}
+	return value ? "on" : "off";
 }
 
-static const char *RB_CullName (unsigned state)
+static void RB_CaptureGLStateSnapshot (rb_gl_state_snapshot_t *snapshot)
 {
-	switch (state & GLS_MASK_CULL)
+	GLint prev_active_tex;
+	int i;
+
+	memset (snapshot, 0, sizeof (*snapshot));
+
+	glGetIntegerv (GL_DRAW_FRAMEBUFFER_BINDING, &snapshot->draw_fbo);
+	glGetIntegerv (GL_READ_FRAMEBUFFER_BINDING, &snapshot->read_fbo);
+	glGetIntegerv (GL_VIEWPORT, snapshot->viewport);
+	snapshot->scissor_enable = glIsEnabled (GL_SCISSOR_TEST);
+	glGetIntegerv (GL_SCISSOR_BOX, snapshot->scissor_box);
+	glGetIntegerv (GL_DEPTH_FUNC, &snapshot->depth_func);
+	glGetBooleanv (GL_DEPTH_WRITEMASK, &snapshot->depth_mask);
+	glGetIntegerv (GL_BLEND_SRC_RGB, &snapshot->blend_src);
+	glGetIntegerv (GL_BLEND_DST_RGB, &snapshot->blend_dst);
+	glGetIntegerv (GL_BLEND_EQUATION_RGB, &snapshot->blend_equation);
+	snapshot->cull_enable = glIsEnabled (GL_CULL_FACE);
+	glGetIntegerv (GL_CULL_FACE_MODE, &snapshot->cull_mode);
+	glGetBooleanv (GL_COLOR_WRITEMASK, snapshot->color_mask);
+	snapshot->stencil_enable = glIsEnabled (GL_STENCIL_TEST);
+	glGetIntegerv (GL_STENCIL_FUNC, &snapshot->stencil_func);
+	glGetIntegerv (GL_STENCIL_REF, &snapshot->stencil_ref);
+	glGetIntegerv (GL_STENCIL_VALUE_MASK, &snapshot->stencil_value_mask);
+	glGetIntegerv (GL_STENCIL_FAIL, &snapshot->stencil_sfail);
+	glGetIntegerv (GL_STENCIL_PASS_DEPTH_FAIL, &snapshot->stencil_dpfail);
+	glGetIntegerv (GL_STENCIL_PASS_DEPTH_PASS, &snapshot->stencil_dppass);
+	glGetIntegerv (GL_STENCIL_WRITEMASK, &snapshot->stencil_writemask);
+	glGetIntegerv (GL_CURRENT_PROGRAM, &snapshot->program);
+	glGetIntegerv (GL_VERTEX_ARRAY_BINDING, &snapshot->vao);
+	glGetIntegerv (GL_ARRAY_BUFFER_BINDING, &snapshot->array_buffer);
+	glGetIntegerv (GL_ELEMENT_ARRAY_BUFFER_BINDING, &snapshot->element_array_buffer);
+	glGetIntegerv (GL_ACTIVE_TEXTURE, &snapshot->active_texture);
+	snapshot->framebuffer_srgb = glIsEnabled (GL_FRAMEBUFFER_SRGB);
+	glGetIntegerv (GL_POLYGON_MODE, snapshot->polygon_mode);
+
+	prev_active_tex = snapshot->active_texture;
+	for (i = 0; i < 3; ++i)
 	{
-	case GLS_CULL_BACK: return "back";
-	case GLS_CULL_NONE: return "none";
-	case GLS_CULL_FRONT: return "front";
-	default: return "invalid";
+		GL_ActiveTextureFunc (GL_TEXTURE0 + i);
+		glGetIntegerv (GL_TEXTURE_BINDING_2D, &snapshot->tex2d[i]);
+		GL_GetIntegeri_vFunc (GL_SAMPLER_BINDING, i, &snapshot->sampler_bindings[i]);
 	}
+	GL_ActiveTextureFunc (prev_active_tex);
 }
 
-static void RB_LogIncomingStateDiff (rb_pass_t pass, unsigned expected_state, unsigned current_state,
-	GLint current_program, GLint tex2d_0, GLint tex2d_1, GLint tex2d_2)
+static qboolean RB_LogIncomingStateDiff (rb_pass_t pass, const rb_pass_baseline_gl_t *expected, const rb_gl_state_snapshot_t *actual)
 {
 	qboolean mismatch = false;
+	int i;
 
-	if ((current_state & GLS_MASK_BLEND) != (expected_state & GLS_MASK_BLEND))
-	{
-		if (!mismatch)
-			Con_Warning ("RB_BeginPass(%s): incoming state mismatch\n", rb_pass_info[pass].debug_name);
-		Con_Warning ("  blend: expected=%s actual=%s last_owner=%s\n",
-			RB_BlendName (expected_state),
-			RB_BlendName (current_state),
-			RB_DebugOwnerOrUnknown (rb_state_debug.last_blend_owner));
-		mismatch = true;
-	}
+	#define RB_LOG_MISMATCH(fmt, ...) \
+		do { \
+			if (!mismatch) \
+				Con_Warning ("RB_BeginPass(%s): incoming state mismatch\n", rb_pass_info[pass].debug_name); \
+			Con_Warning (fmt, __VA_ARGS__); \
+			mismatch = true; \
+		} while (0)
 
-	if ((current_state & (GLS_NO_ZTEST | GLS_NO_ZWRITE)) != (expected_state & (GLS_NO_ZTEST | GLS_NO_ZWRITE)))
+	if (actual->draw_fbo != expected->draw_fbo)
+		RB_LOG_MISMATCH ("  draw_fbo: expected=%d actual=%d last_owner=%s\n", expected->draw_fbo, actual->draw_fbo, RB_DebugOwnerOrUnknown (rb_state_debug.last_fbo_owner));
+	if (actual->read_fbo != expected->read_fbo)
+		RB_LOG_MISMATCH ("  read_fbo: expected=%d actual=%d last_owner=%s\n", expected->read_fbo, actual->read_fbo, RB_DebugOwnerOrUnknown (rb_state_debug.last_fbo_owner));
+	if (memcmp (actual->viewport, expected->viewport, sizeof (actual->viewport)) != 0)
+		RB_LOG_MISMATCH ("  viewport: expected=(%d %d %d %d) actual=(%d %d %d %d)\n", expected->viewport[0], expected->viewport[1], expected->viewport[2], expected->viewport[3], actual->viewport[0], actual->viewport[1], actual->viewport[2], actual->viewport[3]);
+	if ((actual->scissor_enable != (GLboolean)expected->scissor_enable) || memcmp (actual->scissor_box, expected->scissor_box, sizeof (actual->scissor_box)) != 0)
+		RB_LOG_MISMATCH ("  scissor: expected=(%s %d %d %d %d) actual=(%s %d %d %d %d)\n", RB_BoolName (expected->scissor_enable), expected->scissor_box[0], expected->scissor_box[1], expected->scissor_box[2], expected->scissor_box[3], RB_BoolName (actual->scissor_enable), actual->scissor_box[0], actual->scissor_box[1], actual->scissor_box[2], actual->scissor_box[3]);
+	if (actual->depth_func != (GLint)expected->depth_func || actual->depth_mask != expected->depth_mask)
+		RB_LOG_MISMATCH ("  depth: expected=(func=%#x mask=%d) actual=(func=%#x mask=%d) last_owner=%s\n", expected->depth_func, expected->depth_mask, actual->depth_func, actual->depth_mask, RB_DebugOwnerOrUnknown (rb_state_debug.last_depth_owner));
+	if (actual->blend_src != (GLint)expected->blend_src || actual->blend_dst != (GLint)expected->blend_dst || actual->blend_equation != (GLint)expected->blend_equation)
+		RB_LOG_MISMATCH ("  blend: expected=(src=%#x dst=%#x eq=%#x) actual=(src=%#x dst=%#x eq=%#x) last_owner=%s\n", expected->blend_src, expected->blend_dst, expected->blend_equation, actual->blend_src, actual->blend_dst, actual->blend_equation, RB_DebugOwnerOrUnknown (rb_state_debug.last_blend_owner));
+	if (actual->cull_enable != (GLboolean)((expected->cull_mode == GL_FRONT) || (expected->cull_mode == GL_BACK)) || (actual->cull_enable && actual->cull_mode != (GLint)expected->cull_mode))
+		RB_LOG_MISMATCH ("  cull: expected=(%s mode=%#x) actual=(%s mode=%#x) last_owner=%s\n", RB_BoolName ((expected->cull_mode == GL_FRONT) || (expected->cull_mode == GL_BACK)), expected->cull_mode, RB_BoolName (actual->cull_enable), actual->cull_mode, RB_DebugOwnerOrUnknown (rb_state_debug.last_cull_owner));
+	if (memcmp (actual->color_mask, expected->color_mask, sizeof (actual->color_mask)) != 0)
+		RB_LOG_MISMATCH ("  color_mask: expected=(%d%d%d%d) actual=(%d%d%d%d)\n", expected->color_mask[0], expected->color_mask[1], expected->color_mask[2], expected->color_mask[3], actual->color_mask[0], actual->color_mask[1], actual->color_mask[2], actual->color_mask[3]);
+	if (actual->stencil_enable != (GLboolean)expected->stencil_enable || actual->stencil_func != (GLint)expected->stencil_func || actual->stencil_ref != expected->stencil_ref || actual->stencil_value_mask != (GLint)expected->stencil_value_mask || actual->stencil_sfail != (GLint)expected->stencil_sfail || actual->stencil_dpfail != (GLint)expected->stencil_dpfail || actual->stencil_dppass != (GLint)expected->stencil_dppass || actual->stencil_writemask != (GLint)expected->stencil_writemask)
+		RB_LOG_MISMATCH ("  stencil: expected=(%s func=%#x ref=%d mask=%#x op=%#x/%#x/%#x wmask=%#x) actual=(%s func=%#x ref=%d mask=%#x op=%#x/%#x/%#x wmask=%#x)\n", RB_BoolName (expected->stencil_enable), expected->stencil_func, expected->stencil_ref, expected->stencil_value_mask, expected->stencil_sfail, expected->stencil_dpfail, expected->stencil_dppass, expected->stencil_writemask, RB_BoolName (actual->stencil_enable), actual->stencil_func, actual->stencil_ref, actual->stencil_value_mask, actual->stencil_sfail, actual->stencil_dpfail, actual->stencil_dppass, actual->stencil_writemask);
+	if (actual->program != (GLint)expected->program)
+		RB_LOG_MISMATCH ("  program: expected=%u actual=%d last_owner=%s\n", expected->program, actual->program, RB_DebugOwnerOrUnknown (rb_state_debug.last_program_owner));
+	if (actual->vao != (GLint)expected->vao)
+		RB_LOG_MISMATCH ("  vao: expected=%u actual=%d last_owner=%s\n", expected->vao, actual->vao, RB_DebugOwnerOrUnknown (rb_state_debug.last_vao_owner));
+	if (actual->array_buffer != (GLint)expected->array_buffer)
+		RB_LOG_MISMATCH ("  array_buffer: expected=%u actual=%d last_owner=%s\n", expected->array_buffer, actual->array_buffer, RB_DebugOwnerOrUnknown (rb_state_debug.last_array_buffer_owner));
+	if (actual->element_array_buffer != (GLint)expected->element_array_buffer)
+		RB_LOG_MISMATCH ("  element_array_buffer: expected=%u actual=%d last_owner=%s\n", expected->element_array_buffer, actual->element_array_buffer, RB_DebugOwnerOrUnknown (rb_state_debug.last_element_array_buffer_owner));
+	if (actual->active_texture != (GLint)expected->active_texture)
+		RB_LOG_MISMATCH ("  active_texture: expected=%d actual=%d\n", expected->active_texture - GL_TEXTURE0, actual->active_texture - GL_TEXTURE0);
+	for (i = 0; i < 3; ++i)
 	{
-		if (!mismatch)
-			Con_Warning ("RB_BeginPass(%s): incoming state mismatch\n", rb_pass_info[pass].debug_name);
-		Con_Warning ("  depth: expected=(ztest:%d zwrite:%d) actual=(ztest:%d zwrite:%d) last_owner=%s\n",
-			(expected_state & GLS_NO_ZTEST) == 0,
-			(expected_state & GLS_NO_ZWRITE) == 0,
-			(current_state & GLS_NO_ZTEST) == 0,
-			(current_state & GLS_NO_ZWRITE) == 0,
-			RB_DebugOwnerOrUnknown (rb_state_debug.last_depth_owner));
-		mismatch = true;
+		if (actual->tex2d[i] != 0)
+			RB_LOG_MISMATCH ("  texture[%d]: expected=0 actual=%d last_owner=%s\n", i, actual->tex2d[i], RB_DebugOwnerOrUnknown (rb_state_debug.last_texture_owner[i]));
+		if (actual->sampler_bindings[i] != (GLint)expected->sampler_bindings[i])
+			RB_LOG_MISMATCH ("  sampler[%d]: expected=%u actual=%d last_owner=%s\n", i, expected->sampler_bindings[i], actual->sampler_bindings[i], RB_DebugOwnerOrUnknown (rb_state_debug.last_sampler_owner[i]));
 	}
+	if (actual->framebuffer_srgb != (GLboolean)expected->framebuffer_srgb)
+		RB_LOG_MISMATCH ("  framebuffer_srgb: expected=%s actual=%s\n", RB_BoolName (expected->framebuffer_srgb), RB_BoolName (actual->framebuffer_srgb));
+	if (actual->polygon_mode[0] != (GLint)expected->polygon_mode || actual->polygon_mode[1] != (GLint)expected->polygon_mode)
+		RB_LOG_MISMATCH ("  polygon_mode: expected=%#x actual=%#x/%#x\n", expected->polygon_mode, actual->polygon_mode[0], actual->polygon_mode[1]);
 
-	if ((current_state & GLS_MASK_CULL) != (expected_state & GLS_MASK_CULL))
-	{
-		if (!mismatch)
-			Con_Warning ("RB_BeginPass(%s): incoming state mismatch\n", rb_pass_info[pass].debug_name);
-		Con_Warning ("  cull: expected=%s actual=%s last_owner=%s\n",
-			RB_CullName (expected_state),
-			RB_CullName (current_state),
-			RB_DebugOwnerOrUnknown (rb_state_debug.last_cull_owner));
-		mismatch = true;
-	}
-
-	if (current_program != 0)
-	{
-		if (!mismatch)
-			Con_Warning ("RB_BeginPass(%s): incoming state mismatch\n", rb_pass_info[pass].debug_name);
-		Con_Warning ("  program: expected=0 actual=%d last_owner=%s\n",
-			(int)current_program,
-			RB_DebugOwnerOrUnknown (rb_state_debug.last_program_owner));
-		mismatch = true;
-	}
-
-	if (tex2d_0 != 0)
-	{
-		if (!mismatch)
-			Con_Warning ("RB_BeginPass(%s): incoming state mismatch\n", rb_pass_info[pass].debug_name);
-		Con_Warning ("  texture[0]: expected=0 actual=%d last_owner=%s\n",
-			(int)tex2d_0,
-			RB_DebugOwnerOrUnknown (rb_state_debug.last_texture_owner[0]));
-		mismatch = true;
-	}
-	if (tex2d_1 != 0)
-	{
-		if (!mismatch)
-			Con_Warning ("RB_BeginPass(%s): incoming state mismatch\n", rb_pass_info[pass].debug_name);
-		Con_Warning ("  texture[1]: expected=0 actual=%d last_owner=%s\n",
-			(int)tex2d_1,
-			RB_DebugOwnerOrUnknown (rb_state_debug.last_texture_owner[1]));
-		mismatch = true;
-	}
-	if (tex2d_2 != 0)
-	{
-		if (!mismatch)
-			Con_Warning ("RB_BeginPass(%s): incoming state mismatch\n", rb_pass_info[pass].debug_name);
-		Con_Warning ("  texture[2]: expected=0 actual=%d last_owner=%s\n",
-			(int)tex2d_2,
-			RB_DebugOwnerOrUnknown (rb_state_debug.last_texture_owner[2]));
-		mismatch = true;
-	}
+	#undef RB_LOG_MISMATCH
 
 	if (mismatch && r_rb_assert_state.value > 0.f)
 		Sys_Error ("RB_BeginPass(%s): incoming state mismatch", rb_pass_info[pass].debug_name);
+
+	return mismatch;
 }
 #endif
 
-static void RB_ResetMinimalTextureBindings (void)
+static rb_pass_baseline_gl_t RB_BuildPassBaselineGL (rb_pass_t pass)
 {
-	GLint previous_active_tex;
+	rb_pass_baseline_gl_t baseline = rb_pass_info[pass].baseline_gl;
+
+	baseline.viewport[0] = glx;
+	baseline.viewport[1] = gly;
+	baseline.viewport[2] = glwidth;
+	baseline.viewport[3] = glheight;
+	baseline.scissor_box[0] = glx;
+	baseline.scissor_box[1] = gly;
+	baseline.scissor_box[2] = glwidth;
+	baseline.scissor_box[3] = glheight;
+	baseline.depth_func = gl_clipcontrol_able ? GL_GEQUAL : GL_LEQUAL;
+
+	return baseline;
+}
+
+static void RB_ApplyPassBaselineGL (const rb_pass_baseline_gl_t *baseline)
+{
 	int i;
 
-	glGetIntegerv (GL_ACTIVE_TEXTURE, &previous_active_tex);
-
+	RB_BindFramebufferWithOwner (GL_DRAW_FRAMEBUFFER, baseline->draw_fbo, "RB_BeginPass");
+	RB_BindFramebufferWithOwner (GL_READ_FRAMEBUFFER, baseline->read_fbo, "RB_BeginPass");
+	RB_Viewport (baseline->viewport[0], baseline->viewport[1], baseline->viewport[2], baseline->viewport[3]);
+	if (baseline->scissor_enable)
+		glEnable (GL_SCISSOR_TEST);
+	else
+		glDisable (GL_SCISSOR_TEST);
+	RB_Scissor (baseline->scissor_box[0], baseline->scissor_box[1], baseline->scissor_box[2], baseline->scissor_box[3]);
+	RB_DepthFunc (baseline->depth_func);
+	glDepthMask (baseline->depth_mask);
+	RB_BlendFunc (baseline->blend_src, baseline->blend_dst);
+	GL_BlendEquationFunc (baseline->blend_equation);
+	if (baseline->cull_mode == GL_FRONT || baseline->cull_mode == GL_BACK)
+	{
+		glEnable (GL_CULL_FACE);
+		glCullFace (baseline->cull_mode);
+	}
+	else
+	{
+		glDisable (GL_CULL_FACE);
+	}
+	glColorMask (baseline->color_mask[0], baseline->color_mask[1], baseline->color_mask[2], baseline->color_mask[3]);
+	if (baseline->stencil_enable)
+		glEnable (GL_STENCIL_TEST);
+	else
+		glDisable (GL_STENCIL_TEST);
+	glStencilFunc (baseline->stencil_func, baseline->stencil_ref, baseline->stencil_value_mask);
+	glStencilOp (baseline->stencil_sfail, baseline->stencil_dpfail, baseline->stencil_dppass);
+	glStencilMask (baseline->stencil_writemask);
+	RB_UseProgramWithOwner (baseline->program, "RB_BeginPass");
+	RB_BindVertexArrayWithOwner (baseline->vao, "RB_BeginPass");
+	RB_BindBufferWithOwner (GL_ARRAY_BUFFER, baseline->array_buffer, "RB_BeginPass");
+	RB_BindBufferWithOwner (GL_ELEMENT_ARRAY_BUFFER, baseline->element_array_buffer, "RB_BeginPass");
+	GL_ActiveTextureFunc (baseline->active_texture);
 	for (i = 0; i < 3; ++i)
 	{
 		GL_ActiveTextureFunc (GL_TEXTURE0 + i);
 		glBindTexture (GL_TEXTURE_2D, 0);
+		RB_BindSamplerWithOwner ((GLuint)i, baseline->sampler_bindings[i], "RB_BeginPass");
 	}
-	GL_ActiveTextureFunc (previous_active_tex);
+	GL_ActiveTextureFunc (baseline->active_texture);
+	if (baseline->framebuffer_srgb)
+		glEnable (GL_FRAMEBUFFER_SRGB);
+	else
+		glDisable (GL_FRAMEBUFFER_SRGB);
+	glPolygonMode (GL_FRONT_AND_BACK, baseline->polygon_mode);
 }
 
 void RB_SetState_Owner (unsigned mask, const char *owner)
@@ -326,9 +453,7 @@ void RB_SetPassSetupHook (rb_pass_setup_hook_t hook)
 
 void RB_BeginPass (rb_pass_t pass)
 {
-	GLint current_program = 0;
-	GLint previous_active_tex = 0;
-	GLint tex2d_0 = 0, tex2d_1 = 0, tex2d_2 = 0;
+	rb_pass_baseline_gl_t baseline_gl;
 
 	if (pass < 0 || pass >= PASS_COUNT)
 		pass = PASS_WORLD_OPAQUE;
@@ -336,28 +461,20 @@ void RB_BeginPass (rb_pass_t pass)
 	if (rb_pass_active)
 		RB_EndPass ();
 
+	baseline_gl = RB_BuildPassBaselineGL (pass);
+
 	#if RB_DEBUG_STATE
 	if (r_gl_state_validate.value > 0.f)
 	{
-		glGetIntegerv (GL_CURRENT_PROGRAM, &current_program);
-		glGetIntegerv (GL_ACTIVE_TEXTURE, &previous_active_tex);
-
-		GL_ActiveTextureFunc (GL_TEXTURE0);
-		glGetIntegerv (GL_TEXTURE_BINDING_2D, &tex2d_0);
-		GL_ActiveTextureFunc (GL_TEXTURE1);
-		glGetIntegerv (GL_TEXTURE_BINDING_2D, &tex2d_1);
-		GL_ActiveTextureFunc (GL_TEXTURE2);
-		glGetIntegerv (GL_TEXTURE_BINDING_2D, &tex2d_2);
-		GL_ActiveTextureFunc (previous_active_tex);
-
-		RB_LogIncomingStateDiff (pass, rb_pass_info[pass].baseline_state, glstate, current_program, tex2d_0, tex2d_1, tex2d_2);
+		rb_gl_state_snapshot_t incoming_state;
+		RB_CaptureGLStateSnapshot (&incoming_state);
+		RB_LogIncomingStateDiff (pass, &baseline_gl, &incoming_state);
 	}
 	#endif
 
 	GL_BeginGroup (rb_pass_info[pass].debug_name);
 	RB_SetState (rb_pass_info[pass].baseline_state);
-	RB_UseProgram (0);
-	RB_ResetMinimalTextureBindings ();
+	RB_ApplyPassBaselineGL (&baseline_gl);
 
 	if (rb_pass_setup_hook)
 		rb_pass_setup_hook (pass);


### PR DESCRIPTION
### Motivation
- Make render-pass transitions fully deterministic by explicitly setting a comprehensive GL baseline per pass instead of relying on partial `GL_SetState` only.
- Improve diagnostics for `r_gl_state_validate` by comparing a full captured GL snapshot against the expected baseline and reporting Soll/Ist mismatches for each state category.

### Description
- Added a typed per-pass GL baseline `rb_pass_baseline_gl_t` and embedded `baseline_gl` into `rb_pass_info_t` to record expected GL values (FBO draw/read, viewport, scissor + enable, depth func/mask, blend func/equation, cull mode, color mask, stencil enable/func/op/mask, program, VAO/VBO/EBO, active texture, sampler binds, framebuffer sRGB, polygon mode).
- Centralized baseline application in `RB_BeginPass` by building a runtime-aware baseline via `RB_BuildPassBaselineGL` and applying it with `RB_ApplyPassBaselineGL` before any pass-specific draws/hooks run.
- Implemented full-state capture in `RB_CaptureGLStateSnapshot` and extended diagnostics with `RB_LogIncomingStateDiff` to print expected vs actual (Soll/Ist) per state category including owner context when `RB_DEBUG_STATE` and `r_gl_state_validate` are enabled.
- Kept existing compact `baseline_state` behavior and integrated the new full baseline so runtime-dependent fields (viewport/scissor/depth func) are resolved dynamically in `RB_BuildPassBaselineGL` to remain deterministic while matching the current render context.

### Testing
- Ran a project build attempt with `make -C Quake -j4`; the build could not complete in this environment due to missing SDL2 development tooling and headers (`sdl2-config`, `SDL.h`), so no full binary test was produced (build failed early with missing SDL errors).
- Static checks: source file `Quake/rb_gl.c` compiles locally up to dependency resolution; no unit tests were available or executed in this environment.
- Runtime validation notes: with `r_gl_state_validate > 0` and `RB_DEBUG_STATE` active the code will now capture and log mismatches per pass (no mismatches expected once the baseline is used consistently).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1921893d4832ea5ba50d6d64ab3b8)