### PR TITLE
Extract shared UI/Particles draw functions and route backend paths to them

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -4878,16 +4878,21 @@ static qboolean R_DrawWorldOpaque_Backend (void)
 	return true;
 }
 
-static void R_DrawParticlesOpaque_Legacy (void)
+static void R_DrawParticlesOpaque_Common (void)
 {
 	RB_BeginPass (PASS_PARTICLES);
 	R_DrawParticles (false);
 	RB_EndPass ();
 }
 
+static void R_DrawParticlesOpaque_Legacy (void)
+{
+	R_DrawParticlesOpaque_Common ();
+}
+
 static qboolean R_DrawParticlesOpaque_Backend (void)
 {
-	R_DrawParticlesOpaque_Legacy ();
+	R_DrawParticlesOpaque_Common ();
 	return true;
 }
 
@@ -4910,16 +4915,21 @@ static qboolean R_DrawWorldAlpha_Backend (void)
 	return true;
 }
 
-static void R_DrawParticlesAlpha_Legacy (void)
+static void R_DrawParticlesAlpha_Common (void)
 {
 	RB_BeginPass (PASS_PARTICLES);
 	R_DrawParticles (true);
 	RB_EndPass ();
 }
 
+static void R_DrawParticlesAlpha_Legacy (void)
+{
+	R_DrawParticlesAlpha_Common ();
+}
+
 static qboolean R_DrawParticlesAlpha_Backend (void)
 {
-	R_DrawParticlesAlpha_Legacy ();
+	R_DrawParticlesAlpha_Common ();
 	return true;
 }
 

--- a/Quake/gl_screen.c
+++ b/Quake/gl_screen.c
@@ -2147,7 +2147,7 @@ static qboolean SCR_BackendPostFXPathAvailable (const char **reason)
 	return true;
 }
 
-static void SCR_DrawUI2D_Legacy (void)
+static void SCR_DrawUI2D_Common (void)
 {
 	RB_BeginPass (PASS_UI2D);
 	GL_BeginGroup ("2D");
@@ -2207,9 +2207,14 @@ static void SCR_DrawUI2D_Legacy (void)
 	RB_EndPass ();
 }
 
+static void SCR_DrawUI2D_Legacy (void)
+{
+	SCR_DrawUI2D_Common ();
+}
+
 static qboolean SCR_DrawUI2D_Backend (void)
 {
-	SCR_DrawUI2D_Legacy ();
+	SCR_DrawUI2D_Common ();
 	return true;
 }
 


### PR DESCRIPTION
### Motivation
- Incrementally migrate backend dispatch blocks away from directly calling legacy wrappers by introducing small, shared blocks for UI and particles so backend paths can call backend-specific code without changing fallback behavior.
- Start with minimal-risk areas (UI/2D and particles) to ensure the fallback (legacy) path remains functional while removing at least one direct `*_Legacy()` call from backend functions.

### Description
- Extracted the UI 2D drawing body from `Quake/gl_screen.c` into a shared function `SCR_DrawUI2D_Common()` and updated `SCR_DrawUI2D_Backend()` to call `SCR_DrawUI2D_Common()` instead of invoking `SCR_DrawUI2D_Legacy()` directly, while keeping `SCR_DrawUI2D_Legacy()` as a thin wrapper that calls the common implementation.
- Extracted particle drawing bodies in `Quake/gl_rmain.c` into `R_DrawParticlesOpaque_Common()` and `R_DrawParticlesAlpha_Common()`, made `R_DrawParticlesOpaque_Legacy()` and `R_DrawParticlesAlpha_Legacy()` wrappers that call the common implementations, and changed the backend functions to call the common functions directly.
- The changes preserve the legacy wrapper functions so fallback behavior and call sites that expect `*_Legacy()` remain functional.

### Testing
- Verified source changes with code searches using `rg` to confirm `SCR_DrawUI2D_Backend`, `R_DrawParticlesOpaque_Backend`, and `R_DrawParticlesAlpha_Backend` now invoke the shared common functions instead of calling the legacy wrappers, and the patterns are present in the modified files (search succeeded).
- Attempted a full configure/build with `cmake -S . -B build && cmake --build build -j2`, but configuration failed in the environment due to a missing `SDL2` CMake package (`SDL2Config.cmake` / `sdl2-config.cmake`), so a complete compile could not be performed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1ba264ba4832e8f23dcc0634f8f22)