### PR TITLE
Use SDL_CondSignal for normal job queue wakeups

### DIFF
--- a/Quake/async.c
+++ b/Quake/async.c
@@ -19,6 +19,8 @@ static unsigned int jobs_pending;
 static unsigned int jobs_peak_pending;
 static unsigned int jobs_dropped;
 static unsigned int jobs_sync_fallbacks;
+static unsigned int jobs_wake_signals;
+static unsigned int jobs_wake_broadcasts;
 
 static qboolean Jobs_SubmitNode (jobnode_t *node);
 static void Jobs_LogQueueStats (const char *reason);
@@ -147,7 +149,8 @@ static qboolean Jobs_SubmitNode (jobnode_t *node)
 	jobs_pending++;
 	if (jobs_pending > jobs_peak_pending)
 		jobs_peak_pending = jobs_pending;
-	SDL_CondBroadcast (jobs_cond);
+	SDL_CondSignal (jobs_cond);
+	jobs_wake_signals++;
 	SDL_UnlockMutex (jobs_mutex);
 	Jobs_LogQueueStats ("enqueue");
 	return true;
@@ -157,12 +160,14 @@ static void Jobs_LogQueueStats (const char *reason)
 {
 	if (!developer.value)
 		return;
-	Con_DPrintf ("Async jobs %s: pending=%u peak=%u dropped=%u sync_fallbacks=%u max_pending=%d\n",
+	Con_DPrintf ("Async jobs %s: pending=%u peak=%u dropped=%u sync_fallbacks=%u wake_signals=%u wake_broadcasts=%u max_pending=%d\n",
 		reason,
 		jobs_pending,
 		jobs_peak_pending,
 		jobs_dropped,
 		jobs_sync_fallbacks,
+		jobs_wake_signals,
+		jobs_wake_broadcasts,
 		(int) host_async_max_pending.value);
 }
 
@@ -441,6 +446,7 @@ void Jobs_Shutdown (void)
 	SDL_LockMutex (jobs_mutex);
 	jobs_shutdown = true;
 	SDL_CondBroadcast (jobs_cond);
+	jobs_wake_broadcasts++;
 	SDL_UnlockMutex (jobs_mutex);
 
 	if (jobs_threads)


### PR DESCRIPTION
### Motivation
- Reduce spurious wakeups when enqueuing jobs so a single waiter is woken per new job instead of all workers, improving efficiency under bursty enqueue patterns and with higher `host_async_workers` counts.
- Preserve broadcast semantics on shutdown so all blocked workers are awakened to exit cleanly.
- Provide developer-visible counters to measure wakeup behaviour before/after the change.

### Description
- Replace `SDL_CondBroadcast(jobs_cond)` with `SDL_CondSignal(jobs_cond)` in `Jobs_SubmitNode` to wake a single waiter for normal enqueues.
- Add developer-only counters `jobs_wake_signals` and `jobs_wake_broadcasts` and increment `jobs_wake_signals` on normal enqueue and `jobs_wake_broadcasts` on shutdown.
- Include the new counters in `Jobs_LogQueueStats` output when `developer.value` is enabled.
- Keep `SDL_CondBroadcast(jobs_cond)` in `Jobs_Shutdown` so all waiters are woken when `jobs_shutdown = true`.

### Testing
- Performed static verification by searching the source to ensure enqueue uses `SDL_CondSignal` and shutdown still uses `SDL_CondBroadcast`, and inspected the modified `Quake/async.c` to confirm counters and logging were added (successful).
- Attempted to configure and build with `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build -j$(nproc)`, which failed due to a missing SDL2 CMake package (`SDL2Config.cmake`) in the environment so no runtime tests were run.
- No automated runtime tests were available in this environment; the change is confined to wakeup semantics and logging without modifying worker loop logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5fc4afa08832e8a601ad6bdf800b6)