### PR TITLE
async: replace JobHandle polling with per-handle condition variable

### DIFF
--- a/Quake/async.c
+++ b/Quake/async.c
@@ -54,7 +54,10 @@ static int Jobs_Worker (void *unused)
 		SDL_UnlockMutex (jobs_mutex);
 
 		node->func (node->userdata);
-		node->handle->done = 1;
+		SDL_LockMutex (node->handle->mutex);
+		node->handle->done = true;
+		SDL_CondSignal (node->handle->cond);
+		SDL_UnlockMutex (node->handle->mutex);
 		free (node);
 	}
 	return 0;
@@ -68,11 +71,18 @@ JobHandle *Jobs_Submit (jobs_func_t func, void *userdata)
 	handle = (JobHandle *) calloc (1, sizeof (*handle));
 	if (!handle)
 		Sys_Error ("Jobs_Submit: out of memory");
+	handle->mutex = SDL_CreateMutex ();
+	handle->cond = SDL_CreateCond ();
+	if (!handle->mutex || !handle->cond)
+		Sys_Error ("Jobs_Submit: failed to create handle sync primitives");
 
 	if (!Host_AsyncEnabled () || !jobs_thread)
 	{
 		func (userdata);
-		handle->done = 1;
+		SDL_LockMutex (handle->mutex);
+		handle->done = true;
+		SDL_CondSignal (handle->cond);
+		SDL_UnlockMutex (handle->mutex);
 		return handle;
 	}
 
@@ -99,8 +109,12 @@ void Jobs_Wait (JobHandle *handle)
 {
 	if (!handle)
 		return;
+	SDL_LockMutex (handle->mutex);
 	while (!handle->done)
-		SDL_Delay (1);
+		SDL_CondWait (handle->cond, handle->mutex);
+	SDL_UnlockMutex (handle->mutex);
+	SDL_DestroyCond (handle->cond);
+	SDL_DestroyMutex (handle->mutex);
 	free (handle);
 }
 
@@ -284,7 +298,10 @@ void Jobs_Shutdown (void)
 	while ((node = jobs_head) != NULL)
 	{
 		jobs_head = node->next;
-		node->handle->done = 1;
+		SDL_LockMutex (node->handle->mutex);
+		node->handle->done = true;
+		SDL_CondSignal (node->handle->cond);
+		SDL_UnlockMutex (node->handle->mutex);
 		free (node);
 	}
 	jobs_tail = NULL;

--- a/Quake/common.h
+++ b/Quake/common.h
@@ -419,8 +419,15 @@ void COM_CloseFile (int h);
 
 typedef struct jobhandle_s
 {
-	volatile int done;
+	SDL_mutex *mutex;
+	SDL_cond *cond;
+	qboolean done;
 } JobHandle;
+
+// Thread-safety contract:
+// - completion is published while holding handle->mutex and signaled via handle->cond.
+// - Jobs_Wait may be called from any thread, but at most once per handle.
+// - ownership of the handle transfers to Jobs_Wait, which frees it.
 
 typedef void (*jobs_func_t)(void *userdata);
 


### PR DESCRIPTION
### Motivation
- Replace busy-wait polling in `Jobs_Wait` (previously `SDL_Delay(1)` loop on a `volatile int`) with an efficient blocking wait to reduce CPU waste and provide proper memory visibility across threads.
- Provide a clear thread-safety and ownership contract for job completion handles so callers know how and when a handle may be waited on and freed.

### Description
- Updated `JobHandle` in `Quake/common.h` to contain per-handle `SDL_mutex *mutex`, `SDL_cond *cond`, and a `qboolean done` flag, and documented the thread-safety/ownership contract for handle completion.
- Modified `Jobs_Submit` in `Quake/async.c` to allocate and initialize the per-handle `SDL_mutex` and `SDL_cond`, and to publish synchronous completions under the handle lock and signal the condition variable.
- Changed the worker completion path to set `handle->done` while holding `handle->mutex` and to call `SDL_CondSignal(handle->cond)` so waiters are awakened reliably.
- Rewrote `Jobs_Wait` to block on `SDL_CondWait` instead of busy polling, and to destroy the per-handle synchronization primitives before freeing the handle; also updated `Jobs_Shutdown` to signal pending handles using the same lock+signal pattern.

### Testing
- Ran CMake configuration with `cmake -S . -B build` to validate build configuration, but it failed due to a missing SDL2 development package in the environment so compilation could not be validated here. (Configuration failure is environmental, not due to the change.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4401442e8832ea88198bd9034915e)