### PR TITLE
Document GL exceptions and add A2 marker check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,3 +180,8 @@ if (WIN32)
 	endif()
 endif()
 
+
+add_custom_target(check_gl_exceptions
+	COMMAND ${CMAKE_COMMAND} -E env PYTHONIOENCODING=utf-8 python3 ${CMAKE_CURRENT_SOURCE_DIR}/scripts/check_gl_exceptions.py
+	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+	COMMENT "Checking direct gl* exceptions in A2-relevant files")

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -196,7 +196,7 @@ static const float r_identity_mat4[16] = {
 
 static void GL_LogErrorIfDeveloper (const char *label)
 {
-	GLenum err = glGetError ();
+	GLenum err = glGetError (); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
 	if (err != GL_NO_ERROR)
 		Con_DPrintf ("GL error after %s: 0x%04X\n", label, err);
 }
@@ -720,11 +720,11 @@ static GLuint GL_CreateSSAONoiseTexture (void)
 		noise[i * 2 + 1] = (unsigned char)CLAMP (0.f, y * 255.f, 255.f);
 	}
 
-	glGenTextures (1, &texnum);
+	glGenTextures (1, &texnum); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
 	GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, texnum);
 	GL_ObjectLabelFunc (GL_TEXTURE, texnum, -1, "ssao noise");
 	GL_TexStorage2DFunc (GL_TEXTURE_2D, 1, GL_RG8, SSAO_NOISE_SIZE, SSAO_NOISE_SIZE);
-	glTexSubImage2D (GL_TEXTURE_2D, 0, 0, 0, SSAO_NOISE_SIZE, SSAO_NOISE_SIZE, GL_RG, GL_UNSIGNED_BYTE, noise);
+	glTexSubImage2D (GL_TEXTURE_2D, 0, 0, 0, SSAO_NOISE_SIZE, SSAO_NOISE_SIZE, GL_RG, GL_UNSIGNED_BYTE, noise); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
 	RB_TexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 	RB_TexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 	RB_TexParameteri (GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
@@ -746,7 +746,7 @@ static GLuint GL_CreateFBOAttachment (GLenum format, int samples, GLenum filter,
 	GLuint texnum;
 	qboolean is_depth_format = (format == GL_DEPTH24_STENCIL8 || format == GL_DEPTH32F_STENCIL8 || format == GL_DEPTH_COMPONENT24 || format == GL_DEPTH_COMPONENT32F);
 
-	glGenTextures (1, &texnum);
+	glGenTextures (1, &texnum); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
 	GL_BindNative (GL_TEXTURE0, target, texnum);
 	GL_ObjectLabelFunc (GL_TEXTURE, texnum, -1, name);
 	if (samples > 1)
@@ -777,7 +777,7 @@ static GLuint GL_CreateTexture2D (GLenum format, int width, int height, GLenum f
 {
 	GLuint texnum;
 
-	glGenTextures (1, &texnum);
+	glGenTextures (1, &texnum); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
 	GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, texnum);
 	GL_ObjectLabelFunc (GL_TEXTURE, texnum, -1, name);
 	GL_TexStorage2DFunc (GL_TEXTURE_2D, 1, format, width, height);
@@ -852,8 +852,8 @@ void GL_CreateFrameBuffers (void)
 	GLenum depth_format = GL_DEPTH24_STENCIL8;
 
 	/* query MSAA limits */
-	glGetIntegerv (GL_MAX_COLOR_TEXTURE_SAMPLES, &framebufs.max_color_tex_samples);
-	glGetIntegerv (GL_MAX_DEPTH_TEXTURE_SAMPLES, &framebufs.max_depth_tex_samples);
+	glGetIntegerv (GL_MAX_COLOR_TEXTURE_SAMPLES, &framebufs.max_color_tex_samples); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
+	glGetIntegerv (GL_MAX_DEPTH_TEXTURE_SAMPLES, &framebufs.max_depth_tex_samples); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
 	framebufs.max_samples = q_min (framebufs.max_color_tex_samples, framebufs.max_depth_tex_samples);
 
 	/* main framebuffer (color + depth + stencil) */
@@ -1308,21 +1308,21 @@ static void GL_LogSSAODepthInfo (GLuint depth_tex, GLuint ao_tex, int ssao_width
 	const char *target_name = "GL_TEXTURE_2D";
 
 	GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, depth_tex);
-	glGetIntegerv (GL_TEXTURE_BINDING_2D, &bound_depth_tex);
-	glGetTexLevelParameteriv (GL_TEXTURE_2D, 0, GL_TEXTURE_INTERNAL_FORMAT, &internal_format);
-	glGetTexLevelParameteriv (GL_TEXTURE_2D, 0, GL_TEXTURE_WIDTH, &tex_width);
-	glGetTexLevelParameteriv (GL_TEXTURE_2D, 0, GL_TEXTURE_HEIGHT, &tex_height);
-	glGetTexParameteriv (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE, &compare_mode);
+	glGetIntegerv (GL_TEXTURE_BINDING_2D, &bound_depth_tex); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
+	glGetTexLevelParameteriv (GL_TEXTURE_2D, 0, GL_TEXTURE_INTERNAL_FORMAT, &internal_format); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
+	glGetTexLevelParameteriv (GL_TEXTURE_2D, 0, GL_TEXTURE_WIDTH, &tex_width); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
+	glGetTexLevelParameteriv (GL_TEXTURE_2D, 0, GL_TEXTURE_HEIGHT, &tex_height); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
+	glGetTexParameteriv (GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE, &compare_mode); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
 	GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, ao_tex);
-	glGetTexLevelParameteriv (GL_TEXTURE_2D, 0, GL_TEXTURE_INTERNAL_FORMAT, &ao_internal_format);
-	glGetTexLevelParameteriv (GL_TEXTURE_2D, 0, GL_TEXTURE_WIDTH, &ao_width);
-	glGetTexLevelParameteriv (GL_TEXTURE_2D, 0, GL_TEXTURE_HEIGHT, &ao_height);
-	glGetFloatv (GL_DEPTH_RANGE, depth_range);
-	glGetIntegerv (GL_VIEWPORT, viewport);
-	glGetIntegerv (GL_SCISSOR_BOX, scissor_box);
-	glGetIntegerv (GL_FRAMEBUFFER_BINDING, &draw_fbo);
-	scissor_enabled = glIsEnabled (GL_SCISSOR_TEST);
-	glGetBooleanv (GL_COLOR_WRITEMASK, color_mask);
+	glGetTexLevelParameteriv (GL_TEXTURE_2D, 0, GL_TEXTURE_INTERNAL_FORMAT, &ao_internal_format); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
+	glGetTexLevelParameteriv (GL_TEXTURE_2D, 0, GL_TEXTURE_WIDTH, &ao_width); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
+	glGetTexLevelParameteriv (GL_TEXTURE_2D, 0, GL_TEXTURE_HEIGHT, &ao_height); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
+	glGetFloatv (GL_DEPTH_RANGE, depth_range); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
+	glGetIntegerv (GL_VIEWPORT, viewport); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
+	glGetIntegerv (GL_SCISSOR_BOX, scissor_box); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
+	glGetIntegerv (GL_FRAMEBUFFER_BINDING, &draw_fbo); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
+	scissor_enabled = glIsEnabled (GL_SCISSOR_TEST); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
+	glGetBooleanv (GL_COLOR_WRITEMASK, color_mask); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
 
 	Con_DPrintf ("SSAO depth input: tex=%u bound=%d target=%s format=0x%X size=%dx%d compare=0x%X viewport=%dx%d+%d+%d fbo=%d scissor=%s %dx%d+%d+%d colorMask=%d%d%d%d\n",
 		depth_tex, bound_depth_tex, target_name, internal_format, tex_width, tex_height,
@@ -1935,12 +1935,12 @@ static void GL_SetFramebufferSRGB (qboolean enable)
 #ifdef GL_FRAMEBUFFER_SRGB
 	if (enable && !gl_framebuffer_srgb_enabled)
 	{
-		glEnable (GL_FRAMEBUFFER_SRGB);
+		glEnable (GL_FRAMEBUFFER_SRGB); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
 		gl_framebuffer_srgb_enabled = true;
 	}
 	else if (!enable && gl_framebuffer_srgb_enabled)
 	{
-		glDisable (GL_FRAMEBUFFER_SRGB);
+		glDisable (GL_FRAMEBUFFER_SRGB); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
 		gl_framebuffer_srgb_enabled = false;
 	}
 #else
@@ -1982,11 +1982,11 @@ static void GL_PostProcessFallback (void)
 
 	RB_BindFramebuffer (GL_FRAMEBUFFER, framebufs.composite.fbo);
 	RB_ReadBuffer (GL_COLOR_ATTACHMENT0);
-	glPixelStorei (GL_PACK_ALIGNMENT, 1);
-	glReadPixels (0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
+	glPixelStorei (GL_PACK_ALIGNMENT, 1); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
+	glReadPixels (0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, pixels); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
 	RB_BindFramebuffer (GL_FRAMEBUFFER, 0);
 	RB_ReadBuffer (GL_BACK);
-	glPixelStorei (GL_UNPACK_ALIGNMENT, 1);
+	glPixelStorei (GL_UNPACK_ALIGNMENT, 1); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
 	{
 		qboolean srgb_output = GL_UseSRGBFramebuffer ();
 		GL_SetFramebufferSRGB (srgb_output);
@@ -2040,22 +2040,22 @@ static void GL_PostProcessFallback (void)
 		pixels[i * 4 + 2] = (byte)CLAMP (0, (int)Q_rint (color[2] * 255.f), 255);
 	}
 
-	glDisable (GL_DEPTH_TEST);
-	glDisable (GL_BLEND);
+	glDisable (GL_DEPTH_TEST); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
+	glDisable (GL_BLEND); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
         RB_UseProgram (0);
-	glMatrixMode (GL_PROJECTION);
-	glPushMatrix ();
-	glLoadIdentity ();
-	glOrtho (0, width, 0, height, -1, 1);
-	glMatrixMode (GL_MODELVIEW);
-	glPushMatrix ();
-	glLoadIdentity ();
-	glRasterPos2i (0, 0);
-	glDrawPixels (width, height, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
-	glPopMatrix ();
-	glMatrixMode (GL_PROJECTION);
-	glPopMatrix ();
-	glMatrixMode (GL_MODELVIEW);
+	glMatrixMode (GL_PROJECTION); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
+	glPushMatrix (); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
+	glLoadIdentity (); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
+	glOrtho (0, width, 0, height, -1, 1); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
+	glMatrixMode (GL_MODELVIEW); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
+	glPushMatrix (); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
+	glLoadIdentity (); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
+	glRasterPos2i (0, 0); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
+	glDrawPixels (width, height, GL_RGBA, GL_UNSIGNED_BYTE, pixels); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
+	glPopMatrix (); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
+	glMatrixMode (GL_PROJECTION); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
+	glPopMatrix (); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
+	glMatrixMode (GL_MODELVIEW); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
 
 	free (pixels);
 }
@@ -2138,8 +2138,8 @@ static qboolean GL_SampleAutoExposureLuminance (float *out_luminance)
 
 	RB_BindFramebuffer (GL_READ_FRAMEBUFFER, framebufs.autoexposure.fbo);
 	RB_ReadBuffer (GL_COLOR_ATTACHMENT0);
-	glGetIntegerv (GL_PACK_ALIGNMENT, &prev_pack_alignment);
-	glPixelStorei (GL_PACK_ALIGNMENT, 1);
+	glGetIntegerv (GL_PACK_ALIGNMENT, &prev_pack_alignment); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
+	glPixelStorei (GL_PACK_ALIGNMENT, 1); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
 
 	if (r_autoexposure_async.value > 0.f && framebufs.autoexposure.pbo[0] && framebufs.autoexposure.pbo[1] && GL_AutoExposurePBOAvailable ())
 	{
@@ -2148,7 +2148,7 @@ static qboolean GL_SampleAutoExposureLuminance (float *out_luminance)
 		qboolean got_data = false;
 
 		GL_BindBufferFunc (GL_PIXEL_PACK_BUFFER, framebufs.autoexposure.pbo[write_index]);
-		glReadPixels (0, 0, width, height, GL_RGBA, GL_FLOAT, NULL);
+		glReadPixels (0, 0, width, height, GL_RGBA, GL_FLOAT, NULL); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
 
 		GL_BindBufferFunc (GL_PIXEL_PACK_BUFFER, framebufs.autoexposure.pbo[read_index]);
 		if (framebufs.autoexposure.pbo_ready)
@@ -2165,7 +2165,7 @@ static qboolean GL_SampleAutoExposureLuminance (float *out_luminance)
 		GL_BindBufferFunc (GL_PIXEL_PACK_BUFFER, 0);
 		framebufs.autoexposure.pbo_index = read_index;
 		framebufs.autoexposure.pbo_ready = true;
-		glPixelStorei (GL_PACK_ALIGNMENT, prev_pack_alignment);
+		glPixelStorei (GL_PACK_ALIGNMENT, prev_pack_alignment); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
 
 		if (!got_data)
 		{
@@ -2181,8 +2181,8 @@ static qboolean GL_SampleAutoExposureLuminance (float *out_luminance)
 		else if (r_autoexposure_async.value <= 0.f && framebufs.autoexposure.pbo_ready)
 			GL_AutoExposureDeletePBOs ();
 
-		glReadPixels (0, 0, width, height, GL_RGBA, GL_FLOAT, pixels);
-		glPixelStorei (GL_PACK_ALIGNMENT, prev_pack_alignment);
+		glReadPixels (0, 0, width, height, GL_RGBA, GL_FLOAT, pixels); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
+		glPixelStorei (GL_PACK_ALIGNMENT, prev_pack_alignment); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
 	}
 	RB_BindFramebuffer (GL_FRAMEBUFFER, 0);
 	RB_ReadBuffer (GL_BACK);
@@ -2871,20 +2871,20 @@ void GL_PolygonOffset (int offset)
 
 	if (offset > 0)
 	{
-		glEnable (GL_POLYGON_OFFSET_FILL);
-		glEnable (GL_POLYGON_OFFSET_LINE);
-		glPolygonOffset (1, offset);
+		glEnable (GL_POLYGON_OFFSET_FILL); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
+		glEnable (GL_POLYGON_OFFSET_LINE); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
+		glPolygonOffset (1, offset); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
 	}
 	else if (offset < 0)
 	{
-		glEnable (GL_POLYGON_OFFSET_FILL);
-		glEnable (GL_POLYGON_OFFSET_LINE);
-		glPolygonOffset (-1, offset);
+		glEnable (GL_POLYGON_OFFSET_FILL); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
+		glEnable (GL_POLYGON_OFFSET_LINE); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
+		glPolygonOffset (-1, offset); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
 	}
 	else
 	{
-		glDisable (GL_POLYGON_OFFSET_FILL);
-		glDisable (GL_POLYGON_OFFSET_LINE);
+		glDisable (GL_POLYGON_OFFSET_FILL); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
+		glDisable (GL_POLYGON_OFFSET_LINE); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
 	}
 }
 
@@ -2901,21 +2901,21 @@ void GL_DepthRange (zrange_t range)
 	{
 	default:
 	case ZRANGE_FULL:
-		glDepthRange (0.f, 1.f);
+		glDepthRange (0.f, 1.f); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
 		break;
 
 	case ZRANGE_VIEWMODEL:
 		if (gl_clipcontrol_able)
-			glDepthRange (0.7f, 1.f);
+			glDepthRange (0.7f, 1.f); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
 		else
-			glDepthRange (0.f, 0.3f);
+			glDepthRange (0.f, 0.3f); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
 		break;
 
 	case ZRANGE_NEAR:
 		if (gl_clipcontrol_able)
-			glDepthRange (1.f, 1.f);
+			glDepthRange (1.f, 1.f); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
 		else
-			glDepthRange (0.f, 0.f);
+			glDepthRange (0.f, 0.f); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
 		break;
 	}
 }
@@ -3416,23 +3416,23 @@ void R_GLStateDump (const char *tag)
 	GLint prev_active_texture = 0;
 	GLint ubo0 = 0, ubo1 = 0, ubo2 = 0;
 	GLint tex2d_0 = 0, tex2d_1 = 0, tex2d_2 = 0;
-	GLboolean blend = glIsEnabled (GL_BLEND);
-	GLboolean depth_test = glIsEnabled (GL_DEPTH_TEST);
-	GLboolean cull = glIsEnabled (GL_CULL_FACE);
-	GLboolean scissor = glIsEnabled (GL_SCISSOR_TEST);
-	GLboolean srgb = glIsEnabled (GL_FRAMEBUFFER_SRGB);
+	GLboolean blend = glIsEnabled (GL_BLEND); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
+	GLboolean depth_test = glIsEnabled (GL_DEPTH_TEST); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
+	GLboolean cull = glIsEnabled (GL_CULL_FACE); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
+	GLboolean scissor = glIsEnabled (GL_SCISSOR_TEST); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
+	GLboolean srgb = glIsEnabled (GL_FRAMEBUFFER_SRGB); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
 	GLboolean depth_mask = GL_TRUE;
 
 	if (r_gl_state_validate.value <= 0.f)
 		return;
 
-	glGetIntegerv (GL_CURRENT_PROGRAM, &program);
-	glGetIntegerv (GL_ACTIVE_TEXTURE, &active_texture);
-	glGetIntegerv (GL_VIEWPORT, viewport);
-	glGetIntegerv (GL_SCISSOR_BOX, scissor_box);
-	glGetIntegerv (GL_DRAW_FRAMEBUFFER_BINDING, &draw_fbo);
-	glGetIntegerv (GL_READ_FRAMEBUFFER_BINDING, &read_fbo);
-	glGetBooleanv (GL_DEPTH_WRITEMASK, &depth_mask);
+	glGetIntegerv (GL_CURRENT_PROGRAM, &program); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
+	glGetIntegerv (GL_ACTIVE_TEXTURE, &active_texture); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
+	glGetIntegerv (GL_VIEWPORT, viewport); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
+	glGetIntegerv (GL_SCISSOR_BOX, scissor_box); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
+	glGetIntegerv (GL_DRAW_FRAMEBUFFER_BINDING, &draw_fbo); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
+	glGetIntegerv (GL_READ_FRAMEBUFFER_BINDING, &read_fbo); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
+	glGetBooleanv (GL_DEPTH_WRITEMASK, &depth_mask); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
 	prev_active_texture = active_texture;
 
 	GL_GetIntegeri_vFunc (GL_UNIFORM_BUFFER_BINDING, 0, &ubo0);
@@ -3440,11 +3440,11 @@ void R_GLStateDump (const char *tag)
 	GL_GetIntegeri_vFunc (GL_UNIFORM_BUFFER_BINDING, 2, &ubo2);
 
 	GL_ActiveTextureFunc (GL_TEXTURE0);
-	glGetIntegerv (GL_TEXTURE_BINDING_2D, &tex2d_0);
+	glGetIntegerv (GL_TEXTURE_BINDING_2D, &tex2d_0); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
 	GL_ActiveTextureFunc (GL_TEXTURE1);
-	glGetIntegerv (GL_TEXTURE_BINDING_2D, &tex2d_1);
+	glGetIntegerv (GL_TEXTURE_BINDING_2D, &tex2d_1); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
 	GL_ActiveTextureFunc (GL_TEXTURE2);
-	glGetIntegerv (GL_TEXTURE_BINDING_2D, &tex2d_2);
+	glGetIntegerv (GL_TEXTURE_BINDING_2D, &tex2d_2); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
 	GL_ActiveTextureFunc (prev_active_texture);
 
 	Con_Printf ("GL_STATE[%s] %s prog=%d acttex=%d fbo(draw/read)=%d/%d vp=(%d %d %d %d) sci=%d box=(%d %d %d %d) blend=%d depth=%d depthmask=%d cull=%d srgb=%d ubo(0/1/2)=%d/%d/%d tex2d(0/1/2)=%d/%d/%d\n",
@@ -4618,7 +4618,7 @@ void R_ShowTris (void)
 
 	if (r_showtris.value == 1)
 		GL_DepthRange (ZRANGE_NEAR);
-	glPolygonMode (GL_FRONT_AND_BACK, GL_LINE);
+	glPolygonMode (GL_FRONT_AND_BACK, GL_LINE); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
 	GL_PolygonOffset (OFFSET_SHOWTRIS);
 
 	ofs = cl_modtype_ofs;
@@ -4641,7 +4641,7 @@ void R_ShowTris (void)
 
 	R_DrawParticles_ShowTris ();
 
-	glPolygonMode (GL_FRONT_AND_BACK, GL_FILL);
+	glPolygonMode (GL_FRONT_AND_BACK, GL_FILL); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
 	GL_PolygonOffset (OFFSET_NONE);
 	if (r_showtris.value == 1)
 		GL_DepthRange (ZRANGE_FULL);
@@ -5090,7 +5090,7 @@ static void R_RenderView_Legacy (void)
 	time1 = 0; /* avoid compiler warning */
 	if (r_speeds.value)
 	{
-		glFinish ();
+		glFinish (); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
 		time1 = Sys_DoubleTime ();
 
 		//johnfitz -- rendering statistics
@@ -5098,7 +5098,7 @@ static void R_RenderView_Legacy (void)
 			rs_dynamiclightmaps = rs_aliaspasses = rs_skypasses = rs_brushpasses = 0;
 	}
         else if (gl_finish.value)
-                glFinish ();
+                glFinish (); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_rmainc
 
 	R_SetupView (); //johnfitz -- this does everything that should be done once per frame
         Fog_EnableGFog ();

--- a/Quake/r_fogvol.c
+++ b/Quake/r_fogvol.c
@@ -210,10 +210,10 @@ static void R_FogVol_LogBufferMarker (const char *marker)
 	if (!R_FogVol_TestDebugEnabled ())
 		return;
 
-	glGetIntegerv (GL_DRAW_FRAMEBUFFER_BINDING, &draw_fbo);
-	glGetIntegerv (GL_READ_FRAMEBUFFER_BINDING, &read_fbo);
-	glGetIntegerv (GL_DRAW_BUFFER, &draw_buffer);
-	glGetIntegerv (GL_READ_BUFFER, &read_buffer);
+	glGetIntegerv (GL_DRAW_FRAMEBUFFER_BINDING, &draw_fbo); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_fogvolc
+	glGetIntegerv (GL_READ_FRAMEBUFFER_BINDING, &read_fbo); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_fogvolc
+	glGetIntegerv (GL_DRAW_BUFFER, &draw_buffer); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_fogvolc
+	glGetIntegerv (GL_READ_BUFFER, &read_buffer); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_fogvolc
 	Con_Printf ("FOGVOL_TEST marker=%s draw_fbo=%d read_fbo=%d draw_buffer=0x%04x read_buffer=0x%04x\n",
 		marker, draw_fbo, read_fbo, (unsigned)draw_buffer, (unsigned)read_buffer);
 }
@@ -242,14 +242,14 @@ static void R_FogVol_LogPipelineState (const char *marker)
 	if (!R_FogVol_TestDebugEnabled ())
 		return;
 
-	glGetIntegerv (GL_DRAW_FRAMEBUFFER_BINDING, &draw_fbo);
-	glGetIntegerv (GL_READ_FRAMEBUFFER_BINDING, &read_fbo);
-	glGetIntegerv (GL_VIEWPORT, viewport);
-	scissor_enabled = glIsEnabled (GL_SCISSOR_TEST);
-	glGetIntegerv (GL_SCISSOR_BOX, scissor_box);
-	glGetIntegerv (GL_CURRENT_PROGRAM, &program);
-	glGetIntegerv (GL_DRAW_BUFFER, &draw_buffer);
-	glGetIntegerv (GL_READ_BUFFER, &read_buffer);
+	glGetIntegerv (GL_DRAW_FRAMEBUFFER_BINDING, &draw_fbo); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_fogvolc
+	glGetIntegerv (GL_READ_FRAMEBUFFER_BINDING, &read_fbo); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_fogvolc
+	glGetIntegerv (GL_VIEWPORT, viewport); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_fogvolc
+	scissor_enabled = glIsEnabled (GL_SCISSOR_TEST); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_fogvolc
+	glGetIntegerv (GL_SCISSOR_BOX, scissor_box); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_fogvolc
+	glGetIntegerv (GL_CURRENT_PROGRAM, &program); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_fogvolc
+	glGetIntegerv (GL_DRAW_BUFFER, &draw_buffer); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_fogvolc
+	glGetIntegerv (GL_READ_BUFFER, &read_buffer); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_fogvolc
 
 	Con_Printf (
 		"FOGVOL_TEST marker=%s draw_fbo=%d read_fbo=%d viewport=(%d %d %d %d) "
@@ -295,8 +295,8 @@ static void R_FogVol_LogHazardPass (const char *pass,
 	if (!R_FogVol_TestDebugEnabled ())
 		return;
 
-	glGetIntegerv (GL_DRAW_FRAMEBUFFER_BINDING, &draw_fbo);
-	glGetIntegerv (GL_READ_FRAMEBUFFER_BINDING, &read_fbo);
+	glGetIntegerv (GL_DRAW_FRAMEBUFFER_BINDING, &draw_fbo); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_fogvolc
+	glGetIntegerv (GL_READ_FRAMEBUFFER_BINDING, &read_fbo); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_fogvolc
 	draw_tex = R_FogVol_GetFramebufferColorAttachmentTexture (GL_DRAW_FRAMEBUFFER);
 	read_tex = R_FogVol_GetFramebufferColorAttachmentTexture (GL_READ_FRAMEBUFFER);
 
@@ -356,22 +356,22 @@ static void R_FogVol_TestState_Capture (fogvol_test_state_t *state)
 	 * separates its internal cache bitfield from the applied bitfield,
 	 * record the cache-side value here independently. */
 	state->cache_statebits = glstate;
-	glGetIntegerv (GL_VIEWPORT, state->viewport);
-	state->scissor_test = glIsEnabled (GL_SCISSOR_TEST);
-	glGetIntegerv (GL_SCISSOR_BOX, state->scissor_box);
-	glGetIntegerv (GL_DRAW_FRAMEBUFFER_BINDING, &state->draw_fbo);
-	glGetIntegerv (GL_READ_FRAMEBUFFER_BINDING, &state->read_fbo);
-	glGetIntegerv (GL_DRAW_BUFFER, &state->draw_buffer);
-	glGetIntegerv (GL_READ_BUFFER, &state->read_buffer);
+	glGetIntegerv (GL_VIEWPORT, state->viewport); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_fogvolc
+	state->scissor_test = glIsEnabled (GL_SCISSOR_TEST); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_fogvolc
+	glGetIntegerv (GL_SCISSOR_BOX, state->scissor_box); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_fogvolc
+	glGetIntegerv (GL_DRAW_FRAMEBUFFER_BINDING, &state->draw_fbo); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_fogvolc
+	glGetIntegerv (GL_READ_FRAMEBUFFER_BINDING, &state->read_fbo); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_fogvolc
+	glGetIntegerv (GL_DRAW_BUFFER, &state->draw_buffer); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_fogvolc
+	glGetIntegerv (GL_READ_BUFFER, &state->read_buffer); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_fogvolc
 	state->num_draw_buffers = 0;
 	for (int i = 0; i < (int)countof (state->draw_buffers); ++i)
 		state->draw_buffers[i] = GL_NONE;
 	{
 		GLint max_draw_buffers = 0;
-		glGetIntegerv (GL_MAX_DRAW_BUFFERS, &max_draw_buffers);
+		glGetIntegerv (GL_MAX_DRAW_BUFFERS, &max_draw_buffers); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_fogvolc
 		state->num_draw_buffers = q_min (max_draw_buffers, (int)countof (state->draw_buffers));
 		for (int i = 0; i < state->num_draw_buffers; ++i)
-			glGetIntegerv (GL_DRAW_BUFFER0 + i, &state->draw_buffers[i]);
+			glGetIntegerv (GL_DRAW_BUFFER0 + i, &state->draw_buffers[i]); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_fogvolc
 	}
 	state->draw_status = (GLint)GL_CheckFramebufferStatusFunc (GL_DRAW_FRAMEBUFFER);
 	state->read_status = (GLint)GL_CheckFramebufferStatusFunc (GL_READ_FRAMEBUFFER);
@@ -407,21 +407,21 @@ static void R_FogVol_TestState_Capture (fogvol_test_state_t *state)
 		GL_FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE, &state->read_depth_type);
 	GL_GetFramebufferAttachmentParameterivFunc (GL_READ_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
 		GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME, &state->read_depth_name);
-	glGetIntegerv (GL_CURRENT_PROGRAM, &state->program);
-	glGetIntegerv (GL_VERTEX_ARRAY_BINDING, &state->vao);
-	state->blend = glIsEnabled (GL_BLEND);
-	glGetIntegerv (GL_BLEND_SRC_RGB, &state->blend_src_rgb);
-	glGetIntegerv (GL_BLEND_DST_RGB, &state->blend_dst_rgb);
-	glGetIntegerv (GL_BLEND_EQUATION_RGB, &state->blend_equation_rgb);
-	state->depth_test = glIsEnabled (GL_DEPTH_TEST);
-	glGetBooleanv (GL_DEPTH_WRITEMASK, &state->depth_writemask);
-	glGetBooleanv (GL_COLOR_WRITEMASK, state->color_writemask);
-	state->cull_face = glIsEnabled (GL_CULL_FACE);
-	glGetIntegerv (GL_POLYGON_MODE, state->polygon_mode);
-	glGetFloatv (GL_COLOR_CLEAR_VALUE, state->color_clear_value);
-	state->framebuffer_srgb = glIsEnabled (GL_FRAMEBUFFER_SRGB);
-	state->dither = glIsEnabled (GL_DITHER);
-	state->multisample = glIsEnabled (GL_MULTISAMPLE);
+	glGetIntegerv (GL_CURRENT_PROGRAM, &state->program); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_fogvolc
+	glGetIntegerv (GL_VERTEX_ARRAY_BINDING, &state->vao); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_fogvolc
+	state->blend = glIsEnabled (GL_BLEND); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_fogvolc
+	glGetIntegerv (GL_BLEND_SRC_RGB, &state->blend_src_rgb); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_fogvolc
+	glGetIntegerv (GL_BLEND_DST_RGB, &state->blend_dst_rgb); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_fogvolc
+	glGetIntegerv (GL_BLEND_EQUATION_RGB, &state->blend_equation_rgb); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_fogvolc
+	state->depth_test = glIsEnabled (GL_DEPTH_TEST); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_fogvolc
+	glGetBooleanv (GL_DEPTH_WRITEMASK, &state->depth_writemask); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_fogvolc
+	glGetBooleanv (GL_COLOR_WRITEMASK, state->color_writemask); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_fogvolc
+	state->cull_face = glIsEnabled (GL_CULL_FACE); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_fogvolc
+	glGetIntegerv (GL_POLYGON_MODE, state->polygon_mode); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_fogvolc
+	glGetFloatv (GL_COLOR_CLEAR_VALUE, state->color_clear_value); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_fogvolc
+	state->framebuffer_srgb = glIsEnabled (GL_FRAMEBUFFER_SRGB); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_fogvolc
+	state->dither = glIsEnabled (GL_DITHER); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_fogvolc
+	state->multisample = glIsEnabled (GL_MULTISAMPLE); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_fogvolc
 	state->cache_draw_fbo = r_fogvol_state_cache.draw_fbo;
 	state->cache_read_fbo = r_fogvol_state_cache.read_fbo;
 	state->cache_program = r_fogvol_state_cache.program;
@@ -483,18 +483,18 @@ static void R_FogVol_TestState_Log (const char *phase, const fogvol_test_state_t
 
 static void R_FogVol_CaptureRestoreState (fogvol_restore_state_t *state)
 {
-	glGetIntegerv (GL_VIEWPORT, state->viewport);
-	state->scissor_test = glIsEnabled (GL_SCISSOR_TEST);
-	glGetIntegerv (GL_SCISSOR_BOX, state->scissor_box);
-	glGetIntegerv (GL_DRAW_FRAMEBUFFER_BINDING, &state->draw_fbo);
-	glGetIntegerv (GL_READ_FRAMEBUFFER_BINDING, &state->read_fbo);
-	glGetIntegerv (GL_DRAW_BUFFER, &state->draw_buffer);
-	glGetIntegerv (GL_READ_BUFFER, &state->read_buffer);
-	glGetIntegerv (GL_CURRENT_PROGRAM, &state->program);
-	glGetIntegerv (GL_VERTEX_ARRAY_BINDING, &state->vao);
-	glGetIntegerv (GL_ACTIVE_TEXTURE, &state->active_texture);
+	glGetIntegerv (GL_VIEWPORT, state->viewport); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_fogvolc
+	state->scissor_test = glIsEnabled (GL_SCISSOR_TEST); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_fogvolc
+	glGetIntegerv (GL_SCISSOR_BOX, state->scissor_box); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_fogvolc
+	glGetIntegerv (GL_DRAW_FRAMEBUFFER_BINDING, &state->draw_fbo); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_fogvolc
+	glGetIntegerv (GL_READ_FRAMEBUFFER_BINDING, &state->read_fbo); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_fogvolc
+	glGetIntegerv (GL_DRAW_BUFFER, &state->draw_buffer); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_fogvolc
+	glGetIntegerv (GL_READ_BUFFER, &state->read_buffer); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_fogvolc
+	glGetIntegerv (GL_CURRENT_PROGRAM, &state->program); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_fogvolc
+	glGetIntegerv (GL_VERTEX_ARRAY_BINDING, &state->vao); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_fogvolc
+	glGetIntegerv (GL_ACTIVE_TEXTURE, &state->active_texture); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_fogvolc
 	state->glstate_bits = glstate;
-	state->framebuffer_srgb = glIsEnabled (GL_FRAMEBUFFER_SRGB);
+	state->framebuffer_srgb = glIsEnabled (GL_FRAMEBUFFER_SRGB); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_fogvolc
 }
 
 static void R_FogVol_Restore3DRenderState (const fogvol_restore_state_t *state)

--- a/Quake/r_postfx.c
+++ b/Quake/r_postfx.c
@@ -148,12 +148,12 @@ void R_PostFX_ReloadLUTs (void)
 	}
 	R_PostFX_GenerateIdentityLUT (lut_storage, size);
 
-	glGenTextures (1, &r_postfx_lut_tex);
+	glGenTextures (1, &r_postfx_lut_tex); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_postfxc
 	GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D_ARRAY, r_postfx_lut_tex);
-	glTexParameteri (GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-	glTexParameteri (GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-	glTexParameteri (GL_TEXTURE_2D_ARRAY, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-	glTexParameteri (GL_TEXTURE_2D_ARRAY, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+	glTexParameteri (GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MIN_FILTER, GL_LINEAR); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_postfxc
+	glTexParameteri (GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MAG_FILTER, GL_LINEAR); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_postfxc
+	glTexParameteri (GL_TEXTURE_2D_ARRAY, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_postfxc
+	glTexParameteri (GL_TEXTURE_2D_ARRAY, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#r_postfxc
 	GL_TexImage3DFunc (GL_TEXTURE_2D_ARRAY, 0, GL_RGBA8, size * size, size, PFX_LUT_COUNT, 0, GL_RGBA, GL_UNSIGNED_BYTE, lut_storage);
 	GL_ObjectLabelFunc (GL_TEXTURE, r_postfx_lut_tex, -1, "postfx lut");
 

--- a/docs/render_backend_gl_exceptions.md
+++ b/docs/render_backend_gl_exceptions.md
@@ -3,28 +3,79 @@
 Diese Liste dokumentiert bewusst erlaubte direkte OpenGL-Aufrufe außerhalb der RB-Implementierung (`Quake/rb_gl.c`).
 
 ## Grundsatz
-- Direkte `gl*`-Aufrufe im Renderpfad sind nur erlaubt, wenn es aktuell keine passende `RB_*`-Abstraktion gibt oder der Pfad explizit als Debug-/Capture-Hook arbeitet.
-- Jede Ausnahme muss mit `GL-EXCEPTION` im Code markiert und hier referenziert sein.
+- Direkte `gl*`-Aufrufe im Renderpfad sind nur erlaubt, wenn es aktuell keine passende `RB_*`-Abstraktion gibt oder der Pfad explizit als Debug-/Capture-/Initialisierungshook arbeitet.
+- Jede A2-relevante Ausnahme muss mit `GL-EXCEPTION` im Code markiert und hier referenziert sein.
 
-## Ausnahmen
+## A2-relevanter Prüfumfang (Marker-Pflicht)
+Die automatische Prüfung (`scripts/check_gl_exceptions.py`) behandelt aktuell folgende Dateien als A2-relevant:
+- `Quake/backend_gl_exec.c`
+- `Quake/gl_screen.c`
+- `Quake/gl_sky.c`
+- `Quake/gl_rmain.c`
+- `Quake/r_fogvol.c`
+- `Quake/r_postfx.c`
 
-### `backend_gl_exec.c`
+## Ausnahmen (vollständige Bestandsaufnahme außerhalb `rb_gl.c`)
+
+### `backend_gl_exec.c` {#backend_gl_execc}
 - **Datei/Stellen:** `Quake/backend_gl_exec.c:268-271`.
-- **Direkte Calls:** `glGetIntegerv`, `glPixelStorei`, `glReadPixels`, `glPixelStorei`.
+- **Direkte Calls:** `glGetIntegerv`, `glPixelStorei`, `glReadPixels`.
 - **Begründung:** Debug-Framehash erfasst explizit den Backbuffer inklusive temporärem Pack-Alignment-Save/Restore.
-- **Eigentümer:** Render Backend Maintainer.
-- **Geplante Ablösung:** Einführung einer RB-Hilfsfunktion (z. B. `RB_ReadPixelsRGB`) mit internem Alignment-Handling und optionalem Hash-Pfad.
+- **Ablöseplan:** `RB_ReadPixelsRGB` als zentrale Readback-Hilfe (inkl. Alignment-Handling) einführen und diesen Pfad darauf umstellen.
 
-### `gl_screen.c`
+### `gl_screen.c` {#gl_screenc}
 - **Datei/Stellen:** `Quake/gl_screen.c:1843-1844`.
 - **Direkte Calls:** `glPixelStorei`, `glReadPixels`.
 - **Begründung:** Screenshot-Pfad liest den finalen Framebuffer direkt aus; derzeit kein RB-Screenshot-API vorhanden.
-- **Eigentümer:** UI/Screenshot Maintainer.
-- **Geplante Ablösung:** Umstellung auf zentrale RB-Readback-API, die Screenshot und Debug-Framehash gemeinsam nutzen.
+- **Ablöseplan:** Screenshot und Framehash auf gemeinsame RB-Readback-API konsolidieren.
 
-### `gl_sky.c`
+### `gl_sky.c` {#gl_skyc}
 - **Datei/Stellen:** `Quake/gl_sky.c:782`, `Quake/gl_sky.c:796`.
 - **Direkte Calls:** `glEnable(GL_STENCIL_TEST)`, `glDisable(GL_STENCIL_TEST)`.
-- **Begründung:** RB bietet aktuell keine dedizierte Stencil-Test Toggle-API; Sky-Stencil-Maskierung benötigt explizites Enable/Disable.
-- **Eigentümer:** World/Sky Rendering Maintainer.
-- **Geplante Ablösung:** Ergänzung einer RB-API für Stencil-Test Enable/Disable (oder Pass-Konfiguration), danach Migration von `gl_sky.c`.
+- **Begründung:** RB bietet aktuell keine dedizierte Stencil-Test-Toggle-API für den Sky-Maskierungspfad.
+- **Ablöseplan:** Stencil-Test als RB-Stateflag in `RB_SetState`/Pass-Konfiguration ergänzen und direkte Toggles entfernen.
+
+### `gl_rmain.c` {#gl_rmainc}
+- **Datei/Stellen:** `Quake/gl_rmain.c:199-5101` (siehe direkte `gl*`-Aufrufe mit Marker in Datei).
+- **Direkte Calls (Cluster):** State-Introspection (`glGet*`, `glIsEnabled`), Readback/Debug (`glReadPixels`, `glPixelStorei`, `glGetError`), Fixed-Function Debug/Overlay (`glMatrixMode`, `glOrtho`, `glDrawPixels`, etc.), Raster-/Depth-/Polygon-State (`glDepthRange`, `glPolygonMode`, `glPolygonOffset`, `glEnable`/`glDisable`, `glFinish`).
+- **Begründung:** Übergangsdatei mit Legacy- und Backend-Dispatch-Pfaden; enthält Debug-Validierung, Readback-Hooks und Legacy-Stateblöcke, für die noch keine vollständigen RB-APIs existieren.
+- **Ablöseplan:**
+  1. Debug/Validate-Readback in dedizierte RB-Debug-API auslagern.
+  2. Fixed-Function-Overlaypfade auf shaderbasierten RB-2D-Path migrieren.
+  3. Verbleibende State-Queries in Backend-State-Tracker kapseln.
+
+### `r_fogvol.c` {#r_fogvolc}
+- **Datei/Stellen:** `Quake/r_fogvol.c:213-497`.
+- **Direkte Calls:** überwiegend `glGet*`/`glIsEnabled` zur Sicherung/Wiederherstellung von FogVol-spezifischem GL-Zustand.
+- **Begründung:** FogVol benötigt aktuell feingranulare State-Snapshots, die RB noch nicht vollständig als strukturierte Save/Restore-API bereitstellt.
+- **Ablöseplan:** RB-State-Snapshot-Objekt für FogVol einführen (Capture/Restore), anschließend direkte `glGet*`-Abfragen entfernen.
+
+### `r_postfx.c` {#r_postfxc}
+- **Datei/Stellen:** `Quake/r_postfx.c:151-156`.
+- **Direkte Calls:** `glGenTextures`, `glTexParameteri`.
+- **Begründung:** LUT-Texturinitialisierung nutzt bisher direkten GL-Setup-Pfad ohne RB-Ressourcen-Factory.
+- **Ablöseplan:** Texture-Create/Param in RB-Ressourcenlayer (`RB_CreateTexture*`, `RB_SetTextureParams`) konsolidieren.
+
+### `gl_vidsdl.c`
+- **Datei/Stellen:** `Quake/gl_vidsdl.c:534-1329`.
+- **Direkte Calls:** Context-/Capabilities-/Initialisierungs-Calls (`glGetString`, `glGetIntegerv`, `glEnable`, `glBlendFunc`, etc.).
+- **Begründung:** Plattform- und Kontextinitialisierung liegt bewusst außerhalb des Render-Backend-Hotpaths.
+- **Ablöseplan:** Optional spätere Trennung in eigenes GL-Device-Layer; aktuell **nicht** A2-Blocker.
+
+### `gl_ktx2.c`
+- **Datei/Stellen:** `Quake/gl_ktx2.c:339-356`.
+- **Direkte Calls:** Textur-Upload/Parameter (`glBindTexture`, `glTexParameteri`, `glTexImage2D`, `glGetError`).
+- **Begründung:** Asset-Decode/Upload-Pfad nutzt Legacy-Texmgr-Schnittstellen ohne RB-Ressourcenabstraktion.
+- **Ablöseplan:** KTX2-Uploads auf denselben RB-Texture-Factory-Pfad wie PostFX migrieren.
+
+### `gl_texmgr.c`
+- **Datei/Stellen:** `Quake/gl_texmgr.c:198-2963`.
+- **Direkte Calls:** vollständiger Legacy-Texture-Manager (`glGenTextures`, `glTexImage2D`, `glTexSubImage2D`, `glGetTexImage`, ...).
+- **Begründung:** zentraler Legacy-Subsystem-Baustein; große, derzeit noch nicht in RB abstrahierte Altlast.
+- **Ablöseplan:** schrittweise Backend-Ressourcenmigration (create/update/readback/delete), danach Reduktion auf Wrapper oder Entfernung.
+
+### `gl_rmisc.c`
+- **Datei/Stellen:** `Quake/gl_rmisc.c:437-1451`.
+- **Direkte Calls:** `glClearColor`, `glFinish`, `glGetError`.
+- **Begründung:** Misc-/Lifecycle-/Synchronisationspfade außerhalb des eigentlichen A2-Draw-Hotpaths.
+- **Ablöseplan:** Synchronisations-/Lifecycle-Hooks in RB-Frame-API verlagern; Fehlerabfragen zentralisieren.

--- a/scripts/check_gl_exceptions.py
+++ b/scripts/check_gl_exceptions.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+A2_FILES = [
+    Path("Quake/backend_gl_exec.c"),
+    Path("Quake/gl_screen.c"),
+    Path("Quake/gl_sky.c"),
+    Path("Quake/gl_rmain.c"),
+    Path("Quake/r_fogvol.c"),
+    Path("Quake/r_postfx.c"),
+]
+GL_CALL_RE = re.compile(r"\bgl[A-Z][A-Za-z0-9_]*\s*\(")
+MARKER = "GL-EXCEPTION"
+
+
+def main() -> int:
+    violations = []
+    for rel_path in A2_FILES:
+        path = REPO_ROOT / rel_path
+        if not path.exists():
+            violations.append(f"{rel_path}: Datei nicht gefunden")
+            continue
+
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            if GL_CALL_RE.search(line) and MARKER not in line:
+                violations.append(f"{rel_path}:{lineno}: {line.strip()}")
+
+    if violations:
+        print("ERROR: direkte gl*-Aufrufe ohne GL-EXCEPTION-Marker gefunden:")
+        print("\n".join(violations))
+        return 1
+
+    print("OK: Keine unmarkierten direkten gl*-Aufrufe in A2-relevanten Dateien gefunden.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Motivation
- Create a single, reviewable inventory of all remaining direct `gl*` usages outside `Quake/rb_gl.c` with rationale and a migration plan so exceptions are explicit and tracked.
- Enforce the project rule that all A2-relevant direct GL calls must be annotated with a `GL-EXCEPTION` marker to prevent regressions when migrating state into the render backend.
- Provide a simple automated guard so new unmarked direct `gl*` calls in the A2 scope are detected early in CI or local checks.

### Description
- Expanded `docs/render_backend_gl_exceptions.md` into a full inventory (per-file rationale and ablöseplan) and explicitly listed the A2-relevant scope files that require `GL-EXCEPTION` markers. 
- Added `GL-EXCEPTION` inline markers to direct `gl*` calls in the A2 files that were missing them (`Quake/gl_rmain.c`, `Quake/r_fogvol.c`, `Quake/r_postfx.c`) and documented other remaining direct-GL locations for planned migration. 
- Added `scripts/check_gl_exceptions.py` to scan the A2-relevant file list and fail on any direct `gl*` call that lacks `GL-EXCEPTION`, and wired this check into CMake as the `check_gl_exceptions` custom target. 

### Testing
- Ran `python3 scripts/check_gl_exceptions.py` and it exited successfully with the message `OK: Keine unmarkierten direkten gl*-Aufrufe in A2-relevanten Dateien gefunden.`. 
- Ran the repository grep-based verification used during rollout (`rg ... | rg -v "GL-EXCEPTION"` wrapper) which returned `OK: only marked direct gl calls in A2 files`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1af14e8a4832eb89fb9b850940e43)