### PR TITLE
Optimize dlight render collection with top-K selection

### DIFF
--- a/Quake/r_dlight_pool.c
+++ b/Quake/r_dlight_pool.c
@@ -192,6 +192,21 @@ static int DLightPool_CompareScore (const void *a, const void *b)
 	return 0;
 }
 
+static qboolean DLightPool_IsBetterScore (const dlight_t *candidate, const dlight_t *current)
+{
+	if (candidate->last_score > current->last_score)
+		return true;
+	if (candidate->last_score < current->last_score)
+		return false;
+	if (candidate->spawn_time > current->spawn_time)
+		return true;
+	if (candidate->spawn_time < current->spawn_time)
+		return false;
+	if (candidate->id < current->id)
+		return true;
+	return false;
+}
+
 static dlight_t *DLightPool_EvictWorstTransient (double time)
 {
 	int best_index = -1;
@@ -427,9 +442,10 @@ int DLightPool_CollectForRender (double time, const vec3_t vieworg, const mleaf_
 		return 0;
 	}
 
-	DLightPool_EnsureScratch (dlight_pool.capacity);
+	const int selection_max = q_min (out_max, dlight_pool.capacity);
+	DLightPool_EnsureScratch (selection_max);
 
-	int found = 0;
+	int selected = 0;
 	for (int i = 0; i < dlight_pool.capacity; i++)
 	{
 		dlight_t *dl = &dlight_pool.items[i];
@@ -459,13 +475,31 @@ int DLightPool_CollectForRender (double time, const vec3_t vieworg, const mleaf_
 			continue;
 
 		dl->last_score = DLightPool_ScoreLight (dl, time, vieworg);
-		dlight_pool.scratch[found++] = dl;
+
+		if (selected < selection_max)
+		{
+			int insert_at = selected;
+			while (insert_at > 0 && DLightPool_IsBetterScore (dl, dlight_pool.scratch[insert_at - 1]))
+			{
+				dlight_pool.scratch[insert_at] = dlight_pool.scratch[insert_at - 1];
+				insert_at--;
+			}
+			dlight_pool.scratch[insert_at] = dl;
+			selected++;
+		}
+		else if (selected > 0 && DLightPool_IsBetterScore (dl, dlight_pool.scratch[selected - 1]))
+		{
+			int insert_at = selected - 1;
+			while (insert_at > 0 && DLightPool_IsBetterScore (dl, dlight_pool.scratch[insert_at - 1]))
+			{
+				dlight_pool.scratch[insert_at] = dlight_pool.scratch[insert_at - 1];
+				insert_at--;
+			}
+			dlight_pool.scratch[insert_at] = dl;
+		}
 	}
 
-	if (found > 1)
-		qsort (dlight_pool.scratch, found, sizeof (dlight_pool.scratch[0]), DLightPool_CompareScore);
-
-	const int submit_count = q_min (found, out_max);
+	const int submit_count = selected;
 	for (int i = 0; i < submit_count; i++)
 		out[i] = dlight_pool.scratch[i];
 


### PR DESCRIPTION
### Motivation
- Reduce work when selecting dynamic lights for rendering by avoiding a full `qsort` of all candidates and only keeping the top `K` (`K = out_max`) candidates.
- Preserve existing visual ordering and scoring semantics so behavior remains consistent in-game.

### Description
- Replace full-candidate `qsort` path in `DLightPool_CollectForRender` with an incremental top-K insertion-sorted buffer sized to `q_min(out_max, dlight_pool.capacity)`, so only the best `K` lights are tracked and emitted.
- Add `DLightPool_IsBetterScore` helper to centralize the ranking/tie-break comparison using the existing rules (`last_score` desc, then `spawn_time` desc, then `id` asc).
- Adjust scratch buffer sizing via `DLightPool_EnsureScratch(selection_max)` and emit only the `selected` entries instead of sorting all found candidates.
- Preserve all original filtering and stats updates (`expired` increments during filtering, `submitted` assignment, and active/persistent/transient counters via `DLightPool_UpdateStats`).

### Testing
- Attempted an automated build with `make -C Quake -j4`; the build could not complete in this environment due to missing SDL development tooling and headers (`sdl2-config` / `SDL.h`), so compilation could not be fully validated here (build failed).
- No additional automated tests were present or executed for this change in the current environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4bf044e58832e82f76ac0d8a3f493)