### PR TITLE
Fix BSPX lighting override call signature

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -4057,8 +4057,6 @@ static void Mod_LoadBrushModel (qmodel_t *mod, void *buffer)
                          * Extended BSPX lighting variants are selected by Mod_LoadLighting
                          * with explicit precedence.
                          */
-                        BSPX_ApplyLumpOverride("LIGHTING", &header.lumps[LUMP_LIGHTING]);
-
                         BSPX_ApplyLumpOverride(mod, "BSPX_ENTITYSTRING", &header.lumps[LUMP_ENTITIES], (size_t)com_filesize);
 
                         BSPX_ApplyLumpOverride(mod, "BSPX_MODELS", &header.lumps[LUMP_MODELS], (size_t)com_filesize);


### PR DESCRIPTION
### Motivation
- Remove an incorrect `BSPX_ApplyLumpOverride` invocation that used the wrong parameter types and caused MSVC errors C4133/C2198 during compilation.

### Description
- Delete the standalone `BSPX_ApplyLumpOverride("LIGHTING", &header.lumps[LUMP_LIGHTING]);` call in `Mod_LoadBrushModel` so the call sites match the helper signature and the `LUMP_LIGHTING` handling remains under `Mod_LoadLighting` as intended.

### Testing
- Ran `git diff --check` to ensure no whitespace or patch issues and it succeeded.
- Verified repository status with `git status --short` and committed the change successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a49bbcb410832e88ae3c61d507bd26)