### PR TITLE
Unify fog attenuation sign handling in shaders (use abs(Fog.w))

### DIFF
--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -42,6 +42,7 @@ float bayer(ivec2 coord)
         return bayer01(coord) - 0.5;
 }
 
+// AliasFrameBuffer.Fog.w is treated as a signed-friendly density; use abs() so negative CPU values do not invert attenuation.
 vec3 ApplyFog(vec3 clr, vec3 p)
 {
         float fog = exp2(-abs(AliasFrameBuffer.Fog.w) * dot(p, p));

--- a/Quake/shaders/debug3d.vert
+++ b/Quake/shaders/debug3d.vert
@@ -1,8 +1,9 @@
 #include "frame_uniforms.glsl"
 
+// Fog.w is treated as a signed-friendly density; use abs(Fog.w) so negative CPU values do not invert attenuation.
 vec3 ApplyFog(vec3 clr, vec3 p)
 {
-	float fog = exp2(-Fog.w * dot(p, p));
+	float fog = exp2(-abs(Fog.w) * dot(p, p));
 	fog = clamp(fog, 0.0, 1.0);
 	return mix(Fog.rgb, clr, fog);
 }

--- a/Quake/shaders/particles.frag
+++ b/Quake/shaders/particles.frag
@@ -1,8 +1,9 @@
 #include "frame_uniforms.glsl"
 
+// Fog.w is treated as a signed-friendly density; use abs(Fog.w) so negative CPU values do not invert attenuation.
 vec3 ApplyFog(vec3 clr, vec3 p)
 {
-	float fog = exp2(-Fog.w * dot(p, p));
+	float fog = exp2(-abs(Fog.w) * dot(p, p));
 	fog = clamp(fog, 0.0, 1.0);
 	return mix(Fog.rgb, clr, fog);
 }
@@ -109,7 +110,7 @@ void main()
 	float pixel = fwidth(radius);
 	out_fragcolor.a *= clamp((1. - radius) / pixel, 0., 1.);
 #if DITHER
-	if (Fog.w > 0.)
+	if (abs(Fog.w) > 0.)
 	{
 		out_fragcolor.rgb = sqrt(out_fragcolor.rgb);
 		out_fragcolor.rgb += SCREEN_SPACE_NOISE() * ScreenDither;

--- a/Quake/shaders/particles.vert
+++ b/Quake/shaders/particles.vert
@@ -1,8 +1,9 @@
 #include "frame_uniforms.glsl"
 
+// Fog.w is treated as a signed-friendly density; use abs(Fog.w) so negative CPU values do not invert attenuation.
 vec3 ApplyFog(vec3 clr, vec3 p)
 {
-	float fog = exp2(-Fog.w * dot(p, p));
+	float fog = exp2(-abs(Fog.w) * dot(p, p));
 	fog = clamp(fog, 0.0, 1.0);
 	return mix(Fog.rgb, clr, fog);
 }

--- a/Quake/shaders/sky_cubemap.frag
+++ b/Quake/shaders/sky_cubemap.frag
@@ -1,8 +1,9 @@
 #include "frame_uniforms.glsl"
 
+// Fog.w is treated as a signed-friendly density; use abs(Fog.w) so negative CPU values do not invert attenuation.
 vec3 ApplyFog(vec3 clr, vec3 p)
 {
-	float fog = exp2(-Fog.w * dot(p, p));
+	float fog = exp2(-abs(Fog.w) * dot(p, p));
 	fog = clamp(fog, 0.0, 1.0);
 	return mix(Fog.rgb, clr, fog);
 }

--- a/Quake/shaders/sky_cubemap.vert
+++ b/Quake/shaders/sky_cubemap.vert
@@ -8,9 +8,10 @@
 
 #include "frame_uniforms.glsl"
 
+// Fog.w is treated as a signed-friendly density; use abs(Fog.w) so negative CPU values do not invert attenuation.
 vec3 ApplyFog(vec3 clr, vec3 p)
 {
-	float fog = exp2(-Fog.w * dot(p, p));
+	float fog = exp2(-abs(Fog.w) * dot(p, p));
 	fog = clamp(fog, 0.0, 1.0);
 	return mix(Fog.rgb, clr, fog);
 }

--- a/Quake/shaders/sky_layers.frag
+++ b/Quake/shaders/sky_layers.frag
@@ -7,9 +7,10 @@
 
 #include "frame_uniforms.glsl"
 
+// Fog.w is treated as a signed-friendly density; use abs(Fog.w) so negative CPU values do not invert attenuation.
 vec3 ApplyFog(vec3 clr, vec3 p)
 {
-	float fog = exp2(-Fog.w * dot(p, p));
+	float fog = exp2(-abs(Fog.w) * dot(p, p));
 	fog = clamp(fog, 0.0, 1.0);
 	return mix(Fog.rgb, clr, fog);
 }

--- a/Quake/shaders/sky_layers.vert
+++ b/Quake/shaders/sky_layers.vert
@@ -8,9 +8,10 @@
 
 #include "frame_uniforms.glsl"
 
+// Fog.w is treated as a signed-friendly density; use abs(Fog.w) so negative CPU values do not invert attenuation.
 vec3 ApplyFog(vec3 clr, vec3 p)
 {
-	float fog = exp2(-Fog.w * dot(p, p));
+	float fog = exp2(-abs(Fog.w) * dot(p, p));
 	fog = clamp(fog, 0.0, 1.0);
 	return mix(Fog.rgb, clr, fog);
 }

--- a/Quake/shaders/skystencil.vert
+++ b/Quake/shaders/skystencil.vert
@@ -8,9 +8,10 @@
 
 #include "frame_uniforms.glsl"
 
+// Fog.w is treated as a signed-friendly density; use abs(Fog.w) so negative CPU values do not invert attenuation.
 vec3 ApplyFog(vec3 clr, vec3 p)
 {
-	float fog = exp2(-Fog.w * dot(p, p));
+	float fog = exp2(-abs(Fog.w) * dot(p, p));
 	fog = clamp(fog, 0.0, 1.0);
 	return mix(Fog.rgb, clr, fog);
 }

--- a/Quake/shaders/sprites.frag
+++ b/Quake/shaders/sprites.frag
@@ -1,8 +1,9 @@
 #include "frame_uniforms.glsl"
 
+// Fog.w is treated as a signed-friendly density; use abs(Fog.w) so negative CPU values do not invert attenuation.
 vec3 ApplyFog(vec3 clr, vec3 p)
 {
-	float fog = exp2(-Fog.w * dot(p, p));
+	float fog = exp2(-abs(Fog.w) * dot(p, p));
 	fog = clamp(fog, 0.0, 1.0);
 	return mix(Fog.rgb, clr, fog);
 }
@@ -78,7 +79,7 @@ void main()
         out_fragcolor = result;
         out_velocity = vec4(0.0, 0.0, 0.0, 2.0);
 #if DITHER
-	if (Fog.w > 0.)
+	if (abs(Fog.w) > 0.)
 	{
 	out_fragcolor.rgb = sqrt(out_fragcolor.rgb);
 	out_fragcolor.rgb += SCREEN_SPACE_NOISE() * ScreenDither;

--- a/Quake/shaders/sprites.vert
+++ b/Quake/shaders/sprites.vert
@@ -1,8 +1,9 @@
 #include "frame_uniforms.glsl"
 
+// Fog.w is treated as a signed-friendly density; use abs(Fog.w) so negative CPU values do not invert attenuation.
 vec3 ApplyFog(vec3 clr, vec3 p)
 {
-	float fog = exp2(-Fog.w * dot(p, p));
+	float fog = exp2(-abs(Fog.w) * dot(p, p));
 	fog = clamp(fog, 0.0, 1.0);
 	return mix(Fog.rgb, clr, fog);
 }

--- a/Quake/shaders/water.frag
+++ b/Quake/shaders/water.frag
@@ -127,6 +127,7 @@ layout(location=7) noperspective in vec4 in_prev_clip;
         layout(location=1) out vec4 out_velocity;
 #endif // OIT
 
+// Fog.w is treated as a signed-friendly density; use abs(Fog.w) so negative CPU values do not invert attenuation.
 void main()
 {
         vec3 fullbright = vec3(0.0);
@@ -163,7 +164,7 @@ void main()
         result.rgb += fullbright;
         result.rgb += emissive;
         result.rgb = clamp(result.rgb, 0.0, 1.0);
-        float fog = exp2(-Fog.w * dot(in_pos - EyePos, in_pos - EyePos));
+        float fog = exp2(-abs(Fog.w) * dot(in_pos - EyePos, in_pos - EyePos));
         fog = clamp(fog, 0.0, 1.0);
 
         result.rgb = mix(Fog.rgb, result.rgb, fog);
@@ -180,7 +181,7 @@ void main()
         out_velocity = vec4(velocityOut, 0.0, materialMask);
 #endif
 #if DITHER
-	if (Fog.w > 0.)
+	if (abs(Fog.w) > 0.)
 	{
 		out_fragcolor.rgb = sqrt(out_fragcolor.rgb);
 		out_fragcolor.rgb += SCREEN_SPACE_NOISE() * ScreenDither;

--- a/Quake/shaders/water.vert
+++ b/Quake/shaders/water.vert
@@ -8,9 +8,10 @@
 
 #include "frame_uniforms.glsl"
 
+// Fog.w is treated as a signed-friendly density; use abs(Fog.w) so negative CPU values do not invert attenuation.
 vec3 ApplyFog(vec3 clr, vec3 p)
 {
-	float fog = exp2(-Fog.w * dot(p, p));
+	float fog = exp2(-abs(Fog.w) * dot(p, p));
 	fog = clamp(fog, 0.0, 1.0);
 	return mix(Fog.rgb, clr, fog);
 }

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -9,8 +9,7 @@ layout(binding=2) uniform sampler2D LMTex;
 layout(binding=3) uniform sampler2D LMTexDir;
 #include "frame_uniforms.glsl"
 
-// BUG FIX: world.vert uses exp2(-Fog.w * ...) but frag used exp2(-abs(Fog.w) * ...)
-// Keep abs() for safety but unify sign convention with vertex shader
+// Fog.w is treated as a signed-friendly density; use abs(Fog.w) so negative CPU values do not invert attenuation.
 vec3 ApplyFog(vec3 clr, vec3 p)
 {
 	float fog = exp2(-abs(Fog.w) * dot(p, p));
@@ -582,7 +581,7 @@ void main()
 	OUT_COLOR.rgb = sqrt(OUT_COLOR.rgb);
 	float luma     = dot(OUT_COLOR.rgb, vec3(0.25, 0.625, 0.125));
 	float nearnoise = tri(whitenoise01(lmuv * lmsize)) * luma * TextureDither;
-	float farnoise  = (Fog.w > 0.0) ? SCREEN_SPACE_NOISE() * ScreenDither : 0.0;
+	float farnoise  = (abs(Fog.w) > 0.0) ? SCREEN_SPACE_NOISE() * ScreenDither : 0.0;
 	OUT_COLOR.rgb  += mix(nearnoise, farnoise, farblend);
 	OUT_COLOR.rgb  *= OUT_COLOR.rgb;
 #endif

--- a/Quake/shaders/world.vert
+++ b/Quake/shaders/world.vert
@@ -8,12 +8,10 @@
 
 #include "frame_uniforms.glsl"
 
-// NOTE: world.vert and world.frag both define ApplyFog but with a subtle difference:
-// vert uses exp2(-Fog.w * ...) while frag uses exp2(-abs(Fog.w) * ...).
-// frag version is safer (handles negative Fog.w). Keep them consistent if you unify.
+// Fog.w is treated as a signed-friendly density; use abs(Fog.w) so negative CPU values do not invert attenuation.
 vec3 ApplyFog(vec3 clr, vec3 p)
 {
-	float fog = exp2(-Fog.w * dot(p, p));
+	float fog = exp2(-abs(Fog.w) * dot(p, p));
 	fog = clamp(fog, 0.0, 1.0);
 	return mix(Fog.rgb, clr, fog);
 }

--- a/Quake/shaders/world_dlight.frag
+++ b/Quake/shaders/world_dlight.frag
@@ -16,6 +16,7 @@ layout(location=0) uniform vec4 DLightConfig0; // x: scale, y: radius scale, z: 
 layout(location=1) uniform vec4 DLightConfig1; // x: core boost, y: core exp, z: soft knee, w: ndotl mix
 layout(location=2) uniform vec4 DLightConfig2; // x: saturation chop
 
+// Fog.w is treated as a signed-friendly density; use abs(Fog.w) so negative CPU values do not invert attenuation.
 vec3 ApplyFog(vec3 clr, vec3 p)
 {
         float fog = exp2(-abs(Fog.w) * dot(p, p));


### PR DESCRIPTION
### Motivation
- Various shader variants used inconsistent fog attenuation (some used `exp2(-Fog.w * ...)`, others used `exp2(-abs(Fog.w) * ...)`), which can invert attenuation when `Fog.w` is negative; this change standardizes the convention to avoid visual inversions.
- The chosen convention treats `Fog.w` as a signed-friendly density and protects attenuation in shaders with `abs(Fog.w)` so negative CPU-supplied values cannot invert fog falloff.

### Description
- Replaced `exp2(-Fog.w * dot(p,p))` with `exp2(-abs(Fog.w) * dot(p,p))` in all `ApplyFog` helpers across shader variants including `world.vert/.frag`, `world_dlight.frag`, `particles.vert/.frag`, `sprites.vert/.frag`, `sky_layers.vert/.frag`, `sky_cubemap.vert/.frag`, `water.vert/.frag`, `skystencil.vert`, `debug3d.vert`, and `alias.frag` to enforce one canonical attenuation rule. 
- Added a short comment above each `ApplyFog` helper documenting the expected `Fog.w` domain and why `abs()` is used (i.e., `Fog.w` is treated as a signed-friendly density; use `abs(Fog.w)` so negative CPU values do not invert attenuation). 
- Normalized fog gating checks used for dithering/noise to `if (abs(Fog.w) > 0)` where present so conditional behavior matches the attenuation convention. 
- Ensured the `AliasFrameBuffer.Fog.w` case uses the same `abs()` handling.

### Testing
- Ran automated repository scans (`rg`) to find all `ApplyFog` instances and verify each was updated to the canonical formula; this verification succeeded. 
- Attempted to rebuild the engine via `make -C Quake -j4` to exercise the engine startup path and trigger runtime shader compilation, but the build environment is missing SDL development tools/headers (`sdl2-config` / `SDL.h`), so the full engine startup and runtime shader compilation could not be completed here (build failed early for missing SDL). 
- Checked for local GLSL offline compilers (`glslangValidator` / `glslc`) and none were available in the environment, so shader-only compile checks were not performed; however, all changed files were inspected and confirmed to contain the new formula and comments via automated search.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4ab43be08832e9c20c168040cca4b)