### PR TITLE
Add tunable sun visibility attenuation in world shader

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -34,6 +34,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 extern gltexture_t *lightmap_dir_texture;
 extern cvar_t r_sun_light;
+extern cvar_t r_sun_visibility;
 
 qboolean	r_cache_thrash;		// compatability
 
@@ -3491,7 +3492,7 @@ void R_SetupView (void)
         r_framedata.colorspace_params[3] = 0.f;
         r_framedata.shader_params[0] = r_shader_debug.value;
         r_framedata.shader_params[1] = r_tcgen_debug.value;
-        r_framedata.shader_params[2] = 0.f;
+        r_framedata.shader_params[2] = CLAMP (0.f, r_sun_visibility.value, 1.f);
         r_framedata.shader_params[3] = 0.f;
 
 	{

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -463,7 +463,7 @@ typedef struct gpuframedata_s {
         vec4_t          lightgrid_params; // x: enabled, yzw: unused
         vec4_t          dlight_params;  // x: style, y: debug view, z: pass selector, w: padding
         vec4_t          colorspace_params; // x: debug mode, y: manual gamma, z: output sRGB, w: unused
-        vec4_t          shader_params;  // x: shader debug, y: tcgen debug, zw: unused
+        vec4_t          shader_params;  // x: shader debug, y: tcgen debug, z: sun visibility attenuation, w: unused
         vec4_t          sun_dir_enabled; // xyz: sun dir (scene->sun), w: enabled
         vec4_t          sun_color_intensity; // rgb: sun color, w: intensity
         unsigned int    numlights;

--- a/Quake/mat_shader.c
+++ b/Quake/mat_shader.c
@@ -144,6 +144,7 @@ static qboolean mat_shader_keyword_seen[countof (mat_shader_keyword_table)];
 cvar_t r_shaders = { "r_shaders", "1", CVAR_ARCHIVE };
 cvar_t r_shader_debug = { "r_shader_debug", "0", CVAR_ARCHIVE };
 cvar_t r_tcgen_debug = { "r_tcgen_debug", "0", CVAR_ARCHIVE };
+cvar_t r_sun_visibility = { "r_sun_visibility", "0.35", CVAR_ARCHIVE };
 cvar_t r_matshader_debug_parse = { "r_matshader_debug_parse", "0", CVAR_ARCHIVE };
 cvar_t r_particles_shader_strict = { "r_particles_shader_strict", "0", CVAR_ARCHIVE };
 static cvar_t r_reloadshaders = { "r_reloadshaders", "0", CVAR_NONE };
@@ -1180,6 +1181,7 @@ void Mat_Shader_Init (void)
 	Cvar_RegisterVariable (&r_shaders);
 	Cvar_RegisterVariable (&r_shader_debug);
 	Cvar_RegisterVariable (&r_tcgen_debug);
+	Cvar_RegisterVariable (&r_sun_visibility);
 	Cvar_RegisterVariable (&r_matshader_debug_parse);
 	Cvar_RegisterVariable (&r_particles_shader_strict);
 	Cvar_RegisterVariable (&r_reloadshaders);

--- a/Quake/mat_shader.h
+++ b/Quake/mat_shader.h
@@ -270,6 +270,7 @@ typedef struct texture_s texture_t;
 extern cvar_t r_shaders;
 extern cvar_t r_shader_debug;
 extern cvar_t r_tcgen_debug;
+extern cvar_t r_sun_visibility;
 extern cvar_t r_matshader_debug_parse;
 extern cvar_t r_particles_shader_strict;
 

--- a/Quake/shaders/frame_uniforms.glsl
+++ b/Quake/shaders/frame_uniforms.glsl
@@ -46,7 +46,7 @@ layout(std140, binding=0) uniform FrameDataUBO
     vec4    LightgridParams;    // 320
     vec4    DLightParams;       // 336
     vec4    ColorSpaceParams;   // 352
-    vec4    ShaderParams;       // 368
+    vec4    ShaderParams;       // 368  x: shader debug, y: tcgen debug, z: sun visibility attenuation, w: unused
     vec4    SunDirEnabled;  // 384  xyz: scene->sun direction, w: enabled
     vec4    SunColorIntensity; // 400 rgb: sun color, w: intensity
 

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -521,7 +521,11 @@ void main()
 			float ndotl = max(dot(surface_normal, sun_to_surface), 0.0);
 			if (ndotl > 0.0)
 			{
-				vec3 sun_contrib = SunColorIntensity.rgb * SunColorIntensity.a * ndotl;
+				/* Minimal stopgap visibility: sky surfaces always receive full sun,
+				 * non-sky surfaces get a conservative attenuation from ShaderParams.z
+				 * (driven by cvar r_sun_visibility, clamped to [0,1] on CPU). */
+				float sun_visibility = ((in_flags & CF_MAT_SKY) != 0u) ? 1.0 : ShaderParams.z;
+				vec3 sun_contrib = SunColorIntensity.rgb * SunColorIntensity.a * ndotl * sun_visibility;
 				total_light += max(min(sun_contrib, 1.0 - total_light), 0.0);
 			}
 		}


### PR DESCRIPTION
### Motivation
- Prevent full sun from lighting fragments that cannot plausibly see the sky by applying a conservative, tunable visibility factor to sunlight in the fragment shader. 
- Provide a simple, runtime-tunable stopgap (non-raytraced) mechanism until a more accurate per-fragment visibility mask is available. 

### Description
- Multiplied the sun contribution in `Quake/shaders/world.frag` by a per-fragment `sun_visibility` factor so sky surfaces keep full sun and non-sky surfaces use `ShaderParams.z` as an attenuation multiplier. 
- Added a new archived cvar `r_sun_visibility` (default `0.35`) in `Quake/mat_shader.c` and declared it in `Quake/mat_shader.h`. 
- Wrote the clamped CPU-side value of `r_sun_visibility` into `r_framedata.shader_params[2]` in `Quake/gl_rmain.c` (clamped to `[0,1]`). 
- Updated UBO layout comments in `Quake/glquake.h` and `Quake/shaders/frame_uniforms.glsl` to document that `shader_params.z` carries the sun visibility attenuation.

### Testing
- Ran `git diff --check` to ensure no whitespace/index issues, which completed with no errors. 
- Verified working tree status with `git status --short` which reported a clean state after committing the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5feb22d28832ea8fb91f1e948129b)