### PR TITLE
Fix implicit renderer declarations in r_framegraph.c

### DIFF
--- a/Quake/r_framegraph.c
+++ b/Quake/r_framegraph.c
@@ -4,6 +4,10 @@
 
 #include "r_fogvol.h"
 
+void R_SetupView (void);
+void R_RenderScene (void);
+void R_WarpScaleView (void);
+
 /*
  * Framegraph pass order and data dependencies
  * ------------------------------------------


### PR DESCRIPTION
### Motivation
- Resolve MSVC `C4013` warnings (treated as errors `C2220`) caused by implicit declarations of renderer functions referenced from `r_framegraph.c` so the Windows/MSVC build can complete.

### Description
- Add explicit prototypes `void R_SetupView(void);`, `void R_RenderScene(void);`, and `void R_WarpScaleView(void);` at the top of `Quake/r_framegraph.c` to eliminate implicit-declaration warnings without changing runtime behavior.

### Testing
- No automated build or unit tests were run in this Linux container; the change is a harmless source-level declaration fix and is expected to remove the MSVC `C4013`/`C2220` errors during a Windows/Visual Studio build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7413aaef4832eb54fa22cce854037)