### PR TITLE
Replace undefined `q_strlen` with `strlen` in Q3P parser to fix MSVC build

### DIFF
--- a/Quake/r_part_q3p.c
+++ b/Quake/r_part_q3p.c
@@ -179,7 +179,7 @@ static qboolean Q3P_PRT_NextToken (q3p_prt_parser_t *parser)
 	if (!parser->token[0])
 		return false;
 
-	token_start = parser->cursor - q_strlen (parser->token);
+	token_start = parser->cursor - strlen (parser->token);
 	if (token_start < parser->text_start)
 		token_start = parser->text_start;
 	parser->token_start = token_start;


### PR DESCRIPTION
### Motivation
- MSVC reported warning C4013 for an undefined `q_strlen`, which was promoted to error C2220 and prevented Windows builds; the intent is to use the standard library `strlen` to avoid the undefined symbol.

### Description
- Replace `q_strlen` with `strlen` when computing `token_start` in `Q3P_PRT_NextToken` in `Quake/r_part_q3p.c` to use the standard, available function.

### Testing
- No automated Windows/MSVC build was executed in this environment; the change is a single-symbol replacement and was validated via local diff inspection and static code review.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5e34cdba8832e84ad2d86397f73ce)