### PR TITLE
Add QA preset aliases and document GL state-leak workflow

### DIFF
--- a/Misc/pak/default.cfg
+++ b/Misc/pak/default.cfg
@@ -53,6 +53,8 @@ bind	MWHEELUP			"impulse 12"
 // zoom
 alias zoom_in "togglezoom"
 alias zoom_out "togglezoom"
+alias qa_stateleaks_on "r_gl_state_validate 1; r_rb_assert_state 1; echo [QA] state-leak preset ON (validate=1 assert=1)"
+alias qa_stateleaks_off "r_gl_state_validate 0; r_rb_assert_state 0; echo [QA] state-leak preset OFF"
 bind F11 zoom_in
 
 // Function keys

--- a/Quake/default_cfg.h
+++ b/Quake/default_cfg.h
@@ -45,6 +45,8 @@ static const char default_cfg[] =
 
 "alias zoom_in \"togglezoom\"\n"
 "alias zoom_out \"togglezoom\"\n"
+"alias qa_stateleaks_on \"r_gl_state_validate 1; r_rb_assert_state 1; echo [QA] state-leak preset ON (validate=1 assert=1)\"\n"
+"alias qa_stateleaks_off \"r_gl_state_validate 0; r_rb_assert_state 0; echo [QA] state-leak preset OFF\"\n"
 "bind F11 zoom_in\n"
 
 "bind F1 \"help\"\n"

--- a/docs/render_backend_readiness.md
+++ b/docs/render_backend_readiness.md
@@ -21,6 +21,20 @@ Dieses Dokument definiert einen **reproduzierbaren** Ablauf, um Legacy-Renderpfa
 5. GL-State-Validierung muss aktiv sein:
    - `r_gl_state_validate 1`
 
+### 1.1.1 Debug-Preset für Pass-State-Leaks (Pflicht für QA-Läufe)
+Für konsistente Leak-Reports werden `r_gl_state_validate` und `r_rb_assert_state` gemeinsam als Preset geschaltet.
+
+**Preset aktivieren (empfohlen):**
+- `qa_stateleaks_on`
+
+**Preset deaktivieren (nach dem Lauf):**
+- `qa_stateleaks_off`
+
+**Fallback ohne Alias (optional):**
+- `r_gl_state_validate 1; r_rb_assert_state 1`
+
+Wenn `r_rb_assert_state 1` aktiv ist, werden Pass-Ein-/Ausstiegsmismatches als harter Fehler (`Sys_Error`) sichtbar und können im QA-Protokoll reproduzierbar als Leak-Report erfasst werden.
+
 ### 1.2 Standard-Setup pro Lauf
 Diese CVars **vor jedem** Lauf explizit setzen:
 
@@ -36,6 +50,7 @@ r_backend_framehash_debug 1
 r_backend_framehash_scene <scene_id>
 r_backend_framehash_epsilon <0..255>
 r_gl_state_validate 1
+r_rb_assert_state 1
 ```
 
 ### 1.3 Zwei-Pass-Prozedur je Szene
@@ -52,6 +67,7 @@ Für jede Szene exakt diese Reihenfolge verwenden:
 host_maxfps 0
 r_vsync 0
 r_gl_state_validate 1
+r_rb_assert_state 1
 
 r_backend_framehash_scene <scene_id>
 r_backend_framehash_debug 1


### PR DESCRIPTION
### Motivation
- Make Pass-Ein-/Ausstiegsmismatches (GL state leaks) consistently visible during QA runs by providing a reproducible preset that enables both validation and assert modes. 
- Provide a lightweight, copy/paste-friendly workflow so testers can reliably reproduce and capture leak reports across embedded and pak configs.

### Description
- Add two console aliases `qa_stateleaks_on` and `qa_stateleaks_off` to the embedded default config (`Quake/default_cfg.h`) to toggle `r_gl_state_validate` and `r_rb_assert_state` together with an informative `echo` message. 
- Mirror the same two aliases in the pak default config (`Misc/pak/default.cfg`) so the preset is available from both config sources. 
- Update `docs/render_backend_readiness.md` to document the preset workflow, add a dedicated "Debug-Preset for Pass-State-Leaks" section, and include `r_rb_assert_state 1` in the standard setup and minimal-template examples.

### Testing
- Verified presence of the aliases and documentation updates by running `rg -n "qa_stateleaks" Quake/default_cfg.h Misc/pak/default.cfg docs/render_backend_readiness.md`, which found the new entries. 
- Inspected modified files to confirm the new alias lines appear in both `Quake/default_cfg.h` and `Misc/pak/default.cfg` and that the docs contain the new preset section and template changes. 
- Ran `git diff --check` to ensure no whitespace or simple diff issues were introduced and it completed with no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1bdd630a8832e809edbc1c0107da9)