### PR TITLE
Restore world BSP rendering and remove duplicate `R_SetupGL` in `gl_rmain.c`

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -3790,6 +3790,8 @@ R_DrawEntitiesOnList
 void R_DrawEntitiesOnList (qboolean alphapass) //johnfitz -- added parameter
 {
 	int* ofs;
+	int brush_start;
+	int brush_count;
 	entity_t** entlist = cl_sorted_visedicts;
 	const char *alias_unavailable_reason = NULL;
 	qboolean alias_backend_available;
@@ -3797,7 +3799,14 @@ void R_DrawEntitiesOnList (qboolean alphapass) //johnfitz -- added parameter
 	GL_BeginGroup (alphapass ? "Translucent entities" : "Opaque entities");
 
 	ofs = cl_modtype_ofs + (alphapass ? 1 : 0);
-	R_DrawBrushModels (entlist + ofs[2 * mod_brush], ofs[2 * mod_brush + 1] - ofs[2 * mod_brush]);
+	brush_start = ofs[2 * mod_brush];
+	brush_count = ofs[2 * mod_brush + 1] - brush_start;
+	if (!alphapass && brush_count > 0 && entlist[brush_start] == &cl_entities[0])
+	{
+		brush_start++;
+		brush_count--;
+	}
+	R_DrawBrushModels (entlist + brush_start, brush_count);
 	r_alias_dispatch_entlist = entlist + ofs[2 * mod_alias];
 	r_alias_dispatch_count = ofs[2 * mod_alias + 1] - ofs[2 * mod_alias];
 	alias_backend_available = R_BackendAliasPathAvailable (&alias_unavailable_reason);
@@ -3807,6 +3816,15 @@ void R_DrawEntitiesOnList (qboolean alphapass) //johnfitz -- added parameter
 		R_DrawSpriteModels (entlist + cl_modtype_ofs[2 * mod_sprite], cl_modtype_ofs[2 * mod_sprite + 2] - cl_modtype_ofs[2 * mod_sprite]);
 
 	GL_EndGroup ();
+}
+
+static void R_DrawWorld (void)
+{
+	int count;
+	entity_t **ents = R_GetVisEntities (mod_brush, false, &count);
+
+	if (count > 0 && ents[0] == &cl_entities[0])
+		R_DrawBrushModels (ents, 1);
 }
 
 /*
@@ -4859,6 +4877,7 @@ static void R_DrawDLightPass (void)
 static void R_DrawWorldOpaqueBody_Common (void)
 {
 	RB_BeginPass (PASS_WORLD_OPAQUE);
+	R_DrawWorld ();
 	R_DrawViewModel ();
 	RB_EndPass ();
 	S_ExtraUpdate ();
@@ -4977,7 +4996,6 @@ void R_RenderScene (void)
 	qboolean world_backend_available;
 	qboolean particles_backend_available;
 	R_SetupScene (); //johnfitz -- this does everything that should be done once per call to RenderScene
-	R_SetupGL ();
 	R_Clear ();
 
 	// Upload frame data after fog has been set up to ensure fog parameters


### PR DESCRIPTION
### Motivation
- A refactor of the GL rendering passes omitted drawing the static BSP world from the opaque world pass causing a black screen while game logic and audio continued.
- `R_RenderScene` contained a redundant `R_SetupGL()` call because `R_SetupScene()` already performs GL setup, which is logically incorrect and a latent stability risk.

### Description
- Inserted an explicit world draw call into the opaque world pass by adding `R_DrawWorld()` at the start of `PASS_WORLD_OPAQUE` in `Quake/gl_rmain.c` so static BSP geometry is rendered before the viewmodel.
- Added a local helper `R_DrawWorld()` that obtains visible brush entities and renders the world brush (`cl_entities[0]`) when present using `R_GetVisEntities` and `R_DrawBrushModels`.
- Updated `R_DrawEntitiesOnList` to skip the world brush entry for the opaque brush batch by computing `brush_start`/`brush_count` and removing `cl_entities[0]` from the opaque brush list to avoid double-draw.
- Removed the redundant `R_SetupGL()` call from `R_RenderScene` because `R_SetupScene()` already invokes GL setup.

### Testing
- Ran a CMake configure/build attempt with `cmake -S . -B build && cmake --build build -j2`, which failed at configure time due to a missing system dependency (`SDL2` development package), so no full build/test was completed.
- Verified source-level changes by inspecting `Quake/gl_rmain.c` and running targeted `rg`/`sed` checks to confirm the new `R_DrawWorld()` usage, the adjusted entity list handling, and the removed duplicate `R_SetupGL()` call.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1e52d20a8832e84ab82c3b23f1a61)