### PR TITLE
Refresh player skins when gl_nocolors is disabled

### DIFF
--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -255,6 +255,8 @@ qboolean use_simd;
 
 extern gltexture_t *playertextures[MAX_SCOREBOARD]; //johnfitz
 
+static qboolean r_gl_nocolors_enabled;
+
 extern char r_showbboxes_filter_strings[MAXCMDLINE];
 extern qboolean r_showbboxes_filter_byindex;
 
@@ -362,6 +364,35 @@ GL_Fullbrights_f -- johnfitz
 static void GL_Fullbrights_f (cvar_t *var)
 {
 	TexMgr_ReloadNobrightImages ();
+}
+
+/*
+====================
+GL_NoColors_f
+====================
+*/
+static void GL_NoColors_f (cvar_t *var)
+{
+	const qboolean gl_nocolors_enabled = (var->value != 0.0f);
+
+	if (r_gl_nocolors_enabled && !gl_nocolors_enabled)
+	{
+		int i;
+		for (i = 0; i < cl.maxclients; i++)
+		{
+			entity_t *e = &cl_entities[1 + i];
+
+			if (!e->model)
+				continue;
+
+			if (playertextures[i])
+				R_TranslatePlayerSkin (i);
+			else
+				R_TranslateNewPlayerSkin (i);
+		}
+	}
+
+	r_gl_nocolors_enabled = gl_nocolors_enabled;
 }
 
 /*
@@ -728,6 +759,8 @@ Cvar_RegisterVariable (&r_vignette);
 	Cvar_RegisterVariable (&gl_polyblend);
 	Cvar_RegisterVariable (&gl_playermip);
 	Cvar_RegisterVariable (&gl_nocolors);
+	Cvar_SetCallback (&gl_nocolors, GL_NoColors_f);
+	r_gl_nocolors_enabled = (gl_nocolors.value != 0.0f);
 
 	//johnfitz -- new cvars
 	Cvar_RegisterVariable (&r_clearcolor);


### PR DESCRIPTION
### Motivation
- Ensure that when `gl_nocolors` is toggled off at runtime, player textures are refreshed once so rendered player skins match scoreboard colors.

### Description
- Add a renderer static state `r_gl_nocolors_enabled` to track the previous `gl_nocolors` value.
- Implement a callback `GL_NoColors_f` that detects a transition from enabled → disabled and iterates `cl.maxclients` to refresh skins.
- In the callback, skip clients with missing models via `!e->model` and call `R_TranslatePlayerSkin(i)` when a player texture exists or `R_TranslateNewPlayerSkin(i)` when a texture must be recreated.
- Hook the callback into cvar registration with `Cvar_SetCallback(&gl_nocolors, GL_NoColors_f)` and initialize `r_gl_nocolors_enabled` from `gl_nocolors.value` during `R_Init`.

### Testing
- Verified the patch with `git diff -- Quake/gl_rmisc.c` to confirm the change was applied as expected (success).
- Attempted a local build with `make -j4` in `Quake/` to validate compilation, but the build was blocked by missing SDL2 build dependencies (`sdl2-config` / `SDL.h`), so full compile-time validation could not be completed (failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5f9858884832e9095e4122877cdac)