### PR TITLE
Make fog-volume scene/post gating capability-aware

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -3154,7 +3154,7 @@ qboolean GL_NeedsSceneEffects (void)
         if (R_DoFEnabled ())
 		return true;
 
-	if (r_fogvol.value > 0.f)
+	if (r_fogvol.value > 0.f && R_FogVol_CanRenderGlobal ())
 		return true;
 
 	return false;
@@ -3184,7 +3184,7 @@ qboolean GL_NeedsPostprocess (void)
 		return true;
 	if (r_godrays.value > 0.f)
 		return true;
-	if (r_fogvol.value > 0.f)
+	if (r_fogvol.value > 0.f && R_FogVol_CanRenderGlobal ())
 		return true;
 	return false;
 }


### PR DESCRIPTION
### Motivation
- Ensure fog-volume activation is consistent between capability detection and effect-path activation so unsupported fog volumes do not force extra rendering passes.
- Avoid unnecessary FBO/composite and postprocess passes when fog volumes are disabled or cannot be rendered globally while preserving current behavior when they are supported.

### Description
- Updated `GL_NeedsSceneEffects` to gate fog-volume activation behind `r_fogvol.value > 0.f && R_FogVol_CanRenderGlobal()` instead of the plain `r_fogvol.value > 0.f` check.
- Updated `GL_NeedsPostprocess` to use the same capability-aware predicate `r_fogvol.value > 0.f && R_FogVol_CanRenderGlobal()` so postprocessing is only forced when fog volumes can actually render globally.
- This brings early-path checks in line with the existing composite-time check near the fogvol texture fetch which already uses `r_fogvol.value > 0.f && R_FogVol_CanRenderGlobal()`.

### Testing
- Searched the modified file to confirm all fog-volume gating sites now use `r_fogvol.value > 0.f && R_FogVol_CanRenderGlobal()` and the search returned the expected locations (success).
- Inspected the updated `Quake/gl_rmain.c` to verify the two `if` conditions in `GL_NeedsSceneEffects` and `GL_NeedsPostprocess` were replaced as intended (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a498207b6c832eb005c10ada9e4f98)