### PR TITLE
Unify underwater PostFX state and water warp precedence

### DIFF
--- a/Quake/cl_postfx.c
+++ b/Quake/cl_postfx.c
@@ -42,6 +42,7 @@ static postfx_event_t	postfx_events[POSTFX_MAX_EVENTS];
 static double			postfx_last_time;
 static int				postfx_contents = CONTENTS_EMPTY;
 static qboolean			postfx_underwater;
+static qboolean			postfx_underwater_postfx_active;
 static float			postfx_underwater_grade;
 static float			postfx_underwater_fog;
 static int				postfx_powerup_lut = PFX_LUT_NONE;
@@ -208,6 +209,7 @@ void CL_PostFX_Reset (void)
 	postfx_last_time = cl.time;
 	postfx_contents = CONTENTS_EMPTY;
 	postfx_underwater = false;
+	postfx_underwater_postfx_active = false;
 	postfx_underwater_grade = 0.f;
 	postfx_underwater_fog = 0.f;
 	postfx_powerup_lut = PFX_LUT_NONE;
@@ -264,10 +266,10 @@ void CL_PostFX_Frame (void)
 	else
 		postfx_powerup_lut = PFX_LUT_NONE;
 
-	grade_strength = (r_postfx_underwater.value > 0.f && postfx_underwater)
+	grade_strength = (r_postfx_underwater.value > 0.f && postfx_underwater_postfx_active)
 		? q_max (0.f, q_max (r_postfx_underwater_grade_strength.value, r_postfx_lut_strength_underwater.value))
 		: 0.f;
-	fog_strength = (r_postfx_underwater.value > 0.f && postfx_underwater)
+	fog_strength = (r_postfx_underwater.value > 0.f && postfx_underwater_postfx_active)
 		? q_max (0.f, r_postfx_underwater_fog_strength.value)
 		: 0.f;
 	ramp_in = q_max (0.f, r_postfx_underwater_ramp_in.value);
@@ -360,10 +362,11 @@ void CL_PostFX_PushDamage (float damage_amount)
 	event->active = true;
 }
 
-void CL_PostFX_SetContents (int contents, qboolean underwater_active)
+void CL_PostFX_SetContents (int contents, qboolean underwater_active, qboolean underwater_postfx_active)
 {
 	postfx_contents = contents;
 	postfx_underwater = underwater_active;
+	postfx_underwater_postfx_active = underwater_postfx_active;
 }
 
 void CL_PostFX_GetState (postfx_state_t *out_state)
@@ -446,13 +449,14 @@ void CL_PostFX_GetState (postfx_state_t *out_state)
 	out_state->underwater_fog_color[0] = PostFX_Saturate (fog_r);
 	out_state->underwater_fog_color[1] = PostFX_Saturate (fog_g);
 	out_state->underwater_fog_color[2] = PostFX_Saturate (fog_b);
+	out_state->underwater_postfx_active = (postfx_underwater && postfx_underwater_postfx_active);
 
 	if (postfx_powerup_strength > 0.f)
 	{
 		out_state->lut_id = postfx_powerup_lut;
 		out_state->lut_strength = PostFX_Saturate (postfx_powerup_strength);
 	}
-	else if (postfx_underwater_grade > 0.f)
+	else if (postfx_underwater_postfx_active && postfx_underwater_grade > 0.f)
 	{
 		if (postfx_contents == CONTENTS_SLIME)
 			out_state->lut_id = PFX_LUT_SLIME;

--- a/Quake/cl_postfx.h
+++ b/Quake/cl_postfx.h
@@ -54,6 +54,7 @@ typedef struct postfx_state_s
 	float	underwater_grade_strength;
 	float	underwater_fog_strength;
 	float	underwater_fog_color[3];
+	qboolean	underwater_postfx_active;
 	float	emissive_boost;
 	float	damage_trauma;
 } postfx_state_t;
@@ -63,7 +64,7 @@ void CL_PostFX_Reset (void);
 void CL_PostFX_Frame (void);
 void CL_PostFX_PushPickup (void);
 void CL_PostFX_PushDamage (float damage_amount);
-void CL_PostFX_SetContents (int contents, qboolean underwater_active);
+void CL_PostFX_SetContents (int contents, qboolean underwater_active, qboolean underwater_postfx_active);
 void CL_PostFX_GetState (postfx_state_t *out_state);
 
 #endif

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -128,6 +128,12 @@ static float GL_ConsoleVisibility (void)
 	return CLAMP (0.f, scr_con_current / height, 1.f);
 }
 
+
+static qboolean R_IsUnderwaterContents (int contents)
+{
+	return contents == CONTENTS_WATER || contents == CONTENTS_SLIME || contents == CONTENTS_LAVA;
+}
+
 static float GL_TemperedOverbright (float overbright)
 {
 	if (overbright <= 1.f)
@@ -2450,7 +2456,11 @@ void GL_PostProcess (void)
 		GL_Uniform4fFunc (27, black_lift, black_lift_strength, 0.f, 0.f);
 	}
 	GL_Uniform4fFunc (21, postfx_exposure_add, postfx_bloom_boost, postfx_emissive_boost, postfx_desat);
-	GL_Uniform4fFunc (22, postfx_lut_strength, postfx_state.underwater_grade_strength, postfx_state.underwater_fog_strength, postfx_vignette_softness);
+	GL_Uniform4fFunc (22,
+		postfx_lut_strength,
+		postfx_state.underwater_postfx_active ? postfx_state.underwater_grade_strength : 0.f,
+		postfx_state.underwater_postfx_active ? postfx_state.underwater_fog_strength : 0.f,
+		postfx_vignette_softness);
 	GL_Uniform4fFunc (23, (float)postfx_lut_size, (float)postfx_lut_id, 0.f, 0.f);
 	/* BUG FIX #1: uniform 24 .w was unused (0). Now carries scene fog density from
 	 * r_ssao_saved_fog[3] so postprocess.frag SampleSSAO fog-damping works correctly.
@@ -3457,27 +3467,32 @@ void R_SetupView (void)
 	water_warp = false;
 	{
 		int contents = r_viewleaf->contents;
-		qboolean forced = M_ForcedUnderwater ();
-		qboolean underwater_active = (contents == CONTENTS_WATER || contents == CONTENTS_SLIME || contents == CONTENTS_LAVA || cl.forceunderwater || forced);
-	if (r_waterwarp.value)
-	{
-		if (underwater_active)
+		qboolean submerged = R_IsUnderwaterContents (contents);
+		qboolean forced = (cl.forceunderwater || M_ForcedUnderwater ());
+		qboolean underwater_active = (submerged || forced);
+		qboolean underwater_postfx_active = underwater_active;
+
+		if (r_waterwarp.value && underwater_active)
 		{
 			double t = forced ? realtime : cl.time;
+
 			if (r_waterwarp.value > 1.f)
 			{
-				//variance is a percentage of width, where width = 2 * tan(fov / 2) otherwise the effect is too dramatic at high FOV and too subtle at low FOV.  what a mess!
+				// Legacy warp has priority over postfx underwater treatment when animated FOV warp is active.
+				// variance is a percentage of width, where width = 2 * tan(fov / 2) otherwise the effect is too dramatic at high FOV and too subtle at low FOV. what a mess!
 				r_fovx = atan (tan (DEG2RAD (r_refdef.fov_x) / 2) * (0.97 + sin (t * 1.5) * 0.03)) * 2 / M_PI_DIV_180;
 				r_fovy = atan (tan (DEG2RAD (r_refdef.fov_y) / 2) * (1.03 - sin (t * 1.5) * 0.03)) * 2 / M_PI_DIV_180;
+				underwater_postfx_active = false;
 			}
 			else
 			{
 				water_warp = true;
 			}
 		}
-	}
-	// TODO(postfx): hook underwater contents for postfx stack here.
-	CL_PostFX_SetContents (contents, underwater_active);
+
+		// Postfx stack consumes deterministic underwater state here.
+		// CL_PostFX_Frame aggregates it and GL_PostProcess applies the resulting uniforms/LUT selection.
+		CL_PostFX_SetContents (contents, underwater_active, underwater_postfx_active);
 	}
 	//johnfitz
 


### PR DESCRIPTION
### Motivation

- Make underwater visual effects deterministic by centralizing detection and preventing implicit, scattered derivations of underwater state across renderer and postfx code.
- Provide a single explicit flag that indicates whether underwater PostFX should contribute, and define clear precedence between the legacy `r_waterwarp` path and the new PostFX path.

### Description

- Added an explicit `underwater_postfx_active` boolean to `postfx_state_t` and extended `CL_PostFX_SetContents` to accept `(contents, underwater_active, underwater_postfx_active)`, and propagate that state through `cl_postfx` internals. (files: `Quake/cl_postfx.h`, `Quake/cl_postfx.c`)
- Introduced `R_IsUnderwaterContents(int)` and unified underwater detection in `R_SetupView` so `submerged`, `forced` (`cl.forceunderwater || M_ForcedUnderwater()`), `underwater_active` and `underwater_postfx_active` are computed deterministically in one place. (file: `Quake/gl_rmain.c`)
- Implemented precedence: when the legacy animated FOV warp path is used (`r_waterwarp.value > 1`), `underwater_postfx_active` is disabled for that frame so the old warp has priority; otherwise PostFX may run and ramp underwater grade/fog. (file: `Quake/gl_rmain.c`)
- Gate PostFX uniform/LUT uploads and underwater grade/fog ramp logic on the new `underwater_postfx_active` flag so the postprocess shader only receives underwater contributions when explicitly allowed. (files: `Quake/gl_rmain.c`, `Quake/cl_postfx.c`)
- Replaced the previous TODO at the hook site with comments describing the data flow (produced in `R_SetupView`, consumed by `CL_PostFX_Frame` and `GL_PostProcess`). (file: `Quake/gl_rmain.c`)

### Testing

- Ran repository-wide code inspections and grep to validate callsites and the updated API usage, which verified `CL_PostFX_SetContents` is updated consistently across the codebase and uniforms are gated as intended. All references were updated.
- Attempted a full build with `make -C Quake -j4`; the build could not complete in this environment because system SDL2 build dependencies are missing (`sdl2-config` / `SDL.h`), so compile-time verification was not possible here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3849c200c832e89a7aaabbfb36479)