### PR TITLE
Add RB_BlendName and RB_CullName helpers in Quake/rb_gl.c

### DIFF
--- a/Quake/rb_gl.c
+++ b/Quake/rb_gl.c
@@ -169,6 +169,38 @@ static const char *RB_BoolName (int value)
 	return value ? "on" : "off";
 }
 
+static const char *RB_BlendName (unsigned state)
+{
+	switch (state & GLS_MASK_BLEND)
+	{
+	default:
+	case GLS_BLEND_OPAQUE:
+		return "opaque";
+	case GLS_BLEND_ALPHA_OIT:
+		return "alpha_oit";
+	case GLS_BLEND_ALPHA:
+		return "alpha";
+	case GLS_BLEND_MULTIPLY:
+		return "multiply";
+	case GLS_BLEND_ADD:
+		return "add";
+	}
+}
+
+static const char *RB_CullName (unsigned state)
+{
+	switch (state & GLS_MASK_CULL)
+	{
+	case GLS_CULL_NONE:
+		return "none";
+	case GLS_CULL_FRONT:
+		return "front";
+	default:
+	case GLS_CULL_BACK:
+		return "back";
+	}
+}
+
 static void RB_CaptureGLStateSnapshot (rb_gl_state_snapshot_t *snapshot)
 {
 	GLint prev_active_tex;


### PR DESCRIPTION
### Motivation
- Resolve compiler errors where `RB_BlendName` and `RB_CullName` were referenced but not defined, which produced implicit-int warnings treated as errors and broke debug/warning messages for pass state checks.

### Description
- Add `static const char *RB_BlendName(unsigned state)` to map `GLS_MASK_BLEND` values to human-readable labels (`opaque`, `alpha_oit`, `alpha`, `multiply`, `add`).
- Add `static const char *RB_CullName(unsigned state)` to map `GLS_MASK_CULL` values to human-readable labels (`none`, `front`, `back`).
- Place both helpers next to `RB_BoolName` so they are available to the pass-exit diagnostics code in `rb_gl.c`.

### Testing
- Attempted an automated configure/build with `cmake -S . -B build && cmake --build build -j2`, but CMake configuration failed in this environment because the `SDL2` development package is not available, so a full build could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2f2ea887c832eb6e66d4d01566e5f)