### PR TITLE
Fix particle shader uniform upload in r_part.c

### DIFF
--- a/Quake/r_part.c
+++ b/Quake/r_part.c
@@ -1350,7 +1350,7 @@ static void R_DrawParticles_Real (qboolean alpha, qboolean showtris)
 			0.f, 1.f, 0.f,
 			0.f, 0.f, 1.f
 		};
-		GL_UniformMatrix3fvFunc (1, 1, GL_FALSE, identity3x3);
+		GL_Uniform3fvFunc (1, 3, identity3x3);
 	}
 	GL_Uniform4fFunc (2, 1.f, 1.f, 1.f, 1.f);
 


### PR DESCRIPTION
### Motivation
- Replace an undefined `GL_UniformMatrix3fvFunc` call that caused an MSVC implicit-declaration warning/error by using the existing GL wrapper function.

### Description
- Replace `GL_UniformMatrix3fvFunc (1, 1, GL_FALSE, identity3x3)` with `GL_Uniform3fvFunc (1, 3, identity3x3)` in `Quake/r_part.c` so the 3x3 identity is uploaded as three `vec3` uniforms.

### Testing
- Ran `rg` to verify occurrences, inspected the `git diff` for `Quake/r_part.c`, and committed the change, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5dae2afb8832e8a6579af2be8a114)