### PR TITLE
Include r_part_q3p.c in Windows Visual Studio project to resolve Q3P linker symbols

### DIFF
--- a/Windows/VisualStudio/ironwail.vcxproj
+++ b/Windows/VisualStudio/ironwail.vcxproj
@@ -317,6 +317,7 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
     <ClCompile Include="..\..\Quake\r_fogvol.c" />
     <ClCompile Include="..\..\Quake\r_postfx.c" />
     <ClCompile Include="..\..\Quake\r_part.c" />
+    <ClCompile Include="..\..\Quake\r_part_q3p.c" />
     <ClCompile Include="..\..\Quake\r_sprite.c" />
     <ClCompile Include="..\..\Quake\r_world.c" />
     <ClCompile Include="..\..\Quake\sbar.c" />

--- a/Windows/VisualStudio/ironwail.vcxproj.filters
+++ b/Windows/VisualStudio/ironwail.vcxproj.filters
@@ -192,6 +192,9 @@
     <ClCompile Include="..\..\Quake\r_part.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Quake\r_part_q3p.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\Quake\r_sprite.c">
       <Filter>Source Files</Filter>
     </ClCompile>


### PR DESCRIPTION
### Motivation
- The Windows Visual Studio build was failing with unresolved `Q3P_*` linker symbols because the `r_part_q3p.c` translation unit implementing those symbols was not part of the project.

### Description
- Add a `<ClCompile Include="..\..\Quake\r_part_q3p.c" />` entry to `Windows/VisualStudio/ironwail.vcxproj` so the Q3P implementation is compiled into VS targets.
- Add the corresponding entry to `Windows/VisualStudio/ironwail.vcxproj.filters` so the file appears under `Source Files` in the Solution Explorer.

### Testing
- Verified the new entries are present by running `rg "r_part_q3p.c"` against the project and filters which reported the added lines successfully.
- Inspected the project and filter files with `nl`/`sed` to confirm the insertion point and presence of the `r_part_q3p.c` lines.
- A full MSVC/Visual Studio build was not executed in this Linux container environment, so runtime link validation was not performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5c983aa60832e9c8805370a1142f4)