### PR TITLE
Route standard fog through a global FogVolume base layer

### DIFF
--- a/Quake/gl_fog.c
+++ b/Quake/gl_fog.c
@@ -22,6 +22,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 //gl_fog.c -- global and volumetric fog
 
 #include "quakedef.h"
+#include "r_fogvol.h"
 
 //==============================================================================
 //
@@ -310,9 +311,10 @@ void Fog_SetupFrame (void)
 	const float SphericalCorrection = 0.85f; // compensate higher perceived density with spherical fog
 	const float DensityScale = ExpAdjustment * SphericalCorrection / 96.0f;
 	float density = Fog_GetDensity() * DensityScale;
+	qboolean fogvol_global = R_FogVol_CanRenderGlobal ();
 	memcpy(r_framedata.fogdata, Fog_GetColor(), 3 * sizeof(float));
 	memcpy(r_framedata.skyfogdata, r_framedata.fogdata, 3 * sizeof(float));
-	r_framedata.fogdata[3] = density * density;
+	r_framedata.fogdata[3] = fogvol_global ? 0.f : density * density;
 	r_framedata.skyfogdata[3] = density > 0.f ? CLAMP (0.f, skyfog, 1.f) : 0.f;
 }
 

--- a/Quake/r_fogvol.c
+++ b/Quake/r_fogvol.c
@@ -696,6 +696,57 @@ static float R_FogVol_PointAABBDistance (const vec3_t point, const fog_volume_t 
 	return sqrtf (dist2);
 }
 
+static qboolean R_FogVol_BuildGlobalVolume (fog_volume_t *volume)
+{
+	float density = Fog_GetDensity ();
+	float *color;
+
+	if (density <= 0.f)
+		return false;
+
+	memset (volume, 0, sizeof (*volume));
+	color = Fog_GetColor ();
+	VectorCopy (color, volume->color);
+	volume->density = density;
+	volume->falloff = 0.f;
+	volume->mode = 0;
+	volume->noiseScale = 0.f;
+	volume->noiseAmount = 0.f;
+	volume->noiseBias = 0.f;
+	VectorSet (volume->velocity, 0.f, 0.f, 0.f);
+	volume->maxDistance = 0.f;
+	volume->priority = -9999;
+	volume->enabled = 1;
+	volume->height = 0.f;
+	volume->heightScale = 0.f;
+
+	if (cl.worldmodel)
+	{
+		VectorCopy (cl.worldmodel->mins, volume->mins);
+		VectorCopy (cl.worldmodel->maxs, volume->maxs);
+	}
+	else
+	{
+		VectorSet (volume->mins, -65536.f, -65536.f, -65536.f);
+		VectorSet (volume->maxs,  65536.f,  65536.f,  65536.f);
+	}
+
+	return true;
+}
+
+qboolean R_FogVol_CanRenderGlobal (void)
+{
+	if (Fog_GetDensity () <= 0.f)
+		return false;
+	if (!glprogs.fogvol)
+		return false;
+	if (framebufs.composite.color_tex == 0 || framebufs.fogvol.color_tex[0] == 0)
+		return false;
+	if (framebufs.composite.depth_stencil_tex == 0)
+		return false;
+	return true;
+}
+
 void R_FogVol_ParseEntities (void)
 {
 	const char *data;
@@ -901,6 +952,12 @@ void R_FogVol_BuildList (void)
 	if (r_fogvol_testvolumes.value > 0.f)
 		R_FogVol_AddTestVolumes ();
 
+	{
+		fog_volume_t global_volume;
+		if (R_FogVol_BuildGlobalVolume (&global_volume))
+			R_FogVol_AddVolume (&global_volume);
+	}
+
 	if (r_fogvol.value <= 0.f)
 		goto sort_and_done;
 
@@ -1054,11 +1111,6 @@ void R_FogVol_Render (void)
 	qboolean dumpstate_always;
 	fogvol_restore_state_t restore_state;
 
-	/* BUG FIX (testvolumes): allow rendering when testvolumes are active even
-	 * if r_fogvol=0.  r_fogvolume_count already reflects testvolumes (set in
-	 * BuildList), so skip only if both flags are off. */
-	if (r_fogvol.value <= 0.f && r_fogvol_testvolumes.value <= 0.f)
-		return;
 	if (!glprogs.fogvol)
 		return;
 	if (r_fogvolume_count <= 0)

--- a/Quake/r_fogvol.h
+++ b/Quake/r_fogvol.h
@@ -54,5 +54,6 @@ void R_FogVol_ClearHistory (void);
 void R_FogVol_LogEndFrameState (void);
 void R_FogVol_InjectIntoGrid (froxel_grid_t *grid, const fog_volume_t *vols, int num);
 qboolean R_FogVol_ProjectAABBToScreenRect (const fog_volume_t *v, int *x0, int *y0, int *x1, int *y1, qboolean fullres);
+qboolean R_FogVol_CanRenderGlobal (void);
 
 #endif // R_FOGVOL_H


### PR DESCRIPTION
### Motivation
- Replace the legacy per-frame “standard fog” path with a permanent global `FogVolume` that reproduces the same color/density behavior while keeping entity/map fog volumes working unchanged.
- Avoid double fogging by letting the global fog volume take the standard-fog role while ensuring the old path remains a fallback when fogvol resources are unavailable.
- Make minimal, localized changes with no new CVars, no debug logging, and no major refactorings.

### Description
- Added `R_FogVol_BuildGlobalVolume` and `R_FogVol_CanRenderGlobal` in `Quake/r_fogvol.c` (and exported the prototype in `Quake/r_fogvol.h`) to build a global fog volume from `Fog_GetColor()` / `Fog_GetDensity()` and to detect whether the FogVolume pipeline is available. 
- Inserted the global volume into `R_FogVol_BuildList()` (after test volumes and before entity volumes) with world bounds (or large AABB fallback), `priority = -9999`, `enabled = 1`, `maxDistance = 0`, and minimal/noise/velocity settings. 
- Removed the early `r_fogvol` gating that prevented `R_FogVol_Render()` from running so FogVol rendering will run when `r_fogvolume_count > 0` while preserving all existing FogVol rendering logic. 
- Modified `Quake/gl_fog.c` to include `r_fogvol.h` and to set `r_framedata.fogdata[3]` (the legacy scene fog density) to zero when `R_FogVol_CanRenderGlobal()` is true, preventing additive double-fog; if `R_FogVol_CanRenderGlobal()` is false the old standard-fog behavior remains as a fallback. 
- No new cvars, no debug outputs, and changes localized to `r_fogvol.c`, `r_fogvol.h`, and `gl_fog.c`.

### Testing
- Attempted to build at repository root with `make -j4`, but no top-level build target was present so no build ran there. (automated)  
- Attempted to build `Quake/` with `make -j4`, but the build aborted due to missing system dependencies (`sdl2-config` / `SDL.h`), so a full compile/validation could not be completed in this environment. (automated, failed)
- Performed static inspection of diffs and source locations to verify insertion points and symbol visibility; no automated unit tests exist for this change in the tree. (automated checks only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a314872abc832e9995e569e5eca3a5)