### PR TITLE
Avoid stale fogvol composite textures by adding per-frame validity flag

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -2469,9 +2469,9 @@ void GL_PostProcess (void)
 	 * postprocess.frag samples this to derive per-pixel volumetric transmittance and
 	 * suppress AO where fog is dense — replacing the inaccurate analytical fog formula
 	 * (exp2(-density*dist^2)) which cannot model spatial noise or color variation.
-	 * composite_tex[0] holds the upsampled full-res fogvol output from R_FogVol_Render.
-	 * Passing 0 when fogvol is inactive leaves the binding as the previous frame's tex
-	 * or driver default (black), which FogVolTransmittance treats as transmittance=1. */
+	 * The existing fogvol_active gating is preserved; R_FogVol_GetCompositeTex() now
+	 * returns 0 when no valid composite was produced this frame, preventing stale
+	 * texture handles from scene/context transitions being rebound here. */
 	{
 		GLuint fogvol_composite = 0;
 		float  fogvol_active    = 0.f;

--- a/Quake/r_fogvol.c
+++ b/Quake/r_fogvol.c
@@ -159,6 +159,7 @@ extern cvar_t gl_farclip;
 static int r_fogvol_history_index = 0;
 static int r_fogvol_history_width = 0;
 static int r_fogvol_history_height = 0;
+static qboolean r_fogvol_composite_valid = false;
 
 
 void R_FogVol_ClearHistory (void)
@@ -166,6 +167,7 @@ void R_FogVol_ClearHistory (void)
 	r_fogvol_history_index = 0;
 	r_fogvol_history_width = 0;
 	r_fogvol_history_height = 0;
+	r_fogvol_composite_valid = false;
 
 	if (!framebufs.fogvol.history_fbo[0] || !framebufs.fogvol.history_fbo[1])
 		return;
@@ -1187,6 +1189,9 @@ qboolean R_FogVol_CanRenderGlobal (void)
  * Returns 0 if fogvol did not render this frame (no active volumes). */
 GLuint R_FogVol_GetCompositeTex (void)
 {
+	if (!r_fogvol_composite_valid)
+		return 0;
+
 	GLuint tex = framebufs.fogvol.composite_tex[r_fogvol_history_index];
 	return tex;
 }
@@ -1674,6 +1679,10 @@ void R_FogVol_Render (void)
 	const lightgrid_t *lightgrid = NULL;
 	vec3_t shadow_dir;
 	int shadow_samples;
+
+	/* Per-frame validity: only expose a fogvol composite texture after this
+	 * frame actually produced one. */
+	r_fogvol_composite_valid = false;
 
 	if (!glprogs.fogvol)
 		return;
@@ -2228,6 +2237,8 @@ void R_FogVol_Render (void)
 				GL_COLOR_BUFFER_BIT, GL_NEAREST);
 			glColorMask (GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
 		}
+
+		r_fogvol_composite_valid = true;
 	}
 
 	if (mode == 1)


### PR DESCRIPTION
### Motivation
- Prevent reuse of stale fog volume composite texture handles across frame, scene or context transitions so callers (SSAO/postprocess) do not bind invalid previous-frame textures.
- Ensure SSAO suppression and other consumers only see a fog composite when the renderer actually produced a final composite this frame.

### Description
- Add `static qboolean r_fogvol_composite_valid` to `Quake/r_fogvol.c` and initialize it false.
- Reset `r_fogvol_composite_valid = false` at the start of `R_FogVol_Render()` and set it true only after a successful final composite/write (the `has_drawn` finalization path).
- Make `R_FogVol_GetCompositeTex()` return `0` when the per-frame validity flag is false to avoid exposing stale texture handles.
- Clear the validity flag in `R_FogVol_ClearHistory()` so map/load/vid-reset paths cannot cause reuse of stale composites, and update `Quake/gl_rmain.c` comments to note reliance on the corrected `R_FogVol_GetCompositeTex()` while preserving the existing `fogvol_active` gating.
- Modified files: `Quake/r_fogvol.c`, `Quake/gl_rmain.c`.

### Testing
- Ran `cmake -S . -B build && cmake --build build -j2` to validate build configuration but configuration failed due to missing SDL2 CMake package (`SDL2Config.cmake` / `sdl2-config.cmake`), so a full build could not be performed (failed).
- Attempted `make -j2` but the repository root contains no Makefile/targets in this environment, so no build occurred (no-op/failed).
- No automated unit tests were available or executed in this environment to validate runtime behavior; changes are limited to guarded texture exposure and should be safe to validate in an integrated build/run environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a61498d488832e863e24a48cdc3e45)