### PR TITLE
Use world BSP trace normals for temp-entity impact decals

### DIFF
--- a/Quake/cl_tent.c
+++ b/Quake/cl_tent.c
@@ -126,6 +126,65 @@ static qboolean CL_DecalNormalFromView (const vec3_t impact, vec3_t out_normal)
 	return true;
 }
 
+static qboolean CL_DecalNormalFromImpactTrace (const vec3_t impact, vec3_t out_normal)
+{
+	static const vec3_t directions[] = {
+		{ 1.f, 0.f, 0.f }, {-1.f, 0.f, 0.f },
+		{ 0.f, 1.f, 0.f }, { 0.f,-1.f, 0.f },
+		{ 0.f, 0.f, 1.f }, { 0.f, 0.f,-1.f },
+	};
+	const float trace_dist = 8.f;
+	qboolean found = false;
+	float best_fraction = 2.f;
+	int i;
+
+	if (!cl.worldmodel)
+		return false;
+
+	for (i = 0; i < (int)q_countof(directions); ++i)
+	{
+		trace_t trace;
+		vec3_t start, end;
+
+		VectorCopy (impact, start);
+		VectorMA (impact, trace_dist, directions[i], end);
+
+		memset (&trace, 0, sizeof(trace));
+		trace.fraction = 1.f;
+		trace.allsolid = true;
+		VectorCopy (end, trace.endpos);
+		SV_RecursiveHullCheck (cl.worldmodel->hulls, 0, 0, 1, start, end, &trace);
+
+		if (VectorLengthSquared (trace.plane.normal) < 0.0001f)
+			continue;
+
+		if (trace.fraction >= best_fraction)
+			continue;
+
+		best_fraction = trace.fraction;
+		VectorCopy (trace.plane.normal, out_normal);
+		found = true;
+	}
+
+	if (found)
+		VectorNormalizeFast (out_normal);
+
+	return found;
+}
+
+static qboolean CL_DecalNormalForImpact (const vec3_t impact, vec3_t out_normal)
+{
+	if (CL_DecalNormalFromImpactTrace (impact, out_normal))
+		return true;
+
+	/*
+	 * Demo/network temp entity events only provide an impact position. If we
+	 * cannot recover a nearby world BSP plane from that point, fall back to the
+	 * legacy view-based approximation so these events can still spawn decals.
+	 */
+	return CL_DecalNormalFromView (impact, out_normal);
+}
+
 void CL_ParseTEnt (void)
 {
 	int		type;
@@ -159,7 +218,7 @@ void CL_ParseTEnt (void)
 		pos[1] = MSG_ReadCoord (cl.protocolflags);
 		pos[2] = MSG_ReadCoord (cl.protocolflags);
 		R_RunParticleEffect (pos, vec3_origin, 0, 10);
-		if (CL_DecalNormalFromView (pos, decal_normal))
+		if (CL_DecalNormalForImpact (pos, decal_normal))
 			R_SpawnImpactDecal ("bullet", pos, decal_normal);
 		if ( rand() % 5 )
 			S_StartSound (-1, 0, cl_sfx_tink1, pos, 1, 1);
@@ -179,7 +238,7 @@ void CL_ParseTEnt (void)
 		pos[1] = MSG_ReadCoord (cl.protocolflags);
 		pos[2] = MSG_ReadCoord (cl.protocolflags);
 		R_RunParticleEffect (pos, vec3_origin, 0, 20);
-		if (CL_DecalNormalFromView (pos, decal_normal))
+		if (CL_DecalNormalForImpact (pos, decal_normal))
 			R_SpawnImpactDecal ("bullet", pos, decal_normal);
 
 		if ( rand() % 5 )
@@ -201,7 +260,7 @@ void CL_ParseTEnt (void)
 		pos[1] = MSG_ReadCoord (cl.protocolflags);
 		pos[2] = MSG_ReadCoord (cl.protocolflags);
 		R_RunParticleEffect (pos, vec3_origin, 0, 20);
-		if (CL_DecalNormalFromView (pos, decal_normal))
+		if (CL_DecalNormalForImpact (pos, decal_normal))
 			R_SpawnImpactDecal ("bullet", pos, decal_normal);
 		break;
 
@@ -211,7 +270,7 @@ void CL_ParseTEnt (void)
 		pos[2] = MSG_ReadCoord (cl.protocolflags);
 		V_AddExplosionVibration (pos);
 		R_ParticleExplosion (pos);
-		if (CL_DecalNormalFromView (pos, decal_normal))
+		if (CL_DecalNormalForImpact (pos, decal_normal))
 			R_SpawnImpactDecal ("scorch", pos, decal_normal);
 		dl = CL_AllocDlight (0);
 		VectorCopy (pos, dl->origin);
@@ -230,7 +289,7 @@ void CL_ParseTEnt (void)
 		pos[2] = MSG_ReadCoord (cl.protocolflags);
 		V_AddExplosionVibration (pos);
 		R_BlobExplosion (pos);
-		if (CL_DecalNormalFromView (pos, decal_normal))
+		if (CL_DecalNormalForImpact (pos, decal_normal))
 			R_SpawnImpactDecal ("scorch", pos, decal_normal);
 
 		S_StartSound (-1, 0, cl_sfx_r_exp3, pos, 1, 1);
@@ -276,7 +335,7 @@ void CL_ParseTEnt (void)
 		colorStart = MSG_ReadByte ();
 		colorLength = MSG_ReadByte ();
                 R_ParticleExplosion2 (pos, colorStart, colorLength);
-		if (CL_DecalNormalFromView (pos, decal_normal))
+		if (CL_DecalNormalForImpact (pos, decal_normal))
 			R_SpawnImpactDecal ("scorch", pos, decal_normal);
                 dl = CL_AllocDlight (0);
                 VectorCopy (pos, dl->origin);


### PR DESCRIPTION
### Motivation
- Improve decal orientation for temporary impact entities by recovering the actual nearby world BSP surface normal instead of always using a view-based approximation.
- Keep compatibility with demo/network temp-entity events that only provide an impact position via a documented fallback to the legacy view-based method.

### Description
- Added `CL_DecalNormalFromImpactTrace` in `Quake/cl_tent.c` to probe around an impact point with short traces against `cl.worldmodel->hulls` and pick the nearest valid `trace.plane.normal` for decal orientation.
- Added `CL_DecalNormalForImpact` which prefers the traced plane normal and falls back to `CL_DecalNormalFromView` when no usable BSP plane can be recovered, with a comment explaining the demo/network fallback behavior.
- Updated all `R_SpawnImpactDecal("bullet"/"scorch", pos, decal_normal)` call sites in `CL_ParseTEnt` to use `CL_DecalNormalForImpact` so temp-entity decals use traced normals when available.

### Testing
- Ran `make -C Quake -j4`; dependency generation started but the build failed to complete due to missing SDL2 tooling/headers (`sdl2-config: No such file or directory`, `SDL.h: No such file or directory`), so a full build/test could not be performed.
- Ran `make` at the repo root which reported no targets, and inspected the modified source to verify the new helpers and that all target call sites were updated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a48e9ef85c832e9b70c715bdb927ff)