### PR TITLE
Unify framehash/screenshot readback with RB_ReadPixelsRGB

### DIFF
--- a/Quake/backend_gl_exec.c
+++ b/Quake/backend_gl_exec.c
@@ -241,7 +241,6 @@ void RBackend_DebugCaptureEndFrameHash (void)
 	const int backend_index = ((int)r_backend.value == 1) ? 1 : 0;
 	const int scene_id = (int)Q_rint (r_backend_framehash_scene.value);
 	const size_t rgb_bytes = (size_t)glwidth * (size_t)glheight * 3;
-	GLint prev_pack_alignment = 4;
 	byte *pixels;
 	qboolean scene_changed;
 
@@ -265,10 +264,11 @@ void RBackend_DebugCaptureEndFrameHash (void)
 	if (!pixels)
 		return;
 
-	glGetIntegerv (GL_PACK_ALIGNMENT, &prev_pack_alignment); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#backend_gl_execc
-	glPixelStorei (GL_PACK_ALIGNMENT, 1); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#backend_gl_execc
-	glReadPixels (glx, gly, glwidth, glheight, GL_RGB, GL_UNSIGNED_BYTE, pixels); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#backend_gl_execc
-	glPixelStorei (GL_PACK_ALIGNMENT, prev_pack_alignment); // GL-EXCEPTION: docs/render_backend_gl_exceptions.md#backend_gl_execc
+	if (!RB_ReadPixelsRGB (glx, gly, glwidth, glheight, pixels))
+	{
+		free (pixels);
+		return;
+	}
 
 	if (state->pixels[backend_index])
 		free (state->pixels[backend_index]);

--- a/Quake/gl_screen.c
+++ b/Quake/gl_screen.c
@@ -1840,8 +1840,12 @@ void SCR_ScreenShot_f (void)
 		scr_skipupdate = oldskip;
 	}
 
-	glPixelStorei (GL_PACK_ALIGNMENT, 1);/* GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_screenc */
-	glReadPixels (glx, gly, glwidth, glheight, GL_RGB, GL_UNSIGNED_BYTE, buffer); /* GL-EXCEPTION: docs/render_backend_gl_exceptions.md#gl_screenc */
+	if (!RB_ReadPixelsRGB (glx, gly, glwidth, glheight, buffer))
+	{
+		Con_Printf ("SCR_ScreenShot_f: Failed to read pixels\n");
+		free (buffer);
+		return;
+	}
 
 // now write the file
 	if (!Steam_SaveScreenshot (buffer, glwidth, glheight))

--- a/Quake/rb_gl.c
+++ b/Quake/rb_gl.c
@@ -706,6 +706,39 @@ void RB_ReadBuffer_Owner (GLenum src, const char *owner)
 	glReadBuffer (src);
 }
 
+qboolean RB_ReadPixelsRGB_Owner (GLint x, GLint y, GLsizei width, GLsizei height, void *pixels, const char *owner)
+{
+	GLint prev_pack_alignment = 4;
+	GLenum err;
+
+	if (!pixels)
+	{
+		Con_Warning ("RB_ReadPixelsRGB(%s): NULL destination buffer\n", RB_DebugOwnerOrUnknown (owner));
+		return false;
+	}
+
+	if (width <= 0 || height <= 0)
+	{
+		Con_Warning ("RB_ReadPixelsRGB(%s): invalid size %dx%d\n", RB_DebugOwnerOrUnknown (owner), width, height);
+		return false;
+	}
+
+	glGetIntegerv (GL_PACK_ALIGNMENT, &prev_pack_alignment);
+	glPixelStorei (GL_PACK_ALIGNMENT, 1);
+	glReadPixels (x, y, width, height, GL_RGB, GL_UNSIGNED_BYTE, pixels);
+	err = glGetError ();
+	glPixelStorei (GL_PACK_ALIGNMENT, prev_pack_alignment);
+
+	if (err != GL_NO_ERROR)
+	{
+		Con_Warning ("RB_ReadPixelsRGB(%s): glReadPixels failed (err=%#x, x=%d y=%d w=%d h=%d)\n",
+			RB_DebugOwnerOrUnknown (owner), err, x, y, width, height);
+		return false;
+	}
+
+	return true;
+}
+
 void RB_SetPassSetupHook (rb_pass_setup_hook_t hook)
 {
 	rb_pass_setup_hook = hook;

--- a/Quake/rb_gl.h
+++ b/Quake/rb_gl.h
@@ -40,6 +40,7 @@ void RB_StencilTest_Owner (qboolean enable, const char *owner);
 void RB_TexParameteri_Owner (GLenum target, GLenum pname, GLint param, const char *owner);
 void RB_DrawBuffer_Owner (GLenum buf, const char *owner);
 void RB_ReadBuffer_Owner (GLenum src, const char *owner);
+qboolean RB_ReadPixelsRGB_Owner (GLint x, GLint y, GLsizei width, GLsizei height, void *pixels, const char *owner);
 #define RB_SetState(mask) RB_SetState_Owner ((mask), __func__)
 #define RB_UseProgram(program) RB_UseProgram_Owner ((program), __func__)
 #define RB_BindTexture(texunit, texture) RB_BindTexture_Owner ((texunit), (texture), __func__)
@@ -57,6 +58,7 @@ void RB_ReadBuffer_Owner (GLenum src, const char *owner);
 #define RB_TexParameteri(target, pname, param) RB_TexParameteri_Owner ((target), (pname), (param), __func__)
 #define RB_DrawBuffer(buf) RB_DrawBuffer_Owner ((buf), __func__)
 #define RB_ReadBuffer(src) RB_ReadBuffer_Owner ((src), __func__)
+#define RB_ReadPixelsRGB(x, y, width, height, pixels) RB_ReadPixelsRGB_Owner ((x), (y), (width), (height), (pixels), __func__)
 #define RB_SetStateWithOwner(mask, owner) RB_SetState_Owner ((mask), (owner))
 #define RB_UseProgramWithOwner(program, owner) RB_UseProgram_Owner ((program), (owner))
 #define RB_BindTextureWithOwner(texunit, texture, owner) RB_BindTexture_Owner ((texunit), (texture), (owner))
@@ -75,6 +77,7 @@ void RB_ReadBuffer_Owner (GLenum src, const char *owner);
 #define RB_TexParameteriWithOwner(target, pname, param, owner) RB_TexParameteri_Owner ((target), (pname), (param), (owner))
 #define RB_DrawBufferWithOwner(buf, owner) RB_DrawBuffer_Owner ((buf), (owner))
 #define RB_ReadBufferWithOwner(src, owner) RB_ReadBuffer_Owner ((src), (owner))
+#define RB_ReadPixelsRGBWithOwner(x, y, width, height, pixels, owner) RB_ReadPixelsRGB_Owner ((x), (y), (width), (height), (pixels), (owner))
 void RB_DrawArrays (GLenum mode, GLint first, GLsizei count);
 void RB_DrawElements (GLenum mode, GLsizei count, GLenum type, const GLvoid *indices);
 void RB_Clear (GLbitfield mask);

--- a/docs/render_backend_gl_exceptions.md
+++ b/docs/render_backend_gl_exceptions.md
@@ -17,16 +17,12 @@ Die automatische Prüfung (`scripts/check_gl_exceptions.py`) behandelt aktuell f
 ## Ausnahmen (vollständige Bestandsaufnahme außerhalb `rb_gl.c`)
 
 ### `backend_gl_exec.c` {#backend_gl_execc}
-- **Datei/Stellen:** `Quake/backend_gl_exec.c:268-271`.
-- **Direkte Calls:** `glGetIntegerv`, `glPixelStorei`, `glReadPixels`.
-- **Begründung:** Debug-Framehash erfasst explizit den Backbuffer inklusive temporärem Pack-Alignment-Save/Restore.
-- **Ablöseplan:** `RB_ReadPixelsRGB` als zentrale Readback-Hilfe (inkl. Alignment-Handling) einführen und diesen Pfad darauf umstellen.
+- **Status:** Direkte Readback-Calls entfernt; Pfad nutzt jetzt `RB_ReadPixelsRGB`.
+- **Hinweis:** Koordinaten/Region bleiben unverändert (`glx`, `gly`, `glwidth`, `glheight`) und werden unverändert an die RB-Hilfe durchgereicht.
 
 ### `gl_screen.c` {#gl_screenc}
-- **Datei/Stellen:** `Quake/gl_screen.c:1843-1844`.
-- **Direkte Calls:** `glPixelStorei`, `glReadPixels`.
-- **Begründung:** Screenshot-Pfad liest den finalen Framebuffer direkt aus; derzeit kein RB-Screenshot-API vorhanden.
-- **Ablöseplan:** Screenshot und Framehash auf gemeinsame RB-Readback-API konsolidieren.
+- **Status:** Direkte Readback-Calls entfernt; Pfad nutzt jetzt `RB_ReadPixelsRGB`.
+- **Hinweis:** Bestehende Region (`glx`, `gly`, `glwidth`, `glheight`) bleibt unverändert.
 
 ### `gl_rmain.c` {#gl_rmainc}
 - **Datei/Stellen:** `Quake/gl_rmain.c:199-5101` (siehe direkte `gl*`-Aufrufe mit Marker in Datei).


### PR DESCRIPTION
### Motivation
- Zentralisiere RGB-Framebuffer-Readback in der Render-Backend-Schicht, um wiederholten `glPixelStorei`/`glReadPixels`-Code zu vermeiden und konsistente Fehlerbehandlung zu ermöglichen.
- Stelle sicher, dass bestehendes Verhalten für Region/Koordinaten unverändert bleibt (`glx`, `gly`, `glwidth`, `glheight` werden 1:1 weitergereicht).

### Description
- Füge die RB-API `RB_ReadPixelsRGB` / `RB_ReadPixelsRGB_Owner` in `Quake/rb_gl.h` hinzu und exportiere Makros `RB_ReadPixelsRGB(...)` und `RB_ReadPixelsRGBWithOwner(...)`. 
- Implementiere `RB_ReadPixelsRGB_Owner` in `Quake/rb_gl.c` mit Pack-Alignment Save/Restore, Input-Validierung (`NULL`-Buffer, `width/height <= 0`) und zentralem `glGetError`-Logging (`Con_Warning`) inklusive Owner- und Regionskontext. 
- Migriere die Call-Sites in `Quake/backend_gl_exec.c` (Framehash) und `Quake/gl_screen.c` (Screenshot) auf `RB_ReadPixelsRGB(...)`, und behandle Fehlerfälle dort sauber (Buffer-Freigabe / frühzeitiger Return). 
- Aktualisiere `docs/render_backend_gl_exceptions.md`, entferne/verschlanke die direkten `glReadPixels`-Ausnahmen für die beiden Pfade und dokumentiere den neuen Status; keine Koordinaten-/Regionstransformationen wurden eingeführt. 

### Testing
- Automatischer Prüfskriptlauf `python3 scripts/check_gl_exceptions.py` wurde ausgeführt und meldet Erfolg (`OK: Keine unmarkierten direkten gl*-Aufrufe in A2-relevanten Dateien gefunden`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1c9e9fe24832e9b7cf54357b63913)