### PR TITLE
Add initial q3p particle module and runtime particle mode cvars

### DIFF
--- a/Quake/r_part.c
+++ b/Quake/r_part.c
@@ -22,6 +22,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 */
 
 #include "quakedef.h"
+#include "r_part_q3p.h"
 
 #define MAX_PARTICLES			16384	// default max # of particles at one
 										//  time
@@ -39,6 +40,85 @@ static float uvscale;
 static float texturescalefactor; //johnfitz -- compensate for apparent size of different particle textures
 
 cvar_t	r_particles = {"r_particles","2", CVAR_ARCHIVE}; //johnfitz
+cvar_t	r_particles_mode = {"r_particles_mode", "glquake", CVAR_ARCHIVE};
+cvar_t	r_particles_max = {"r_particles_max", "8192", CVAR_ARCHIVE};
+
+typedef enum
+{
+	PARTICLEMODE_CLASSIC,
+	PARTICLEMODE_GLQUAKE,
+	PARTICLEMODE_Q3P,
+	PARTICLEMODE_HYBRID
+} particlemode_t;
+
+static particlemode_t R_GetParticleMode (void)
+{
+	if (!q_strcasecmp (r_particles_mode.string, "classic"))
+		return PARTICLEMODE_CLASSIC;
+	if (!q_strcasecmp (r_particles_mode.string, "q3p"))
+		return PARTICLEMODE_Q3P;
+	if (!q_strcasecmp (r_particles_mode.string, "hybrid"))
+		return PARTICLEMODE_HYBRID;
+	return PARTICLEMODE_GLQUAKE;
+}
+
+static void R_ParticlesMode_Changed_f (cvar_t *var)
+{
+	if (q_strcasecmp (var->string, "classic")
+		&& q_strcasecmp (var->string, "glquake")
+		&& q_strcasecmp (var->string, "q3p")
+		&& q_strcasecmp (var->string, "hybrid"))
+	{
+		Con_Printf ("Unknown r_particles_mode '%s', reverting to glquake\n", var->string);
+		Cvar_SetQuick (var, "glquake");
+	}
+}
+
+static void R_Q3P_TestSpawn_f (void)
+{
+	int i;
+	int count = 64;
+	entity_t *viewent;
+	vec3_t right, up;
+
+	if (Cmd_Argc () > 1)
+		count = q_max (1, Q_atoi (Cmd_Argv (1)));
+
+	viewent = &cl_entities[cl.viewentity];
+	AngleVectors (cl.viewangles, NULL, right, up);
+
+	for (i = 0; i < count; ++i)
+	{
+		q3p_particle_t particle;
+		float jitter;
+
+		memset (&particle, 0, sizeof(particle));
+		particle.spawn_time = cl.time;
+		particle.lifetime = 1.0f + (rand() & 127) / 255.0f;
+		particle.size = 1.0f;
+		particle.size_ramp = 24.0f;
+		particle.alpha = 1.0f;
+		particle.alpha_ramp = -0.8f;
+		particle.color = 0x6f;
+		particle.gravity = 300.0f;
+		particle.drag = 0.5f;
+		q_strlcpy (particle.material, "*particle", sizeof(particle.material));
+
+		VectorCopy (viewent->origin, particle.org);
+		particle.org[2] += 20.0f;
+
+		jitter = ((rand() % 100) - 50) * 0.5f;
+		VectorScale (right, jitter, particle.vel);
+		jitter = ((rand() % 100) - 50) * 0.5f;
+		VectorMA (particle.vel, jitter, up, particle.vel);
+		particle.vel[2] += 120.0f + (rand() % 120);
+
+		if (!Q3P_Spawn (&particle))
+			break;
+	}
+
+	Con_Printf ("q3p_spawned %d particles (%d active)\n", i, Q3P_ActiveCount ());
+}
 
 typedef struct particlevert_t {
 	vec3_t		pos;
@@ -113,6 +193,13 @@ void R_InitParticles (void)
 	Cvar_RegisterVariable (&r_particles); //johnfitz
 	Cvar_SetCallback (&r_particles, R_SetParticleTexture_f);
 	R_SetParticleTexture_f (&r_particles); // set default
+	Cvar_RegisterVariable (&r_particles_mode);
+	Cvar_SetCallback (&r_particles_mode, R_ParticlesMode_Changed_f);
+	R_ParticlesMode_Changed_f (&r_particles_mode);
+	Cvar_RegisterVariable (&r_particles_max);
+
+	Q3P_Init ();
+	Cmd_AddCommand ("q3p_spawn", R_Q3P_TestSpawn_f);
 }
 
 /*
@@ -184,6 +271,7 @@ R_ClearParticles
 void R_ClearParticles (void)
 {
 	r_numactiveparticles = 0;
+	Q3P_Clear ();
 }
 
 /*
@@ -571,6 +659,13 @@ void CL_RunParticles (void)
 	extern	cvar_t	sv_gravity;
 
 	frametime = cl.time - cl.oldtime;
+
+	if (R_GetParticleMode () != PARTICLEMODE_CLASSIC && R_GetParticleMode () != PARTICLEMODE_GLQUAKE)
+		Q3P_Update (frametime);
+
+	if (R_GetParticleMode () == PARTICLEMODE_Q3P)
+		return;
+
 	time3 = frametime * 15;
 	time2 = frametime * 10;
 	time1 = frametime * 5;
@@ -686,6 +781,12 @@ static void R_DrawParticles_Real (qboolean alpha, qboolean showtris)
 	qboolean		dither, oit;
 	int				i;
 
+	if (R_GetParticleMode () != PARTICLEMODE_CLASSIC && R_GetParticleMode () != PARTICLEMODE_GLQUAKE)
+		Q3P_Draw (alpha, showtris);
+
+	if (R_GetParticleMode () == PARTICLEMODE_Q3P)
+		return;
+
 	if (!r_particles.value)
 		return;
 
@@ -759,4 +860,3 @@ void R_DrawParticles_ShowTris (void)
 {
 	R_DrawParticles_Real (false, true);
 }
-

--- a/Quake/r_part_q3p.c
+++ b/Quake/r_part_q3p.c
@@ -1,0 +1,89 @@
+#include "quakedef.h"
+#include "r_part_q3p.h"
+
+extern cvar_t r_particles_max;
+
+static q3p_particle_t *q3p_particles;
+static int q3p_maxparticles;
+static int q3p_numactive;
+
+void Q3P_Init (void)
+{
+	if (q3p_particles)
+		return;
+
+	q3p_maxparticles = q_max ((int)r_particles_max.value, 0);
+	if (q3p_maxparticles <= 0)
+		q3p_maxparticles = 1;
+
+	q3p_particles = (q3p_particle_t *)Hunk_AllocName (q3p_maxparticles * sizeof(*q3p_particles), "q3particles");
+	q3p_numactive = 0;
+}
+
+void Q3P_Shutdown (void)
+{
+	q3p_particles = NULL;
+	q3p_maxparticles = 0;
+	q3p_numactive = 0;
+}
+
+void Q3P_Clear (void)
+{
+	q3p_numactive = 0;
+}
+
+qboolean Q3P_Spawn (const q3p_particle_t *particle)
+{
+	if (!particle)
+		return false;
+	if (!q3p_particles)
+		Q3P_Init ();
+	if (q3p_numactive >= q3p_maxparticles)
+		return false;
+
+	q3p_particles[q3p_numactive++] = *particle;
+	return true;
+}
+
+void Q3P_Update (float frametime)
+{
+	int i, active;
+	q3p_particle_t *p;
+
+	if (!q3p_particles || q3p_numactive <= 0)
+		return;
+
+	for (i = active = 0, p = q3p_particles; i < q3p_numactive; ++i, ++p)
+	{
+		float age = cl.time - p->spawn_time;
+
+		if (age < 0 || age >= p->lifetime)
+			continue;
+
+		p->size += p->size_ramp * frametime;
+		p->alpha += p->alpha_ramp * frametime;
+		p->alpha = CLAMP (0, p->alpha, 1);
+
+		VectorMA (p->org, frametime, p->vel, p->org);
+		p->vel[2] -= p->gravity * frametime;
+		VectorScale (p->vel, q_max (0.f, 1.f - p->drag * frametime), p->vel);
+
+		if (i != active)
+			q3p_particles[active] = *p;
+		++active;
+	}
+
+	q3p_numactive = active;
+}
+
+void Q3P_Draw (qboolean alpha, qboolean showtris)
+{
+	(void)alpha;
+	(void)showtris;
+	/* Placeholder for future renderer integration. */
+}
+
+int Q3P_ActiveCount (void)
+{
+	return q3p_numactive;
+}

--- a/Quake/r_part_q3p.h
+++ b/Quake/r_part_q3p.h
@@ -1,0 +1,38 @@
+#ifndef R_PART_Q3P_H
+#define R_PART_Q3P_H
+
+#include "quakedef.h"
+
+typedef struct q3p_particle_s {
+	float	spawn_time;
+	float	lifetime;
+	float	size;
+	float	size_ramp;
+	float	alpha;
+	float	alpha_ramp;
+	int		color;
+	vec3_t	org;
+	vec3_t	vel;
+	float	gravity;
+	float	drag;
+	int		flags;
+	char	material[64];
+} q3p_particle_t;
+
+typedef struct q3p_emitter_s {
+	float	rate;
+	int		burst;
+	qboolean triggered;
+	int		entity_num;
+	qboolean local_space;
+} q3p_emitter_t;
+
+void Q3P_Init (void);
+void Q3P_Shutdown (void);
+void Q3P_Clear (void);
+qboolean Q3P_Spawn (const q3p_particle_t *particle);
+void Q3P_Update (float frametime);
+void Q3P_Draw (qboolean alpha, qboolean showtris);
+int Q3P_ActiveCount (void);
+
+#endif


### PR DESCRIPTION
### Motivation

- Introduce a minimal Quake III-style particle subsystem (q3p) and runtime switching so the engine can host a new particle backend without touching gameplay parsing yet.
- Provide a developer-facing spawn API for iterative testing and enable a budgeted q3p pool controlled by a CVar.

### Description

- Added new module files `Quake/r_part_q3p.h` and `Quake/r_part_q3p.c` defining `q3p_particle_t`, `q3p_emitter_t` and the minimal API: `Q3P_Init`, `Q3P_Shutdown`, `Q3P_Clear`, `Q3P_Spawn`, `Q3P_Update`, `Q3P_Draw`, and `Q3P_ActiveCount`.
- Extended `Quake/r_part.c` with CVars `r_particles_mode` (values `classic|glquake|q3p|hybrid`) and `r_particles_max`, a validation callback, and `R_GetParticleMode` for runtime mode checks.
- Wire-up points added: call `Q3P_Init` during `R_InitParticles`, clear q3p state in `R_ClearParticles`, call `Q3P_Update` from `CL_RunParticles` when appropriate, and call `Q3P_Draw` from `R_DrawParticles_Real` while respecting the selected mode (pure `q3p` mode skips legacy particle sim/draw).
- Added a developer command `q3p_spawn [count]` to autonomously spawn test q3p particles near the view entity; `Q3P_Draw` is currently a renderer placeholder.

### Testing

- Attempted a full configure/build with `cmake -S . -B build && cmake --build build -j4`, which failed in this environment due to missing SDL2 CMake configuration files (`SDL2Config.cmake` / `sdl2-config.cmake`), so a local compile could not be completed here.
- No other automated tests were available or executed in this environment; the new files were added and committed successfully to the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a57eaa519c832eb0b2fef46baa0153)