### PR TITLE
Implement fog volume injection into froxel grid

### DIFF
--- a/Quake/r_fogvol.c
+++ b/Quake/r_fogvol.c
@@ -148,6 +148,7 @@ cvar_t r_fogvol_checkerboard = { "r_fogvol_checkerboard", "0", CVAR_ARCHIVE };
 cvar_t r_fogvol_light_subsample = { "r_fogvol_light_subsample", "1", CVAR_ARCHIVE };
 cvar_t r_fogvol_jitter = { "r_fogvol_jitter", "1", CVAR_ARCHIVE };
 cvar_t r_fogvol_debug = { "r_fogvol_debug", "0", CVAR_ARCHIVE };
+cvar_t r_fogvol_inject_debug = { "r_fogvol_inject_debug", "0", CVAR_ARCHIVE };
 cvar_t r_fogvol_density_scale = { "r_fogvol_density_scale", "1", CVAR_ARCHIVE };
 /* r_fogvol_sigma_max: maximum optical depth *per raymarching step*.
  * exp(-4) ≈ 0.018, so 4.0 is already near-black in one step.
@@ -1156,6 +1157,7 @@ void R_FogVol_Init (void)
 	Cvar_RegisterVariable (&r_fogvol_light_subsample);
 	Cvar_RegisterVariable (&r_fogvol_jitter);
 	Cvar_RegisterVariable (&r_fogvol_debug);
+	Cvar_RegisterVariable (&r_fogvol_inject_debug);
 	Cvar_RegisterVariable (&r_fogvol_density_scale);
 	Cvar_RegisterVariable (&r_fogvol_sigma_max);
 	Cvar_RegisterVariable (&r_fogvol_globalfog);
@@ -2513,15 +2515,126 @@ void R_FogVol_LogEndFrameState (void)
 	R_FogVol_LogPipelineState ("END_FRAME");
 }
 
+
+static qboolean R_FogVol_GridBoxOverlap (const vec3_t cell_mins, const vec3_t cell_maxs, const fog_volume_t *vol)
+{
+	return R_FogVol_BoundsOverlap (cell_mins, cell_maxs, vol->mins, vol->maxs);
+}
+
+static qboolean R_FogVol_GridSphereOverlap (const vec3_t cell_mins, const vec3_t cell_maxs, const fog_volume_t *vol)
+{
+	float dist2 = 0.f;
+	for (int a = 0; a < 3; ++a)
+	{
+		float v = vol->sphereCenter[a];
+		if (v < cell_mins[a])
+		{
+			float d = cell_mins[a] - v;
+			dist2 += d * d;
+		}
+		else if (v > cell_maxs[a])
+		{
+			float d = v - cell_maxs[a];
+			dist2 += d * d;
+		}
+	}
+	return dist2 <= vol->sphereRadius * vol->sphereRadius;
+}
+
+static qboolean R_FogVol_GridVolumeOverlapsCell (const fog_volume_t *vol, const vec3_t cell_mins, const vec3_t cell_maxs)
+{
+	if (vol->shape == 1)
+		return R_FogVol_GridSphereOverlap (cell_mins, cell_maxs, vol);
+	return R_FogVol_GridBoxOverlap (cell_mins, cell_maxs, vol);
+}
+
 void R_FogVol_InjectIntoGrid (froxel_grid_t *grid, const fog_volume_t *vols, int num)
 {
-	/* TODO: Inject fog volumes into the froxel grid for Forward+ clustered
-	 * lighting integration.  Currently a no-op stub — clustered rendering
-	 * bypasses this path and the fog volumes are rendered via R_FogVol_Render()
-	 * as a separate post-process pass.  When implemented, this function should
-	 * iterate vols[0..num-1] and mark each froxel that overlaps the AABB or
-	 * sphere of the volume with the volume's density and colour. */
-	(void)grid;
-	(void)vols;
-	(void)num;
+	vec3_t cell_size;
+	const qboolean inject_debug = (r_fogvol_inject_debug.value > 0.f) || (r_fogvol_debug.value >= 7.f);
+
+	if (!grid || !vols || num <= 0)
+		return;
+	if (grid->dims[0] <= 0 || grid->dims[1] <= 0 || grid->dims[2] <= 0)
+		return;
+	if (!grid->density || !grid->color || !grid->emissive)
+		return;
+
+	for (int a = 0; a < 3; ++a)
+		cell_size[a] = (grid->maxs[a] - grid->mins[a]) / (float)grid->dims[a];
+
+	for (int i = 0; i < num; ++i)
+	{
+		const fog_volume_t *vol = &vols[i];
+		vec3_t bmins, bmaxs;
+		int min_i[3], max_i[3];
+		const float vol_density = q_max (0.f, vol->density) * q_max (0.f, r_fogvol_density_scale.value);
+		const int blend_mode = (vol->blendMode >= 0) ? vol->blendMode : (int)Q_rint (r_fogvol_blendmode.value);
+
+		if (!vol->enabled || vol_density <= 0.f)
+			continue;
+
+		R_FogVol_GetVolumeBounds (vol, bmins, bmaxs);
+		if (!R_FogVol_BoundsOverlap (bmins, bmaxs, grid->mins, grid->maxs))
+			continue;
+
+		for (int a = 0; a < 3; ++a)
+		{
+			float cminf = floorf ((bmins[a] - grid->mins[a]) / q_max (cell_size[a], 1e-6f));
+			float cmaxf = floorf ((bmaxs[a] - grid->mins[a]) / q_max (cell_size[a], 1e-6f));
+			min_i[a] = CLAMP (0, (int)cminf, grid->dims[a] - 1);
+			max_i[a] = CLAMP (0, (int)cmaxf, grid->dims[a] - 1);
+		}
+
+		for (int z = min_i[2]; z <= max_i[2]; ++z)
+		for (int y = min_i[1]; y <= max_i[1]; ++y)
+		for (int x = min_i[0]; x <= max_i[0]; ++x)
+		{
+			vec3_t cell_mins, cell_maxs;
+			const int idx = x + grid->dims[0] * (y + grid->dims[1] * z);
+			float *cell_color = &grid->color[idx * 3];
+			float *cell_emissive = &grid->emissive[idx * 3];
+
+			cell_mins[0] = grid->mins[0] + (float)x * cell_size[0];
+			cell_mins[1] = grid->mins[1] + (float)y * cell_size[1];
+			cell_mins[2] = grid->mins[2] + (float)z * cell_size[2];
+			cell_maxs[0] = cell_mins[0] + cell_size[0];
+			cell_maxs[1] = cell_mins[1] + cell_size[1];
+			cell_maxs[2] = cell_mins[2] + cell_size[2];
+
+			if (!R_FogVol_GridVolumeOverlapsCell (vol, cell_mins, cell_maxs))
+				continue;
+
+			if (blend_mode == 1)
+			{
+				grid->density[idx] = q_max (grid->density[idx], vol_density);
+				for (int c = 0; c < 3; ++c)
+				{
+					cell_color[c] = q_max (cell_color[c], vol->color[c]);
+					if (r_fogvol_emissive.value > 0.f && vol->emissiveStrength > 0.f)
+						cell_emissive[c] = q_max (cell_emissive[c], vol->color[c] * vol->emissiveStrength);
+				}
+			}
+			else
+			{
+				const float old_density = grid->density[idx];
+				const float new_density = old_density + vol_density;
+				const float w = (new_density > 1e-6f) ? (vol_density / new_density) : 1.f;
+				grid->density[idx] = new_density;
+				for (int c = 0; c < 3; ++c)
+				{
+					cell_color[c] = cell_color[c] * (1.f - w) + vol->color[c] * w;
+					if (r_fogvol_emissive.value > 0.f && vol->emissiveStrength > 0.f)
+						cell_emissive[c] += vol->color[c] * vol->emissiveStrength * vol_density;
+				}
+			}
+		}
+
+		if (inject_debug)
+		{
+			Con_DPrintf ("FOGVOL_GRID inject i=%d priority=%d shape=%d blend=%d bounds=[%d..%d,%d..%d,%d..%d]\n",
+				i, vol->priority, vol->shape, blend_mode,
+				min_i[0], max_i[0], min_i[1], max_i[1], min_i[2], max_i[2]);
+		}
+	}
 }

--- a/Quake/r_fogvol.h
+++ b/Quake/r_fogvol.h
@@ -31,7 +31,15 @@ typedef struct fog_volume_s
 	float heightScale;
 } fog_volume_t;
 
-typedef struct froxel_grid_s froxel_grid_t;
+typedef struct froxel_grid_s
+{
+	int dims[3];
+	vec3_t mins;
+	vec3_t maxs;
+	float *density;
+	float *color;
+	float *emissive;
+} froxel_grid_t;
 
 extern cvar_t r_fogvol;
 extern cvar_t r_fogvol_halfres;
@@ -63,6 +71,7 @@ extern cvar_t r_fogvol_checkerboard;
 extern cvar_t r_fogvol_light_subsample;
 extern cvar_t r_fogvol_jitter;
 extern cvar_t r_fogvol_debug;
+extern cvar_t r_fogvol_inject_debug;
 extern cvar_t r_fogvol_density_scale;
 extern cvar_t r_fogvol_sigma_max;
 extern cvar_t r_fogvol_testvolumes;


### PR DESCRIPTION
### Motivation
- Wire fog volumes into the Forward+ froxel grid so clustered lighting can consume volumetric fog data and so injected froxels can be validated against the post-process fog output. 
- Use world-space AABB/sphere overlap to compute per-axis froxel ranges and preserve ordering/priority from `R_FogVol_BuildList()` when injecting.

### Description
- Implemented `R_FogVol_InjectIntoGrid()` to rasterize `vols[0..num-1]` into `froxel_grid_t` cells by computing cell bounds, testing overlap, and accumulating density/color/emissive contributions. 
- Added shape-aware overlap helpers: `R_FogVol_GridBoxOverlap`, `R_FogVol_GridSphereOverlap`, and `R_FogVol_GridVolumeOverlapsCell` and used `R_FogVol_GetVolumeBounds()` to compute world-space bounds. 
- Added blend-mode-aware combine rules where blend mode `1` uses max-style composition and other modes perform additive density with density-weighted color/emissive accumulation, and accounted for `r_fogvol_emissive` and `r_fogvol_density_scale`. 
- Introduced an explicit `froxel_grid_t` in `Quake/r_fogvol.h` (dims, mins/maxs, and pointers for `density`, `color`, `emissive`) and added `r_fogvol_inject_debug` (registered in `R_FogVol_Init`) to enable injection debug logging (also enabled when `r_fogvol_debug >= 7`).

### Testing
- Attempted to build the Quake target with `make -C Quake -j4`, which exercises compile-time checks; the build could not complete due to missing system dependencies (`sdl2-config` and `SDL.h`) in the container so full compilation could not be validated. 
- No unit tests exist for the froxel injection path in this environment, so functional validation should be performed in-engine at runtime by enabling `r_fogvol_inject_debug` and comparing froxel data with the post-process fog composite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a620dc2ae0832e92be1ba67fb661f8)