### PR TITLE
fogvol: add directional sun scatter uniforms and controls

### DIFF
--- a/Quake/r_fogvol.c
+++ b/Quake/r_fogvol.c
@@ -169,6 +169,10 @@ cvar_t r_fogvol_shadow_samples = { "r_fogvol_shadow_samples", "2", CVAR_ARCHIVE 
 cvar_t r_fogvol_shadow_strength = { "r_fogvol_shadow_strength", "0.8", CVAR_ARCHIVE };
 cvar_t r_fogvol_shadow_jitter = { "r_fogvol_shadow_jitter", "1", CVAR_ARCHIVE };
 cvar_t r_fogvol_sun_dir = { "r_fogvol_sun_dir", "1", CVAR_ARCHIVE };
+cvar_t r_fogvol_sun_scatter = { "r_fogvol_sun_scatter", "0", CVAR_ARCHIVE };
+cvar_t r_fogvol_sun_color = { "r_fogvol_sun_color", "0 0 0", CVAR_ARCHIVE };
+
+extern float skyflatcolor[3];
 
 extern cvar_t gl_farclip;
 
@@ -1147,6 +1151,8 @@ void R_FogVol_Init (void)
 	Cvar_RegisterVariable (&r_fogvol_shadow_strength);
 	Cvar_RegisterVariable (&r_fogvol_shadow_jitter);
 	Cvar_RegisterVariable (&r_fogvol_sun_dir);
+	Cvar_RegisterVariable (&r_fogvol_sun_scatter);
+	Cvar_RegisterVariable (&r_fogvol_sun_color);
 }
 
 void R_FogVol_Clear (void)
@@ -1804,6 +1810,9 @@ void R_FogVol_Render (void)
 	qboolean fog_lightgrid_has_data = false;
 	const lightgrid_t *lightgrid = NULL;
 	vec3_t shadow_dir;
+	vec3_t sun_color;
+	float sun_intensity = 1.f;
+	float sun_scatter = 0.f;
 	int shadow_samples;
 
 	/* Per-frame validity: only expose a fogvol composite texture after this
@@ -2035,6 +2044,27 @@ void R_FogVol_Render (void)
 	GL_Uniform1fFunc (20, r_fogvol_shadow_jitter.value > 0.f ? 1.f : 0.f);
 	GL_Uniform3fFunc (21, shadow_dir[0], shadow_dir[1], shadow_dir[2]);
 	GL_Uniform1iFunc (22, fog_lightgrid_enabled ? 1 : 0);
+	sun_scatter = q_max (0.f, r_fogvol_sun_scatter.value);
+	if (R_GetSun (NULL, NULL, sun_color, &sun_intensity))
+	{
+		/* worldspawn sun color/intensity are the preferred defaults. */
+	}
+	else
+	{
+		VectorSet (sun_color, skyflatcolor[0], skyflatcolor[1], skyflatcolor[2]);
+		sun_intensity = 1.f;
+		if (sun_color[0] <= 0.f && sun_color[1] <= 0.f && sun_color[2] <= 0.f)
+			VectorSet (sun_color, 1.f, 1.f, 1.f);
+	}
+	if (r_fogvol_sun_color.string && r_fogvol_sun_color.string[0])
+	{
+		vec3_t user_sun_color;
+		R_FogVol_ParseColor (r_fogvol_sun_color.string, user_sun_color);
+		if (user_sun_color[0] > 0.f || user_sun_color[1] > 0.f || user_sun_color[2] > 0.f)
+			VectorCopy (user_sun_color, sun_color);
+	}
+	GL_Uniform1fFunc (30, sun_scatter * q_max (0.f, sun_intensity));
+	GL_Uniform3fFunc (31, q_max (0.f, sun_color[0]), q_max (0.f, sun_color[1]), q_max (0.f, sun_color[2]));
 
 	if (use_halfres)
 		glViewport (0, 0, fog_width, fog_height);

--- a/Quake/shaders/fogvol.frag
+++ b/Quake/shaders/fogvol.frag
@@ -107,6 +107,8 @@ layout(location=26) uniform float FogDomainWarpMaxDist;
 layout(location=27) uniform int   FogCheckerboard;
 layout(location=28) uniform int   FogHalfRes;
 layout(location=29) uniform int   FogLightSubsample;
+layout(location=30) uniform float FogSunScatter;
+layout(location=31) uniform vec3  FogSunColor;
 
 layout(location=0) out vec4 FragColor;
 
@@ -600,6 +602,11 @@ void main()
 	float phaseSun      = (sunDirLenSq > 1e-6)
 		? AnisotropicPhase(clamp(dot(viewDir, sunDir), -1.0, 1.0), ANISO_G_SUN)
 		: 1.0;
+	float sunScatterStrength = max(FogSunScatter, 0.0);
+	vec3 sunScatterColor = max(FogSunColor, vec3(0.0));
+	vec3 sunRadiance = (sunDirLenSq > 1e-6 && sunScatterStrength > 0.0)
+		? (sunScatterColor * (sunScatterStrength * phaseSun))
+		: vec3(0.0);
 	// PERF: Cache active light count and enabled flag to avoid UBO re-fetch in loop.
 	FogLightList lightList = FogLightLists[clamp(FogVolumeIndex, 0, MAX_FOGVOLUMES - 1)];
 	int lightOffset     = max(lightList.offset_count.x, 0);
@@ -660,7 +667,7 @@ void main()
 			: 1.0;
 
 		// phaseSun is already precomputed per-ray (constant for all steps on same ray).
-		vec3  stepScatter = (1.0 - att) * scatterColor * phaseSun;
+		vec3  stepScatter = (1.0 - att) * (scatterColor * phaseSun + sunRadiance * transmittance);
 		if (doLightgrid)
 		{
 			// Static/emissive world contribution comes from the baked lightgrid

--- a/docs/fogvol_debug_notes.md
+++ b/docs/fogvol_debug_notes.md
@@ -31,9 +31,12 @@ The dominant issue was **A + C combined**:
 - `r_fogvol_shadow_samples` (default `2`, clamp `1..8`): shadow raymarch taps per fog step; higher values improve directional shadow stability at higher GPU cost.
 - `r_fogvol_shadow_strength` (default `0.8`): scales shadow optical depth influence; `0` disables darkening, `1` is physical-ish, values `>1` exaggerate shadows.
 - `r_fogvol_shadow_jitter` (default `1`): stochastic offset for shadow taps to reduce banding; may introduce light temporal noise.
+- `r_fogvol_sun_scatter` (default `0`): adds directional sun radiance to volumetric scattering using the existing anisotropic phase; independent from `r_fogvol_shadow` visibility so it can be tuned separately.
+- `r_fogvol_sun_color` (default `0 0 0`): optional override for directional fog light color. When left at `0 0 0`, fog sun color defaults to `R_GetSun` worldspawn color/intensity, and falls back to sky average tint when no sun is defined.
 - Existing diagnostics retained: `r_fogvol_testvolumes`, `r_fogvol_testvolumes_dumpstate`
 
 ## Performance implications of fog shadows
 - Cost scales roughly with `r_fogvol_steps * r_fogvol_shadow_samples` because each fog integration step performs an additional short visibility march.
 - Recommended baseline: keep `r_fogvol_shadow_samples=2` for gameplay, use `4` for captures, and avoid `8` unless fog coverage is limited.
 - If performance is tight, first reduce `r_fogvol_shadow_samples`, then disable jitter, and finally disable `r_fogvol_shadow`.
+- Directional sun radiance adds only a few ALU ops per fog step and no extra texture taps; it is effectively free compared to shadow marching. Keep `r_fogvol_sun_scatter=0` for exact legacy output.


### PR DESCRIPTION
### Motivation
- Provide a low-cost directional sun radiance term for volumetric fog so artists can add sun-tinted scattering without the cost of extra shadow marching.
- Allow the directional fog tint and strength to be controlled via cvars and to default sensibly from existing sun/sky state (`R_GetSun` / sky average) when available.
- Preserve legacy output when the new controls are disabled by default.

### Description
- Added two new cvars in `Quake/r_fogvol.c`: `r_fogvol_sun_scatter` (float, default `0`) and `r_fogvol_sun_color` (string, default `0 0 0`), registered at init and parsed via existing color helper.
- CPU-side now sources a default sun color/intensity from `R_GetSun` when available, falls back to `skyflatcolor` and finally white, and uploads two new uniforms to the fog shader: `FogSunScatter` (location 30) and `FogSunColor` (location 31).
- Shader (`Quake/shaders/fogvol.frag`) adds `FogSunScatter`/`FogSunColor` uniforms, computes `sunRadiance` using the existing anisotropic phase (`ANISO_G_SUN`) and the configured color/strength, and adds the resulting directional radiance into the per-step scattering accumulation modulated by extinction/transmittance so that setting `FogSunScatter = 0` yields legacy behavior.
- Documentation: `docs/fogvol_debug_notes.md` updated under “Useful cvars” with short notes for `r_fogvol_sun_scatter` and `r_fogvol_sun_color` and a performance note clarifying the low overhead of the radiance term.

### Testing
- Static verification: Ran repository searches and inspected the updated CPU->shader uniform plumbing and shader code paths to ensure the new uniforms and cvar parsing are wired and default fallbacks (`R_GetSun` / `skyflatcolor`) are applied; no runtime crashes observed from the textual changes.
- Build attempt: Ran a full CMake configure/build (`cmake` + `cmake --build`) in this environment, but configuration failed due to a missing SDL2 CMake package (external dependency), so a full compile/test was not performed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a61e9d45c4832e9c2588955b5db6ac)