### PR TITLE
Fix MSVC build error in cl_tent decal trace loop

### DIFF
--- a/Quake/cl_tent.c
+++ b/Quake/cl_tent.c
@@ -141,7 +141,7 @@ static qboolean CL_DecalNormalFromImpactTrace (const vec3_t impact, vec3_t out_n
 	if (!cl.worldmodel)
 		return false;
 
-	for (i = 0; i < (int)q_countof(directions); ++i)
+	for (i = 0; i < (int)countof (directions); ++i)
 	{
 		trace_t trace;
 		vec3_t start, end;


### PR DESCRIPTION
### Motivation
- MSVC raised warning `C4013` for an undefined `q_countof` which was treated as error `C2220`, breaking the Windows build of `cl_tent.c`.

### Description
- Replace `q_countof` with the project-standard `countof` macro in the `CL_DecalNormalFromImpactTrace` directions loop in `Quake/cl_tent.c`.

### Testing
- Verified the source update by running `rg "q_countof" -n Quake/cl_tent.c` which returned no matches and inspected the change with `git diff -- Quake/cl_tent.c`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a49237effc832e8001103b496a4414)