### PR TITLE
Avoid mutating r_color_saturation in GL_NeedsPostprocess; use local sanitized saturation

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -2159,6 +2159,7 @@ static float GL_UpdateAutoExposure (void)
 void GL_PostProcess (void)
 {
 	int palidx, variant;
+	float saturation;
 	float dither;
 	qboolean dof_enabled;
 	float dof_focus, dof_range, dof_strength;
@@ -2214,7 +2215,7 @@ void GL_PostProcess (void)
 	float dv_quality;
 	float dv_debug;
 	float dv_time;
-	r_color_saturation.value = CLAMP (0.9f, r_color_saturation.value, 1.2f);
+	saturation = CLAMP (0.9f, r_color_saturation.value, 1.2f);
 	if (!GL_NeedsPostprocess ())
 		return;
 	if (framebufs.composite.fbo == 0 || framebufs.composite.color_tex == 0)
@@ -2459,7 +2460,7 @@ void GL_PostProcess (void)
 	0.f,
 	0.f);
 	GL_Uniform4fFunc (11, teleport_fade, teleport_blur, 0.f, 0.f);
-	GL_Uniform1fFunc (12, CLAMP (0.9f, r_color_saturation.value, 1.2f));
+	GL_Uniform1fFunc (12, saturation);
 	GL_Uniform1fFunc (20, q_max (0.1f, r_color_midtone.value));
 	{
 		float black_lift = CLAMP (0.f, r_tonemap_black_lift.value, 0.05f);
@@ -3148,11 +3149,12 @@ GL_NeedsPostprocess
 */
 qboolean GL_NeedsPostprocess (void)
 {
+	float saturation;
+
 	if (r_postfx.value <= 0.f)
 		return false;
 
-        float saturation = CLAMP (0.9f, r_color_saturation.value, 1.2f);
-	r_color_saturation.value = saturation;
+	saturation = CLAMP (0.9f, r_color_saturation.value, 1.2f);
 	if (softemu || R_GetEffectiveAlphaMode () == ALPHAMODE_OIT || R_DoFEnabled ())
 		return true;
 	if (r_debug_colorspace.value > 0.f)


### PR DESCRIPTION
### Motivation

- The render-path predicate `GL_NeedsPostprocess` was mutating cvar storage by writing to `r_color_saturation.value`, which can undesirably persist sanitized values into user-facing state.
- The goal is to keep clamping local to the render path and ensure shader uniforms use the same sanitized value without writing into cvar storage.

### Description

- Removed the assignment to `r_color_saturation.value` inside `GL_NeedsPostprocess` and introduced a local `saturation` variable used for decision checks via `saturation = CLAMP(0.9f, r_color_saturation.value, 1.2f)`.
- Updated `GL_PostProcess` to declare a local `saturation`, compute the same clamped value once, and pass that local `saturation` to the postprocess shader via `GL_Uniform1fFunc(12, saturation)` instead of reading/writing the raw cvar at bind time.
- Audited usages in `Quake/gl_rmain.c` to ensure no render-path code in this file writes `r_color_saturation.value` anymore and replaced the previous direct clamping/write pattern with local variables.

### Testing

- Ran targeted source searches with `rg` to confirm occurrences were updated and that no `r_color_saturation.value =` writes remain in `Quake/gl_rmain.c`, which succeeded.
- Verified the postprocess uniform is now set from a local sanitized `saturation` by searching for `GL_Uniform1fFunc (12, saturation)`, which succeeded.
- Attempted a full build with `make -C Quake -j4`; the build could not complete in this environment due to missing development dependencies (`sdl2-config`/`SDL.h`), so no binary-level regression test was performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4979a6db8832e90d524a5ba10ab6f)