### PR TITLE
Document and trim direct GL exceptions in render path

### DIFF
--- a/Quake/backend_gl_exec.c
+++ b/Quake/backend_gl_exec.c
@@ -265,10 +265,10 @@ void RBackend_DebugCaptureEndFrameHash (void)
 	if (!pixels)
 		return;
 
-	glGetIntegerv (GL_PACK_ALIGNMENT, &prev_pack_alignment);
-	glPixelStorei (GL_PACK_ALIGNMENT, 1);
-	glReadPixels (glx, gly, glwidth, glheight, GL_RGB, GL_UNSIGNED_BYTE, pixels);
-	glPixelStorei (GL_PACK_ALIGNMENT, prev_pack_alignment);
+	glGetIntegerv (GL_PACK_ALIGNMENT, &prev_pack_alignment); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#backend_gl_execc
+	glPixelStorei (GL_PACK_ALIGNMENT, 1); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#backend_gl_execc
+	glReadPixels (glx, gly, glwidth, glheight, GL_RGB, GL_UNSIGNED_BYTE, pixels); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#backend_gl_execc
+	glPixelStorei (GL_PACK_ALIGNMENT, prev_pack_alignment); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#backend_gl_execc
 
 	if (state->pixels[backend_index])
 		free (state->pixels[backend_index]);

--- a/Quake/gl_screen.c
+++ b/Quake/gl_screen.c
@@ -1840,8 +1840,8 @@ void SCR_ScreenShot_f (void)
 		scr_skipupdate = oldskip;
 	}
 
-	glPixelStorei (GL_PACK_ALIGNMENT, 1);/* for widths that aren't a multiple of 4 */
-	glReadPixels (glx, gly, glwidth, glheight, GL_RGB, GL_UNSIGNED_BYTE, buffer);
+	glPixelStorei (GL_PACK_ALIGNMENT, 1);/* GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_screenc */
+	glReadPixels (glx, gly, glwidth, glheight, GL_RGB, GL_UNSIGNED_BYTE, buffer); /* GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_screenc */
 
 // now write the file
 	if (!Steam_SaveScreenshot (buffer, glwidth, glheight))

--- a/Quake/gl_sky.c
+++ b/Quake/gl_sky.c
@@ -23,6 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 //gl_sky.c
 
 #include "quakedef.h"
+#include "rb_gl.h"
 
 extern	int	rs_skypolys; //for r_speeds readout
 extern	int rs_skypasses; //for r_speeds readout
@@ -754,7 +755,7 @@ void Sky_DrawSkyBox (void)
 		GL_VertexAttribPointerFunc (1, 2, GL_FLOAT, GL_FALSE, sizeof(verts[0]), ofs + offsetof(struct skyboxvert_s, uv));
 
 		GL_Bind (GL_TEXTURE0, skybox->textures[skytexorder[i]]);
-		glDrawArrays (GL_TRIANGLE_FAN, 0, 4);
+		RB_DrawArrays (GL_TRIANGLE_FAN, 0, 4);
 	}
 }
 
@@ -778,21 +779,21 @@ void Sky_DrawSky (void)
 	}
 	else if (skybox)
 	{
-		glEnable (GL_STENCIL_TEST);
-		glStencilMask (1);
-		glStencilFunc (GL_ALWAYS, 1, 1);
-		glStencilOp (GL_KEEP, GL_KEEP, GL_REPLACE);
-		glColorMask (GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
+		glEnable (GL_STENCIL_TEST); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_skyc
+		RB_StencilMask (1);
+		RB_StencilFunc (GL_ALWAYS, 1, 1);
+		RB_StencilOp (GL_KEEP, GL_KEEP, GL_REPLACE);
+		RB_ColorMask (GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
 
 		R_DrawBrushModels_SkyStencil (ents, count);
 
-		glStencilFunc (GL_EQUAL, 1, 1);
-		glStencilOp (GL_KEEP, GL_KEEP, GL_KEEP);
-		glColorMask (GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+		RB_StencilFunc (GL_EQUAL, 1, 1);
+		RB_StencilOp (GL_KEEP, GL_KEEP, GL_KEEP);
+		RB_ColorMask (GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
 
 		Sky_DrawSkyBox ();
 
-		glDisable (GL_STENCIL_TEST);
+		glDisable (GL_STENCIL_TEST); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_skyc
 	}
 	else
 	{

--- a/Quake/r_decals.c
+++ b/Quake/r_decals.c
@@ -22,6 +22,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // r_decals.c -- runtime decal/mark surface rendering
 
 #include "quakedef.h"
+#include "rb_gl.h"
 
 #define MAX_DECALS                      256
 #define DECAL_TEXTURE_SIZE      64
@@ -135,7 +136,7 @@ static void R_FlushDecalBatch (void)
 
         GL_Upload (GL_ELEMENT_ARRAY_BUFFER, decal_indices, sizeof(decal_indices[0]) * decal_batch_count * 6, &buf, &ofs);
         GL_BindBuffer (GL_ELEMENT_ARRAY_BUFFER, buf);
-        glDrawElements (GL_TRIANGLES, decal_batch_count * 6, GL_UNSIGNED_SHORT, ofs);
+        RB_DrawElements (GL_TRIANGLES, decal_batch_count * 6, GL_UNSIGNED_SHORT, ofs);
 
         R_ClearDecalBatch ();
 }

--- a/Quake/view.c
+++ b/Quake/view.c
@@ -23,6 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "quakedef.h"
 #include "cl_postfx.h"
+#include "rb_gl.h"
 
 /*
 
@@ -643,7 +644,7 @@ void V_PolyBlend (void)
 	GL_SetState (GLS_BLEND_ALPHA | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS(0));
 	GL_Uniform4fvFunc (0, 1, v_blend);
 
-	glDrawArrays (GL_TRIANGLES, 0, 3);
+	RB_DrawArrays (GL_TRIANGLES, 0, 3);
 
 	v_blend[3] = 0.f; // make sure this doesn't get applied again later in the pipeline
 }

--- a/docs/render_backend_gl_exceptions.md
+++ b/docs/render_backend_gl_exceptions.md
@@ -1,0 +1,30 @@
+# Render Backend: erlaubte direkte `gl*`-Ausnahmen
+
+Diese Liste dokumentiert bewusst erlaubte direkte OpenGL-Aufrufe außerhalb der RB-Implementierung (`Quake/rb_gl.c`).
+
+## Grundsatz
+- Direkte `gl*`-Aufrufe im Renderpfad sind nur erlaubt, wenn es aktuell keine passende `RB_*`-Abstraktion gibt oder der Pfad explizit als Debug-/Capture-Hook arbeitet.
+- Jede Ausnahme muss mit `GL-EXCEPTION` im Code markiert und hier referenziert sein.
+
+## Ausnahmen
+
+### `backend_gl_exec.c`
+- **Datei/Stellen:** `Quake/backend_gl_exec.c:268-271`.
+- **Direkte Calls:** `glGetIntegerv`, `glPixelStorei`, `glReadPixels`, `glPixelStorei`.
+- **Begründung:** Debug-Framehash erfasst explizit den Backbuffer inklusive temporärem Pack-Alignment-Save/Restore.
+- **Eigentümer:** Render Backend Maintainer.
+- **Geplante Ablösung:** Einführung einer RB-Hilfsfunktion (z. B. `RB_ReadPixelsRGB`) mit internem Alignment-Handling und optionalem Hash-Pfad.
+
+### `gl_screen.c`
+- **Datei/Stellen:** `Quake/gl_screen.c:1843-1844`.
+- **Direkte Calls:** `glPixelStorei`, `glReadPixels`.
+- **Begründung:** Screenshot-Pfad liest den finalen Framebuffer direkt aus; derzeit kein RB-Screenshot-API vorhanden.
+- **Eigentümer:** UI/Screenshot Maintainer.
+- **Geplante Ablösung:** Umstellung auf zentrale RB-Readback-API, die Screenshot und Debug-Framehash gemeinsam nutzen.
+
+### `gl_sky.c`
+- **Datei/Stellen:** `Quake/gl_sky.c:782`, `Quake/gl_sky.c:796`.
+- **Direkte Calls:** `glEnable(GL_STENCIL_TEST)`, `glDisable(GL_STENCIL_TEST)`.
+- **Begründung:** RB bietet aktuell keine dedizierte Stencil-Test Toggle-API; Sky-Stencil-Maskierung benötigt explizites Enable/Disable.
+- **Eigentümer:** World/Sky Rendering Maintainer.
+- **Geplante Ablösung:** Ergänzung einer RB-API für Stencil-Test Enable/Disable (oder Pass-Konfiguration), danach Migration von `gl_sky.c`.


### PR DESCRIPTION
### Motivation
- Reduce and centralize direct OpenGL usage in the render path by routing draw/GL state calls through the render-backend API and documenting unavoidable exceptions. 
- Provide a clear allowlist for reviewers and future maintenance so remaining direct `gl*` calls have an owner and a planned migration path.

### Description
- Added `docs/render_backend_gl_exceptions.md` listing allowed direct `gl*` exceptions with reason, owner and planned replacement for `backend_gl_exec.c`, `gl_screen.c`, and `gl_sky.c`.
- Replaced direct draw calls with render-backend wrappers: `glDrawArrays` -> `RB_DrawArrays` in `Quake/view.c` and `Quake/gl_sky.c`, and `glDrawElements` -> `RB_DrawElements` in `Quake/r_decals.c`, and added `#include "rb_gl.h"` where required.
- Left unavoidable direct calls (frame/screenshot readback and stencil enable/disable) in place and annotated them with `// GL-EXCEPTION: docs/render_backend_gl_exceptions.md#...` comments that reference the new documentation.
- Kept the render-backend implementation (`Quake/rb_gl.c`) as the canonical source of `gl*` usage; planned replacements noted in the docs include adding RB helpers like `RB_ReadPixelsRGB` and stencil toggle/pass APIs.

### Testing
- Ran `rg -n "\bgl[A-Z]\w+\b" Quake/view.c Quake/r_decals.c Quake/gl_sky.c Quake/backend_gl_exec.c Quake/gl_screen.c Quake/rb_gl.c` to verify only documented exceptions and RB implementation contain direct `gl*` usage, and the search returned only the documented exception sites plus `rb_gl.c` (success).
- Verified the diffs and file updates (`Quake/view.c`, `Quake/r_decals.c`, `Quake/gl_sky.c`, `Quake/backend_gl_exec.c`, `Quake/gl_screen.c`, `docs/render_backend_gl_exceptions.md`) were applied and committed (change summary inspection completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1a7896bb4832eb2065200dd98c3ff)