### PR TITLE
Add Jobs_SubmitDetached API for fire-and-forget async jobs

### DIFF
--- a/Quake/async.c
+++ b/Quake/async.c
@@ -4,6 +4,7 @@ typedef struct jobnode_s {
 	jobs_func_t func;
 	void *userdata;
 	JobHandle *handle;
+	qboolean detached;
 	struct jobnode_s *next;
 } jobnode_t;
 
@@ -13,6 +14,8 @@ static SDL_cond *jobs_cond;
 static jobnode_t *jobs_head;
 static jobnode_t *jobs_tail;
 static qboolean jobs_shutdown;
+
+static void Jobs_SubmitNode (jobnode_t *node);
 
 static cvar_t host_async = {"host_async", "0", CVAR_ARCHIVE};
 static cvar_t host_async_fs = {"host_async_fs", "0", CVAR_ARCHIVE};
@@ -54,6 +57,11 @@ static int Jobs_Worker (void *unused)
 		SDL_UnlockMutex (jobs_mutex);
 
 		node->func (node->userdata);
+		if (node->detached)
+		{
+			free (node);
+			continue;
+		}
 		SDL_LockMutex (node->handle->mutex);
 		node->handle->done = true;
 		SDL_CondSignal (node->handle->cond);
@@ -93,6 +101,13 @@ JobHandle *Jobs_Submit (jobs_func_t func, void *userdata)
 	node->userdata = userdata;
 	node->handle = handle;
 
+	Jobs_SubmitNode (node);
+
+	return handle;
+}
+
+static void Jobs_SubmitNode (jobnode_t *node)
+{
 	SDL_LockMutex (jobs_mutex);
 	if (jobs_tail)
 		jobs_tail->next = node;
@@ -101,8 +116,26 @@ JobHandle *Jobs_Submit (jobs_func_t func, void *userdata)
 	jobs_tail = node;
 	SDL_CondSignal (jobs_cond);
 	SDL_UnlockMutex (jobs_mutex);
+}
 
-	return handle;
+void Jobs_SubmitDetached (jobs_func_t func, void *userdata)
+{
+	jobnode_t *node;
+
+	if (!Host_AsyncEnabled () || !jobs_thread)
+	{
+		func (userdata);
+		return;
+	}
+
+	node = (jobnode_t *) calloc (1, sizeof (*node));
+	if (!node)
+		Sys_Error ("Jobs_SubmitDetached: out of memory");
+	node->func = func;
+	node->userdata = userdata;
+	node->detached = true;
+
+	Jobs_SubmitNode (node);
 }
 
 void Jobs_Wait (JobHandle *handle)
@@ -231,7 +264,7 @@ fs_asyncread_handle_t FS_AsyncRead (const char *path, fs_async_cb cb, void *user
 	SDL_UnlockMutex (fs_mutex);
 
 	handle.id = job->id;
-	Jobs_Submit (FS_AsyncReadJob, job);
+	Jobs_SubmitDetached (FS_AsyncReadJob, job);
 	return handle;
 }
 
@@ -298,10 +331,13 @@ void Jobs_Shutdown (void)
 	while ((node = jobs_head) != NULL)
 	{
 		jobs_head = node->next;
-		SDL_LockMutex (node->handle->mutex);
-		node->handle->done = true;
-		SDL_CondSignal (node->handle->cond);
-		SDL_UnlockMutex (node->handle->mutex);
+		if (!node->detached)
+		{
+			SDL_LockMutex (node->handle->mutex);
+			node->handle->done = true;
+			SDL_CondSignal (node->handle->cond);
+			SDL_UnlockMutex (node->handle->mutex);
+		}
 		free (node);
 	}
 	jobs_tail = NULL;

--- a/Quake/common.h
+++ b/Quake/common.h
@@ -432,6 +432,7 @@ typedef struct jobhandle_s
 typedef void (*jobs_func_t)(void *userdata);
 
 JobHandle *Jobs_Submit (jobs_func_t func, void *userdata);
+void Jobs_SubmitDetached (jobs_func_t func, void *userdata);
 void Jobs_Wait (JobHandle *handle);
 void Jobs_Shutdown (void);
 

--- a/Quake/snd_mem.c
+++ b/Quake/snd_mem.c
@@ -176,7 +176,7 @@ static void S_AsyncReadComplete (void *user, uint8_t *data, size_t len, int stat
 		job->done = 1;
 		return;
 	}
-	Jobs_Submit (S_LoadSoundDecodeJob, job);
+	Jobs_SubmitDetached (S_LoadSoundDecodeJob, job);
 }
 
 static sfxcache_t *S_CommitPendingSound (pending_snd_job_t *job)


### PR DESCRIPTION
### Motivation
- Provide a fire-and-forget job submission path that does not allocate a `JobHandle` for tasks that the caller will not wait on, reducing allocations and simplifying call sites. 

### Description
- Added `void Jobs_SubmitDetached(jobs_func_t func, void *userdata);` declaration in `Quake/common.h` and implemented it in `Quake/async.c` as a non-waitable submission path. 
- Extended `jobnode_t` with a `detached` flag and added a `Jobs_SubmitNode` helper to unify queue insertion. 
- Modified the worker and shutdown paths so detached nodes are not signaled or locked with a `JobHandle`, and are freed directly after execution. 
- Replaced fire-and-forget calls to use the detached API: `FS_AsyncRead` now calls `Jobs_SubmitDetached(FS_AsyncReadJob, job)` and `S_AsyncReadComplete` now calls `Jobs_SubmitDetached(S_LoadSoundDecodeJob, job)`; `Jobs_Submit` is retained for waitable tasks. 

### Testing
- Ran `make -j4` at the repo root which failed because no top-level Makefile target exists. (failed)
- Ran CMake configure/build (`cmake -S . -B build && cmake --build build -j4`) which failed during configuration due to missing SDL2 development package in the environment, so a full build could not be performed. (failed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a440f704c8832e8218f5bff93c57c4)