### PR TITLE
Add particle debug overlay, r_particles_debug CVar, and MVP comparison tooling

### DIFF
--- a/Quake/gl_screen.c
+++ b/Quake/gl_screen.c
@@ -30,6 +30,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 extern cvar_t r_autoexposure;
 extern cvar_t r_exposure_debug;
+extern cvar_t r_particles_debug;
 extern float r_autoexposure_debug_exposure;
 extern float r_autoexposure_debug_luminance;
 
@@ -1052,6 +1053,60 @@ void SCR_DrawExposureDebug (void)
 
 	sprintf (str, "AutoExp  %s", r_autoexposure.value > 0.f ? "on" : "off");
 	Draw_String (x, (y++) * 8 - x, str);
+}
+
+
+void SCR_DrawParticleDebug (void)
+{
+	particle_debug_stats_t stats;
+	char str[96];
+	int x = 0;
+	int y = 25 - 8;
+	int i;
+	const char *overdraw;
+
+	if (r_particles_debug.value <= 0.f)
+		return;
+
+	R_GetParticleDebugStats (&stats);
+	if (stats.overdraw_score < 0.05f)
+		overdraw = "low";
+	else if (stats.overdraw_score < 0.15f)
+		overdraw = "med";
+	else
+		overdraw = "high";
+
+	GL_SetCanvas (CANVAS_BOTTOMLEFT);
+	Draw_Fill (x, y * 8, 36 * 8, ((int)r_particles_debug.value >= 2 ? 8 : 5) * 8, 0, 0.5f);
+
+	q_snprintf (str, sizeof (str), "particles debug");
+	Draw_String (x, (y++) * 8 - x, str);
+	q_snprintf (str, sizeof (str), "active legacy=%4d q3p=%4d", stats.active_legacy, stats.active_q3p);
+	Draw_String (x, (y++) * 8 - x, str);
+	q_snprintf (str, sizeof (str), "q3p spawned=%4d drop=%4d cull=%4d", stats.q3p_spawned, stats.q3p_dropped, stats.q3p_culled);
+	Draw_String (x, (y++) * 8 - x, str);
+	q_snprintf (str, sizeof (str), "overdraw=%0.3f (%s)", stats.overdraw_score, overdraw);
+	Draw_String (x, (y++) * 8 - x, str);
+
+	q_snprintf (str, sizeof (str), "buckets:");
+	for (i = 0; i < 8; ++i)
+		q_snprintf (str + strlen (str), sizeof (str) - strlen (str), " %d", stats.bucket_legacy[i]);
+	Draw_String (x, (y++) * 8 - x, str);
+
+	if ((int)r_particles_debug.value >= 2)
+	{
+		if (stats.has_bounds)
+		{
+			q_snprintf (str, sizeof (str), "mins %6.1f %6.1f %6.1f", stats.bounds_mins[0], stats.bounds_mins[1], stats.bounds_mins[2]);
+			Draw_String (x, (y++) * 8 - x, str);
+			q_snprintf (str, sizeof (str), "maxs %6.1f %6.1f %6.1f", stats.bounds_maxs[0], stats.bounds_maxs[1], stats.bounds_maxs[2]);
+			Draw_String (x, (y++) * 8 - x, str);
+		}
+		else
+		{
+			Draw_String (x, (y++) * 8 - x, "bounds: n/a");
+		}
+	}
 }
 
 /*
@@ -2197,6 +2252,7 @@ void SCR_UpdateScreen (void)
 		SCR_CheckDrawCenterString ();
 		Sbar_Draw ();
 		SCR_DrawDevStats (); //johnfitz
+		SCR_DrawParticleDebug ();
 		SCR_DrawExposureDebug ();
 		SCR_DrawClock (); //johnfitz
 		SCR_DrawDemoControls ();

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -66,6 +66,20 @@ typedef struct particle_s
 	float		ramp;
 } particle_t;
 
+typedef struct particle_debug_stats_s
+{
+	int	active_legacy;
+	int	active_q3p;
+	int	bucket_legacy[8];
+	int	q3p_spawned;
+	int	q3p_dropped;
+	int	q3p_culled;
+	float	overdraw_score;
+	qboolean has_bounds;
+	vec3_t	bounds_mins;
+	vec3_t	bounds_maxs;
+} particle_debug_stats_t;
+
 
 //====================================================
 
@@ -496,6 +510,7 @@ void R_DrawParticles (qboolean alpha);
 void R_DrawParticles_ShowTris (void);
 void CL_RunParticles (void);
 void R_ClearParticles (void);
+void R_GetParticleDebugStats (particle_debug_stats_t *stats);
 
 void R_TranslatePlayerSkin (int playernum);
 void R_TranslateNewPlayerSkin (int playernum); //johnfitz -- this handles cases when the actual texture changes

--- a/Quake/r_part.c
+++ b/Quake/r_part.c
@@ -46,6 +46,14 @@ cvar_t	r_particles_sort = {"r_particles_sort", "0", CVAR_ARCHIVE};
 cvar_t	r_particles_cull_dist = {"r_particles_cull_dist", "4096", CVAR_ARCHIVE};
 cvar_t	r_particles_collision = {"r_particles_collision", "1", CVAR_ARCHIVE};
 cvar_t	r_particles_spawn_max = { "r_particles_spawn_max", "2048", CVAR_ARCHIVE};
+cvar_t	r_particles_debug = { "r_particles_debug", "0", CVAR_ARCHIVE};
+
+
+static int r_particles_debug_legacy_buckets[8];
+static vec3_t r_particles_debug_bounds_mins;
+static vec3_t r_particles_debug_bounds_maxs;
+static qboolean r_particles_debug_has_bounds;
+static float r_particles_debug_overdraw_score;
 
 typedef enum
 {
@@ -329,6 +337,7 @@ void R_InitParticles (void)
 	Cvar_RegisterVariable (&r_particles_cull_dist);
 	Cvar_RegisterVariable (&r_particles_collision);
 	Cvar_RegisterVariable (&r_particles_spawn_max);
+	Cvar_RegisterVariable (&r_particles_debug);
 
 	Q3P_Init ();
 	Cmd_AddCommand ("q3p_spawn", R_Q3P_TestSpawn_f);
@@ -882,6 +891,32 @@ void R_RocketTrail (vec3_t start, vec3_t end, int type)
 	}
 }
 
+
+void R_GetParticleDebugStats (particle_debug_stats_t *stats)
+{
+	q3p_debug_stats_t q3p_stats;
+
+	if (!stats)
+		return;
+
+	memset (stats, 0, sizeof (*stats));
+	stats->active_legacy = r_numactiveparticles;
+	memcpy (stats->bucket_legacy, r_particles_debug_legacy_buckets, sizeof (stats->bucket_legacy));
+	stats->overdraw_score = r_particles_debug_overdraw_score;
+	stats->has_bounds = r_particles_debug_has_bounds;
+	if (r_particles_debug_has_bounds)
+	{
+		VectorCopy (r_particles_debug_bounds_mins, stats->bounds_mins);
+		VectorCopy (r_particles_debug_bounds_maxs, stats->bounds_maxs);
+	}
+
+	Q3P_GetDebugStats (&q3p_stats);
+	stats->active_q3p = q3p_stats.active;
+	stats->q3p_spawned = q3p_stats.spawned;
+	stats->q3p_dropped = q3p_stats.dropped;
+	stats->q3p_culled = q3p_stats.culled;
+}
+
 /*
 ===============
 CL_RunParticles -- johnfitz -- all the particle behavior, separated from R_DrawParticles
@@ -976,6 +1011,37 @@ void CL_RunParticles (void)
 	}
 
 	r_numactiveparticles = active;
+
+	memset (r_particles_debug_legacy_buckets, 0, sizeof (r_particles_debug_legacy_buckets));
+	r_particles_debug_has_bounds = false;
+	r_particles_debug_overdraw_score = 0.f;
+	if (r_numactiveparticles > 0)
+	{
+		for (i = 0; i < r_numactiveparticles; ++i)
+		{
+			int bucket = particles[i].type;
+			if (bucket < 0 || bucket >= (int)countof (r_particles_debug_legacy_buckets))
+				bucket = 0;
+			r_particles_debug_legacy_buckets[bucket]++;
+			if (!r_particles_debug_has_bounds)
+			{
+				VectorCopy (particles[i].org, r_particles_debug_bounds_mins);
+				VectorCopy (particles[i].org, r_particles_debug_bounds_maxs);
+				r_particles_debug_has_bounds = true;
+			}
+			else
+			{
+				int j;
+				for (j = 0; j < 3; ++j)
+				{
+					r_particles_debug_bounds_mins[j] = q_min (r_particles_debug_bounds_mins[j], particles[i].org[j]);
+					r_particles_debug_bounds_maxs[j] = q_max (r_particles_debug_bounds_maxs[j], particles[i].org[j]);
+				}
+			}
+		}
+		r_particles_debug_overdraw_score = ((float)r_numactiveparticles * 16.f) /
+			q_max ((float)(r_refdef.vrect.width * r_refdef.vrect.height), 1.f);
+	}
 }
 
 /*

--- a/docs/particle_debug_mvp.md
+++ b/docs/particle_debug_mvp.md
@@ -1,0 +1,59 @@
+# Particle MVP Debug-Overlay und Referenzvergleich
+
+## Neue CVars
+
+- `r_particles_debug 0|1|2`
+  - `0`: aus.
+  - `1`: Overlay mit reproduzierbaren Metriken (`active`, `buckets`, `q3p stats`, `overdraw`).
+  - `2`: wie `1`, zusätzlich Legacy-Partikel-Bounds (`mins/maxs`) im Overlay.
+
+## Debug-Overlay (`r_particles_debug`)
+
+Das Overlay zeigt pro Frame:
+
+- `active legacy` und `active q3p`
+- q3p-Zähler: `spawned`, `drop`, `cull`
+- `buckets` der Legacy-Partikeltypen (Index 0..7 entspricht internem `ptype_t`)
+- Overdraw-Indikator (`low|med|high`) plus numerischer `overdraw`-Score
+- Optional (`r_particles_debug >= 2`): `mins/maxs` Bounding-Werte der aktiven Legacy-Partikel
+
+## Vergleichsprozedur für Referenzeffekte (gleiche Kamera/Seed)
+
+> Ziel: reproduzierbarer A/B-Vergleich zwischen Referenz-Branch und aktuellem Branch.
+
+1. **Determinismus vorbereiten**
+   - Gleiche Map/Startposition laden (z. B. Savegame).
+   - Dieselben CVars setzen (insb. Partikelmodus, Auflösung, PostFX).
+   - Falls Demo vorhanden: gleiche Demo starten und identische Tickposition nutzen.
+2. **Kamera fixieren**
+   - `noclip` + definierte `setpos` / `setang` verwenden.
+3. **Seed fixieren**
+   - Effekt direkt nacheinander in frischem Zustand auslösen (gleicher Ablauf/Skript).
+4. **Screenshots aufnehmen**
+   - Pro Effekt ein Bild: `TE_EXPLOSION`, `GUNSHOT`, `BLOOD`, `LIGHTNING`, `TELEPORT`.
+   - Dateinamen exakt: `TE_EXPLOSION.png`, `GUNSHOT.png`, `BLOOD.png`, `LIGHTNING.png`, `TELEPORT.png`.
+5. **Optional Hash-Diff**
+   - `python/particle_hash_diff.py <baseline_dir> <candidate_dir> --ext png`
+   - Exitcode `0` = alle identisch, `1` = mindestens ein Unterschied/fehlende Datei.
+
+## MVP-Checklist (Akzeptanz)
+
+- [ ] `r_particles_debug 1` zeigt reproduzierbare Metriken bei identischem Setup.
+- [ ] `TE_EXPLOSION` Screenshot erstellt und geprüft.
+- [ ] `GUNSHOT` Screenshot erstellt und geprüft.
+- [ ] `BLOOD` Screenshot erstellt und geprüft.
+- [ ] `LIGHTNING` Screenshot erstellt und geprüft.
+- [ ] `TELEPORT` Screenshot erstellt und geprüft.
+- [ ] Optionaler Hash-Diff ausgeführt und dokumentiert.
+
+## Mod-Kompatibilität
+
+- Overlay ist rein Client-seitig und greift nicht in Netzwerkprotokoll/QC ein.
+- Legacy- und q3p-Metriken werden parallel berichtet; bestehende Mods ohne q3p bleiben lauffähig.
+- `r_particles_debug` beeinflusst Partikelsimulation nicht direkt, nur HUD-Ausgabe/Statistikaggregation.
+
+## Bekannte MVP-Einschränkungen
+
+- Bounds beziehen sich aktuell auf Legacy-Partikel; q3p-Bounds werden nicht separat visualisiert.
+- Overdraw ist ein heuristischer Score, kein GPU-Per-Pixel-Counter.
+- Hash-Diff vergleicht Rohbilder binär; geringe nichtdeterministische Renderabweichungen führen zu "diff".

--- a/python/particle_hash_diff.py
+++ b/python/particle_hash_diff.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Compute sha256 hashes for paired reference screenshots."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+from pathlib import Path
+import sys
+
+EFFECTS = ("TE_EXPLOSION", "GUNSHOT", "BLOOD", "LIGHTNING", "TELEPORT")
+
+
+def sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("baseline_dir", type=Path)
+    parser.add_argument("candidate_dir", type=Path)
+    parser.add_argument("--ext", default="png", help="Screenshot extension (default: png)")
+    args = parser.parse_args()
+
+    ok = True
+    print("effect,baseline,candidate,match")
+    for effect in EFFECTS:
+        base = args.baseline_dir / f"{effect}.{args.ext}"
+        cand = args.candidate_dir / f"{effect}.{args.ext}"
+        if not base.exists() or not cand.exists():
+            print(f"{effect},MISSING,MISSING,false")
+            ok = False
+            continue
+        b = sha256(base)
+        c = sha256(cand)
+        match = b == c
+        print(f"{effect},{b},{c},{str(match).lower()}")
+        ok = ok and match
+
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Motivation

- Provide reproducible per-frame diagnostics for particle systems (legacy vs q3p) to aid debugging and regression testing. 
- Enable a minimal, reproducible MVP workflow for comparing reference particle effects (same camera/seed) and flag visual diffs deterministically.

### Description

- Add `r_particles_debug` CVar and collect per-frame stats in `Quake/r_part.c`: legacy active count, legacy buckets, optional legacy bounds, overdraw score, and q3p debug counters, exposed via `R_GetParticleDebugStats`.
- Define `particle_debug_stats_t` and declare `R_GetParticleDebugStats` in `Quake/glquake.h` so the HUD can read the aggregated stats.
- Implement HUD overlay `SCR_DrawParticleDebug` in `Quake/gl_screen.c` and hook it into the standard draw path; `r_particles_debug=1` shows metrics and `=2` adds legacy bounds.
- Add `python/particle_hash_diff.py` to compute SHA-256 hashes for paired screenshots, and `docs/particle_debug_mvp.md` describing new CVars, the comparison procedure, mod-compat notes, known limitations, and an acceptance checklist for the five MVP effects.

### Testing

- Ran `python3 python/particle_hash_diff.py --help`, which succeeded and printed usage information.
- Ran `cmake -S . -B build` in this environment, which failed due to a missing SDL2 development package (`SDL2Config.cmake` not found) and is an environment issue rather than a code error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a58fb8c40c832e81d2f9995db3f3ce)