### PR TITLE
Generalize async job system to N worker threads

### DIFF
--- a/Quake/async.c
+++ b/Quake/async.c
@@ -8,7 +8,8 @@ typedef struct jobnode_s {
 	struct jobnode_s *next;
 } jobnode_t;
 
-static SDL_Thread *jobs_thread;
+static SDL_Thread **jobs_threads;
+static int jobs_num_threads;
 static SDL_mutex *jobs_mutex;
 static SDL_cond *jobs_cond;
 static jobnode_t *jobs_head;
@@ -25,6 +26,7 @@ static void Jobs_LogQueueStats (const char *reason);
 static cvar_t host_async = {"host_async", "0", CVAR_ARCHIVE};
 static cvar_t host_async_fs = {"host_async_fs", "0", CVAR_ARCHIVE};
 static cvar_t host_async_assets = {"host_async_assets", "0", CVAR_ARCHIVE};
+static cvar_t host_async_workers = {"host_async_workers", "1", CVAR_ARCHIVE};
 static cvar_t host_async_max_pending = {"host_async_max_pending", "128", CVAR_ARCHIVE};
 
 qboolean Host_AsyncEnabled (void)
@@ -92,7 +94,7 @@ JobHandle *Jobs_Submit (jobs_func_t func, void *userdata)
 	if (!handle->mutex || !handle->cond)
 		Sys_Error ("Jobs_Submit: failed to create handle sync primitives");
 
-	if (!Host_AsyncEnabled () || !jobs_thread)
+	if (!Host_AsyncEnabled () || jobs_num_threads <= 0)
 	{
 		func (userdata);
 		SDL_LockMutex (handle->mutex);
@@ -145,7 +147,7 @@ static qboolean Jobs_SubmitNode (jobnode_t *node)
 	jobs_pending++;
 	if (jobs_pending > jobs_peak_pending)
 		jobs_peak_pending = jobs_pending;
-	SDL_CondSignal (jobs_cond);
+	SDL_CondBroadcast (jobs_cond);
 	SDL_UnlockMutex (jobs_mutex);
 	Jobs_LogQueueStats ("enqueue");
 	return true;
@@ -168,7 +170,7 @@ void Jobs_SubmitDetached (jobs_func_t func, void *userdata)
 {
 	jobnode_t *node;
 
-	if (!Host_AsyncEnabled () || !jobs_thread)
+	if (!Host_AsyncEnabled () || jobs_num_threads <= 0)
 	{
 		func (userdata);
 		return;
@@ -376,9 +378,19 @@ void Jobs_Shutdown (void)
 	SDL_CondBroadcast (jobs_cond);
 	SDL_UnlockMutex (jobs_mutex);
 
-	if (jobs_thread)
-		SDL_WaitThread (jobs_thread, NULL);
-	jobs_thread = NULL;
+	if (jobs_threads)
+	{
+		int i;
+
+		for (i = 0; i < jobs_num_threads; ++i)
+		{
+			if (jobs_threads[i])
+				SDL_WaitThread (jobs_threads[i], NULL);
+		}
+		free (jobs_threads);
+		jobs_threads = NULL;
+	}
+	jobs_num_threads = 0;
 
 	SDL_LockMutex (fs_mutex);
 	comp = fs_comp_head;
@@ -422,6 +434,7 @@ void Jobs_Init (void)
 	Cvar_RegisterVariable (&host_async);
 	Cvar_RegisterVariable (&host_async_fs);
 	Cvar_RegisterVariable (&host_async_assets);
+	Cvar_RegisterVariable (&host_async_workers);
 	Cvar_RegisterVariable (&host_async_max_pending);
 
 	jobs_mutex = SDL_CreateMutex ();
@@ -430,7 +443,25 @@ void Jobs_Init (void)
 	if (!jobs_mutex || !jobs_cond || !fs_mutex)
 		Sys_Error ("Jobs_Init: failed to initialize async primitives");
 
-	jobs_thread = SDL_CreateThread (Jobs_Worker, "jobs", NULL);
-	if (!jobs_thread)
-		Sys_Error ("Jobs_Init: failed to create worker thread");
+	{
+		int i;
+		int cpu_count;
+		int worker_count;
+
+		cpu_count = SDL_GetCPUCount ();
+		if (cpu_count < 1)
+			cpu_count = 1;
+		worker_count = CLAMP (1, (int) host_async_workers.value, cpu_count);
+		jobs_threads = (SDL_Thread **) calloc ((size_t) worker_count, sizeof (*jobs_threads));
+		if (!jobs_threads)
+			Sys_Error ("Jobs_Init: out of memory");
+
+		for (i = 0; i < worker_count; ++i)
+		{
+			jobs_threads[i] = SDL_CreateThread (Jobs_Worker, "jobs", NULL);
+			if (!jobs_threads[i])
+				Sys_Error ("Jobs_Init: failed to create worker thread");
+		}
+		jobs_num_threads = worker_count;
+	}
 }


### PR DESCRIPTION
### Motivation
- Allow async job processing to utilize multiple worker threads instead of a single thread to improve parallelism while preserving existing behavior by default.
- Keep filesystem completion callbacks deterministic on the main thread via `FS_PumpAsyncCompletions` to avoid changing observable callback ordering.

### Description
- Replaced single `jobs_thread` with a dynamic worker pool implemented as `jobs_threads` (array) and `jobs_num_threads` (count). 
- Added archived cvar `host_async_workers` (default `"1"`) and clamp the worker count to the range `1..SDL_GetCPUCount()` when creating threads in `Jobs_Init`.
- Wake all waiting workers with `SDL_CondBroadcast` when enqueuing jobs and treat the pool as unavailable when `jobs_num_threads <= 0` so synchronous fallback behavior is preserved (`Jobs_Submit`/`Jobs_SubmitDetached`).
- On shutdown broadcast shutdown, join all worker threads in the array, free the array, and reset `jobs_num_threads` in `Jobs_Shutdown`.

### Testing
- Ran `cmake -S . -B build && cmake --build build -j2` and configuration failed due to a missing SDL2 development package in the environment (build not completed).
- Ran `make -j2` in this environment and it failed because no Makefile/targets are present (no successful build verification).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a442770518832e83b7ccde3f416bb9)