### PR TITLE
Renderer: capability-gated backend block dispatch with reasoned legacy fallback

### DIFF
--- a/Quake/backend_gl_exec.c
+++ b/Quake/backend_gl_exec.c
@@ -194,7 +194,7 @@ void RBackend_DispatchUpdateScreen (void (*legacy_fn)(void))
 }
 
 void RBackend_DispatchBlock (const char *block_name, cvar_t *toggle, qboolean backend_path_available,
-	rbackend_block_fn_t backend_fn, void (*legacy_fn)(void), qboolean *warned_once)
+	const char *unavailable_reason, rbackend_block_fn_t backend_fn, void (*legacy_fn)(void), qboolean *warned_once)
 {
 	const qboolean backend_globally_enabled = ((int)r_backend.value == 1);
 	const qboolean block_toggle_enabled = toggle && (toggle->value != 0.f);
@@ -213,8 +213,9 @@ void RBackend_DispatchBlock (const char *block_name, cvar_t *toggle, qboolean ba
 	{
 		if (warned_once && !*warned_once)
 		{
-			Con_Warning ("render backend: %s backend path unavailable, falling back to legacy\n",
-				block_name ? block_name : "(unknown block)");
+			Con_Warning ("render backend: %s backend path unavailable (%s), falling back to legacy\n",
+				block_name ? block_name : "(unknown block)",
+				unavailable_reason ? unavailable_reason : "unspecified");
 			*warned_once = true;
 		}
 		legacy_fn ();

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -48,6 +48,83 @@ static qboolean r_backend_alias_warned = false;
 static qboolean r_backend_world_warned = false;
 static qboolean r_backend_fogvol_warned = false;
 
+static qboolean R_BackendAliasPathAvailable (const char **reason)
+{
+	if (reason)
+		*reason = NULL;
+
+	if (!glprogs.alias[0][0][0][0])
+	{
+		if (reason)
+			*reason = "missing shader program: alias";
+		return false;
+	}
+
+	return true;
+}
+
+static qboolean R_BackendWorldPathAvailable (const char **reason)
+{
+	if (reason)
+		*reason = NULL;
+
+	if (!glprogs.world[0][0][0])
+	{
+		if (reason)
+			*reason = "missing shader program: world";
+		return false;
+	}
+
+	if (!framebufs.scene.fbo)
+	{
+		if (reason)
+			*reason = "missing world framebuffer: scene.fbo";
+		return false;
+	}
+
+	return true;
+}
+
+static qboolean R_BackendParticlesPathAvailable (const char **reason)
+{
+	if (reason)
+		*reason = NULL;
+
+	if (!glprogs.particles[0][0])
+	{
+		if (reason)
+			*reason = "missing shader program: particles";
+		return false;
+	}
+
+	return true;
+}
+
+static qboolean R_BackendFogvolPathAvailable (const char **reason)
+{
+	if (reason)
+		*reason = NULL;
+
+	if (r_fogvol.value <= 0.f)
+		return true;
+
+	if (!glprogs.fogvol || !glprogs.fogvol_upsample || !glprogs.fogvol_temporal)
+	{
+		if (reason)
+			*reason = "missing shader program: fogvol";
+		return false;
+	}
+
+	if (!framebufs.fogvol.fbo[0] || !framebufs.fogvol.fbo[1] || !framebufs.fogvol.color_tex[0] || !framebufs.fogvol.color_tex[1])
+	{
+		if (reason)
+			*reason = "missing fog volume framebuffer resources";
+		return false;
+	}
+
+	return true;
+}
+
 static void R_DrawFogvol_Legacy (void);
 static qboolean R_DrawFogvol_Backend (void);
 
@@ -3668,6 +3745,8 @@ void R_DrawEntitiesOnList (qboolean alphapass) //johnfitz -- added parameter
 {
 	int* ofs;
 	entity_t** entlist = cl_sorted_visedicts;
+	const char *alias_unavailable_reason = NULL;
+	qboolean alias_backend_available;
 
 	GL_BeginGroup (alphapass ? "Translucent entities" : "Opaque entities");
 
@@ -3675,7 +3754,8 @@ void R_DrawEntitiesOnList (qboolean alphapass) //johnfitz -- added parameter
 	R_DrawBrushModels (entlist + ofs[2 * mod_brush], ofs[2 * mod_brush + 1] - ofs[2 * mod_brush]);
 	r_alias_dispatch_entlist = entlist + ofs[2 * mod_alias];
 	r_alias_dispatch_count = ofs[2 * mod_alias + 1] - ofs[2 * mod_alias];
-	RBackend_DispatchBlock ("alias", &r_backend_alias, true,
+	alias_backend_available = R_BackendAliasPathAvailable (&alias_unavailable_reason);
+	RBackend_DispatchBlock ("alias", &r_backend_alias, alias_backend_available, alias_unavailable_reason,
 		R_DrawAliasBatch_Backend, R_DrawAliasBatch_Legacy, &r_backend_alias_warned);
 	if (!alphapass)
 		R_DrawSpriteModels (entlist + cl_modtype_ofs[2 * mod_sprite], cl_modtype_ofs[2 * mod_sprite + 2] - cl_modtype_ofs[2 * mod_sprite]);
@@ -3715,6 +3795,8 @@ R_DrawViewModel -- johnfitz -- gutted
 void R_DrawViewModel (void)
 {
 	entity_t* e = &cl.viewent;
+	const char *alias_unavailable_reason = NULL;
+	qboolean alias_backend_available;
 
 	if (!R_IsViewModelVisible ())
 		return;
@@ -3725,7 +3807,8 @@ void R_DrawViewModel (void)
 	GL_DepthRange (ZRANGE_VIEWMODEL);
 	r_alias_dispatch_entlist = &e;
 	r_alias_dispatch_count = 1;
-	RBackend_DispatchBlock ("alias", &r_backend_alias, true,
+	alias_backend_available = R_BackendAliasPathAvailable (&alias_unavailable_reason);
+	RBackend_DispatchBlock ("alias", &r_backend_alias, alias_backend_available, alias_unavailable_reason,
 		R_DrawAliasBatch_Backend, R_DrawAliasBatch_Legacy, &r_backend_alias_warned);
 	GL_DepthRange (ZRANGE_FULL);
 
@@ -4809,6 +4892,10 @@ R_RenderScene
 */
 void R_RenderScene (void)
 {
+	const char *world_unavailable_reason = NULL;
+	const char *particles_unavailable_reason = NULL;
+	qboolean world_backend_available;
+	qboolean particles_backend_available;
 	R_SetupScene (); //johnfitz -- this does everything that should be done once per call to RenderScene
 	R_SetupGL ();
 	R_Clear ();
@@ -4820,13 +4907,15 @@ void R_RenderScene (void)
 	/* Backend migration order (keep incremental PRs consistent):
 	 * UI/Console/2D -> Fullscreen passes -> Particles/Sprites/Beams -> Alias ->
 	 * World (Sky->Opaque->Alpha) -> PostFX graph. */
-	RBackend_DispatchBlock ("world_opaque", &r_backend_world, true,
+	world_backend_available = R_BackendWorldPathAvailable (&world_unavailable_reason);
+	particles_backend_available = R_BackendParticlesPathAvailable (&particles_unavailable_reason);
+	RBackend_DispatchBlock ("world_opaque", &r_backend_world, world_backend_available, world_unavailable_reason,
 		R_DrawWorldOpaque_Backend, R_DrawWorldOpaque_Legacy, &r_backend_world_warned);
-	RBackend_DispatchBlock ("particles_opaque", &r_backend_particles, true,
+	RBackend_DispatchBlock ("particles_opaque", &r_backend_particles, particles_backend_available, particles_unavailable_reason,
 		R_DrawParticlesOpaque_Backend, R_DrawParticlesOpaque_Legacy, &r_backend_particles_warned);
-	RBackend_DispatchBlock ("world_alpha", &r_backend_world, true,
+	RBackend_DispatchBlock ("world_alpha", &r_backend_world, world_backend_available, world_unavailable_reason,
 		R_DrawWorldAlpha_Backend, R_DrawWorldAlpha_Legacy, &r_backend_world_warned);
-	RBackend_DispatchBlock ("particles_alpha", &r_backend_particles, true,
+	RBackend_DispatchBlock ("particles_alpha", &r_backend_particles, particles_backend_available, particles_unavailable_reason,
 		R_DrawParticlesAlpha_Backend, R_DrawParticlesAlpha_Legacy, &r_backend_particles_warned);
 	R_ShowTris (); //johnfitz
 	R_ShowBoundingBoxes (); //johnfitz
@@ -4989,6 +5078,8 @@ R_RenderView
 static void R_RenderView_Legacy (void)
 {
 	double	time1, time2;
+	const char *fogvol_unavailable_reason = NULL;
+	qboolean fogvol_backend_available;
 
 	if (r_norefresh.value)
 		return;
@@ -5020,7 +5111,8 @@ static void R_RenderView_Legacy (void)
         r_fogvol_draw_called++;
         if (r_gl_state_validate.value > 0.f)
                 Con_DPrintf ("fogvol_draw_called=%d r_fogvol=%.1f\n", r_fogvol_draw_called, r_fogvol.value);
-	RBackend_DispatchBlock ("fogvol", &r_backend_fogvol, true,
+	fogvol_backend_available = R_BackendFogvolPathAvailable (&fogvol_unavailable_reason);
+	RBackend_DispatchBlock ("fogvol", &r_backend_fogvol, fogvol_backend_available, fogvol_unavailable_reason,
 		R_DrawFogvol_Backend, R_DrawFogvol_Legacy, &r_backend_fogvol_warned);
         /* BUG FIX #1: Capture fog params while r_framedata.fogdata is still valid.
          * GL_GenerateSSAOTexture (called later in GL_PostProcess) uses these for

--- a/Quake/gl_screen.c
+++ b/Quake/gl_screen.c
@@ -2107,6 +2107,46 @@ void SCR_TileClear (void)
 static qboolean scr_backend_ui_warned = false;
 static qboolean scr_backend_postfx_warned = false;
 
+static qboolean SCR_BackendUIPathAvailable (const char **reason)
+{
+	if (reason)
+		*reason = NULL;
+
+	if (!glprogs.gui)
+	{
+		if (reason)
+			*reason = "missing shader program: gui";
+		return false;
+	}
+
+	return true;
+}
+
+static qboolean SCR_BackendPostFXPathAvailable (const char **reason)
+{
+	if (reason)
+		*reason = NULL;
+
+	if (!GL_NeedsPostprocess ())
+		return true;
+
+	if (!framebufs.composite.fbo || !framebufs.composite.color_tex)
+	{
+		if (reason)
+			*reason = "missing postfx framebuffer resources";
+		return false;
+	}
+
+	if (!glprogs.postprocess[0])
+	{
+		if (reason)
+			*reason = "missing shader program: postprocess";
+		return false;
+	}
+
+	return true;
+}
+
 static void SCR_DrawUI2D_Legacy (void)
 {
 	RB_BeginPass (PASS_UI2D);
@@ -2197,6 +2237,10 @@ needs almost the entire 256k of stack space!
 */
 static void SCR_UpdateScreen_Legacy (void)
 {
+	const char *postfx_unavailable_reason = NULL;
+	const char *ui_unavailable_reason = NULL;
+	qboolean postfx_backend_available;
+	qboolean ui_backend_available;
 	vid.numpages = (gl_triplebuffer.value) ? 3 : 2;
 
 	if (scr_disabled_for_loading)
@@ -2232,14 +2276,16 @@ static void SCR_UpdateScreen_Legacy (void)
 
        V_RenderView ();
 
-	RBackend_DispatchBlock ("postfx", &r_backend_postfx, true,
+	postfx_backend_available = SCR_BackendPostFXPathAvailable (&postfx_unavailable_reason);
+	RBackend_DispatchBlock ("postfx", &r_backend_postfx, postfx_backend_available, postfx_unavailable_reason,
 		SCR_PostProcess_Backend, SCR_PostProcess_Legacy, &scr_backend_postfx_warned);
 
        V_PolyBlend ();
 
        R_StorePrevFrameState ();
 
-	RBackend_DispatchBlock ("ui", &r_backend_ui, true,
+	ui_backend_available = SCR_BackendUIPathAvailable (&ui_unavailable_reason);
+	RBackend_DispatchBlock ("ui", &r_backend_ui, ui_backend_available, ui_unavailable_reason,
 		SCR_DrawUI2D_Backend, SCR_DrawUI2D_Legacy, &scr_backend_ui_warned);
 
 	RBackend_DebugCaptureEndFrameHash ();

--- a/Quake/render_backend.h
+++ b/Quake/render_backend.h
@@ -55,7 +55,7 @@ void RBackend_DispatchUpdateScreen (void (*legacy_fn)(void));
  *   (!backend_path_available or backend_fn == NULL) or when backend_fn returns false.
  */
 void RBackend_DispatchBlock (const char *block_name, cvar_t *toggle, qboolean backend_path_available,
-	rbackend_block_fn_t backend_fn, void (*legacy_fn)(void), qboolean *warned_once);
+	const char *unavailable_reason, rbackend_block_fn_t backend_fn, void (*legacy_fn)(void), qboolean *warned_once);
 void RBackend_DebugCaptureEndFrameHash (void);
 
 #endif


### PR DESCRIPTION
### Motivation
- Make backend migration deterministic and safe by checking required shaders/FBOs/extensions/resources per backend block (`ui`, `postfx`, `particles`, `alias`, `world`, `fogvol`) instead of assuming availability. 
- Ensure a reproducible, single-time logged reason when falling back to the legacy path so toggling a backend on/off reproduces a clean legacy fallback (no crashes/artifacts).

### Description
- Extended `RBackend_DispatchBlock` signature to accept an `unavailable_reason` (`const char *`) and include that string in the one-time `Con_Warning` when the backend path is unavailable. (files: `Quake/render_backend.h`, `Quake/backend_gl_exec.c`).
- Added per-block capability-check helpers that return `backend_path_available` plus an optional `unavailable_reason`: `SCR_BackendUIPathAvailable`, `SCR_BackendPostFXPathAvailable` (in `Quake/gl_screen.c`); `R_BackendAliasPathAvailable`, `R_BackendWorldPathAvailable`, `R_BackendParticlesPathAvailable`, `R_BackendFogvolPathAvailable` (in `Quake/gl_rmain.c`).
- Replaced hardcoded `true` at all `RBackend_DispatchBlock(...)` call sites with the computed capability boolean and pass the reason string where appropriate; updated dispatch calls for `ui`, `postfx`, alias batches (world + viewmodel), world/particles opaque & alpha, and `fogvol`. (files: `Quake/gl_screen.c`, `Quake/gl_rmain.c`).
- Behavior: when a backend block is disabled (global toggle or per-block toggle off) legacy path runs; when toggles are enabled but capability check fails, legacy runs and a single `Con_Warning` logs the block name and the `unavailable_reason` to make the fallback reproducible and debuggable.

### Testing
- `git commit` succeeded and the changes were committed (single commit with 4 files modified). (result: success)
- Attempted to build the project in this environment: `make` in repo root had no target, and `make -j4` in `Quake/` failed due to missing system dependencies (`sdl2-config` / `SDL.h`), so full compile-time validation and runtime checks were not possible here. (result: build failed due to environment, not code)
- Sanity checks performed: repository modified files staged/committed and `rg`/`sed` inspections confirmed all dispatch sites and new helpers wired as intended (result: code changes validated by static inspection).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1a12b3ad8832ea4b928bfbb807b76)