### PR TITLE
fogvol: restore composite viewport to view rect in halfres path

### DIFF
--- a/Quake/r_fogvol.c
+++ b/Quake/r_fogvol.c
@@ -1602,10 +1602,7 @@ void R_FogVol_Render (void)
 	{
 		R_FogVol_BindFramebuffer (GL_FRAMEBUFFER, framebufs.composite.fbo);
 		R_FogVol_SetDrawBufferDebug (GL_COLOR_ATTACHMENT0, "HISTORY draw=COLOR_ATTACHMENT0");
-		if (use_halfres)
-			glViewport (0, 0, glwidth, glheight);
-		else
-			glViewport (glx, gly, glwidth, glheight);
+		glViewport (glx, gly, glwidth, glheight);
 		if (use_halfres)
 		{
 			if (composite_src_tex)
@@ -1682,21 +1679,22 @@ done:
 		GLint viewport[4] = {0};
 		GLint scissor_box[4] = {0};
 		GLboolean scissor_enabled = GL_FALSE;
+		const GLint expected_vp[4] = { glx, gly, glwidth, glheight };
 
 		glGetIntegerv (GL_VIEWPORT, viewport);
 		scissor_enabled = glIsEnabled (GL_SCISSOR_TEST);
 		glGetIntegerv (GL_SCISSOR_BOX, scissor_box);
 
-		if (viewport[0] != 0 || viewport[1] != 0 || viewport[2] != vid.width || viewport[3] != vid.height
-			|| (scissor_enabled && (scissor_box[0] != 0 || scissor_box[1] != 0 || scissor_box[2] != vid.width || scissor_box[3] != vid.height)))
+		if (viewport[0] != expected_vp[0] || viewport[1] != expected_vp[1] || viewport[2] != expected_vp[2] || viewport[3] != expected_vp[3]
+			|| (scissor_enabled && (scissor_box[0] != expected_vp[0] || scissor_box[1] != expected_vp[1] || scissor_box[2] != expected_vp[2] || scissor_box[3] != expected_vp[3])))
 		{
 			Con_DPrintf ("FOGVOL_STATE defensive-restore viewport=(%d %d %d %d) scissor=%d box=(%d %d %d %d)\n",
 				viewport[0], viewport[1], viewport[2], viewport[3],
 				scissor_enabled,
 				scissor_box[0], scissor_box[1], scissor_box[2], scissor_box[3]);
-			glViewport (0, 0, vid.width, vid.height);
+			glViewport (expected_vp[0], expected_vp[1], expected_vp[2], expected_vp[3]);
 			GL_SetScissorEnabled (false);
-			glScissor (0, 0, vid.width, vid.height);
+			glScissor (expected_vp[0], expected_vp[1], expected_vp[2], expected_vp[3]);
 		}
 	}
 	if (R_FogVol_TestDebugEnabled ())


### PR DESCRIPTION
### Motivation
- Fix global image shift/stretch that occurs when `r_fogvol_halfres` is enabled because the FogVol half-res path left the GL viewport/scissor in an origin-based state instead of the active view rectangle. (Root cause: `R_FogVol_Render` in `Quake/r_fogvol.c` — incorrect `glViewport` set in the `has_drawn` composite block and defensive restore logic; see around lines ~1601-1607 and ~1677-1698.)
- Keep the change minimal and safe: the FogVol pass may use a half-res viewport internally but must always restore the engine's active full-res view rect before subsequent passes run.

### Description
- Always restore the composite viewport to the active view rectangle `(glx, gly, glwidth, glheight)` after FogVol compositing instead of conditionally using `(0,0,glwidth,glheight)`, by changing the `has_drawn` composite-path `glViewport` call to `glViewport(glx, gly, glwidth, glheight)` in `R_FogVol_Render`.
- Tighten the defensive post-pass check to compare the current `GL_VIEWPORT`/`GL_SCISSOR_BOX` against the expected view rect and restore to that expected rect (new `expected_vp`), instead of restoring to `vid.width/vid.height`.
- The changes are confined to `Quake/r_fogvol.c` and preserve existing debug/hazard logging and guards tied to `r_fogvol_debug`/`developer`.

### Testing
- Attempted a full CMake configure/build with `cmake -S . -B build && cmake --build build -j4`, which failed in this environment due to a missing SDL2 CMake package (`SDL2Config.cmake` / `sdl2-config.cmake`), so no binary build verification was possible here.
- Performed static inspection and repository-level validation (grep/sed) to confirm the modified control flow and state-restore paths; no automated unit tests were present or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a358aa67f4832ebb8dd4e359d4de91)