### PR TITLE
rb_pass_info_t um `baseline_gl` erweitern, damit Initializer passt

### DIFF
--- a/Quake/rb_gl.c
+++ b/Quake/rb_gl.c
@@ -41,6 +41,7 @@ typedef struct rb_pass_info_s
 {
 	const char *debug_name;
 	unsigned baseline_state;
+	rb_pass_baseline_gl_t baseline_gl;
 	unsigned exit_allow_state_mask;
 	unsigned exit_allow_texture_mask;
 	unsigned exit_allow_sampler_mask;


### PR DESCRIPTION
### Motivation
- Die vorhandene `rb_pass_info[PASS_COUNT]`-Tabelle verwendet `baseline_gl` pro Eintrag, weshalb die Struct-Definition angepasst werden muss, damit der Zugriff `rb_pass_info[pass].baseline_gl` legal ist und keine Initializer-/Member-Fehler auftreten.

### Description
- In `Quake/rb_gl.c` wurde der Struct `rb_pass_info_t` um das Feld `rb_pass_baseline_gl_t baseline_gl;` erweitert, sodass die bestehenden Table-Initialisierer mit `baseline_gl` mit der Definition übereinstimmen und `RB_BuildPassBaselineGL` unverändert auf `rb_pass_info[pass].baseline_gl` zugreifen kann.

### Testing
- Versucht: `cmake -S . -B build && cmake --build build -j2`; Ergebnis: fehlgeschlagen in der Konfigurationsphase, weil die CMake-Paketdatei für `SDL2` (`SDL2Config.cmake` / `sdl2-config.cmake`) nicht gefunden wurde, sodass ein vollständiger Build hier nicht ausgeführt werden konnte.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1ab98d7ac832e8fbc2a1dd6b8c6e7)