### PR TITLE
Fix bloom parser cursor declaration

### DIFF
--- a/Quake/mat_shader_parse.c
+++ b/Quake/mat_shader_parse.c
@@ -1839,7 +1839,7 @@ static const char *ParseMaterialBlock (const char *data, const char *name, const
 		if (!q_strcasecmp (com_token, "bloom"))
 		{
 			Mat_Shader_MarkKeywordSeen ("bloom", MAT_SHADER_KEYWORD_SCOPE_TOPLEVEL);
-			cursor = Mat_Shader_ParseToken (data, NULL);
+			const char *cursor = Mat_Shader_ParseToken (data, NULL);
 			if (cursor && com_token[0] && Mat_Shader_IsNumericToken (com_token))
 			{
 				float validated_scale = 1.f;


### PR DESCRIPTION
### Motivation

- The MSVC build reported an undeclared identifier and type-mismatch around `cursor` in `ParseMaterialBlock` for the `bloom` keyword, preventing compilation. 
- Declare `cursor` locally to ensure the bloom branch reads the next token safely and avoid cross-scope misuse.

### Description

- Added a local declaration `const char *cursor = Mat_Shader_ParseToken (data, NULL);` in `Quake/mat_shader_parse.c` inside the `bloom` branch of `ParseMaterialBlock`.
- No other logic was changed; the code now uses a properly typed local pointer for token parsing and validation.
- The change was committed to the repository.

### Testing

- Ran `rg -n "\bcursor\b" Quake/mat_shader_parse.c` to inspect usages, which completed successfully.
- Inspected the surrounding code with `sed -n '1800,1875p' Quake/mat_shader_parse.c` and `nl -ba Quake/mat_shader_parse.c | sed -n '1834,1848p'`, both of which succeeded.
- Verified the patch with `git diff -- Quake/mat_shader_parse.c`, performed `git commit`, and `git status --short`, all of which succeeded.
- A Windows/MSVC build was not run in this environment, so platform compilation was not verified here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4c15c6644832eb3fdb394b5f352db)