### PR TITLE
Initialize wavinfo mutex during sound startup

### DIFF
--- a/Quake/q_sound.h
+++ b/Quake/q_sound.h
@@ -186,8 +186,9 @@ void S_LocalSound (const char *name);
 sfxcache_t *S_LoadSound (sfx_t *s);
 
 wavinfo_t GetWavinfo (const char *name, byte *wav, int wavlength);
+void S_InitWavinfoMutex (void);
+void S_ShutdownWavinfoMutex (void);
 
 void SND_InitScaletable (void);
 
 #endif	/* __QUAKE_SOUND__ */
-

--- a/Quake/snd_dma.c
+++ b/Quake/snd_dma.c
@@ -216,6 +216,8 @@ void S_Init (void)
 	known_sfx = (sfx_t *) Hunk_AllocName (MAX_SFX*sizeof(sfx_t), "sfx_t");
 	num_sfx = 0;
 
+	S_InitWavinfoMutex ();
+
 	snd_initialized = true;
 
 	S_Startup ();
@@ -247,6 +249,7 @@ void S_Shutdown (void)
 	snd_blocked = 0;
 
 	S_CodecShutdown();
+	S_ShutdownWavinfoMutex ();
 
 	SNDDMA_Shutdown();
 	shm = NULL;

--- a/Quake/snd_mem.c
+++ b/Quake/snd_mem.c
@@ -106,6 +106,25 @@ typedef struct pending_snd_job_s
 static pending_snd_job_t *pending_snd_jobs;
 static SDL_mutex *wavinfo_mutex;
 
+void S_InitWavinfoMutex (void)
+{
+	if (wavinfo_mutex)
+		return;
+
+	wavinfo_mutex = SDL_CreateMutex ();
+	if (!wavinfo_mutex)
+		Sys_Error ("S_InitWavinfoMutex: couldn\'t create mutex");
+}
+
+void S_ShutdownWavinfoMutex (void)
+{
+	if (wavinfo_mutex)
+	{
+		SDL_DestroyMutex (wavinfo_mutex);
+		wavinfo_mutex = NULL;
+	}
+}
+
 static sfxcache_t *S_LoadSoundSync (sfx_t *s, const char *namebuffer);
 
 static pending_snd_job_t *S_FindPendingSoundJob (sfx_t *s)
@@ -130,19 +149,9 @@ static void S_LoadSoundDecodeJob (void *userdata)
 	byte *src;
 	byte *dst;
 
-	if (!wavinfo_mutex)
-		wavinfo_mutex = SDL_CreateMutex ();
-
-	if (wavinfo_mutex)
-	{
-		SDL_LockMutex (wavinfo_mutex);
-		job->info = GetWavinfo (job->name, job->file_data, (int) job->file_len);
-		SDL_UnlockMutex (wavinfo_mutex);
-	}
-	else
-	{
-		job->info = GetWavinfo (job->name, job->file_data, (int) job->file_len);
-	}
+	SDL_LockMutex (wavinfo_mutex);
+	job->info = GetWavinfo (job->name, job->file_data, (int) job->file_len);
+	SDL_UnlockMutex (wavinfo_mutex);
 
 	if (job->info.channels != 1 || (job->info.width != 1 && job->info.width != 2))
 	{


### PR DESCRIPTION
### Motivation
- Prevent races and leaks caused by lazy creation of `wavinfo_mutex` inside the worker `S_LoadSoundDecodeJob` by creating/destroying the mutex during the sound subsystem lifecycle.
- Ensure `GetWavinfo` is always protected by a valid mutex when called from background jobs.
- Fail early if the mutex cannot be created to avoid surprising behavior later in worker threads.

### Description
- Added prototypes `S_InitWavinfoMutex` and `S_ShutdownWavinfoMutex` to `Quake/q_sound.h`.
- Implemented `S_InitWavinfoMutex` and `S_ShutdownWavinfoMutex` in `Quake/snd_mem.c`, where init will create the SDL mutex and call `Sys_Error` on failure, and shutdown will destroy and NULL the mutex.
- Removed lazy creation logic from `S_LoadSoundDecodeJob` in `Quake/snd_mem.c` and replaced it with an unconditional `SDL_LockMutex/SDL_UnlockMutex` pair around the `GetWavinfo` call, assuming the mutex is pre-created.
- Wired lifecycle calls into the main sound init/shutdown: call `S_InitWavinfoMutex` from `S_Init` and `S_ShutdownWavinfoMutex` from `S_Shutdown` in `Quake/snd_dma.c`.

### Testing
- Ran `git diff --check` which reported no whitespace or simple diff issues (success).
- Attempted an out-of-tree build with `cmake -S . -B build && cmake --build build -j2`, which failed in this environment due to missing SDL2 development package / CMake config files (no usable SDK present), so a full compile could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5fc4649a0832e96e62791931338e4)