### PR TITLE
Fix decal spawning normals for wall hits

### DIFF
--- a/Quake/cl_tent.c
+++ b/Quake/cl_tent.c
@@ -156,8 +156,40 @@ CL_ParseTEnt
 */
 static qboolean CL_DecalNormalFromView (const vec3_t impact, vec3_t out_normal)
 {
-	vec3_t from;
+	trace_t trace;
+	vec3_t from, to, dir;
+	float len;
+
+	if (!cl.worldmodel)
+		return false;
+
 	VectorCopy (cl_entities[cl.viewentity].origin, from);
+	VectorSubtract (impact, from, dir);
+	len = VectorLength (dir);
+	if (len < 0.0001f)
+		return false;
+	VectorScale (dir, 1.f / len, dir);
+	/*
+	 * TE impacts are quantized and can end up slightly in front of/behind the
+	 * touched plane. Extend the line a little past the impact so hull tracing
+	 * can still recover the contacted world normal.
+	 */
+	VectorMA (impact, 2.f, dir, to);
+
+	memset (&trace, 0, sizeof (trace));
+	trace.fraction = 1.f;
+	trace.allsolid = true;
+	VectorCopy (to, trace.endpos);
+	SV_RecursiveHullCheck (cl.worldmodel->hulls, 0, 0, 1, from, to, &trace);
+
+	if (trace.fraction < 1.f && VectorLengthSquared (trace.plane.normal) >= 0.0001f)
+	{
+		VectorCopy (trace.plane.normal, out_normal);
+		VectorNormalizeFast (out_normal);
+		return true;
+	}
+
+	/* fall back to the legacy approximation when no plane was hit */
 	VectorSubtract (from, impact, out_normal);
 	if (VectorLengthSquared (out_normal) < 0.0001f)
 		return false;
@@ -213,15 +245,13 @@ static qboolean CL_DecalNormalFromImpactTrace (const vec3_t impact, vec3_t out_n
 
 static qboolean CL_DecalNormalForImpact (const vec3_t impact, vec3_t out_normal)
 {
+	if (CL_DecalNormalFromView (impact, out_normal))
+		return true;
+
 	if (CL_DecalNormalFromImpactTrace (impact, out_normal))
 		return true;
 
-	/*
-	 * Demo/network temp entity events only provide an impact position. If we
-	 * cannot recover a nearby world BSP plane from that point, fall back to the
-	 * legacy view-based approximation so these events can still spawn decals.
-	 */
-	return CL_DecalNormalFromView (impact, out_normal);
+	return false;
 }
 
 static qboolean CL_TEntCanUseQ3P (void)


### PR DESCRIPTION
### Motivation
- Decals were frequently missing or only appearing on floors because impact normals were estimated from a simple view->impact vector which is unreliable for quantized temp-entity impact positions and produces incorrect normals for wall hits.

### Description
- Change `CL_DecalNormalFromView` to perform a hull trace from the camera to slightly beyond the impact point and use the traced plane normal when available, falling back to the legacy view-vector approximation only if no plane is hit.
- Change `CL_DecalNormalForImpact` to try the new view-ray trace first, then the omnidirectional impact trace, and return `false` if neither finds a valid normal.
- Modified file: `Quake/cl_tent.c` (normal recovery and selection logic updated).

### Testing
- Attempted a full configure/build with `cmake -S . -B build && cmake --build build -j2`, but the build could not complete in this environment because the SDL2 CMake package files were not available (`SDL2Config.cmake` / `sdl2-config.cmake` not found).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a61a2ff4f8832eb339fa749f669413)