### PR TITLE
Fix SSAO bleeding through volumetric fog

### DIFF
--- a/Quake/shaders/postprocess.frag
+++ b/Quake/shaders/postprocess.frag
@@ -251,10 +251,13 @@ float FogVolTransmittance(vec2 uv)
                 return 1.0; // fogvol inactive — no suppression
         vec3 fogColor = texture(FogVolTexture, uv).rgb;
         float lum = dot(fogColor, vec3(0.299, 0.587, 0.114));
-        // Scale: lum=0.0 → transmittance=1.0 (no fog)
-        //        lum≥0.2 → transmittance=0.0 (full suppression)
-        // The *5.0 factor means 20% fog luminance = fully suppressed AO.
-        return clamp(1.0 - lum * 5.0, 0.0, 1.0);
+        float peak = max(fogColor.r, max(fogColor.g, fogColor.b));
+        // The fog buffer contains composited scene color, so raw luminance alone
+        // underestimates colored/dark fog. Use the stronger of luma and peak
+        // channel and map aggressively so visible fog quickly suppresses AO.
+        float fogSignal = max(lum, peak);
+        float fogAmount = smoothstep(0.02, 0.12, fogSignal);
+        return 1.0 - fogAmount;
 }
 
 float SampleSSAO(vec2 uv, DepthSamplingInfo info, float centerDepth, bool useDepth)


### PR DESCRIPTION
### Motivation
- Prevent SSAO from remaining visible inside dense or colored volumetric fog by improving the fog transmittance metric used to damp AO in the postprocess composite.

### Description
- Update `FogVolTransmittance` in `Quake/shaders/postprocess.frag` to compute a stronger fog signal via `max(luminance, peak_channel)` and replace the prior linear `1 - lum * 5.0` mapping with a smooth ramp using `smoothstep(0.02, 0.12, fogSignal)` so visible fog more reliably suppresses SSAO.

### Testing
- Attempted a full configure/build with `cmake -S . -B build && cmake --build build -j2`, which failed in this environment due to a missing SDL2 CMake package (`SDL2Config.cmake` / `sdl2-config.cmake`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4b3de21f0832ea675ea2fe516c65f)