### PR TITLE
Resolve forced-underwater tint to nearest liquid (fix blue tint over lava)

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -133,6 +133,31 @@ static qboolean R_IsUnderwaterContents (int contents)
 	return contents == CONTENTS_WATER || contents == CONTENTS_SLIME || contents == CONTENTS_LAVA;
 }
 
+static int R_ResolveUnderwaterContents (int view_contents, qboolean forced, const vec3_t vieworg)
+{
+	vec3_t probe;
+	mleaf_t *leaf;
+	int i;
+
+	if (R_IsUnderwaterContents (view_contents) || !forced || !cl.worldmodel)
+		return view_contents;
+
+	VectorCopy (vieworg, probe);
+	for (i = 0; i < 32; ++i)
+	{
+		probe[2] -= 8.f;
+		leaf = Mod_PointInLeaf (probe, cl.worldmodel);
+		if (!leaf)
+			break;
+		if (R_IsUnderwaterContents (leaf->contents))
+			return leaf->contents;
+		if (leaf->contents == CONTENTS_SOLID)
+			break;
+	}
+
+	return view_contents;
+}
+
 
 //johnfitz -- rendering statistics
 int rs_brushpolys, rs_aliaspolys, rs_skypolys;
@@ -3415,19 +3440,24 @@ void R_SetupView (void)
 	r_oldviewleaf = r_viewleaf;
 	r_viewleaf = Mod_PointInLeaf (r_origin, cl.worldmodel);
 
-	V_SetContentsColor (r_viewleaf->contents);
-	V_CalcBlend ();
-
 	//johnfitz -- calculate r_fovx and r_fovy here
 	r_fovx = r_refdef.fov_x;
 	r_fovy = r_refdef.fov_y;
 	water_warp = false;
 	{
-		int contents = r_viewleaf->contents;
+		int view_contents = r_viewleaf->contents;
+		int contents = view_contents;
 		qboolean submerged = R_IsUnderwaterContents (contents);
 		qboolean forced = (cl.forceunderwater || M_ForcedUnderwater ());
 		qboolean underwater_active = (submerged || forced);
 		qboolean underwater_postfx_active = underwater_active;
+
+		contents = R_ResolveUnderwaterContents (view_contents, forced, r_origin);
+		submerged = R_IsUnderwaterContents (contents);
+		underwater_active = (submerged || forced);
+
+		V_SetContentsColor (contents);
+		V_CalcBlend ();
 
 		if (r_waterwarp.value && underwater_active)
 		{


### PR DESCRIPTION
### Motivation
- Walls above lava were receiving the blue water/postfx tint when `forceunderwater` was active, instead of the red lava tint expected for lava volumes below the camera.
- The renderer enabled underwater effects for forced submersion but still used the camera leaf (`r_viewleaf->contents`) to pick the tint/LUT, which is incorrect when the camera is in a non-liquid leaf above a liquid.

### Description
- Added `R_ResolveUnderwaterContents(int view_contents, qboolean forced, const vec3_t vieworg)` which probes downward from the camera to find a nearby liquid leaf (water/slime/lava) when underwater is being forced.
- Updated `R_SetupView()` to call `R_ResolveUnderwaterContents()` and use the resolved `contents` for `V_SetContentsColor()` / `V_CalcBlend()` and for `CL_PostFX_SetContents()`, ensuring postfx and LUT selection match the actual liquid type.
- Kept original behavior when already in a liquid leaf or when `forceunderwater` is not active and guarded against missing `cl.worldmodel`.

### Testing
- Ran a build attempt with `cmake -S . -B build && cmake --build build -j4`, which failed due to environment dependency missing `SDL2Config.cmake` (SDL2 not found), so a full compile/run test could not be completed in this environment.
- Verified the change surface-locally via code inspection and project-wide searches to ensure the new resolver is used where tint/LUT and underwater flags are computed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a74f97e970832ea054239a3fc03c00)