### PR TITLE
Implement RB_ReadPixelsRGB_Owner to resolve linker error

### DIFF
--- a/Quake/rb_gl.c
+++ b/Quake/rb_gl.c
@@ -706,6 +706,17 @@ void RB_ReadBuffer_Owner (GLenum src, const char *owner)
 	glReadBuffer (src);
 }
 
+qboolean RB_ReadPixelsRGB_Owner (GLint x, GLint y, GLsizei width, GLsizei height, void *pixels, const char *owner)
+{
+	GLenum err;
+
+	(void)owner;
+	glReadPixels (x, y, width, height, GL_RGB, GL_UNSIGNED_BYTE, pixels);
+	err = glGetError ();
+
+	return err == GL_NO_ERROR;
+}
+
 void RB_FogVol_CaptureStateSnapshot (rb_fogvol_gl_snapshot_t *snapshot)
 {
 	int i;


### PR DESCRIPTION
### Motivation
- Resolve an unresolved external `RB_ReadPixelsRGB_Owner` symbol that caused a Windows linker error (LNK2001) from code paths that read pixels for screenshots and backend frame hashing.

### Description
- Add an implementation of `RB_ReadPixelsRGB_Owner` in `Quake/rb_gl.c` that calls `glReadPixels(..., GL_RGB, GL_UNSIGNED_BYTE, ...)`, checks `glGetError()`, and returns a `qboolean` success value; the `owner` parameter is accepted but unused to match the existing owner-style API.

### Testing
- Verified the new symbol is present with `rg "qboolean RB_ReadPixelsRGB_Owner" -n Quake/rb_gl.c Quake/rb_gl.h`, which succeeded. 
- Ran `git diff --check` for whitespace/errors, which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1d7fbca50832ebf82f6314750dc76)