### PR TITLE
Enforce upper bound on BSPX `numlumps` during parsing

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -582,6 +582,7 @@ typedef struct
         qboolean used;
         qboolean unsupported;
 } bspx_lump_usage_t;
+#define MAX_BSPX_LUMPS 1024
 #define MAX_BSPX_LUMP_USAGE 256
 static bspx_lump_usage_t bspx_lump_usage[MAX_BSPX_LUMP_USAGE];
 static int bspx_lump_usage_count;
@@ -946,8 +947,11 @@ static qboolean Mod_ParseBSPXDirectory(qmodel_t *mod, const bsp_header_info_t *h
                 return false;
 
         numlumps = LittleLong(h->numlumps);
-        if (numlumps <= 0)
+        if (numlumps <= 0 || numlumps > MAX_BSPX_LUMPS)
+        {
+                Con_Warning("%s has invalid BSPX lump count %d (allowed 1..%d)\n", mod->name, numlumps, MAX_BSPX_LUMPS);
                 return false;
+        }
 
         if (header_offset + sizeof(*h) + sizeof(h->lumps[0]) * (numlumps - 1) > filelen)
                 return false;


### PR DESCRIPTION
### Motivation
- Prevent extremely large or malformed BSPX `numlumps` values from triggering excessive allocations or out-of-bounds behavior when parsing BSPX directories by enforcing a sane upper limit aligned with engine expectations (e.g. 256/1024). 

### Description
- Add a named constant `#define MAX_BSPX_LUMPS 1024` adjacent to the BSPX parsing/usage structures. 
- Validate the decoded `numlumps` in `Mod_ParseBSPXDirectory` and reject when `numlumps <= 0 || numlumps > MAX_BSPX_LUMPS` before performing the existing header/size structural checks. 
- Emit a `Con_Warning` containing the rejected lump count and the map/model name when the cap check fails. 
- Preserve the existing initialization that clears `mod->bspx_entries`, `mod->bspx_entries_count`, and `mod->bspx_header` so they remain reset on failure. 

### Testing
- Ran `git diff -- Quake/gl_model.c` and verified the intended changes are present and correctly placed, which succeeded. 
- Inspected file regions with `nl -ba Quake/gl_model.c | sed -n '576,610p'` and `nl -ba Quake/gl_model.c | sed -n '936,966p'` to confirm the new constant and the `numlumps` cap check appear at the expected locations, which succeeded. 
- Committed the change with `git commit`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a49ba230ac832e91c04c5026a98e5a)