### PR TITLE
Fix black legacy particles after decal spawn

### DIFF
--- a/Quake/r_part.c
+++ b/Quake/r_part.c
@@ -1343,6 +1343,16 @@ static void R_DrawParticles_Real (qboolean alpha, qboolean showtris)
 	dither = (softemu == SOFTEMU_COARSE && !showtris);
 	oit = (alpha && R_GetEffectiveAlphaMode () == ALPHAMODE_OIT);
 	GL_UseProgram (glprogs.particles[oit][dither]);
+	GL_Bind (GL_TEXTURE0, whitetexture);
+	{
+		static const float identity3x3[9] = {
+			1.f, 0.f, 0.f,
+			0.f, 1.f, 0.f,
+			0.f, 0.f, 1.f
+		};
+		GL_UniformMatrix3fvFunc (1, 1, GL_FALSE, identity3x3);
+	}
+	GL_Uniform4fFunc (2, 1.f, 1.f, 1.f, 1.f);
 
 	// compensate for apparent size of different particle textures
 	// this bakes in the additional scaling of vup and vright by 1.5f for billboarding,


### PR DESCRIPTION
### Motivation
- Legacy particles were rendering pitch-black when decals or q3p material draws left particle shader stage state (texture/bindings/uniforms) modified, because the legacy path relied on implicit defaults.

### Description
- In `R_DrawParticles_Real` (in `Quake/r_part.c`) explicitly bind the particle texture to `whitetexture` before drawing legacy particles. 
- Reset the stage-related uniforms used by the shared particle shader by uploading an identity `StageTexMatrix` (`GL_UniformMatrix3fvFunc`) and a white `StageColorMul` (`GL_Uniform4fFunc`) so legacy draws do not inherit prior stage state.
- Change is localized to the legacy particle draw path and executed every frame before particle draw calls.

### Testing
- Attempted a local build with `make -j4` in `Quake/`, which failed due to missing environment dependencies (`sdl2-config` / `SDL.h`), so full compile validation could not be completed. 
- Verified the source changes and presence of the new uniforms with `rg`/`nl` searches and performed a commit (`git commit`) which recorded the single-file change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5d2f6945c832eaaa7bc94efe2c3cd)