### PR TITLE
Add owner-tracked RB GL wrappers and migrate FogVol state mutations

### DIFF
--- a/Quake/r_fogvol.c
+++ b/Quake/r_fogvol.c
@@ -220,13 +220,13 @@ static void R_FogVol_LogBufferMarker (const char *marker)
 
 static void R_FogVol_SetDrawBufferDebug (GLenum buf, const char *marker)
 {
-	glDrawBuffer (buf);
+	RB_DrawBuffer (buf);
 	R_FogVol_LogBufferMarker (marker);
 }
 
 static void R_FogVol_SetReadBufferDebug (GLenum buf, const char *marker)
 {
-	glReadBuffer (buf);
+	RB_ReadBuffer (buf);
 	R_FogVol_LogBufferMarker (marker);
 }
 
@@ -501,26 +501,23 @@ static void R_FogVol_Restore3DRenderState (const fogvol_restore_state_t *state)
 {
 	R_FogVol_BindFramebuffer (GL_DRAW_FRAMEBUFFER, state->draw_fbo);
 	R_FogVol_BindFramebuffer (GL_READ_FRAMEBUFFER, state->read_fbo);
-	glDrawBuffer ((GLenum)state->draw_buffer);
-	glReadBuffer ((GLenum)state->read_buffer);
+	RB_DrawBuffer ((GLenum)state->draw_buffer);
+	RB_ReadBuffer ((GLenum)state->read_buffer);
 	RB_Viewport (state->viewport[0], state->viewport[1], state->viewport[2], state->viewport[3]);
 	if (state->scissor_test)
 		GL_SetScissorEnabled (true);
 	else
 		GL_SetScissorEnabled (false);
-	glScissor (state->scissor_box[0], state->scissor_box[1], state->scissor_box[2], state->scissor_box[3]);
+	RB_Scissor (state->scissor_box[0], state->scissor_box[1], state->scissor_box[2], state->scissor_box[3]);
 	R_FogVol_UseProgram ((GLuint)state->program);
 	R_FogVol_BindVertexArray ((GLuint)state->vao);
 	GL_ActiveTextureFunc ((GLenum)state->active_texture);
 
-	glColorMask (GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+	RB_ColorMask (GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
 	R_FogVol_SetDepthMask (true);
-	glPolygonMode (GL_FRONT_AND_BACK, GL_FILL);
+	RB_PolygonMode (GL_FRONT_AND_BACK, GL_FILL);
 	RB_SetState (state->glstate_bits);
-	if (state->framebuffer_srgb)
-		glEnable (GL_FRAMEBUFFER_SRGB);
-	else
-		glDisable (GL_FRAMEBUFFER_SRGB);
+	RB_EnableFramebufferSRGB (state->framebuffer_srgb);
 }
 
 static qboolean R_FogVol_MatrixInverse4x4 (const float m[16], float out[16])
@@ -1132,7 +1129,7 @@ void R_FogVol_Render (void)
 	R_FogVol_UseProgram (glprogs.fogvol);
 	RB_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
 	GL_SetScissorEnabled (false);
-	glColorMask (GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+	RB_ColorMask (GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
 	GL_Uniform1iFunc (0, steps);
 	GL_Uniform1iFunc (1, r_fogvol_noise.value > 0.f ? 1 : 0);
 	GL_Uniform1iFunc (2, mode);
@@ -1252,7 +1249,7 @@ void R_FogVol_Render (void)
 		GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, src_tex);
 		GL_BindNative (GL_TEXTURE1, GL_TEXTURE_2D, depth_tex);
 		GL_SetScissorEnabled (true);
-		glScissor (x0, y0, x1 - x0, y1 - y0);
+		RB_Scissor (x0, y0, x1 - x0, y1 - y0);
 		GL_Uniform1iFunc (3, i);
 		RB_DrawArrays (GL_TRIANGLES, 0, 3);
 		GL_SetScissorEnabled (false);

--- a/Quake/rb_gl.c
+++ b/Quake/rb_gl.c
@@ -141,6 +141,13 @@ typedef struct rb_state_debug_s
 	const char *last_array_buffer_owner;
 	const char *last_element_array_buffer_owner;
 	const char *last_sampler_owner[3];
+	const char *last_color_mask_owner;
+	const char *last_scissor_owner;
+	const char *last_stencil_owner;
+	const char *last_polygon_mode_owner;
+	const char *last_framebuffer_srgb_owner;
+	const char *last_draw_buffer_owner;
+	const char *last_read_buffer_owner;
 } rb_state_debug_t;
 
 static rb_state_debug_t rb_state_debug;
@@ -443,7 +450,7 @@ static void RB_ApplyPassBaselineGL (const rb_pass_baseline_gl_t *baseline)
 		glEnable (GL_SCISSOR_TEST);
 	else
 		glDisable (GL_SCISSOR_TEST);
-	RB_Scissor (baseline->scissor_box[0], baseline->scissor_box[1], baseline->scissor_box[2], baseline->scissor_box[3]);
+	RB_ScissorWithOwner (baseline->scissor_box[0], baseline->scissor_box[1], baseline->scissor_box[2], baseline->scissor_box[3], "RB_BeginPass");
 	RB_DepthFunc (baseline->depth_func);
 	glDepthMask (baseline->depth_mask);
 	RB_BlendFunc (baseline->blend_src, baseline->blend_dst);
@@ -457,14 +464,14 @@ static void RB_ApplyPassBaselineGL (const rb_pass_baseline_gl_t *baseline)
 	{
 		glDisable (GL_CULL_FACE);
 	}
-	glColorMask (baseline->color_mask[0], baseline->color_mask[1], baseline->color_mask[2], baseline->color_mask[3]);
+	RB_ColorMaskWithOwner (baseline->color_mask[0], baseline->color_mask[1], baseline->color_mask[2], baseline->color_mask[3], "RB_BeginPass");
 	if (baseline->stencil_enable)
 		glEnable (GL_STENCIL_TEST);
 	else
 		glDisable (GL_STENCIL_TEST);
-	glStencilFunc (baseline->stencil_func, baseline->stencil_ref, baseline->stencil_value_mask);
-	glStencilOp (baseline->stencil_sfail, baseline->stencil_dpfail, baseline->stencil_dppass);
-	glStencilMask (baseline->stencil_writemask);
+	RB_StencilFuncWithOwner (baseline->stencil_func, baseline->stencil_ref, baseline->stencil_value_mask, "RB_BeginPass");
+	RB_StencilOpWithOwner (baseline->stencil_sfail, baseline->stencil_dpfail, baseline->stencil_dppass, "RB_BeginPass");
+	RB_StencilMaskWithOwner (baseline->stencil_writemask, "RB_BeginPass");
 	RB_UseProgramWithOwner (baseline->program, "RB_BeginPass");
 	RB_BindVertexArrayWithOwner (baseline->vao, "RB_BeginPass");
 	RB_BindBufferWithOwner (GL_ARRAY_BUFFER, baseline->array_buffer, "RB_BeginPass");
@@ -477,11 +484,8 @@ static void RB_ApplyPassBaselineGL (const rb_pass_baseline_gl_t *baseline)
 		RB_BindSamplerWithOwner ((GLuint)i, baseline->sampler_bindings[i], "RB_BeginPass");
 	}
 	GL_ActiveTextureFunc (baseline->active_texture);
-	if (baseline->framebuffer_srgb)
-		glEnable (GL_FRAMEBUFFER_SRGB);
-	else
-		glDisable (GL_FRAMEBUFFER_SRGB);
-	glPolygonMode (GL_FRONT_AND_BACK, baseline->polygon_mode);
+	RB_EnableFramebufferSRGBWithOwner (baseline->framebuffer_srgb, "RB_BeginPass");
+	RB_PolygonModeWithOwner (GL_FRONT_AND_BACK, baseline->polygon_mode, "RB_BeginPass");
 }
 
 void RB_SetState_Owner (unsigned mask, const char *owner)
@@ -560,6 +564,73 @@ void RB_BindSampler_Owner (GLuint unit, GLuint sampler, const char *owner)
 	GL_BindSamplerFunc (unit, sampler);
 }
 
+
+void RB_ColorMask_Owner (GLboolean red, GLboolean green, GLboolean blue, GLboolean alpha, const char *owner)
+{
+	#if RB_DEBUG_STATE
+	rb_state_debug.last_color_mask_owner = owner;
+	#endif
+
+	glColorMask (red, green, blue, alpha);
+}
+
+void RB_Scissor_Owner (GLint x, GLint y, GLsizei width, GLsizei height, const char *owner)
+{
+	#if RB_DEBUG_STATE
+	rb_state_debug.last_scissor_owner = owner;
+	#endif
+
+	glScissor (x, y, width, height);
+}
+
+void RB_EnableFramebufferSRGB_Owner (qboolean enable, const char *owner)
+{
+	#if RB_DEBUG_STATE
+	rb_state_debug.last_framebuffer_srgb_owner = owner;
+	#endif
+
+	if (enable)
+		glEnable (GL_FRAMEBUFFER_SRGB);
+	else
+		glDisable (GL_FRAMEBUFFER_SRGB);
+}
+
+void RB_PolygonMode_Owner (GLenum face, GLenum mode, const char *owner)
+{
+	#if RB_DEBUG_STATE
+	rb_state_debug.last_polygon_mode_owner = owner;
+	#endif
+
+	glPolygonMode (face, mode);
+}
+
+void RB_StencilFunc_Owner (GLenum func, GLint ref, GLuint mask, const char *owner)
+{
+	#if RB_DEBUG_STATE
+	rb_state_debug.last_stencil_owner = owner;
+	#endif
+
+	glStencilFunc (func, ref, mask);
+}
+
+void RB_StencilOp_Owner (GLenum sfail, GLenum dpfail, GLenum dppass, const char *owner)
+{
+	#if RB_DEBUG_STATE
+	rb_state_debug.last_stencil_owner = owner;
+	#endif
+
+	glStencilOp (sfail, dpfail, dppass);
+}
+
+void RB_StencilMask_Owner (GLuint mask, const char *owner)
+{
+	#if RB_DEBUG_STATE
+	rb_state_debug.last_stencil_owner = owner;
+	#endif
+
+	glStencilMask (mask);
+}
+
 void RB_DrawArrays (GLenum mode, GLint first, GLsizei count)
 {
 	glDrawArrays (mode, first, count);
@@ -582,7 +653,7 @@ void RB_Viewport (GLint x, GLint y, GLsizei width, GLsizei height)
 
 void RB_Scissor (GLint x, GLint y, GLsizei width, GLsizei height)
 {
-	glScissor (x, y, width, height);
+	RB_ScissorWithOwner (x, y, width, height, "RB_Scissor");
 }
 
 void RB_DepthFunc (GLenum func)
@@ -595,13 +666,21 @@ void RB_BlendFunc (GLenum sfactor, GLenum dfactor)
 	glBlendFunc (sfactor, dfactor);
 }
 
-void RB_DrawBuffer (GLenum buf)
+void RB_DrawBuffer_Owner (GLenum buf, const char *owner)
 {
+	#if RB_DEBUG_STATE
+	rb_state_debug.last_draw_buffer_owner = owner;
+	#endif
+
 	glDrawBuffer (buf);
 }
 
-void RB_ReadBuffer (GLenum src)
+void RB_ReadBuffer_Owner (GLenum src, const char *owner)
 {
+	#if RB_DEBUG_STATE
+	rb_state_debug.last_read_buffer_owner = owner;
+	#endif
+
 	glReadBuffer (src);
 }
 
@@ -647,7 +726,7 @@ const char *RB_DebugStateOwnersString (void)
 #if RB_DEBUG_STATE
 	static char info[768];
 	q_snprintf (info, sizeof (info),
-		"pass=%s owner(blend=%s depth=%s cull=%s prog=%s tex0=%s tex1=%s tex2=%s fbo=%s vao=%s arrbuf=%s elembuf=%s samp0=%s samp1=%s samp2=%s)",
+		"pass=%s owner(blend=%s depth=%s cull=%s prog=%s tex0=%s tex1=%s tex2=%s fbo=%s vao=%s arrbuf=%s elembuf=%s samp0=%s samp1=%s samp2=%s colormask=%s scissor=%s stencil=%s polygon=%s fbo_srgb=%s drawbuf=%s readbuf=%s)",
 		rb_pass_info[rb_current_pass].debug_name,
 		RB_DebugOwnerOrUnknown (rb_state_debug.last_blend_owner),
 		RB_DebugOwnerOrUnknown (rb_state_debug.last_depth_owner),
@@ -662,7 +741,14 @@ const char *RB_DebugStateOwnersString (void)
 		RB_DebugOwnerOrUnknown (rb_state_debug.last_element_array_buffer_owner),
 		RB_DebugOwnerOrUnknown (rb_state_debug.last_sampler_owner[0]),
 		RB_DebugOwnerOrUnknown (rb_state_debug.last_sampler_owner[1]),
-		RB_DebugOwnerOrUnknown (rb_state_debug.last_sampler_owner[2]));
+		RB_DebugOwnerOrUnknown (rb_state_debug.last_sampler_owner[2]),
+		RB_DebugOwnerOrUnknown (rb_state_debug.last_color_mask_owner),
+		RB_DebugOwnerOrUnknown (rb_state_debug.last_scissor_owner),
+		RB_DebugOwnerOrUnknown (rb_state_debug.last_stencil_owner),
+		RB_DebugOwnerOrUnknown (rb_state_debug.last_polygon_mode_owner),
+		RB_DebugOwnerOrUnknown (rb_state_debug.last_framebuffer_srgb_owner),
+		RB_DebugOwnerOrUnknown (rb_state_debug.last_draw_buffer_owner),
+		RB_DebugOwnerOrUnknown (rb_state_debug.last_read_buffer_owner));
 	return info;
 #else
 	return "pass=<tracker disabled>";

--- a/Quake/rb_gl.h
+++ b/Quake/rb_gl.h
@@ -22,6 +22,15 @@ void RB_BindFramebuffer_Owner (GLenum target, GLuint framebuffer, const char *ow
 void RB_BindVertexArray_Owner (GLuint array, const char *owner);
 void RB_BindBuffer_Owner (GLenum target, GLuint buffer, const char *owner);
 void RB_BindSampler_Owner (GLuint unit, GLuint sampler, const char *owner);
+void RB_ColorMask_Owner (GLboolean red, GLboolean green, GLboolean blue, GLboolean alpha, const char *owner);
+void RB_Scissor_Owner (GLint x, GLint y, GLsizei width, GLsizei height, const char *owner);
+void RB_EnableFramebufferSRGB_Owner (qboolean enable, const char *owner);
+void RB_PolygonMode_Owner (GLenum face, GLenum mode, const char *owner);
+void RB_StencilFunc_Owner (GLenum func, GLint ref, GLuint mask, const char *owner);
+void RB_StencilOp_Owner (GLenum sfail, GLenum dpfail, GLenum dppass, const char *owner);
+void RB_StencilMask_Owner (GLuint mask, const char *owner);
+void RB_DrawBuffer_Owner (GLenum buf, const char *owner);
+void RB_ReadBuffer_Owner (GLenum src, const char *owner);
 #define RB_SetState(mask) RB_SetState_Owner ((mask), __func__)
 #define RB_UseProgram(program) RB_UseProgram_Owner ((program), __func__)
 #define RB_BindTexture(texunit, texture) RB_BindTexture_Owner ((texunit), (texture), __func__)
@@ -29,6 +38,14 @@ void RB_BindSampler_Owner (GLuint unit, GLuint sampler, const char *owner);
 #define RB_BindVertexArray(array) RB_BindVertexArray_Owner ((array), __func__)
 #define RB_BindBuffer(target, buffer) RB_BindBuffer_Owner ((target), (buffer), __func__)
 #define RB_BindSampler(unit, sampler) RB_BindSampler_Owner ((unit), (sampler), __func__)
+#define RB_ColorMask(red, green, blue, alpha) RB_ColorMask_Owner ((red), (green), (blue), (alpha), __func__)
+#define RB_EnableFramebufferSRGB(enable) RB_EnableFramebufferSRGB_Owner ((enable), __func__)
+#define RB_PolygonMode(face, mode) RB_PolygonMode_Owner ((face), (mode), __func__)
+#define RB_StencilFunc(func, ref, mask) RB_StencilFunc_Owner ((func), (ref), (mask), __func__)
+#define RB_StencilOp(sfail, dpfail, dppass) RB_StencilOp_Owner ((sfail), (dpfail), (dppass), __func__)
+#define RB_StencilMask(mask) RB_StencilMask_Owner ((mask), __func__)
+#define RB_DrawBuffer(buf) RB_DrawBuffer_Owner ((buf), __func__)
+#define RB_ReadBuffer(src) RB_ReadBuffer_Owner ((src), __func__)
 #define RB_SetStateWithOwner(mask, owner) RB_SetState_Owner ((mask), (owner))
 #define RB_UseProgramWithOwner(program, owner) RB_UseProgram_Owner ((program), (owner))
 #define RB_BindTextureWithOwner(texunit, texture, owner) RB_BindTexture_Owner ((texunit), (texture), (owner))
@@ -36,6 +53,15 @@ void RB_BindSampler_Owner (GLuint unit, GLuint sampler, const char *owner);
 #define RB_BindVertexArrayWithOwner(array, owner) RB_BindVertexArray_Owner ((array), (owner))
 #define RB_BindBufferWithOwner(target, buffer, owner) RB_BindBuffer_Owner ((target), (buffer), (owner))
 #define RB_BindSamplerWithOwner(unit, sampler, owner) RB_BindSampler_Owner ((unit), (sampler), (owner))
+#define RB_ColorMaskWithOwner(red, green, blue, alpha, owner) RB_ColorMask_Owner ((red), (green), (blue), (alpha), (owner))
+#define RB_ScissorWithOwner(x, y, width, height, owner) RB_Scissor_Owner ((x), (y), (width), (height), (owner))
+#define RB_EnableFramebufferSRGBWithOwner(enable, owner) RB_EnableFramebufferSRGB_Owner ((enable), (owner))
+#define RB_PolygonModeWithOwner(face, mode, owner) RB_PolygonMode_Owner ((face), (mode), (owner))
+#define RB_StencilFuncWithOwner(func, ref, mask, owner) RB_StencilFunc_Owner ((func), (ref), (mask), (owner))
+#define RB_StencilOpWithOwner(sfail, dpfail, dppass, owner) RB_StencilOp_Owner ((sfail), (dpfail), (dppass), (owner))
+#define RB_StencilMaskWithOwner(mask, owner) RB_StencilMask_Owner ((mask), (owner))
+#define RB_DrawBufferWithOwner(buf, owner) RB_DrawBuffer_Owner ((buf), (owner))
+#define RB_ReadBufferWithOwner(src, owner) RB_ReadBuffer_Owner ((src), (owner))
 void RB_DrawArrays (GLenum mode, GLint first, GLsizei count);
 void RB_DrawElements (GLenum mode, GLsizei count, GLenum type, const GLvoid *indices);
 void RB_Clear (GLbitfield mask);
@@ -43,8 +69,6 @@ void RB_Viewport (GLint x, GLint y, GLsizei width, GLsizei height);
 void RB_Scissor (GLint x, GLint y, GLsizei width, GLsizei height);
 void RB_DepthFunc (GLenum func);
 void RB_BlendFunc (GLenum sfactor, GLenum dfactor);
-void RB_DrawBuffer (GLenum buf);
-void RB_ReadBuffer (GLenum src);
 
 typedef void (*rb_pass_setup_hook_t) (rb_pass_t pass);
 void RB_SetPassSetupHook (rb_pass_setup_hook_t hook);


### PR DESCRIPTION
### Motivation

- Centralize GL state mutations behind the render-backend (`rb_gl`) so FogVol no longer performs undocumented direct `gl*` state changes and so owner tracking can attribute who last changed each state.
- Extend debug diagnostics to include additional state classes (color mask, scissor, stencil, polygon mode, sRGB, draw/read buffer) for easier state mismatch investigation.

### Description

- Added owner-tracked wrappers and macros to `Quake/rb_gl.h` for `ColorMask`, `Scissor`, `StencilFunc/Op/Mask`, `PolygonMode`, `Enable/Disable(GL_FRAMEBUFFER_SRGB)`, and `DrawBuffer/ReadBuffer` and corresponding `*WithOwner` variants. (file: `Quake/rb_gl.h`)
- Implemented the new `*_Owner` wrappers in `Quake/rb_gl.c`, including debug-owner bookkeeping fields (`last_color_mask_owner`, `last_scissor_owner`, `last_stencil_owner`, `last_polygon_mode_owner`, `last_framebuffer_srgb_owner`, `last_draw_buffer_owner`, `last_read_buffer_owner`). (file: `Quake/rb_gl.c`)
- Switched `RB_ApplyPassBaselineGL` to use the new wrappers so pass baseline setup records owners for these states. (file: `Quake/rb_gl.c`)
- Extended `RB_DebugStateOwnersString` to include the new owner fields so debug output reports the new state classes. (file: `Quake/rb_gl.c`)
- Replaced direct GL state calls in Fog volume code with the RB wrappers: `glDrawBuffer`/`glReadBuffer` → `RB_DrawBuffer`/`RB_ReadBuffer`, `glScissor` → `RB_Scissor`, `glColorMask` → `RB_ColorMask`, `glPolygonMode` → `RB_PolygonMode`, `glEnable/glDisable(GL_FRAMEBUFFER_SRGB)` → `RB_EnableFramebufferSRGB`. This covers restore path and render loop changes. (file: `Quake/r_fogvol.c`)

### Testing

- Ran a targeted search with ripgrep to verify FogVol no longer contains direct calls to the migrated GL state functions using `rg` for `glColorMask|glScissor|glDrawBuffer|glReadBuffer|glPolygonMode|Enable\s*\(GL_FRAMEBUFFER_SRGB|Disable\s*\(GL_FRAMEBUFFER_SRGB` and observed no matches in `Quake/r_fogvol.c`, satisfying the Done criterion for FogVol.
- Attempted a local build with `make -j2` in `Quake/`; the build in this environment failed due to missing system dependencies (`sdl2-config` / `SDL.h`), so a full compile/test could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a19caceb78832eae02c8fe9db66751)