### PR TITLE
Require exact 24-byte BSPX lump-name matches in dispatch

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -576,6 +576,26 @@ typedef struct
 } bsp_header_info_t;
 static bspx_header_t *BSPX_Setup(qmodel_t *mod, const bsp_header_info_t *header, size_t filelen);
 static void *BSPX_FindLump(bspx_header_t *bspxheader, void *base, const char *lumpname, size_t *lumpsize);
+
+/*
+ * BSPX lump names are fixed 24-byte, zero-padded fields (max 23 chars + NUL).
+ * Compare against the full field so handler aliases never match by prefix.
+ */
+static qboolean BSPX_LumpNameEquals(const char entry_name[24], const char *name)
+{
+	char expected_name[24];
+	size_t len;
+
+	len = strlen(name);
+	if (len >= sizeof(expected_name))
+		return false;
+
+	memset(expected_name, 0, sizeof(expected_name));
+	memcpy(expected_name, name, len);
+
+	return !memcmp(entry_name, expected_name, sizeof(expected_name));
+}
+
 typedef struct
 {
         char lumpname[sizeof(((bspx_lump_disk_t *)0)->lumpname) + 1];
@@ -1089,7 +1109,11 @@ static void Mod_DispatchBSPXLumps(qmodel_t *mod)
 
                 for (handler = bspx_handlers; handler->handler; handler++)
                 {
-                        if (!strncmp(entry->name, handler->name, strlen(handler->name)))
+                        /*
+                         * Must be exact BSPX name equality (24-byte field semantics),
+                         * not prefix matching.
+                         */
+                        if (BSPX_LumpNameEquals(entry->name, handler->name))
                         {
                                 handled = true;
                                 if (handler->handler(mod, mod_base + entry->offset, entry->size))


### PR DESCRIPTION
### Motivation
- Prevent handler aliases from matching by prefix and ensure comparisons follow BSPX on-disk semantics (24-byte, zero-padded name fields).

### Description
- Add `BSPX_LumpNameEquals` to compare an entry name against a C string using full 24-byte, zero-padded field semantics and reject overlong names.
- Replace the prefix `strncmp(..., strlen(handler->name))` check inside `Mod_DispatchBSPXLumps` with `BSPX_LumpNameEquals` and add comments explaining why prefix matching is incorrect.
- Preserve the compatibility aliases (`LIGHTRID`, `LGHTGRID`, `LIGHTGRID`) in the handler table but require each alias to match the full 24-byte name exactly.

### Testing
- Ran `make -j4` in the repository root which reported "No targets specified and no makefile found." and therefore did not build.
- Ran `make -j4` in `Quake/` to validate compilation; the build failed due to missing SDL2 development tooling/headers (`sdl2-config` and `SDL.h`), so no binary was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a49c800330832eb5dc9d7e06583995)