### PR TITLE
Validate clipnode child indices for BSP and BSP2

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -3559,6 +3559,13 @@ static void Mod_FindUsedTextures (qmodel_t *mod)
 	//Con_Printf("%s: %d/%d textures\n", mod->name, count, mod->numtextures);
 }
 
+static void ValidateClipnodeChildIndex (int child, int childslot, int nodeindex, int totalcount)
+{
+	if (child >= 0 && child >= totalcount)
+		Host_Error ("Mod_LoadClipnodes: clipnode %d child[%d] index %d out of bounds (count %d)",
+			nodeindex, childslot, child, totalcount);
+}
+
 /*
 =================
 Mod_LoadClipnodes
@@ -3638,7 +3645,9 @@ static void Mod_LoadClipnodes (lump_t *l, qboolean bsp2)
 
 			out->children[0] = LittleLong(inl->children[0]);
 			out->children[1] = LittleLong(inl->children[1]);
-			//Spike: FIXME: bounds check
+
+			ValidateClipnodeChildIndex (out->children[0], 0, i, count);
+			ValidateClipnodeChildIndex (out->children[1], 1, i, count);
 		}
 	}
 	else
@@ -3660,6 +3669,9 @@ static void Mod_LoadClipnodes (lump_t *l, qboolean bsp2)
 				out->children[0] -= 65536;
 			if (out->children[1] >= count)
 				out->children[1] -= 65536;
+
+			ValidateClipnodeChildIndex (out->children[0], 0, i, count);
+			ValidateClipnodeChildIndex (out->children[1], 1, i, count);
 			//johnfitz
 		}
 	}


### PR DESCRIPTION
### Motivation

- Prevent crashes or undefined behavior when loading malformed BSP/BSP2 maps by validating clipnode child indices after endian conversion and sign-fix adjustments. 
- Allow negative leaf sentinels while rejecting invalid non-negative indices that reference past `count` so map debugging becomes easier.

### Description

- Add `ValidateClipnodeChildIndex(int child, int childslot, int nodeindex, int totalcount)` and place it adjacent to `Mod_LoadClipnodes` to centralize validation and emit a precise `Host_Error` including clipnode index, child slot, offending value, and total count. 
- For BSP2 path, validate `children[0]` and `children[1]` immediately after `LittleLong(...)` so checks operate on final endian-converted values. 
- For BSP (16-bit) path, run validation after the existing sign-fix logic (`if (child >= count) child -= 65536`) so checks operate on the final adjusted values. 
- The validation accepts negative sentinel contents but rejects non-negative indices `>= count` and reports them with full diagnostic context.

### Testing

- Attempted to build with `make -j4 -C Quake`, but the build failed due to missing `sdl2-config`/`SDL.h` in the environment so compile-time validation could not complete (failed). 
- No automated unit tests exist for this code path in-tree, so no additional automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5f983cc50832eab367f95ddbdd849)