### PR TITLE
Parse and validate worldspawn sun parameters

### DIFF
--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -886,6 +886,7 @@ R_NewGame -- johnfitz -- handle a game switch
 static qboolean r_worldspawn_has_sun = false;
 r_sun_t r_sun;
 cvar_t r_sun_light = { "r_sun_light", "0", CVAR_ARCHIVE };
+// Enables dynamic directional sunlight from parsed worldspawn sun keys (not baked lightmaps).
 
 static void R_ResetSunState (void)
 {
@@ -973,6 +974,9 @@ static void R_ParseWorldspawn (void)
 {
 	char key[128], value[4096];
 	const char *data;
+	qboolean sun_dir_parsed = false;
+	qboolean sun_intensity_parsed = false;
+	qboolean sun_color_parsed = false;
 
 	map_fallbackalpha = r_wateralpha.value;
 	R_ResetSunState ();
@@ -1003,30 +1007,70 @@ static void R_ParseWorldspawn (void)
 		data = COM_ParseEx(data, CPE_ALLOWTRUNC);
 		if (!data)
 			return; // error
-                q_strlcpy(value, com_token, sizeof(value));
+		q_strlcpy(value, com_token, sizeof(value));
 
-if (!strcmp("wateralpha", key))
-map_wateralpha = atof(value);
+		if (!strcmp("wateralpha", key))
+			map_wateralpha = atof(value);
 
-if (!strcmp("sunlight", key) || !strcmp("sun_mangle", key))
-{
-	r_worldspawn_has_sun = true;
-	r_sun.enabled = true;
-}
+		if (!strcmp("sun_mangle", key))
+		{
+			vec3_t ang;
+			if (sscanf(value, "%f %f %f", &ang[0], &ang[1], &ang[2]) == 3)
+			{
+				AngleVectors (ang, r_sun.dir, NULL, NULL);
+				if (DotProduct (r_sun.dir, r_sun.dir) > 1e-6f)
+				{
+					VectorNormalize (r_sun.dir);
+					sun_dir_parsed = true;
+				}
+			}
+		}
 
-if (!strcmp("telealpha", key))
-map_telealpha = atof(value);
+		if (!strcmp("sunlight", key))
+		{
+			char *endptr;
+			float intensity = strtof (value, &endptr);
 
-if (!strcmp("slimealpha", key))
-map_slimealpha = atof(value);
+			while (endptr && *endptr == ' ')
+				endptr++;
+			if (endptr && endptr != value && *endptr == '\0')
+			{
+				r_sun.intensity = q_max (0.f, intensity);
+				sun_intensity_parsed = true;
+			}
+		}
 
-}
+		if (!strcmp("sunlight_color", key) || !strcmp("sun_color", key) || !strcmp("suncolour", key))
+		{
+			vec3_t color;
+			if (sscanf(value, "%f %f %f", &color[0], &color[1], &color[2]) == 3)
+			{
+				r_sun.color[0] = q_max (0.f, color[0]);
+				r_sun.color[1] = q_max (0.f, color[1]);
+				r_sun.color[2] = q_max (0.f, color[2]);
+				sun_color_parsed = true;
+			}
+		}
 
-map_fallbackalpha = CLAMP(0.f, map_fallbackalpha, 1.f);
-map_wateralpha = CLAMP(0.f, map_wateralpha, 1.f);
-map_lavaalpha = 1.0f;
-map_telealpha = CLAMP(0.f, map_telealpha, 1.f);
-map_slimealpha = CLAMP(0.f, map_slimealpha, 1.f);
+		if (!strcmp("telealpha", key))
+			map_telealpha = atof(value);
+
+		if (!strcmp("slimealpha", key))
+			map_slimealpha = atof(value);
+
+	}
+
+	if (sun_dir_parsed || sun_intensity_parsed || sun_color_parsed)
+	{
+		r_worldspawn_has_sun = true;
+		r_sun.enabled = true;
+	}
+
+	map_fallbackalpha = CLAMP(0.f, map_fallbackalpha, 1.f);
+	map_wateralpha = CLAMP(0.f, map_wateralpha, 1.f);
+	map_lavaalpha = 1.0f;
+	map_telealpha = CLAMP(0.f, map_telealpha, 1.f);
+	map_slimealpha = CLAMP(0.f, map_slimealpha, 1.f);
 
 }
 


### PR DESCRIPTION
### Motivation
- Improve worldspawn sun handling by replacing the previous boolean-only detection with real parsing so maps can specify sun direction, intensity, and color.
- Ensure `R_ApplyDefaultSunIfMissing` remains the fallback when map-provided sun data is absent or invalid.
- Clarify that `r_sun_light` controls dynamic directional sunlight from worldspawn keys (not baked lightmaps).

### Description
- In `R_ParseWorldspawn` added parsing for `sun_mangle` as three angles and converted them with `AngleVectors` into a normalized `r_sun.dir` only when valid.
- Parse `sunlight` as a numeric intensity using `strtof` and clamp to non-negative values before assigning `r_sun.intensity`.
- Added optional sun color parsing for common keys (`sunlight_color`, `sun_color`, `suncolour`) with per-channel non-negative clamping into `r_sun.color`.
- Only set `r_worldspawn_has_sun` and `r_sun.enabled` when at least one of direction, intensity, or color was successfully parsed, preserving `R_ApplyDefaultSunIfMissing` when no valid sun data exists, and added a clarifying comment near the `r_sun_light` cvar.

### Testing
- Ran `make -j4` from the repository root which failed due to no top-level Makefile/targets.
- Ran `cmake -S . -B build && cmake --build build -j4` which failed during configuration because the SDL2 development package/configuration file was not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5feb44b84832e9e7f9d6154b9b1f4)