### PR TITLE
Wire sun fallback into fog volumes and world lighting

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -3412,6 +3412,30 @@ void R_SetupView (void)
         r_framedata.shader_params[2] = 0.f;
         r_framedata.shader_params[3] = 0.f;
 
+	{
+		vec3_t sun_dir;
+		vec3_t sun_color;
+		float sun_intensity = 1.f;
+		qboolean sun_enabled = (r_sun_light.value > 0.f) && R_GetSun (sun_dir, NULL, sun_color, &sun_intensity);
+
+		if (!sun_enabled)
+		{
+			VectorSet (sun_dir, 0.f, 0.f, -1.f);
+			VectorSet (sun_color, 1.f, 1.f, 1.f);
+			sun_intensity = 1.f;
+		}
+
+		r_framedata.sun_dir_enabled[0] = sun_dir[0];
+		r_framedata.sun_dir_enabled[1] = sun_dir[1];
+		r_framedata.sun_dir_enabled[2] = sun_dir[2];
+		r_framedata.sun_dir_enabled[3] = sun_enabled ? 1.f : 0.f;
+
+		r_framedata.sun_color_intensity[0] = sun_color[0];
+		r_framedata.sun_color_intensity[1] = sun_color[1];
+		r_framedata.sun_color_intensity[2] = sun_color[2];
+		r_framedata.sun_color_intensity[3] = q_max (0.f, sun_intensity);
+	}
+
 	double prev_delta = cl.time - r_prev_frame_time;
 	qboolean prev_valid = r_prev_frame_valid && prev_delta > 0.0;
 

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -281,6 +281,7 @@ extern cvar_t r_godrays_max_shift;
 extern cvar_t r_godrays_reset_on_teleport;
 extern cvar_t r_godrays_debug;
 extern cvar_t r_godrays_debug_source;
+extern cvar_t r_sun_light;
 extern cvar_t r_vignette;
 extern cvar_t r_vignette_radius_inner;
 extern cvar_t r_vignette_radius_outer;
@@ -809,6 +810,7 @@ Cvar_RegisterVariable (&r_vignette);
 	Cvar_RegisterVariable (&r_telealpha);
 	Cvar_RegisterVariable (&r_slimealpha);
 	Cvar_RegisterVariable (&r_scale);
+	Cvar_RegisterVariable (&r_sun_light);
 	Cvar_SetCallback (&r_telealpha, R_SetTelealpha_f);
 	Cvar_SetCallback (&r_slimealpha, R_SetSlimealpha_f);
 
@@ -893,16 +895,50 @@ R_NewGame -- johnfitz -- handle a game switch
 
 static qboolean r_worldspawn_has_sun = false;
 r_sun_t r_sun;
+cvar_t r_sun_light = { "r_sun_light", "0", CVAR_ARCHIVE };
+
+static void R_ResetSunState (void)
+{
+	r_worldspawn_has_sun = false;
+	r_sun.enabled = false;
+	VectorClear (r_sun.origin);
+	VectorClear (r_sun.dir);
+	VectorSet (r_sun.color, 1.f, 1.f, 1.f);
+	r_sun.intensity = 1.f;
+}
+
+qboolean R_WorldHasSun (void)
+{
+	return r_sun.enabled;
+}
+
+qboolean R_GetSun (vec3_t dir, vec3_t origin, vec3_t color, float *intensity)
+{
+	if (!r_sun.enabled)
+		return false;
+
+	if (dir)
+	{
+		if (DotProduct (r_sun.dir, r_sun.dir) > 1e-6f)
+			VectorCopy (r_sun.dir, dir);
+		else
+			VectorSet (dir, 0.f, 0.f, -1.f);
+	}
+	if (origin)
+		VectorCopy (r_sun.origin, origin);
+	if (color)
+		VectorCopy (r_sun.color, color);
+	if (intensity)
+		*intensity = r_sun.intensity;
+	return true;
+}
 
 static void R_ApplyDefaultSunIfMissing (qmodel_t *world)
 {
 	vec3_t center;
 	vec3_t ang;
 
-	if (!world)
-		return;
-
-	if (r_worldspawn_has_sun)
+	if (!world || r_sun.enabled || r_worldspawn_has_sun)
 		return;
 
 	center[0] = 0.5f * (world->mins[0] + world->maxs[0]);
@@ -917,8 +953,13 @@ static void R_ApplyDefaultSunIfMissing (qmodel_t *world)
 	ang[ROLL] = 0.0f;
 
 	AngleVectors (ang, r_sun.dir, NULL, NULL);
-	VectorNormalize (r_sun.dir);
+	if (VectorLength (r_sun.dir) < 0.001f)
+		VectorSet (r_sun.dir, 0.f, 0.f, -1.f);
+	else
+		VectorNormalize (r_sun.dir);
 
+	VectorSet (r_sun.color, 1.f, 1.f, 1.f);
+	r_sun.intensity = 1.f;
 	r_sun.enabled = true;
 }
 
@@ -944,7 +985,7 @@ static void R_ParseWorldspawn (void)
 	const char *data;
 
 	map_fallbackalpha = r_wateralpha.value;
-	r_worldspawn_has_sun = false;
+	R_ResetSunState ();
 	map_wateralpha = (cl.worldmodel->contentstransparent&SURF_DRAWWATER)?r_wateralpha.value:1;
 	map_lavaalpha = 1.0f;
 	map_telealpha = (cl.worldmodel->contentstransparent&SURF_DRAWTELE)?r_telealpha.value:1;
@@ -978,7 +1019,10 @@ if (!strcmp("wateralpha", key))
 map_wateralpha = atof(value);
 
 if (!strcmp("sunlight", key) || !strcmp("sun_mangle", key))
+{
 	r_worldspawn_has_sun = true;
+	r_sun.enabled = true;
+}
 
 if (!strcmp("telealpha", key))
 map_telealpha = atof(value);
@@ -1017,10 +1061,7 @@ void R_NewMap (void)
 	R_ResetGodraysStabilization ();
 	R_FogVol_ClearHistory ();
 
-	r_worldspawn_has_sun = false;
-	r_sun.enabled = false;
-	VectorClear (r_sun.origin);
-	VectorClear (r_sun.dir);
+	R_ResetSunState ();
 
 	GL_BuildLightmaps ();
         GL_BuildBModelVertexBuffer ();

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -450,6 +450,8 @@ typedef struct gpuframedata_s {
         vec4_t          dlight_params;  // x: style, y: debug view, z: pass selector, w: padding
         vec4_t          colorspace_params; // x: debug mode, y: manual gamma, z: output sRGB, w: unused
         vec4_t          shader_params;  // x: shader debug, y: tcgen debug, zw: unused
+        vec4_t          sun_dir_enabled; // xyz: sun dir (scene->sun), w: enabled
+        vec4_t          sun_color_intensity; // rgb: sun color, w: intensity
         unsigned int    numlights;
         unsigned int    prev_frame_valid;
         unsigned int    _padding1;
@@ -460,9 +462,11 @@ typedef struct r_sun_s {
 	qboolean enabled;
 	vec3_t origin;
 	vec3_t dir;
+	vec3_t color;
+	float intensity;
 } r_sun_t;
 
-COMPILE_TIME_ASSERT (gpuframedata_std140_size, sizeof (gpuframedata_t) == 400);
+COMPILE_TIME_ASSERT (gpuframedata_std140_size, sizeof (gpuframedata_t) == 432);
 
 typedef enum
 {
@@ -476,6 +480,9 @@ extern gpuframedata_t r_framedata;
 extern float r_lightstyle_framefrac;
 extern dlight_t *r_dlight_sources[DLIGHT_GPU_MAX];
 extern r_sun_t r_sun;
+
+qboolean R_WorldHasSun (void);
+qboolean R_GetSun (vec3_t dir, vec3_t origin, vec3_t color, float *intensity);
 
 void R_AnimateLight (void);
 void R_MarkSurfaces (void);

--- a/Quake/r_fogvol.c
+++ b/Quake/r_fogvol.c
@@ -133,6 +133,7 @@ cvar_t r_fogvol_shadow = { "r_fogvol_shadow", "1", CVAR_ARCHIVE };
 cvar_t r_fogvol_shadow_samples = { "r_fogvol_shadow_samples", "2", CVAR_ARCHIVE };
 cvar_t r_fogvol_shadow_strength = { "r_fogvol_shadow_strength", "0.8", CVAR_ARCHIVE };
 cvar_t r_fogvol_shadow_jitter = { "r_fogvol_shadow_jitter", "1", CVAR_ARCHIVE };
+cvar_t r_fogvol_sun_dir = { "r_fogvol_sun_dir", "1", CVAR_ARCHIVE };
 
 extern cvar_t gl_farclip;
 
@@ -843,6 +844,7 @@ void R_FogVol_Init (void)
 	Cvar_RegisterVariable (&r_fogvol_shadow_samples);
 	Cvar_RegisterVariable (&r_fogvol_shadow_strength);
 	Cvar_RegisterVariable (&r_fogvol_shadow_jitter);
+	Cvar_RegisterVariable (&r_fogvol_sun_dir);
 }
 
 void R_FogVol_Clear (void)
@@ -1636,7 +1638,16 @@ void R_FogVol_Render (void)
 	GL_Uniform1iFunc (15, CLAMP (0, (int)Q_rint (r_fogvol_blendmode.value), 1));
 	GL_Uniform1iFunc (16, fog_light_enabled ? 1 : 0);
 	shadow_samples = CLAMP (1, (int)Q_rint (r_fogvol_shadow_samples.value), 8);
-	VectorScale (vpn, -1.f, shadow_dir);
+	if (r_fogvol_sun_dir.value > 0.f && R_GetSun (shadow_dir, NULL, NULL, NULL))
+	{
+		/* Convention: r_sun.dir points from scene toward the sun (light source).
+		 * Fog shadow marching moves from sample point toward the blocker, so use
+		 * the same direction without flipping to keep shader/CPU conventions aligned. */
+	}
+	else
+	{
+		VectorScale (vpn, -1.f, shadow_dir);
+	}
 	/* BUG FIX (C-09): Length check must happen BEFORE VectorNormalize.
 	 * VectorNormalize on a zero-vector causes division-by-zero / NaN.
 	 * Only normalize when the vector is non-degenerate. */

--- a/Quake/shaders/frame_uniforms.glsl
+++ b/Quake/shaders/frame_uniforms.glsl
@@ -47,17 +47,20 @@ layout(std140, binding=0) uniform FrameDataUBO
     vec4    DLightParams;       // 336
     vec4    ColorSpaceParams;   // 352
     vec4    ShaderParams;       // 368
+    vec4    SunDirEnabled;  // 384  xyz: scene->sun direction, w: enabled
+    vec4    SunColorIntensity; // 400 rgb: sun color, w: intensity
 
-    // ── Global params ── offset 384
+    // ── Global params ── offset 416
     // NOTE: These members must stay layout-compatible with gpuframedata_t
     // their expected offsets.
 
 
-    // ── Misc ──────────────────────────────────────────── offset 880
-    uint    NumLights;      // 880
-    uint    PrevFrameValid; // 884
-    uint    _Pad1;          // 888
-    uint    _Pad2;          // 892
-};                          // Total: 896 bytes
+    // ── Misc ──────────────────────────────────────────── offset 416
+    uint    NumLights;      // 416
+    uint    PrevFrameValid; // 420
+    uint    _Pad1;          // 424
+    uint    _Pad2;          // 428
+};                          // Total: 432 bytes
+
 
 #endif // FRAME_UNIFORMS_GLSL

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -514,6 +514,18 @@ void main()
 		}
 
 		// Sun light
+		if (SunDirEnabled.w > 0.5)
+		{
+			/* SunDirEnabled.xyz stores scene->sun direction. Surface lighting needs
+			 * incoming-light direction (sun->scene), therefore we negate it. */
+			vec3 sun_to_surface = -SunDirEnabled.xyz;
+			float ndotl = max(dot(surface_normal, sun_to_surface), 0.0);
+			if (ndotl > 0.0)
+			{
+				vec3 sun_contrib = SunColorIntensity.rgb * SunColorIntensity.a * ndotl;
+				total_light += max(min(sun_contrib, 1.0 - total_light), 0.0);
+			}
+		}
 
 		// Apply lighting
 #if DITHER >= 2


### PR DESCRIPTION
### Motivation

- Provide a single, reliable source-of-truth for the map sun state so render paths can query a normalized sun direction and avoid ad-hoc global accesses.  
- Let Fog Volumes consume a meaningful light/shadow direction (sun) instead of being view-locked while keeping a safe legacy fallback.  
- Implement the existing `// Sun light section` placeholder in `world.frag` in a minimal, opt-in way so at least one additional render path consumes the sun state without causing visual regressions.

### Description

- Added sun API and state: extended `r_sun_t` with `color` and `intensity`, declared `R_WorldHasSun()` and `R_GetSun()` in `glquake.h`, and implemented `R_ResetSunState()`, `R_WorldHasSun()` and `R_GetSun()` plus safer fallback logic in `Quake/gl_rmisc.c` (ensures normalized non-zero `dir`, idempotent reset on mapload, and one-place default application).  
- FogVol shadow direction: added `cvar_t r_fogvol_sun_dir` (default `1`) in `Quake/r_fogvol.c` and changed the CPU-side shadow-dir selection to prefer `R_GetSun()` when enabled, otherwise fall back to the legacy `-vpn` path while preserving zero-length guards and normalization.  
- GPU wiring: extended `gpuframedata_t` and `FrameDataUBO` with `sun_dir_enabled` and `sun_color_intensity` (std140-safe padding and `COMPILE_TIME_ASSERT` updated) and populate those members per-frame in `Quake/gl_rmain.c` using `R_GetSun()` (sun data is clamped/gated so shaders see deterministic values).  
- World shader consumer: implemented a minimal additive Lambert sun-term in `Quake/shaders/world.frag` gated by the frame UBO `SunDirEnabled.w` and controlled by a new `cvar_t r_sun_light` (default `0` to avoid regressing visuals).  
- Registration and map-load hygiene: registered new CVars (`r_sun_light`, `r_fogvol_sun_dir`) and moved map parsing/reset to call `R_ResetSunState()` so worldspawn keys keep precedence and fallback sun is only applied when appropriate.

### Testing

- Ran `git diff --check` to validate whitespace/patch issues and found no problems.  
- Attempted a full Debug build with `cmake -S . -B build-debug -DCMAKE_BUILD_TYPE=Debug && cmake --build build-debug -j4`, which failed in this environment due to missing SDL2 CMake config (`SDL2Config.cmake` / `sdl2-config.cmake`), so a local full build/test was not completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a44ea7ceac832e89d209254fba03ef)