### PR TITLE
Implement name-based filtering for light-texture godrays (`r_godrays_lighttex_name_match`)

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -428,6 +428,8 @@ cvar_t	r_godrays_emissive_threshold = { "r_godrays_emissive_threshold", "0.4", C
 cvar_t	r_godrays_light_threshold = { "r_godrays_light_threshold", "0.6", CVAR_ARCHIVE };
 cvar_t	r_godrays_mask_knee = { "r_godrays_mask_knee", "0.0", CVAR_ARCHIVE };
 cvar_t	r_godrays_blur = { "r_godrays_blur", "1.5", CVAR_ARCHIVE };
+/* When enabled, light-texture godray stages are emitted only if the texture/stage/material
+ * name contains a light token (light, lamp, glow, flare, neon, torch, lantern). */
 cvar_t	r_godrays_lighttex_name_match = { "r_godrays_lighttex_name_match", "1", CVAR_ARCHIVE };
 cvar_t	r_godrays_samples = { "r_godrays_samples", "48", CVAR_ARCHIVE };
 cvar_t	r_godrays_density = { "r_godrays_density", "0.9", CVAR_ARCHIVE };

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -501,6 +501,47 @@ static unsigned R_StageOutputCallFlags (const mat_shader_stage_t *stage)
 	return flags;
 }
 
+static qboolean R_GodraysNameContainsLightToken (const char *name)
+{
+	static const char *const tokens[] = {
+		"light",
+		"lamp",
+		"glow",
+		"flare",
+		"neon",
+		"torch",
+		"lantern"
+	};
+
+	if (!name || !name[0])
+		return false;
+
+	for (size_t i = 0; i < countof (tokens); ++i)
+	{
+		if (q_strcasestr (name, tokens[i]))
+			return true;
+	}
+
+	return false;
+}
+
+static qboolean R_GodraysLighttexNameMatches (const texture_t *t, const mat_shader_stage_t *stage)
+{
+	if (r_godrays_lighttex_name_match.value <= 0.f)
+		return true;
+
+	if (R_GodraysNameContainsLightToken (t ? t->name : NULL))
+		return true;
+	if (R_GodraysNameContainsLightToken (t ? t->shader_map : NULL))
+		return true;
+	if (R_GodraysNameContainsLightToken (stage ? stage->map_path : NULL))
+		return true;
+	if (R_GodraysNameContainsLightToken (t && t->shader ? t->shader->name : NULL))
+		return true;
+
+	return false;
+}
+
 qboolean R_TextureEmitsGodrays (texture_t *t)
 {
 	if (!t)
@@ -516,18 +557,23 @@ qboolean R_TextureEmitsGodrays (texture_t *t)
 	{
 		size_t stage_count = VEC_SIZE (t->shader->stages);
 		qboolean has_godray = false;
+		qboolean has_light_match = false;
 		qboolean has_emissive = false;
 
 		for (size_t i = 0; i < stage_count; ++i)
 		{
 			const mat_shader_stage_t *stage = &t->shader->stages[i];
 			if (stage->outputs & MAT_STAGE_OUT_GODRAY_SOURCE)
+			{
 				has_godray = true;
+				if (R_GodraysLighttexNameMatches (t, stage))
+					has_light_match = true;
+			}
 			if (stage->outputs & MAT_STAGE_OUT_EMISSIVE)
 				has_emissive = true;
 		}
 
-		if (has_godray && r_godrays_emit_lighttex.value > 0.f)
+		if (has_godray && has_light_match && r_godrays_emit_lighttex.value > 0.f)
 			return true;
 		if (has_godray && has_emissive && r_godrays_emit_emissive.value > 0.f)
 			return true;
@@ -1337,7 +1383,8 @@ static void R_DrawBrushModels_GodrayStages (entity_t **ents, int count)
 						fb = NULL;
 				}
 
-				if (r_godrays_emit_lighttex.value > 0.f)
+				if (r_godrays_emit_lighttex.value > 0.f
+					&& R_GodraysLighttexNameMatches (t, stage))
 					extra_flags |= CALLFLAG_GODRAYS_LIGHT;
 
 				if (wants_emissive && r_godrays_emit_emissive.value > 0.f)

--- a/docs/EMISSIVE_MAPS.md
+++ b/docs/EMISSIVE_MAPS.md
@@ -25,3 +25,16 @@ other details that should glow regardless of scene lighting.
 After adding emissive textures, launch the game normally. The renderer will
 automatically bind and apply the glow contribution when the matching base
 texture is loaded.
+
+## Godrays source name filtering
+- `r_godrays_emit_lighttex` controls whether materials that declare `godraySource` output
+  can contribute to the godrays source pass.
+- `r_godrays_lighttex_name_match` adds an additional safety/name filter for that light-texture
+  path: when set to `1` (default), the material is used only if one of these names contains
+  a light token (`light`, `lamp`, `glow`, `flare`, `neon`, `torch`, `lantern`):
+  - BSP texture name,
+  - resolved shader map path (`map`),
+  - stage map path, or
+  - shader material name.
+- Set `r_godrays_lighttex_name_match 0` to disable this filter and allow all `godraySource`
+  stages to emit via the light-texture path.


### PR DESCRIPTION
### Motivation
- `r_godrays_lighttex_name_match` was defined/registered but had no runtime decision path, causing all `godraySource` stages to be treated the same regardless of texture/stage/material names.  
- Add a clear, safe match path so only intended light-like textures/stages contribute via the light-texture godray path by default.

### Description
- Added `R_GodraysNameContainsLightToken` and `R_GodraysLighttexNameMatches` in `Quake/r_world.c` to check for light-like tokens (`light`, `lamp`, `glow`, `flare`, `neon`, `torch`, `lantern`) in BSP texture names, resolved shader map paths, stage map paths, and shader material names.  
- Updated `R_TextureEmitsGodrays` to require the name-match (or the CVar disabled) before reporting that a texture emits via the light-texture godray path.  
- Applied the same `R_GodraysLighttexNameMatches` check directly before setting `CALLFLAG_GODRAYS_LIGHT` in the brush-model / stage draw path so emission and culling are consistent.  
- Added an inline comment next to the CVar in `Quake/gl_rmain.c` explaining the filter semantics and updated `docs/EMISSIVE_MAPS.md` to document `r_godrays_emit_lighttex` and `r_godrays_lighttex_name_match` and how to disable the filter (`0`).

### Testing
- Verified presence and usage of the CVar and the new checks via repository searches (`rg`) and inspected modified source with `sed`/`nl`; these checks confirmed the new functions are referenced from both the emission test (`R_TextureEmitsGodrays`) and the draw-call path. (success)  
- Attempted an automated build with `make -C Quake -j2`; the build could not complete in this environment because SDL2 development files/tools (`sdl2-config`, `SDL.h`) are missing, so a full compile/test run was not possible here (failure due to missing dependencies).  
- Changes are limited to `Quake/r_world.c`, `Quake/gl_rmain.c`, and `docs/EMISSIVE_MAPS.md` and were validated by static inspection and grep-based verification (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6ad788ac4832eace8dcedd1dcd7ac)