### PR TITLE
Add q3p trails and beam attachment with q3p beam rendering

### DIFF
--- a/Quake/cl_tent.c
+++ b/Quake/cl_tent.c
@@ -59,6 +59,34 @@ void CL_InitTEnts (void)
 CL_ParseBeam
 =================
 */
+
+static qboolean CL_BeamCanUseQ3P (void)
+{
+	return !q_strcasecmp (r_particles_mode.string, "q3p")
+		|| !q_strcasecmp (r_particles_mode.string, "hybrid");
+}
+
+static qboolean CL_BeamResolveAttachment (int entnum, qboolean local_space, const vec3_t fallback, vec3_t out)
+{
+	if (entnum <= 0 || entnum >= cl.num_entities)
+	{
+		VectorCopy (fallback, out);
+		return false;
+	}
+
+	if (!cl_entities[entnum].model)
+	{
+		VectorCopy (fallback, out);
+		return false;
+	}
+
+	if (local_space)
+		VectorAdd (cl_entities[entnum].origin, fallback, out);
+	else
+		VectorCopy (cl_entities[entnum].origin, out);
+	return true;
+}
+
 void CL_ParseBeam (qmodel_t *m)
 {
 	int		ent;
@@ -84,8 +112,12 @@ void CL_ParseBeam (qmodel_t *m)
 			b->model = m;
 			b->starttime = cl.time - 0.001;
 			b->endtime = cl.time + 0.2;
+			b->attach_entity = ent;
+			b->local_space = false;
 			VectorCopy (start, b->start);
 			VectorCopy (end, b->end);
+			VectorCopy (start, b->start_local);
+			VectorCopy (end, b->end_local);
 			return;
 		}
 
@@ -98,8 +130,12 @@ void CL_ParseBeam (qmodel_t *m)
 			b->model = m;
 			b->starttime = cl.time - 0.001;
 			b->endtime = cl.time + 0.2;
+			b->attach_entity = ent;
+			b->local_space = false;
 			VectorCopy (start, b->start);
 			VectorCopy (end, b->end);
+			VectorCopy (start, b->start_local);
+			VectorCopy (end, b->end_local);
 			return;
 		}
 	}
@@ -430,6 +466,53 @@ void CL_ParseTEnt (void)
 }
 
 
+
+static void CL_AddQ3PBeamSegments (const beam_t *b, const vec3_t start, const vec3_t end)
+{
+	vec3_t dir, org;
+	float len;
+	float step = 20.f;
+	int color;
+
+	if (!CL_BeamCanUseQ3P ())
+		return;
+
+	if (!b || !b->model)
+		return;
+
+	VectorSubtract (end, start, dir);
+	len = VectorNormalize (dir);
+	if (len <= 0.01f)
+		return;
+
+	if (strstr (b->model->name, "progs/bolt"))
+		color = 0xe8;
+	else
+		color = 0x6f;
+
+	VectorCopy (start, org);
+	while (len > 0.f)
+	{
+		q3p_particle_t p;
+		memset (&p, 0, sizeof(p));
+		p.spawn_time = cl.time;
+		p.lifetime = 0.08f;
+		p.size = 3.0f;
+		p.size_ramp = -1.0f;
+		p.alpha = 1.0f;
+		p.alpha_ramp = -8.0f;
+		p.color = color;
+		p.drag = 0.0f;
+		p.gravity = 0.0f;
+		q_strlcpy (p.material, "lightning", sizeof(p.material));
+		VectorCopy (org, p.org);
+		if (!Q3P_Spawn (&p))
+			break;
+		VectorMA (org, step, dir, org);
+		len -= step;
+	}
+}
+
 /*
 =================
 CL_NewTempEntity
@@ -479,10 +562,18 @@ void CL_UpdateTEnts (void)
 		if (!b->model || b->starttime > cl.time || b->endtime < cl.time)
 			continue;
 
-	// if coming from the player, update the start position
-		if (b->entity == cl.viewentity)
-		{
+	// resolve attached beam endpoints (worldspace or localspace offsets)
+		CL_BeamResolveAttachment (b->attach_entity, b->local_space, b->start_local, b->start);
+		CL_BeamResolveAttachment (b->attach_entity, b->local_space, b->end_local, b->end);
+
+	// if coming from the player, keep the start position synced to the view entity
+		if (b->entity == cl.viewentity && !b->local_space)
 			VectorCopy (cl_entities[cl.viewentity].origin, b->start);
+
+		if (CL_BeamCanUseQ3P ())
+		{
+			CL_AddQ3PBeamSegments (b, b->start, b->end);
+			continue;
 		}
 
 	// calculate pitch and yaw

--- a/Quake/client.h
+++ b/Quake/client.h
@@ -117,6 +117,10 @@ typedef struct
 	float	starttime;
 	float	endtime;
 	vec3_t	start, end;
+	int		attach_entity;
+	qboolean	local_space;
+	vec3_t	start_local;
+	vec3_t	end_local;
 } beam_t;
 
 #define	MAX_MAPSTRING	2048

--- a/Quake/r_part.c
+++ b/Quake/r_part.c
@@ -628,6 +628,15 @@ void R_RocketTrail (vec3_t start, vec3_t end, int type)
 	particle_t	*p;
 	int			dec;
 	static int	tracercount;
+	qboolean	use_q3p;
+	const char	*trail_material = NULL;
+	float		trail_lifetime = 0.f;
+	float		trail_size = 0.f;
+	float		trail_size_ramp = 0.f;
+	float		trail_alpha_ramp = 0.f;
+	float		trail_gravity = 0.f;
+	float		trail_drag = 0.f;
+	int			trail_color = 0;
 
 	VectorSubtract (end, start, vec);
 	len = VectorNormalize (vec);
@@ -639,80 +648,141 @@ void R_RocketTrail (vec3_t start, vec3_t end, int type)
 		type -= 128;
 	}
 
-	while (len > 0)
+	use_q3p = R_CanUseQ3PForLegacyParticleEffect ();
+	if (use_q3p)
 	{
-		len -= dec;
-
-		if (!(p = R_AllocParticle ()))
-			return;
-
-		VectorCopy (vec3_origin, p->vel);
-		p->die = cl.time + 2;
-
 		switch (type)
 		{
-			case 0:	// rocket trail
-				p->ramp = (rand()&3);
-				p->color = ramp3[(int)p->ramp];
-				p->type = pt_fire;
-				for (j=0 ; j<3 ; j++)
-					p->org[j] = start[j] + ((rand()%6)-3);
-				break;
+		case 0:
+			trail_material = "smoke";
+			trail_lifetime = 0.65f;
+			trail_size = 2.8f;
+			trail_size_ramp = 10.0f;
+			trail_alpha_ramp = -1.35f;
+			trail_drag = 0.25f;
+			trail_color = ramp3[0];
+			break;
+		case 1:
+			trail_material = "smoke";
+			trail_lifetime = 0.85f;
+			trail_size = 2.5f;
+			trail_size_ramp = 9.5f;
+			trail_alpha_ramp = -1.1f;
+			trail_drag = 0.35f;
+			trail_color = ramp3[2];
+			break;
+		case 6:
+			trail_material = "voor";
+			trail_lifetime = 0.25f;
+			trail_size = 2.0f;
+			trail_size_ramp = 2.0f;
+			trail_alpha_ramp = -3.0f;
+			trail_drag = 0.05f;
+			trail_color = 9*16 + 9;
+			break;
+		default:
+			break;
+		}
+	}
 
-			case 1:	// smoke smoke
-				p->ramp = (rand()&3) + 2;
-				p->color = ramp3[(int)p->ramp];
-				p->type = pt_fire;
-				for (j=0 ; j<3 ; j++)
-					p->org[j] = start[j] + ((rand()%6)-3);
-				break;
+	while (len > 0)
+	{
+		qboolean spawned_q3p = false;
+		len -= dec;
 
-			case 2:	// blood
-				p->type = pt_grav;
-				p->color = 67 + (rand()&3);
-				for (j=0 ; j<3 ; j++)
-					p->org[j] = start[j] + ((rand()%6)-3);
-				break;
+		if (trail_material)
+		{
+			q3p_particle_t qp;
+			memset (&qp, 0, sizeof(qp));
+			qp.spawn_time = cl.time;
+			qp.lifetime = trail_lifetime;
+			qp.size = trail_size + ((rand() & 7) - 3) * 0.05f;
+			qp.size_ramp = trail_size_ramp;
+			qp.alpha = 1.0f;
+			qp.alpha_ramp = trail_alpha_ramp;
+			qp.color = trail_color;
+			qp.gravity = trail_gravity;
+			qp.drag = trail_drag;
+			q_strlcpy (qp.material, trail_material, sizeof(qp.material));
+			for (j = 0; j < 3; ++j)
+				qp.org[j] = start[j] + ((rand() & 7) - 3);
+			if (Q3P_Spawn (&qp))
+				spawned_q3p = true;
+		}
 
-			case 3:
-			case 5:	// tracer
-				p->die = cl.time + 0.5;
-				p->type = pt_static;
-				if (type == 3)
-					p->color = 52 + ((tracercount&4)<<1);
-				else
-					p->color = 230 + ((tracercount&4)<<1);
+		if (!spawned_q3p)
+		{
+			if (!(p = R_AllocParticle ()))
+				return;
 
-				tracercount++;
+			VectorCopy (vec3_origin, p->vel);
+			p->die = cl.time + 2;
 
-				VectorCopy (start, p->org);
-				if (tracercount & 1)
-				{
-					p->vel[0] = 30*vec[1];
-					p->vel[1] = 30*-vec[0];
-				}
-				else
-				{
-					p->vel[0] = 30*-vec[1];
-					p->vel[1] = 30*vec[0];
-				}
-				break;
+			switch (type)
+			{
+				case 0:	// rocket trail
+					p->ramp = (rand()&3);
+					p->color = ramp3[(int)p->ramp];
+					p->type = pt_fire;
+					for (j=0 ; j<3 ; j++)
+						p->org[j] = start[j] + ((rand()%6)-3);
+					break;
 
-			case 4:	// slight blood
-				p->type = pt_grav;
-				p->color = 67 + (rand()&3);
-				for (j=0 ; j<3 ; j++)
-					p->org[j] = start[j] + ((rand()%6)-3);
-				len -= 3;
-				break;
+				case 1:	// smoke smoke
+					p->ramp = (rand()&3) + 2;
+					p->color = ramp3[(int)p->ramp];
+					p->type = pt_fire;
+					for (j=0 ; j<3 ; j++)
+						p->org[j] = start[j] + ((rand()%6)-3);
+					break;
 
-			case 6:	// voor trail
-				p->color = 9*16 + 8 + (rand()&3);
-				p->type = pt_static;
-				p->die = cl.time + 0.3;
-				for (j=0 ; j<3 ; j++)
-					p->org[j] = start[j] + ((rand()&15)-8);
-				break;
+				case 2:	// blood
+					p->type = pt_grav;
+					p->color = 67 + (rand()&3);
+					for (j=0 ; j<3 ; j++)
+						p->org[j] = start[j] + ((rand()%6)-3);
+					break;
+
+				case 3:
+				case 5:	// tracer
+					p->die = cl.time + 0.5;
+					p->type = pt_static;
+					if (type == 3)
+						p->color = 52 + ((tracercount&4)<<1);
+					else
+						p->color = 230 + ((tracercount&4)<<1);
+
+					tracercount++;
+
+					VectorCopy (start, p->org);
+					if (tracercount & 1)
+					{
+						p->vel[0] = 30*vec[1];
+						p->vel[1] = 30*-vec[0];
+					}
+					else
+					{
+						p->vel[0] = 30*-vec[1];
+						p->vel[1] = 30*vec[0];
+					}
+					break;
+
+				case 4:	// slight blood
+					p->type = pt_grav;
+					p->color = 67 + (rand()&3);
+					for (j=0 ; j<3 ; j++)
+						p->org[j] = start[j] + ((rand()%6)-3);
+					len -= 3;
+					break;
+
+				case 6:	// voor trail
+					p->color = 9*16 + 8 + (rand()&3);
+					p->type = pt_static;
+					p->die = cl.time + 0.3;
+					for (j=0 ; j<3 ; j++)
+						p->org[j] = start[j] + ((rand()&15)-8);
+					break;
+			}
 		}
 
 		VectorAdd (start, vec, start);


### PR DESCRIPTION
### Motivation
- Modernize legacy particle trails and lightning by mapping `R_RocketTrail` classes to `q3p` emitter presets so rocket/smoke/voor trails can use the q3p particle renderer while keeping the old path as a fallback. 
- Provide a q3p-based beam (lightning) renderer option (segmented sprite approach) to render `TE_BEAM`/lightning when `r_particles_mode` is `q3p` or `hybrid`.
- Support attaching beams to entities (worldspace or local offsets) so beam endpoints can follow entity origins or local offsets.

### Description
- Map legacy trail types in `R_RocketTrail` (`Quake/r_part.c`) to q3p presets (material, lifetime, size, size ramp, alpha ramp, drag, color) and attempt `Q3P_Spawn` per segment, with automatic fallback to the original legacy particle spawning on spawn failure. 
- Add a q3p beam renderer `CL_AddQ3PBeamSegments` in `Quake/cl_tent.c` which spawns segmented q3p particles (lightning material) along beam start→end when `r_particles_mode` is `q3p`/`hybrid`.
- Implement beam attach metadata in `beam_t` (`Quake/client.h`) by adding `attach_entity`, `local_space`, `start_local`, and `end_local` fields, and populate them in `CL_ParseBeam` (`Quake/cl_tent.c`).
- Provide helper functions `CL_BeamCanUseQ3P` and `CL_BeamResolveAttachment` to decide when to use q3p and to resolve attached endpoints from an entity origin with optional local-space offsets; integrate resolution and q3p-path selection into `CL_UpdateTEnts` so the legacy model-based per-segment entities remain as a fallback when q3p is not active. 

### Testing
- Attempted the normal build with `cmake -S . -B build && cmake --build build -j4`, which failed during configuration because the SDL2 development package / `SDL2Config.cmake` is missing in this environment (build did not complete). 
- Ran repository inspections via `rg` and file diffs to confirm new symbols and modified code paths are present and referenced (`CL_AddQ3PBeamSegments`, `CL_BeamResolveAttachment`, `attach_entity`, and the `R_RocketTrail` q3p branch), which succeeded. 
- An in-repo `make` invocation failed early because no top-level Makefile target is present in this tree (expected for this project layout).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a588a1afc8832ea707da5ab9dd0a85)