### PR TITLE
Fix LIGHTGRID_OCTREE color channel order (BGR -> RGB)

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -2816,9 +2816,14 @@ static qboolean LightgridOctree_LoadBSPX (qmodel_t *mod, void *data, int size)
 			{
 				uint8_t style = *cursor++;
 				uint8_t color[3];
-				color[0] = *cursor++;
-				color[1] = *cursor++;
-				color[2] = *cursor++;
+				/*
+				 * LIGHTGRID_OCTREE stores sample colors in BGR byte order.
+				 * Keep the runtime representation in RGB to match the rest of
+				 * the renderer (fog volume, alias lighting, debug output).
+				 */
+				color[2] = *cursor++; /* B */
+				color[1] = *cursor++; /* G */
+				color[0] = *cursor++; /* R */
 
 				if (!chosen_set)
 				{


### PR DESCRIPTION
### Motivation
- The LIGHTGRID_OCTREE loader was interpreting stored sample bytes as `R,G,B` while the lump format stores them as `B,G,R`, which swapped red and blue channels and produced blue-tinted lava lighting.

### Description
- In `Quake/gl_model.c` inside `LightgridOctree_LoadBSPX` the sample byte unpacking was changed to read disk bytes as BGR and populate the runtime `color` as RGB, and an inline comment documenting the on-disk BGR order was added.

### Testing
- Attempted to configure and build with `cmake -S . -B build && cmake --build build -j4`, but configuration failed due to a missing `SDL2` CMake package in the environment, so no compiled binary tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a74a327c10832e94da4da94d39b5a7)