### PR TITLE
Sanitize gl_farclip in R_SetFrustum to prevent invalid depth math

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -3060,9 +3060,11 @@ R_SetFrustum
 */
 void R_SetFrustum (void)
 {
+	static qboolean warned_invalid_farclip = false;
 	float w, h, d;
 	float znear, zfar;
 	float logznear, logzfar;
+	float logrange;
 	float translation[16];
 	float rotation[16];
 	int i;
@@ -3073,6 +3075,19 @@ void R_SetFrustum (void)
 	d = 12.f * q_min (w, h);
 	znear = CLAMP (0.5f, d, 4.f);
 	zfar = gl_farclip.value;
+	if (zfar <= znear || zfar <= 0.f)
+	{
+		const float sanitized_zfar = q_max (znear + 1.f, 1.f);
+
+		if (!warned_invalid_farclip)
+		{
+			Con_DPrintf ("gl_farclip %0.4f is invalid for znear %0.4f; clamping to %0.4f\n",
+				zfar, znear, sanitized_zfar);
+			warned_invalid_farclip = true;
+		}
+
+		zfar = sanitized_zfar;
+	}
 
 	view_znear = znear;
 	view_zfar = zfar;
@@ -3109,10 +3124,14 @@ void R_SetFrustum (void)
 
 	logznear = log2f (znear);
 	logzfar = log2f (zfar);
-        memcpy (r_framedata.viewproj, r_matviewproj, 16 * sizeof (float));
-        memcpy (r_framedata.view, r_matview, 16 * sizeof (float));
-        r_framedata.zparams[0] = LIGHT_TILES_Z / (logzfar - logznear);
-        r_framedata.zparams[1] = -r_framedata.zparams[0] * logznear;
+	logrange = logzfar - logznear;
+	if (fabsf (logrange) < 1e-6f)
+		logrange = (logrange < 0.f) ? -1e-6f : 1e-6f;
+
+	memcpy (r_framedata.viewproj, r_matviewproj, 16 * sizeof (float));
+	memcpy (r_framedata.view, r_matview, 16 * sizeof (float));
+	r_framedata.zparams[0] = LIGHT_TILES_Z / logrange;
+	r_framedata.zparams[1] = -r_framedata.zparams[0] * logznear;
 }
 
 /*


### PR DESCRIPTION
### Motivation

- Prevent invalid user-provided `gl_farclip.value` from producing NaN/Inf or division-by-zero in the projection and log-depth math inside `R_SetFrustum`.
- Preserve deterministic behavior for valid settings while making misconfigured cvars diagnosable without spamming per-frame logs.

### Description

- Added a static `warned_invalid_farclip` flag and sanitize `zfar` when `zfar <= znear || zfar <= 0.f` by clamping to `q_max(znear + 1.f, 1.f)` and issuing a one-time `Con_DPrintf` warning.
- Ensure `view_znear`/`view_zfar` and `GL_FrustumMatrix` are used only after sanitization so projection math is stable for invalid inputs.
- Introduced `logrange = logzfar - logznear` and floor it to a signed epsilon when `fabsf(logrange) < 1e-6f` to avoid division-by-zero, then compute `r_framedata.zparams[0]` and `[1]` using the guarded `logrange`.

### Testing

- Attempted to run `make -j4` but the environment has no top-level Makefile so a build could not be executed and the command failed.
- Verified the updated function block was applied in `Quake/gl_rmain.c` and inspected the modified lines to confirm the sanitization, one-time diagnostic, and epsilon guard were inserted as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a497903d98832eb0da1c3ffa92e214)