### PR TITLE
Add q3p particle batching draw path, `r_particles_sort` CVar, and GL state restore

### DIFF
--- a/Quake/r_part.c
+++ b/Quake/r_part.c
@@ -42,6 +42,7 @@ static float texturescalefactor; //johnfitz -- compensate for apparent size of d
 cvar_t	r_particles = {"r_particles","2", CVAR_ARCHIVE}; //johnfitz
 cvar_t	r_particles_mode = {"r_particles_mode", "glquake", CVAR_ARCHIVE};
 cvar_t	r_particles_max = {"r_particles_max", "8192", CVAR_ARCHIVE};
+cvar_t	r_particles_sort = {"r_particles_sort", "0", CVAR_ARCHIVE};
 
 typedef enum
 {
@@ -197,6 +198,7 @@ void R_InitParticles (void)
 	Cvar_SetCallback (&r_particles_mode, R_ParticlesMode_Changed_f);
 	R_ParticlesMode_Changed_f (&r_particles_mode);
 	Cvar_RegisterVariable (&r_particles_max);
+	Cvar_RegisterVariable (&r_particles_sort);
 
 	Q3P_Init ();
 	Cmd_AddCommand ("q3p_spawn", R_Q3P_TestSpawn_f);
@@ -781,7 +783,7 @@ static void R_DrawParticles_Real (qboolean alpha, qboolean showtris)
 	qboolean		dither, oit;
 	int				i;
 
-	if (R_GetParticleMode () != PARTICLEMODE_CLASSIC && R_GetParticleMode () != PARTICLEMODE_GLQUAKE)
+	if (R_GetParticleMode () == PARTICLEMODE_Q3P || R_GetParticleMode () == PARTICLEMODE_HYBRID)
 		Q3P_Draw (alpha, showtris);
 
 	if (R_GetParticleMode () == PARTICLEMODE_Q3P)

--- a/Quake/r_part_q3p.c
+++ b/Quake/r_part_q3p.c
@@ -2,10 +2,66 @@
 #include "r_part_q3p.h"
 
 extern cvar_t r_particles_max;
+extern cvar_t r_particles_sort;
 
 static q3p_particle_t *q3p_particles;
 static int q3p_maxparticles;
 static int q3p_numactive;
+
+typedef struct q3p_drawitem_s {
+	int particle_index;
+	int blend_group;
+	unsigned material_id;
+	float depth;
+} q3p_drawitem_t;
+
+typedef struct q3p_particlevert_s {
+	vec3_t		pos;
+	GLubyte		color[4];
+} q3p_particlevert_t;
+
+static q3p_drawitem_t *q3p_drawitems;
+static q3p_particlevert_t *q3p_partverts;
+static int q3p_numdrawitems;
+static int q3p_numpartverts;
+
+static unsigned Q3P_MaterialId (const char *material)
+{
+	unsigned id = 2166136261u;
+
+	if (!material || !*material)
+		return 0;
+
+	while (*material)
+	{
+		id ^= (unsigned char)*material++;
+		id *= 16777619u;
+	}
+
+	return id;
+}
+
+static int Q3P_DrawSortCmp (const void *a, const void *b)
+{
+	const q3p_drawitem_t *da = (const q3p_drawitem_t *)a;
+	const q3p_drawitem_t *db = (const q3p_drawitem_t *)b;
+
+	if (da->blend_group != db->blend_group)
+		return da->blend_group - db->blend_group;
+	if (da->material_id < db->material_id)
+		return -1;
+	if (da->material_id > db->material_id)
+		return 1;
+	if (r_particles_sort.value > 0.f)
+	{
+		if (da->depth < db->depth)
+			return 1;
+		if (da->depth > db->depth)
+			return -1;
+	}
+
+	return da->particle_index - db->particle_index;
+}
 
 void Q3P_Init (void)
 {
@@ -17,19 +73,29 @@ void Q3P_Init (void)
 		q3p_maxparticles = 1;
 
 	q3p_particles = (q3p_particle_t *)Hunk_AllocName (q3p_maxparticles * sizeof(*q3p_particles), "q3particles");
+	q3p_drawitems = (q3p_drawitem_t *)Hunk_AllocName (q3p_maxparticles * sizeof(*q3p_drawitems), "q3pdrawitems");
+	q3p_partverts = (q3p_particlevert_t *)Hunk_AllocName (q3p_maxparticles * sizeof(*q3p_partverts), "q3ppartverts");
 	q3p_numactive = 0;
+	q3p_numdrawitems = 0;
+	q3p_numpartverts = 0;
 }
 
 void Q3P_Shutdown (void)
 {
 	q3p_particles = NULL;
+	q3p_drawitems = NULL;
+	q3p_partverts = NULL;
 	q3p_maxparticles = 0;
 	q3p_numactive = 0;
+	q3p_numdrawitems = 0;
+	q3p_numpartverts = 0;
 }
 
 void Q3P_Clear (void)
 {
 	q3p_numactive = 0;
+	q3p_numdrawitems = 0;
+	q3p_numpartverts = 0;
 }
 
 qboolean Q3P_Spawn (const q3p_particle_t *particle)
@@ -76,11 +142,93 @@ void Q3P_Update (float frametime)
 	q3p_numactive = active;
 }
 
+static void Q3P_FlushParticleBatch (void)
+{
+	GLuint buf;
+	GLbyte *ofs;
+
+	if (!q3p_numpartverts)
+		return;
+
+	GL_Upload (GL_ARRAY_BUFFER, q3p_partverts, sizeof(q3p_partverts[0]) * q3p_numpartverts, &buf, &ofs);
+	GL_BindBuffer (GL_ARRAY_BUFFER, buf);
+	GL_VertexAttribPointerFunc (0, 3, GL_FLOAT, GL_FALSE, sizeof(q3p_partverts[0]), ofs + offsetof(q3p_particlevert_t, pos));
+	GL_VertexAttribPointerFunc (1, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(q3p_partverts[0]), ofs + offsetof(q3p_particlevert_t, color));
+	GL_DrawArraysInstancedFunc (GL_TRIANGLE_STRIP, 0, 4, q3p_numpartverts);
+
+	q3p_numpartverts = 0;
+}
+
 void Q3P_Draw (qboolean alpha, qboolean showtris)
 {
-	(void)alpha;
-	(void)showtris;
-	/* Placeholder for future renderer integration. */
+	int i;
+	float scalex, scaley;
+	qboolean dither, oit;
+	unsigned saved_state;
+	GLubyte white[4] = {255, 255, 255, 255};
+
+	if (!q3p_particles || q3p_numactive <= 0)
+		return;
+
+	q3p_numdrawitems = 0;
+	for (i = 0; i < q3p_numactive; ++i)
+	{
+		q3p_particle_t *p = &q3p_particles[i];
+		int blend_group = p->alpha < 1.f;
+
+		if (!showtris && alpha != blend_group)
+			continue;
+
+		q3p_drawitems[q3p_numdrawitems].particle_index = i;
+		q3p_drawitems[q3p_numdrawitems].blend_group = blend_group;
+		q3p_drawitems[q3p_numdrawitems].material_id = Q3P_MaterialId (p->material);
+		q3p_drawitems[q3p_numdrawitems].depth = DotProduct (r_origin, vpn) - DotProduct (p->org, vpn);
+		++q3p_numdrawitems;
+	}
+
+	if (!q3p_numdrawitems)
+		return;
+
+	qsort (q3p_drawitems, q3p_numdrawitems, sizeof(q3p_drawitems[0]), Q3P_DrawSortCmp);
+
+	GL_BeginGroup ("Q3P Particles");
+
+	dither = (softemu == SOFTEMU_COARSE && !showtris);
+	oit = (alpha && R_GetEffectiveAlphaMode () == ALPHAMODE_OIT);
+	GL_UseProgram (glprogs.particles[oit][dither]);
+
+	scalex = scaley = 0.375f;
+	scalex *=  r_matproj[1*4 + 0];
+	scaley *= -r_matproj[2*4 + 1];
+	GL_Uniform3fFunc (0, scalex, scaley, 0.25f);
+
+	saved_state = glstate;
+	if (alpha)
+		GL_SetState (GLS_BLEND_ALPHA_OIT | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (2) | GLS_INSTANCED_ATTRIBS (2));
+	else
+		GL_SetState (GLS_BLEND_OPAQUE | GLS_CULL_NONE | GLS_ATTRIBS (2) | GLS_INSTANCED_ATTRIBS (2));
+
+	q3p_numpartverts = 0;
+	for (i = 0; i < q3p_numdrawitems; ++i)
+	{
+		q3p_particle_t *p = &q3p_particles[q3p_drawitems[i].particle_index];
+		q3p_particlevert_t *v;
+		const GLubyte *c = showtris ? white : (const GLubyte *)&d_8to24table[p->color & 0xff];
+
+		if (q3p_numpartverts == q3p_maxparticles)
+			Q3P_FlushParticleBatch ();
+
+		v = &q3p_partverts[q3p_numpartverts++];
+		VectorCopy (p->org, v->pos);
+		v->color[0] = c[0];
+		v->color[1] = c[1];
+		v->color[2] = c[2];
+		v->color[3] = (GLubyte)(CLAMP (0.f, p->alpha, 1.f) * 255.f);
+	}
+
+	Q3P_FlushParticleBatch ();
+	GL_SetState (saved_state);
+	GL_EndGroup ();
 }
 
 int Q3P_ActiveCount (void)


### PR DESCRIPTION
### Motivation
- Add a dedicated draw path for q3-style particles (q3p) so they can be batched and optionally depth-sorted without modifying the classic particle path. 
- Expose a simple CVar to toggle depth-sorting to allow opt-in sorting behavior without changing other particle rendering modes. 
- Prevent global render-state side-effects from q3p draws by saving and restoring GL state around the q3p draw code. 

### Description
- Introduced `r_particles_sort` CVar (default `0`) and registered it in `R_InitParticles` via `Cvar_RegisterVariable (&r_particles_sort);`. 
- Implemented a new q3p draw pipeline in `Quake/r_part_q3p.c` that: builds per-particle draw items, computes a placeholder material hash (`Q3P_MaterialId`), groups by `blend_group` + `material_id`, optionally depth-sorts when `r_particles_sort` > 0, uploads instance data and issues instanced draws, and early-outs when the q3p pool is empty. 
- Integrated the q3p draw invocation into the existing particle flow in `Quake/r_part.c` so `Q3P_Draw` is called when `r_particles_mode` is `q3p` or `hybrid`, and the classic particle path is skipped in strict `q3p` mode. 
- Added batch-flush helper `Q3P_FlushParticleBatch`, allocations for draw-item and instance arrays in `Q3P_Init`, and saved/restored GL state (`saved_state = glstate; ... GL_SetState(saved_state);`) around the q3p draw to avoid leaking `GLS_NO_ZWRITE`/blend changes. 

### Testing
- Attempted an automated build with `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build -j4`, which failed due to missing system dependency (`SDL2` CMake package / `SDL2Config.cmake` not found), so no full compile-tested binary was produced. 
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a57f95edb8832e96562a27c3b584e1)