### PR TITLE
Tighten decal depth clipping for normal-space vertex reconstruction

### DIFF
--- a/Quake/r_decals.c
+++ b/Quake/r_decals.c
@@ -368,7 +368,11 @@ static int R_ProjectDecalToSurface (const msurface_t *surf, const vec3_t origin,
 	vec3_t sdir, tdir, normal;
 	int i, count = surf->numedges;
 	int total_added = 0;
-	float depth = q_max (2.f, radius * 0.5f);
+	/*
+	 * Keep depth clipping conservative now that we reconstruct decal verts with
+	 * their normal-space offset to avoid pushing decals through nearby geometry.
+	 */
+	float depth = q_max (1.f, radius * 0.25f);
 
 	if (count < 3 || count >= MAX_POLY_VERTS)
 		return 0;


### PR DESCRIPTION
### Motivation
- Reconstructed decal vertices include the normal offset when converting clipped local coordinates back to world space, which can cause decals to be pushed through nearby geometry; depth clipping should be more conservative to avoid over-penetration.

### Description
- Change `depth` in `R_ProjectDecalToSurface` from `q_max(2.f, radius * 0.5f)` to `q_max(1.f, radius * 0.25f)` and add an inline comment explaining the rationale; UV generation and the s/t/normal reconstruction remain unchanged.

### Testing
- Ran `cmake -S . -B build && cmake --build build -j4` to validate the change, but configuration failed due to missing SDL2 CMake package/development files, so no build artifacts were produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a474939f64832e9e3ff4e7025f5427)