### PR TITLE
Harden SPR_FACING_UPRIGHT sprite orientation fallback

### DIFF
--- a/Quake/r_sprite.c
+++ b/Quake/r_sprite.c
@@ -210,18 +210,47 @@ static void R_DrawSpriteModel_Real (entity_t *e, qboolean showtris)
 		s_right = v_right;
 		break;
 	case SPR_FACING_UPRIGHT: //faces camera origin, up is towards the heavens
+	{
+		float forward_len2;
+
 		VectorSubtract(e->origin, r_origin, v_forward);
 		v_forward[2] = 0;
-		VectorNormalizeFast(v_forward);
-		v_right[0] = v_forward[1];
-		v_right[1] = -v_forward[0];
-		v_right[2] = 0;
+		forward_len2 = DotProduct(v_forward, v_forward);
+
+		if (forward_len2 > 0.000001f)
+		{
+			VectorNormalizeFast(v_forward);
+			v_right[0] = v_forward[1];
+			v_right[1] = -v_forward[0];
+			v_right[2] = 0;
+		}
+		else
+		{
+			/*
+			 * Degenerate case: sprite origin is on (or extremely close to)
+			 * the camera origin in the XY plane, so the facing direction
+			 * cannot be normalized reliably. Reuse the camera right axis,
+			 * projected to XY, and fall back to a fixed world axis if needed.
+			 */
+			v_right[0] = vright[0];
+			v_right[1] = vright[1];
+			v_right[2] = 0;
+			if (DotProduct(v_right, v_right) <= 0.000001f)
+			{
+				v_right[0] = 1;
+				v_right[1] = 0;
+				v_right[2] = 0;
+			}
+			VectorNormalizeFast(v_right);
+		}
+
 		v_up[0] = 0;
 		v_up[1] = 0;
 		v_up[2] = 1;
 		s_up = v_up;
 		s_right = v_right;
 		break;
+	}
 	case SPR_VP_PARALLEL: //faces view plane, up is towards the top of the screen
 		s_up = vup;
 		s_right = vright;


### PR DESCRIPTION
### Motivation
- Prevent division/normalization of a near-zero XY forward vector when a sprite sits on or very near the camera origin, which can produce NaNs/degenerate orientation.
- Ensure sprite basis vectors remain finite and orthogonal in the degenerate case.
- Document the fallback rationale inline for future maintainers.

### Description
- Compute the squared XY length `forward_len2 = DotProduct(v_forward, v_forward)` before normalizing in the `SPR_FACING_UPRIGHT` branch of `R_DrawSpriteModel_Real`.
- Only call `VectorNormalizeFast(v_forward)` when `forward_len2 > 0.000001f`; otherwise enter a degenerate fallback path.
- In the fallback, reuse the camera `vright` projected into XY and, if that projection is also degenerate, fall back to fixed world X axis `(1,0,0)`, then normalize `v_right`.
- Keep `v_up` as world up `(0,0,1)` and set `s_up`/`s_right` accordingly, and add an in-code comment explaining the degenerate case and rationale.

### Testing
- Ran `git diff --check` on the workspace to validate spacing/whitespace issues and it succeeded (no problems found).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4dd4e9fcc832eba5d456f0da045ba)