### PR TITLE
Fix MSVC build by replacing undeclared Con_VPrintf in CL_IWMusic_DPrintf

### DIFF
--- a/Quake/cl_iwmusic.c
+++ b/Quake/cl_iwmusic.c
@@ -101,12 +101,16 @@ static qboolean CL_IWMusic_DebugEnabled (void)
 static void CL_IWMusic_DPrintf (const char *fmt, ...)
 {
 	va_list argptr;
+	char msg[1024];
+
 	if (!CL_IWMusic_DebugEnabled())
 		return;
+
 	va_start(argptr, fmt);
-	Con_Printf("[iwmusic] ");
-	Con_VPrintf(fmt, argptr);
+	q_vsnprintf(msg, sizeof(msg), fmt, argptr);
 	va_end(argptr);
+
+	Con_Printf("[iwmusic] %s", msg);
 }
 
 static qboolean CL_IWMusic_ParseVec3 (const char *s, vec3_t out)


### PR DESCRIPTION
### Motivation
- Visual Studio treated the implicit call to `Con_VPrintf` in `CL_IWMusic_DPrintf` as an error because `Con_VPrintf` is not declared, causing MSVC C4013/C2220 failures.

### Description
- Reworked `CL_IWMusic_DPrintf` in `Quake/cl_iwmusic.c` to format variadic arguments with `q_vsnprintf` into a local buffer and emit the result via `Con_Printf` instead of calling `Con_VPrintf`.
- Added a local `char msg[1024];` buffer and replaced the previous `Con_VPrintf` usage with `q_vsnprintf(msg, sizeof(msg), fmt, argptr); Con_Printf("[iwmusic] %s", msg);`.
- No external skills were used for this change; standard repository edits were applied directly.

### Testing
- Ran repository search to ensure no remaining `Con_VPrintf` references with `rg -n "Con_VPrintf" Quake Windows` and found none (success).
- Verified the affected source is included in the Visual Studio project and filters with `rg -n "cl_iwmusic.c|mat_shader.c|mat_shader_parse.c" Windows/VisualStudio/ironwail.vcxproj Windows/VisualStudio/ironwail.vcxproj.filters` (success).
- Inspected the file diff for the intended change with `git diff -- Quake/cl_iwmusic.c` and confirmed only the expected modifications were introduced (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5ff3822e8832eb12e263f82b1b07c)