### PR TITLE
Define particle shader MVP contract with strict/tolerant stage policy

### DIFF
--- a/Quake/gl_shaders.c
+++ b/Quake/gl_shaders.c
@@ -36,8 +36,8 @@ Particle material MVP contract (quad/beam path):
   and tcMod {scroll,scale,rotate,turb,stretch}.
 - Deferred (non-MVP): alphaFunc, tcGen environment/lightmap, q3 sky/fog/deform,
   and advanced stage directives outside the list above.
-- Degradation strategy: any unsupported stage falls back to safe default particle
-  rendering; when r_particles_shader_strict=1, emit debug diagnostics for the skip.
+- Degradation strategy: unsupported particle stages are classified via material shader
+  policy (tolerant: skip/fallback, strict: hard-fail for non-MVP directives).
 */
 
 typedef struct shader_cache_s

--- a/Quake/mat_shader.c
+++ b/Quake/mat_shader.c
@@ -1080,9 +1080,11 @@ static void Mat_Shader_FuzzCommand_f (void)
 }
 
 
-qboolean Mat_Shader_StageSupportsParticleMVP (const mat_shader_stage_t *stage, char *reason, size_t reason_size)
+mat_particle_stage_support_t Mat_Shader_ClassifyParticleStage (const mat_shader_stage_t *stage,
+	mat_particle_policy_t policy, char *reason, size_t reason_size)
 {
 	int i;
+	qboolean strict = (policy == MAT_PARTICLE_POLICY_STRICT);
 
 	if (reason && reason_size)
 		reason[0] = '\0';
@@ -1091,14 +1093,14 @@ qboolean Mat_Shader_StageSupportsParticleMVP (const mat_shader_stage_t *stage, c
 	{
 		if (reason && reason_size)
 			q_strlcpy (reason, "missing stage", reason_size);
-		return false;
+		return MAT_PARTICLE_STAGE_HARD_FAIL;
 	}
 
 	if (stage->map_type == MAT_MAP_LIGHTMAP)
 	{
 		if (reason && reason_size)
 			q_strlcpy (reason, "map $lightmap unsupported for particles", reason_size);
-		return false;
+		return strict ? MAT_PARTICLE_STAGE_HARD_FAIL : MAT_PARTICLE_STAGE_SKIPPED;
 	}
 
 	if (stage->map_type != MAT_MAP_MAP && stage->map_type != MAT_MAP_CLAMPMAP &&
@@ -1106,7 +1108,7 @@ qboolean Mat_Shader_StageSupportsParticleMVP (const mat_shader_stage_t *stage, c
 	{
 		if (reason && reason_size)
 			q_strlcpy (reason, "unsupported map type", reason_size);
-		return false;
+		return strict ? MAT_PARTICLE_STAGE_HARD_FAIL : MAT_PARTICLE_STAGE_SKIPPED;
 	}
 
 	if (stage->rgbgen != MAT_RGBGEN_IDENTITY && stage->rgbgen != MAT_RGBGEN_VERTEX &&
@@ -1114,7 +1116,7 @@ qboolean Mat_Shader_StageSupportsParticleMVP (const mat_shader_stage_t *stage, c
 	{
 		if (reason && reason_size)
 			q_strlcpy (reason, "unsupported rgbGen", reason_size);
-		return false;
+		return strict ? MAT_PARTICLE_STAGE_HARD_FAIL : MAT_PARTICLE_STAGE_SKIPPED;
 	}
 
 	if (stage->alphagen != MAT_ALPHAGEN_IDENTITY && stage->alphagen != MAT_ALPHAGEN_VERTEX &&
@@ -1122,21 +1124,21 @@ qboolean Mat_Shader_StageSupportsParticleMVP (const mat_shader_stage_t *stage, c
 	{
 		if (reason && reason_size)
 			q_strlcpy (reason, "unsupported alphaGen", reason_size);
-		return false;
+		return strict ? MAT_PARTICLE_STAGE_HARD_FAIL : MAT_PARTICLE_STAGE_SKIPPED;
 	}
 
 	if (stage->tcgen != MAT_TCGEN_BASE)
 	{
 		if (reason && reason_size)
 			q_strlcpy (reason, "tcGen must be base", reason_size);
-		return false;
+		return strict ? MAT_PARTICLE_STAGE_HARD_FAIL : MAT_PARTICLE_STAGE_SKIPPED;
 	}
 
 	if (stage->tcmod_count > countof (stage->tcmods))
 	{
 		if (reason && reason_size)
 			q_strlcpy (reason, "tcMod count overflow", reason_size);
-		return false;
+		return MAT_PARTICLE_STAGE_HARD_FAIL;
 	}
 
 	for (i = 0; i < stage->tcmod_count; ++i)
@@ -1147,7 +1149,7 @@ qboolean Mat_Shader_StageSupportsParticleMVP (const mat_shader_stage_t *stage, c
 		{
 			if (reason && reason_size)
 				q_strlcpy (reason, "unsupported tcMod type", reason_size);
-			return false;
+			return strict ? MAT_PARTICLE_STAGE_HARD_FAIL : MAT_PARTICLE_STAGE_SKIPPED;
 		}
 	}
 
@@ -1157,11 +1159,20 @@ qboolean Mat_Shader_StageSupportsParticleMVP (const mat_shader_stage_t *stage, c
 		{
 			if (reason && reason_size)
 				q_strlcpy (reason, "invalid custom blend factors", reason_size);
-			return false;
+			return MAT_PARTICLE_STAGE_HARD_FAIL;
 		}
 	}
 
-	return true;
+	return MAT_PARTICLE_STAGE_SUPPORTED;
+}
+
+qboolean Mat_Shader_StageSupportsParticleMVP (const mat_shader_stage_t *stage, char *reason, size_t reason_size)
+{
+	mat_particle_policy_t policy = r_particles_shader_strict.value > 0.f
+		? MAT_PARTICLE_POLICY_STRICT
+		: MAT_PARTICLE_POLICY_TOLERANT;
+
+	return Mat_Shader_ClassifyParticleStage (stage, policy, reason, reason_size) == MAT_PARTICLE_STAGE_SUPPORTED;
 }
 
 void Mat_Shader_Init (void)

--- a/Quake/mat_shader.h
+++ b/Quake/mat_shader.h
@@ -159,6 +159,19 @@ typedef struct mat_tcmod_s
 	float args[4];
 } mat_tcmod_t;
 
+typedef enum
+{
+	MAT_PARTICLE_STAGE_SUPPORTED = 0,
+	MAT_PARTICLE_STAGE_SKIPPED,
+	MAT_PARTICLE_STAGE_HARD_FAIL
+} mat_particle_stage_support_t;
+
+typedef enum
+{
+	MAT_PARTICLE_POLICY_TOLERANT = 0,
+	MAT_PARTICLE_POLICY_STRICT
+} mat_particle_policy_t;
+
 typedef struct mat_texmatrix_s
 {
 	float m[3][3];
@@ -298,5 +311,7 @@ void Mat_Shader_Remove (const shader_material_t *material);
 void Mat_Shader_MarkKeywordSeen (const char *keyword, mat_shader_keyword_scope_t scope);
 void Mat_Shader_ReportUnknownToken (const char *token, mat_shader_keyword_scope_t scope, const char *context, const char *source_file, unsigned int line);
 qboolean Mat_Shader_StageSupportsParticleMVP (const mat_shader_stage_t *stage, char *reason, size_t reason_size);
+mat_particle_stage_support_t Mat_Shader_ClassifyParticleStage (const mat_shader_stage_t *stage,
+	mat_particle_policy_t policy, char *reason, size_t reason_size);
 
 #endif // MAT_SHADER_H

--- a/docs/particle_shader_contract.md
+++ b/docs/particle_shader_contract.md
@@ -1,0 +1,119 @@
+# Particle Shader Contract (MVP)
+
+Diese Spezifikation beschreibt den **MVP-Partikel-Shader-Vertrag** auf Basis von `mat_shader.h/.c`.
+
+## 1) Vertragsumfang pro Stage
+
+Eine Stage ist für den Partikelpfad klassifiziert als:
+
+- `MAT_PARTICLE_STAGE_SUPPORTED`
+- `MAT_PARTICLE_STAGE_SKIPPED`
+- `MAT_PARTICLE_STAGE_HARD_FAIL`
+
+Die Bewertung erfolgt mit `Mat_Shader_ClassifyParticleStage(stage, policy, reason, reason_size)`.
+
+### Erlaubte `map`-Typen
+
+- `map <path>` (`MAT_MAP_MAP`)
+- `clampmap <path>` (`MAT_MAP_CLAMPMAP`)
+- `map $whiteimage` (`MAT_MAP_WHITE`)
+- `map $blackimage` (`MAT_MAP_BLACK`)
+
+Nicht erlaubt im Partikel-MVP:
+
+- `map $lightmap` (`MAT_MAP_LIGHTMAP`)
+
+### Erlaubte `rgbGen`/`alphaGen`
+
+- `identity`
+- `vertex`
+- `const`
+- `wave`
+
+### Erlaubte `tcMod`
+
+- `scroll`
+- `scale`
+- `rotate`
+- `turb`
+- `stretch`
+
+Zusätzlich gilt:
+
+- `tcGen` muss `base` sein.
+- Mehr als `countof(stage->tcmods)` ist ein Hard-Fail (inkonsistente Stage-Daten).
+
+### Erlaubte Blend-Modi
+
+- `replace`
+- `alpha` (`blend`)
+- `add`
+- `mult` (`filter`)
+- `premult`
+- `custom` nur mit gültigen `blend_src`/`blend_dst` Faktoren.
+
+## 2) MVP-Subset (Quad/Sprite)
+
+Der MVP umfasst die Features, die direkt im Partikel-Rendering sinnvoll sind:
+
+- Quad/Sprite-Stage mit einer unterstützten `map`/`clampmap`.
+- `animMap` (FPS + Frame-Liste).
+- UV-Modulation über `tcMod`: `scroll`, `scale`, `rotate`, `turb`, `stretch`.
+- Farb-/Alpha-Modulation über `rgbGen`/`alphaGen`: `identity`, `vertex`, `const`, `wave`.
+- Blending über die oben definierten Modi.
+
+Bewusst außerhalb des MVP (deferred):
+
+- `alphaFunc`
+- `tcGen environment/lightmap`
+- nicht unterstützte `tcMod`-Typen
+- sonstige Stage-Direktiven außerhalb der obigen Liste
+
+## 3) Policy: tolerant vs. strict
+
+`r_particles_shader_strict` steuert das Verhalten für **nicht unterstützte, aber syntaktisch valide** Stage-Features:
+
+- `r_particles_shader_strict 0` (tolerant):
+  - Ergebnis: `MAT_PARTICLE_STAGE_SKIPPED`
+  - Fallback: Stage wird verworfen, Renderer nutzt sichere Standard-Partikelpfade.
+- `r_particles_shader_strict 1` (strict):
+  - Ergebnis: `MAT_PARTICLE_STAGE_HARD_FAIL`
+  - Fallback: Shader-/Stage-Kandidat gilt als nicht nutzbar für den Partikelpfad.
+
+Unabhängig von strict/tolerant bleiben **inkonsistente Daten** Hard-Fail:
+
+- fehlende Stage (`NULL`)
+- `tcMod` overflow
+- `blendFunc` custom mit ungültigen Faktoren
+
+## 4) Akzeptanzkriterien und Tests
+
+Für jede Stage muss eindeutig klassifiziert sein:
+
+- supported
+- skipped
+- hard-fail
+
+### Testmatrix (Soll-Verhalten)
+
+1. `map textures/particles/smoke` + `rgbGen vertex` + `alphaGen wave` + `tcMod scroll` → **supported**
+2. `map $whiteimage` + `blendFunc add` → **supported**
+3. `map $lightmap`:
+   - tolerant → **skipped**
+   - strict → **hard-fail**
+4. `tcGen environment`:
+   - tolerant → **skipped**
+   - strict → **hard-fail**
+5. `tcMod transform` (nicht MVP):
+   - tolerant → **skipped**
+   - strict → **hard-fail**
+6. `blendFunc GL_ONE ???` mit ungültigem Faktor-Parsing → **hard-fail**
+7. `stage == NULL` → **hard-fail**
+8. `tcmod_count > countof(tcmods)` → **hard-fail**
+
+### Dokumentierter Fallback
+
+Wenn eine Stage nicht unterstützt wird, ist der Fallback deterministisch:
+
+- tolerant: Stage skippen und auf sichere Partikel-Defaults degradieren.
+- strict: Stage als Hard-Fail markieren und nicht als MVP-kompatibel akzeptieren.


### PR DESCRIPTION
### Motivation
- Formalize and centralize the Particles MVP contract so the engine can deterministically decide per-stage whether a shader stage is usable for particle rendering. 
- Allow a configurable strict vs tolerant policy so unsupported but syntactically valid stage features either cause a hard reject or a safe fallback.

### Description
- Added enums `mat_particle_stage_support_t` and `mat_particle_policy_t` and a new API `Mat_Shader_ClassifyParticleStage(...)` to `Quake/mat_shader.h` to represent supported/skipped/hard-fail and policy selection. 
- Implemented `Mat_Shader_ClassifyParticleStage(...)` in `Quake/mat_shader.c` with the particle-MVP checks (allowed `map` types, allowed `rgbGen`/`alphaGen`, `tcGen` == base, `tcMod` whitelist and count, and blend custom-factor validation) and strict/tolerant branching. 
- Updated `Mat_Shader_StageSupportsParticleMVP(...)` to delegate to the classifier and map `r_particles_shader_strict` to the new policy enum. 
- Updated the particle-contract comment in `Quake/gl_shaders.c` to document the new policy semantics (tolerant = skip/fallback, strict = hard-fail). 
- Added `docs/particle_shader_contract.md` documenting allowed features, the MVP subset (sprite/quad + `animMap`, `scroll`/`scale`/`rotate`/`turb`/`stretch`, blend modes, `rgbGen`/`alphaGen`), strict vs tolerant policy, acceptance criteria and a test matrix.

### Testing
- Ran repository text searches (`rg`) to verify symbol presence and references after changes, and confirmed the new symbols and docs are present.
- Attempted an automated build with `make -C Quake -j2`, which failed in this environment due to missing system dependencies (`sdl2-config` / `SDL.h`) and not because of the changes.  No unit tests were available in-tree for the new classifier; behaviour covered by the added spec and will be exercised at runtime when SDL development headers are present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a57c59caac832e80dda3c9168a6629)