### PR TITLE
Prevent startup black screen when OIT+MSAA active without scene effects

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -2981,6 +2981,16 @@ R_GetEffectiveAlphaMode
 */
 alphamode_t R_GetEffectiveAlphaMode (void)
 {
+	/*
+	 * OIT needs a valid off-screen accumulation framebuffer. When scene effects
+	 * are disabled we render directly to the default framebuffer, and in MSAA
+	 * mode there is no composite OIT target available. Falling back to sorted
+	 * blending avoids binding FBO 0 as an OIT MRT target (which can clear the
+	 * backbuffer to black and leave startup/menu frames blank).
+	 */
+	if (r_oit.value && !GL_NeedsSceneEffects () && framebufs.scene.samples > 1)
+		return ALPHAMODE_SORTED;
+
 	if (map_checks.value)
 		return ALPHAMODE_BASIC;
 	return R_GetAlphaMode ();


### PR DESCRIPTION
### Motivation
- Prevent startup/menu frames from remaining black when `r_oit` (order-independent transparency) is enabled but scene effects are disabled and MSAA is active, a configuration that previously caused the renderer to attempt OIT against the default framebuffer and leave the backbuffer cleared/blank.

### Description
- Add a guard in `R_GetEffectiveAlphaMode()` in `Quake/gl_rmain.c` that returns `ALPHAMODE_SORTED` when `r_oit` is enabled but `!GL_NeedsSceneEffects()` and `framebufs.scene.samples > 1`, and document the rationale with an inline comment.

### Testing
- Ran configuration/build attempt with `cmake -S . -B build && cmake --build build -j4`, which failed in this environment due to a missing SDL2 development package, so a full build/test run could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1e365ab48832ea4889d7d41127928)