### PR TITLE
Use RB owner-tracked wrappers for stencil, color mask and texture params in gl_rmain

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -725,11 +725,11 @@ static GLuint GL_CreateSSAONoiseTexture (void)
 	GL_ObjectLabelFunc (GL_TEXTURE, texnum, -1, "ssao noise");
 	GL_TexStorage2DFunc (GL_TEXTURE_2D, 1, GL_RG8, SSAO_NOISE_SIZE, SSAO_NOISE_SIZE);
 	glTexSubImage2D (GL_TEXTURE_2D, 0, 0, 0, SSAO_NOISE_SIZE, SSAO_NOISE_SIZE, GL_RG, GL_UNSIGNED_BYTE, noise);
-	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
-	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
-	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0);
+	RB_TexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+	RB_TexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+	RB_TexParameteri (GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
+	RB_TexParameteri (GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
+	RB_TexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0);
 	GL_LogErrorIfDeveloper ("GL_CreateSSAONoiseTexture");
 
 	return texnum;
@@ -756,12 +756,12 @@ static GLuint GL_CreateFBOAttachment (GLenum format, int samples, GLenum filter,
 	else
 	{
 		GL_TexStorage2DFunc (target, 1, format, vid.width, vid.height);
-		glTexParameteri (target, GL_TEXTURE_MAG_FILTER, filter);
-		glTexParameteri (target, GL_TEXTURE_MIN_FILTER, filter);
+		RB_TexParameteri (target, GL_TEXTURE_MAG_FILTER, filter);
+		RB_TexParameteri (target, GL_TEXTURE_MIN_FILTER, filter);
 		if (is_depth_format)
-			glTexParameteri (target, GL_TEXTURE_COMPARE_MODE, GL_NONE);
+			RB_TexParameteri (target, GL_TEXTURE_COMPARE_MODE, GL_NONE);
 	}
-	glTexParameteri (target, GL_TEXTURE_MAX_LEVEL, 0);
+	RB_TexParameteri (target, GL_TEXTURE_MAX_LEVEL, 0);
 	GL_LogErrorIfDeveloper ("GL_CreateFBOAttachment");
 
 	return texnum;
@@ -781,11 +781,11 @@ static GLuint GL_CreateTexture2D (GLenum format, int width, int height, GLenum f
 	GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, texnum);
 	GL_ObjectLabelFunc (GL_TEXTURE, texnum, -1, name);
 	GL_TexStorage2DFunc (GL_TEXTURE_2D, 1, format, width, height);
-	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, filter);
-	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, filter);
-	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0);
+	RB_TexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, filter);
+	RB_TexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, filter);
+	RB_TexParameteri (GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+	RB_TexParameteri (GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+	RB_TexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0);
 	GL_LogErrorIfDeveloper ("GL_CreateTexture2D");
 
 	return texnum;
@@ -1478,7 +1478,7 @@ static GLuint GL_GenerateSSAOTexture (float view_min_x, float view_min_y, float 
 	}
 	// SSAO FIX: Reset viewport/scissor/color mask per pass to avoid banding from stale state.
 	GL_SetScissorEnabled (false);
-	glColorMask (GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+	RB_ColorMask (GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
 	RB_Viewport (0, 0, width, height);
 	{
 		const float clear[4] = { 1.f, 1.f, 1.f, 1.f };
@@ -1560,7 +1560,7 @@ static GLuint GL_GenerateSSAOTexture (float view_min_x, float view_min_y, float 
 		RB_BindFramebuffer (GL_FRAMEBUFFER, framebufs.ssao.blur_fbo[index]);
 		GL_LogErrorIfDeveloper ("SSAO blur bind FBO");
 		GL_SetScissorEnabled (false);
-		glColorMask (GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+		RB_ColorMask (GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
 		RB_Viewport (0, 0, width, height);
 		GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, framebufs.ssao.ao_tex[index]);
 		GL_Uniform4fFunc (2, 1.f, 0.f, 0.f, 0.f);
@@ -1569,7 +1569,7 @@ static GLuint GL_GenerateSSAOTexture (float view_min_x, float view_min_y, float 
 
 		RB_BindFramebuffer (GL_FRAMEBUFFER, framebufs.ssao.ao_fbo[index]);
 		GL_SetScissorEnabled (false);
-		glColorMask (GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+		RB_ColorMask (GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
 		GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, framebufs.ssao.blur_tex[index]);
 		GL_Uniform4fFunc (2, 0.f, 1.f, 0.f, 0.f);
 		RB_DrawArrays (GL_TRIANGLES, 0, 3);
@@ -3372,7 +3372,7 @@ void R_Clear (void)
 		clearbits |= GL_COLOR_BUFFER_BIT;
 
 	RB_SetState (glstate & ~GLS_NO_ZWRITE); // make sure depth writes are enabled
-	glStencilMask (~0u);
+	RB_StencilMask (~0u);
 	RB_Clear (clearbits);
 }
 
@@ -4669,10 +4669,10 @@ static void R_BeginTranslucency (void)
 		GL_ClearBufferfvFunc (GL_COLOR, 0, zeroes);
 		GL_ClearBufferfvFunc (GL_COLOR, 1, ones);
 
-		glEnable (GL_STENCIL_TEST);
-		glStencilMask (2);
-		glStencilFunc (GL_ALWAYS, 2, 2);
-		glStencilOp (GL_KEEP, GL_KEEP, GL_REPLACE);
+		RB_StencilTest (true);
+		RB_StencilMask (2);
+		RB_StencilFunc (GL_ALWAYS, 2, 2);
+		RB_StencilOp (GL_KEEP, GL_KEEP, GL_REPLACE);
 	}
 }
 
@@ -4689,8 +4689,8 @@ static void R_EndTranslucency (void)
 
 		RB_BindFramebuffer (GL_FRAMEBUFFER, framesetup.scene_fbo);
 
-		glStencilFunc (GL_EQUAL, 2, 2);
-		glStencilOp (GL_KEEP, GL_KEEP, GL_KEEP);
+		RB_StencilFunc (GL_EQUAL, 2, 2);
+		RB_StencilOp (GL_KEEP, GL_KEEP, GL_KEEP);
 
 		RB_UseProgram (glprogs.oit_resolve[framebufs.scene.samples > 1]);
 		RB_SetState (GLS_BLEND_ALPHA | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
@@ -4699,7 +4699,7 @@ static void R_EndTranslucency (void)
 
 		RB_DrawArrays (GL_TRIANGLES, 0, 3);
 
-		glDisable (GL_STENCIL_TEST);
+		RB_StencilTest (false);
 
 		GL_EndGroup ();
 	}
@@ -5057,8 +5057,8 @@ void R_WarpScaleView (void)
 	// View blends are applied after postprocess/UI to avoid AO/tone-map affecting overlays.
 	GL_Uniform4fFunc (1, 0.f, 0.f, 0.f, 0.f);
 	GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, msaa ? framebufs.resolved_scene.color_tex : framebufs.scene.color_tex);
-	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, water_warp && msaa ? GL_LINEAR : GL_NEAREST);
-	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, water_warp && msaa ? GL_LINEAR : GL_NEAREST);
+	RB_TexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, water_warp && msaa ? GL_LINEAR : GL_NEAREST);
+	RB_TexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, water_warp && msaa ? GL_LINEAR : GL_NEAREST);
 
 	RB_DrawArrays (GL_TRIANGLES, 0, 3);
 

--- a/Quake/rb_gl.c
+++ b/Quake/rb_gl.c
@@ -632,6 +632,24 @@ void RB_StencilMask_Owner (GLuint mask, const char *owner)
 	glStencilMask (mask);
 }
 
+void RB_StencilTest_Owner (qboolean enable, const char *owner)
+{
+	#if RB_DEBUG_STATE
+	rb_state_debug.last_stencil_owner = owner;
+	#endif
+
+	if (enable)
+		glEnable (GL_STENCIL_TEST);
+	else
+		glDisable (GL_STENCIL_TEST);
+}
+
+void RB_TexParameteri_Owner (GLenum target, GLenum pname, GLint param, const char *owner)
+{
+	(void)owner;
+	glTexParameteri (target, pname, param);
+}
+
 void RB_DrawArrays (GLenum mode, GLint first, GLsizei count)
 {
 	glDrawArrays (mode, first, count);

--- a/Quake/rb_gl.h
+++ b/Quake/rb_gl.h
@@ -29,6 +29,8 @@ void RB_PolygonMode_Owner (GLenum face, GLenum mode, const char *owner);
 void RB_StencilFunc_Owner (GLenum func, GLint ref, GLuint mask, const char *owner);
 void RB_StencilOp_Owner (GLenum sfail, GLenum dpfail, GLenum dppass, const char *owner);
 void RB_StencilMask_Owner (GLuint mask, const char *owner);
+void RB_StencilTest_Owner (qboolean enable, const char *owner);
+void RB_TexParameteri_Owner (GLenum target, GLenum pname, GLint param, const char *owner);
 void RB_DrawBuffer_Owner (GLenum buf, const char *owner);
 void RB_ReadBuffer_Owner (GLenum src, const char *owner);
 #define RB_SetState(mask) RB_SetState_Owner ((mask), __func__)
@@ -44,6 +46,8 @@ void RB_ReadBuffer_Owner (GLenum src, const char *owner);
 #define RB_StencilFunc(func, ref, mask) RB_StencilFunc_Owner ((func), (ref), (mask), __func__)
 #define RB_StencilOp(sfail, dpfail, dppass) RB_StencilOp_Owner ((sfail), (dpfail), (dppass), __func__)
 #define RB_StencilMask(mask) RB_StencilMask_Owner ((mask), __func__)
+#define RB_StencilTest(enable) RB_StencilTest_Owner ((enable), __func__)
+#define RB_TexParameteri(target, pname, param) RB_TexParameteri_Owner ((target), (pname), (param), __func__)
 #define RB_DrawBuffer(buf) RB_DrawBuffer_Owner ((buf), __func__)
 #define RB_ReadBuffer(src) RB_ReadBuffer_Owner ((src), __func__)
 #define RB_SetStateWithOwner(mask, owner) RB_SetState_Owner ((mask), (owner))
@@ -60,6 +64,8 @@ void RB_ReadBuffer_Owner (GLenum src, const char *owner);
 #define RB_StencilFuncWithOwner(func, ref, mask, owner) RB_StencilFunc_Owner ((func), (ref), (mask), (owner))
 #define RB_StencilOpWithOwner(sfail, dpfail, dppass, owner) RB_StencilOp_Owner ((sfail), (dpfail), (dppass), (owner))
 #define RB_StencilMaskWithOwner(mask, owner) RB_StencilMask_Owner ((mask), (owner))
+#define RB_StencilTestWithOwner(enable, owner) RB_StencilTest_Owner ((enable), (owner))
+#define RB_TexParameteriWithOwner(target, pname, param, owner) RB_TexParameteri_Owner ((target), (pname), (param), (owner))
 #define RB_DrawBufferWithOwner(buf, owner) RB_DrawBuffer_Owner ((buf), (owner))
 #define RB_ReadBufferWithOwner(src, owner) RB_ReadBuffer_Owner ((src), (owner))
 void RB_DrawArrays (GLenum mode, GLint first, GLsizei count);


### PR DESCRIPTION
### Motivation
- Centralize owner-tracked GL state changes to the render backend by replacing scattered direct GL calls with RB helpers that record the last owner and enable state-diff diagnostics.
- Targeted hotspots include clear/SSAO passes, the OIT translucency begin/end block, and the warp/scale view path to reduce stale-state bugs and improve diagnosability.

### Description
- Added wrapper APIs `RB_StencilTest_Owner`/`RB_StencilTest` and `RB_TexParameteri_Owner`/`RB_TexParameteri` to `Quake/rb_gl.h` and implemented them in `Quake/rb_gl.c` with owner-tracking where applicable.
- Replaced direct calls in `Quake/gl_rmain.c`: `glTexParameteri` → `RB_TexParameteri`, `glColorMask` → `RB_ColorMask`, `glStencilMask` → `RB_StencilMask`, and `glEnable(GL_STENCIL_TEST)/glDisable(GL_STENCIL_TEST)` → `RB_StencilTest` in the requested areas (`R_Clear`, OIT `R_BeginTranslucency`/`R_EndTranslucency`, SSAO setup/blur, and `R_WarpScaleView`).
- Kept other direct GL calls untouched where they are outside the requested replacement set or are documented exceptions, and added macro shims to maintain the existing `RB_*` macro API surface.

### Testing
- Ran `rg -n "glStencilMask|glEnable\s*\(\s*GL_STENCIL_TEST|glDisable\s*\(\s*GL_STENCIL_TEST|glStencilFunc|glStencilOp|glColorMask|glTexParameteri" Quake/gl_rmain.c` which returned no matches, satisfying the replacement criterion for that call-group.
- Verified with `rg -n "\bgl[A-Z]\w+\b" Quake/gl_rmain.c` that remaining direct GL calls are other documented exceptions and not part of the requested replacements.
- Attempted `make -j4` but no top-level Makefile/targets were present so a full build could not be performed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1ac9c3848832ea50ec91d6cfe7bf1)