### PR TITLE
Enforce A2 render state via RB_SetState

### DIFF
--- a/Quake/gl_draw.c
+++ b/Quake/gl_draw.c
@@ -602,7 +602,7 @@ void Draw_Flush (void)
 		Scrap_Upload ();
 
 	GL_UseProgram (glprogs.gui);
-	GL_SetState (glcanvas.blendmode | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS(3));
+	RB_SetState (glcanvas.blendmode | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS(3));
 	GL_Bind (GL_TEXTURE0, glcanvas.texture);
 
 	GL_Upload (GL_ARRAY_BUFFER, batchverts, sizeof(batchverts[0]) * 4 * numbatchquads, &buf, &ofs);

--- a/Quake/render_backend.h
+++ b/Quake/render_backend.h
@@ -6,6 +6,7 @@
 
 typedef struct render_backend_vtable_s
 {
+	/* Render-hotpath state rule: all GL state mutations in A2 render paths must flow through RB_SetState/IRenderBackend helpers; direct GL_SetState usage is only allowed when listed as a temporary exception in the central A2 TODO list. */
 	/* Preconditions: active GL context on render thread; Side effects: starts backend frame bookkeeping/debug scope; Threading: single render thread only. */
 	void (*BeginFrame) (const char *label);
 	/* Preconditions: matching BeginFrame already issued for current frame; Side effects: flushes/completes backend frame scope; Threading: single render thread only. */
@@ -29,6 +30,11 @@ typedef struct render_backend_vtable_s
 } render_backend_vtable_t;
 
 typedef render_backend_vtable_t IRenderBackend;
+
+/*
+ * Central A2 render-state TODO exceptions (temporary):
+ * - none
+ */
 
 extern cvar_t r_backend;
 extern cvar_t r_backend_ui;


### PR DESCRIPTION
### Motivation
- Prevent parallel GL-state mutations on the A2 render hotpath by requiring all state changes to go through the RB API so the backend can own render-state transitions.

### Description
- Add an explicit render-hotpath rule and a central temporary-exception TODO list in `Quake/render_backend.h` that mandates using `RB_SetState`/IRenderBackend for A2 paths. 
- Replace the remaining A2-path `GL_SetState` call in `Quake/gl_draw.c` (`Draw_Flush`) with `RB_SetState` so there are no unmarked direct `GL_SetState` usages in the targeted files.

### Testing
- Searched for remaining usages with `rg -n "GL_SetState" Quake/gl_draw.c Quake/gl_rmain.c Quake/r_world.c Quake/r_alias.c Quake/r_part.c` and confirmed no unmarked occurrences in the targeted files. 
- Verified state-call presence with `rg -n "RB_SetState|GL_SetState" Quake/gl_draw.c Quake/gl_rmain.c Quake/r_world.c Quake/r_alias.c Quake/r_part.c` and confirmed remaining calls are `RB_SetState` as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1a4330b94832ebac2cd38c770918e)