### PR TITLE
Guard optional outputs in AngleVectors

### DIFF
--- a/Quake/mathlib.c
+++ b/Quake/mathlib.c
@@ -251,15 +251,26 @@ void AngleVectors (vec3_t angles, vec3_t forward, vec3_t right, vec3_t up)
 	sr = sin(angle);
 	cr = cos(angle);
 
-	forward[0] = cp*cy;
-	forward[1] = cp*sy;
-	forward[2] = -sp;
-	right[0] = (-1*sr*sp*cy+-1*cr*-sy);
-	right[1] = (-1*sr*sp*sy+-1*cr*cy);
-	right[2] = -1*sr*cp;
-	up[0] = (cr*sp*cy+-sr*-sy);
-	up[1] = (cr*sp*sy+-sr*cy);
-	up[2] = cr*cp;
+	if (forward)
+	{
+		forward[0] = cp*cy;
+		forward[1] = cp*sy;
+		forward[2] = -sp;
+	}
+
+	if (right)
+	{
+		right[0] = (-1*sr*sp*cy+-1*cr*-sy);
+		right[1] = (-1*sr*sp*sy+-1*cr*cy);
+		right[2] = -1*sr*cp;
+	}
+
+	if (up)
+	{
+		up[0] = (cr*sp*cy+-sr*-sy);
+		up[1] = (cr*sp*sy+-sr*cy);
+		up[2] = cr*cp;
+	}
 }
 
 int VectorCompare (const vec3_t v1, const vec3_t v2)


### PR DESCRIPTION
### Motivation
- `R_ApplyDefaultSunIfMissing` calls `AngleVectors(ang, r_sun.dir, NULL, NULL)` which demonstrates callers may pass `NULL` for outputs they don't need, but `AngleVectors` previously wrote into `right` and `up` without checking for `NULL`, causing sporadic crashes. 
- The change addresses an API mismatch by making `AngleVectors` resilient to optional `NULL` output pointers so callers can request only the vectors they need.

### Description
- Add `NULL` guards around writes to `forward`, `right`, and `up` in `AngleVectors` to avoid dereferencing missing output buffers in `Quake/mathlib.c`.
- Preserve the existing vector math and only skip writing individual output vectors when the corresponding pointer is `NULL`.
- This makes existing call sites such as `R_ApplyDefaultSunIfMissing` safe without changing their behavior.

### Testing
- Searched for call sites that pass `NULL` with `rg -n "AngleVectors \([^\)]*NULL"` to validate usage patterns and confirmed `R_ApplyDefaultSunIfMissing` passes `NULL` for unused outputs. 
- Attempted a full build with `make -C Quake -j2`, but the container lacks SDL2 tooling/headers (`sdl2-config`/`SDL.h`), so a complete build could not be completed in this environment. 
- Reviewed the modified lines in `Quake/mathlib.c` to ensure the guards cover all output writes and no other behavior was altered.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4276a8bcc832ea4ee2cbe4ad50a02)