### PR TITLE
Route GL backend DrawElements through RB instrumentation

### DIFF
--- a/Quake/backend_gl_exec.c
+++ b/Quake/backend_gl_exec.c
@@ -120,7 +120,7 @@ static void BackendGL_DrawArrays (GLenum mode, GLint first, GLsizei count)
 
 static void BackendGL_DrawElements (GLenum mode, GLsizei count, GLenum type, const GLvoid *indices)
 {
-	glDrawElements (mode, count, type, indices);
+	RB_DrawElements (mode, count, type, indices);
 }
 
 static void BackendGL_DispatchCompute (GLuint num_groups_x, GLuint num_groups_y, GLuint num_groups_z)


### PR DESCRIPTION
### Motivation
- Einheitliche Instrumentierung aller GL-Backends-Draw-Entrypoints, damit Draw-Aufrufe konsistent durch die RB-Schicht laufen und Debug-Owner/Pass-Kontext erhalten bleiben.

### Description
- Ersetzte in `Quake/backend_gl_exec.c` die direkte `glDrawElements`-Aufrufstelle in `BackendGL_DrawElements` durch `RB_DrawElements`, sodass sowohl `BackendGL_DrawArrays` als auch `BackendGL_DrawElements` über die RB-Wrappers laufen.

### Testing
- Ausgeführt: `rg -n "glDrawElements|RB_DrawElements|BackendGL_Draw" Quake/backend_gl_exec.c Quake/rb_gl.c` und `git show --stat --oneline HEAD`, welche bestätigen, dass `BackendGL_DrawElements` nun `RB_DrawElements` aufruft und das finale `glDrawElements` weiterhin in `Quake/rb_gl.c` verbleibt.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a19f05dda0832ead33629c36aed8b2)