### PR TITLE
Include r_decals.c in Visual Studio project to fix unresolved decal linker symbols

### DIFF
--- a/Windows/VisualStudio/ironwail.vcxproj
+++ b/Windows/VisualStudio/ironwail.vcxproj
@@ -258,6 +258,7 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
     <ClCompile Include="..\..\Quake\gl_rlight.c" />
     <ClCompile Include="..\..\Quake\gl_rmain.c" />
     <ClCompile Include="..\..\Quake\gl_rmisc.c" />
+    <ClCompile Include="..\..\Quake\r_decals.c" />
     <ClCompile Include="..\..\Quake\gl_screen.c" />
     <ClCompile Include="..\..\Quake\gl_shaders.c" />
     <ClCompile Include="..\..\Quake\gl_sky.c" />

--- a/Windows/VisualStudio/ironwail.vcxproj.filters
+++ b/Windows/VisualStudio/ironwail.vcxproj.filters
@@ -87,6 +87,9 @@
     <ClCompile Include="..\..\Quake\gl_rmisc.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Quake\r_decals.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\Quake\gl_screen.c">
       <Filter>Source Files</Filter>
     </ClCompile>


### PR DESCRIPTION
### Motivation
- The Windows build produced linker errors for decal renderer functions such as `R_SpawnImpactDecal`, `R_DrawDecals`, `R_UpdateDecals`, `R_InitDecals`, `R_ReloadDecals`, and `R_ClearDecals` because the implementation in `r_decals.c` was not compiled into the Visual Studio target.
- Adding the missing source to the project ensures those symbols are linked into `ironwail.exe` and resolves the unresolved externals. 

### Description
- Added `..\..\Quake\r_decals.c` to `Windows/VisualStudio/ironwail.vcxproj` so the file is compiled into the Windows target.
- Added the same `..\..\Quake\r_decals.c` entry to `Windows/VisualStudio/ironwail.vcxproj.filters` to keep the IDE source filters consistent.
- Committed the changes with the message `Fix missing decals source in Visual Studio project`.

### Testing
- Ran `rg -n "R_SpawnImpactDecal|R_DrawDecals|R_UpdateDecals|R_InitDecals|R_ReloadDecals|R_ClearDecals"` to confirm the functions are referenced in the codebase, which succeeded.
- Ran `rg -n "r_decals.c" Windows/VisualStudio/ironwail.vcxproj Windows/VisualStudio/ironwail.vcxproj.filters` to verify the new entries exist, which succeeded.
- Printed relevant sections with `nl -ba` and `sed -n` to confirm the inserted lines are present and ran `git status --short` and `git commit` to record the change, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a46e1a1bdc832e9e4894d7c10f0cd9)