### PR TITLE
Fix SSAO intensity clamp and allow full SSAO debug modes

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -2384,10 +2384,13 @@ void GL_PostProcess (void)
 	inv_scale = r_refdef.scale > 0 ? 1.f / (float)r_refdef.scale : 1.f;
 
 	ssao_texture = GL_GenerateSSAOTexture (view_min_x, view_min_y, view_max_x, view_max_y);
-	ssao_intensity = R_SanitizeSSAOValue (r_ssao_intensity.value, 0.f, 0.f, 1.f);
+	/* Keep SSAO intensity aligned with the cvar's intended tuning range.
+	 * Clamping to 1.0 made the default 1.5 weaker than expected and could make
+	 * user configs look like SSAO had no effect when toggled on. */
+	ssao_intensity = R_SanitizeSSAOValue (r_ssao_intensity.value, 1.5f, 0.f, 8.f);
 	{
 		int debug_cvar = (int)Q_rint (r_ssao_debug.value);
-		int debug_mode_i = (debug_cvar > 0) ? CLAMP (1, debug_cvar, 11) : -1;
+		int debug_mode_i = (debug_cvar > 0) ? CLAMP (1, debug_cvar, 14) : -1;
 		ssao_debug_mode = (debug_mode_i > 0) ? (float)debug_mode_i : -1.f;
 	}
 	if (ssao_texture == 0)


### PR DESCRIPTION
### Motivation
- Users reported `r_ssao` producing no visible effect because the postprocess intensity was effectively clamped to `1.0`, making the default `r_ssao_intensity` (`1.5`) weaker than intended.
- Several SSAO debug views implemented in shaders were unreachable because the debug mode clamp only allowed up to `11` instead of the full set the shaders expect.

### Description
- Adjusted SSAO intensity sanitization in `GL_PostProcess` to use `R_SanitizeSSAOValue(r_ssao_intensity.value, 1.5f, 0.f, 8.f)` so the cvar can exceed `1.0` and the default `1.5` has the expected effect (file: `Quake/gl_rmain.c`).
- Expanded the debug-mode clamp to allow `1..14` so modes `12..14` (AO mask / fog transmittance / fog-damped AO) are forwarded into the shader path (file: `Quake/gl_rmain.c`).
- Added a short comment explaining the intensity range rationale.

### Testing
- Attempted an out-of-tree CMake configure/build (`cmake -S . -B build && cmake --build build`), which failed due to missing system dependency `SDL2` (`SDL2Config.cmake` not found); this is an environment issue and not a code error.
- Verified the patched lines and generated diff applying cleanly and committed the changes; no further automated unit tests are present in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5e8020e88832e8962618aad6a8a37)