### PR TITLE
Detect and report shader include cycles immediately

### DIFF
--- a/Quake/gl_shaders.c
+++ b/Quake/gl_shaders.c
@@ -355,7 +355,7 @@ static GLuint GL_CreateProgramFromShaders (const GLuint *shaders, int numshaders
 GL_CreateProgramFromSources
 ====================
 */
-static char *GL_LoadShaderFile_Internal (const char *path, int depth)
+static char *GL_LoadShaderFile_Internal (const char *path, int depth, const char **include_stack, int include_stack_size)
 {
         size_t capacity, result_len;
         char *result;
@@ -371,6 +371,11 @@ static char *GL_LoadShaderFile_Internal (const char *path, int depth)
 
         if (depth >= 32)
                 Sys_Error ("GL_LoadShaderFile: include depth overflow for %s", path);
+
+        if (include_stack_size >= 32)
+                Sys_Error ("GL_LoadShaderFile: include stack overflow for %s", path);
+
+        include_stack[include_stack_size++] = path;
 
         if (shader_cache_count == countof(shader_cache))
                 Sys_Error ("GL_LoadShaderFile: shader cache overflow");
@@ -465,7 +470,34 @@ static char *GL_LoadShaderFile_Internal (const char *path, int depth)
 										path, include_path, reason ? reason : "invalid path");
 								}
 
-                                        included = GL_LoadShaderFile_Internal (full_path, depth + 1);
+                                        for (i = 0; i < include_stack_size; i++)
+                                        {
+                                                if (!strcmp (include_stack[i], full_path))
+                                                {
+                                                        char cycle[4096];
+                                                        char *dst = cycle;
+                                                        size_t remaining = sizeof (cycle);
+                                                        int j;
+
+                                                        cycle[0] = '\0';
+                                                        for (j = i; j < include_stack_size; j++)
+                                                        {
+                                                                int written = q_snprintf (dst, remaining, "%s -> ", include_stack[j]);
+                                                                if (written < 0 || (size_t) written >= remaining)
+                                                                        break;
+                                                                dst += written;
+                                                                remaining -= (size_t) written;
+                                                        }
+                                                        if (remaining > 0)
+                                                                q_snprintf (dst, remaining, "%s", full_path);
+
+                                                        free (result);
+                                                        free (source);
+                                                        GL_InitError ("Shader include cycle detected: %s", cycle);
+                                                }
+                                        }
+
+                                        included = GL_LoadShaderFile_Internal (full_path, depth + 1, include_stack, include_stack_size);
                                         if (included)
                                         {
                                                 APPEND_STR (included, strlen (included));
@@ -496,7 +528,8 @@ static char *GL_LoadShaderFile_Internal (const char *path, int depth)
 
 static char *GL_LoadShaderFile (const char *path)
 {
-        return GL_LoadShaderFile_Internal (path, 0);
+        const char *include_stack[32];
+        return GL_LoadShaderFile_Internal (path, 0, include_stack, 0);
 }
 
 static GLuint GL_CreateProgramFromFiles (int count, const char **paths, const GLenum *types, const char *name, va_list argptr)


### PR DESCRIPTION
### Motivation
- Prevent infinite recursion and confusing failures when shader files include each other by detecting direct and indirect include cycles early and reporting a readable trace.

### Description
- Change `GL_LoadShaderFile_Internal` signature to accept an include stack (`const char **include_stack`, `int include_stack_size`) and thread it through recursive calls.
- Preserve the existing shader cache short-circuit by still checking `shader_cache` before any stack work, keeping normal non-cyclic caching behavior unchanged.
- Add an include stack bound check and push the current `path` onto the active stack before processing includes.
- Before recursing on an include, scan the active stack for `full_path` and, if found, build a cycle trace string (e.g. `A -> B -> A`) and call `GL_InitError` to abort; retain the existing `depth >= 32` guard as a secondary safety check.
- Initialize a local `include_stack[32]` in the `GL_LoadShaderFile` wrapper and call the updated internal function with `include_stack` and initial size `0`.

### Testing
- Ran `make -j2` from the repo root as an automated build check which failed due to there being no top-level Makefile in this checkout, so no compile-time validation was performed (failure expected: `No targets specified and no makefile found.`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4ab4f2140832ea977a0acb2ee7bfe)