### PR TITLE
q3p: preserve normalized cache keys for fallback materials

### DIFF
--- a/Quake/r_part.c
+++ b/Quake/r_part.c
@@ -151,6 +151,20 @@ static void R_Q3P_ResetStats_f (void)
 	Con_Printf ("q3p: debug stats reset\n");
 }
 
+static void R_Q3P_StressMaterialCache_f (void)
+{
+	int iterations = (Cmd_Argc () > 1) ? q_max (1, Q_atoi (Cmd_Argv (1))) : 2048;
+	int unique_names = (Cmd_Argc () > 2) ? q_max (1, Q_atoi (Cmd_Argv (2))) : 1;
+	int before = 0;
+	int after = 0;
+	qboolean ok = Q3P_DebugStressMaterialCache (iterations, unique_names, &before, &after);
+
+	Con_Printf ("q3p_material_cache_stress: iterations=%d unique=%d before=%d after=%d %s\n",
+		iterations, unique_names, before, after, ok ? "ok" : "failed");
+	if (!ok)
+		Con_DWarning ("q3p: material cache stress test detected unexpected cache growth\n");
+}
+
 static void R_Q3P_AddWorldEmitter_f (void)
 {
 	q3p_emitter_t e;
@@ -350,6 +364,7 @@ void R_InitParticles (void)
 	Cmd_AddCommand ("q3p_spawn", R_Q3P_TestSpawn_f);
 	Cmd_AddCommand ("q3p_stats", R_Q3P_DebugStats_f);
 	Cmd_AddCommand ("q3p_stats_reset", R_Q3P_ResetStats_f);
+	Cmd_AddCommand ("q3p_material_cache_stress", R_Q3P_StressMaterialCache_f);
 	Cmd_AddCommand ("q3p_emitter_add", R_Q3P_AddWorldEmitter_f);
 	Cmd_AddCommand ("q3p_emitter_clear", Q3P_ClearWorldEmitters);
 }

--- a/Quake/r_part_q3p.c
+++ b/Quake/r_part_q3p.c
@@ -33,12 +33,21 @@ enum
 	Q3P_MATFLAG_FALLBACK = 1u << 2
 };
 
+enum
+{
+	Q3P_MATWARN_STRICT_SKIP = 1u << 0,
+	Q3P_MATWARN_BEST_EFFORT = 1u << 1
+};
+
 typedef struct q3p_material_cache_entry_s {
 	qboolean used;
 	char key[64];
 	unsigned material_id;
+	char resolved_key[64];
+	unsigned resolved_material_id;
 	const shader_material_t *material;
 	unsigned flags;
+	unsigned warned_flags;
 	int supported_stage_count;
 } q3p_material_cache_entry_t;
 
@@ -490,6 +499,8 @@ static const q3p_material_cache_entry_t *Q3P_ResolveMaterialCached (const char *
 		entry->used = true;
 		q_strlcpy (entry->key, normalized, sizeof (entry->key));
 		entry->material_id = Q3P_HashMaterialId (entry->key);
+		q_strlcpy (entry->resolved_key, entry->key, sizeof (entry->resolved_key));
+		entry->resolved_material_id = entry->material_id;
 
 		material = Mat_Shader_Find (entry->key);
 		if (!material)
@@ -530,18 +541,25 @@ static const q3p_material_cache_entry_t *Q3P_ResolveMaterialCached (const char *
 
 		if (!material || (!stage0_ok && r_particles_shader_strict.value > 0.f))
 		{
-			if (material && !stage0_ok)
+			if (material && !stage0_ok && !(entry->warned_flags & Q3P_MATWARN_STRICT_SKIP))
+			{
 				Con_Warning ("Q3P: strict mode skipping particle material '%s' (%s)\n", normalized, fallback_reason[0] ? fallback_reason : "unsupported stage");
+				entry->warned_flags |= Q3P_MATWARN_STRICT_SKIP;
+			}
 			entry->flags |= Q3P_MATFLAG_FALLBACK;
 			entry->material = NULL;
-			q_strlcpy (entry->key, Q3P_MATERIAL_DEFAULT_REF, sizeof (entry->key));
-			entry->material_id = Q3P_HashMaterialId (entry->key);
+			q_strlcpy (entry->resolved_key, Q3P_MATERIAL_DEFAULT_REF, sizeof (entry->resolved_key));
+			entry->resolved_material_id = Q3P_HashMaterialId (entry->resolved_key);
 		}
 		else
 		{
-			if (entry->supported_stage_count < (int)VEC_SIZE (material->stages))
+			if (entry->supported_stage_count < (int)VEC_SIZE (material->stages)
+				&& !(entry->warned_flags & Q3P_MATWARN_BEST_EFFORT))
+			{
 				Con_Warning ("Q3P: particle material '%s' has unsupported stages (%d/%d supported), rendering best-effort\n",
 					normalized, entry->supported_stage_count, (int)VEC_SIZE (material->stages));
+				entry->warned_flags |= Q3P_MATWARN_BEST_EFFORT;
+			}
 			entry->material = material;
 		}
 
@@ -549,6 +567,58 @@ static const q3p_material_cache_entry_t *Q3P_ResolveMaterialCached (const char *
 	}
 
 	return NULL;
+}
+
+static int Q3P_DebugMaterialCacheUsedCount (void)
+{
+	int i;
+	int used = 0;
+
+	for (i = 0; i < Q3P_MATERIAL_CACHE_SIZE; ++i)
+	{
+		if (q3p_material_cache[i].used)
+			++used;
+	}
+
+	return used;
+}
+
+qboolean Q3P_DebugStressMaterialCache (int iterations, int unique_names, int *before_out, int *after_out)
+{
+	int i;
+	int before;
+	int after;
+	char material[64];
+
+	if (iterations <= 0)
+		iterations = 256;
+	if (unique_names <= 0)
+		unique_names = 1;
+
+	before = Q3P_DebugMaterialCacheUsedCount ();
+	if (before_out)
+		*before_out = before;
+
+	for (i = 0; i < iterations; ++i)
+	{
+		q_snprintf (material, sizeof (material), "__q3p_missing_material_%d", i % unique_names);
+		if (!Q3P_ResolveMaterialCached (material))
+			break;
+	}
+
+	after = Q3P_DebugMaterialCacheUsedCount ();
+	if (after_out)
+		*after_out = after;
+
+	if (i < iterations)
+		return false;
+
+	/* Re-resolving the same unsupported material should not consume additional slots. */
+	Q3P_ResolveMaterialCached ("__q3p_missing_material_repeat");
+	if (Q3P_DebugMaterialCacheUsedCount () > after)
+		return false;
+
+	return true;
 }
 
 
@@ -706,7 +776,7 @@ qboolean Q3P_Spawn (const q3p_particle_t *particle)
 	if (cache_entry)
 	{
 		q_strlcpy (dst->material, cache_entry->key, sizeof (dst->material));
-		dst->material_id = cache_entry->material_id;
+		dst->material_id = cache_entry->resolved_material_id;
 	}
 	else
 	{

--- a/Quake/r_part_q3p.h
+++ b/Quake/r_part_q3p.h
@@ -85,5 +85,6 @@ void Q3P_ResetDebugStats (void);
 int Q3P_AddWorldEmitter (const q3p_emitter_t *emitter);
 void Q3P_ClearWorldEmitters (void);
 qboolean Q3P_GetEffectDef (const char *name, q3p_effectdef_t *out_def);
+qboolean Q3P_DebugStressMaterialCache (int iterations, int unique_names, int *before_out, int *after_out);
 
 #endif


### PR DESCRIPTION
### Motivation
- Prevent cache entries for requested material names from being mutated when a fallback rendering material is selected so repeated lookups reuse the same cache slot.
- Keep rendering/sorting behavior correct by storing which material will actually be used for rendering separate from the normalized request key.
- Avoid spamming warnings by making strict/best-effort warnings one-time-per-cache-entry.
- Provide a small debug/stress helper to exercise unknown-material lookups and detect unbounded cache growth.

### Description
- Keep `entry->key` as the normalized requested material name and add `entry->resolved_key` and `entry->resolved_material_id` to record the actual fallback/resolved material used for rendering when a fallback is required.
- Use `entry->resolved_material_id` for particle `material_id` used in sorting/rendering while leaving `entry->key` unchanged for lookup identity.
- Add `warned_flags` plus enums `Q3P_MATWARN_STRICT_SKIP` and `Q3P_MATWARN_BEST_EFFORT` so strict-skip and best-effort warnings are only emitted once per cached entry.
- Add `Q3P_DebugMaterialCacheUsedCount()` and `Q3P_DebugStressMaterialCache()` debug helper that repeatedly resolves missing materials to confirm the cache does not grow unbounded, and expose it via the dev console command `q3p_material_cache_stress`.
- Export the debug helper in `Quake/r_part_q3p.h` and wire the console command in `Quake/r_part.c`.

### Testing
- Attempted to build with `make -j4` from the repository root, which did nothing because no top-level target was specified in that context.
- Attempted to build with `make -j4` in `Quake/`, which ran but failed due to missing SDL2 build tools/headers (`sdl2-config` and `SDL.h`), so an in-container compile could not be completed.
- Added the stress helper and dev command; no runtime automated tests were available in this environment, but the helper is included for interactive/manual verification via `q3p_material_cache_stress` once runtime dependencies are present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5b888ac10832ea0f20384f3fb2974)