### PR TITLE
Refactor AsyncQueue_Drain to execute callbacks outside mutex

### DIFF
--- a/Quake/host.c
+++ b/Quake/host.c
@@ -798,9 +798,11 @@ static void AsyncQueue_Drain (asyncqueue_t *queue)
 	SDL_LockMutex (queue->mutex);
 	while (queue->head != queue->tail)
 	{
-		asyncproc_t *proc = &queue->procs[(queue->head++) & (queue->capacity - 1)];
-		proc->func (proc->param);
+		asyncproc_t proc = queue->procs[(queue->head++) & (queue->capacity - 1)];
 		SDL_CondSignal (queue->notfull);
+		SDL_UnlockMutex (queue->mutex);
+		proc.func (proc.param);
+		SDL_LockMutex (queue->mutex);
 	}
 	SDL_UnlockMutex (queue->mutex);
 }


### PR DESCRIPTION
### Motivation

- Reduce the time the queue mutex is held by ensuring callbacks are invoked without holding the lock, avoiding potential deadlocks or long critical sections. 
- Preserve FIFO/ring-buffer semantics and existing queue indexing while making the drain loop more concurrency-friendly. 
- Keep `AsyncQueue_Destroy` semantics safe when it calls `AsyncQueue_Drain` after setting `teardown`.

### Description

- Pop a single `asyncproc_t` entry into a local variable using `asyncproc_t proc = queue->procs[(queue->head++) & (queue->capacity - 1)];` to decouple callback invocation from the queue storage. 
- Signal `notfull` while still holding the mutex immediately after popping the entry. 
- Unlock the mutex before calling `proc.func (proc.param)` and re-lock the mutex after the callback returns to continue draining. 
- Preserved the original ring-buffer indexing (`head++` with mask) and overall drain logic while shrinking the mutex hold window.

### Testing

- No automated tests were run for this threading-focused refactor.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5fc414908832e8632b1fb61de3cdc)