### PR TITLE
Fix intermittent bullet/rocket impact decal spawning

### DIFF
--- a/Quake/r_decals.c
+++ b/Quake/r_decals.c
@@ -448,6 +448,40 @@ static int R_ProjectDecalToSurface (const msurface_t *surf, const vec3_t origin,
 	return total_added;
 }
 
+static mleaf_t *R_FindImpactLeaf (const vec3_t origin, const vec3_t normal)
+{
+	/*
+	 * Temp entity impacts are quantized and can land a hair inside solid space.
+	 * Probe both sides of the recovered impact normal so we can still find the
+	 * nearby render leaf that owns the wall/floor mark surfaces.
+	 */
+	static const float offsets[] = {0.f, 1.f, -1.f, 2.f, -2.f};
+	mleaf_t *fallback = NULL;
+	int i;
+
+	for (i = 0; i < (int) countof (offsets); ++i)
+	{
+		vec3_t sample;
+		mleaf_t *leaf;
+
+		VectorCopy (origin, sample);
+		if (offsets[i] != 0.f)
+			VectorMA (sample, offsets[i], normal, sample);
+
+		leaf = Mod_PointInLeaf (sample, cl.worldmodel);
+		if (!leaf || !leaf->nummarksurfaces)
+			continue;
+
+		if (leaf->contents != CONTENTS_SOLID)
+			return leaf;
+
+		if (!fallback)
+			fallback = leaf;
+	}
+
+	return fallback;
+}
+
 void R_SpawnImpactDecal (const char *category, const vec3_t origin, const vec3_t normal)
 {
 	decaldef_t *def;
@@ -480,7 +514,7 @@ void R_SpawnImpactDecal (const char *category, const vec3_t origin, const vec3_t
 	radius = def->size_min + ((float) rand () / (float) RAND_MAX) * (def->size_max - def->size_min);
 	alpha = def->alpha_min + ((float) rand () / (float) RAND_MAX) * (def->alpha_max - def->alpha_min);
 
-	{ vec3_t point; VectorCopy (origin, point); leaf = Mod_PointInLeaf (point, cl.worldmodel); }
+	leaf = R_FindImpactLeaf (origin, n);
 	if (!leaf || !leaf->nummarksurfaces)
 		return;
 


### PR DESCRIPTION
### Motivation
- Temporary-entity impact positions are quantized and can land slightly inside solid space, causing a single `Mod_PointInLeaf` sample at the raw impact point to pick a leaf without usable mark surfaces and result in missing bullet/rocket/scorch decals.
- Improve robustness of decal spawning so impacts consistently find the render leaf that owns wall/floor mark surfaces even when the reported impact point is a hair off the visible surface.

### Description
- Add a helper `R_FindImpactLeaf` to `Quake/r_decals.c` that samples the impact point plus a small set of offsets along the impact normal (`{0, ±1, ±2}`) and returns the first nearby non-solid leaf with `nummarksurfaces`, or a fallback leaf that has mark surfaces.
- Replace the previous inline single-sample `Mod_PointInLeaf` usage in `R_SpawnImpactDecal` with a call to `R_FindImpactLeaf(origin, n)` so decals are projected from a more reliable leaf selection.
- Limit changes to `Quake/r_decals.c` and preserve existing decal projection and culling logic (`R_ProjectDecalToSurface`, radius/alpha/rotation handling, and the existing filtering of surface flags).

### Testing
- Ran a full build with `make -j2` as an automated check, which could not complete in this environment because `sdl2-config` and `SDL.h` were not available, so compilation failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a496a7da68832eb8e6a868500b0c6a)