### PR TITLE
Fix gl_rmisc world model type for default sun helper

### DIFF
--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -951,7 +951,7 @@ static void R_ParseSunData (void)
 	}
 }
 
-static void R_ApplyDefaultSunIfMissing (model_t *world)
+static void R_ApplyDefaultSunIfMissing (qmodel_t *world)
 {
 	vec3_t center;
 	vec3_t ang;


### PR DESCRIPTION
### Motivation
- Resolve MSVC parse/type errors caused by an incorrect/nonexistent `model_t` parameter type in the default-sun helper so the function signature matches the engine's model type.

### Description
- Update the function signature in `Quake/gl_rmisc.c` from `static void R_ApplyDefaultSunIfMissing (model_t *world)` to `static void R_ApplyDefaultSunIfMissing (qmodel_t *world)`.

### Testing
- Ran `rg "R_ApplyDefaultSunIfMissing|model_t \*world" Quake/gl_rmisc.c` to verify the signature was updated, which succeeded.
- Ran `git status --short` after committing the change to verify the working tree is clean, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a421c5e98c832e8aeb527dba3f9fe9)