### PR TITLE
Fix Visual Studio linker errors for renderer feature modules

### DIFF
--- a/Windows/VisualStudio/ironwail.vcxproj
+++ b/Windows/VisualStudio/ironwail.vcxproj
@@ -315,11 +315,15 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
     <ClCompile Include="..\..\Quake\r_alias.c" />
     <ClCompile Include="..\..\Quake\r_brush.c" />
     <ClCompile Include="..\..\Quake\r_dlight_pool.c" />
+    <ClCompile Include="..\..\Quake\r_framegraph.c" />
     <ClCompile Include="..\..\Quake\r_fogvol.c" />
+    <ClCompile Include="..\..\Quake\r_godrays.c" />
     <ClCompile Include="..\..\Quake\r_postfx.c" />
     <ClCompile Include="..\..\Quake\r_part.c" />
     <ClCompile Include="..\..\Quake\r_part_q3p.c" />
+    <ClCompile Include="..\..\Quake\r_ssao.c" />
     <ClCompile Include="..\..\Quake\r_sprite.c" />
+    <ClCompile Include="..\..\Quake\r_tonemap.c" />
     <ClCompile Include="..\..\Quake\r_world.c" />
     <ClCompile Include="..\..\Quake\sbar.c" />
     <ClCompile Include="..\..\Quake\snd_codec.c" />

--- a/Windows/VisualStudio/ironwail.vcxproj.filters
+++ b/Windows/VisualStudio/ironwail.vcxproj.filters
@@ -189,7 +189,19 @@
     <ClCompile Include="..\..\Quake\r_dlight_pool.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Quake\r_framegraph.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\Quake\r_fogvol.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Quake\r_godrays.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Quake\r_postfx.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Quake\r_ssao.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\Quake\r_part.c">
@@ -199,6 +211,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\Quake\r_sprite.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Quake\r_tonemap.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\Quake\r_world.c">


### PR DESCRIPTION
### Motivation
- Windows builds failed at link time with unresolved symbols referenced from `gl_rmain.obj` and `gl_rmisc.obj` because several renderer translation units were not included in the Visual Studio project.

### Description
- Added the missing renderer source files to `Windows/VisualStudio/ironwail.vcxproj`: `r_framegraph.c`, `r_godrays.c`, `r_ssao.c`, and `r_tonemap.c` so their symbols are compiled and linked into the Windows build.
- Updated `Windows/VisualStudio/ironwail.vcxproj.filters` to add the same files under `Source Files` in the IDE (keeps `r_postfx.c` grouped consistently).
- Committed the project and filters changes to the repository.

### Testing
- Ran `rg` to confirm the new entries exist in both `Windows/VisualStudio/ironwail.vcxproj` and `Windows/VisualStudio/ironwail.vcxproj.filters`, which succeeded.
- Parsed both XML files with `xml.etree.ElementTree` to validate well-formed project/filter files, which succeeded.
- Verified repository status and created a commit (`git add` + `git commit`), which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a73ea18b58832ead46d6853b1ca67e)