### PR TITLE
Disable bindless textures on unstable software/Intel renderers

### DIFF
--- a/Quake/gl_vidsdl.c
+++ b/Quake/gl_vidsdl.c
@@ -1103,6 +1103,18 @@ static void GL_CheckExtensions (void)
 		GL_InitFunctions (gl_arb_bindless_texture_functions, false)
 	;
 
+	if (gl_bindless_able &&
+		(
+			q_strcasestr (gl_vendor, "Intel") ||
+			q_strcasestr (gl_renderer, "llvmpipe") ||
+			q_strcasestr (gl_renderer, "softpipe") ||
+			q_strcasestr (gl_renderer, "SwiftShader")
+		))
+	{
+		Con_Warning ("disabling bindless textures on this renderer due to known stability issues\n");
+		gl_bindless_able = false;
+	}
+
 	gl_clipcontrol_able =
 		!COM_CheckParm ("-noclipcontrol") &&
 		GL_FindExtension ("GL_ARB_clip_control") &&


### PR DESCRIPTION
### Motivation
- Some GL stacks advertise bindless texture support but behave incorrectly at runtime (missing world textures, very low FPS and map-load crashes), so force a safer legacy texture path on known unstable renderers.

### Description
- Add a safety gate in `GL_CheckExtensions` (`Quake/gl_vidsdl.c`) that clears `gl_bindless_able` when `gl_vendor`/`gl_renderer` match `Intel`, `llvmpipe`, `softpipe`, or `SwiftShader` and emit a warning via `Con_Warning`.
- This keeps the engine on the classic texture-binding path even if bindless extensions are present to avoid stability/performance regressions.

### Testing
- Attempted `cmake --build build -j4` which failed because `/workspace/ironwail/build` does not exist (failed).
- Attempted `make -C Quake -j4` to compile the modified code, but the build aborted due to missing SDL2 development tools/headers (`sdl2-config` / `SDL.h`), so full compile validation could not be completed (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2f612ede4832ebc4f4399686b69e7)