### PR TITLE
Fix decal starvation by compacting decal vertex pool

### DIFF
--- a/Quake/r_decals.c
+++ b/Quake/r_decals.c
@@ -74,6 +74,28 @@ static int decal_inst_count;
 static cvar_t r_decals = {"r_decals", "1", CVAR_ARCHIVE};
 static cvar_t r_decals_max = {"r_decals_max", "256", CVAR_ARCHIVE};
 
+static void R_Decals_CompactVerts (void)
+{
+	int i;
+	int write_cursor = 0;
+
+	for (i = 0; i < MAX_DECAL_INSTANCES; ++i)
+	{
+		decalinst_t *inst = &decal_instances[i];
+
+		if (!inst->active || inst->num_verts <= 0)
+			continue;
+
+		if (inst->first_vert != write_cursor)
+			memmove (&decal_verts[write_cursor], &decal_verts[inst->first_vert], sizeof (decalvert_t) * inst->num_verts);
+
+		inst->first_vert = write_cursor;
+		write_cursor += inst->num_verts;
+	}
+
+	decal_vert_cursor = write_cursor;
+}
+
 static void R_Decals_ResetRuntime (void)
 {
 	memset (decal_instances, 0, sizeof (decal_instances));
@@ -262,7 +284,14 @@ static int R_DecalAllocInstance (int priority)
 	}
 
 	if (pick >= 0 && decal_instances[pick].priority <= priority)
+	{
+		if (decal_instances[pick].active)
+		{
+			decal_instances[pick].active = false;
+			decal_inst_count = q_max (0, decal_inst_count - 1);
+		}
 		return pick;
+	}
 	return -1;
 }
 
@@ -456,6 +485,14 @@ void R_SpawnImpactDecal (const char *category, const vec3_t origin, const vec3_t
 		return;
 
 	first_vert = decal_vert_cursor;
+	if (first_vert + MAX_POLY_VERTS >= MAX_DECAL_VERTS)
+	{
+		R_Decals_CompactVerts ();
+		first_vert = decal_vert_cursor;
+		if (first_vert + MAX_POLY_VERTS >= MAX_DECAL_VERTS)
+			return;
+	}
+
 	for (i = 0; i < leaf->nummarksurfaces; ++i)
 	{
 		msurface_t *surf = &cl.worldmodel->surfaces[leaf->firstmarksurface[i]];
@@ -524,8 +561,14 @@ void R_UpdateDecals (void)
 		if (!decal_instances[i].active)
 			continue;
 		if (decal_instances[i].die_time <= cl.time)
+		{
 			decal_instances[i].active = false;
+			decal_inst_count = q_max (0, decal_inst_count - 1);
+		}
 	}
+
+	if (decal_vert_cursor + MAX_POLY_VERTS >= MAX_DECAL_VERTS)
+		R_Decals_CompactVerts ();
 }
 
 static int R_DecalSortCmp (const void *a, const void *b)


### PR DESCRIPTION
### Motivation
- Long play sessions and expired/evicted decals left holes in the `decal_verts` array so `decal_vert_cursor` eventually hit `MAX_DECAL_VERTS`, preventing new decals from projecting and making most impacts appear to not stick.
- The runtime bookkeeping for instance replacement/expiry did not reclaim vertex space or keep `decal_inst_count` consistent, so vertex exhaustion accumulated over time.

### Description
- Added `R_Decals_CompactVerts` which compacts active decal vertex ranges with `memmove` and updates each instance's `first_vert`, reclaiming space from inactive decals.
- Call `R_Decals_CompactVerts` proactively in `R_SpawnImpactDecal` when the vertex cursor is near capacity so a new decal can still be allocated or the spawn aborts early if truly full.
- Update `R_DecalAllocInstance` to deactivate an evicted instance and decrement `decal_inst_count` when an instance is reused, preventing stale accounting.
- Update `R_UpdateDecals` to decrement `decal_inst_count` when decals expire and to opportunistically compact the vertex pool when near capacity.

### Testing
- Ran `git -C /workspace/ironwail diff -- Quake/r_decals.c` to verify the patch was applied and the file changed as intended, which succeeded.
- Verified working-tree status with `git -C /workspace/ironwail status --short` and committed the change, which succeeded.
- Attempted a build with `make -C /workspace/ironwail/Quake -j4` to validate compilation, but the build environment lacks `sdl2-config`/`SDL.h` so full compile validation is blocked (make produced header-missing errors covering SDL).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a49378ae88832e8b7edcf85b84cbbb)