### PR TITLE
Unify godrays sky CVars to canonical `r_godrays_sky_*` and remove bidirectional sync

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -415,8 +415,8 @@ cvar_t	r_godrays = { "r_godrays", "0", CVAR_ARCHIVE };
 /*
  * Godrays sky parameter schema:
  * - Canonical CVars are exclusively r_godrays_sky_*.
- * - Legacy compatibility aliases (r_godray_sky_*) remain registered and are
- *   synchronized during cvar init/runtime so old configs keep working.
+ * - Legacy compatibility aliases (r_godray_sky_*) remain registered as
+ *   one-way parse/set shims into canonical CVars for old configs.
  * - Rendering code reads only canonical CVars via R_GetGodraysSkyParams().
  */
 cvar_t	r_godrays_emit_emissive = { "r_godrays_emit_emissive", "1", CVAR_ARCHIVE };

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -520,34 +520,14 @@ float GL_WaterAlphaForTextureType (textype_t type)
 }
 
 
-static qboolean r_godrays_sky_cvar_sync_active;
-
-static void R_GodraysSyncCanonicalSkyFromLegacy (cvar_t *unused)
+static void R_GodraysMigrateLegacySkyToCanonical (cvar_t *unused)
 {
 	(void)unused;
 
-	if (r_godrays_sky_cvar_sync_active)
-		return;
-	r_godrays_sky_cvar_sync_active = true;
 	Cvar_SetQuick (&r_godrays_sky_enable, r_godray_sky_enable.string);
 	Cvar_SetQuick (&r_godrays_sky_threshold, r_godray_sky_threshold.string);
 	Cvar_SetQuick (&r_godrays_sky_intensity, r_godray_sky_intensity.string);
 	Cvar_SetQuick (&r_godrays_sky_softness, r_godray_sky_blur.string);
-	r_godrays_sky_cvar_sync_active = false;
-}
-
-static void R_GodraysSyncLegacySkyFromCanonical (cvar_t *unused)
-{
-	(void)unused;
-
-	if (r_godrays_sky_cvar_sync_active)
-		return;
-	r_godrays_sky_cvar_sync_active = true;
-	Cvar_SetQuick (&r_godray_sky_enable, r_godrays_sky_enable.string);
-	Cvar_SetQuick (&r_godray_sky_threshold, r_godrays_sky_threshold.string);
-	Cvar_SetQuick (&r_godray_sky_intensity, r_godrays_sky_intensity.string);
-	Cvar_SetQuick (&r_godray_sky_blur, r_godrays_sky_softness.string);
-	r_godrays_sky_cvar_sync_active = false;
 }
 
 
@@ -763,17 +743,13 @@ Cvar_RegisterVariable (&r_godrays_decay);
 Cvar_RegisterVariable (&r_godrays_exposure);
 Cvar_RegisterVariable (&r_godrays_threshold);
 Cvar_RegisterVariable (&r_godrays_sky_softness);
-	/* Legacy r_godray_sky_* aliases stay available, but canonical r_godrays_sky_* owns runtime reads. */
-	Cvar_SetCallback (&r_godray_sky_enable, R_GodraysSyncCanonicalSkyFromLegacy);
-	Cvar_SetCallback (&r_godray_sky_threshold, R_GodraysSyncCanonicalSkyFromLegacy);
-	Cvar_SetCallback (&r_godray_sky_intensity, R_GodraysSyncCanonicalSkyFromLegacy);
-	Cvar_SetCallback (&r_godray_sky_blur, R_GodraysSyncCanonicalSkyFromLegacy);
-	Cvar_SetCallback (&r_godrays_sky_enable, R_GodraysSyncLegacySkyFromCanonical);
-	Cvar_SetCallback (&r_godrays_sky_threshold, R_GodraysSyncLegacySkyFromCanonical);
-	Cvar_SetCallback (&r_godrays_sky_intensity, R_GodraysSyncLegacySkyFromCanonical);
-	Cvar_SetCallback (&r_godrays_sky_softness, R_GodraysSyncLegacySkyFromCanonical);
-	/* One-time migration at init: legacy values (if present in old cfg) seed canonical cvars. */
-	R_GodraysSyncCanonicalSkyFromLegacy (NULL);
+	/* Legacy r_godray_sky_* aliases are parse/set shims that write canonical r_godrays_sky_* values. */
+	Cvar_SetCallback (&r_godray_sky_enable, R_GodraysMigrateLegacySkyToCanonical);
+	Cvar_SetCallback (&r_godray_sky_threshold, R_GodraysMigrateLegacySkyToCanonical);
+	Cvar_SetCallback (&r_godray_sky_intensity, R_GodraysMigrateLegacySkyToCanonical);
+	Cvar_SetCallback (&r_godray_sky_blur, R_GodraysMigrateLegacySkyToCanonical);
+	/* Startup migration: values restored into legacy names seed canonical cvars once. */
+	R_GodraysMigrateLegacySkyToCanonical (NULL);
 Cvar_RegisterVariable (&r_godrays_light_sharpness);
 Cvar_RegisterVariable (&r_godrays_max_radius);
 Cvar_RegisterVariable (&r_godrays_light_x);

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -29,7 +29,7 @@ extern cvar_t gl_fullbrights, r_oldskyleaf, r_showtris; //johnfitz
 extern cvar_t r_godrays_emit_emissive;
 extern cvar_t r_godrays_emit_lighttex;
 extern cvar_t r_godrays_lighttex_name_match;
-extern cvar_t r_godray_sky_enable;
+extern cvar_t r_godrays_sky_enable;
 extern cvar_t gl_zfix; // QuakeSpasm z-fighting fix
 extern cvar_t r_oit;
 
@@ -587,7 +587,7 @@ qboolean R_SurfaceEmitsGodrays (msurface_t *s)
 	if (!s)
 		return false;
 
-	if ((s->flags & SURF_DRAWSKY) && r_godray_sky_enable.value > 0.f)
+	if ((s->flags & SURF_DRAWSKY) && r_godrays_sky_enable.value > 0.f)
 	{
 		if (cl.worldmodel && s->texinfo && s->texinfo->texnum >= 0 && s->texinfo->texnum < cl.worldmodel->numtextures)
 		{


### PR DESCRIPTION
### Motivation
- Consolidate runtime configuration around a single canonical namespace so rendering reads are deterministic and future refactors only target one set of CVars.
- Preserve backwards compatibility by keeping legacy names available as one-way aliases so old configs still apply without maintaining cyclic synchronization.
- Remove brittle bidirectional callback syncing that introduced cycles and made behavior hard to reason about.

### Description
- Clarified the in-code schema comment in `Quake/gl_rmain.c` to state that `r_godrays_sky_*` are canonical and that `r_godray_sky_*` are legacy parse/set shims.
- Replaced the two-way callback sync in `Quake/gl_rmisc.c` with a single function `R_GodraysMigrateLegacySkyToCanonical` that copies legacy `r_godray_sky_*` values into canonical `r_godrays_sky_*` and removed the sync-state flag and legacy backward-sync function.
- Registered per-legacy-variable callbacks to call `R_GodraysMigrateLegacySkyToCanonical` so legacy writes update canonical CVars, and invoked the migration once at startup to seed canonical values from restored legacy names.
- Updated runtime usage in `Quake/r_world.c` to read `r_godrays_sky_enable` (canonical) instead of the legacy `r_godray_sky_enable`.

### Testing
- Verified occurrences with ripgrep using patterns like `rg -n "r_godray_|r_godrays_|godrays" Quake` to ensure legacy names remain only as aliases and canonical names drive runtime reads, and this check succeeded.
- Performed a targeted source inspection to confirm the removal of the bidirectional callbacks and the addition of `R_GodraysMigrateLegacySkyToCanonical` in `Quake/gl_rmisc.c`.
- Attempted a build with `make -C Quake -j4` to surface integration issues, but the build could not complete due to missing SDL tools/headers in the environment (`sdl2-config`/`SDL.h`), so full compile validation was not possible.
- No automated unit tests were present for these CVars; changes are limited to CVar registration/callbacks and a small runtime usage site.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a70490b974832ea9d4b0e2316f9652)