### PR TITLE
Fix fog volume shader link failure from oversized FogLights UBO

### DIFF
--- a/Quake/r_fogvol.c
+++ b/Quake/r_fogvol.c
@@ -56,7 +56,7 @@ typedef struct fog_light_list_gpu_s
 typedef struct fog_light_lists_gpu_s
 {
 	fog_light_list_gpu_t volumes[MAX_FOGVOLUMES];
-	fog_light_gpu_t lights[MAX_FOGVOLUMES * 32];
+	fog_light_gpu_t lights[MAX_FOGVOLUMES * MAX_FOGLIGHTS];
 } fog_light_lists_gpu_t;
 
 typedef struct fog_lightgrid_gpu_s
@@ -1692,7 +1692,7 @@ void R_FogVol_Render (void)
 
 	if (r_fogvol_light.value > 0.f)
 	{
-		int max_lights = CLAMP (0, (int)Q_rint (r_fogvol_light_max.value), 32);
+		int max_lights = CLAMP (0, (int)Q_rint (r_fogvol_light_max.value), MAX_FOGLIGHTS);
 		int write_offset = 0;
 
 		for (int i = 0; i < r_fogvolume_count; ++i)

--- a/Quake/r_fogvol.h
+++ b/Quake/r_fogvol.h
@@ -2,6 +2,7 @@
 #define R_FOGVOL_H
 
 #define MAX_FOGVOLUMES 64
+#define MAX_FOGLIGHTS 31 /* keep FogLightsUBO under 64KB std140 limit on NVIDIA */
 
 typedef struct fog_volume_s
 {

--- a/Quake/shaders/fogvol.frag
+++ b/Quake/shaders/fogvol.frag
@@ -31,7 +31,7 @@
 #include "frame_uniforms.glsl"
 
 #define MAX_FOGVOLUMES 64
-#define MAX_FOGLIGHTS 32
+#define MAX_FOGLIGHTS 31 // keep FogLightsUBO under 64KB std140 limit on some drivers
 
 layout(binding=0) uniform sampler2D SceneColor;
 layout(binding=1) uniform sampler2D SceneDepth;


### PR DESCRIPTION
### Motivation
- Some NVIDIA drivers failed to link the fog volume shader with an error that `FogLights` was too large because the std140 UBO for fog lights (64 volumes × 32 lights) exceeded practical driver limits.
- Reduce the FogLights UBO footprint so shader programs can link reliably while keeping CPU/GPU layouts consistent.

### Description
- Added a shared constant `MAX_FOGLIGHTS` set to `31` in `Quake/r_fogvol.h` to limit per-volume fog lights and keep the FogLights UBO under ~64KB. 
- Updated CPU-side packing to use `MAX_FOGLIGHTS` for the fog light array in `Quake/r_fogvol.c` instead of the hardcoded `32` and adjusted the runtime clamping of `r_fogvol_light_max` to `MAX_FOGLIGHTS`.
- Updated the fog volume fragment shader (`Quake/shaders/fogvol.frag`) to use `MAX_FOGLIGHTS 31` so the shader UBO size matches the C-side layout.

### Testing
- Ran a project-wide pattern search with `rg` to ensure there are no remaining hardcoded `32` usages for the fog-lights UBO and the search returned no matches.
- Inspected the updated header, C source and shader (`nl`/file prints) to confirm `MAX_FOGLIGHTS` and the array sizes were updated consistently and the checks succeeded.
- No build/run tests were performed in this rollout; this change is narrowly scoped to layout constants and runtime clamping to prevent shader link-time UBO overflow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5cf3c82ac832e9b12a878a74dca51)