### PR TITLE
Refactor DemoList searchpath scanning into reusable extension helper

### DIFF
--- a/Quake/host_cmd.c
+++ b/Quake/host_cmd.c
@@ -1338,47 +1338,82 @@ void DemoList_Rebuild (void)
 	DemoList_Init ();
 }
 
-// TODO: Factor out to a general-purpose file searching function
+typedef qboolean (*searchpath_exclude_fn_t) (const searchpath_t *search, void *userdata);
+typedef void (*searchpath_file_callback_t) (const char *path, const searchpath_t *search, void *userdata);
+
+/*
+==================
+SearchPaths_ForEachExtension
+
+Iterate over files from all com_searchpaths entries that match an extension.
+`extension` may be passed with or without a leading '.'.
+If `exclude` is set and returns true for a search path, that path is skipped.
+==================
+*/
+static void SearchPaths_ForEachExtension (const char *extension, searchpath_exclude_fn_t exclude, void *excludeuserdata, searchpath_file_callback_t callback, void *callbackuserdata)
+{
+	const char	*ext;
+	searchpath_t	*search;
+
+	if (!extension || !*extension || !callback)
+		return;
+
+	ext = extension[0] == '.' ? extension + 1 : extension;
+
+	for (search = com_searchpaths; search; search = search->next)
+	{
+		pack_t *pak;
+		int i;
+
+		if (exclude && exclude (search, excludeuserdata))
+			continue;
+
+		if (*search->filename) // directory
+		{
+			findfile_t *find;
+			for (find = Sys_FindFirst (search->filename, ext); find; find = Sys_FindNext (find))
+			{
+				if (find->attribs & FA_DIRECTORY)
+					continue;
+				callback (find->name, search, callbackuserdata);
+			}
+		}
+		else // pakfile
+		{
+			for (i = 0, pak = search->pack; i < pak->numfiles; i++)
+			{
+				if (!q_strcasecmp (COM_FileGetExtension (pak->files[i].name), ext))
+					callback (pak->files[i].name, search, callbackuserdata);
+			}
+		}
+	}
+}
+
+static qboolean DemoList_ExcludeBasePak (const searchpath_t *search, void *userdata)
+{
+	const char *ignorepakdir = (const char *) userdata;
+
+	return !*search->filename && strstr (search->pack->filename, ignorepakdir) != NULL;
+}
+
+static void DemoList_AddFile (const char *path, const searchpath_t *search, void *userdata)
+{
+	char demname[MAX_QPATH];
+
+	(void)search;
+	COM_StripExtension (path, demname, sizeof (demname));
+	FileList_Add (demname, (filelist_item_t **) userdata);
+}
+
 void DemoList_Init (void)
 {
-	char		demname[32];
-	char		ignorepakdir[32];
-	searchpath_t	*search;
-	pack_t		*pak;
-	int		i;
+	char ignorepakdir[MAX_QPATH];
 
 	// we don't want to list the demos in id1 pakfiles,
 	// because these are not "add-on" demos
 	q_snprintf (ignorepakdir, sizeof (ignorepakdir), "/%s/", GAMENAME);
-	
-	for (search = com_searchpaths; search; search = search->next)
-	{
-		if (*search->filename) //directory
-		{
-			findfile_t *find;
-			for (find = Sys_FindFirst (search->filename, "dem"); find; find = Sys_FindNext (find))
-			{
-				if (find->attribs & FA_DIRECTORY)
-					continue;
-				COM_StripExtension (find->name, demname, sizeof (demname));
-				FileList_Add (demname, &demolist);
-			}
-		}
-		else //pakfile
-		{
-			if (!strstr(search->pack->filename, ignorepakdir))
-			{ //don't list standard id demos
-				for (i = 0, pak = search->pack; i < pak->numfiles; i++)
-				{
-					if (!strcmp (COM_FileGetExtension (pak->files[i].name), "dem"))
-					{
-						COM_StripExtension (pak->files[i].name, demname, sizeof (demname));
-						FileList_Add (demname, &demolist);
-					}
-				}
-			}
-		}
-	}
+
+	SearchPaths_ForEachExtension (".dem", DemoList_ExcludeBasePak, ignorepakdir, DemoList_AddFile, &demolist);
 }
 
 //==============================================================================
@@ -3817,4 +3852,3 @@ void Host_InitCommands (void)
 	Cmd_AddCommand ("viewnext", Host_Viewnext_f);
 	Cmd_AddCommand ("viewprev", Host_Viewprev_f);
 }
-


### PR DESCRIPTION
### Motivation

- Replace duplicated iteration over `com_searchpaths` (directory + pak) with a reusable helper to make file discovery logic shareable (e.g. for demos, maps, saves).
- Allow callers to filter by extension and to customize both exclusion of searchpaths and per-file handling via callbacks.
- Reduce risk of name truncation by using larger safer buffers for temporary names used during iteration.

### Description

- Add a generic helper `SearchPaths_ForEachExtension` with signature `SearchPaths_ForEachExtension(const char *extension, searchpath_exclude_fn_t exclude, void *excludeuserdata, searchpath_file_callback_t callback, void *callbackuserdata)` and inline docs stating that `extension` may be passed with or without a leading dot and that `exclude` returning true skips that search path.
- Introduce typedefs `searchpath_exclude_fn_t` and `searchpath_file_callback_t` to decouple exclusion logic and result handling from the iteration logic.
- Implement `DemoList_ExcludeBasePak` (skips id1 base pakfiles) and `DemoList_AddFile` (strips extension and calls `FileList_Add`) and rewrite `DemoList_Init` to call `SearchPaths_ForEachExtension(".dem", DemoList_ExcludeBasePak, ignorepakdir, DemoList_AddFile, &demolist)`.
- Use `MAX_QPATH` for temporary buffers such as `ignorepakdir` and demo name storage in the callback to reduce truncation risk and perform case-insensitive extension checks with `q_strcasecmp` for pak entries.

### Testing

- Attempted to build with CMake via `cmake -S . -B build && cmake --build build -j4`, but configuration failed in this environment because the `SDL2` CMake package (`SDL2Config.cmake` / `sdl2-config.cmake`) was not found, so a full build could not be validated.
- A plain `make` invocation reported "No targets specified" in this environment, so no further automated builds were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3849aa854832e9aa80d9de80275d5)