### PR TITLE
Add configurable fog volume edge_softness

### DIFF
--- a/Quake/r_fogvol.c
+++ b/Quake/r_fogvol.c
@@ -41,6 +41,7 @@ typedef struct fog_volume_gpu_s
 	float wind_turbulence[4];
 	float misc[4];
 	float extra[4];
+	float params2[4];
 } fog_volume_gpu_t;
 
 COMPILE_TIME_ASSERT (fog_volume_gpu_align16, (sizeof (fog_volume_gpu_t) % 16) == 0);
@@ -1269,6 +1270,7 @@ static void R_FogVol_ClampVolume (fog_volume_t *volume)
 	volume->emissiveStrength = CLAMP (0.f, volume->emissiveStrength, 16.f);
 	volume->shape = CLAMP (0, volume->shape, 2);
 	volume->blendMode = CLAMP (-1, volume->blendMode, 1);
+	volume->edgeSoftness = CLAMP (0.f, volume->edgeSoftness, 1.f);
 }
 
 static void R_FogVol_AddVolume (const fog_volume_t *volume)
@@ -1410,7 +1412,7 @@ static void R_FogVol_EntitySetShape (fog_volume_t *volume, fogvol_entity_parse_s
  *   shape, radius, center
  *   blendmode, emissive
  *   wind_dir, wind_speed, turbulence
- *   height, height_scale */
+ *   height, height_scale, edge_softness */
 static const fogvol_entity_key_dispatch_t fogvol_entity_key_dispatch[] = {
 	{"classname", FOGVOL_ENTITY_KEY_SPECIAL, 0, R_FogVol_EntitySetClassname},
 	{"model", FOGVOL_ENTITY_KEY_SPECIAL, 0, R_FogVol_EntitySetModel},
@@ -1435,6 +1437,7 @@ static const fogvol_entity_key_dispatch_t fogvol_entity_key_dispatch[] = {
 	{"turbulence", FOGVOL_ENTITY_KEY_FLOAT, offsetof (fog_volume_t, turbulence), NULL},
 	{"height", FOGVOL_ENTITY_KEY_FLOAT, offsetof (fog_volume_t, height), NULL},
 	{"height_scale", FOGVOL_ENTITY_KEY_FLOAT, offsetof (fog_volume_t, heightScale), NULL},
+	{"edge_softness", FOGVOL_ENTITY_KEY_FLOAT, offsetof (fog_volume_t, edgeSoftness), NULL},
 };
 
 static const fogvol_entity_key_dispatch_t *R_FogVol_FindEntityKeyDispatch (const char *key)
@@ -1545,6 +1548,7 @@ static void R_FogVol_AddGlobalFog (void)
 	volume.enabled = 1;
 	volume.height = r_fogvol_globalfog_height.value;
 	volume.heightScale = r_fogvol_globalfog_height_scale.value;
+	volume.edgeSoftness = 0.f;
 
 	R_FogVol_AddVolume (&volume);
 }
@@ -1637,6 +1641,7 @@ void R_FogVol_ParseEntities (void)
 		volume.enabled = 1;
 		volume.height = 0.f;
 		volume.heightScale = 0.f;
+		volume.edgeSoftness = 0.f;
 		memset (&parse_state, 0, sizeof (parse_state));
 
 		while (1)
@@ -1730,6 +1735,7 @@ void R_FogVol_AddTestVolumes (void)
 	volume.maxDistance = 0.f;
 	volume.priority   = 0;
 	volume.enabled    = 1;
+	volume.edgeSoftness = 0.f;
 	/* Place the box 100..260 units ahead, 96 units wide, 80 units tall.
 	 * Compute proper axis-aligned bounds from the oriented corners. */
 	{
@@ -2232,6 +2238,11 @@ void R_FogVol_Render (void)
 		gpu->extra[1] = (float)((v->blendMode >= 0) ? v->blendMode : (int)Q_rint (r_fogvol_blendmode.value));
 		gpu->extra[2] = v->emissiveStrength;
 		gpu->extra[3] = v->heightScale;
+
+		gpu->params2[0] = v->edgeSoftness;
+		gpu->params2[1] = 0.f;
+		gpu->params2[2] = 0.f;
+		gpu->params2[3] = 0.f;
 	}
 
 	GL_Upload (GL_UNIFORM_BUFFER, gpu_volumes, sizeof (fog_volume_gpu_t) * r_fogvolume_count, &buf, &ofs);

--- a/Quake/r_fogvol.h
+++ b/Quake/r_fogvol.h
@@ -29,6 +29,7 @@ typedef struct fog_volume_s
 	int enabled;
 	float height;
 	float heightScale;
+	float edgeSoftness;
 } fog_volume_t;
 
 typedef struct froxel_grid_s

--- a/Quake/shaders/fogvol.frag
+++ b/Quake/shaders/fogvol.frag
@@ -53,6 +53,7 @@ struct FogVolume
 	vec4 wind_turbulence;
 	vec4 misc;
 	vec4 extra;
+	vec4 params2;
 };
 
 layout(std140, binding=2) uniform FogVolumeUBO
@@ -357,6 +358,14 @@ float FogEdgeFade(vec3 p, vec3 bmin, vec3 bmax, float falloff)
 	return smoothstep(0.0, edgeThickness, edgeDist);
 }
 
+float FogEdgeSoftnessMask(float edgeDist, float falloff, float edgeSoftness)
+{
+	if (edgeSoftness <= 0.0)
+		return 1.0;
+	float softnessWidth = max(1.0, max(falloff, 0.0)) * clamp(edgeSoftness, 0.0, 1.0);
+	return smoothstep(0.0, softnessWidth, max(edgeDist, 0.0));
+}
+
 bool PointInsideVolume(vec3 p, FogVolume volume)
 {
 	if (volume.extra.x > 0.5)
@@ -381,16 +390,21 @@ vec3 SampleFogLightgrid(vec3 p, FogVolume volume)
 // PERF: lod=0 full quality (near), lod=1 coarse (far). Caller passes based on distance.
 float EvaluateFogSigma(vec3 p, FogVolume volume, float density, float falloff, float noiseScalePre, vec3 flowPre, int lod, float marchDist)
 {
+	float edgeDist;
 	float edgeFade;
+	float edgeSoftness = clamp(volume.params2.x, 0.0, 1.0);
 	if (volume.extra.x > 0.5)
 	{
-		float d = volume.sphere.w - length(p - volume.sphere.xyz);
-		edgeFade = (falloff <= 0.0) ? 1.0 : smoothstep(0.0, falloff, d);
+		edgeDist = volume.sphere.w - length(p - volume.sphere.xyz);
+		edgeFade = (falloff <= 0.0) ? 1.0 : smoothstep(0.0, falloff, edgeDist);
 	}
 	else
 	{
+		vec3 d = min(p - volume.mins.xyz, volume.maxs.xyz - p);
+		edgeDist = min(d.x, min(d.y, d.z));
 		edgeFade = FogEdgeFade(p, volume.mins.xyz, volume.maxs.xyz, falloff);
 	}
+	edgeFade *= FogEdgeSoftnessMask(edgeDist, falloff, edgeSoftness);
 
 	// PERF: If edgeFade is zero, density is zero regardless of noise — skip noise entirely.
 	if (edgeFade < 1e-5)


### PR DESCRIPTION
### Motivation
- Ermöglichen eines einstellbaren weichen Übergangs am Rand von Nebel-Volumes, damit Distanz‑Masken an Volumenrändern geglättet werden können.
- Änderung so standardisiert, dass bestehende Maps unverändert bleiben (Default=0.0).

### Description
- `fog_volume_t` um Feld `edgeSoftness` ergänzt (`Quake/r_fogvol.h`).
- Entity-Parser/Dispatch in `R_FogVol_ParseEntities` um Key `edge_softness` erweitert und in `R_FogVol_ClampVolume` auf `[0,1]` geclamped; Defaults auf `0.0` (Entity-Parse, GlobalFog, Testvolumes) gesetzt (`Quake/r_fogvol.c`).
- GPU-Layout erweitert: `fog_volume_gpu_t` bekam `params2[4]` und `params2[0]` wird mit `edgeSoftness` hochgeladen (UBO binding) (`Quake/r_fogvol.c`).
- Shader-Struct `FogVolume` um `params2` erweitert und `fogvol.frag` bekommt die Helper-Funktion `FogEdgeSoftnessMask` sowie die Anwendung der Weichzeichnung in `EvaluateFogSigma` für Box- und Kugel-Volumes (Verwendung von `smoothstep` basierend auf `edge_softness`).
- Voreinstellung `edge_softness = 0.0` sorgt für vollständige Rückwärtskompatibilität (keine visuellen Änderungen, falls nicht gesetzt).

### Testing
- Projektkonfiguration versucht mit `cmake -S . -B build`, die Konfiguration schlug fehl wegen fehlendem SDL2-Entwicklungspaket in der aktuellen Umgebung (Fehler ist umgebungsbedingt und nicht durch die Codeänderung verursacht).
- Keine weitere automatisierte Build- oder shader-Regressionstestinfrastruktur im Container ausgeführt; Änderungen wurden lokal im Repository angewendet und commitet.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a713bbd308832e9cd87a1e2758d0ec)