### PR TITLE
Unify dynamic light flicker to submit-time processing

### DIFF
--- a/Quake/client.h
+++ b/Quake/client.h
@@ -373,9 +373,22 @@ static inline qboolean CL_DlightTransientIsLiveAtTime (const dlight_t *dl, doubl
 	return dl->spawn <= time;
 }
 
-static inline qboolean CL_DlightShouldFlicker (const dlight_t *dl)
+/*
+Dynamic light flicker model (single source of truth lives in render submit path):
+  - Radius flicker: explosion, torch, lava.
+  - Color intensity flicker: torch, lava.
+  - Additional torch warm/cool color shift: torch only.
+Keep these helpers in sync with R_PushDlightArray so type-specific tuning stays
+predictable and does not accidentally diverge between pool update and submit.
+*/
+static inline qboolean CL_DlightShouldFlickerRadius (const dlight_t *dl)
 {
 	return dl && (dl->type == DLIGHT_EXPLOSION || dl->type == DLIGHT_TORCH || dl->type == DLIGHT_LAVA);
+}
+
+static inline qboolean CL_DlightShouldFlickerColor (const dlight_t *dl)
+{
+	return dl && (dl->type == DLIGHT_TORCH || dl->type == DLIGHT_LAVA);
 }
 
 extern	entity_t		*cl_entities; //johnfitz -- was a static array, now on hunk

--- a/Quake/gl_rlight.c
+++ b/Quake/gl_rlight.c
@@ -383,7 +383,7 @@ static void R_PushDlightArray (dlight_t *const *lights, int count)
 		if (!CL_DlightIsActive (l))
 			continue;
 
-		if (CL_DlightShouldFlicker (l))
+		if (CL_DlightShouldFlickerRadius (l))
 			radius = l->baseradius * (1.f + 0.1f * (float) sin (cl.time * 9.0 + l->flicker_seed));
 		else
 			radius = l->baseradius;
@@ -411,7 +411,7 @@ static void R_PushDlightArray (dlight_t *const *lights, int count)
 		finalcolor[0] = l->color[0] * (*temp)[0] * radiusFactor;
 		finalcolor[1] = l->color[1] * (*temp)[1] * radiusFactor;
 		finalcolor[2] = l->color[2] * (*temp)[2] * radiusFactor;
-		if (CL_DlightShouldFlicker (l))
+		if (CL_DlightShouldFlickerColor (l))
 		{
 			float flicker = 1.f + (float)sin (cl.time * 15.0 + l->key) * 0.1f;
 			finalcolor[0] *= flicker;

--- a/Quake/r_dlight_pool.c
+++ b/Quake/r_dlight_pool.c
@@ -1,7 +1,6 @@
 #include "quakedef.h"
 #include "r_dlight_pool.h"
 #include <float.h>
-#include <math.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -389,12 +388,12 @@ void DLightPool_Decay (float frametime, double time)
 		if (dl->baseradius < 0.f)
 			dl->baseradius = 0.f;
 
-		if (CL_DlightShouldFlicker (dl))
-			dl->radius = dl->baseradius * (1.0f + 0.1f * (float) sin (time * 9.0 + dl->flicker_seed));
-		else
-			dl->radius = dl->baseradius;
-		if (dl->radius < 0.f)
-			dl->radius = 0.f;
+		/*
+		Keep pool state authoritative for raw light values only.
+		Type-specific flicker is applied in R_PushDlightArray so there is a single
+		submit-time source of truth for radius/color modulation.
+		*/
+		dl->radius = dl->baseradius;
 	}
 }
 
@@ -479,10 +478,10 @@ int DLightPool_CollectForRender (double time, const vec3_t vieworg, const mleaf_
 		return 0;
 	}
 
-	int found = 0;
+	int selected = 0;
 	for (int i = 0; i < dlight_pool.capacity; i++)
 	{
-		if (found >= max_scratch)
+		if (selected >= max_scratch)
 			break;
 
 		dlight_t *dl = &dlight_pool.items[i];


### PR DESCRIPTION
### Motivation

- Avoid duplicated flicker math and make a single source of truth for dynamic light modulation by keeping pool state as raw/decayed values and doing type-specific flicker only at render submit time.
- Make type-specific behavior explicit so future tuning (radius vs color flicker) is predictable and cannot drift between code paths.

### Description

- `Quake/r_dlight_pool.c`: `DLightPool_Decay` now only decays `baseradius` and mirrors it to `radius`, and the previous sinusoidal flicker was removed so the pool holds raw values only; also removed an unused `#include <math.h>`.
- `Quake/gl_rlight.c`: `R_PushDlightArray` now applies submit-time modulation and uses `CL_DlightShouldFlickerRadius` for radius flicker and `CL_DlightShouldFlickerColor` for color intensity flicker, and preserves the torch warm/cool color shift behavior.
- `Quake/client.h`: documented the intended flicker model near the helper APIs and split the old helper into `CL_DlightShouldFlickerRadius` and `CL_DlightShouldFlickerColor` to make radius vs color behavior explicit (radius: explosion/torch/lava; color: torch/lava; torch-only color shift).
- Minor bookkeeping in `DLightPool_CollectForRender` to use `selected` as the local selection counter for readability/consistency.

### Testing

- Ran `make -j4` from the repository root which failed because no top-level Makefile exists in this layout, so no top-level build was executed here.
- Ran `make -j4` in `Quake/` to validate compilation; the build could not complete in this environment due to missing SDL2 toolchain (`sdl2-config` / `SDL.h`), so full compile verification could not be performed locally.
- Static code adjustments were exercised via local searches and commits; no unit tests exist for this subsystem and no automated rendering tests were available in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4c01734e0832ea120d4bec74791f7)