### PR TITLE
Fix Q3P particle alpha depth sorting

### DIFF
--- a/Quake/r_part_q3p.c
+++ b/Quake/r_part_q3p.c
@@ -667,14 +667,25 @@ static int Q3P_DrawSortCmp (const void *a, const void *b)
 {
 	const q3p_drawitem_t *da = (const q3p_drawitem_t *)a;
 	const q3p_drawitem_t *db = (const q3p_drawitem_t *)b;
+	qboolean alpha_group;
 
 	if (da->blend_group != db->blend_group)
 		return da->blend_group - db->blend_group;
+
+	alpha_group = da->blend_group != 0;
+	if (alpha_group && r_particles_sort.value > 0.f)
+	{
+		if (da->depth < db->depth)
+			return 1;
+		if (da->depth > db->depth)
+			return -1;
+	}
+
 	if (da->material_id < db->material_id)
 		return -1;
 	if (da->material_id > db->material_id)
 		return 1;
-	if (r_particles_sort.value > 0.f)
+	if (!alpha_group && r_particles_sort.value > 0.f)
 	{
 		if (da->depth < db->depth)
 			return 1;
@@ -982,7 +993,7 @@ void Q3P_Draw (qboolean alpha, qboolean showtris)
 		q3p_drawitems[q3p_numdrawitems].particle_index = i;
 		q3p_drawitems[q3p_numdrawitems].blend_group = blend_group;
 		q3p_drawitems[q3p_numdrawitems].material_id = p->material_id;
-		q3p_drawitems[q3p_numdrawitems].depth = DotProduct (r_origin, vpn) - DotProduct (p->org, vpn);
+		q3p_drawitems[q3p_numdrawitems].depth = DotProduct (p->org, vpn) - DotProduct (r_origin, vpn);
 		++q3p_numdrawitems;
 	}
 


### PR DESCRIPTION
### Motivation
- Ensure alpha-blended particles are rendered in correct back-to-front order by using a view-space forward distance depth key while preserving opaque material/state batching.

### Description
- Recompute particle depth in `Q3P_Draw` as `DotProduct(p->org, vpn) - DotProduct(r_origin, vpn)` so depth increases with distance from the camera.
- Update `Q3P_DrawSortCmp` to sort alpha blend group (`blend_group != 0`) back-to-front (far first) when `r_particles_sort > 0`, and keep opaque grouping material-first as before.

### Testing
- Ran `git diff -- Quake/r_part_q3p.c` to verify the diff; the command completed successfully.
- Ran `git status --short` to confirm the working tree state; the command completed successfully.
- Committed the change with `git commit` and the commit operation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5bd2023c8832eae8de623e63c3663)