### PR TITLE
Refactor render target recreation into VID_RecreateRenderTargets helper

### DIFF
--- a/Quake/gl_vidsdl.c
+++ b/Quake/gl_vidsdl.c
@@ -657,6 +657,23 @@ static void VID_ApplyVSync (void)
 }
 
 /*
+=====================
+VID_RecreateRenderTargets
+=====================
+*/
+static void VID_RecreateRenderTargets (const char *reason, qboolean delete_existing)
+{
+	if (reason && *reason)
+		Con_DPrintf ("Recreating render targets (%s)\n", reason);
+
+	if (delete_existing)
+		GL_DeleteFrameBuffers ();
+
+	GL_CreateFrameBuffers ();
+	R_FogVol_ClearHistory ();
+}
+
+/*
 =================
 VID_VSync_f
 
@@ -677,12 +694,10 @@ Called when vid_fsaa changes
 */
 static void VID_FSAA_f (cvar_t *cvar)
 {
-        if (!host_initialized)
-                return;
-        GL_DeleteFrameBuffers ();
-        GL_CreateFrameBuffers ();
-	R_FogVol_ClearHistory ();
-        gl_lodbias.callback (&gl_lodbias);
+	if (!host_initialized)
+		return;
+	VID_RecreateRenderTargets ("vid_fsaa changed", true);
+	gl_lodbias.callback (&gl_lodbias);
 }
 
 /*
@@ -778,8 +793,7 @@ static void VID_Restart (void)
 	//conwidth and conheight need to be recalculated
 	VID_RecalcInterfaceSize ();
 
-	GL_CreateFrameBuffers ();
-	R_FogVol_ClearHistory ();
+	VID_RecreateRenderTargets ("vid_restart", false);
 //
 // keep cvars in line with actual mode
 //
@@ -1382,10 +1396,9 @@ static void GL_Init (void)
 	}
 	//johnfitz
 
-        GL_CreateShaders ();
-        GL_CreateFrameBuffers ();
-	R_FogVol_ClearHistory ();
-        GLLight_CreateResources ();
+	GL_CreateShaders ();
+	VID_RecreateRenderTargets ("gl_init", false);
+	GLLight_CreateResources ();
 	GLPalette_CreateResources ();
 
 	GL_ClearBufferBindings ();
@@ -1400,11 +1413,11 @@ GL_BeginRendering -- sets values of glx, gly, glwidth, glheight
 */
 void GL_BeginRendering (int *x, int *y, int *width, int *height)
 {
-        if (vid.resized)
-        {
-                vid.resized = false;
-                vid.recalc_refdef = true;
-                if (vid_saveresize.value)
+	if (vid.resized)
+	{
+		vid.resized = false;
+		vid.recalc_refdef = true;
+		if (vid_saveresize.value)
 		{
 			qboolean was_locked = vid_locked;
 			vid_locked = true; // avoid "vid_width will be applied after a vid_restart" spam
@@ -1412,11 +1425,9 @@ void GL_BeginRendering (int *x, int *y, int *width, int *height)
 			Cvar_SetValueQuick (&vid_height, vid.height);
 			vid_locked = was_locked;
 		}
-                VID_RecalcInterfaceSize ();
-                GL_DeleteFrameBuffers ();
-                GL_CreateFrameBuffers ();
-	R_FogVol_ClearHistory ();
-                }
+		VID_RecalcInterfaceSize ();
+		VID_RecreateRenderTargets ("window resized", true);
+	}
 
 	*x = *y = 0;
 	*width = vid.width;


### PR DESCRIPTION
### Motivation
- Reduce duplicated code paths that perform framebuffer recreation and fog-volume history clearing by centralizing them in a single helper. 
- Preserve existing call ordering and semantics for Resize, FSAA, Mode/Vid_Restart and init paths while allowing optional logging. 

### Description
- Add static helper `VID_RecreateRenderTargets(const char *reason, qboolean delete_existing)` to encapsulate optional `GL_DeleteFrameBuffers()`, `GL_CreateFrameBuffers()`, `R_FogVol_ClearHistory()` and optional `Con_DPrintf` logging. 
- Replace duplicated sequences with calls to the helper at these sites: `VID_FSAA_f` (uses delete_existing=true), `VID_Restart` (post-mode recreate with delete_existing=false while keeping the original pre-`VID_SetMode` `GL_DeleteFrameBuffers()`), `GL_Init` (initial create via helper), and the resize handling in `GL_BeginRendering` (uses delete_existing=true). 
- Maintain original ordering and behavior so no special-case semantics are lost; formatting/whitespace adjusted in the affected blocks. 

### Testing
- Confirmed occurrences and replacements with `rg` to ensure the duplicate sequences were consolidated, which succeeded. 
- Verified source changes via `git diff -- Quake/gl_vidsdl.c` and inspected updated file slices with `sed`/`nl`, which succeeded. 
- Committed the change with `git commit` and verified the commit with `git show --stat --oneline -1`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a704c86c20832e9a51cdf0e3264db4)