### PR TITLE
Fix particles leaking into bloom extraction

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -3198,6 +3198,11 @@ qboolean GL_NeedsSceneEffects (void)
         if (framebufs.scene.samples > 1 || water_warp || r_refdef.scale != 1)
 		return true;
 
+	/* Bloom extraction relies on material masks in scene velocity alpha.
+	 * Route bloom frames through the scene FBO so particles (mask=2) stay excluded. */
+	if (r_bloom.value > 0.f)
+		return true;
+
 	if (r_dlight_mode.value > 0.f && r_dlight_style.value > 0.f && r_dlight_buffer.value > 0.f && framebufs.dlight.fbo)
 		return true;
 


### PR DESCRIPTION
### Motivation
- Particles were sometimes receiving the bloom pass because bloom extraction depends on material masks stored in the scene velocity alpha, and the particle draw path did not provide that mask, so bloom frames must be routed through the scene FBO.

### Description
- Update `GL_NeedsSceneEffects()` in `Quake/gl_rmain.c` to return `true` when `r_bloom.value > 0.f` and add a comment documenting that this forces bloom rendering via the scene FBO so particle mask entries stay excluded.

### Testing
- Validated the change with `git diff -- Quake/gl_rmain.c`, `git diff --check`, and `git show --stat --oneline -1`, and the commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5dd27dca8832e9f9a5eb1cab15bc5)