### PR TITLE
CI: add Debug builds for Linux, Windows and MinGW

### DIFF
--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -2,15 +2,16 @@ name: Linux CI
 on: [push, pull_request]
 jobs:
   build:
-    name: Linux / ${{ matrix.compiler }}
+    name: Linux / ${{ matrix.compiler }} / ${{ matrix.build_name }}
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
         compiler: ["clang", "gcc"]
+        build_name: [Release, Debug]
     steps:
     - uses: actions/checkout@v4
     - name: Install Dependencies
       run: sudo apt update && sudo apt install libcurl4-openssl-dev libmpg123-dev libsdl2-dev libvorbis-dev
     - name: Build
-      run: make --jobs=3 --keep-going --directory=Quake CC=${{ matrix.compiler }}
+      run: make --jobs=3 --keep-going --directory=Quake CC=${{ matrix.compiler }} ${{ matrix.build_name == 'Debug' && 'DEBUG=1' || '' }}

--- a/.github/workflows/mingw_ci.yml
+++ b/.github/workflows/mingw_ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build-linux:
-    name: Build MinGW
+    name: Build MinGW / ${{ matrix.config.target }} / ${{ matrix.config.build_name }}
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -12,8 +12,20 @@ jobs:
         config:
           - target: win32
             package: i686-win32
+            build_name: Release
+            debug_flag: ""
+          - target: win32
+            package: i686-win32
+            build_name: Debug
+            debug_flag: "DEBUG=1"
           - target: win64
             package: x86-64
+            build_name: Release
+            debug_flag: ""
+          - target: win64
+            package: x86-64
+            build_name: Debug
+            debug_flag: "DEBUG=1"
 
     steps:
       - uses: actions/checkout@v4
@@ -21,7 +33,7 @@ jobs:
       - name: Install Dependencies
         run: sudo apt update && sudo apt install gcc-mingw-w64-${{ matrix.config.package }}
 
-      - name: Build MinGW ${{ matrix.config.target }}
+      - name: Build MinGW ${{ matrix.config.target }} (${{ matrix.config.build_name }})
         run: |
           export MAKEFLAGS=--jobs=3\ --keep-going
-          cd Quake && ./build_cross_${{ matrix.config.target }}-sdl2.sh
+          cd Quake && ./build_cross_${{ matrix.config.target }}-sdl2.sh ${{ matrix.config.debug_flag }}

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -2,12 +2,13 @@ name: Windows CI
 on: [push, pull_request]
 jobs:
   build:
-    name: Windows / ${{ matrix.platform }}
+    name: Windows / ${{ matrix.platform }} / ${{ matrix.configuration }}
     runs-on: windows-2022
     strategy:
       fail-fast: false
       matrix:
         platform: [x64, Win32]
+        configuration: [Release, Debug]
     steps:
     - uses: actions/checkout@v4
     - name: Set environment variables
@@ -29,7 +30,7 @@ jobs:
         $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
         $msbuild = & "$vswhere" -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe | select-object -first 1
         $options = @( `
-          '-property:Configuration=Release', `
+          '-property:Configuration=${{ matrix.configuration }}', `
           '-property:Platform=${{ matrix.platform }}', `
           '-maxcpucount', `
           '-verbosity:minimal' `
@@ -37,7 +38,7 @@ jobs:
         & $msbuild Windows\VisualStudio\ironwail.sln $options
         if (-not $?) { throw "Build failed" }
     - name: Prepare archive
-      if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
+      if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && matrix.configuration == 'Release'
       run: |
             $compiledir = "Windows\VisualStudio\${env:BUILD_DIR}"
             $zipdir = "artifact\${env:BUILD_ARTIFACT}"
@@ -50,7 +51,7 @@ jobs:
             copy Quakespasm-Music.txt $zipdir
             copy LICENSE.txt $zipdir
     - name: Upload archive
-      if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
+      if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && matrix.configuration == 'Release'
       uses: actions/upload-artifact@v4
       with:
         name: ${{ env.BUILD_ARTIFACT }}


### PR DESCRIPTION
### Motivation
- Ensure both Debug and Release configurations are built and validated on CI so PRs break when either configuration stops building on supported platforms.
- Keep release packaging behavior unchanged while making Debug builds a required validation step.

### Description
- Add a `build_name` matrix to `Linux CI` and pass `DEBUG=1` to `make` when `build_name` is `Debug` so both `Release` and `Debug` are built for `clang` and `gcc` in ` .github/workflows/linux_ci.yml`.
- Add a `configuration` matrix to `Windows CI` and feed `-property:Configuration=${{ matrix.configuration }}` to `MSBuild`, and restrict archive preparation/upload to `Release` only in ` .github/workflows/windows_ci.yml`.
- Extend `MinGW CI` matrix to include `Release` and `Debug` variants and forward a `debug_flag` to the cross-build scripts so MinGW cross-builds also run in Debug when configured in ` .github/workflows/mingw_ci.yml`.

### Testing
- Validated the updated workflow YAML files by loading them with Ruby (`require 'yaml'`), which succeeded for ` .github/workflows/linux_ci.yml`, ` .github/workflows/windows_ci.yml`, and ` .github/workflows/mingw_ci.yml`.
- Attempted to validate with Python YAML parsing but the environment lacks `PyYAML`, causing that check to fail. 
- The workflows were inspected to ensure `Release` packaging/upload remains limited to `Release` builds only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1a6aba3d8832ea80dc2f0e3c691d4)