### PR TITLE
Add fog volume shadow visibility term and tuning cvars

### DIFF
--- a/Quake/r_fogvol.c
+++ b/Quake/r_fogvol.c
@@ -120,6 +120,10 @@ cvar_t r_fogvol_globalfog_height_scale = { "r_fogvol_globalfog_height_scale", "0
 cvar_t r_fogvol_globalfog_priority = { "r_fogvol_globalfog_priority", "-1", CVAR_ARCHIVE };
 cvar_t r_fogvol_light = { "r_fogvol_light", "0", CVAR_ARCHIVE };
 cvar_t r_fogvol_light_max = { "r_fogvol_light_max", "16", CVAR_ARCHIVE };
+cvar_t r_fogvol_shadow = { "r_fogvol_shadow", "1", CVAR_ARCHIVE };
+cvar_t r_fogvol_shadow_samples = { "r_fogvol_shadow_samples", "2", CVAR_ARCHIVE };
+cvar_t r_fogvol_shadow_strength = { "r_fogvol_shadow_strength", "0.8", CVAR_ARCHIVE };
+cvar_t r_fogvol_shadow_jitter = { "r_fogvol_shadow_jitter", "1", CVAR_ARCHIVE };
 
 extern cvar_t gl_farclip;
 
@@ -810,6 +814,10 @@ void R_FogVol_Init (void)
 	Cvar_RegisterVariable (&r_fogvol_globalfog_priority);
 	Cvar_RegisterVariable (&r_fogvol_light);
 	Cvar_RegisterVariable (&r_fogvol_light_max);
+	Cvar_RegisterVariable (&r_fogvol_shadow);
+	Cvar_RegisterVariable (&r_fogvol_shadow_samples);
+	Cvar_RegisterVariable (&r_fogvol_shadow_strength);
+	Cvar_RegisterVariable (&r_fogvol_shadow_jitter);
 }
 
 void R_FogVol_Clear (void)
@@ -1365,7 +1373,7 @@ void R_FogVol_Render (void)
 	GLbyte *ofs;
 	fog_volume_gpu_t gpu_volumes[MAX_FOGVOLUMES];
 	fog_light_list_gpu_t fog_lights;
-	const int mode = CLAMP (0, (int)Q_rint (r_fogvol_debug.value), 7);
+	const int mode = CLAMP (0, (int)Q_rint (r_fogvol_debug.value), 8);
 	float inv_viewproj[16];
 	GLuint src_tex;
 	GLuint dst_tex;
@@ -1397,6 +1405,8 @@ void R_FogVol_Render (void)
 	qboolean dumpstate_always;
 	fogvol_restore_state_t restore_state;
 	qboolean fog_light_enabled = false;
+	vec3_t shadow_dir;
+	int shadow_samples;
 
 	if (!glprogs.fogvol)
 		return;
@@ -1565,6 +1575,16 @@ void R_FogVol_Render (void)
 	GL_Uniform1iFunc (14, r_fogvol_emissive.value > 0.f ? 1 : 0);
 	GL_Uniform1iFunc (15, CLAMP (0, (int)Q_rint (r_fogvol_blendmode.value), 1));
 	GL_Uniform1iFunc (16, fog_light_enabled ? 1 : 0);
+	shadow_samples = CLAMP (1, (int)Q_rint (r_fogvol_shadow_samples.value), 8);
+	VectorNegate (vpn, shadow_dir);
+	if (VectorLength (shadow_dir) < 0.001f)
+		VectorSet (shadow_dir, 0.f, 0.f, -1.f);
+	VectorNormalize (shadow_dir);
+	GL_Uniform1iFunc (17, r_fogvol_shadow.value > 0.f ? 1 : 0);
+	GL_Uniform1iFunc (18, shadow_samples);
+	GL_Uniform1fFunc (19, CLAMP (0.f, r_fogvol_shadow_strength.value, 4.f));
+	GL_Uniform1fFunc (20, r_fogvol_shadow_jitter.value > 0.f ? 1.f : 0.f);
+	GL_Uniform3fFunc (21, shadow_dir[0], shadow_dir[1], shadow_dir[2]);
 
 	if (use_halfres)
 		glViewport (0, 0, fog_width, fog_height);

--- a/Quake/r_fogvol.h
+++ b/Quake/r_fogvol.h
@@ -68,6 +68,10 @@ extern cvar_t r_fogvol_globalfog_height_scale;
 extern cvar_t r_fogvol_globalfog_priority;
 extern cvar_t r_fogvol_light;
 extern cvar_t r_fogvol_light_max;
+extern cvar_t r_fogvol_shadow;
+extern cvar_t r_fogvol_shadow_samples;
+extern cvar_t r_fogvol_shadow_strength;
+extern cvar_t r_fogvol_shadow_jitter;
 
 void R_FogVol_Init (void);
 void R_FogVol_Clear (void);

--- a/Quake/shaders/fogvol.frag
+++ b/Quake/shaders/fogvol.frag
@@ -84,6 +84,11 @@ layout(location=13) uniform vec2  FogDensityParams;  // x: density scale, y: sig
 layout(location=14) uniform int   FogEmissiveEnabled;
 layout(location=15) uniform int   FogBlendModeDefault;
 layout(location=16) uniform int   FogLightEnabled;
+layout(location=17) uniform int   FogShadowEnabled;
+layout(location=18) uniform int   FogShadowSamples;
+layout(location=19) uniform float FogShadowStrength;
+layout(location=20) uniform float FogShadowJitter;
+layout(location=21) uniform vec3  FogShadowDir;
 
 layout(location=0) out vec4 FragColor;
 
@@ -284,6 +289,71 @@ float FogEdgeFade(vec3 p, vec3 bmin, vec3 bmax, float falloff)
 	return smoothstep(0.0, edgeThickness, edgeDist);
 }
 
+bool PointInsideVolume(vec3 p, FogVolume volume)
+{
+	if (volume.extra.x > 0.5)
+		return length(p - volume.sphere.xyz) <= volume.sphere.w;
+	return all(greaterThanEqual(p, volume.mins.xyz)) && all(lessThanEqual(p, volume.maxs.xyz));
+}
+
+float EvaluateFogSigma(vec3 p, FogVolume volume, float density, float falloff, float noiseScalePre, vec3 flowPre)
+{
+	float edgeFade;
+	if (volume.extra.x > 0.5)
+	{
+		float d = volume.sphere.w - length(p - volume.sphere.xyz);
+		edgeFade = (falloff <= 0.0) ? 1.0 : smoothstep(0.0, falloff, d);
+	}
+	else
+	{
+		edgeFade = FogEdgeFade(p, volume.mins.xyz, volume.maxs.xyz, falloff);
+	}
+
+	float noiseFactor = 1.0;
+	if (FogNoiseEnabled != 0)
+	{
+		vec3 noisePos = p * noiseScalePre + flowPre * Time * noiseScalePre;
+		if (volume.wind_turbulence.w > 1e-4)
+			noisePos += vec3(FBM(p * noiseScalePre * 2.03), FBM(p.yzx * noiseScalePre * 2.71), FBM(p.zxy * noiseScalePre * 1.91)) * volume.wind_turbulence.w * 0.35;
+		float n = FogNoise(noisePos);
+		float noiseBias = clamp(volume.noise_params.z, 0.0, 1.0);
+		if (noiseBias > 0.0)
+			n = smoothstep(noiseBias, 1.0, n);
+		float amt = clamp(volume.noise_params.y, 0.0, 1.0);
+		noiseFactor = mix(1.0, clamp(2.0 * n, 0.0, 2.0), amt);
+	}
+
+	float sigma = density * noiseFactor * edgeFade * HeightFactor(p, volume);
+	return IsFiniteFloat(sigma) ? max(sigma, 0.0) : 0.0;
+}
+
+float EstimateShadowVisibility(vec3 p, FogVolume volume, float density, float falloff, float noiseScalePre, vec3 flowPre, float stepLen)
+{
+	if (FogShadowEnabled == 0 || FogShadowSamples <= 0)
+		return 1.0;
+
+	vec3 lightDir = normalize(FogShadowDir);
+	if (dot(lightDir, lightDir) < 1e-6)
+		return 1.0;
+
+	int sampleCount = min(FogShadowSamples, 8);
+	float jitter = (FogShadowJitter > 0.0) ? (InterleavedGradientNoise(gl_FragCoord.xy + p.xy * 0.03125 + Time * 13.37) - 0.5) : 0.0;
+	float shadowStep = max(stepLen * 2.0, 8.0);
+	float tauLight = 0.0;
+
+	for (int s = 0; s < sampleCount; ++s)
+	{
+		float sampleDist = (float(s) + 1.0 + jitter) * shadowStep;
+		vec3 sp = p + lightDir * sampleDist;
+		if (!PointInsideVolume(sp, volume))
+			break;
+		float sigma = EvaluateFogSigma(sp, volume, density, falloff, noiseScalePre, flowPre);
+		tauLight += sigma * shadowStep;
+	}
+
+	return exp(-max(FogShadowStrength, 0.0) * tauLight);
+}
+
 // ── main ───────────────────────────────────────────────────────────────────
 
 void main()
@@ -374,6 +444,8 @@ void main()
 	vec3  accum        = vec3(0.0);
 	float transmittance = 1.0;
 	float tau           = 0.0;
+	float shadowVisAccum = 0.0;
+	float shadowWeightAccum = 0.0;
 
 	// FIX #8: Removed stepsTaken / edgeFadeSum / earlyTerminated — they were
 	// accumulated but never consumed, silently wasting ALU every iteration.
@@ -401,38 +473,13 @@ void main()
 			break;
 
 		vec3  p        = ro + rd * t;
-		float edgeFade;
-		if (volume.extra.x > 0.5)
-		{
-			float d = volume.sphere.w - length(p - volume.sphere.xyz);
-			edgeFade = (falloff <= 0.0) ? 1.0 : smoothstep(0.0, falloff, d);
-		}
-		else
-		{
-			edgeFade = FogEdgeFade(p, volume.mins.xyz, volume.maxs.xyz, falloff);
-		}
-
 		// BUG FIX: Cap optical depth per step (sigma*stepLen), not sigma itself.
 		// FogDensityParams.y is sigma_max; capping sigma ignores stepLen and
 		// causes instant opacity at any step count > ~10. See r_fogvol.c comment.
-		float noiseFactor = 1.0;
-		if (FogNoiseEnabled != 0)
-		{
-			vec3 noisePos = p * noiseScalePre + flowPre * Time * noiseScalePre;
-			// PERF: Domain warp only when turbulence > 0 (global fog always skips).
-			if (volume.wind_turbulence.w > 1e-4)
-				noisePos += vec3(FBM(p * noiseScalePre * 2.03), FBM(p.yzx * noiseScalePre * 2.71), FBM(p.zxy * noiseScalePre * 1.91)) * volume.wind_turbulence.w * 0.35;
-			float n = FogNoise(noisePos);
-			float noiseBias = clamp(volume.noise_params.z, 0.0, 1.0);
-			if (noiseBias > 0.0)
-				n = smoothstep(noiseBias, 1.0, n);
-			float amt = clamp(volume.noise_params.y, 0.0, 1.0);
-			noiseFactor = mix(1.0, clamp(2.0 * n, 0.0, 2.0), amt);
-		}
-		float rawSigma = density * noiseFactor * edgeFade * HeightFactor(p, volume);
-		if (!IsFiniteFloat(rawSigma)) rawSigma = 0.0;
+		float rawSigma = EvaluateFogSigma(p, volume, density, falloff, noiseScalePre, flowPre);
 		float opticalDepth = min(rawSigma * stepLen, FogDensityParams.y);
 		float att        = exp(-opticalDepth);
+		float shadowVisibility = EstimateShadowVisibility(p, volume, density, falloff, noiseScalePre, flowPre, stepLen);
 		vec3  stepScatter = (1.0 - att) * scatterColor;
 		if (FogLightEnabled != 0 && FogLightMeta.x > 0)
 		{
@@ -458,9 +505,12 @@ void main()
 			}
 			stepScatter += lightScatter * (1.0 - att);
 		}
+		stepScatter *= shadowVisibility;
 		accum            += transmittance * stepScatter;
 		transmittance    *= att;
 		tau              += opticalDepth;
+		shadowVisAccum += shadowVisibility * (1.0 - att);
+		shadowWeightAccum += (1.0 - att);
 
 		// BUG FIX 3: Early-out was at transmittance < 0.01, which aborts the
 		// ray before reaching nearby dynamic lights when fog is dense.
@@ -504,6 +554,15 @@ void main()
 	if (FogDebugMode == 6)
 	{
 		FragColor = vec4(vec3(clamp(transmittance, 0.0, 1.0)), 1.0);
+		return;
+	}
+	if (FogDebugMode == 8)
+	{
+		float avgShadow = (shadowWeightAccum > 1e-6) ? (shadowVisAccum / shadowWeightAccum) : 1.0;
+		float shadowedLum = dot(accum, vec3(0.299, 0.587, 0.114));
+		float unshadowedLum = shadowedLum / max(avgShadow, 1e-3);
+		float ratio = clamp(shadowedLum / max(unshadowedLum, 1e-3), 0.0, 1.0);
+		FragColor = vec4(clamp(shadowedLum * 2.0, 0.0, 1.0), clamp(unshadowedLum * 2.0, 0.0, 1.0), ratio, 1.0);
 		return;
 	}
 

--- a/docs/fogvol_debug_notes.md
+++ b/docs/fogvol_debug_notes.md
@@ -15,6 +15,7 @@ The dominant issue was **A + C combined**:
 - `5`: integrated extinction (sigma/tau-like visualization)
 - `6`: transmittance visualization
 - `7`: temporal history contribution (`R=alpha, G=history valid, B=motion factor`)
+- `8`: fog shadow debug (`R=shadowed scattering, G=unshadowed estimate, B=visibility ratio`)
 
 ## Added guardrails
 - Runtime depth conventions are now passed explicitly (`near/far/reverseZ/skyCutoff`) to fog shader.
@@ -26,4 +27,13 @@ The dominant issue was **A + C combined**:
 - `r_fogvol_debug`
 - `r_fogvol_density_scale`
 - `r_fogvol_sigma_max`
+- `r_fogvol_shadow` (default `1`): enables per-step shadow visibility term for volumetric scattering.
+- `r_fogvol_shadow_samples` (default `2`, clamp `1..8`): shadow raymarch taps per fog step; higher values improve directional shadow stability at higher GPU cost.
+- `r_fogvol_shadow_strength` (default `0.8`): scales shadow optical depth influence; `0` disables darkening, `1` is physical-ish, values `>1` exaggerate shadows.
+- `r_fogvol_shadow_jitter` (default `1`): stochastic offset for shadow taps to reduce banding; may introduce light temporal noise.
 - Existing diagnostics retained: `r_fogvol_testvolumes`, `r_fogvol_testvolumes_dumpstate`
+
+## Performance implications of fog shadows
+- Cost scales roughly with `r_fogvol_steps * r_fogvol_shadow_samples` because each fog integration step performs an additional short visibility march.
+- Recommended baseline: keep `r_fogvol_shadow_samples=2` for gameplay, use `4` for captures, and avoid `8` unless fog coverage is limited.
+- If performance is tight, first reduce `r_fogvol_shadow_samples`, then disable jitter, and finally disable `r_fogvol_shadow`.


### PR DESCRIPTION
### Motivation
- Add a low-cost shadow visibility term to the volumetric fog raymarch so per-step in-scattering is reduced where light is occluded, improving shadowing inside dense fog volumes.
- Provide runtime controls for quality/cost and an easy debug visualization to tune behavior and diagnose rendering issues.
- Document defaults and performance trade-offs so integrators can pick sensible settings for gameplay vs captures.

### Description
- Shader changes (`Quake/shaders/fogvol.frag`): added uniforms `FogShadowEnabled`, `FogShadowSamples`, `FogShadowStrength`, `FogShadowJitter`, `FogShadowDir`; factored density/noise into `EvaluateFogSigma`; added `EstimateShadowVisibility` (directional in-volume visibility march with optional jitter); added `PointInsideVolume`; multiplied per-step scattering by the visibility term and accumulated values for debug visualization; added debug mode `8` to visualize shadowed vs unshadowed scattering.
- Runtime wiring (`Quake/r_fogvol.c` / header): introduced cvars `r_fogvol_shadow` (default `1`), `r_fogvol_shadow_samples` (default `2`, clamped `1..8`), `r_fogvol_shadow_strength` (default `0.8`), and `r_fogvol_shadow_jitter` (default `1`); registered the cvars in `R_FogVol_Init`; extended debug clamp range to include mode `8`; computed a fallback shadow direction and uploaded the new uniforms from `R_FogVol_Render`.
- API exposure: added `extern` declarations in `Quake/r_fogvol.h` for the new cvars so they are available to other translation units.
- Documentation: updated `docs/fogvol_debug_notes.md` with the new debug mode, default values, and performance guidance (cost scaling with `r_fogvol_steps * r_fogvol_shadow_samples` and recommended baselines).

### Testing
- Attempted a local build with `make -C Quake -j2`; build failed due to missing development dependencies (`sdl2-config` / `SDL.h`) in the container, so a full compile/run validation could not be completed (failure expected from environment, not code).
- Ran repository checks and inspections (`rg`/`sed` listings and `git status`) and committed the changes successfully (commit message: `Add volumetric fog shadow visibility controls`).
- No automated renderer/unit tests were available in this environment; recommend CI build + GPU run and in-engine scene captures to validate visual correctness and perf impact (try `r_fogvol_shadow_samples=2..4` and debug mode `r_fogvol_debug 8`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a38ff1519c832e8db8cf1c84cd6859)