### PR TITLE
Introduce medium scatter/transmittance source interface for godrays and postprocess

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -1709,6 +1709,35 @@ static void GL_GenerateGodraysSource (qboolean draw_sky, qboolean draw_brush)
 	GL_EndGroup ();
 }
 
+
+typedef struct medium_scatter_source_s {
+	GLuint texture;
+	float valid;
+} medium_scatter_source_t;
+
+static medium_scatter_source_t GL_GetMediumScatterSource (void)
+{
+	medium_scatter_source_t medium = { 0, 0.f };
+
+	/*
+	 * Medium scatter/transmittance texture contract (shared by postprocess + godrays):
+	 *  - RGB: medium in-scatter/radiance already composited in display space.
+	 *  - A:   medium coverage proxy = 1 - transmittance.
+	 *         Expected normalized range: [0, 1] where 0 means no medium and 1 means
+	 *         fully opaque medium for this pixel.
+	 *  - valid: CPU-side frame validity gate. Only sample texture when valid > 0.5.
+	 *
+	 * Compatibility layer: FogVol is the first implementation of this interface.
+	 */
+	if (R_FogVol_HasValidComposite ())
+	{
+		medium.texture = R_FogVol_GetCompositeTex ();
+		medium.valid = 1.f;
+	}
+
+	return medium;
+}
+
 static GLuint GL_GenerateGodraysTexture (GLuint *out_mask)
 {
 	int width = framebufs.godrays.width;
@@ -1749,13 +1778,15 @@ static GLuint GL_GenerateGodraysTexture (GLuint *out_mask)
 	float light_y = R_SanitizeGodraysValue (r_godrays_light_y.value, 0.5f, 0.f, 1.f);
 	float stabilized_x = light_x;
 	float stabilized_y = light_y;
+	medium_scatter_source_t medium = { 0, 0.f };
 	GLuint volumetric_tex = 0;
 	float volumetric_enabled = 0.f;
 
-	if (r_godrays_volumetric.value > 0.f && R_FogVol_HasValidComposite ())
+	if (r_godrays_volumetric.value > 0.f)
 	{
-		volumetric_tex = R_FogVol_GetCompositeTex ();
-		volumetric_enabled = 1.f;
+		medium = GL_GetMediumScatterSource ();
+		volumetric_tex = medium.texture;
+		volumetric_enabled = medium.valid;
 	}
 
 	GL_GetGodraysLightPos (width, height, light_x, light_y, &stabilized_x, &stabilized_y);
@@ -2222,18 +2253,12 @@ static float GL_UpdateAutoExposure (void)
 }
 
 
-static void GL_PostProcess_SetFogVolUniforms (void)
+static void GL_PostProcess_SetMediumScatterUniforms (void)
 {
-	GLuint fogvol_composite = 0;
-	float fogvol_active = 0.f;
+	medium_scatter_source_t medium = GL_GetMediumScatterSource ();
 
-	if (R_FogVol_HasValidComposite ())
-	{
-		fogvol_composite = R_FogVol_GetCompositeTex ();
-		fogvol_active = 1.f;
-	}
-	GL_BindNative (GL_TEXTURE10, GL_TEXTURE_2D, fogvol_composite);
-	GL_Uniform4fFunc (28, fogvol_active, 0.f, 0.f, 0.f);
+	GL_BindNative (GL_TEXTURE10, GL_TEXTURE_2D, medium.texture);
+	GL_Uniform4fFunc (28, medium.valid, 0.f, 0.f, 0.f);
 }
 
 void GL_PostProcess (void)
@@ -2507,14 +2532,10 @@ void GL_PostProcess (void)
 	GL_BindNative (GL_TEXTURE7, GL_TEXTURE_2D, godrays_source);
 	GL_BindNative (GL_TEXTURE8, GL_TEXTURE_2D, ssao_texture);
 	GL_BindNative (GL_TEXTURE9, GL_TEXTURE_2D_ARRAY, R_PostFX_GetLUTTexture ());
-	/* Bind fogvol composite texture at slot 10 for SSAO suppression in postprocess.frag.
-	 * postprocess.frag samples this to derive per-pixel volumetric transmittance and
-	 * suppress AO where fog is dense — replacing the inaccurate analytical fog formula
-	 * (exp2(-density*dist^2)) which cannot model spatial noise or color variation.
-	 * The existing fogvol_active gating is preserved; R_FogVol_GetCompositeTex() now
-	 * returns 0 when no valid composite was produced this frame, preventing stale
-	 * texture handles from scene/context transitions being rebound here. */
-	GL_PostProcess_SetFogVolUniforms ();
+	/* Bind medium scatter/transmittance texture at slot 10 for SSAO suppression
+	 * in postprocess.frag. The current implementation sources FogVol composite via
+	 * GL_GetMediumScatterSource(), preserving validity gating and stale-handle safety. */
+	GL_PostProcess_SetMediumScatterUniforms ();
 	GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 0, gl_palette_buffer[palidx], 0, 256 * sizeof (GLuint));
 	if (variant != 2) // some AMD drivers optimize out the uniform in variant #2
 	{

--- a/Quake/shaders/godrays.frag
+++ b/Quake/shaders/godrays.frag
@@ -1,14 +1,14 @@
-// FogVol Composite Contract:
-//   RGB = fog radiance composited over scene color (display-space contribution).
+// Medium Scatter/Transmittance Contract:
+//   RGB = medium in-scatter/radiance composited over scene color (display-space contribution).
 //   A   = fog coverage proxy = 1.0 - transmittance (0=no fog medium, 1=opaque medium).
-//   Valid only when CPU marks fogvol composite as ready for this frame.
+//   Valid only when the CPU marks the current medium source as ready for this frame.
 
 layout(binding=0) uniform sampler2D MaskTexture;
-layout(binding=1) uniform sampler2D VolumetricTexture;
+layout(binding=1) uniform sampler2D MediumTexture;
 
 layout(location=0) uniform vec4 LightParams; // xy: light position, z: density, w: weight
 layout(location=1) uniform vec4 ScatterParams; // x: decay, y: exposure, z: max radius, w: samples
-layout(location=2) uniform vec4 VolumetricParams; // x: enable, y: medium exponent, z: texture valid
+layout(location=2) uniform vec4 MediumParams; // x: enable, y: medium exponent, z: texture valid
 
 layout(location=0) out vec4 outColor;
 
@@ -37,15 +37,15 @@ void main()
         vec3 volColor = vec3(0.0);
         float volMedium = 1.0;
 
-        if (VolumetricParams.x > 0.5 && VolumetricParams.z > 0.5)
+        if (MediumParams.x > 0.5 && MediumParams.z > 0.5)
         {
-                vec4 vol = texture(VolumetricTexture, uv);
+                vec4 vol = texture(MediumTexture, uv);
                 volColor = max(vol.rgb, vec3(0.0));
-                // Godrays volumetric coupling uses FogVol alpha directly as medium
+                // Godrays medium coupling uses MediumTexture alpha directly as medium
                 // strength proxy (A = 1 - transmittance), then applies an optional
-                // artistic shaping exponent (VolumetricParams.y).
+                // artistic shaping exponent (MediumParams.y).
                 volMedium = clamp(vol.a, 0.0, 1.0);
-                volMedium = pow(volMedium, max(VolumetricParams.y, 0.0));
+                volMedium = pow(volMedium, max(MediumParams.y, 0.0));
         }
 
         for (int i = 0; i < 128; ++i)
@@ -59,7 +59,7 @@ void main()
                 illuminationDecay *= decay;
         }
 
-        if (VolumetricParams.x > 0.5 && VolumetricParams.z > 0.5)
+        if (MediumParams.x > 0.5 && MediumParams.z > 0.5)
         {
                 float volLum = dot(volColor, vec3(0.299, 0.587, 0.114));
                 vec3 volTint = (volLum > 1e-4) ? (volColor / volLum) : vec3(1.0);


### PR DESCRIPTION
### Motivation
- Introduce an abstraction for a medium scatter/transmittance source so postprocess and godrays code no longer access FogVol internals directly.
- Explicitly document the texture channel semantics and expected value ranges for any future medium source implementations.
- Rename shader-facing identifiers to reflect the generic medium contract while preserving existing visual behavior.
- Provide a FogVol compatibility layer as the first implementation of the new interface.

### Description
- Added a small interface in `Quake/gl_rmain.c`: `medium_scatter_source_t` and `GL_GetMediumScatterSource()` which returns a texture handle and a CPU-side `valid` gate and documents that `RGB` = in-scatter/radiance and `A` = coverage proxy (`1 - transmittance`, normalized `[0,1]`).
- Switched `GL_GenerateGodraysTexture()` to use `GL_GetMediumScatterSource()` instead of calling `R_FogVol_GetCompositeTex()` directly and plumbed `.texture` / `.valid` through the existing godrays uniforms.
- Replaced the postprocess helper `GL_PostProcess_SetFogVolUniforms` with `GL_PostProcess_SetMediumScatterUniforms` which binds the medium texture at slot 10 and exposes the `valid` flag to shaders.
- Updated `Quake/shaders/godrays.frag` to rename `VolumetricTexture` → `MediumTexture` and `VolumetricParams` → `MediumParams` and adjusted comments to the new contract without changing sampling or math logic.

### Testing
- Ran a repository search (`rg -n "GL_GetMediumScatterSource|MediumParams|MediumTexture|PostProcess_SetMediumScatterUniforms"`) which confirmed the new interface is used and shader names were updated (succeeded).
- Attempted to configure and build with CMake (`cmake -S . -B build && cmake --build build -j4`) which failed at configure time due to a missing `SDL2` development package in the environment (expected environmental failure, not related to the change).
- Attempted `make -j4` but no top-level `Makefile` exists in this workspace (no-op for validation here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6add05ecc832ea8859a525da73758)