### PR TITLE
Remove screen darken cvars and postprocess logic

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -453,8 +453,6 @@ cvar_t	r_vignette_color_g = { "r_vignette_color_g", "0.0", CVAR_ARCHIVE };
 cvar_t	r_vignette_color_b = { "r_vignette_color_b", "0.0", CVAR_ARCHIVE };
 cvar_t	r_vignette_blend_mode = { "r_vignette_blend_mode", "0", CVAR_ARCHIVE };
 cvar_t	r_vignette_noise = { "r_vignette_noise", "0.0", CVAR_ARCHIVE };
-cvar_t	r_screendarken = { "r_screendarken", "0", CVAR_ARCHIVE };
-cvar_t	r_screendarken_depth = { "r_screendarken_depth", "0.4", CVAR_ARCHIVE };
 cvar_t	r_teleportfx = { "r_teleportfx", "1", CVAR_ARCHIVE };
 cvar_t	r_teleportfx_time = { "r_teleportfx_time", "0.35", CVAR_ARCHIVE };
 
@@ -2179,9 +2177,6 @@ void GL_PostProcess (void)
 	float motion_min_velocity;
 	float motion_depth_threshold;
 	int motion_max_samples;
-	qboolean screen_darken_enabled;
-	float screen_darken_strength;
-	float screen_darken_depth;
 	float teleport_fade;
 	float teleport_blur;
 	qboolean godrays_enabled;
@@ -2263,9 +2258,6 @@ void GL_PostProcess (void)
 	float bloom_intensity_effective = bloom_intensity;
 	float exposure = q_max (0.f, r_tonemap_exposure.value);
 	float tonemap_mode = q_max (0.f, r_tonemap.value);
-	screen_darken_strength = q_min (1.f, q_max (0.f, r_screendarken.value));
-	screen_darken_depth = q_max (0.f, r_screendarken_depth.value);
-	screen_darken_enabled = (screen_darken_strength > 0.f);
 	teleport_fade = 0.f;
 	teleport_blur = 0.f;
 	{
@@ -2444,8 +2436,8 @@ void GL_PostProcess (void)
 		q_min (2.f, q_max (0.f, r_vignette_blend_mode.value)));
 	GL_Uniform4fFunc (10,
 	q_min (0.1f, q_max (0.f, r_vignette_noise.value)),
-	screen_darken_strength,
-	screen_darken_depth,
+	0.f,
+	0.f,
 	0.f);
 	GL_Uniform4fFunc (11, teleport_fade, teleport_blur, 0.f, 0.f);
 	GL_Uniform1fFunc (12, CLAMP (0.9f, r_color_saturation.value, 1.2f));
@@ -2504,7 +2496,7 @@ void GL_PostProcess (void)
 	{
 		qboolean ssao_needs_depth = (ssao_texture != 0
 			&& (r_ssao_halfres.value > 0.f || ssao_debug_mode == 8.f || ssao_fog_strength > 0.f));
-		if (framebufs.composite.depth_stencil_tex && (dof_enabled || screen_darken_enabled || (motion_enabled && motion_depth_threshold > 0.f) || ssao_needs_depth))
+		if (framebufs.composite.depth_stencil_tex && (dof_enabled || (motion_enabled && motion_depth_threshold > 0.f) || ssao_needs_depth))
 			depth_texture = framebufs.composite.depth_stencil_tex;
 	}
 	GL_BindNative (GL_TEXTURE2, GL_TEXTURE_2D, depth_texture);

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -290,8 +290,6 @@ extern cvar_t r_vignette_color_g;
 extern cvar_t r_vignette_color_b;
 extern cvar_t r_vignette_blend_mode;
 extern cvar_t r_vignette_noise;
-extern cvar_t r_screendarken;
-extern cvar_t r_screendarken_depth;
 extern cvar_t r_teleportfx;
 extern cvar_t r_teleportfx_time;
 
@@ -764,8 +762,6 @@ Cvar_RegisterVariable (&r_vignette);
 	Cvar_RegisterVariable (&r_vignette_color_b);
 	Cvar_RegisterVariable (&r_vignette_blend_mode);
 	Cvar_RegisterVariable (&r_vignette_noise);
-	Cvar_RegisterVariable (&r_screendarken);
-	Cvar_RegisterVariable (&r_screendarken_depth);
 	Cvar_RegisterVariable (&r_teleportfx);
 	Cvar_RegisterVariable (&r_teleportfx_time);
         Cvar_RegisterVariable (&r_overbrightbits);

--- a/Quake/shaders/postprocess.frag
+++ b/Quake/shaders/postprocess.frag
@@ -126,7 +126,7 @@ layout(location=6) uniform vec4 MotionParams0; // x: enabled, y: shutter strengt
 layout(location=7) uniform vec4 MotionParams1; // x: max blur radius (pixels), y: max samples, z: velocity texture available, w: reserved
 layout(location=8) uniform vec4 PostFXParams0; // x: vignette strength, y: inner radius, z: outer radius, w: falloff
 layout(location=9) uniform vec4 PostFXParams1; // xyz: vignette color, w: blend mode
-layout(location=10) uniform vec4 PostFXParams2; // x: vignette noise amount, y: screen-space darken strength, z: screen-space darken depth range, w: unused
+layout(location=10) uniform vec4 PostFXParams2; // x: vignette noise amount, yzw: unused
 layout(location=11) uniform vec4 TeleportParams; // x: teleport fade, y: blur radius (pixels)
 layout(location=12) uniform float u_saturation;
 layout(location=16) uniform vec4 GodraysParams; // x: enabled, y: debug, z: debug source mode, w: unused
@@ -437,17 +437,6 @@ void main()
         {
                 vec2 viewUV = clamp((uv - viewMin) / viewSize, vec2(0.0), vec2(1.0));
                 float aspect = texSize.y > 0.0 ? texSize.x / texSize.y : 1.0;
-
-                float screenDarkenStrength = clamp(PostFXParams2.y, 0.0, 1.0);
-                float screenDarkenDepth = max(PostFXParams2.z, 1e-4);
-                if (screenDarkenStrength > 0.0 && depthInfo.valid)
-                {
-                        float linearDepth = SampleLinearDepth(gl_FragCoord.xy, depthInfo);
-                        float depthRange = max(DoFParams1.y - DoFParams1.x, 1e-6);
-                        float normalizedDepth = clamp((linearDepth - DoFParams1.x) / depthRange, 0.0, 1.0);
-                        float screenAO = smoothstep(0.0, screenDarkenDepth, 1.0 - normalizedDepth);
-                        color.rgb *= mix(vec3(1.0), vec3(screenAO), screenDarkenStrength);
-                }
 
                 float vignetteStrength = clamp(PostFXParams0.x, 0.0, 1.0);
                 float vignetteInner = max(PostFXParams0.y, 0.0);


### PR DESCRIPTION
### Motivation
- The screen-space darkening postprocess feature (and its runtime controls) is being removed to simplify the postprocess pipeline and eliminate unused cvars and shader paths.

### Description
- Removed `r_screendarken` and `r_screendarken_depth` cvar declarations from `Quake/gl_rmain.c` and stopped writing their values into the postprocess uniform parameters.
- Removed the local runtime state and gating for screen-darken inside `GL_PostProcess` so the CPU no longer drives that effect or requires depth for it.
- Removed `r_screendarken` extern declarations and `Cvar_RegisterVariable` calls from `Quake/gl_rmisc.c`.
- Removed the screen-space darken block from `Quake/shaders/postprocess.frag` and updated `PostFXParams2` comment to mark `yzw` as unused while keeping `x` (vignette noise) intact and passing zeros for the unused components from the CPU side.

### Testing
- Searched the codebase with `rg -n "screendarken|screenDarken|screen_darken"` and confirmed there are no remaining references in the modified files (no matches after the changes).
- Ran `make -C Quake -j4` to attempt a build, but the build cannot complete in this environment due to missing SDL headers / `sdl2-config` (compile dependency errors were reported), so full compile-time validation could not be completed here.
- Ran `make` at repository root which reported no targets because there is no top-level Makefile in this workspace.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3924ab9b4832e8bd6582bea9fd809)