### PR TITLE
Fix black startup screen by binding the correct scene target

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -3364,7 +3364,11 @@ void R_SetupGL (void)
 
 		RB_BindFramebuffer (GL_FRAMEBUFFER, target);
 		GL_SetFramebufferSRGB (srgb_output);
-		framesetup.scene_fbo = framebufs.composite.fbo;
+		/* Keep resolve target aligned with the currently bound scene destination.
+		 * Using composite.fbo unconditionally here can redirect later passes (e.g.
+		 * buffered dlights/OIT resolve) into an off-screen FBO when postfx is off,
+		 * leaving the default framebuffer black. */
+		framesetup.scene_fbo = target;
 		framesetup.oit_fbo = framebufs.oit.fbo_composite;
 		framesetup.composite_ready = (target == framebufs.composite.fbo);
 		if (target)


### PR DESCRIPTION
### Motivation
- A startup regression could leave the backbuffer black because later render passes were targeted at an off-screen composite FBO even when postprocessing was inactive.
- The engine must keep the resolve target aligned with the actually bound framebuffer so subsequent passes render into the visible output.

### Description
- In `R_SetupGL`, replace the unconditional `framesetup.scene_fbo = framebufs.composite.fbo` with `framesetup.scene_fbo = target` so the scene resolve target follows the currently bound framebuffer.
- Added an explanatory comment in `Quake/gl_rmain.c` explaining why the resolve target must track the bound target to avoid rendering into an off-screen FBO when postfx are disabled.
- No other behavior changes were made; this only affects the non-scene-effects code path where `GL_NeedsSceneEffects()` is false.

### Testing
- Ran `make -j4` in `Quake/` to validate compilation flow, but the build could not complete due to missing SDL2 tooling/headers (`sdl2-config` and `SDL.h`) in the environment, so a full compile test was not possible (build step failed with missing dependencies). 
- Ran basic repository checks and inspected the modified source to ensure the change is syntactically correct and the new assignment matches the currently bound framebuffer; no syntax errors were observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1e21e3bac832e94665bbb90ec20c2)