### PR TITLE
Add `r_particles_prt_debug` cvar to gate .prt particle-definition load logging

### DIFF
--- a/Quake/r_part.c
+++ b/Quake/r_part.c
@@ -47,6 +47,7 @@ cvar_t	r_particles_cull_dist = {"r_particles_cull_dist", "4096", CVAR_ARCHIVE};
 cvar_t	r_particles_collision = {"r_particles_collision", "1", CVAR_ARCHIVE};
 cvar_t	r_particles_spawn_max = { "r_particles_spawn_max", "2048", CVAR_ARCHIVE};
 cvar_t	r_particles_debug = { "r_particles_debug", "0", CVAR_ARCHIVE};
+cvar_t	r_particles_prt_debug = { "r_particles_prt_debug", "0", CVAR_ARCHIVE};
 
 
 static int r_particles_debug_legacy_buckets[8];
@@ -608,6 +609,7 @@ void R_InitParticles (void)
 	Cvar_RegisterVariable (&r_particles_collision);
 	Cvar_RegisterVariable (&r_particles_spawn_max);
 	Cvar_RegisterVariable (&r_particles_debug);
+	Cvar_RegisterVariable (&r_particles_prt_debug);
 
 	Q3P_Init ();
 	Cmd_AddCommand ("q3p_spawn", R_Q3P_TestSpawn_f);

--- a/Quake/r_part_q3p.c
+++ b/Quake/r_part_q3p.c
@@ -8,6 +8,7 @@ extern cvar_t r_particles_shader_strict;
 extern cvar_t r_particles_cull_dist;
 extern cvar_t r_particles_collision;
 extern cvar_t r_particles_spawn_max;
+extern cvar_t r_particles_prt_debug;
 
 static q3p_particle_t *q3p_particles;
 static int q3p_maxparticles;
@@ -259,7 +260,7 @@ static void Q3P_LoadEffectDefs (void)
 		}
 	}
 
-	if (loaded > 0)
+	if (loaded > 0 && r_particles_prt_debug.value > 0.f)
 		Con_Printf ("Q3P: loaded %d .prt particle definition files\n", loaded);
 }
 


### PR DESCRIPTION
### Motivation
- Provide a runtime/configuration toggle to silence or enable console logging when Q3P `.prt` particle definition files are discovered and loaded to reduce noisy output.

### Description
- Add a new archived cvar `r_particles_prt_debug` (default `0`) in `Quake/r_part.c` next to the existing particle cvars.
- Register the new cvar in `R_InitParticles` via `Cvar_RegisterVariable(&r_particles_prt_debug)` so it is available at runtime.
- Declare `extern cvar_t r_particles_prt_debug;` in `Quake/r_part_q3p.c` and gate the `.prt` load message in `Q3P_LoadEffectDefs` so the `Con_Printf` only runs when `r_particles_prt_debug.value > 0.f`.

### Testing
- Attempted a CMake configure/build with `cmake -S . -B build && cmake --build build -j2` to validate compilation, which failed due to the environment missing the SDL2 CMake package (`SDL2Config.cmake` / `sdl2-config.cmake`), so a full build could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5dd5756c8832e831e66a2b42f424c)