### PR TITLE
Fix undefined ARRAY_SIZE use in fog volume parser

### DIFF
--- a/Quake/r_fogvol.c
+++ b/Quake/r_fogvol.c
@@ -1441,7 +1441,7 @@ static const fogvol_entity_key_dispatch_t *R_FogVol_FindEntityKeyDispatch (const
 {
 	int i;
 
-	for (i = 0; i < (int)ARRAY_SIZE (fogvol_entity_key_dispatch); ++i)
+	for (i = 0; i < (int)countof (fogvol_entity_key_dispatch); ++i)
 	{
 		if (!strcmp (fogvol_entity_key_dispatch[i].key, key))
 			return &fogvol_entity_key_dispatch[i];


### PR DESCRIPTION
### Motivation
- Fix a Windows build break where the undefined `ARRAY_SIZE` macro in `r_fogvol.c` caused MSVC C4013/C2220 errors during compilation.

### Description
- Replace `ARRAY_SIZE(fogvol_entity_key_dispatch)` with the project-standard `countof(fogvol_entity_key_dispatch)` in `R_FogVol_FindEntityKeyDispatch`, retaining behavior while using a defined macro.

### Testing
- Ran `rg "ARRAY_SIZE\s*\(" -n Quake/r_fogvol.c Quake` and confirmed no remaining `ARRAY_SIZE(...)` usages, indicating the substitution succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a71f997408832ebd922d833708f9c5)