### PR TITLE
Clarify A2 hotpath state ownership and transition helpers

### DIFF
--- a/Quake/rb_gl.c
+++ b/Quake/rb_gl.c
@@ -452,24 +452,13 @@ static void RB_ApplyPassBaselineGL (const rb_pass_baseline_gl_t *baseline)
 	else
 		glDisable (GL_SCISSOR_TEST);
 	RB_ScissorWithOwner (baseline->scissor_box[0], baseline->scissor_box[1], baseline->scissor_box[2], baseline->scissor_box[3], "RB_BeginPass");
+	/* Transition helper: legacy paths still override depth func directly. */
 	RB_DepthFunc (baseline->depth_func);
-	glDepthMask (baseline->depth_mask);
+	/* Transition helper: legacy paths still use explicit blend tuples. */
 	RB_BlendFunc (baseline->blend_src, baseline->blend_dst);
 	GL_BlendEquationFunc (baseline->blend_equation);
-	if (baseline->cull_mode == GL_FRONT || baseline->cull_mode == GL_BACK)
-	{
-		glEnable (GL_CULL_FACE);
-		glCullFace (baseline->cull_mode);
-	}
-	else
-	{
-		glDisable (GL_CULL_FACE);
-	}
 	RB_ColorMaskWithOwner (baseline->color_mask[0], baseline->color_mask[1], baseline->color_mask[2], baseline->color_mask[3], "RB_BeginPass");
-	if (baseline->stencil_enable)
-		glEnable (GL_STENCIL_TEST);
-	else
-		glDisable (GL_STENCIL_TEST);
+	RB_StencilTestWithOwner (baseline->stencil_enable, "RB_BeginPass");
 	RB_StencilFuncWithOwner (baseline->stencil_func, baseline->stencil_ref, baseline->stencil_value_mask, "RB_BeginPass");
 	RB_StencilOpWithOwner (baseline->stencil_sfail, baseline->stencil_dpfail, baseline->stencil_dppass, "RB_BeginPass");
 	RB_StencilMaskWithOwner (baseline->stencil_writemask, "RB_BeginPass");
@@ -675,11 +664,13 @@ void RB_Scissor (GLint x, GLint y, GLsizei width, GLsizei height)
 	RB_ScissorWithOwner (x, y, width, height, "RB_Scissor");
 }
 
+/* Transition helper: temporarily allowed for legacy stage/material code. */
 void RB_DepthFunc (GLenum func)
 {
 	glDepthFunc (func);
 }
 
+/* Transition helper: temporarily allowed for legacy stage/material code. */
 void RB_BlendFunc (GLenum sfactor, GLenum dfactor)
 {
 	glBlendFunc (sfactor, dfactor);

--- a/Quake/rb_gl.h
+++ b/Quake/rb_gl.h
@@ -9,6 +9,10 @@
  * Build guard: wrappers are pass-through only during the initial migration.
  * Keep this set to 1 until backend behavior intentionally diverges.
  *
+ * A2 hotpath rule: state ownership stays in RB_* wrappers. Direct GL state calls
+ * are not allowed in A2 paths, except for explicit transition helpers listed in
+ * render_backend.h (currently RB_DepthFunc/RB_BlendFunc).
+ *
  * Debug guard: RB_DEBUG_STATE enables state-owner tracking + incoming state-diff
  * diagnostics. Default maps to debug builds (!defined(NDEBUG) || defined(_DEBUG)
  * || defined(DEBUG)); override at build-time if needed.
@@ -73,7 +77,9 @@ void RB_DrawElements (GLenum mode, GLsizei count, GLenum type, const GLvoid *ind
 void RB_Clear (GLbitfield mask);
 void RB_Viewport (GLint x, GLint y, GLsizei width, GLsizei height);
 void RB_Scissor (GLint x, GLint y, GLsizei width, GLsizei height);
+/* Transition helper: temporarily allowed for legacy stage/material code. */
 void RB_DepthFunc (GLenum func);
+/* Transition helper: temporarily allowed for legacy stage/material code. */
 void RB_BlendFunc (GLenum sfactor, GLenum dfactor);
 
 typedef void (*rb_pass_setup_hook_t) (rb_pass_t pass);

--- a/Quake/render_backend.h
+++ b/Quake/render_backend.h
@@ -6,7 +6,13 @@
 
 typedef struct render_backend_vtable_s
 {
-	/* Render-hotpath state rule: all GL state mutations in A2 render paths must flow through RB_SetState/IRenderBackend helpers; direct GL_SetState usage is only allowed when listed as a temporary exception in the central A2 TODO list. */
+	/*
+	 * A2 render-hotpath state rule:
+	 * - GL state changes in A2 paths must go through RB_* / IRenderBackend entry points.
+	 * - direct GL_* / GL_SetState calls are forbidden in A2 hotpaths.
+	 * - temporary migration exceptions are explicitly listed below and treated as
+	 *   transition-only helpers that must be removed once their callers migrate.
+	 */
 	/* Preconditions: active GL context on render thread; Side effects: starts backend frame bookkeeping/debug scope; Threading: single render thread only. */
 	void (*BeginFrame) (const char *label);
 	/* Preconditions: matching BeginFrame already issued for current frame; Side effects: flushes/completes backend frame scope; Threading: single render thread only. */
@@ -32,8 +38,13 @@ typedef struct render_backend_vtable_s
 typedef render_backend_vtable_t IRenderBackend;
 
 /*
- * Central A2 render-state TODO exceptions (temporary):
- * - none
+ * Central A2 render-state transition exceptions (temporary, explicitly allowed):
+ * - RB_DepthFunc: legacy material code still overrides depth func per stage.
+ * - RB_BlendFunc: legacy material code still uses custom blend tuples not yet
+ *   representable through GLS_* blend policy.
+ *
+ * Everything else in A2 hotpaths must route state through RB_SetState plus the
+ * RB_* owner wrappers.
  */
 
 extern cvar_t r_backend;


### PR DESCRIPTION
### Motivation
- Enforce the A2 render-hotpath rule that GL state must be owned and mutated via RB_* / IRenderBackend entry points to avoid scattered direct GL state changes. 
- Provide a short-lived, explicit list of legacy transition helpers so ongoing migration work can rely on controlled exceptions. 

### Description
- Clarified the A2 hotpath ownership rule and added a central, explicit transition-exception list in `Quake/render_backend.h`. 
- Mirrored the rule in `Quake/rb_gl.h` and marked `RB_DepthFunc` and `RB_BlendFunc` declarations as temporary transition helpers. 
- Aligned `Quake/rb_gl.c` baseline application to the rule by annotating transition-helper callsites/definitions, removing redundant direct cull/depth-mask steering from the baseline code path, and routing stencil enable/disable through `RB_StencilTestWithOwner`. 
- Added short comments on the transition helpers so callers and future reviewers can find and remove these exceptions once migration completes. 

### Testing
- Ran repository integrity checks using `git diff --check` which reported no whitespace/patch errors. 
- Inspected the commit summary/stat output to verify the modified file set and change sizes which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1b114c4e4832e99d4a1eee10e6132)