### PR TITLE
Replace undefined VectorNegate with VectorInverse in r_decals.c to fix MSVC build error

### DIFF
--- a/Quake/r_decals.c
+++ b/Quake/r_decals.c
@@ -428,7 +428,7 @@ void R_SpawnImpactDecal (const char *category, const vec3_t origin, const vec3_t
 
 		VectorCopy (surf->plane->normal, surf_normal);
 		if (surf->flags & SURF_PLANEBACK)
-			VectorNegate (surf_normal, surf_normal);
+			VectorInverse (surf_normal);
 		d = fabsf (DotProduct (origin, surf_normal) - (surf->flags & SURF_PLANEBACK ? -surf->plane->dist : surf->plane->dist));
 		if (d > radius + 2.f)
 			continue;


### PR DESCRIPTION
### Motivation
- MSVC treated an undefined `VectorNegate` as an implicit declaration (warning C4013, promoted to error C2220), so the decal code must use a defined in-place negation helper to build cleanly.

### Description
- Replace `VectorNegate (surf_normal, surf_normal);` with `VectorInverse (surf_normal);` in `Quake/r_decals.c` so plane-back normals are negated using the existing math helper.

### Testing
- Verified the source change with `rg` that no longer finds `VectorNegate` and now finds `VectorInverse (surf_normal)` and the checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a46ecfe700832eb5f824411d48babc)