### PR TITLE
Fix unresolved async/job linker symbols in Visual Studio build

### DIFF
--- a/Windows/VisualStudio/ironwail.vcxproj
+++ b/Windows/VisualStudio/ironwail.vcxproj
@@ -223,6 +223,7 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\Quake\async.c" />
     <ClCompile Include="..\..\Quake\bgmusic.c" />
     <ClCompile Include="..\..\Quake\bc7enc.c">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>

--- a/Windows/VisualStudio/ironwail.vcxproj.filters
+++ b/Windows/VisualStudio/ironwail.vcxproj.filters
@@ -15,6 +15,9 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\Quake\async.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\Quake\bgmusic.c">
       <Filter>Source Files</Filter>
     </ClCompile>


### PR DESCRIPTION
### Motivation
- The Windows Visual Studio build failed with unresolved externals for async file I/O and job-system functions (e.g. `FS_AsyncAdvanceGeneration`, `FS_PumpAsyncCompletions`, `Jobs_Init`, `Jobs_Shutdown`) because `Quake/async.c` was not included in the project.

### Description
- Added a `ClCompile` entry for `..\..\Quake\async.c` to `Windows/VisualStudio/ironwail.vcxproj` and the matching entry to `Windows/VisualStudio/ironwail.vcxproj.filters` so the async/job implementations are compiled and visible under the VS "Source Files" filter.

### Testing
- Verified the new project entries with `rg -F "..\\..\\Quake\\async.c" -n Windows/VisualStudio/ironwail.vcxproj Windows/VisualStudio/ironwail.vcxproj.filters`, which found the added lines, indicating the files were included correctly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a39abc34b4832eab98274c65337fa3)