### PR TITLE
Respect global bloom, add per-stage bloom scale, and adjust postfx bloom handling

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -1265,8 +1265,9 @@ static void R_CompositeDlightBuffer (void)
 		return;
 
 	float scale = q_max (0.f, r_dlight_scale.value);
-	float bloom_enabled = q_max (0.f, r_dlight_bloom.value);
-	float bloom_scale = q_max (0.f, r_dlight_bloom_scale.value);
+	float bloom_master = q_max (0.f, r_bloom.value);
+	float bloom_enabled = (bloom_master > 0.f) ? q_max (0.f, r_dlight_bloom.value) : 0.f;
+	float bloom_scale = q_max (0.f, r_dlight_bloom_scale.value) * bloom_master;
 	float bloom_radius = q_max (0.f, r_dlight_bloom_radius.value);
 	float bloom_threshold = q_max (0.f, r_dlight_bloom_threshold.value);
 
@@ -2330,10 +2331,18 @@ void GL_PostProcess (void)
 			exposure *= auto_exposure;
 	}
 	r_autoexposure_debug_exposure = exposure;
-	if (r_postfx_bloom_mode.value > 0.f)
-		bloom_intensity_effective = q_max (bloom_intensity, postfx_bloom_boost);
+	if (bloom_intensity > 0.f)
+	{
+		if (r_postfx_bloom_mode.value > 0.f)
+			bloom_intensity_effective = q_max (bloom_intensity, postfx_bloom_boost);
+		else
+			bloom_intensity_effective = bloom_intensity + postfx_bloom_boost;
+	}
 	else
-		bloom_intensity_effective = bloom_intensity + postfx_bloom_boost;
+	{
+		bloom_intensity_effective = 0.f;
+		postfx_bloom_boost = 0.f;
+	}
 	bloom_intensity_effective = q_max (0.f, bloom_intensity_effective);
 
 	if (r_postfx_lut_debug_id.value > 0.f)

--- a/Quake/mat_shader_parse.c
+++ b/Quake/mat_shader_parse.c
@@ -1839,11 +1839,27 @@ static const char *ParseMaterialBlock (const char *data, const char *name, const
 		if (!q_strcasecmp (com_token, "bloom"))
 		{
 			Mat_Shader_MarkKeywordSeen ("bloom", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL);
+			cursor = Mat_Shader_ParseToken (data, NULL);
+			if (cursor && com_token[0] && Mat_Shader_IsNumericToken (com_token))
+			{
+				float validated_scale = 1.f;
+				if (!ParseFloat (&data, &scale, state))
+				{
+					data = ResyncMaterialBlock (data, state);
+					break;
+				}
+				Mat_Shader_ValidateFiniteFloat (state, "bloom", scale, 1.f, &validated_scale);
+				material.bloom_scale = CLAMP (0.f, validated_scale, MAT_SHADER_SCALE_MAX);
+				material.bloom_enable = (material.bloom_scale > 0.f);
+				continue;
+			}
 			if (!ParseRequiredBool (&data, &material.bloom_enable, state))
 			{
 				data = ResyncMaterialBlock (data, state);
 				break;
 			}
+			if (!material.bloom_enable)
+				material.bloom_scale = 0.f;
 			continue;
 		}
 		if (!q_strcasecmp (com_token, "godray"))

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -1131,6 +1131,12 @@ static void R_DrawBrushModels_MaterialStages (entity_t **ents, int count, brushp
 					continue;
 
 				R_EvalStageColorAlpha (stage, cl.time, stage_color);
+				if (stage->outputs & MAT_STAGE_OUT_BLOOM)
+				{
+					stage_color[0] *= stage->bloom_scale;
+					stage_color[1] *= stage->bloom_scale;
+					stage_color[2] *= stage->bloom_scale;
+				}
 
 				if (stage_index == 0 && stage_tex == t->gltexture)
 				{


### PR DESCRIPTION
### Motivation

- Ensure bloom behavior is consistent across engine-wide and material-level settings and prevent unintended bloom when global bloom is disabled.
- Allow materials/shader stages to specify a bloom scale so emissive/stage contributions can be amplified for bloom separately from base color.
- Fix post-processing bloom intensity computation so `postfx_bloom_boost` interacts correctly with the configured bloom mode.

### Description

- In `gl_rmain.c` updated `R_CompositeDlightBuffer` to respect a global master bloom control `r_bloom` by gating per-dlight bloom enable and scaling bloom intensity by the master value. 
- In `gl_rmain.c` changed bloom intensity logic in `GL_PostProcess` to compute `bloom_intensity_effective` differently when `r_postfx_bloom_mode` is disabled and to clear boost when no bloom is present.
- In `mat_shader_parse.c` extended the `bloom` material keyword parsing to accept an optional numeric scale, validate and clamp it, set `material.bloom_scale`, and update `material.bloom_enable` accordingly, and ensure `bloom_scale` is zeroed when bloom is explicitly disabled.
- In `r_world.c` applied per-stage bloom scaling by multiplying stage color components by `stage->bloom_scale` when a stage advertises `MAT_STAGE_OUT_BLOOM` to drive bloom extraction correctly.

### Testing

- Built the project with `make` and the build completed without errors. 
- Ran the engine's automated test/run scripts for rendering and material parsing, and the tests completed successfully with no regressions detected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4b57ee678832ea130040838c3d96f)