### PR TITLE
Include mat_shader.h and fix token comparisons in r_part_q3p.c

### DIFF
--- a/Quake/r_part_q3p.c
+++ b/Quake/r_part_q3p.c
@@ -1,4 +1,5 @@
 #include "quakedef.h"
+#include "mat_shader.h"
 #include "r_part_q3p.h"
 
 extern cvar_t r_particles_max;
@@ -154,7 +155,7 @@ static void Q3P_ParseEffectDefText (const char *source_name, char *text)
 		def = entry->def;
 
 		cursor = COM_Parse (cursor);
-		if (!cursor || q_strcmp (com_token, "{"))
+		if (!cursor || strcmp (com_token, "{"))
 		{
 			Con_Warning ("Q3P: expected '{' after effect '%s' in %s\n", effect_name, source_name);
 			return;
@@ -162,7 +163,7 @@ static void Q3P_ParseEffectDefText (const char *source_name, char *text)
 
 		while ((cursor = COM_Parse (cursor)) != NULL)
 		{
-			if (!q_strcmp (com_token, "}"))
+			if (!strcmp (com_token, "}"))
 				break;
 
 			if (!q_strcasecmp (com_token, "material"))


### PR DESCRIPTION
### Motivation
- Fix a cascade of compile errors in `Quake/r_part_q3p.c` caused by missing shader type/function declarations and undefined token-compare calls that produced implicit-int/prototype problems on modern compilers.

### Description
- Add `#include "mat_shader.h"` to `Quake/r_part_q3p.c` so `shader_material_t` and related shader helpers are visible, and replace two uses of undefined `q_strcmp` with `strcmp` in the effect-definition parser.

### Testing
- Attempted a full build with `cmake -S . -B build && cmake --build build -j2`, which failed in this environment due to missing SDL2 CMake package/config (so a complete build could not be completed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5cb0f246c832ea808b6c3628e5af2)