### PR TITLE
Add .prt particle effect definitions and Q3P effect parsing/usage

### DIFF
--- a/Quake/cl_tent.c
+++ b/Quake/cl_tent.c
@@ -235,6 +235,21 @@ static qboolean CL_TEntTrySpawnQ3P (const char *material, const vec3_t pos, cons
 	float alpha_ramp, float gravity, float drag, int color)
 {
 	int i;
+	q3p_effectdef_t def;
+	qboolean has_def = Q3P_GetEffectDef (material, &def);
+
+	if (has_def)
+	{
+		count = q_max (1, def.count);
+		lifetime_min = def.lifetime_min;
+		lifetime_rand = def.lifetime_rand;
+		size = def.size;
+		size_rand = def.size_rand;
+		alpha_ramp = def.alpha_ramp;
+		gravity = def.gravity;
+		drag = def.drag;
+		color = def.color;
+	}
 
 	if (!CL_TEntCanUseQ3P ())
 		return false;
@@ -246,26 +261,26 @@ static qboolean CL_TEntTrySpawnQ3P (const char *material, const vec3_t pos, cons
 		memset (&p, 0, sizeof(p));
 		p.spawn_time = cl.time;
 		p.lifetime = lifetime_min + ((rand() & 255) / 255.0f) * lifetime_rand;
-		p.size = size + ((rand() & 255) / 255.0f) * size_rand;
-		p.size_ramp = p.size * 8.0f;
-		p.alpha = 1.0f;
-		p.alpha_ramp = alpha_ramp;
-		p.color = color;
-		p.gravity = gravity;
-		p.drag = drag;
-		p.restitution = 0.35f;
-		p.min_bounce_speed = 35.f;
-		p.flags = Q3P_PARTICLE_COLLIDE_WORLD;
+			p.size = size + ((rand() & 255) / 255.0f) * size_rand;
+			p.size_ramp = has_def ? def.size_ramp : p.size * 8.0f;
+			p.alpha = has_def ? def.alpha : 1.0f;
+			p.alpha_ramp = alpha_ramp;
+			p.color = color;
+			p.gravity = gravity;
+			p.drag = drag;
+			p.restitution = has_def ? def.restitution : 0.35f;
+			p.min_bounce_speed = has_def ? def.min_bounce_speed : 35.f;
+			p.flags = (has_def ? (def.collide_world ? Q3P_PARTICLE_COLLIDE_WORLD : 0) : Q3P_PARTICLE_COLLIDE_WORLD);
 
-		q_strlcpy (p.material, material, sizeof(p.material));
+			q_strlcpy (p.material, has_def ? def.material : material, sizeof(p.material));
 
-		p.org[0] = pos[0] + ((rand() & 15) - 8);
-		p.org[1] = pos[1] + ((rand() & 15) - 8);
-		p.org[2] = pos[2] + ((rand() & 15) - 8);
+			p.org[0] = pos[0] + ((rand() & 15) - 8) * (has_def ? def.org_jitter / 8.f : 1.f);
+			p.org[1] = pos[1] + ((rand() & 15) - 8) * (has_def ? def.org_jitter / 8.f : 1.f);
+			p.org[2] = pos[2] + ((rand() & 15) - 8) * (has_def ? def.org_jitter / 8.f : 1.f);
 
-		p.vel[0] = vel_base[0] + (float)((rand() & 255) - 128);
-		p.vel[1] = vel_base[1] + (float)((rand() & 255) - 128);
-		p.vel[2] = vel_base[2] + (float)((rand() & 255) - 128);
+			p.vel[0] = vel_base[0] * (has_def ? def.vel_scale : 1.f) + (float)((rand() & 255) - 128) * (has_def ? def.vel_jitter / 128.f : 1.f);
+			p.vel[1] = vel_base[1] * (has_def ? def.vel_scale : 1.f) + (float)((rand() & 255) - 128) * (has_def ? def.vel_jitter / 128.f : 1.f);
+			p.vel[2] = vel_base[2] * (has_def ? def.vel_scale : 1.f) + (float)((rand() & 255) - 128) * (has_def ? def.vel_jitter / 128.f : 1.f);
 
 		if (!Q3P_Spawn (&p))
 			return false;

--- a/Quake/particles/default.prt
+++ b/Quake/particles/default.prt
@@ -1,0 +1,87 @@
+impact_puff
+{
+	material impact_puff
+	count 20
+	lifetime_min 0.20
+	lifetime_rand 0.14
+	size 1.35
+	size_rand 0.65
+	size_ramp 8.0
+	alpha 1.0
+	alpha_ramp -3.0
+	color 111
+	gravity 260
+	drag 0.25
+	restitution 0.35
+	min_bounce_speed 35
+	org_jitter 8
+	vel_jitter 128
+	vel_scale 1.0
+	collide_world 1
+}
+
+smoke
+{
+	material smoke
+	count 1
+	lifetime_min 0.65
+	lifetime_rand 0.15
+	size 2.8
+	size_rand 0.35
+	size_ramp 10.0
+	alpha 1.0
+	alpha_ramp -1.35
+	color 109
+	gravity 0
+	drag 0.25
+	restitution 0
+	min_bounce_speed 0
+	org_jitter 3
+	vel_jitter 12
+	vel_scale 1.0
+	collide_world 0
+}
+
+bullet
+{
+	material bullet
+	count 1
+	lifetime_min 0.10
+	lifetime_rand 0.40
+	size 1.25
+	size_rand 0.75
+	size_ramp 8.0
+	alpha 1.0
+	alpha_ramp -3.0
+	color 111
+	gravity 300
+	drag 0.2
+	restitution 0.25
+	min_bounce_speed 40
+	org_jitter 8
+	vel_jitter 0
+	vel_scale 1.0
+	collide_world 1
+}
+
+explosion
+{
+	material explosion
+	count 1024
+	lifetime_min 0.45
+	lifetime_rand 0.20
+	size 8.0
+	size_rand 4.0
+	size_ramp 64.0
+	alpha 1.0
+	alpha_ramp -2.0
+	color 111
+	gravity 100
+	drag 0.5
+	restitution 0.30
+	min_bounce_speed 25
+	org_jitter 16
+	vel_jitter 256
+	vel_scale 1.0
+	collide_world 1
+}

--- a/Quake/r_part.c
+++ b/Quake/r_part.c
@@ -189,6 +189,8 @@ static qboolean R_TrySpawnQ3PLegacyParticleEffect (const vec3_t org, const vec3_
 	int i;
 	const qboolean rocket_explosion = (count == 1024);
 	const char *material = rocket_explosion ? "explosion" : "bullet";
+	q3p_effectdef_t def;
+	qboolean has_def = Q3P_GetEffectDef (material, &def);
 	const float lifetime_min = rocket_explosion ? 0.45f : 0.10f;
 	const float lifetime_rand = rocket_explosion ? 0.20f : 0.40f;
 	const float size = rocket_explosion ? 8.0f : 1.25f;
@@ -200,45 +202,50 @@ static qboolean R_TrySpawnQ3PLegacyParticleEffect (const vec3_t org, const vec3_
 	if (!R_CanUseQ3PForLegacyParticleEffect ())
 		return false;
 
+	if (has_def)
+	{
+		count = q_max (1, def.count);
+	}
+
 	for (i = 0; i < count; ++i)
 	{
 		q3p_particle_t p;
 
 		memset (&p, 0, sizeof(p));
 		p.spawn_time = cl.time;
-		p.lifetime = lifetime_min + ((rand() & 255) / 255.0f) * lifetime_rand;
-		p.size = size + ((rand() & 255) / 255.0f) * size_rand;
-		p.size_ramp = p.size * 8.0f;
-		p.alpha = 1.0f;
-		p.alpha_ramp = alpha_ramp;
-		p.color = rocket_explosion ? ramp1[0] : color;
-		p.gravity = gravity;
-		p.drag = drag;
-		p.restitution = rocket_explosion ? 0.30f : 0.25f;
-		p.min_bounce_speed = rocket_explosion ? 25.f : 40.f;
-		p.flags = Q3P_PARTICLE_COLLIDE_WORLD;
+		p.lifetime = (has_def ? def.lifetime_min : lifetime_min) + ((rand() & 255) / 255.0f) * (has_def ? def.lifetime_rand : lifetime_rand);
+		p.size = (has_def ? def.size : size) + ((rand() & 255) / 255.0f) * (has_def ? def.size_rand : size_rand);
+		p.size_ramp = has_def ? def.size_ramp : p.size * 8.0f;
+		p.alpha = has_def ? def.alpha : 1.0f;
+		p.alpha_ramp = has_def ? def.alpha_ramp : alpha_ramp;
+		p.color = has_def ? def.color : (rocket_explosion ? ramp1[0] : color);
+		p.gravity = has_def ? def.gravity : gravity;
+		p.drag = has_def ? def.drag : drag;
+		p.restitution = has_def ? def.restitution : (rocket_explosion ? 0.30f : 0.25f);
+		p.min_bounce_speed = has_def ? def.min_bounce_speed : (rocket_explosion ? 25.f : 40.f);
+		p.flags = (has_def ? (def.collide_world ? Q3P_PARTICLE_COLLIDE_WORLD : 0) : Q3P_PARTICLE_COLLIDE_WORLD);
 
-		q_strlcpy (p.material, material, sizeof(p.material));
+		q_strlcpy (p.material, has_def ? def.material : material, sizeof(p.material));
 
 		if (rocket_explosion)
 		{
-			p.org[0] = org[0] + ((rand() % 32) - 16);
-			p.org[1] = org[1] + ((rand() % 32) - 16);
-			p.org[2] = org[2] + ((rand() % 32) - 16);
+			p.org[0] = org[0] + ((rand() % 32) - 16) * (has_def ? def.org_jitter / 16.f : 1.f);
+			p.org[1] = org[1] + ((rand() % 32) - 16) * (has_def ? def.org_jitter / 16.f : 1.f);
+			p.org[2] = org[2] + ((rand() % 32) - 16) * (has_def ? def.org_jitter / 16.f : 1.f);
 
-			p.vel[0] = (float)((rand() % 512) - 256);
-			p.vel[1] = (float)((rand() % 512) - 256);
-			p.vel[2] = (float)((rand() % 512) - 256);
+			p.vel[0] = (float)((rand() % 512) - 256) * (has_def ? def.vel_jitter / 256.f : 1.f);
+			p.vel[1] = (float)((rand() % 512) - 256) * (has_def ? def.vel_jitter / 256.f : 1.f);
+			p.vel[2] = (float)((rand() % 512) - 256) * (has_def ? def.vel_jitter / 256.f : 1.f);
 		}
 		else
 		{
-			p.org[0] = org[0] + ((rand() & 15) - 8);
-			p.org[1] = org[1] + ((rand() & 15) - 8);
-			p.org[2] = org[2] + ((rand() & 15) - 8);
+			p.org[0] = org[0] + ((rand() & 15) - 8) * (has_def ? def.org_jitter / 8.f : 1.f);
+			p.org[1] = org[1] + ((rand() & 15) - 8) * (has_def ? def.org_jitter / 8.f : 1.f);
+			p.org[2] = org[2] + ((rand() & 15) - 8) * (has_def ? def.org_jitter / 8.f : 1.f);
 
-			p.vel[0] = dir[0] * 15.f;
-			p.vel[1] = dir[1] * 15.f;
-			p.vel[2] = dir[2] * 15.f;
+			p.vel[0] = dir[0] * 15.f * (has_def ? def.vel_scale : 1.f) + (has_def ? ((rand() & 255) - 128) * (def.vel_jitter / 128.f) : 0.f);
+			p.vel[1] = dir[1] * 15.f * (has_def ? def.vel_scale : 1.f) + (has_def ? ((rand() & 255) - 128) * (def.vel_jitter / 128.f) : 0.f);
+			p.vel[2] = dir[2] * 15.f * (has_def ? def.vel_scale : 1.f) + (has_def ? ((rand() & 255) - 128) * (def.vel_jitter / 128.f) : 0.f);
 		}
 
 		if (!Q3P_Spawn (&p))
@@ -697,6 +704,8 @@ void R_RocketTrail (vec3_t start, vec3_t end, int type)
 	static int	tracercount;
 	qboolean	use_q3p;
 	const char	*trail_material = NULL;
+	q3p_effectdef_t trail_def;
+	qboolean	trail_has_def = false;
 	float		trail_lifetime = 0.f;
 	float		trail_size = 0.f;
 	float		trail_size_ramp = 0.f;
@@ -770,6 +779,9 @@ void R_RocketTrail (vec3_t start, vec3_t end, int type)
 		default:
 			break;
 		}
+
+		if (trail_material)
+			trail_has_def = Q3P_GetEffectDef (trail_material, &trail_def);
 	}
 
 	while (len > 0)
@@ -777,31 +789,37 @@ void R_RocketTrail (vec3_t start, vec3_t end, int type)
 		qboolean spawned_q3p = false;
 		len -= dec;
 
-		if (trail_material)
-		{
-			q3p_particle_t qp;
-			memset (&qp, 0, sizeof(qp));
-			qp.spawn_time = cl.time;
-			qp.lifetime = trail_lifetime;
-			qp.size = trail_size + ((rand() & 7) - 3) * 0.05f;
-			qp.size_ramp = trail_size_ramp;
-			qp.alpha = 1.0f;
-			qp.alpha_ramp = trail_alpha_ramp;
-			qp.color = trail_color;
-			qp.gravity = trail_gravity;
-			qp.drag = trail_drag;
-			if (type == 2 || type == 4)
+			if (trail_material)
 			{
-				qp.restitution = 0.2f;
-				qp.min_bounce_speed = 20.f;
-				qp.flags = Q3P_PARTICLE_COLLIDE_WORLD;
+				q3p_particle_t qp;
+				memset (&qp, 0, sizeof(qp));
+				qp.spawn_time = cl.time;
+				qp.lifetime = trail_has_def ? (trail_def.lifetime_min + ((rand() & 255) / 255.f) * trail_def.lifetime_rand) : trail_lifetime;
+				qp.size = trail_has_def ? (trail_def.size + ((rand() & 255) / 255.f) * trail_def.size_rand) : (trail_size + ((rand() & 7) - 3) * 0.05f);
+				qp.size_ramp = trail_has_def ? trail_def.size_ramp : trail_size_ramp;
+				qp.alpha = trail_has_def ? trail_def.alpha : 1.0f;
+				qp.alpha_ramp = trail_has_def ? trail_def.alpha_ramp : trail_alpha_ramp;
+				qp.color = trail_has_def ? trail_def.color : trail_color;
+				qp.gravity = trail_has_def ? trail_def.gravity : trail_gravity;
+				qp.drag = trail_has_def ? trail_def.drag : trail_drag;
+				if (type == 2 || type == 4)
+				{
+					qp.restitution = trail_has_def ? trail_def.restitution : 0.2f;
+					qp.min_bounce_speed = trail_has_def ? trail_def.min_bounce_speed : 20.f;
+					qp.flags = trail_has_def ? (trail_def.collide_world ? Q3P_PARTICLE_COLLIDE_WORLD : 0) : Q3P_PARTICLE_COLLIDE_WORLD;
+				}
+				q_strlcpy (qp.material, trail_has_def ? trail_def.material : trail_material, sizeof(qp.material));
+				for (j = 0; j < 3; ++j)
+					qp.org[j] = start[j] + ((rand() & 7) - 3) * (trail_has_def ? trail_def.org_jitter / 3.f : 1.f);
+				if (trail_has_def && trail_def.vel_jitter > 0.f)
+				{
+					qp.vel[0] = ((rand() & 255) - 128) * (trail_def.vel_jitter / 128.f);
+					qp.vel[1] = ((rand() & 255) - 128) * (trail_def.vel_jitter / 128.f);
+					qp.vel[2] = ((rand() & 255) - 128) * (trail_def.vel_jitter / 128.f);
+				}
+				if (Q3P_Spawn (&qp))
+					spawned_q3p = true;
 			}
-			q_strlcpy (qp.material, trail_material, sizeof(qp.material));
-			for (j = 0; j < 3; ++j)
-				qp.org[j] = start[j] + ((rand() & 7) - 3);
-			if (Q3P_Spawn (&qp))
-				spawned_q3p = true;
-		}
 
 		if (!spawned_q3p)
 		{

--- a/Quake/r_part_q3p.c
+++ b/Quake/r_part_q3p.c
@@ -60,6 +60,217 @@ static q3p_particlevert_t *q3p_partverts;
 static int q3p_numdrawitems;
 static int q3p_numpartverts;
 
+#define Q3P_MAX_EFFECT_DEFS 256
+typedef struct q3p_named_effectdef_s {
+	qboolean used;
+	char name[64];
+	q3p_effectdef_t def;
+} q3p_named_effectdef_t;
+
+static q3p_named_effectdef_t q3p_effect_defs[Q3P_MAX_EFFECT_DEFS];
+
+static void Q3P_EffectDefSetDefaults (q3p_effectdef_t *def)
+{
+	memset (def, 0, sizeof (*def));
+	def->count = 1;
+	def->lifetime_min = 0.2f;
+	def->lifetime_rand = 0.0f;
+	def->size = 1.0f;
+	def->size_rand = 0.0f;
+	def->size_ramp = 0.0f;
+	def->alpha = 1.0f;
+	def->alpha_ramp = -1.0f;
+	def->color = 0x6f;
+	def->gravity = 0.0f;
+	def->drag = 0.0f;
+	def->restitution = 0.0f;
+	def->min_bounce_speed = 0.0f;
+	def->org_jitter = 0.0f;
+	def->vel_jitter = 0.0f;
+	def->vel_scale = 1.0f;
+	def->collide_world = false;
+	q_strlcpy (def->material, "*particle", sizeof (def->material));
+}
+
+static q3p_named_effectdef_t *Q3P_FindOrAllocEffectDef (const char *name)
+{
+	int i;
+	int free_slot = -1;
+
+	for (i = 0; i < Q3P_MAX_EFFECT_DEFS; ++i)
+	{
+		if (q3p_effect_defs[i].used)
+		{
+			if (!q_strcasecmp (q3p_effect_defs[i].name, name))
+				return &q3p_effect_defs[i];
+		}
+		else if (free_slot < 0)
+		{
+			free_slot = i;
+		}
+	}
+
+	if (free_slot < 0)
+		return NULL;
+
+	q3p_effect_defs[free_slot].used = true;
+	q_strlcpy (q3p_effect_defs[free_slot].name, name, sizeof (q3p_effect_defs[free_slot].name));
+	Q3P_EffectDefSetDefaults (&q3p_effect_defs[free_slot].def);
+	return &q3p_effect_defs[free_slot];
+}
+
+static void Q3P_ParseEffectDefText (const char *source_name, char *text)
+{
+	const char *cursor = text;
+
+	while ((cursor = COM_Parse (cursor)) != NULL)
+	{
+		q3p_named_effectdef_t *entry;
+		q3p_effectdef_t def;
+		char effect_name[64];
+
+		if (!com_token[0])
+			break;
+
+		q_strlcpy (effect_name, com_token, sizeof (effect_name));
+		entry = Q3P_FindOrAllocEffectDef (effect_name);
+		if (!entry)
+		{
+			Con_Warning ("Q3P: effect def table full, skipping '%s' from %s\n", effect_name, source_name);
+			return;
+		}
+
+		def = entry->def;
+
+		cursor = COM_Parse (cursor);
+		if (!cursor || q_strcmp (com_token, "{"))
+		{
+			Con_Warning ("Q3P: expected '{' after effect '%s' in %s\n", effect_name, source_name);
+			return;
+		}
+
+		while ((cursor = COM_Parse (cursor)) != NULL)
+		{
+			if (!q_strcmp (com_token, "}"))
+				break;
+
+			if (!q_strcasecmp (com_token, "material"))
+			{
+				if (!(cursor = COM_Parse (cursor))) break;
+				q_strlcpy (def.material, com_token, sizeof (def.material));
+			}
+			else if (!q_strcasecmp (com_token, "count"))
+			{
+				if (!(cursor = COM_Parse (cursor))) break;
+				def.count = q_max (1, Q_atoi (com_token));
+			}
+			else if (!q_strcasecmp (com_token, "lifetime_min")) { if (!(cursor = COM_Parse (cursor))) break; def.lifetime_min = Q_atof (com_token); }
+			else if (!q_strcasecmp (com_token, "lifetime_rand")) { if (!(cursor = COM_Parse (cursor))) break; def.lifetime_rand = Q_atof (com_token); }
+			else if (!q_strcasecmp (com_token, "size")) { if (!(cursor = COM_Parse (cursor))) break; def.size = Q_atof (com_token); }
+			else if (!q_strcasecmp (com_token, "size_rand")) { if (!(cursor = COM_Parse (cursor))) break; def.size_rand = Q_atof (com_token); }
+			else if (!q_strcasecmp (com_token, "size_ramp")) { if (!(cursor = COM_Parse (cursor))) break; def.size_ramp = Q_atof (com_token); }
+			else if (!q_strcasecmp (com_token, "alpha")) { if (!(cursor = COM_Parse (cursor))) break; def.alpha = CLAMP (0.f, Q_atof (com_token), 1.f); }
+			else if (!q_strcasecmp (com_token, "alpha_ramp")) { if (!(cursor = COM_Parse (cursor))) break; def.alpha_ramp = Q_atof (com_token); }
+			else if (!q_strcasecmp (com_token, "color")) { if (!(cursor = COM_Parse (cursor))) break; def.color = Q_atoi (com_token); }
+			else if (!q_strcasecmp (com_token, "gravity")) { if (!(cursor = COM_Parse (cursor))) break; def.gravity = Q_atof (com_token); }
+			else if (!q_strcasecmp (com_token, "drag")) { if (!(cursor = COM_Parse (cursor))) break; def.drag = Q_atof (com_token); }
+			else if (!q_strcasecmp (com_token, "restitution")) { if (!(cursor = COM_Parse (cursor))) break; def.restitution = Q_atof (com_token); }
+			else if (!q_strcasecmp (com_token, "min_bounce_speed")) { if (!(cursor = COM_Parse (cursor))) break; def.min_bounce_speed = Q_atof (com_token); }
+			else if (!q_strcasecmp (com_token, "org_jitter")) { if (!(cursor = COM_Parse (cursor))) break; def.org_jitter = Q_atof (com_token); }
+			else if (!q_strcasecmp (com_token, "vel_jitter")) { if (!(cursor = COM_Parse (cursor))) break; def.vel_jitter = Q_atof (com_token); }
+			else if (!q_strcasecmp (com_token, "vel_scale")) { if (!(cursor = COM_Parse (cursor))) break; def.vel_scale = Q_atof (com_token); }
+			else if (!q_strcasecmp (com_token, "collide_world")) { if (!(cursor = COM_Parse (cursor))) break; def.collide_world = Q_atoi (com_token) != 0; }
+			else
+			{
+				Con_DWarning ("Q3P: unknown key '%s' in effect '%s' (%s)\n", com_token, effect_name, source_name);
+				cursor = COM_Parse (cursor);
+			}
+		}
+
+		def.loaded = true;
+		entry->def = def;
+	}
+}
+
+static void Q3P_LoadEffectDefs (void)
+{
+	searchpath_t *search;
+	int loaded = 0;
+
+	memset (q3p_effect_defs, 0, sizeof (q3p_effect_defs));
+
+	for (search = com_searchpaths; search; search = search->next)
+	{
+		if (search->pack)
+		{
+			int i;
+			for (i = 0; i < search->pack->numfiles; ++i)
+			{
+				const char *path = search->pack->files[i].name;
+				byte *buffer;
+				size_t size = (size_t)search->pack->files[i].filelen;
+
+				if (q_strncasecmp (path, "particles/", 10) || q_strcasecmp (COM_FileGetExtension (path), "prt"))
+					continue;
+				buffer = COM_LoadMallocFile (path, NULL);
+				if (!buffer)
+					continue;
+				Q3P_ParseEffectDefText (path, (char *)buffer);
+				Z_Free (buffer);
+				if (size > 0)
+					++loaded;
+			}
+		}
+		else
+		{
+			char folder[MAX_OSPATH];
+			findfile_t *find;
+
+			if ((size_t)q_snprintf (folder, sizeof (folder), "%s/particles", search->filename) >= sizeof (folder))
+				continue;
+
+			for (find = Sys_FindFirst (folder, "prt"); find; find = Sys_FindNext (find))
+			{
+				char rel[MAX_QPATH];
+				byte *buffer;
+
+				if (find->attribs & FA_DIRECTORY)
+					continue;
+				q_snprintf (rel, sizeof (rel), "particles/%s", find->name);
+				buffer = COM_LoadMallocFile (rel, NULL);
+				if (!buffer)
+					continue;
+				Q3P_ParseEffectDefText (rel, (char *)buffer);
+				Z_Free (buffer);
+				++loaded;
+			}
+		}
+	}
+
+	if (loaded > 0)
+		Con_Printf ("Q3P: loaded %d .prt particle definition files\n", loaded);
+}
+
+qboolean Q3P_GetEffectDef (const char *name, q3p_effectdef_t *out_def)
+{
+	int i;
+
+	if (!name || !name[0] || !out_def)
+		return false;
+
+	for (i = 0; i < Q3P_MAX_EFFECT_DEFS; ++i)
+	{
+		if (!q3p_effect_defs[i].used)
+			continue;
+		if (q_strcasecmp (q3p_effect_defs[i].name, name))
+			continue;
+		*out_def = q3p_effect_defs[i].def;
+		return out_def->loaded;
+	}
+
+	return false;
+}
+
 
 static void Q3P_RefreshBudget (void)
 {
@@ -425,6 +636,7 @@ void Q3P_Init (void)
 	q3p_spawn_budget_remaining = 0;
 	memset (q3p_emitters, 0, sizeof (q3p_emitters));
 	memset (q3p_material_cache, 0, sizeof (q3p_material_cache));
+	Q3P_LoadEffectDefs ();
 	Q3P_RefreshBudget ();
 }
 

--- a/Quake/r_part_q3p.h
+++ b/Quake/r_part_q3p.h
@@ -51,6 +51,28 @@ typedef struct q3p_debug_stats_s {
 	int culled;
 } q3p_debug_stats_t;
 
+typedef struct q3p_effectdef_s {
+	qboolean loaded;
+	int		count;
+	float	lifetime_min;
+	float	lifetime_rand;
+	float	size;
+	float	size_rand;
+	float	size_ramp;
+	float	alpha;
+	float	alpha_ramp;
+	int		color;
+	float	gravity;
+	float	drag;
+	float	restitution;
+	float	min_bounce_speed;
+	float	org_jitter;
+	float	vel_jitter;
+	float	vel_scale;
+	qboolean collide_world;
+	char	material[64];
+} q3p_effectdef_t;
+
 void Q3P_Init (void);
 void Q3P_Shutdown (void);
 void Q3P_Clear (void);
@@ -62,5 +84,6 @@ void Q3P_GetDebugStats (q3p_debug_stats_t *stats);
 void Q3P_ResetDebugStats (void);
 int Q3P_AddWorldEmitter (const q3p_emitter_t *emitter);
 void Q3P_ClearWorldEmitters (void);
+qboolean Q3P_GetEffectDef (const char *name, q3p_effectdef_t *out_def);
 
 #endif


### PR DESCRIPTION
### Motivation

- Introduce configurable particle effect definitions to allow tuning particle parameters (count, lifetime, size, jitter, collisions, etc.) and to make Q3P particle behavior data-driven.
- Use parsed effect definitions to unify legacy/hybrid particle spawning and allow .prt files shipped with packages to override hardcoded defaults.

### Description

- Add a new `q3p_effectdef_t` structure and effect-definition storage with parser and loader in `r_part_q3p.c`, including `Q3P_LoadEffectDefs()`, `Q3P_ParseEffectDefText()`, `Q3P_FindOrAllocEffectDef()` and `Q3P_GetEffectDef()` to read `.prt` files from search paths and pack files.
- Initialize effect definitions from `Q3P_LoadEffectDefs()` in `Q3P_Init()` and set sensible defaults via `Q3P_EffectDefSetDefaults()`.
- Update particle spawn code paths to consult effect definitions when available: `CL_TEntTrySpawnQ3P()` (impact/temp entities), `R_TrySpawnQ3PLegacyParticleEffect()` (legacy/bullet/explosion effects), and `R_RocketTrail()` (rocket trails) now override spawn parameters (count, lifetime, size, size_ramp, alpha, color, gravity, drag, restitution, collision flags, material, origin jitter, velocity jitter/scale, etc.) when a matching `.prt` definition is found.
- Add a default `particles/default.prt` file containing definitions for `impact_puff`, `smoke`, `bullet`, and `explosion` to provide baseline effect values.
- Minor adjustments to spawn logic to respect per-effect `collide_world` flag and apply jitter/scales only when provided by the effect definition.

### Testing

- Project compiles successfully with the updated codebase using the standard build (`make`) without compile errors.
- No automated unit tests were added for this new data-driven particle feature (existing automated tests, if any, were not modified).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a57ac867d8832e82b83d306239569c)