### PR TITLE
Clarify fs completion queue cleanup locking in Jobs_Shutdown

### DIFF
--- a/Quake/async.c
+++ b/Quake/async.c
@@ -457,6 +457,7 @@ void Jobs_Shutdown (void)
 	}
 	jobs_num_threads = 0;
 
+	/* Detach the completion queue under lock, then free nodes after unlock. */
 	SDL_LockMutex (fs_mutex);
 	comp = fs_comp_head;
 	fs_comp_head = fs_comp_tail = NULL;


### PR DESCRIPTION
### Motivation
- Ensure the FS completion queue is detached while holding `fs_mutex` and that nodes are freed only after the mutex is released, preventing unbalanced lock/unlock sequences and making the intent explicit.

### Description
- Added a short comment above the FS completion cleanup block in `Jobs_Shutdown()` noting that the completion queue is detached under `fs_mutex` and that node freeing happens after unlocking, and verified the canceled-id cleanup retains balanced lock/unlock pairing.

### Testing
- Inspected `Quake/async.c` and ran `rg`/`git diff`/`git commit` to confirm the comment insertion and that `SDL_LockMutex(fs_mutex)`/`SDL_UnlockMutex(fs_mutex)` sequences around the completion and canceled-id detachment remain balanced (commands succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5fc3d1994832ea71932a92c37bad3)