### PR TITLE
RB: add stencil state bit and migrate sky stencil toggles to RB

### DIFF
--- a/Quake/gl_sky.c
+++ b/Quake/gl_sky.c
@@ -779,7 +779,7 @@ void Sky_DrawSky (void)
 	}
 	else if (skybox)
 	{
-		glEnable (GL_STENCIL_TEST); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_skyc
+		RB_StencilTest (true);
 		RB_StencilMask (1);
 		RB_StencilFunc (GL_ALWAYS, 1, 1);
 		RB_StencilOp (GL_KEEP, GL_KEEP, GL_REPLACE);
@@ -793,7 +793,7 @@ void Sky_DrawSky (void)
 
 		Sky_DrawSkyBox ();
 
-		glDisable (GL_STENCIL_TEST); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_skyc
+		RB_StencilTest (false);
 	}
 	else
 	{

--- a/Quake/rb_gl.c
+++ b/Quake/rb_gl.c
@@ -480,8 +480,11 @@ static void RB_ApplyPassBaselineGL (const rb_pass_baseline_gl_t *baseline)
 
 void RB_SetState_Owner (unsigned mask, const char *owner)
 {
+	unsigned gl_mask = mask & ~RB_GLS_STENCIL_TEST;
+	qboolean stencil_enable = (mask & RB_GLS_STENCIL_TEST) != 0;
+
 	#if RB_DEBUG_STATE
-	unsigned changed = glstate ^ mask;
+	unsigned changed = glstate ^ gl_mask;
 
 	if ((changed & GLS_MASK_BLEND) != 0)
 		rb_state_debug.last_blend_owner = owner;
@@ -489,9 +492,12 @@ void RB_SetState_Owner (unsigned mask, const char *owner)
 		rb_state_debug.last_depth_owner = owner;
 	if ((changed & GLS_MASK_CULL) != 0)
 		rb_state_debug.last_cull_owner = owner;
+	if ((glIsEnabled (GL_STENCIL_TEST) ? 1 : 0) != (stencil_enable ? 1 : 0))
+		rb_state_debug.last_stencil_owner = owner;
 	#endif
 
-	GL_SetState (mask);
+	GL_SetState (gl_mask);
+	RB_StencilTestWithOwner (stencil_enable, owner);
 }
 
 void RB_UseProgram_Owner (GLuint program, const char *owner)

--- a/Quake/rb_gl.h
+++ b/Quake/rb_gl.h
@@ -19,6 +19,9 @@
  */
 #define RB_GL_PASSTHROUGH_ONLY 1
 
+/* RB-local extension bit for RB_SetState: toggles GL_STENCIL_TEST. */
+#define RB_GLS_STENCIL_TEST (1u << 31)
+
 void RB_SetState_Owner (unsigned mask, const char *owner);
 void RB_UseProgram_Owner (GLuint program, const char *owner);
 qboolean RB_BindTexture_Owner (GLenum texunit, gltexture_t *texture, const char *owner);

--- a/docs/render_backend_gl_exceptions.md
+++ b/docs/render_backend_gl_exceptions.md
@@ -10,7 +10,6 @@ Diese Liste dokumentiert bewusst erlaubte direkte OpenGL-Aufrufe außerhalb der 
 Die automatische Prüfung (`scripts/check_gl_exceptions.py`) behandelt aktuell folgende Dateien als A2-relevant:
 - `Quake/backend_gl_exec.c`
 - `Quake/gl_screen.c`
-- `Quake/gl_sky.c`
 - `Quake/gl_rmain.c`
 - `Quake/r_fogvol.c`
 - `Quake/r_postfx.c`
@@ -28,12 +27,6 @@ Die automatische Prüfung (`scripts/check_gl_exceptions.py`) behandelt aktuell f
 - **Direkte Calls:** `glPixelStorei`, `glReadPixels`.
 - **Begründung:** Screenshot-Pfad liest den finalen Framebuffer direkt aus; derzeit kein RB-Screenshot-API vorhanden.
 - **Ablöseplan:** Screenshot und Framehash auf gemeinsame RB-Readback-API konsolidieren.
-
-### `gl_sky.c` {#gl_skyc}
-- **Datei/Stellen:** `Quake/gl_sky.c:782`, `Quake/gl_sky.c:796`.
-- **Direkte Calls:** `glEnable(GL_STENCIL_TEST)`, `glDisable(GL_STENCIL_TEST)`.
-- **Begründung:** RB bietet aktuell keine dedizierte Stencil-Test-Toggle-API für den Sky-Maskierungspfad.
-- **Ablöseplan:** Stencil-Test als RB-Stateflag in `RB_SetState`/Pass-Konfiguration ergänzen und direkte Toggles entfernen.
 
 ### `gl_rmain.c` {#gl_rmainc}
 - **Datei/Stellen:** `Quake/gl_rmain.c:199-5101` (siehe direkte `gl*`-Aufrufe mit Marker in Datei).


### PR DESCRIPTION
### Motivation
- Provide a dedicated render-backend control for enabling/disabling the GL stencil test so state ownership is handled by RB instead of direct `glEnable`/`glDisable` calls.
- Migrate the sky rendering path away from direct stencil toggles to the RB API to comply with A2 hotpath rules while preserving existing sky masking behavior.
- Remove the now-obsolete documentation exception for `gl_sky.c` once the direct calls are eliminated.

### Description
- Added `RB_GLS_STENCIL_TEST` (an RB-local state bit) to `Quake/rb_gl.h` to represent stencil-test enable in `RB_SetState`.
- Updated `RB_SetState_Owner` in `Quake/rb_gl.c` to mask out the RB-local stencil bit, compute `stencil_enable`, call `GL_SetState` with the remaining mask, and route stencil enable/disable through `RB_StencilTestWithOwner` while preserving debug-owner tracking.
- Replaced direct `glEnable(GL_STENCIL_TEST)` / `glDisable(GL_STENCIL_TEST)` in `Quake/gl_sky.c` with `RB_StencilTest(true)` / `RB_StencilTest(false)` and kept the existing `RB_StencilMask` / `RB_StencilFunc` / `RB_StencilOp` / `RB_ColorMask` ordering intact.
- Removed the `gl_sky.c` direct-GL exception block from `docs/render_backend_gl_exceptions.md` now that the path is migrated.

### Testing
- Ran `python scripts/check_gl_exceptions.py` to validate there are no unmarked direct `gl*` calls in A2-relevant files and it completed successfully.
- Verified via `rg` searches that `glEnable(GL_STENCIL_TEST)` / `glDisable(GL_STENCIL_TEST)` no longer appear in `Quake/gl_sky.c` and that `RB_StencilTest` is used instead, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1c89032e8832ea1b7889adebee5e0)