### PR TITLE
Consolidate BSPX lighting source policy in brush model loader

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -729,13 +729,19 @@ void Mod_LoadRGBLightingBSPX (qmodel_t *mod, void *buffer, int size)
         int expected_size;
         byte *memptr;
 
-        if (!mod || !mod->lightdatasize)
+        if (!mod)
                 return;
 
-        expected_size = mod->lightdatasize * 3;
+        expected_size = mod->lightdatasamples ? (mod->lightdatasamples * 3) : (mod->lightdatasize * 3);
+        if (!expected_size)
+                return;
 
         if (size != expected_size)
+        {
+                Q1BSPX_MarkUnsupported("RGBLIGHTING");
+                Con_DWarning("BSPX: RGBLIGHTING size mismatch (%d bytes, expected %d)\n", size, expected_size);
                 return;
+        }
 
         memptr = (byte *)Hunk_AllocName(size, loadname);
         memcpy(memptr, buffer, size);
@@ -1542,12 +1548,14 @@ static void Mod_LoadLighting (lump_t *l)
 {
 	int i, mark;
 	byte *in, *out, *data;
+	byte *bspx_lighting;
+	byte *bspx_rgblighting;
+	byte *bspx_dlit;
 	byte d, q64_b0, q64_b1;
 	char litfilename[MAX_OSPATH];
 	const char *lighting_source;
 	unsigned int path_id;
-	int	bspxsize;
-	qboolean bspx_dlit;
+	int	bspxsize, bspx_lighting_size, bspx_rgb_size, bspx_dlit_size;
 
 	loadmodel->lightdata = NULL;
 	loadmodel->lightdatasamples = 0;
@@ -1559,7 +1567,19 @@ static void Mod_LoadLighting (lump_t *l)
 	loadmodel->lightdatasize = l->filelen;
 	loadmodel->flags &= ~MOD_HDRLIGHTING;
 	loadmodel->litfile = false;
-	bspx_dlit = Q1BSPX_IsProcessed("DLIT");
+	bspx_lighting = Q1BSPX_FindLump("LIGHTING", &bspx_lighting_size);
+	bspx_rgblighting = Q1BSPX_FindLump("RGBLIGHTING", &bspx_rgb_size);
+	bspx_dlit = Q1BSPX_FindLump("DLIT", &bspx_dlit_size);
+
+	/*
+	 * Lighting source precedence for loadmodel->lightdata:
+	 * 1) external .lit
+	 * 2) BSPX LIGHTING_E5BGR9
+	 * 3) BSPX RGBLIGHTING
+	 * 4) BSPX DLIT
+	 * 5) BSPX LIGHTING (classic bytes)
+	 * 6) embedded BSP LUMP_LIGHTING (classic bytes)
+	 */
 	// LordHavoc: check for a .lit file
 	q_strlcpy(litfilename, loadmodel->name, sizeof(litfilename));
 	COM_StripExtension(litfilename, litfilename, sizeof(litfilename));
@@ -1673,7 +1693,7 @@ static void Mod_LoadLighting (lump_t *l)
 		}
 	}
 	// LordHavoc: no .lit found, expand the white lighting data to color
-	if (!l->filelen)
+	if (!l->filelen && !(bspx_lighting && bspx_lighting_size > 0))
 		goto loadlightdir;
 
         if (gl_loadlitfiles.value > 0) // woods #loadlits
@@ -1696,25 +1716,24 @@ static void Mod_LoadLighting (lump_t *l)
                         Con_DWarning("LIGHTING_E5BGR9 lump size %d is not a multiple of 4 bytes\n", bspxsize);
                 }
 
-                in = Q1BSPX_FindLump("RGBLIGHTING", &bspxsize);
-                if (in && (bspxsize % 3 == 0))
+                if (bspx_rgblighting && (bspx_rgb_size % 3 == 0))
                 {
-                        int samples = bspxsize / 3;
+                        int samples = bspx_rgb_size / 3;
 
-                        loadmodel->lightdata = (byte*)Hunk_AllocName(bspxsize, litfilename);
+			loadmodel->lightdata = (byte*)Hunk_AllocName(bspx_rgb_size, litfilename);
                         loadmodel->lightdatasamples = samples;
                         loadmodel->litfile = true;
 
-                        memcpy(loadmodel->lightdata, in, bspxsize);
+			memcpy(loadmodel->lightdata, bspx_rgblighting, bspx_rgb_size);
                         Q1BSPX_MarkUsed("RGBLIGHTING");
 
 					Con_Printf("loaded BSPX lighting (%d samples)\n", samples);
                         goto loadlightdir;
                 }
-                else if (in)
+                else if (bspx_rgblighting)
                 {
                         Q1BSPX_MarkUnsupported("RGBLIGHTING");
-                        Con_DWarning("RGBLIGHTING lump size %d is not a multiple of 3 bytes\n", bspxsize);
+			Con_DWarning("RGBLIGHTING lump size %d is not a multiple of 3 bytes\n", bspx_rgb_size);
                 }
 
         }
@@ -1722,14 +1741,14 @@ static void Mod_LoadLighting (lump_t *l)
                 Con_DPrintf2("gl_loadlitfiles 0: ignoring BSPX colored lighting lumps\n");
         }
 
-        if (bspx_dlit && l->filelen && !loadmodel->lightdata)
+        if (bspx_dlit && bspx_dlit_size > 0 && !loadmodel->lightdata)
         {
-                int samples = l->filelen / 6;
+                int samples = bspx_dlit_size / 6;
 
-                if (l->filelen % 6)
+                if (bspx_dlit_size % 6)
                 {
                         Q1BSPX_MarkUnsupported("DLIT");
-                        Con_DWarning("DLIT lump size %d is not a multiple of 6 bytes\n", l->filelen);
+                        Con_DWarning("DLIT lump size %d is not a multiple of 6 bytes\n", bspx_dlit_size);
                 }
                 else
                 {
@@ -1739,7 +1758,7 @@ static void Mod_LoadLighting (lump_t *l)
                         loadmodel->lightdatasamples = samples;
                         loadmodel->lightdirdata = (byte *)Hunk_AllocName(samples * 3, litfilename);
                         loadmodel->lightdirsamples = samples;
-                        in = mod_base + l->fileofs;
+                        in = bspx_dlit;
                         out = loadmodel->lightdata;
                         luxout = loadmodel->lightdirdata;
 
@@ -1758,6 +1777,25 @@ static void Mod_LoadLighting (lump_t *l)
                         goto loadlightdir;
                 }
         }
+
+
+	if (bspx_lighting && bspx_lighting_size > 0)
+	{
+		loadmodel->lightdata = (byte *) Hunk_AllocName (bspx_lighting_size * 3, litfilename);
+		loadmodel->lightdatasamples = bspx_lighting_size;
+		in = loadmodel->lightdata + bspx_lighting_size * 2;
+		out = loadmodel->lightdata;
+		memcpy (in, bspx_lighting, bspx_lighting_size);
+		for (unsigned int sample = 0; sample < (unsigned int)bspx_lighting_size; sample++)
+		{
+			d = *in++;
+			*out++ = d;
+			*out++ = d;
+			*out++ = d;
+		}
+		Q1BSPX_MarkUsed("LIGHTING");
+		goto loadlightdir;
+	}
 
         // Quake64 bsp lighmap data
         if (loadmodel->bspversion == BSPVERSION_QUAKE64)
@@ -1802,6 +1840,9 @@ static void Mod_LoadLighting (lump_t *l)
 
 
 loadlightdir:
+	if (bspx_rgblighting && loadmodel->lightdatasamples)
+		Mod_LoadRGBLightingBSPX(loadmodel, bspx_rgblighting, bspx_rgb_size);
+
 	if (!loadmodel->lightdirdata)
 	{
 		in = Q1BSPX_FindLump("LIGHTINGDIR", &bspxsize);
@@ -3952,9 +3993,12 @@ static void Mod_LoadBrushModel (qmodel_t *mod, void *buffer)
                         BSPX_ApplyLumpOverride("BSPX_VERTS", &header.lumps[LUMP_VERTEXES]);
                         BSPX_ApplyLumpOverride("BSPX_FACES", &header.lumps[LUMP_FACES]);
 
+                        /*
+                         * Keep LUMP_LIGHTING tied to classic lighting data.
+                         * Extended BSPX lighting variants are selected by Mod_LoadLighting
+                         * with explicit precedence.
+                         */
                         BSPX_ApplyLumpOverride("LIGHTING", &header.lumps[LUMP_LIGHTING]);
-                        BSPX_ApplyLumpOverride("DLIT", &header.lumps[LUMP_LIGHTING]);
-                        BSPX_ApplyLumpOverride("RGBLIGHTING", &header.lumps[LUMP_LIGHTING]);
 
                         BSPX_ApplyLumpOverride("BSPX_ENTITYSTRING", &header.lumps[LUMP_ENTITIES]);
 
@@ -3983,17 +4027,6 @@ static void Mod_LoadBrushModel (qmodel_t *mod, void *buffer)
 	Mod_LoadSurfedges (&header.lumps[LUMP_SURFEDGES]);
 	Mod_LoadTextures (&header.lumps[LUMP_TEXTURES]);
 	Mod_LoadLighting (&header.lumps[LUMP_LIGHTING]);
-	if (is_main_model)
-	{
-		void *lump;
-		int lumpsize;
-
-		lump = Q1BSPX_FindLump("RGBLIGHTING", &lumpsize);
-		if (lump && lumpsize > 0)
-		{
-			Mod_LoadRGBLightingBSPX(mod, lump, lumpsize);
-		}
-	}
 	Mod_LoadPlanes (&header.lumps[LUMP_PLANES]);
 	Mod_LoadTexinfo (&header.lumps[LUMP_TEXINFO]);
 	Mod_LoadEntities (&header.lumps[LUMP_ENTITIES]);	//Spike: moved this earlier, so that we can parse worldspawn keys earlier.


### PR DESCRIPTION
### Motivation
- Make lighting selection deterministic by centralizing BSPX lighting choice so `Mod_LoadLighting` receives a single clear source policy.
- Avoid multiple overrides of `header.lumps[LUMP_LIGHTING]` and duplicate reads that caused competing/ambiguous lighting paths.
- Ensure BSPX usage bookkeeping (`Q1BSPX_MarkUsed` / `Q1BSPX_MarkUnsupported`) reflects the actual path taken and invalid data is marked unsupported.
- Preserve attachment of directional data (`DLIT` / `LIGHTINGDIR`) with consistent sample-count validation for whatever lighting source is selected.

### Description
- Documented and implemented an explicit lighting precedence comment in `Mod_LoadLighting`: external `.lit` → `LIGHTING_E5BGR9` → `RGBLIGHTING` → `DLIT` → BSPX `LIGHTING` → embedded BSP `LUMP_LIGHTING`.
- Centralized BSPX lighting lump discovery into `Mod_LoadLighting` by calling `Q1BSPX_FindLump` for `LIGHTING`, `RGBLIGHTING` and `DLIT` once and operating on those buffers/sizes there.
- Changed `DLIT` handling to use the BSPX `DLIT` lump payload directly (instead of reading `LUMP_LIGHTING`), and allocate both color and directional buffers from the chosen lump while preserving sample alignment.
- Stopped overriding the BSP header `LUMP_LIGHTING` with `DLIT`/`RGBLIGHTING` in `Mod_LoadBrushModel` and removed the later ad-hoc `RGBLIGHTING` re-fetch there so selection is not duplicated.
- Improved validation and bookkeeping: `Mod_LoadRGBLightingBSPX` now computes `expected_size` from `loadmodel->lightdatasamples` (falling back to `lightdatasize`) and marks `RGBLIGHTING` unsupported on size mismatch; `LIGHTINGDIR` is validated against `loadmodel->lightdatasamples` so directional data attaches only when sample counts match.
- When BSPX `LIGHTING` (classic byte samples) is used, it is expanded to RGB in `Mod_LoadLighting` and `Q1BSPX_MarkUsed("LIGHTING")` is set consistently; `Mod_LoadRGBLightingBSPX` is invoked at the loader end if an RGB BSPX buffer is present and sample counts are known.

### Testing
- Attempted to build the project to validate compilation: `make -j4` at repo root failed because there is no top-level Makefile in this environment.
- Attempted to build the Quake target: `make -C Quake -j4` executed the build system and progressed to compilation, but failed due to missing SDL2 development tools/headers (errors: missing `sdl2-config` and `SDL.h`), so a full compile/test could not complete in the current environment.
- Ran repository inspections (`rg`/code review) and local edits to ensure no duplicate `RGBLIGHTING`/`DLIT` override remained and that `Mod_LoadLighting` contains the new precedence and centralized logic (changes are limited to `Quake/gl_model.c`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a49a1c23b0832e99ccd98147faf722)