### PR TITLE
Fix fogvol noise_amount scaling in fog shader

### DIFF
--- a/Quake/shaders/fogvol.frag
+++ b/Quake/shaders/fogvol.frag
@@ -391,7 +391,10 @@ void main()
 			if (noiseBias > 0.0)
 				n = smoothstep(noiseBias, 1.0, n);
 			float amt   = clamp(volume.noise_params.y, 0.0, 1.0);
-			noiseFactor = mix(1.0, n, amt);
+			// Keep average density stable while scaling modulation strength.
+			// n is [0..1], so remap to a factor centered around 1.0.
+			float modulation = clamp(2.0 * n, 0.0, 2.0);
+			noiseFactor = mix(1.0, modulation, amt);
 		}
 
 		float sigma  = min(density * noiseFactor * edgeFade * HeightFactor(p, volume), FogDensityParams.y);


### PR DESCRIPTION
### Motivation
- Correct a bias in volumetric fog where `noise_amount` increased would darken overall density because the shader mixed directly with `n` (mean ~0.5) instead of a modulation centered on 1.0.

### Description
- Change in `Quake/shaders/fogvol.frag`: remap sampled noise `n` from `[0..1]` to `modulation = clamp(2.0 * n, 0.0, 2.0)` and use `noiseFactor = mix(1.0, modulation, amt)` so `noise_amount` controls modulation strength without shifting baseline density, and add a short explanatory comment.

### Testing
- Attempted to configure and build with `cmake -S . -B build && cmake --build build -j2`, but configuration failed due to missing SDL2 CMake package (`SDL2Config.cmake` / `sdl2-config.cmake`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a33ddb17dc832e97ff36a993559621)