### PR TITLE
Async sound load/commit: FS completion pump and pending jobs

### DIFF
--- a/Quake/async.c
+++ b/Quake/async.c
@@ -408,19 +408,22 @@ void FS_PumpAsyncCompletions (void)
 	{
 		fs_completion_t *next = list->next;
 		qboolean canceled;
+		qboolean stale;
 
 		SDL_LockMutex (fs_mutex);
-		/*
-		 * A completion is canceled only if its exact handle id was canceled.
-		 * Generation mismatches are still treated as stale and dropped.
-		 */
-		canceled = FS_TakeCanceledIdLocked (list->id) || list->generation != fs_generation;
+		canceled = FS_TakeCanceledIdLocked (list->id);
+		stale = list->generation != fs_generation;
 		SDL_UnlockMutex (fs_mutex);
 
-		if (!canceled)
+		if (!canceled && !stale)
 			list->cb (list->user, list->data, list->len, list->status);
-		else if (list->data)
-			free (list->data);
+		else
+		{
+			if (stale)
+				list->cb (list->user, NULL, 0, -1);
+			if (list->data)
+				free (list->data);
+		}
 		free (list);
 		list = next;
 	}

--- a/Quake/snd_mem.c
+++ b/Quake/snd_mem.c
@@ -106,6 +106,21 @@ typedef struct pending_snd_job_s
 static pending_snd_job_t *pending_snd_jobs;
 static SDL_mutex *wavinfo_mutex;
 
+static sfxcache_t *S_LoadSoundSync (sfx_t *s, const char *namebuffer);
+
+static pending_snd_job_t *S_FindPendingSoundJob (sfx_t *s)
+{
+	pending_snd_job_t *job;
+
+	for (job = pending_snd_jobs; job; job = job->next)
+	{
+		if (job->sfx == s)
+			return job;
+	}
+
+	return NULL;
+}
+
 static void S_LoadSoundDecodeJob (void *userdata)
 {
 	pending_snd_job_t *job = (pending_snd_job_t *) userdata;
@@ -115,9 +130,19 @@ static void S_LoadSoundDecodeJob (void *userdata)
 	byte *src;
 	byte *dst;
 
-	SDL_LockMutex (wavinfo_mutex);
-	job->info = GetWavinfo (job->name, job->file_data, (int) job->file_len);
-	SDL_UnlockMutex (wavinfo_mutex);
+	if (!wavinfo_mutex)
+		wavinfo_mutex = SDL_CreateMutex ();
+
+	if (wavinfo_mutex)
+	{
+		SDL_LockMutex (wavinfo_mutex);
+		job->info = GetWavinfo (job->name, job->file_data, (int) job->file_len);
+		SDL_UnlockMutex (wavinfo_mutex);
+	}
+	else
+	{
+		job->info = GetWavinfo (job->name, job->file_data, (int) job->file_len);
+	}
 
 	if (job->info.channels != 1 || (job->info.width != 1 && job->info.width != 2))
 	{
@@ -232,10 +257,7 @@ S_LoadSound
 sfxcache_t *S_LoadSound (sfx_t *s)
 {
 	char	namebuffer[256];
-	byte	*data;
-	wavinfo_t	info;
-	int		len;
-	float	stepscale;
+	pending_snd_job_t *job;
 	sfxcache_t	*sc;
 
 // see if still in memory
@@ -248,6 +270,44 @@ sfxcache_t *S_LoadSound (sfx_t *s)
 // load it in
 	q_strlcpy(namebuffer, "sound/", sizeof(namebuffer));
 	q_strlcat(namebuffer, s->name, sizeof(namebuffer));
+
+	job = S_FindPendingSoundJob (s);
+	if (job)
+	{
+		if (!job->done)
+			return NULL;
+		sc = S_CommitPendingSound (job);
+		if (sc)
+			return sc;
+		return S_LoadSoundSync (s, namebuffer);
+	}
+
+	if (Host_AsyncAssetsEnabled ())
+	{
+		job = (pending_snd_job_t *) calloc (1, sizeof (*job));
+		if (!job)
+			Sys_Error ("S_LoadSound: out of memory");
+
+		job->sfx = s;
+		q_strlcpy (job->name, s->name, sizeof (job->name));
+
+		job->next = pending_snd_jobs;
+		pending_snd_jobs = job;
+
+		FS_AsyncRead (namebuffer, S_AsyncReadComplete, job);
+		return NULL;
+	}
+
+	return S_LoadSoundSync (s, namebuffer);
+}
+
+static sfxcache_t *S_LoadSoundSync (sfx_t *s, const char *namebuffer)
+{
+	byte	*data;
+	wavinfo_t	info;
+	int		len;
+	float	stepscale;
+	sfxcache_t	*sc;
 
 //	Con_Printf ("loading %s\n",namebuffer);
 
@@ -502,4 +562,3 @@ wavinfo_t GetWavinfo (const char *name, byte *wav, int wavlength)
 
 	return info;
 }
-


### PR DESCRIPTION
### Motivation
- Add a safe async FS completion and asset staging path for sounds so file I/O and decoding can run off the main thread while ownership/commit stays on the main thread.
- Preserve existing behavior and avoid refactors by gating async behavior behind the existing `host_async*` CVars and keeping the synchronous fallback intact.

### Description
- Add pending sound-job tracking and a non-blocking path in `S_LoadSound` that enqueues `FS_AsyncRead` + worker decode and defers cache commit to the main thread via existing commit logic (`Quake/snd_mem.c`).
- Harden worker-side WAV parsing by lazily creating/guarding `wavinfo_mutex` around `GetWavinfo` to avoid races in decode jobs (`Quake/snd_mem.c`).
- Update `FS_PumpAsyncCompletions` to separate canceled vs stale-generation completions and signal stale completions to callbacks with an error status while freeing worker buffers, preventing stuck pending assets on fast generation/map changes (`Quake/async.c`).
- Keep the original synchronous load path as a fallback and do not introduce large refactors or new heavy dependencies.

### Testing
- ✅ `rg -n "FS_|COM_LoadFile|LoadFile|pak|Pack|WAV|OGG|S_Load|S_Paint|snd|mixer|stb|image|tex|glTex|Upload|cache"` (repo discovery and verification of touched entry points).
- ❌ `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug` (configure failed due to missing SDL2 CMake package in this environment).
- ✅ `git commit -m "Add async sound load/commit path using FS completion pump"` (changes committed locally).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5fa44d5c0832ea0110dcc46d3acd2)