### PR TITLE
Refactor fog volume frame-readiness API

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -1750,10 +1750,10 @@ static GLuint GL_GenerateGodraysTexture (GLuint *out_mask)
 	GLuint volumetric_tex = 0;
 	float volumetric_enabled = 0.f;
 
-	if (r_godrays_volumetric.value > 0.f && r_fogvol.value > 0.f && R_FogVol_CanRenderGlobal ())
+	if (r_godrays_volumetric.value > 0.f && R_FogVol_HasValidComposite ())
 	{
 		volumetric_tex = R_FogVol_GetCompositeTex ();
-		volumetric_enabled = (volumetric_tex != 0) ? 1.f : 0.f;
+		volumetric_enabled = 1.f;
 	}
 
 	GL_GetGodraysLightPos (width, height, light_x, light_y, &stabilized_x, &stabilized_y);
@@ -2499,10 +2499,10 @@ void GL_PostProcess (void)
 	{
 		GLuint fogvol_composite = 0;
 		float  fogvol_active    = 0.f;
-		if (r_fogvol.value > 0.f && R_FogVol_CanRenderGlobal ())
+		if (R_FogVol_HasValidComposite ())
 		{
 			fogvol_composite = R_FogVol_GetCompositeTex ();
-			fogvol_active    = (fogvol_composite != 0) ? 1.f : 0.f;
+			fogvol_active    = 1.f;
 		}
 		GL_BindNative (GL_TEXTURE10, GL_TEXTURE_2D, fogvol_composite);
 		GL_Uniform4fFunc (28, fogvol_active, 0.f, 0.f, 0.f);
@@ -3240,7 +3240,7 @@ qboolean GL_NeedsSceneEffects (void)
         if (R_DoFEnabled ())
 		return true;
 
-	if (r_fogvol.value > 0.f && R_FogVol_CanRenderGlobal ())
+	if (R_FogVol_ShouldAffectPostFX ())
 		return true;
 
 	return false;
@@ -3271,7 +3271,7 @@ qboolean GL_NeedsPostprocess (void)
 		return true;
 	if (r_godrays.value > 0.f)
 		return true;
-	if (r_fogvol.value > 0.f && R_FogVol_CanRenderGlobal ())
+	if (R_FogVol_ShouldAffectPostFX ())
 		return true;
 	return false;
 }

--- a/Quake/r_fogvol.c
+++ b/Quake/r_fogvol.c
@@ -1330,8 +1330,10 @@ static void R_FogVol_AddGlobalFog (void)
 	R_FogVol_AddVolume (&volume);
 }
 
-qboolean R_FogVol_CanRenderGlobal (void)
+qboolean R_FogVol_IsEnabledForFrame (void)
 {
+	if (r_fogvol.value <= 0.f)
+		return false;
 	if (Fog_GetDensity () <= 0.f)
 		return false;
 	if (!glprogs.fogvol)
@@ -1343,17 +1345,38 @@ qboolean R_FogVol_CanRenderGlobal (void)
 	return true;
 }
 
+qboolean R_FogVol_HasValidComposite (void)
+{
+	if (!R_FogVol_IsEnabledForFrame ())
+		return false;
+	if (!r_fogvol_composite_valid)
+		return false;
+	if (framebufs.fogvol.composite_tex[r_fogvol_history_index] == 0)
+		return false;
+	return true;
+}
+
+qboolean R_FogVol_ShouldAffectPostFX (void)
+{
+	return R_FogVol_IsEnabledForFrame ();
+}
+
+qboolean R_FogVol_CanRenderGlobal (void)
+{
+	return R_FogVol_IsEnabledForFrame ();
+}
+
 /* Returns the fogvol composite texture that was rendered this frame.
  * After R_FogVol_Render(), r_fogvol_history_index points to the slot that
  * received the temporal composite output — that is the most recent result.
- * Returns 0 if fogvol did not render this frame (no active volumes). */
+ * Returns 0 if fogvol did not render this frame (no active volumes).
+ * Semantics: returns a non-zero texture only when output is valid this frame. */
 GLuint R_FogVol_GetCompositeTex (void)
 {
-	if (!r_fogvol_composite_valid)
+	if (!R_FogVol_HasValidComposite ())
 		return 0;
 
-	GLuint tex = framebufs.fogvol.composite_tex[r_fogvol_history_index];
-	return tex;
+	return framebufs.fogvol.composite_tex[r_fogvol_history_index];
 }
 
 void R_FogVol_ParseEntities (void)

--- a/Quake/r_fogvol.h
+++ b/Quake/r_fogvol.h
@@ -109,6 +109,12 @@ void R_FogVol_ClearHistory (void);
 void R_FogVol_LogEndFrameState (void);
 void R_FogVol_InjectIntoGrid (froxel_grid_t *grid, const fog_volume_t *vols, int num);
 qboolean R_FogVol_ProjectAABBToScreenRect (const fog_volume_t *v, int *x0, int *y0, int *x1, int *y1, qboolean fullres);
+/* Feature-level gate: fogvol is enabled by cvar and all global render resources/programs are ready this frame. */
+qboolean R_FogVol_IsEnabledForFrame (void);
+/* Output-level gate: fogvol produced a valid composite texture this frame (safe to sample now). */
+qboolean R_FogVol_HasValidComposite (void);
+/* PostFX gate: fogvol should contribute to postprocess passes this frame. */
+qboolean R_FogVol_ShouldAffectPostFX (void);
 qboolean R_FogVol_CanRenderGlobal (void);
 /* Returns the composite texture that received the fogvol temporal output this
  * frame. Use this for SSAO suppression — it is the correct per-pixel fog density


### PR DESCRIPTION
### Motivation
- Consolidate duplicated fog-volume readiness checks into a small, well-documented API so callers can reason about feature enablement vs per-frame output validity vs postfx participation.
- Prevent stale texture handles from being rebound by making sampling sites depend on an explicit per-frame validity check rather than ad-hoc `r_fogvol`/tex!=0 combinations.

### Description
- Added API declarations and short semantic comments to `Quake/r_fogvol.h`: `R_FogVol_IsEnabledForFrame()`, `R_FogVol_HasValidComposite()`, and `R_FogVol_ShouldAffectPostFX()`.
- Implemented `R_FogVol_IsEnabledForFrame()`, `R_FogVol_HasValidComposite()`, and `R_FogVol_ShouldAffectPostFX()` in `Quake/r_fogvol.c`, and made `R_FogVol_CanRenderGlobal()` forward to the new readiness gate.
- Changed `R_FogVol_GetCompositeTex()` to return a non-zero texture only when `R_FogVol_HasValidComposite()` is true (documented semantic in comment).
- Replaced direct condition chains in `Quake/gl_rmain.c` with the new API at the following sites: `GL_NeedsSceneEffects`, `GL_NeedsPostprocess`, fogvol bind in `GL_PostProcess`, and the volumetric branch in `GL_GenerateGodraysTexture`.

### Testing
- Attempted a local build with `make -C Quake gl_rmain.o r_fogvol.o`, which failed in this environment due to missing SDL development files (`sdl2-config` / `SDL.h`), so compilation could not be verified here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6a0ebd930832ea7859d9f6b78c2da)