### PR TITLE
Q3P particles: optional world collision, culling, and impact presets

### DIFF
--- a/Quake/cl_tent.c
+++ b/Quake/cl_tent.c
@@ -253,6 +253,9 @@ static qboolean CL_TEntTrySpawnQ3P (const char *material, const vec3_t pos, cons
 		p.color = color;
 		p.gravity = gravity;
 		p.drag = drag;
+		p.restitution = 0.35f;
+		p.min_bounce_speed = 35.f;
+		p.flags = Q3P_PARTICLE_COLLIDE_WORLD;
 
 		q_strlcpy (p.material, material, sizeof(p.material));
 
@@ -278,14 +281,14 @@ static qboolean CL_TEntRunImpactDispatcher (int type, const vec3_t pos)
 	switch (type)
 	{
 	case TE_SPIKE:
-		return CL_TEntTrySpawnQ3P ("bullet", pos, vel_zero, 10, 0.20f, 0.10f, 1.25f, 0.5f, -3.0f, 300.f, 0.2f, 0x6f);
+		return CL_TEntTrySpawnQ3P ("sparks", pos, vel_zero, 10, 0.16f, 0.08f, 0.9f, 0.4f, -4.0f, 420.f, 0.35f, 0x6f);
 	case TE_SUPERSPIKE:
 	case TE_GUNSHOT:
-		return CL_TEntTrySpawnQ3P ("bullet", pos, vel_zero, 20, 0.20f, 0.10f, 1.25f, 0.5f, -3.0f, 300.f, 0.2f, 0x6f);
+		return CL_TEntTrySpawnQ3P ("impact_puff", pos, vel_zero, 20, 0.20f, 0.14f, 1.35f, 0.65f, -3.0f, 260.f, 0.25f, 0x6f);
 	case TE_EXPLOSION:
-		return CL_TEntTrySpawnQ3P ("explosion", pos, vel_zero, 96, 0.45f, 0.20f, 8.0f, 4.0f, -2.0f, 100.f, 0.5f, 0x6f);
+		return CL_TEntTrySpawnQ3P ("debris", pos, vel_zero, 96, 0.50f, 0.24f, 2.2f, 1.8f, -1.4f, 220.f, 0.35f, 0x6f);
 	case TE_EXPLOSION2:
-		return CL_TEntTrySpawnQ3P ("explosion", pos, vel_zero, 96, 0.45f, 0.20f, 8.0f, 4.0f, -2.0f, 100.f, 0.5f, 0x6f);
+		return CL_TEntTrySpawnQ3P ("debris", pos, vel_zero, 96, 0.50f, 0.24f, 2.2f, 1.8f, -1.4f, 220.f, 0.35f, 0x6f);
 	default:
 		break;
 	}

--- a/Quake/r_part.c
+++ b/Quake/r_part.c
@@ -43,6 +43,8 @@ cvar_t	r_particles = {"r_particles","2", CVAR_ARCHIVE}; //johnfitz
 cvar_t	r_particles_mode = {"r_particles_mode", "glquake", CVAR_ARCHIVE};
 cvar_t	r_particles_max = {"r_particles_max", "8192", CVAR_ARCHIVE};
 cvar_t	r_particles_sort = {"r_particles_sort", "0", CVAR_ARCHIVE};
+cvar_t	r_particles_cull_dist = {"r_particles_cull_dist", "4096", CVAR_ARCHIVE};
+cvar_t	r_particles_collision = {"r_particles_collision", "1", CVAR_ARCHIVE};
 
 typedef enum
 {
@@ -103,6 +105,9 @@ static void R_Q3P_TestSpawn_f (void)
 		particle.color = 0x6f;
 		particle.gravity = 300.0f;
 		particle.drag = 0.5f;
+		particle.restitution = 0.35f;
+		particle.min_bounce_speed = 30.0f;
+		particle.flags = Q3P_PARTICLE_COLLIDE_WORLD;
 		q_strlcpy (particle.material, "*particle", sizeof(particle.material));
 
 		VectorCopy (viewent->origin, particle.org);
@@ -158,6 +163,9 @@ static qboolean R_TrySpawnQ3PLegacyParticleEffect (const vec3_t org, const vec3_
 		p.color = rocket_explosion ? ramp1[0] : color;
 		p.gravity = gravity;
 		p.drag = drag;
+		p.restitution = rocket_explosion ? 0.30f : 0.25f;
+		p.min_bounce_speed = rocket_explosion ? 25.f : 40.f;
+		p.flags = Q3P_PARTICLE_COLLIDE_WORLD;
 
 		q_strlcpy (p.material, material, sizeof(p.material));
 
@@ -267,6 +275,8 @@ void R_InitParticles (void)
 	R_ParticlesMode_Changed_f (&r_particles_mode);
 	Cvar_RegisterVariable (&r_particles_max);
 	Cvar_RegisterVariable (&r_particles_sort);
+	Cvar_RegisterVariable (&r_particles_cull_dist);
+	Cvar_RegisterVariable (&r_particles_collision);
 
 	Q3P_Init ();
 	Cmd_AddCommand ("q3p_spawn", R_Q3P_TestSpawn_f);
@@ -671,6 +681,26 @@ void R_RocketTrail (vec3_t start, vec3_t end, int type)
 			trail_drag = 0.35f;
 			trail_color = ramp3[2];
 			break;
+		case 2:
+			trail_material = "blood_heavy";
+			trail_lifetime = 0.45f;
+			trail_size = 1.35f;
+			trail_size_ramp = 1.5f;
+			trail_alpha_ramp = -2.3f;
+			trail_gravity = 240.f;
+			trail_drag = 0.05f;
+			trail_color = 67;
+			break;
+		case 4:
+			trail_material = "blood_light";
+			trail_lifetime = 0.3f;
+			trail_size = 1.1f;
+			trail_size_ramp = 1.0f;
+			trail_alpha_ramp = -2.8f;
+			trail_gravity = 220.f;
+			trail_drag = 0.05f;
+			trail_color = 67;
+			break;
 		case 6:
 			trail_material = "voor";
 			trail_lifetime = 0.25f;
@@ -703,6 +733,12 @@ void R_RocketTrail (vec3_t start, vec3_t end, int type)
 			qp.color = trail_color;
 			qp.gravity = trail_gravity;
 			qp.drag = trail_drag;
+			if (type == 2 || type == 4)
+			{
+				qp.restitution = 0.2f;
+				qp.min_bounce_speed = 20.f;
+				qp.flags = Q3P_PARTICLE_COLLIDE_WORLD;
+			}
 			q_strlcpy (qp.material, trail_material, sizeof(qp.material));
 			for (j = 0; j < 3; ++j)
 				qp.org[j] = start[j] + ((rand() & 7) - 3);

--- a/Quake/r_part_q3p.c
+++ b/Quake/r_part_q3p.c
@@ -4,6 +4,8 @@
 extern cvar_t r_particles_max;
 extern cvar_t r_particles_sort;
 extern cvar_t r_particles_shader_strict;
+extern cvar_t r_particles_cull_dist;
+extern cvar_t r_particles_collision;
 
 static q3p_particle_t *q3p_particles;
 static int q3p_maxparticles;
@@ -284,6 +286,41 @@ static const q3p_material_cache_entry_t *Q3P_ResolveMaterialCached (const char *
 	return NULL;
 }
 
+
+static qboolean Q3P_ParticleFinite (const q3p_particle_t *p)
+{
+	return !IS_NAN (p->org[0]) && !IS_NAN (p->org[1]) && !IS_NAN (p->org[2])
+		&& !IS_NAN (p->vel[0]) && !IS_NAN (p->vel[1]) && !IS_NAN (p->vel[2])
+		&& !IS_NAN (p->alpha) && !IS_NAN (p->size);
+}
+
+static qboolean Q3P_TraceWorld (const vec3_t start, const vec3_t end, trace_t *trace)
+{
+	vec3_t start_copy, end_copy;
+
+	if (!cl.worldmodel)
+		return false;
+
+	memset (trace, 0, sizeof (*trace));
+	trace->fraction = 1.f;
+	VectorCopy (start, start_copy);
+	VectorCopy (end, end_copy);
+	SV_RecursiveHullCheck (cl.worldmodel->hulls, 0, 0.f, 1.f, start_copy, end_copy, trace);
+	return true;
+}
+
+static qboolean Q3P_ShouldCullParticle (const q3p_particle_t *p)
+{
+	float cull_dist = q_max (0.f, r_particles_cull_dist.value);
+	vec3_t to_particle;
+
+	if (cull_dist <= 0.f)
+		return false;
+
+	VectorSubtract (p->org, r_origin, to_particle);
+	return DotProduct (to_particle, to_particle) > cull_dist * cull_dist;
+}
+
 static int Q3P_DrawSortCmp (const void *a, const void *b)
 {
 	const q3p_drawitem_t *da = (const q3p_drawitem_t *)a;
@@ -375,6 +412,7 @@ void Q3P_Update (float frametime)
 {
 	int i, active;
 	q3p_particle_t *p;
+	qboolean collision_enabled = r_particles_collision.value > 0.f;
 
 	if (!q3p_particles || q3p_numactive <= 0)
 		return;
@@ -382,17 +420,57 @@ void Q3P_Update (float frametime)
 	for (i = active = 0, p = q3p_particles; i < q3p_numactive; ++i, ++p)
 	{
 		float age = cl.time - p->spawn_time;
+		vec3_t prevorg, nextorg;
 
 		if (age < 0 || age >= p->lifetime)
+			continue;
+		if (!Q3P_ParticleFinite (p))
+			continue;
+		if (Q3P_ShouldCullParticle (p))
 			continue;
 
 		p->size += p->size_ramp * frametime;
 		p->alpha += p->alpha_ramp * frametime;
 		p->alpha = CLAMP (0, p->alpha, 1);
 
-		VectorMA (p->org, frametime, p->vel, p->org);
+		VectorCopy (p->org, prevorg);
+		VectorMA (p->org, frametime, p->vel, nextorg);
 		p->vel[2] -= p->gravity * frametime;
 		VectorScale (p->vel, q_max (0.f, 1.f - p->drag * frametime), p->vel);
+
+		if (collision_enabled && (p->flags & Q3P_PARTICLE_COLLIDE_WORLD))
+		{
+			trace_t trace;
+			if (Q3P_TraceWorld (prevorg, nextorg, &trace) && trace.fraction < 1.f)
+			{
+				float vn;
+				vec3_t vnormal;
+				float speed;
+
+				VectorCopy (trace.endpos, p->org);
+				vn = DotProduct (p->vel, trace.plane.normal);
+				VectorScale (trace.plane.normal, vn, vnormal);
+				VectorMA (p->vel, -(1.f + CLAMP (0.f, p->restitution, 1.f)), vnormal, p->vel);
+				p->org[0] += trace.plane.normal[0] * 0.5f;
+				p->org[1] += trace.plane.normal[1] * 0.5f;
+				p->org[2] += trace.plane.normal[2] * 0.5f;
+
+				speed = VectorLength (p->vel);
+				if (speed < q_max (0.f, p->min_bounce_speed))
+					continue;
+			}
+			else
+			{
+				VectorCopy (nextorg, p->org);
+			}
+		}
+		else
+		{
+			VectorCopy (nextorg, p->org);
+		}
+
+		if (!Q3P_ParticleFinite (p))
+			continue;
 
 		if (i != active)
 			q3p_particles[active] = *p;

--- a/Quake/r_part_q3p.h
+++ b/Quake/r_part_q3p.h
@@ -15,10 +15,17 @@ typedef struct q3p_particle_s {
 	vec3_t	vel;
 	float	gravity;
 	float	drag;
+	float	restitution;
+	float	min_bounce_speed;
 	int		flags;
 	char	material[64];
 	unsigned material_id;
 } q3p_particle_t;
+
+enum
+{
+	Q3P_PARTICLE_COLLIDE_WORLD = 1 << 0
+};
 
 typedef struct q3p_emitter_s {
 	float	rate;


### PR DESCRIPTION
### Motivation
- Add optional world collision and bounce to Q3P particles to make debris deterministic and avoid NaN/explosion errors while giving a budget control mechanism and useful impact presets.
- Provide runtime knobs for distance-culling and enabling/disabling collision to stay within particle budgets.

### Description
- Added `restitution`, `min_bounce_speed` and a collision flag (`Q3P_PARTICLE_COLLIDE_WORLD`) to `q3p_particle_t` in `Quake/r_part_q3p.h` to support per-particle bounce behavior.
- Implemented safety and collision helpers in `Quake/r_part_q3p.c`: `Q3P_ParticleFinite`, `Q3P_TraceWorld`, `Q3P_ShouldCullParticle`, and integrated a simplified world-hull trace+bounce into `Q3P_Update` that applies restitution, nudges particles out of the surface, and kills particles below `min_bounce_speed`.
- Added global CVars `r_particles_cull_dist` and `r_particles_collision` in `Quake/r_part.c`, registered them, and used `r_particles_cull_dist` in update culling and `r_particles_collision` to gate collision for budget control.
- Set reasonable collision defaults for legacy and temp-entity spawns and added/adjusted presets (`sparks`, `impact_puff`, `debris`, `blood_heavy`, `blood_light`) in `Quake/cl_tent.c` and `Quake/r_part.c` so impact/debris effects behave physically and deterministically.

### Testing
- Ran `git diff --check` with no issues reported.
- Attempted to build with `make -C Quake -j4`, but the full compile was blocked in this environment due to missing SDL2 tooling/headers (`sdl2-config` / `SDL.h`), so runtime validation could not complete here.
- Performed static code inspection and repository searches to verify new symbols and that the update path includes NaN checks, culling and collision code paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a58b263a24832ea1a4c342b8ebc5ea)