### PR TITLE
Fix undeclared `godrays_preview` reference in `R_WarpScaleView`

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -4825,7 +4825,7 @@ void R_WarpScaleView (void)
 	fbodest = GL_NeedsPostprocess () ? framebufs.composite.fbo : 0;
 	need_depth_resolve = (fbodest == framebufs.composite.fbo)
 		&& (R_DoFEnabled () || r_ssao.value > 0.f || r_ssao_debug.value > 0.f || r_fogvol.value > 0.f
-			|| godrays_preview);
+			|| (R_GodraysReady () && (r_godrays.value > 0.f || r_godrays_debug.value > 0.f || r_godrays_debug_source.value > 0.f)));
 
 	if (msaa)
 	{


### PR DESCRIPTION
### Motivation
- Resolve a Windows compile error caused by referencing the out-of-scope local `godrays_preview` inside `R_WarpScaleView` in `Quake/gl_rmain.c` by using an equivalent, in-scope condition.

### Description
- Replace the `godrays_preview` reference with an inline check using `R_GodraysReady()` combined with the godrays cvars `r_godrays`, `r_godrays_debug`, and `r_godrays_debug_source` so the `need_depth_resolve` expression remains correct and in-scope in `R_WarpScaleView` in `Quake/gl_rmain.c`.

### Testing
- Applied the patch and committed the change successfully, as verified by the repository status and commit output; the `apply_patch` and `git commit` steps both succeeded. 
- Verified the file diff with `git diff -- Quake/gl_rmain.c` and inspected the changed lines with `nl -ba Quake/gl_rmain.c | sed -n '4818,4836p'`, both of which showed the intended modification. 
- No full project build was executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4db0f9704832eb07a316760d4e559)