### PR TITLE
Add forward declaration for Q1BSPX_FindLump to fix MSVC implicit-declaration errors

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -699,6 +699,8 @@ static qboolean Q1BSPX_IsProcessed(const char *lumpname)
         return usage && (usage->used || usage->unsupported);
 }
 
+static void *Q1BSPX_FindLump(const char *lumpname, int *lumpsize);
+
 static void Q1BSPX_DecodeE5BGR9Lighting(byte *dst, const unsigned int *src, int samples)
 {
         /* E5BGR9 bit layout: [31:27]=exp [26:18]=R [17:9]=G [8:0]=B.


### PR DESCRIPTION
### Motivation
- MSVC treated a missing prototype for `Q1BSPX_FindLump` as an implicit `int` declaration, causing `C4013` and follow-on pointer/int mismatch diagnostics (`C2040`/`C4047`) when the function was used earlier in the file.

### Description
- Inserted a forward declaration `static void *Q1BSPX_FindLump(const char *lumpname, int *lumpsize);` in `Quake/gl_model.c` before the function's first use to provide the correct prototype without changing runtime behavior.

### Testing
- Ran `cmake -S . -B build && cmake --build build -j2` which failed due to missing `SDL2` CMake package files (`SDL2Config.cmake` / `sdl2-config.cmake`) in this environment; build could not be completed here.
- Verified the change was staged and committed with `git add Quake/gl_model.c` and `git commit`, and produced the expected single-file modification.}

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a76c6b0fbc832e8b1b977ec756be50)