### PR TITLE
Restore static BSP world draw in opaque world pass

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -3831,10 +3831,25 @@ void R_DrawEntitiesOnList (qboolean alphapass) //johnfitz -- added parameter
 static void R_DrawWorld (void)
 {
 	int count;
+	int i;
 	entity_t **ents = R_GetVisEntities (mod_brush, false, &count);
 
-	if (count > 0 && ents[0] == &cl_entities[0])
-		R_DrawBrushModels (ents, 1);
+	for (i = 0; i < count; i++)
+	{
+		if (ents[i] == &cl_entities[0])
+		{
+			R_DrawBrushModels (ents + i, 1);
+			return;
+		}
+	}
+
+	/* Keep the static BSP world in the opaque pass even if entity sorting
+	 * omitted worldspawn from the brush list during backend pass refactors. */
+	if (r_drawworld_cheatsafe && cl_entities[0].model && cl_entities[0].model->type == mod_brush)
+	{
+		entity_t *world = &cl_entities[0];
+		R_DrawBrushModels (&world, 1);
+	}
 }
 
 /*


### PR DESCRIPTION
### Motivation
- A recent backend refactor could omit the static BSP world (worldspawn) from the opaque brush entity list, producing a black screen while game logic and audio continued. This change restores reliable drawing of the BSP world in the opaque pass.

### Description
- Update `R_DrawWorld` in `Quake/gl_rmain.c` to scan the opaque brush entity list for `cl_entities[0]` instead of assuming it is the first entry. 
- Add a guarded fallback that explicitly draws `cl_entities[0]` when it was omitted by sorting/refactor paths, protected by `r_drawworld_cheatsafe` and a brush-model check. 
- Minor local variable addition (`int i`) and early-return behavior when worldspawn is found.

### Testing
- Attempted a local build with `make -C Quake -j4`, but the environment lacks `sdl2-config`/`SDL.h` so a full compile could not be completed and verification of the binary was not possible.
- Lightweight repository inspections (`rg`/`sed`) were used to validate the source patch and ensure the new code path is reachable; no runtime tests could be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1f57c8a3c832ea925ea46e8f2bfd5)