### PR TITLE
Fix SDL forward declarations in common.h for MSVC builds

### DIFF
--- a/Quake/common.h
+++ b/Quake/common.h
@@ -419,8 +419,8 @@ void COM_CloseFile (int h);
 
 typedef struct jobhandle_s
 {
-	SDL_mutex *mutex;
-	SDL_cond *cond;
+	struct SDL_mutex *mutex;
+	struct SDL_cond *cond;
 	qboolean done;
 } JobHandle;
 


### PR DESCRIPTION
### Motivation
- MSVC compilation produced syntax errors (e.g. `C2061`/`C2143`/`C4431`) when translation units included `Quake/common.h` before SDL headers because the `SDL_mutex`/`SDL_cond` typedefs were not visible at parse time.

### Description
- Change the `JobHandle` fields in `Quake/common.h` from `SDL_mutex *` and `SDL_cond *` to opaque pointer types `struct SDL_mutex *` and `struct SDL_cond *` to avoid requiring SDL typedef visibility at include time.
- This is a compile-time, type-visibility only change with no runtime behavior modifications.

### Testing
- Ran source inspections with `rg` and header excerpts with `nl` to confirm SDL includes and verify the edit, and those commands succeeded.
- Performed VCS checks with `git status`, `git diff`, `git commit`, and `git show --stat` to record the change, and the commit succeeded.
- The original MSVC build failure that motivated this change came from the provided Windows build log and was not re-run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4438f6e3c832eb90571bbee84345b)