### PR TITLE
Fix startup black screen when world entity model is temporarily missing

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -3830,15 +3830,33 @@ void R_DrawEntitiesOnList (qboolean alphapass) //johnfitz -- added parameter
 
 static void R_DrawWorld (void)
 {
+	entity_t world;
+
 	/* R_DrawEntitiesOnList intentionally skips cl_entities[0] (worldspawn) so
 	 * that the static BSP world is drawn here, in its own dedicated pass.
 	 * Draw worldspawn directly -- do not search the sorted vis list, because
 	 * worldspawn is excluded from the slice returned by R_GetVisEntities after
 	 * R_DrawEntitiesOnList strips it from the front of the brush entity range. */
-	if (r_drawworld_cheatsafe && cl_entities[0].model && cl_entities[0].model->type == mod_brush)
+	if (!r_drawworld_cheatsafe)
+		return;
+
+	/* During signon/level transitions some mods leave cl_entities[0].model
+	 * temporarily unset while cl.worldmodel is already valid. Use worldmodel as
+	 * fallback to avoid presenting a black frame while simulation/audio continue. */
+	if (cl_entities[0].model && cl_entities[0].model->type == mod_brush)
 	{
 		entity_t *world = &cl_entities[0];
 		R_DrawBrushModels (&world, 1);
+		return;
+	}
+
+	if (cl.worldmodel && cl.worldmodel->type == mod_brush)
+	{
+		entity_t *worldlist[1];
+		world = cl_entities[0];
+		world.model = cl.worldmodel;
+		worldlist[0] = &world;
+		R_DrawBrushModels (worldlist, 1);
 	}
 }
 


### PR DESCRIPTION
### Motivation
- Prevent a black frame during startup/level transitions when the world geometry is not drawn even though simulation and sound continue, by handling cases where `cl_entities[0].model` is temporarily unset while `cl.worldmodel` is valid. 

### Description
- Updated `R_DrawWorld` in `Quake/gl_rmain.c` to early-return if `r_drawworld_cheatsafe` is disabled to preserve existing cheat-safe gating. 
- If `cl_entities[0].model` is present and a brush model, draw it as before using `R_DrawBrushModels`. 
- Added a fallback that, when `cl_entities[0].model` is missing but `cl.worldmodel` is a brush, constructs a temporary `entity_t` (copied from `cl_entities[0]` with `model` set to `cl.worldmodel`) and draws it via `R_DrawBrushModels`. 
- Introduced a small local `entity_t world` and a one-element world list to safely pass the temporary entity to the existing draw path without altering higher-level logic. 

### Testing
- Ran CMake configuration with `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` to validate build setup, which failed due to a missing SDL2 CMake package (`SDL2Config.cmake` / `sdl2-config.cmake`), so a full compile/test could not be performed in this environment. 
- Verified the source changes with a local `git diff` and ensured the modified logic compiles cleanly in-editor (no syntax errors reported by static checks here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1fc966cc0832ea24a2d37b8cebc6b)