### PR TITLE
Delay impact decal instance allocation until projection succeeds

### DIFF
--- a/Quake/r_decals.c
+++ b/Quake/r_decals.c
@@ -488,7 +488,7 @@ void R_SpawnImpactDecal (const char *category, const vec3_t origin, const vec3_t
 	mleaf_t *leaf;
 	vec3_t n;
 	float radius, alpha, rot;
-	int i, inst_idx, first_vert;
+	int i, inst_idx, first_vert, temp_count;
 	decalinst_t *inst;
 
 	if (!r_decals.value || !cl.worldmodel || !category)
@@ -496,10 +496,6 @@ void R_SpawnImpactDecal (const char *category, const vec3_t origin, const vec3_t
 
 	def = R_FindDecalDefByCategory (category);
 	if (!def)
-		return;
-
-	inst_idx = R_DecalAllocInstance (def->priority);
-	if (inst_idx < 0)
 		return;
 
 	VectorCopy (normal, n);
@@ -526,6 +522,7 @@ void R_SpawnImpactDecal (const char *category, const vec3_t origin, const vec3_t
 		if (first_vert + MAX_POLY_VERTS >= MAX_DECAL_VERTS)
 			return;
 	}
+	temp_count = 0;
 
 	for (i = 0; i < leaf->nummarksurfaces; ++i)
 	{
@@ -545,14 +542,18 @@ void R_SpawnImpactDecal (const char *category, const vec3_t origin, const vec3_t
 		if (d > radius + 2.f)
 			continue;
 
-		if (decal_vert_cursor + MAX_POLY_VERTS >= MAX_DECAL_VERTS)
+		if (first_vert + temp_count + MAX_POLY_VERTS >= MAX_DECAL_VERTS)
 			break;
 
-		added = R_ProjectDecalToSurface (surf, origin, rot, radius, alpha, def->color, decal_vert_cursor);
-		decal_vert_cursor += added;
+		added = R_ProjectDecalToSurface (surf, origin, rot, radius, alpha, def->color, first_vert + temp_count);
+		temp_count += added;
 	}
 
-	if (decal_vert_cursor == first_vert)
+	if (temp_count <= 0)
+		return;
+
+	inst_idx = R_DecalAllocInstance (def->priority);
+	if (inst_idx < 0)
 		return;
 
 	inst = &decal_instances[inst_idx];
@@ -564,7 +565,8 @@ void R_SpawnImpactDecal (const char *category, const vec3_t origin, const vec3_t
 	inst->blend = def->blend;
 	inst->texture = def->texture;
 	inst->first_vert = first_vert;
-	inst->num_verts = decal_vert_cursor - first_vert;
+	inst->num_verts = temp_count;
+	decal_vert_cursor = first_vert + temp_count;
 	decal_inst_count++;
 }
 


### PR DESCRIPTION
### Motivation
- Prevent decal instance slots from being evicted or reused when a spawn ultimately produces no geometry. 
- Keep vertex/geometry generation provisional until all validation and projection succeed to avoid side effects on early returns. 
- Ensure that instance state is only committed when there is non-zero decal geometry to display.

### Description
- Postponed calling `R_DecalAllocInstance(def->priority)` until after impact-normal validation, impact-leaf check, vertex-space availability/compaction, vertex projection, and at least one successful surface projection. 
- Introduced a local `temp_count` and used `first_vert + temp_count` for provisional geometry generation instead of mutating `decal_vert_cursor` during projection. 
- Only mark `decal_instances[inst_idx].active = true` and increment `decal_inst_count` after `temp_count > 0` and allocation succeeds, and commit `decal_vert_cursor` at the end. 
- Updated overflow checks to account for `first_vert + temp_count` while iterating surfaces.

### Testing
- Ran `make -C Quake -j4` to validate the change, but the build could not complete because the environment is missing SDL2 tooling/headers (`sdl2-config` / `SDL.h`), so a full compile was not possible. 
- No additional automated tests are present for decals; changes are limited to `Quake/r_decals.c` and compile-time validation was otherwise exercised where possible given environment constraints.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4dc048748832eaad338cb3375ea73)