### PR TITLE
Fix godrays debug source preview when rays are disabled

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -2379,7 +2379,12 @@ void GL_PostProcess (void)
 	godrays_source = 0;
 	if (godrays_preview)
 	{
-		godrays_texture = GL_GenerateGodraysTexture (&godrays_mask);
+		/* Keep source debug useful even when scatter generation is disabled/unsupported. */
+		if (godrays_debug_source > 0.f && R_GodraysReady ())
+			GL_GenerateGodraysSource (true, true);
+
+		if (godrays_enabled || godrays_debug > 0.f)
+			godrays_texture = GL_GenerateGodraysTexture (&godrays_mask);
 		godrays_source = framebufs.godrays.source_tex;
 	}
 


### PR DESCRIPTION
### Motivation
- Ensure `r_godrays_debug_source` displays a meaningful source texture in the postprocess preview even when the full godrays scatter generation is disabled so the debug source mode does not produce a completely black image.

### Description
- Call `GL_GenerateGodraysSource(true, true)` when `godrays_debug_source > 0.f` and `R_GodraysReady()` to generate the source buffer independently, and only invoke `GL_GenerateGodraysTexture(&godrays_mask)` when `godrays_enabled || godrays_debug > 0.f` so full shafts generation is performed only when requested.

### Testing
- Ran `cmake -S . -B build` in this environment which failed due to missing SDL2 development/CMake configuration files, so a full build could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6226b5f3c832ea4b17f30948e81e7)