### PR TITLE
Move Q3P particle culling to render path

### DIFF
--- a/Quake/r_part_q3p.c
+++ b/Quake/r_part_q3p.c
@@ -15,6 +15,7 @@ static int q3p_budgetparticles;
 static int q3p_spawned_counter;
 static int q3p_dropped_counter;
 static int q3p_culled_counter;
+static int q3p_culled_counter_frame;
 static float q3p_spawn_budget_time;
 static int q3p_spawn_budget_remaining;
 
@@ -632,6 +633,7 @@ void Q3P_Init (void)
 	q3p_spawned_counter = 0;
 	q3p_dropped_counter = 0;
 	q3p_culled_counter = 0;
+	q3p_culled_counter_frame = -1;
 	q3p_spawn_budget_time = -1.f;
 	q3p_spawn_budget_remaining = 0;
 	memset (q3p_emitters, 0, sizeof (q3p_emitters));
@@ -652,6 +654,7 @@ void Q3P_Shutdown (void)
 	q3p_spawned_counter = 0;
 	q3p_dropped_counter = 0;
 	q3p_culled_counter = 0;
+	q3p_culled_counter_frame = -1;
 	q3p_spawn_budget_time = -1.f;
 	q3p_spawn_budget_remaining = 0;
 	memset (q3p_emitters, 0, sizeof (q3p_emitters));
@@ -667,6 +670,7 @@ void Q3P_Clear (void)
 	q3p_spawned_counter = 0;
 	q3p_dropped_counter = 0;
 	q3p_culled_counter = 0;
+	q3p_culled_counter_frame = -1;
 	q3p_spawn_budget_time = -1.f;
 	q3p_spawn_budget_remaining = 0;
 }
@@ -735,12 +739,6 @@ void Q3P_Update (float frametime)
 			continue;
 		if (!Q3P_ParticleFinite (p))
 			continue;
-		if (Q3P_ShouldCullParticle (p))
-		{
-			++q3p_culled_counter;
-			continue;
-		}
-
 		p->size += p->size_ramp * frametime;
 		p->alpha += p->alpha_ramp * frametime;
 		p->alpha = CLAMP (0, p->alpha, 1);
@@ -889,6 +887,13 @@ void Q3P_Draw (qboolean alpha, qboolean showtris)
 	if (q3p_numactive <= 0)
 		return;
 
+	/* Track render-time culls once per rendered frame (opaque pass). */
+	if (q3p_culled_counter_frame != r_framecount)
+	{
+		q3p_culled_counter = 0;
+		q3p_culled_counter_frame = r_framecount;
+	}
+
 	q3p_numdrawitems = 0;
 	for (i = 0; i < q3p_numactive; ++i)
 	{
@@ -897,6 +902,12 @@ void Q3P_Draw (qboolean alpha, qboolean showtris)
 
 		if (!showtris && alpha != blend_group)
 			continue;
+		if (Q3P_ShouldCullParticle (p))
+		{
+			if (!showtris && !alpha)
+				++q3p_culled_counter;
+			continue;
+		}
 
 		q3p_drawitems[q3p_numdrawitems].particle_index = i;
 		q3p_drawitems[q3p_numdrawitems].blend_group = blend_group;
@@ -1010,6 +1021,7 @@ void Q3P_ResetDebugStats (void)
 	q3p_spawned_counter = 0;
 	q3p_dropped_counter = 0;
 	q3p_culled_counter = 0;
+	q3p_culled_counter_frame = -1;
 }
 
 int Q3P_AddWorldEmitter (const q3p_emitter_t *emitter)


### PR DESCRIPTION
### Motivation
- Prevent particles from being removed from simulation purely due to frustum/distance checks so they preserve lifetime/state while off-screen and reappear when the camera returns.
- Make cull statistics unambiguous by ensuring `q3p_culled_counter` reflects render-time (per-frame) culls rather than particles removed from the simulation.

### Description
- Removed simulation-time removal in `Q3P_Update()` by deleting the `Q3P_ShouldCullParticle()` early-continue path so particles are no longer dropped from `q3p_particles` during update.
- Moved frustum/distance culling into the draw-item construction in `Q3P_Draw()` so culling only affects whether a particle is rendered this frame.
- Added `q3p_culled_counter_frame` and reset `q3p_culled_counter` once per `r_framecount` inside `Q3P_Draw()` to make the counter explicitly represent "render-culled this frame"; increments occur only in the opaque draw pass.
- Initialized/reset the new frame-tracker in `Q3P_Init()`, `Q3P_Shutdown()`, `Q3P_Clear()` and `Q3P_ResetDebugStats()` to keep behavior deterministic across lifecycle transitions.

### Testing
- Ran `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`, which failed in this environment due to a missing `SDL2` CMake package, so a full build verification could not be completed.
- Inspected diffs with `git diff` and recorded the commit (`Move Q3P particle culling to render path`), and verified the repository state with `git show --stat` (both succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5b7ddf75c832ea8d4c435bbf22c36)