### PR TITLE
Fix startup crash from fallback sun parsing

### DIFF
--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -891,65 +891,8 @@ R_NewGame -- johnfitz -- handle a game switch
 ===============
 */
 
-static qboolean r_map_has_sun = false;
+static qboolean r_worldspawn_has_sun = false;
 r_sun_t r_sun;
-
-static void R_ParseSunData (void)
-{
-	const char *data;
-
-	r_map_has_sun = false;
-	r_sun.enabled = false;
-	VectorClear (r_sun.origin);
-	VectorClear (r_sun.dir);
-
-	if (!cl.worldmodel || !cl.worldmodel->entities)
-		return;
-
-	data = cl.worldmodel->entities;
-	data = COM_Parse (data);
-	while (data && com_token[0])
-	{
-		qboolean is_sun_entity = false;
-
-		if (com_token[0] != '{')
-			break;
-
-		while (1)
-		{
-			char key[128], value[4096];
-
-			data = COM_Parse (data);
-			if (!data || !com_token[0])
-				return;
-			if (com_token[0] == '}')
-				break;
-
-			if (com_token[0] == '_')
-				q_strlcpy (key, com_token + 1, sizeof (key));
-			else
-				q_strlcpy (key, com_token, sizeof (key));
-			while (key[0] && key[strlen (key) - 1] == ' ')
-				key[strlen (key) - 1] = 0;
-
-			data = COM_ParseEx (data, CPE_ALLOWTRUNC);
-			if (!data)
-				return;
-			q_strlcpy (value, com_token, sizeof (value));
-
-			if (!strcmp (key, "sunlight") || !strcmp (key, "sun_mangle"))
-				r_map_has_sun = true;
-
-			if (!strcmp (key, "classname") && !strcmp (value, "sun"))
-				is_sun_entity = true;
-		}
-
-		if (is_sun_entity)
-			r_map_has_sun = true;
-
-		data = COM_Parse (data);
-	}
-}
 
 static void R_ApplyDefaultSunIfMissing (qmodel_t *world)
 {
@@ -959,7 +902,7 @@ static void R_ApplyDefaultSunIfMissing (qmodel_t *world)
 	if (!world)
 		return;
 
-	if (r_map_has_sun)
+	if (r_worldspawn_has_sun)
 		return;
 
 	center[0] = 0.5f * (world->mins[0] + world->maxs[0]);
@@ -1001,6 +944,7 @@ static void R_ParseWorldspawn (void)
 	const char *data;
 
 	map_fallbackalpha = r_wateralpha.value;
+	r_worldspawn_has_sun = false;
 	map_wateralpha = (cl.worldmodel->contentstransparent&SURF_DRAWWATER)?r_wateralpha.value:1;
 	map_lavaalpha = 1.0f;
 	map_telealpha = (cl.worldmodel->contentstransparent&SURF_DRAWTELE)?r_telealpha.value:1;
@@ -1032,6 +976,9 @@ static void R_ParseWorldspawn (void)
 
 if (!strcmp("wateralpha", key))
 map_wateralpha = atof(value);
+
+if (!strcmp("sunlight", key) || !strcmp("sun_mangle", key))
+	r_worldspawn_has_sun = true;
 
 if (!strcmp("telealpha", key))
 map_telealpha = atof(value);
@@ -1070,7 +1017,10 @@ void R_NewMap (void)
 	R_ResetGodraysStabilization ();
 	R_FogVol_ClearHistory ();
 
-	r_map_has_sun = false;
+	r_worldspawn_has_sun = false;
+	r_sun.enabled = false;
+	VectorClear (r_sun.origin);
+	VectorClear (r_sun.dir);
 
 	GL_BuildLightmaps ();
         GL_BuildBModelVertexBuffer ();
@@ -1084,7 +1034,6 @@ void R_NewMap (void)
         Sky_NewMap (); //johnfitz -- skybox in worldspawn
         Fog_NewMap (); //johnfitz -- global fog in worldspawn
         R_ParseWorldspawn (); //ericw -- wateralpha, telealpha, slimealpha in worldspawn
-        R_ParseSunData ();
         R_ApplyDefaultSunIfMissing (cl.worldmodel);
         R_ParseDlightEntities (); // persistent dlights from BSP entities
         R_FogVol_ParseEntities (); // fog volume entities from BSP


### PR DESCRIPTION
### Motivation
- Engine could crash at startup after adding a safe fallback for sun values because a separate pass parsed the full BSP entity lump again and could destabilize startup on malformed or edge-case entity data. 
- The intent is to preserve the fallback sun behavior for maps without sun data while avoiding the fragile second entity-lump parse.

### Description
- Removed the separate, full-entity-lump sun scanner and the `R_ParseSunData` path in `Quake/gl_rmisc.c` and replaced it with a simple flag used by the existing worldspawn parser. 
- Added `r_worldspawn_has_sun` and detect `sunlight` / `sun_mangle` keys inside `R_ParseWorldspawn` so sun presence is recorded during the single, robust parse pass. 
- Keep `R_ApplyDefaultSunIfMissing` to provide the fallback sun when the worldspawn did not declare sun data. 
- Explicitly reset `r_sun` state and the worldspawn-sun flag during map initialization before applying the fallback to ensure deterministic startup state.

### Testing
- Ran pattern searches (`rg`) to verify the fragile parser path and symbols were removed and the new detection points were added, which succeeded. 
- Attempted to configure and build (`cmake -S . -B build`) in this environment but it failed due to missing `SDL2` CMake package, so a full build/test could not be completed here. 
- No automated unit tests were present or runnable in this environment; the changes are limited to parsing/initialization logic and guarded by the worldspawn parser to reduce crash risk.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a422a3bb04832eb494ec0e6f4bb23c)