### PR TITLE
Handle dlight pool realloc failures safely

### DIFF
--- a/Quake/r_dlight_pool.c
+++ b/Quake/r_dlight_pool.c
@@ -101,22 +101,31 @@ void DLightPool_ClearPersistent (void)
 	}
 }
 
-static void DLightPool_EnsureScratch (int needed)
+static qboolean DLightPool_EnsureScratch (int needed)
 {
 	if (needed <= dlight_pool.scratch_capacity)
-		return;
+		return true;
 
-	dlight_pool.scratch = (dlight_t **)realloc (dlight_pool.scratch, sizeof (dlight_pool.scratch[0]) * needed);
+	dlight_t **new_scratch = (dlight_t **)realloc (dlight_pool.scratch, sizeof (dlight_pool.scratch[0]) * needed);
+	if (!new_scratch)
+	{
+		Con_DPrintf ("DLightPool_EnsureScratch: allocation failed for %d entries (capacity stays %d)\n",
+				needed, dlight_pool.scratch_capacity);
+		return false;
+	}
+
+	dlight_pool.scratch = new_scratch;
 	dlight_pool.scratch_capacity = needed;
+	return true;
 }
 
-static void DLightPool_EnsureCapacity (int desired)
+static qboolean DLightPool_EnsureCapacity (int desired)
 {
 	const int pool_max = DLightPool_GetPoolMax ();
 	if (desired > pool_max)
 		desired = pool_max;
 	if (desired <= dlight_pool.capacity)
-		return;
+		return true;
 
 	int new_capacity = dlight_pool.capacity ? dlight_pool.capacity * 2 : 64;
 	if (new_capacity < desired)
@@ -124,11 +133,20 @@ static void DLightPool_EnsureCapacity (int desired)
 	if (new_capacity > pool_max)
 		new_capacity = pool_max;
 	if (new_capacity <= dlight_pool.capacity)
-		return;
+		return true;
 
-	dlight_pool.items = (dlight_t *)realloc (dlight_pool.items, sizeof (dlight_pool.items[0]) * new_capacity);
+	dlight_t *new_items = (dlight_t *)realloc (dlight_pool.items, sizeof (dlight_pool.items[0]) * new_capacity);
+	if (!new_items)
+	{
+		Con_Warning ("DLightPool_EnsureCapacity: allocation failed for %d lights (capacity stays %d)\n",
+				new_capacity, dlight_pool.capacity);
+		return false;
+	}
+
+	dlight_pool.items = new_items;
 	memset (dlight_pool.items + dlight_pool.capacity, 0, sizeof (dlight_pool.items[0]) * (new_capacity - dlight_pool.capacity));
 	dlight_pool.capacity = new_capacity;
+	return true;
 }
 
 static void DLightPool_ResetLight (dlight_t *dl, dlight_kind_t kind, double time)
@@ -394,12 +412,18 @@ const dlight_t *const *DLightPool_GetActiveList (int *count)
 
 	DLightPool_EnsureScratch (dlight_pool.capacity);
 
+	const int max_scratch = q_min (dlight_pool.capacity, dlight_pool.scratch_capacity);
+	if (!dlight_pool.scratch || max_scratch <= 0)
+		return NULL;
+
 	int found = 0;
 	for (int i = 0; i < dlight_pool.capacity; i++)
 	{
 		dlight_t *dl = &dlight_pool.items[i];
 		if (!CL_DlightIsActive (dl))
 			continue;
+		if (found >= max_scratch)
+			break;
 		dlight_pool.scratch[found++] = dl;
 	}
 
@@ -431,9 +455,20 @@ int DLightPool_CollectForRender (double time, const vec3_t vieworg, const mleaf_
 
 	DLightPool_EnsureScratch (dlight_pool.capacity);
 
+	const int max_scratch = q_min (dlight_pool.capacity, dlight_pool.scratch_capacity);
+	if (!dlight_pool.scratch || max_scratch <= 0)
+	{
+		dlight_pool.stats.submitted = 0;
+		DLightPool_UpdateStats ();
+		return 0;
+	}
+
 	int found = 0;
 	for (int i = 0; i < dlight_pool.capacity; i++)
 	{
+		if (found >= max_scratch)
+			break;
+
 		dlight_t *dl = &dlight_pool.items[i];
 		if (!dl->active)
 			continue;


### PR DESCRIPTION
### Motivation

- Prevent state corruption and potential null-dereferences when `realloc` fails while growing the dlight item pool or scratch list.  
- Ensure the pool keeps its previous pointers and capacity on allocation failure and provide developer-visible diagnostics.

### Description

- Change `DLightPool_EnsureScratch` and `DLightPool_EnsureCapacity` to return `qboolean` and use temporary pointers for `realloc`, preserving existing pointers/capacities when allocation fails and logging via `Con_DPrintf` for scratch and `Con_Warning` for the item pool.  
- Harden `DLightPool_GetActiveList` and `DLightPool_CollectForRender` to compute a `max_scratch` (the minimum of `dlight_pool.capacity` and `dlight_pool.scratch_capacity`), early-return when no scratch storage is available, and clamp writes so code never writes past the current scratch capacity.  
- Keep successful-path behavior unchanged, including zero-initialization of newly allocated `dlight_pool.items` region after a successful resize.

### Testing

- Attempted a CMake configure with `cmake -S . -B build`, which failed in this environment due to a missing SDL2 CMake package (`SDL2Config.cmake` / `sdl2-config.cmake`), so a full build could not be run here (failed).  
- No automated unit tests were executed in this environment; recommend running a full build and runtime smoke tests to validate behavior under low-memory/allocation-failure conditions (not run here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4bf4caa4c832eac4bf7725f1f90c0)