### PR TITLE
Add missing PCH include to renderer modules

### DIFF
--- a/Quake/r_framegraph.c
+++ b/Quake/r_framegraph.c
@@ -1,3 +1,5 @@
+#include "quakedef.h"
+
 #include "r_framegraph.h"
 
 #include "r_fogvol.h"

--- a/Quake/r_godrays.c
+++ b/Quake/r_godrays.c
@@ -1,3 +1,5 @@
+#include "quakedef.h"
+
 #include "r_godrays.h"
 
 #include <float.h>

--- a/Quake/r_ssao.c
+++ b/Quake/r_ssao.c
@@ -1,3 +1,5 @@
+#include "quakedef.h"
+
 #include "r_ssao.h"
 
 #include <math.h>


### PR DESCRIPTION
### Motivation
- MSVC was failing with `error C1010` for several renderer compilation units because the precompiled-header `quakedef.h` was not included at the top of those source files.

### Description
- Inserted `#include "quakedef.h"` at the top of `Quake/r_framegraph.c`, `Quake/r_godrays.c`, and `Quake/r_ssao.c` to satisfy the project's precompiled-header requirement.

### Testing
- Verified the new include appears at the top of each file using `head -n 8 <file>` and `nl -ba <file>`, which showed the expected `#include "quakedef.h"` on line 1 for all three files (succeeded). 
- Confirmed the pattern with `rg -n '^#include "quakedef.h"' Quake/*.c`, which matched all three modified files (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7408ac920832eade3fbc8bb8c952e)