### PR TITLE
Document FogVol composite contract in headers and shaders; add debug alpha-dynamics check

### DIFF
--- a/Quake/r_fogvol.c
+++ b/Quake/r_fogvol.c
@@ -304,6 +304,8 @@ static int r_fogvol_history_index = 0;
 static int r_fogvol_history_width = 0;
 static int r_fogvol_history_height = 0;
 static qboolean r_fogvol_composite_valid = false;
+static int r_fogvol_alpha_extreme_streak = 0;
+static int r_fogvol_alpha_extreme_last_frame = -1;
 
 
 void R_FogVol_ClearHistory (void)
@@ -512,6 +514,50 @@ static void R_FogVol_SetReadBufferDebug (GLenum buf, const char *marker)
 {
 	glReadBuffer (buf);
 	R_FogVol_LogBufferMarker (marker);
+}
+
+static void R_FogVol_DebugCheckCompositeAlphaDynamics (int fog_width, int fog_height)
+{
+	float alpha_sample = 0.f;
+	int px;
+	int py;
+	GLint prev_read_fbo = 0;
+	GLint prev_read_buf = 0;
+
+	if (r_fogvol_debug.value <= 0.f && developer.value <= 0.f)
+		return;
+
+	if (!r_fogvol_composite_valid || fog_width <= 0 || fog_height <= 0)
+	{
+		r_fogvol_alpha_extreme_streak = 0;
+		return;
+	}
+
+	if (r_fogvol_alpha_extreme_last_frame >= 0 && r_framecount != r_fogvol_alpha_extreme_last_frame + 1)
+		r_fogvol_alpha_extreme_streak = 0;
+	r_fogvol_alpha_extreme_last_frame = r_framecount;
+
+	px = fog_width / 2;
+	py = fog_height / 2;
+	glGetIntegerv (GL_READ_FRAMEBUFFER_BINDING, &prev_read_fbo);
+	glGetIntegerv (GL_READ_BUFFER, &prev_read_buf);
+	R_FogVol_BindFramebuffer (GL_READ_FRAMEBUFFER, framebufs.composite.fbo);
+	glReadBuffer (GL_COLOR_ATTACHMENT0);
+	glReadPixels (px, py, 1, 1, GL_ALPHA, GL_FLOAT, &alpha_sample);
+	R_FogVol_BindFramebuffer (GL_READ_FRAMEBUFFER, (GLuint)prev_read_fbo);
+	glReadBuffer ((GLenum)prev_read_buf);
+
+	if (alpha_sample <= 0.001f || alpha_sample >= 0.999f)
+		++r_fogvol_alpha_extreme_streak;
+	else
+		r_fogvol_alpha_extreme_streak = 0;
+
+	if (r_fogvol_alpha_extreme_streak >= 8 && (r_fogvol_alpha_extreme_streak % 32) == 8)
+	{
+		Con_DPrintf (
+			"FOGVOL_WARN composite alpha appears static/extreme for %d frames (sample=%.3f at center). Contract expects dynamic A=1-transmittance where fog is present.\n",
+			r_fogvol_alpha_extreme_streak, alpha_sample);
+	}
 }
 
 static void R_FogVol_LogPipelineState (const char *marker)
@@ -2543,6 +2589,7 @@ void R_FogVol_Render (void)
 		}
 
 		r_fogvol_composite_valid = true;
+		R_FogVol_DebugCheckCompositeAlphaDynamics (fog_width, fog_height);
 	}
 
 	if (mode == 1)

--- a/Quake/r_fogvol.h
+++ b/Quake/r_fogvol.h
@@ -116,6 +116,13 @@ qboolean R_FogVol_HasValidComposite (void);
 /* PostFX gate: fogvol should contribute to postprocess passes this frame. */
 qboolean R_FogVol_ShouldAffectPostFX (void);
 qboolean R_FogVol_CanRenderGlobal (void);
+/*
+ * FogVol Composite Contract (for CPU + shader users):
+ *  - RGB: fog radiance already composited over the scene color (display-space contribution).
+ *  - A:   fog coverage proxy = 1 - transmittance (a.k.a. integrated fog density/opacity).
+ *         0.0 = no volumetric medium on this pixel, 1.0 = fully opaque medium.
+ *  - Validity: sample only when R_FogVol_HasValidComposite() is true for the frame.
+ */
 /* Returns the composite texture that received the fogvol temporal output this
  * frame. Use this for SSAO suppression — it is the correct per-pixel fog density
  * source for spatial/noisy volumetric fog that cannot be modelled analytically. */

--- a/Quake/shaders/fogvol.frag
+++ b/Quake/shaders/fogvol.frag
@@ -28,6 +28,11 @@
 //     misleading future readers; keep only tau / transmittance / accum.
 // ───────────────────────────────────────────────────────────────────────────
 
+// FogVol Composite Contract:
+//   RGB = fog radiance composited over scene color (display-space contribution).
+//   A   = fog coverage proxy = 1.0 - transmittance (0=no fog medium, 1=opaque medium).
+//   Valid only when CPU marks fogvol composite as ready for this frame.
+
 #include "frame_uniforms.glsl"
 
 #define MAX_FOGVOLUMES 64

--- a/Quake/shaders/fogvol_temporal.frag
+++ b/Quake/shaders/fogvol_temporal.frag
@@ -33,6 +33,11 @@
 //     (compile-time) but flagged.
 // ───────────────────────────────────────────────────────────────────────────
 
+// FogVol Composite Contract:
+//   RGB = fog radiance composited over scene color (display-space contribution).
+//   A   = fog coverage proxy = 1.0 - transmittance (0=no fog medium, 1=opaque medium).
+//   Valid only when CPU marks fogvol composite as ready for this frame.
+
 #include "frame_uniforms.glsl"
 
 layout(binding=0) uniform sampler2D FogCurrent;

--- a/Quake/shaders/fogvol_upsample.frag
+++ b/Quake/shaders/fogvol_upsample.frag
@@ -34,6 +34,11 @@
 //     clamp bounds.
 // ───────────────────────────────────────────────────────────────────────────
 
+// FogVol Composite Contract:
+//   RGB = fog radiance composited over scene color (display-space contribution).
+//   A   = fog coverage proxy = 1.0 - transmittance (0=no fog medium, 1=opaque medium).
+//   Valid only when CPU marks fogvol composite as ready for this frame.
+
 layout(binding=0) uniform sampler2D FogColor;
 layout(binding=1) uniform sampler2D SceneDepth;
 

--- a/Quake/shaders/godrays.frag
+++ b/Quake/shaders/godrays.frag
@@ -1,3 +1,8 @@
+// FogVol Composite Contract:
+//   RGB = fog radiance composited over scene color (display-space contribution).
+//   A   = fog coverage proxy = 1.0 - transmittance (0=no fog medium, 1=opaque medium).
+//   Valid only when CPU marks fogvol composite as ready for this frame.
+
 layout(binding=0) uniform sampler2D MaskTexture;
 layout(binding=1) uniform sampler2D VolumetricTexture;
 
@@ -36,6 +41,9 @@ void main()
         {
                 vec4 vol = texture(VolumetricTexture, uv);
                 volColor = max(vol.rgb, vec3(0.0));
+                // Godrays volumetric coupling uses FogVol alpha directly as medium
+                // strength proxy (A = 1 - transmittance), then applies an optional
+                // artistic shaping exponent (VolumetricParams.y).
                 volMedium = clamp(vol.a, 0.0, 1.0);
                 volMedium = pow(volMedium, max(VolumetricParams.y, 0.0));
         }

--- a/Quake/shaders/postprocess.frag
+++ b/Quake/shaders/postprocess.frag
@@ -1,3 +1,8 @@
+// FogVol Composite Contract:
+//   RGB = fog radiance composited over scene color (display-space contribution).
+//   A   = fog coverage proxy = 1.0 - transmittance (0=no fog medium, 1=opaque medium).
+//   Valid only when CPU marks fogvol composite as ready for this frame.
+
 layout(binding=0) uniform sampler2D GammaTexture;
 layout(binding=1) uniform usampler3D PaletteLUT;
 layout(binding=2) uniform sampler2D DepthTexture;
@@ -8,10 +13,9 @@ layout(binding=6) uniform sampler2D GodraysMaskTexture;
 layout(binding=7) uniform sampler2D GodraysSourceTexture;
 layout(binding=8) uniform sampler2D SSAOTexture;
 layout(binding=9) uniform sampler2DArray PostFXLUT;
-// Fog volume composite texture (halfres, upsampled to full-res by fogvol pass).
-// RGB = composited fog color as blended into the scene. Used to derive per-pixel
-// volumetric transmittance for SSAO suppression. Binding is left unbound (→ black)
-// when fogvol is inactive, giving transmittance=1.0 and no suppression.
+// FogVol composite texture input for post effects.
+// Sample alpha (A = 1-transmittance) for fog-aware suppression logic.
+// Binding may be left unbound when fogvol is inactive; callers must gate via CPU validity.
 layout(binding=10) uniform sampler2D FogVolTexture;
 layout(std430, binding=0) restrict readonly buffer PaletteBuffer
 {


### PR DESCRIPTION
### Motivation
- Make the FogVol composite semantics explicit to avoid mismatches between CPU and shaders when reading the composite texture (RGB vs alpha meaning and per-frame validity). 
- Ensure all relevant shaders share the same contract so future shader edits do not break SSAO/godrays/postprocess coupling. 
- Provide a non-invasive debug path that can alert when the composite alpha appears static/extreme (indicating a broken alpha=1-transmittance contract or shader bug). 

### Description
- Added a central FogVol composite contract comment to `Quake/r_fogvol.h` that documents: RGB = fog radiance already composited over scene color, A = coverage proxy = 1 - transmittance, and the requirement to sample only when `R_FogVol_HasValidComposite()` is true. 
- Mirrored the same contract header into the shader sources `Quake/shaders/fogvol.frag`, `Quake/shaders/fogvol_temporal.frag`, `Quake/shaders/fogvol_upsample.frag`, `Quake/shaders/postprocess.frag` and `Quake/shaders/godrays.frag` for consistent in-shader documentation. 
- Added `R_FogVol_DebugCheckCompositeAlphaDynamics()` and supporting state in `Quake/r_fogvol.c`, which samples the composite alpha (center pixel) in debug/developer mode, tracks an "extreme" streak and logs a warning if alpha remains near 0 or 1 across many consecutive frames, while restoring read-FBO/read-buffer state to avoid side effects. 
- Explicitly documented in `Quake/shaders/godrays.frag` that godrays volumetric coupling consumes FogVol alpha directly as the medium strength proxy and then applies the optional shaping exponent, to remove ambiguity for future shader changes. 

### Testing
- Ran `git diff --check` to verify there are no whitespace/patch-format issues, and it passed. 
- Verified repository changes with `git status --short` to confirm the intended files were modified and staged, and it matched expectations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6ac9c5d04832e8eaf2be4fdcba604)