### PR TITLE
Fix Visual Studio linker errors for render-backend symbols

### DIFF
--- a/Windows/VisualStudio/ironwail.vcxproj
+++ b/Windows/VisualStudio/ironwail.vcxproj
@@ -235,6 +235,7 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
       <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">CompileAsCpp</CompileAs>
     </ClCompile>
     <ClCompile Include="..\..\Quake\cd_null.c" />
+    <ClCompile Include="..\..\Quake\backend_gl_exec.c" />
     <ClCompile Include="..\..\Quake\cfgfile.c" />
     <ClCompile Include="..\..\Quake\chase.c" />
     <ClCompile Include="..\..\Quake\cl_demo.c" />
@@ -310,6 +311,7 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|x64'">quakedef.h</PrecompiledHeaderFile>
     </ClCompile>
     <ClCompile Include="..\..\Quake\r_alias.c" />
+    <ClCompile Include="..\..\Quake\rb_gl.c" />
     <ClCompile Include="..\..\Quake\r_brush.c" />
     <ClCompile Include="..\..\Quake\r_dlight_pool.c" />
     <ClCompile Include="..\..\Quake\r_fogvol.c" />
@@ -422,6 +424,8 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
     <ClInclude Include="..\..\Quake\r_dlight_pool.h" />
     <ClInclude Include="..\..\Quake\r_fogvol.h" />
     <ClInclude Include="..\..\Quake\resource.h" />
+    <ClInclude Include="..\..\Quake\render_backend.h" />
+    <ClInclude Include="..\..\Quake\rb_gl.h" />
     <ClInclude Include="..\..\Quake\sbar.h" />
     <ClInclude Include="..\..\Quake\screen.h" />
     <ClInclude Include="..\..\Quake\sidebar.h" />

--- a/Windows/VisualStudio/ironwail.vcxproj.filters
+++ b/Windows/VisualStudio/ironwail.vcxproj.filters
@@ -174,6 +174,9 @@
     <ClCompile Include="..\..\Quake\r_alias.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Quake\rb_gl.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\Quake\r_brush.c">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -292,6 +295,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\Quake\cd_null.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Quake\backend_gl_exec.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\Quake\snd_mpg123.c">
@@ -528,6 +534,12 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Quake\jsmn.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Quake\render_backend.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Quake\rb_gl.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
### Motivation
- Windows builds failed with many unresolved `RB_*`/`RBackend_*` symbols because the render-backend implementation files were not compiled into the Visual Studio project.
- The project view also lacked the corresponding header entries which made the IDE project inconsistent with the source tree.

### Description
- Added `..\..\Quake\backend_gl_exec.c` and `..\..\Quake\rb_gl.c` to `Windows/VisualStudio/ironwail.vcxproj` so the render-backend implementations are compiled.
- Added `..\..\Quake\render_backend.h` and `..\..\Quake\rb_gl.h` to the project include list so headers appear in the IDE.
- Updated `Windows/VisualStudio/ironwail.vcxproj.filters` to put the new source files in `Source Files` and the headers in `Header Files` for correct project filtering.

### Testing
- Verified the new entries are present with `rg -n "backend_gl_exec.c|rb_gl.c|render_backend.h|rb_gl.h"` against the `.vcxproj` and `.vcxproj.filters` files, and the command succeeded.
- Parsed both XML project files using `python -c "import xml.etree.ElementTree as ET; ET.parse('path')"` to ensure the modified `.vcxproj` and `.vcxproj.filters` remain valid XML, and parsing succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1d52eb918832e94ec3c235588fa63)