### PR TITLE
Map legacy svc_particle to q3p presets in R_ParseParticleEffect

### DIFF
--- a/Quake/r_part.c
+++ b/Quake/r_part.c
@@ -121,6 +121,74 @@ static void R_Q3P_TestSpawn_f (void)
 	Con_Printf ("q3p_spawned %d particles (%d active)\n", i, Q3P_ActiveCount ());
 }
 
+static qboolean R_CanUseQ3PForLegacyParticleEffect (void)
+{
+	particlemode_t mode = R_GetParticleMode ();
+
+	return mode == PARTICLEMODE_Q3P || mode == PARTICLEMODE_HYBRID;
+}
+
+static qboolean R_TrySpawnQ3PLegacyParticleEffect (const vec3_t org, const vec3_t dir, int color, int count)
+{
+	int i;
+	const qboolean rocket_explosion = (count == 1024);
+	const char *material = rocket_explosion ? "explosion" : "bullet";
+	const float lifetime_min = rocket_explosion ? 0.45f : 0.10f;
+	const float lifetime_rand = rocket_explosion ? 0.20f : 0.40f;
+	const float size = rocket_explosion ? 8.0f : 1.25f;
+	const float size_rand = rocket_explosion ? 4.0f : 0.75f;
+	const float alpha_ramp = rocket_explosion ? -2.0f : -3.0f;
+	const float gravity = rocket_explosion ? 100.f : 300.f;
+	const float drag = rocket_explosion ? 0.5f : 0.2f;
+
+	if (!R_CanUseQ3PForLegacyParticleEffect ())
+		return false;
+
+	for (i = 0; i < count; ++i)
+	{
+		q3p_particle_t p;
+
+		memset (&p, 0, sizeof(p));
+		p.spawn_time = cl.time;
+		p.lifetime = lifetime_min + ((rand() & 255) / 255.0f) * lifetime_rand;
+		p.size = size + ((rand() & 255) / 255.0f) * size_rand;
+		p.size_ramp = p.size * 8.0f;
+		p.alpha = 1.0f;
+		p.alpha_ramp = alpha_ramp;
+		p.color = rocket_explosion ? ramp1[0] : color;
+		p.gravity = gravity;
+		p.drag = drag;
+
+		q_strlcpy (p.material, material, sizeof(p.material));
+
+		if (rocket_explosion)
+		{
+			p.org[0] = org[0] + ((rand() % 32) - 16);
+			p.org[1] = org[1] + ((rand() % 32) - 16);
+			p.org[2] = org[2] + ((rand() % 32) - 16);
+
+			p.vel[0] = (float)((rand() % 512) - 256);
+			p.vel[1] = (float)((rand() % 512) - 256);
+			p.vel[2] = (float)((rand() % 512) - 256);
+		}
+		else
+		{
+			p.org[0] = org[0] + ((rand() & 15) - 8);
+			p.org[1] = org[1] + ((rand() & 15) - 8);
+			p.org[2] = org[2] + ((rand() & 15) - 8);
+
+			p.vel[0] = dir[0] * 15.f;
+			p.vel[1] = dir[1] * 15.f;
+			p.vel[2] = dir[2] * 15.f;
+		}
+
+		if (!Q3P_Spawn (&p))
+			return true;
+	}
+
+	return true;
+}
+
 typedef struct particlevert_t {
 	vec3_t		pos;
 	GLubyte		color[4];
@@ -299,6 +367,9 @@ void R_ParseParticleEffect (void)
 		count = 1024;
 	else
 		count = msgcount;
+
+	if (R_TrySpawnQ3PLegacyParticleEffect (org, dir, color, count))
+		return;
 
 	R_RunParticleEffect (org, dir, color, count);
 }

--- a/docs/q3p_phase0_particle_mapping.md
+++ b/docs/q3p_phase0_particle_mapping.md
@@ -45,3 +45,32 @@ Damit bleibt Phase 0 rein dokumentarisch/spezifikativ; es gibt keine Verhaltens�
 - [x] Für jeden `TE_*` aus `Quake/protocol.h` gibt es genau einen Mapping-Eintrag in der Tabelle.
 - [x] Für jeden bestehenden Aufrufpfad (`svc_particle`, `svc_temp_entity`, QC `particle()`) ist eine explizite Fallback-Entscheidung dokumentiert.
 - [x] Review-Check: **keine** Änderung am Laufzeitverhalten in Phase 0 (nur Dokumentation).
+
+## 5) Implementierungsstatus `R_ParseParticleEffect` (legacy `(org,dir,color,count)` → q3p)
+
+- `R_ParseParticleEffect` liest weiterhin unverändert `org/dir/msgcount/color` aus `svc_particle`.
+- Ist `msgcount == 255`, bleibt die Legacy-Semantik `count = 1024` (Rocket-Explosion).
+- Für `r_particles_mode = q3p|hybrid` wird nun ein q3p-Preset-Mapping ausgeführt:
+  - `count == 1024` → Material `explosion` (Explosion-Preset).
+  - sonst → Material `bullet` (klassischer `R_RunParticleEffect`-Sprühpfad).
+- Für andere Modi (`classic|glquake`) bleibt der alte Pfad vollständig erhalten (`R_RunParticleEffect`).
+
+### Indirekter QC-`particle()`-Pfad (`sv_main.c`/`pr_cmds.c` → `svc_particle` → Client)
+
+Der Laufweg ist unverändert und weiter konsistent:
+
+1. QC `particle(origin, dir, color, count)` ruft `PF_particle` auf.
+2. `PF_particle` ruft `SV_StartParticle(org, dir, color, count)`.
+3. `SV_StartParticle` serialisiert ein `svc_particle`-Event (`org`, quantisiertes `dir`, `count`, `color`).
+4. Client empfängt `svc_particle` und landet in `R_ParseParticleEffect`, das jetzt abhängig vom Partikelmodus q3p-Presets oder Legacy rendert.
+
+### Farb-/Count-Semantik und bekannte Abweichungen
+
+- **Beibehalten:**
+  - Netz-/QC-Werte `color` und `count` werden weiterhin aus demselben `svc_particle`-Payload gelesen.
+  - Sonderfall `count == 255` auf dem Netzkanal bleibt `1024` (Explosion).
+  - Bei deaktiviertem q3p ist das Verhalten byte-identisch zum alten Pfad.
+- **Abweichungen im q3p-Pfad (dokumentiert):**
+  - Legacy-Rand-Color-Jitter `(color&~7)+(rand&7)` wird nicht 1:1 repliziert; q3p übernimmt den Basisfarbwert als `p.color`.
+  - Legacy-Partikeltypen (`pt_slowgrav`, `pt_explode`, `pt_explode2`) werden durch q3p-Material-Presets (`bullet`/`explosion`) angenähert.
+  - Bei erschöpftem q3p-Partikelpool wird der Spawn früh beendet (best-effort) statt auf Legacy zurückzufallen.


### PR DESCRIPTION
### Motivation

- Alte `svc_particle`-Events und QC-`particle()` sollen bei aktiviertem q3p den modernen q3p-Renderer nutzen, ohne das klassische Verhalten bei deaktiviertem q3p zu ändern.
- Ziel ist ein Phase‑0-Mapping, das `(org,dir,color,count)` aus der Netzmessage zu einem q3p-Preset (explosion/bullet) abbildet und dabei die Legacy-Semantik soweit möglich bewahrt.

### Description

- Neue Helper-Funktionen in `Quake/r_part.c`: `R_CanUseQ3PForLegacyParticleEffect()` prüft `r_particles_mode`, und `R_TrySpawnQ3PLegacyParticleEffect(org,dir,color,count)` spawnt q3p-Partikel (Mapping `count==1024` → material `explosion`, sonst → `bullet`).
- `R_ParseParticleEffect()` liest wie zuvor `org/dir/msgcount/color` (mit `msgcount==255` → `count=1024`) und versucht zuerst die q3p-Spawn-Route; bei Rückgabe `false`/Nichtverfügbarkeit fällt es auf `R_RunParticleEffect` zurück.
- Farb-/Count-Semantik: Netz- und QC-Bytes werden unverändert gelesen, der q3p-Pfad nutzt jedoch den Basisfarbwert statt des Legacy-Color-Jitters und approximiert Legacy-Partikeltypen über q3p-Materialpresets (dokumentiert).
- Dokumentation in `docs/q3p_phase0_particle_mapping.md` erweitert, um die Implementierungsdetails, den indirekten QC→`svc_particle`-Pfad (`PF_particle`→`SV_StartParticle`→`svc_particle`→`R_ParseParticleEffect`) und bekannte Abweichungen zu beschreiben.

### Testing

- `git add`/`git commit` wurden erfolgreich ausgeführt and changes committed.
- Ein Build-Versuch mit `make -C Quake -j4` wurde automatisiert ausgeführt, scheiterte jedoch in dieser Umgebung an fehlenden Build-Dependencies (`sdl2-config` / `SDL.h`), sodass keine vollständige Kompilations- oder runtime-Validierung möglich war.
- Es existieren in-tree keine automatischen unit-tests für diesen Pfad; funktionale Laufzeittests (Mod-Kompatibilität / Effektvergleich q3p vs. legacy) sind ausstehend und sollten in einer Umgebung mit SDL/GUI-Unterstützung durchgeführt werden.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a58694c06c832ea225bb586b3e1078)