### PR TITLE
Fix undeclared r_sun_light in gl_rmain build

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -33,6 +33,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define NOISESCALE     (1.0f / 127.0f)
 
 extern gltexture_t *lightmap_dir_texture;
+extern cvar_t r_sun_light;
 
 qboolean	r_cache_thrash;		// compatability
 


### PR DESCRIPTION
### Motivation
- Resolve MSVC compile errors in `Quake/gl_rmain.c` caused by use of `r_sun_light.value` without a prior declaration.

### Description
- Add the missing `extern cvar_t r_sun_light;` declaration to the top of `Quake/gl_rmain.c` so the symbol is available where `r_sun_light.value` is referenced.

### Testing
- Ran `git diff --check` which produced no errors and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a452747ef4832ea8bc55ff175f483f)