### PR TITLE
fogvol: add static lightgrid scattering path

### DIFF
--- a/Quake/r_fogvol.c
+++ b/Quake/r_fogvol.c
@@ -22,6 +22,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "quakedef.h"
 #include "draw.h"
+#include "gl_lightgrid.h"
 #include "r_fogvol.h"
 #include "r_dlight_pool.h"
 #include <math.h>
@@ -53,8 +54,14 @@ typedef struct fog_light_list_gpu_s
 	fog_light_gpu_t lights[32];
 } fog_light_list_gpu_t;
 
+typedef struct fog_lightgrid_gpu_s
+{
+	float probe_rgb[8][4];
+} fog_lightgrid_gpu_t;
+
 COMPILE_TIME_ASSERT (fog_light_gpu_align16, (sizeof (fog_light_gpu_t) % 16) == 0);
 COMPILE_TIME_ASSERT (fog_light_list_gpu_align16, (sizeof (fog_light_list_gpu_t) % 16) == 0);
+COMPILE_TIME_ASSERT (fog_lightgrid_gpu_align16, (sizeof (fog_lightgrid_gpu_t) % 16) == 0);
 
 typedef struct fogvol_light_candidate_s
 {
@@ -128,6 +135,7 @@ cvar_t r_fogvol_globalfog_height = { "r_fogvol_globalfog_height", "0", CVAR_ARCH
 cvar_t r_fogvol_globalfog_height_scale = { "r_fogvol_globalfog_height_scale", "0", CVAR_ARCHIVE };
 cvar_t r_fogvol_globalfog_priority = { "r_fogvol_globalfog_priority", "-1", CVAR_ARCHIVE };
 cvar_t r_fogvol_light = { "r_fogvol_light", "0", CVAR_ARCHIVE };
+cvar_t r_fogvol_lightgrid = { "r_fogvol_lightgrid", "1", CVAR_ARCHIVE };
 cvar_t r_fogvol_light_max = { "r_fogvol_light_max", "16", CVAR_ARCHIVE };
 cvar_t r_fogvol_shadow = { "r_fogvol_shadow", "1", CVAR_ARCHIVE };
 cvar_t r_fogvol_shadow_samples = { "r_fogvol_shadow_samples", "2", CVAR_ARCHIVE };
@@ -839,6 +847,7 @@ void R_FogVol_Init (void)
 	Cvar_RegisterVariable (&r_fogvol_globalfog_height_scale);
 	Cvar_RegisterVariable (&r_fogvol_globalfog_priority);
 	Cvar_RegisterVariable (&r_fogvol_light);
+	Cvar_RegisterVariable (&r_fogvol_lightgrid);
 	Cvar_RegisterVariable (&r_fogvol_light_max);
 	Cvar_RegisterVariable (&r_fogvol_shadow);
 	Cvar_RegisterVariable (&r_fogvol_shadow_samples);
@@ -1425,6 +1434,7 @@ void R_FogVol_Render (void)
 	GLbyte *ofs;
 	fog_volume_gpu_t gpu_volumes[MAX_FOGVOLUMES];
 	fog_light_list_gpu_t fog_lights;
+	fog_lightgrid_gpu_t fog_lightgrid;
 	const int mode = CLAMP (0, (int)Q_rint (r_fogvol_debug.value), 8);
 	float inv_viewproj[16];
 	GLuint src_tex;
@@ -1458,6 +1468,9 @@ void R_FogVol_Render (void)
 	qboolean dumpstate_always;
 	fogvol_restore_state_t restore_state;
 	qboolean fog_light_enabled = false;
+	qboolean fog_lightgrid_enabled = false;
+	qboolean fog_lightgrid_has_data = false;
+	const lightgrid_t *lightgrid = NULL;
 	vec3_t shadow_dir;
 	int shadow_samples;
 
@@ -1516,6 +1529,10 @@ void R_FogVol_Render (void)
 	steps = CLAMP (8, steps, q_max (8, (int)Q_rint (r_fogvol_maxsteps.value)));
 
 	memset (&fog_lights, 0, sizeof (fog_lights));
+	lightgrid = Lightgrid_Get ();
+	fog_lightgrid_has_data = (lightgrid && lightgrid->octree && r_lightgrid.value > 0.f);
+	fog_lightgrid_enabled = fog_lightgrid_has_data && (r_fogvol_lightgrid.value > 0.f);
+
 	if (r_fogvol_light.value > 0.f)
 	{
 		int max_lights = CLAMP (0, (int)Q_rint (r_fogvol_light_max.value), (int)countof (fog_lights.lights));
@@ -1660,6 +1677,7 @@ void R_FogVol_Render (void)
 	GL_Uniform1fFunc (19, CLAMP (0.f, r_fogvol_shadow_strength.value, 4.f));
 	GL_Uniform1fFunc (20, r_fogvol_shadow_jitter.value > 0.f ? 1.f : 0.f);
 	GL_Uniform3fFunc (21, shadow_dir[0], shadow_dir[1], shadow_dir[2]);
+	GL_Uniform1iFunc (22, fog_lightgrid_enabled ? 1 : 0);
 
 	if (use_halfres)
 		glViewport (0, 0, fog_width, fog_height);
@@ -1699,6 +1717,10 @@ void R_FogVol_Render (void)
 		fog_volume_t *v = &r_fogvolumes[i];
 		int x0, y0, x1, y1;
 		GLuint src_fbo;
+		static const vec3_t corner_lut[8] = {
+			{0.f, 0.f, 0.f}, {1.f, 0.f, 0.f}, {0.f, 1.f, 0.f}, {1.f, 1.f, 0.f},
+			{0.f, 0.f, 1.f}, {1.f, 0.f, 1.f}, {0.f, 1.f, 1.f}, {1.f, 1.f, 1.f}
+		};
 
 		if (!v->enabled)
 			continue;
@@ -1777,6 +1799,27 @@ void R_FogVol_Render (void)
 				i, src_tex, depth_tex, dst_tex, src_fbo, dst_fbo, x0, y0, x1 - x0, y1 - y0);
 		R_FogVol_AssertNoFeedbackHazard ("ITER", dst_tex, src_tex);
 		R_FogVol_AssertNoBoundFeedbackHazard ("ITER");
+		memset (&fog_lightgrid, 0, sizeof (fog_lightgrid));
+		if (fog_lightgrid_enabled)
+		{
+			for (int c = 0; c < 8; ++c)
+			{
+				vec3_t probe_pos;
+				const lightgrid_probe_t *probe;
+				probe_pos[0] = v->mins[0] + (v->maxs[0] - v->mins[0]) * corner_lut[c][0];
+				probe_pos[1] = v->mins[1] + (v->maxs[1] - v->mins[1]) * corner_lut[c][1];
+				probe_pos[2] = v->mins[2] + (v->maxs[2] - v->mins[2]) * corner_lut[c][2];
+				probe = R_GetLightgridSample (probe_pos);
+				if (probe)
+				{
+					fog_lightgrid.probe_rgb[c][0] = probe->rgb[0] * probe->ao;
+					fog_lightgrid.probe_rgb[c][1] = probe->rgb[1] * probe->ao;
+					fog_lightgrid.probe_rgb[c][2] = probe->rgb[2] * probe->ao;
+				}
+			}
+		}
+		GL_Upload (GL_UNIFORM_BUFFER, &fog_lightgrid, sizeof (fog_lightgrid), &buf, &ofs);
+		GL_BindBufferRange (GL_UNIFORM_BUFFER, 5, buf, (GLintptr)ofs, sizeof (fog_lightgrid));
 		GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, src_tex);
 		GL_BindNative (GL_TEXTURE1, GL_TEXTURE_2D, depth_tex);
 		GL_SetScissorEnabled (true);

--- a/Quake/r_fogvol.h
+++ b/Quake/r_fogvol.h
@@ -76,6 +76,7 @@ extern cvar_t r_fogvol_globalfog_height;
 extern cvar_t r_fogvol_globalfog_height_scale;
 extern cvar_t r_fogvol_globalfog_priority;
 extern cvar_t r_fogvol_light;
+extern cvar_t r_fogvol_lightgrid;
 extern cvar_t r_fogvol_light_max;
 extern cvar_t r_fogvol_shadow;
 extern cvar_t r_fogvol_shadow_samples;

--- a/Quake/shaders/fogvol.frag
+++ b/Quake/shaders/fogvol.frag
@@ -67,6 +67,11 @@ layout(std140, binding=4) uniform FogLightsUBO
 	FogLight FogLights[MAX_FOGLIGHTS];
 };
 
+layout(std140, binding=5) uniform FogLightgridUBO
+{
+	vec4 FogLightgridProbeRGB[8];
+};
+
 layout(location=0)  uniform int   FogSteps;
 layout(location=1)  uniform int   FogNoiseEnabled;
 layout(location=2)  uniform int   FogDebugMode;
@@ -89,6 +94,7 @@ layout(location=18) uniform int   FogShadowSamples;
 layout(location=19) uniform float FogShadowStrength;
 layout(location=20) uniform float FogShadowJitter;
 layout(location=21) uniform vec3  FogShadowDir;
+layout(location=22) uniform int   FogLightgridEnabled;
 
 layout(location=0) out vec4 FragColor;
 
@@ -339,6 +345,20 @@ bool PointInsideVolume(vec3 p, FogVolume volume)
 	return all(greaterThanEqual(p, volume.mins.xyz)) && all(lessThanEqual(p, volume.maxs.xyz));
 }
 
+vec3 SampleFogLightgrid(vec3 p, FogVolume volume)
+{
+	vec3 size = max(volume.maxs.xyz - volume.mins.xyz, vec3(1e-3));
+	vec3 local = clamp((p - volume.mins.xyz) / size, 0.0, 1.0);
+
+	vec3 c00 = mix(FogLightgridProbeRGB[0].rgb, FogLightgridProbeRGB[1].rgb, local.x);
+	vec3 c10 = mix(FogLightgridProbeRGB[2].rgb, FogLightgridProbeRGB[3].rgb, local.x);
+	vec3 c01 = mix(FogLightgridProbeRGB[4].rgb, FogLightgridProbeRGB[5].rgb, local.x);
+	vec3 c11 = mix(FogLightgridProbeRGB[6].rgb, FogLightgridProbeRGB[7].rgb, local.x);
+	vec3 c0 = mix(c00, c10, local.y);
+	vec3 c1 = mix(c01, c11, local.y);
+	return mix(c0, c1, local.z);
+}
+
 // PERF: lod=0 full quality (near), lod=1 coarse (far). Caller passes based on distance.
 float EvaluateFogSigma(vec3 p, FogVolume volume, float density, float falloff, float noiseScalePre, vec3 flowPre, int lod)
 {
@@ -559,6 +579,7 @@ void main()
 		: 1.0;
 	// PERF: Cache active light count and enabled flag to avoid UBO re-fetch in loop.
 	bool  doLights      = (FogLightEnabled != 0 && FogLightMeta.x > 0);
+	bool  doLightgrid   = (FogLightgridEnabled != 0);
 	int   lightCount    = FogLightMeta.x;
 
 	// FIX #8: Removed stepsTaken / edgeFadeSum / earlyTerminated — they were
@@ -604,6 +625,14 @@ void main()
 
 		// phaseSun is already precomputed per-ray (constant for all steps on same ray).
 		vec3  stepScatter = (1.0 - att) * scatterColor * phaseSun;
+		if (doLightgrid)
+		{
+			// Static/emissive world contribution comes from the baked lightgrid
+			// probe data; explicit fog volume emissive remains handled separately
+			// by FogEmissiveEnabled/volume.extra.z below.
+			vec3 staticScatter = SampleFogLightgrid(p, volume);
+			stepScatter += staticScatter * (1.0 - att);
+		}
 
 		if (doLights)
 		{


### PR DESCRIPTION
### Motivation
- Improve volumetric fog realism by adding a cheap static-scene lighting term sampled from the existing lightgrid so fog receives baked ambient/emissive contribution in addition to local dynamic dlights. 

### Description
- Add a new cvar `r_fogvol_lightgrid` (default `1`) and export/register it so the fog pipeline can be gated by user/config and by available lightgrid data. 
- Gather a lightweight CPU-side probe set per fog volume (8 AABB-corner probes) using `R_GetLightgridSample` and pack the results into a small UBO uploaded per-volume (UBO binding 5). 
- Add a `FogLightgridUBO` and `SampleFogLightgrid()` in `Quake/shaders/fogvol.frag` that trilinearly interpolates the 8 probes and adds that static RGB as an extra scattering term separate from `FogLights` (dynamic dlights remain additive highlights). 
- Wire a shader uniform `FogLightgridEnabled` (location 22) from the renderer so the path is only active when `r_lightgrid` data exists and `r_fogvol_lightgrid` is enabled, and document emissive handling so baked/emissive surfaces are provided via the lightgrid while explicit fog emissive remains on the existing emissive channel. 

### Testing
- Attempted an automated build with `make -j4` from repository root which failed because no Makefile was present at that path. 
- Attempted an automated build with `make -j4` in `Quake/` which exercised dependency generation but the compile failed due to missing SDL2 development tooling/headers (`sdl2-config` / `SDL.h`), so a full compile/test run could not be completed in this environment. 
- Static code inspection and local shader/UBO wiring verification were performed and the modified files were updated: `Quake/r_fogvol.c`, `Quake/r_fogvol.h`, and `Quake/shaders/fogvol.frag`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4e0d1dc94832ea75b5f2898b0be39)