### PR TITLE
Add fallback default sun when map omits sun data

### DIFF
--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -890,6 +890,95 @@ void R_TranslateNewPlayerSkin (int playernum)
 R_NewGame -- johnfitz -- handle a game switch
 ===============
 */
+
+static qboolean r_map_has_sun = false;
+r_sun_t r_sun;
+
+static void R_ParseSunData (void)
+{
+	const char *data;
+
+	r_map_has_sun = false;
+	r_sun.enabled = false;
+	VectorClear (r_sun.origin);
+	VectorClear (r_sun.dir);
+
+	if (!cl.worldmodel || !cl.worldmodel->entities)
+		return;
+
+	data = cl.worldmodel->entities;
+	data = COM_Parse (data);
+	while (data && com_token[0])
+	{
+		qboolean is_sun_entity = false;
+
+		if (com_token[0] != '{')
+			break;
+
+		while (1)
+		{
+			char key[128], value[4096];
+
+			data = COM_Parse (data);
+			if (!data || !com_token[0])
+				return;
+			if (com_token[0] == '}')
+				break;
+
+			if (com_token[0] == '_')
+				q_strlcpy (key, com_token + 1, sizeof (key));
+			else
+				q_strlcpy (key, com_token, sizeof (key));
+			while (key[0] && key[strlen (key) - 1] == ' ')
+				key[strlen (key) - 1] = 0;
+
+			data = COM_ParseEx (data, CPE_ALLOWTRUNC);
+			if (!data)
+				return;
+			q_strlcpy (value, com_token, sizeof (value));
+
+			if (!strcmp (key, "sunlight") || !strcmp (key, "sun_mangle"))
+				r_map_has_sun = true;
+
+			if (!strcmp (key, "classname") && !strcmp (value, "sun"))
+				is_sun_entity = true;
+		}
+
+		if (is_sun_entity)
+			r_map_has_sun = true;
+
+		data = COM_Parse (data);
+	}
+}
+
+static void R_ApplyDefaultSunIfMissing (model_t *world)
+{
+	vec3_t center;
+	vec3_t ang;
+
+	if (!world)
+		return;
+
+	if (r_map_has_sun)
+		return;
+
+	center[0] = 0.5f * (world->mins[0] + world->maxs[0]);
+	center[1] = 0.5f * (world->mins[1] + world->maxs[1]);
+	center[2] = 0.5f * (world->mins[2] + world->maxs[2]);
+
+	VectorCopy (center, r_sun.origin);
+	r_sun.origin[2] += 128.0f;
+
+	ang[PITCH] = 45.0f;
+	ang[YAW] = 225.0f;
+	ang[ROLL] = 0.0f;
+
+	AngleVectors (ang, r_sun.dir, NULL, NULL);
+	VectorNormalize (r_sun.dir);
+
+	r_sun.enabled = true;
+}
+
 void R_NewGame (void)
 {
 	int i;
@@ -981,6 +1070,8 @@ void R_NewMap (void)
 	R_ResetGodraysStabilization ();
 	R_FogVol_ClearHistory ();
 
+	r_map_has_sun = false;
+
 	GL_BuildLightmaps ();
         GL_BuildBModelVertexBuffer ();
         GL_BuildBModelMarkBuffers ();
@@ -993,6 +1084,8 @@ void R_NewMap (void)
         Sky_NewMap (); //johnfitz -- skybox in worldspawn
         Fog_NewMap (); //johnfitz -- global fog in worldspawn
         R_ParseWorldspawn (); //ericw -- wateralpha, telealpha, slimealpha in worldspawn
+        R_ParseSunData ();
+        R_ApplyDefaultSunIfMissing (cl.worldmodel);
         R_ParseDlightEntities (); // persistent dlights from BSP entities
         R_FogVol_ParseEntities (); // fog volume entities from BSP
 

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -456,6 +456,12 @@ typedef struct gpuframedata_s {
         unsigned int    _padding2;
 } gpuframedata_t;
 
+typedef struct r_sun_s {
+	qboolean enabled;
+	vec3_t origin;
+	vec3_t dir;
+} r_sun_t;
+
 COMPILE_TIME_ASSERT (gpuframedata_std140_size, sizeof (gpuframedata_t) == 400);
 
 typedef enum
@@ -469,6 +475,7 @@ extern gpulightbuffer_t r_lightbuffer;
 extern gpuframedata_t r_framedata;
 extern float r_lightstyle_framefrac;
 extern dlight_t *r_dlight_sources[DLIGHT_GPU_MAX];
+extern r_sun_t r_sun;
 
 void R_AnimateLight (void);
 void R_MarkSurfaces (void);


### PR DESCRIPTION
### Motivation
- Some maps do not provide any sun parameters or sun entities which leaves the renderer without a usable sun; add a non-invasive fallback after map load so rendering features that expect a sun still behave.

### Description
- Add a small `r_sun_t` type and an external `r_sun` instance in `Quake/glquake.h` to hold renderer sun state without adding CVars or refactoring rendering paths.
- Add a map-level flag `r_map_has_sun` and the parser `R_ParseSunData()` in `Quake/gl_rmisc.c` which scans the loaded BSP entity string and sets the flag when `_sunlight`, `_sun_mangle`, or `classname "sun"` is present (underscore keys normalized like existing parsing).
- Add `R_ApplyDefaultSunIfMissing(model_t *world)` in `Quake/gl_rmisc.c` which, when no sun is detected, computes map center from `world->mins/maxs`, sets `r_sun.origin = center + (0,0,128)`, sets angles `pitch=45, yaw=225, roll=0`, converts to a normalized direction and enables `r_sun` (no overriding of map-provided values).
- Wire the flow in `R_NewMap()` to reset `r_map_has_sun`, call `R_ParseSunData()` after worldspawn parsing, and then call `R_ApplyDefaultSunIfMissing(cl.worldmodel)` before other renderer entity parsing runs; modified files: `Quake/gl_rmisc.c`, `Quake/glquake.h`.

### Testing
- Ran an attempted build with `make -C Quake -j4`; the build could not be completed in this environment because `sdl2-config` and `SDL.h` are missing, so a full compile/test could not be executed (dependency failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a420732b1c832e8d77b5585472ba83)