### PR TITLE
Refactor fog volumetric light selection to per-volume indirection

### DIFF
--- a/Quake/r_fogvol.c
+++ b/Quake/r_fogvol.c
@@ -50,9 +50,14 @@ typedef struct fog_light_gpu_s
 
 typedef struct fog_light_list_gpu_s
 {
-	int light_count[4];
-	fog_light_gpu_t lights[32];
+	int offset_count[4];
 } fog_light_list_gpu_t;
+
+typedef struct fog_light_lists_gpu_s
+{
+	fog_light_list_gpu_t volumes[MAX_FOGVOLUMES];
+	fog_light_gpu_t lights[MAX_FOGVOLUMES * 32];
+} fog_light_lists_gpu_t;
 
 typedef struct fog_lightgrid_gpu_s
 {
@@ -61,6 +66,7 @@ typedef struct fog_lightgrid_gpu_s
 
 COMPILE_TIME_ASSERT (fog_light_gpu_align16, (sizeof (fog_light_gpu_t) % 16) == 0);
 COMPILE_TIME_ASSERT (fog_light_list_gpu_align16, (sizeof (fog_light_list_gpu_t) % 16) == 0);
+COMPILE_TIME_ASSERT (fog_light_lists_gpu_align16, (sizeof (fog_light_lists_gpu_t) % 16) == 0);
 COMPILE_TIME_ASSERT (fog_lightgrid_gpu_align16, (sizeof (fog_lightgrid_gpu_t) % 16) == 0);
 
 typedef struct fogvol_light_candidate_s
@@ -729,7 +735,38 @@ static int R_FogVol_CompareLightCandidate (const void *a, const void *b)
 	return 0;
 }
 
-static int R_FogVol_BuildLightList (fog_light_gpu_t *out, int max_count)
+static float R_FogVol_DistanceToVolume (const fog_volume_t *volume, const vec3_t p)
+{
+	if (!volume)
+		return 999999.f;
+
+	if (volume->shape > 0)
+	{
+		vec3_t d;
+		VectorSubtract (p, volume->sphereCenter, d);
+		return q_max (0.f, VectorLength (d) - q_max (0.f, volume->sphereRadius));
+	}
+
+	{
+		float dx = q_max (q_max (volume->mins[0] - p[0], 0.f), p[0] - volume->maxs[0]);
+		float dy = q_max (q_max (volume->mins[1] - p[1], 0.f), p[1] - volume->maxs[1]);
+		float dz = q_max (q_max (volume->mins[2] - p[2], 0.f), p[2] - volume->maxs[2]);
+		return sqrtf (dx * dx + dy * dy + dz * dz);
+	}
+}
+
+static qboolean R_FogVol_LightOverlapsVolume (const fog_volume_t *volume, const vec3_t light_origin, float light_radius)
+{
+	float dist;
+
+	if (!volume || light_radius <= 0.f)
+		return false;
+
+	dist = R_FogVol_DistanceToVolume (volume, light_origin);
+	return dist <= light_radius;
+}
+
+static int R_FogVol_BuildLightListForVolume (const fog_volume_t *volume, fog_light_gpu_t *out, int max_count)
 {
 	const dlight_t *const *active;
 	fogvol_light_candidate_t candidates[256];
@@ -737,7 +774,7 @@ static int R_FogVol_BuildLightList (fog_light_gpu_t *out, int max_count)
 	int candidate_count = 0;
 	int copy_count;
 
-	if (!out || max_count <= 0)
+	if (!volume || !out || max_count <= 0)
 		return 0;
 
 	active = DLightPool_GetActiveList (&active_count);
@@ -747,8 +784,7 @@ static int R_FogVol_BuildLightList (fog_light_gpu_t *out, int max_count)
 	for (int i = 0; i < active_count && candidate_count < countof (candidates); ++i)
 	{
 		const dlight_t *dl = active[i];
-		vec3_t to_light;
-		float dist2;
+		float volume_dist;
 		float intensity;
 		float radius;
 		float score;
@@ -764,20 +800,12 @@ static int R_FogVol_BuildLightList (fog_light_gpu_t *out, int max_count)
 		if (intensity <= 0.f)
 			continue;
 
-		VectorSubtract (dl->origin, r_refdef.vieworg, to_light);
-		dist2 = DotProduct (to_light, to_light);
-		/* BUG FIX (C-03): Original cull was dist2 > (radius + farclip)^2, which
-		 * is far too permissive — it accepted lights across the whole scene.
-		 * Use a tighter range: beyond 2x radius the quadratic attenuation gives
-		 * at most 25% contribution, beyond 3x it's <11%.  Use a 3x radius cull
-		 * so distant unimportant lights are rejected early without scoring. */
-		{
-			float cull_range = radius * 3.f;
-			if (dist2 > cull_range * cull_range)
-				continue;
-		}
+		if (!R_FogVol_LightOverlapsVolume (volume, dl->origin, radius))
+			continue;
 
-		score = (intensity * radius) / (dist2 + 1.f);
+		volume_dist = R_FogVol_DistanceToVolume (volume, dl->origin);
+
+		score = (intensity * radius) / (volume_dist * volume_dist + 1.f);
 		if (score <= 0.f)
 			continue;
 
@@ -1433,7 +1461,7 @@ void R_FogVol_Render (void)
 	GLuint buf;
 	GLbyte *ofs;
 	fog_volume_gpu_t gpu_volumes[MAX_FOGVOLUMES];
-	fog_light_list_gpu_t fog_lights;
+	fog_light_lists_gpu_t fog_lights;
 	fog_lightgrid_gpu_t fog_lightgrid;
 	const int mode = CLAMP (0, (int)Q_rint (r_fogvol_debug.value), 8);
 	float inv_viewproj[16];
@@ -1535,10 +1563,24 @@ void R_FogVol_Render (void)
 
 	if (r_fogvol_light.value > 0.f)
 	{
-		int max_lights = CLAMP (0, (int)Q_rint (r_fogvol_light_max.value), (int)countof (fog_lights.lights));
-		int light_count = R_FogVol_BuildLightList (fog_lights.lights, max_lights);
-		fog_lights.light_count[0] = light_count;
-		fog_light_enabled = (light_count > 0);
+		int max_lights = CLAMP (0, (int)Q_rint (r_fogvol_light_max.value), 32);
+		int write_offset = 0;
+
+		for (int i = 0; i < r_fogvolume_count; ++i)
+		{
+			int remaining = (int)countof (fog_lights.lights) - write_offset;
+			int count = 0;
+			if (remaining > 0 && max_lights > 0)
+			{
+				int per_volume_cap = q_min (max_lights, remaining);
+				count = R_FogVol_BuildLightListForVolume (&r_fogvolumes[i], &fog_lights.lights[write_offset], per_volume_cap);
+			}
+
+			fog_lights.volumes[i].offset_count[0] = write_offset;
+			fog_lights.volumes[i].offset_count[1] = count;
+			write_offset += count;
+			fog_light_enabled = fog_light_enabled || (count > 0);
+		}
 	}
 
 	for (int i = 0; i < r_fogvolume_count; ++i)
@@ -1612,7 +1654,7 @@ void R_FogVol_Render (void)
 	if (glGetError () != GL_NO_ERROR)
 	{
 		fog_light_enabled = false;
-		fog_lights.light_count[0] = 0;
+		memset (&fog_lights, 0, sizeof (fog_lights));
 		GL_Upload (GL_UNIFORM_BUFFER, &fog_lights, sizeof (fog_lights), &buf, &ofs);
 		GL_BindBufferRange (GL_UNIFORM_BUFFER, 4, buf, (GLintptr)ofs, sizeof (fog_lights));
 	}

--- a/Quake/shaders/fogvol.frag
+++ b/Quake/shaders/fogvol.frag
@@ -61,10 +61,15 @@ struct FogLight
 	vec4 col_int;
 };
 
+struct FogLightList
+{
+	ivec4 offset_count; // x = global light offset, y = per-volume light count
+};
+
 layout(std140, binding=4) uniform FogLightsUBO
 {
-	ivec4 FogLightMeta; // x = light count
-	FogLight FogLights[MAX_FOGLIGHTS];
+	FogLightList FogLightLists[MAX_FOGVOLUMES];
+	FogLight FogLights[MAX_FOGVOLUMES * MAX_FOGLIGHTS];
 };
 
 layout(std140, binding=5) uniform FogLightgridUBO
@@ -578,9 +583,11 @@ void main()
 		? AnisotropicPhase(clamp(dot(viewDir, sunDir), -1.0, 1.0), ANISO_G_SUN)
 		: 1.0;
 	// PERF: Cache active light count and enabled flag to avoid UBO re-fetch in loop.
-	bool  doLights      = (FogLightEnabled != 0 && FogLightMeta.x > 0);
+	FogLightList lightList = FogLightLists[clamp(FogVolumeIndex, 0, MAX_FOGVOLUMES - 1)];
+	int lightOffset     = max(lightList.offset_count.x, 0);
+	int lightCount      = clamp(lightList.offset_count.y, 0, MAX_FOGLIGHTS);
+	bool  doLights      = (FogLightEnabled != 0 && lightCount > 0);
 	bool  doLightgrid   = (FogLightgridEnabled != 0);
-	int   lightCount    = FogLightMeta.x;
 
 	// FIX #8: Removed stepsTaken / edgeFadeSum / earlyTerminated — they were
 	// accumulated but never consumed, silently wasting ALU every iteration.
@@ -644,15 +651,17 @@ void main()
 			for (int l = 0; l < MAX_FOGLIGHTS; ++l)
 			{
 				if (l >= lightCount) break;
-				vec3 lightVec = FogLights[l].pos_rad.xyz - p;
+				int lightIndex = lightOffset + l;
+				if (lightIndex >= MAX_FOGVOLUMES * MAX_FOGLIGHTS) break;
+				vec3 lightVec = FogLights[lightIndex].pos_rad.xyz - p;
 				float lightDist = length(lightVec);
-				float radius = max(FogLights[l].pos_rad.w, 1e-3);
+				float radius = max(FogLights[lightIndex].pos_rad.w, 1e-3);
 				float atten = clamp(1.0 - lightDist / radius, 0.0, 1.0);
 				atten *= atten; // quadratic falloff
 				if (atten < 1e-5) continue; // PERF: Skip lights with negligible contribution
 				vec3 lightDir = (lightDist > 1e-5) ? (lightVec / lightDist) : vec3(0.0);
 				float phaseLocal = AnisotropicPhase(clamp(dot(viewDir, lightDir), -1.0, 1.0), ANISO_G_LOCAL);
-				lightScatter += FogLights[l].col_int.rgb * (atten * 0.25 * phaseLocal);
+				lightScatter += FogLights[lightIndex].col_int.rgb * (atten * 0.25 * phaseLocal);
 			}
 			stepScatter += lightScatter * (1.0 - att);
 		}


### PR DESCRIPTION
### Motivation
- Prevent unrelated dynamic lights from affecting every fog volume and causing color bleed by selecting lights per-volume instead of building one global list. 
- Limit per-volume work using the existing `r_fogvol_light_max` cap so cost is controllable. 
- Keep GPU layout binding stable while introducing indirection so shaders can iterate only the lights assigned to the current volume.

### Description
- Replace the flat fog-light UBO layout with per-volume metadata plus a packed global light array by introducing `fog_light_lists_gpu_t` (per-volume `offset_count` + packed `lights`) and keep UBO binding `4` unchanged. 
- Add CPU helpers `R_FogVol_DistanceToVolume` and `R_FogVol_LightOverlapsVolume` and implement `R_FogVol_BuildLightListForVolume` which computes per-volume candidate sets using overlap and distance scoring. 
- Update `R_FogVol_Render` to build per-volume light ranges (store `offset`/`count` per volume), write a packed lights array, and enforce `r_fogvol_light_max` as a per-volume cap. 
- Update `Quake/shaders/fogvol.frag` to read the per-volume `offset/count` (`FogLightLists[ FogVolumeIndex ]`) and iterate only that slice of `FogLights`, with an added bounds guard on the computed global light index. 

### Testing
- Attempted an automated build with `cmake -S . -B build && cmake --build build -j2`, which failed during configuration due to a missing system dependency (`SDL2`) in this environment. 
- Performed repository checks: `git status` and the changes were committed successfully as `Refactor fog volume lights to per-volume lists`. 
- No runtime/graphics validation (e.g. the two-color fog volume test) could be executed in this CI-like environment due to missing GPU/windowing dependencies and the failed local build step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5471481f8832eb064d03bc09c332e)