### PR TITLE
Drain queued async FS completions during shutdown

### DIFF
--- a/Quake/async.c
+++ b/Quake/async.c
@@ -282,6 +282,7 @@ void FS_PumpAsyncCompletions (void)
 void Jobs_Shutdown (void)
 {
 	jobnode_t *node;
+	fs_completion_t *comp;
 
 	if (!jobs_mutex)
 		return;
@@ -294,6 +295,20 @@ void Jobs_Shutdown (void)
 	if (jobs_thread)
 		SDL_WaitThread (jobs_thread, NULL);
 	jobs_thread = NULL;
+
+	SDL_LockMutex (fs_mutex);
+	comp = fs_comp_head;
+	fs_comp_head = fs_comp_tail = NULL;
+	SDL_UnlockMutex (fs_mutex);
+
+	while (comp)
+	{
+		fs_completion_t *next = comp->next;
+		if (comp->data)
+			free (comp->data);
+		free (comp);
+		comp = next;
+	}
 
 	while ((node = jobs_head) != NULL)
 	{


### PR DESCRIPTION
### Motivation

- Prevent async file callbacks from running during engine shutdown and ensure queued completion memory is reclaimed.
- Avoid use-after-free or race conditions by draining the FS completion list before destroying `fs_mutex`.
- Ensure shutdown ordering: join worker thread first, then detach and free pending completions, then tear down mutexes.

### Description

- Added a local `fs_completion_t *comp` and, after `SDL_WaitThread` returns, lock `fs_mutex`, detach `fs_comp_head/fs_comp_tail` into `comp`, and unlock `fs_mutex`.
- Walk the detached list and for each completion free `data` when non-null and then free the completion node without invoking the completion callback.
- Kept existing job queue draining and destruction of job sync primitives unchanged and left `fs_mutex` destruction after the new drain step.

### Testing

- Ran `git diff --check` which produced no warnings or errors and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a44148afe8832e98f3d5cef16ffdec)