### PR TITLE
Harden GLSL macro define parsing in GL_CreateProgramFromFiles

### DIFF
--- a/Quake/gl_shaders.c
+++ b/Quake/gl_shaders.c
@@ -250,6 +250,42 @@ static qboolean AppendString (char **dst, const char *dstend, const char *str, i
 	return true;
 }
 
+static qboolean GL_IsValidMacroIdentifier (const char *name, size_t len)
+{
+	size_t i;
+
+	if (!len)
+		return false;
+
+	if (!(q_isalpha ((unsigned char)name[0]) || name[0] == '_'))
+		return false;
+
+	for (i = 1; i < len; i++)
+	{
+		if (!(q_isalnum ((unsigned char)name[i]) || name[i] == '_'))
+			return false;
+	}
+
+	return true;
+}
+
+#ifndef NDEBUG
+static void GL_DebugTestMacroIdentifierParser (void)
+{
+	static qboolean ran;
+
+	if (ran)
+		return;
+	ran = true;
+
+	assert (GL_IsValidMacroIdentifier ("FOO", 3));
+	assert (GL_IsValidMacroIdentifier ("_BAR9", 5));
+	assert (!GL_IsValidMacroIdentifier ("", 0));
+	assert (!GL_IsValidMacroIdentifier ("9BAD", 4));
+	assert (!GL_IsValidMacroIdentifier ("BAD-NAME", 8));
+}
+#endif
+
 /*
 =============
 GL_CreateShader
@@ -554,23 +590,61 @@ static GLuint GL_CreateProgramFromFiles (int count, const char **paths, const GL
 		char *dstend = macros + sizeof (macros);
 		char *src = eval + 1 + (pipe - name);
 
+#ifndef NDEBUG
+		GL_DebugTestMacroIdentifierParser ();
+#endif
+
 		while (*src == ' ')
 			src++;
 
 		while (*src)
 		{
-			char *srcend = src + 1;
+			char *srcend = src;
+			char *tokstart, *tokend;
+			char *namestart, *nameend;
+			char *valuestart;
 			while (*srcend && *srcend != ';')
 				srcend++;
 
+			tokstart = src;
+			while (tokstart < srcend && q_isspace ((unsigned char)*tokstart))
+				tokstart++;
+			tokend = srcend;
+			while (tokend > tokstart && q_isspace ((unsigned char)tokend[-1]))
+				tokend--;
+
+			if (tokstart == tokend)
+				GL_InitError ("GL_CreateProgram '%s': empty macro token in '%s'", name, eval);
+
+			namestart = tokstart;
+			nameend = namestart;
+			while (nameend < tokend && !q_isspace ((unsigned char)*nameend))
+				nameend++;
+
+			if (!GL_IsValidMacroIdentifier (namestart, nameend - namestart))
+				GL_InitError ("GL_CreateProgram '%s': invalid macro identifier '%.*s' in '%s'",
+					name, (int)(nameend - namestart), namestart, eval);
+
+			valuestart = nameend;
+			while (valuestart < tokend && q_isspace ((unsigned char)*valuestart))
+				valuestart++;
+
 			if (!AppendString (&dst, dstend, "#define ", 8) ||
-				!AppendString (&dst, dstend, src, srcend - src) ||
+				!AppendString (&dst, dstend, namestart, nameend - namestart) ||
+				(valuestart < tokend && (!AppendString (&dst, dstend, " ", 1) ||
+					!AppendString (&dst, dstend, valuestart, tokend - valuestart))) ||
 				!AppendString (&dst, dstend, "\n", 1))
 				Sys_Error ("GL_CreateProgram: symbol overflow for %s", eval);
 
 			src = srcend;
-			while (*src == ';' || *src == ' ')
+			if (*src == ';')
+			{
 				src++;
+				while (*src == ' ')
+					src++;
+				if (!*src)
+					GL_InitError ("GL_CreateProgram '%s': empty trailing macro token in '%s'", name, eval);
+			}
 		}
 
 		AppendString (&dst, dstend, "\n", 1);


### PR DESCRIPTION
### Motivation
- Prevent malformed or malicious macro tokens from producing invalid `#define` lines by parsing and validating each `;`-delimited macro token early in `GL_CreateProgramFromFiles`.
- Provide actionable error messages that include the offending program name so initialization failures are diagnosable.

### Description
- Tightened parsing in `Quake/gl_shaders.c` to split the `|` symbol list into individual `;`-delimited tokens, trim whitespace, and isolate name/value portions before generating `#define` output in the `macros` buffer.
- Added `GL_IsValidMacroIdentifier` to enforce identifier syntax `[A-Za-z_][A-Za-z0-9_]*` and call `GL_InitError` with the program name on invalid identifiers.
- Reject empty tokens and empty trailing tokens with `GL_InitError` that include the offending program/context string, while preserving the existing `AppendString` overflow handling (existing `Sys_Error`/overflow path unchanged).
- Included a debug-only, one-time assertion test (`GL_DebugTestMacroIdentifierParser`) to exercise the identifier parser when built without `NDEBUG`.

### Testing
- Attempted an in-repo build with `make -j4`, which failed because there is no top-level Makefile in this environment (no build run).
- Attempted configuration with `cmake -S . -B build`, which failed due to a missing `SDL2` CMake package (`SDL2Config.cmake` / `sdl2-config.cmake`).
- No lightweight C unit-test harness was found in the repository, so a debug-only assertion self-test was added instead and is exercised only in non-`NDEBUG` builds.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4b2d2dad8832ea11f1258dabb0cf1)