### PR TITLE
docs: präzisiere reproduzierbaren backend-framehash QA-Ablauf

### DIFF
--- a/docs/render_backend_readiness.md
+++ b/docs/render_backend_readiness.md
@@ -1,71 +1,31 @@
 # Render Backend Readiness Matrix (QA)
 
-## Ziel
-Dieses Dokument definiert eine reproduzierbare QA-Matrix für den Vergleich von Legacy-Renderpfad (`r_backend 0`) und Backend-Renderpfad (`r_backend 1`) über 7 Szenentypen.
+## Ziel und Done-Kriterium
+Dieses Dokument definiert einen **reproduzierbaren** Ablauf, um Legacy-Renderpfad (`r_backend 0`) und Backend-Renderpfad (`r_backend 1`) pro Szene ohne Interpretationsspielraum zu vergleichen.
 
-**Done-Kriterium:** Ein Entwickler kann jeden Testfall ohne Interpretationsspielraum ausführen, Hashes vergleichen und ein eindeutiges Pass/Fail ableiten.
-
----
-
-## Globale Testvoraussetzungen
-
-1. Identische Build-Version, identische GPU-Treiber-Version und identische Videoeinstellungen (`vid_*`, Auflösung, VSync, MSAA, Anisotropie).
-2. Startparameter für reproduzierbare Läufe:
-   - `+host_maxfps 0`
-   - `+r_vsync 0`
-   - falls vorhanden: fixer Demo-/Kamera-Pfad pro Szene.
-3. Vor jedem Szenenlauf:
-   - Neues Engine-Starten (kalter Start) **oder** mindestens `map <szene>` nach `disconnect`.
-   - Konsole leeren/log neu beginnen.
-4. Framehash-Logik:
-   - Referenzlauf immer mit `r_backend 0`.
-   - Vergleichslauf immer mit `r_backend 1`.
-5. Pro Testlauf ist `r_gl_state_validate 1` verpflichtend.
+**Done-Kriterium:** Ein Reviewer kann mit den unten stehenden Schritten backend `0/1` vergleichen, Mismatch-Logs eindeutig bewerten und pro Szene ein belastbares **PASS/FAIL** vergeben.
 
 ---
 
-## Standard-CVar-Block (für alle Szenen)
+## 1) Reproduzierbarer Ablauf (Pflicht)
 
-Diese CVars werden pro Lauf explizit gesetzt, damit nichts vom Nutzerprofil „durchblutet“:
+### 1.1 Testvoraussetzungen
+1. Gleicher Build-Stand, gleicher GPU-Treiber, gleiche Video-Basisparameter (`vid_*`, Auflösung, VSync, MSAA/AF).
+2. Für reproduzierbare Frametimings immer setzen:
+   - `host_maxfps 0`
+   - `r_vsync 0`
+3. Pro Szene immer mit frischem Zustand starten:
+   - Engine-Neustart **oder** `disconnect` + `map <szene>`.
+4. Framehash-Debug muss aktiv sein:
+   - `r_backend_framehash_debug 1`
+5. GL-State-Validierung muss aktiv sein:
+   - `r_gl_state_validate 1`
+
+### 1.2 Standard-Setup pro Lauf
+Diese CVars **vor jedem** Lauf explizit setzen:
 
 ```cfg
 r_backend <0|1>
-r_backend_ui <0|1>
-r_backend_postfx <0|1>
-r_backend_particles <0|1>
-r_backend_alias <0|1>
-r_backend_world <0|1>
-r_backend_fogvol <0|1>
-r_backend_framehash_debug 1
-r_backend_framehash_epsilon <0|1|2>
-r_gl_state_validate 1
-```
-
-Hinweis: `r_backend_framehash_scene` wird pro Szene explizit auf die unten definierte Szenen-ID gesetzt.
-
----
-
-## Szenenmatrix (7 Szenen)
-
-> Konvention: Subtoggles stehen standardmäßig auf `1`, außer in der jeweiligen Szene explizit anders angegeben.
-
-| ID | Szene | Zielabdeckung | r_backend 0 (Referenz) | r_backend 1 (Vergleich) | r_backend_* Subtoggles | framehash_debug | framehash_epsilon | r_gl_state_validate |
-|---|---|---|---|---|---|---|---|---|
-| 1 | Startmap | Basis-World + UI-HUD | `r_backend 0` | `r_backend 1` | `ui=1, postfx=1, particles=1, alias=1, world=1, fogvol=1` | `1` | `0` | `1` |
-| 2 | Open area | Große Sichtweite, viele World-Batches | `r_backend 0` | `r_backend 1` | `ui=1, postfx=1, particles=1, alias=1, world=1, fogvol=1` | `1` | `0` | `1` |
-| 3 | Partikel-lastig | Opaque/Alpha-Particles, Blend-Reihenfolge | `r_backend 0` | `r_backend 1` | `ui=1, postfx=1, particles=1, alias=1, world=1, fogvol=1` | `1` | `1` (nur Partikelrauschen) | `1` |
-| 4 | Wasser/Warp/Teleport | Refraktion/Warp/Teleport-Visuals | `r_backend 0` | `r_backend 1` | `ui=1, postfx=1, particles=1, alias=1, world=1, fogvol=1` | `1` | `1` (Warp-Rundung) | `1` |
-| 5 | Viewmodel + Dlights | Weapon-Viewmodel, dynamische Lichter | `r_backend 0` | `r_backend 1` | `ui=1, postfx=1, particles=1, alias=1, world=1, fogvol=1` | `1` | `0` | `1` |
-| 6 | UI/Console Overlay | HUD, Menüs, Konsole/Overdraw-Reihenfolge | `r_backend 0` | `r_backend 1` | `ui=1, postfx=1, particles=1, alias=1, world=1, fogvol=1` | `1` | `0` | `1` |
-| 7 | FogVol/Godray/SSAO | FogVol-Backend + PostFX-Pfad | `r_backend 0` | `r_backend 1` | `ui=1, postfx=1, particles=1, alias=1, world=1, fogvol=1` | `1` | `2` (PostFX/FogVol Toleranz) | `1` |
-
-### Szenen-spezifische Kommandoblöcke
-
-Für eindeutige Reproduktion pro Szene immer folgende Sequenz verwenden (Beispiel Szene 3):
-
-```cfg
-r_backend_framehash_scene 3
-r_backend 0
 r_backend_ui 1
 r_backend_postfx 1
 r_backend_particles 1
@@ -73,40 +33,101 @@ r_backend_alias 1
 r_backend_world 1
 r_backend_fogvol 1
 r_backend_framehash_debug 1
-r_backend_framehash_epsilon 1
+r_backend_framehash_scene <scene_id>
+r_backend_framehash_epsilon <0..255>
 r_gl_state_validate 1
-map <partikel_map>
 ```
 
-Danach identischer Block mit nur einer Änderung:
+### 1.3 Zwei-Pass-Prozedur je Szene
+Für jede Szene exakt diese Reihenfolge verwenden:
+
+1. `r_backend_framehash_scene <scene_id>` setzen.
+2. **Pass A (Referenz):** `r_backend 0`, gewünschtes `r_backend_framehash_epsilon`, dann `map <szene>` laden und Framehash-Zeile protokollieren.
+3. **Pass B (Vergleich):** identische Konfiguration, nur `r_backend 1`, gleiche Szene erneut laden, Framehash-Zeile protokollieren.
+4. Falls Warnung `backend framehash mismatch` erscheint: nach Kapitel „Vergleichsregeln“ entscheiden.
+
+### 1.4 Minimal-Template (copy/paste)
 
 ```cfg
+host_maxfps 0
+r_vsync 0
+r_gl_state_validate 1
+
+r_backend_framehash_scene <scene_id>
+r_backend_framehash_debug 1
+r_backend_framehash_epsilon <eps>
+
+r_backend_ui 1
+r_backend_postfx 1
+r_backend_particles 1
+r_backend_alias 1
+r_backend_world 1
+r_backend_fogvol 1
+
+r_backend 0
+map <mapname>
+
 r_backend 1
+map <mapname>
 ```
 
 ---
 
-## Pass/Fail-Kriterien
+## 2) Szenenliste (QA-Matrix)
 
-Ein Testfall ist nur **PASS**, wenn **alle** Bedingungen erfüllt sind:
+> Konvention: Alle `r_backend_*` Subtoggles stehen auf `1`, sofern in einer Szene nicht anders angegeben.
 
-1. **Framehash-Kriterium**
-   - Primär: Hashes von `r_backend 0` und `r_backend 1` sind gleich.
-   - Ausnahmefall: Hash-Differenz ist zulässig, wenn die Szene einen `r_backend_framehash_epsilon > 0` vorgibt **und** die Abweichung innerhalb dieser Epsilon-Grenze liegt.
-   - Jede Epsilon-Ausnahme muss im QA-Log begründet werden (z. B. „Partikel-Noise in Szene 3“).
-
-2. **Stabilitäts-/Leak-Kriterium**
-   - Keine Leak-Warnings im Log (insbesondere Render-/GPU-Ressourcen-Leaks).
-   - Keine zusätzlichen GL-Validate-Fehler bei `r_gl_state_validate 1`.
-
-3. **Reproduzierbarkeit**
-   - Ein zweiter Lauf mit identischer Konfiguration führt zum gleichen Urteil (PASS oder FAIL).
-
-Ein Testfall ist **FAIL**, sobald eine der obigen Bedingungen verletzt ist.
+| Szene-ID (`r_backend_framehash_scene`) | Szene | Abdeckung | `r_backend_framehash_epsilon` | Hinweise |
+|---|---|---|---:|---|
+| 1 | Startmap Baseline | World + HUD/UI-Basis | 0 | Strikter Hash-Gleichstand erwartet |
+| 2 | Open Area / Long View | Viele World-Batches, Sichtweite | 0 | Strikter Hash-Gleichstand erwartet |
+| 3 | Partikel-lastig | Alpha/Blend, dichte Partikel | 1 | Kleine Pixel-Abweichungen tolerierbar |
+| 4 | Wasser/Warp/Teleport | Warp-/Teleport-Effekte | 1 | Rundungs-/Samplingdifferenzen tolerierbar |
+| 5 | Viewmodel + Dlights | Weaponmodel + dynamische Lichter | 0 | Strikter Hash-Gleichstand erwartet |
+| 6 | UI/Console Overlay | HUD/Menu/Console-Reihenfolge | 0 | Strikter Hash-Gleichstand erwartet |
+| 7 | FogVol/Godray/SSAO | FogVol + PostFX-Pfad | 2 | Nur bei aktiver PostFX-Ausnahme zulässig |
 
 ---
 
-## QA-Protokollvorlage (pro Szene)
+## 3) Vergleichsregeln (verbindlich)
+
+### 3.1 Logzeilen, die bewertet werden
+- Debug-Ausgabe pro Lauf:
+  - `backend framehash: map=<...> scene=<id> backend=<0|1> frame=<n> hash=<...>`
+- Mismatch-Ausgabe:
+  - `backend framehash mismatch: ... ctx[... eps=<n>]`
+
+### 3.2 Entscheidungslogik PASS/FAIL
+Ein Szenenvergleich ist **PASS**, wenn alle Punkte erfüllt sind:
+1. **Framehash-Regel**
+   - Entweder Hashes backend 0/1 sind identisch.
+   - Oder (nur Ausnahmefall): `r_backend_framehash_epsilon > 0` **und** zulässige PostFX-Ausnahme ist aktiv (siehe 3.3) **und** Pixel-Differenz liegt innerhalb Epsilon.
+2. **Stabilitätsregel**
+   - Keine Leak-Warnings im Log.
+   - Keine GL-Validate-Fehler bei `r_gl_state_validate 1`.
+3. **Reproduzierbarkeit**
+   - Wiederholung derselben Szene mit identischer Konfiguration ergibt dasselbe Urteil.
+
+Sobald einer dieser Punkte verletzt ist, ist das Ergebnis **FAIL**.
+
+### 3.3 Erlaubte PostFX-Epsilon-Ausnahmen (verbindlich)
+`r_backend_framehash_epsilon` darf **nur** als Ausnahme gewertet werden, wenn PostFX aktiv ist und mindestens einer der bekannten schwankenden PostFX-Pfade aktiv ist.
+
+| Bedingung | Muss erfüllt sein |
+|---|---|
+| PostFX global aktiv | `r_postfx > 0` |
+| Mindestens eine Ausnahmequelle aktiv | `r_postfx_damage > 0` **oder** `r_postfx_pickup > 0` **oder** `r_postfx_powerup > 0` **oder** `r_postfx_underwater > 0` **oder** `r_motionblur > 0` **oder** `r_dof > 0` **oder** `r_autoexposure > 0` |
+
+Wenn diese Bedingungen **nicht** erfüllt sind, zählt ein Mismatch trotz gesetztem Epsilon als **FAIL**.
+
+### 3.4 Bewertungsregel für Mismatches
+- Mismatch mit `eps=0` => **immer FAIL**.
+- Mismatch mit `eps>0`, aber ohne gültige PostFX-Ausnahme aus 3.3 => **FAIL**.
+- Mismatch mit `eps>0` und gültiger PostFX-Ausnahme => nur dann **PASS**, wenn keine weiteren Regeln verletzt sind und der Fall im QA-Protokoll begründet wird.
+
+---
+
+## 4) QA-Protokollvorlage (pro Szene)
 
 | Feld | Wert |
 |---|---|
@@ -114,20 +135,22 @@ Ein Testfall ist **FAIL**, sobald eine der obigen Bedingungen verletzt ist.
 | Map / Startpunkt | |
 | Lauf A (`r_backend 0`) Hash | |
 | Lauf B (`r_backend 1`) Hash | |
-| Epsilon gesetzt | |
-| Epsilon-Begründung (falls > 0) | |
+| Mismatch-Warnung vorhanden | Ja/Nein |
+| `r_backend_framehash_epsilon` | |
+| PostFX-Ausnahme aktiv gemäß 3.3 | Ja/Nein |
+| Epsilon-Begründung | |
 | Leak-Warnings gefunden | Ja/Nein |
 | GL-Validate-Fehler gefunden | Ja/Nein |
+| Re-Run identisch | Ja/Nein |
 | Ergebnis | PASS / FAIL |
 | Tester + Datum | |
 
 ---
 
-## Abschlussregel für Readiness
+## 5) Abschlussregel für Backend-Readiness
 
 `Render Backend Ready` gilt erst dann, wenn:
-
-- alle 7 Szenen mindestens einmal mit PASS abgeschlossen sind,
-- kein FAIL offen ist,
-- alle Epsilon-Ausnahmen dokumentiert und technisch begründet sind,
-- keine Leak-Warnings in irgendeiner Szene aufgetreten sind.
+1. alle 7 Szenen mit obigem Ablauf mindestens einmal **PASS** sind,
+2. kein offener **FAIL** existiert,
+3. alle Epsilon-Fälle auf zulässige PostFX-Ausnahmen (3.3) zurückgeführt und dokumentiert sind,
+4. in keinem Lauf Leak-Warnings oder GL-Validate-Fehler verbleiben.


### PR DESCRIPTION
### Motivation
- Das QA-Dokument soll einen eindeutigen, reproduzierbaren Ablauf liefern, um Unterschiede zwischen Legacy-Renderpfad (`r_backend 0`) und Backend-Renderpfad (`r_backend 1`) zu erkennen und zu bewerten.
- Insbesondere sollen die Nutzung von `r_backend_framehash_debug`, `r_backend_framehash_scene` und optional `r_backend_framehash_epsilon` festgelegt sowie erlaubte PostFX-Epsilon-Ausnahmen klar definiert werden.
- Ziel ist, dass ein Reviewer ohne Interpretationsspielraum backend `0/1` vergleichen und Mismatches eindeutig als PASS/FAIL bewerten kann.

### Description
- Vollständige Überarbeitung von `docs/render_backend_readiness.md` zu einem strukturierten, verpflichtenden Zwei-Pass-Ablauf mit Copy/Paste-Template für reproduzierbare Läufe (Referenz `r_backend 0` und Vergleich `r_backend 1`).
- Standard-Setup/CVar-Block explizit festgelegt, inklusive `r_backend_framehash_debug`, `r_backend_framehash_scene`, `r_backend_framehash_epsilon` und `r_gl_state_validate` sowie empfohlene Subtoggles (`r_backend_ui`, `r_backend_postfx`, `r_backend_particles`, `r_backend_alias`, `r_backend_world`, `r_backend_fogvol`).
- Hinzugefügt: klare Szenenliste (Szenen-IDs) mit zugewiesenem `r_backend_framehash_epsilon` pro Szene und Hinweise zur erwarteten Toleranz.
- Vergleichsregeln und Bewertungslogik definiert: präzise Logzeilen, PASS/FAIL-Entscheidungskriterien, verbindliche Bedingungen für PostFX-Epsilon-Ausnahmen (konkrete CVar-Bedingungen) sowie erweitertes QA-Protokoll-Template.

### Testing
- `git diff --check` ausgeführt und es wurden keine Whitespace- oder Patch-Fehler gemeldet (erfolgreich).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1bc4a2ba4832eba148fe1c66bd849)