### PR TITLE
Centralize renderer sun parameters into single sun_t state

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -1566,9 +1566,9 @@ static GLuint GL_GenerateGodraysTexture (GLuint *out_mask)
 	samples = CLAMP (8, samples, 128);
 
 	float threshold = R_Godrays_SanitizeValue (r_godrays_threshold.value, 0.f, 0.f, FLT_MAX);
-	float density = R_Godrays_SanitizeValue (r_godrays_density.value, 0.9f, 0.f, FLT_MAX);
+	float density = R_GetSun ()->ray_density;
 	float weight = R_Godrays_SanitizeValue (r_godrays_weight.value, 0.015f, 0.f, FLT_MAX);
-	float decay = R_Godrays_SanitizeValue (r_godrays_decay.value, 0.97f, 0.f, FLT_MAX);
+	float decay = R_GetSun ()->ray_decay;
 	float exposure = R_Godrays_SanitizeValue (r_godrays_exposure.value, 1.f, 0.f, FLT_MAX);
 	float softness = R_Godrays_SanitizeValue (r_godrays_blur.value, 1.5f, 0.f, FLT_MAX);
 	float sharpness = 1.25f;
@@ -3361,27 +3361,18 @@ void R_SetupView (void)
         r_framedata.shader_params[3] = 0.f;
 
 	{
-		vec3_t sun_dir;
-		vec3_t sun_color;
-		float sun_intensity = 1.f;
-		qboolean sun_enabled = (r_sun_light.value > 0.f) && R_GetSun (sun_dir, NULL, sun_color, &sun_intensity);
+		const sun_t *sun = R_GetSun ();
+		qboolean sun_enabled = (r_sun_light.value > 0.f) && R_WorldHasSun ();
 
-		if (!sun_enabled)
-		{
-			VectorSet (sun_dir, 0.f, 0.f, -1.f);
-			VectorSet (sun_color, 1.f, 1.f, 1.f);
-			sun_intensity = 1.f;
-		}
-
-		r_framedata.sun_dir_enabled[0] = sun_dir[0];
-		r_framedata.sun_dir_enabled[1] = sun_dir[1];
-		r_framedata.sun_dir_enabled[2] = sun_dir[2];
+		r_framedata.sun_dir_enabled[0] = sun->dir[0];
+		r_framedata.sun_dir_enabled[1] = sun->dir[1];
+		r_framedata.sun_dir_enabled[2] = sun->dir[2];
 		r_framedata.sun_dir_enabled[3] = sun_enabled ? 1.f : 0.f;
 
-		r_framedata.sun_color_intensity[0] = sun_color[0];
-		r_framedata.sun_color_intensity[1] = sun_color[1];
-		r_framedata.sun_color_intensity[2] = sun_color[2];
-		r_framedata.sun_color_intensity[3] = q_max (0.f, sun_intensity);
+		r_framedata.sun_color_intensity[0] = sun->color[0];
+		r_framedata.sun_color_intensity[1] = sun->color[1];
+		r_framedata.sun_color_intensity[2] = sun->color[2];
+		r_framedata.sun_color_intensity[3] = sun->intensity;
 	}
 
 	double prev_delta = cl.time - r_prev_frame_time;

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -135,6 +135,8 @@ extern cvar_t r_vignette_noise;
 extern cvar_t r_teleportfx;
 extern cvar_t r_teleportfx_time;
 extern cvar_t r_sun_light;
+extern cvar_t r_godrays_decay;
+extern cvar_t r_godrays_density;
 
 #if defined(USE_SIMD)
 extern cvar_t r_simd;
@@ -663,75 +665,171 @@ R_NewGame -- johnfitz -- handle a game switch
 ===============
 */
 
+typedef struct
+{
+	qboolean dir_defined;
+	qboolean color_defined;
+	qboolean intensity_defined;
+} sun_presence_t;
+
 static qboolean r_worldspawn_has_sun = false;
-r_sun_t r_sun;
+static sun_presence_t r_worldspawn_sun_presence;
+sun_t r_sun_state;
 cvar_t r_sun_light = { "r_sun_light", "0", CVAR_ARCHIVE };
 // Enables dynamic directional sunlight from parsed worldspawn sun keys (not baked lightmaps).
 
-static void R_ResetSunState (void)
+static void R_SetDefaultSunDirection (vec3_t dir)
 {
-	r_worldspawn_has_sun = false;
-	r_sun.enabled = false;
-	VectorClear (r_sun.origin);
-	VectorClear (r_sun.dir);
-	VectorSet (r_sun.color, 1.f, 1.f, 1.f);
-	r_sun.intensity = 1.f;
+	vec3_t ang;
+	ang[PITCH] = 45.0f;
+	ang[YAW] = 225.0f;
+	ang[ROLL] = 0.0f;
+	AngleVectors (ang, dir, NULL, NULL);
+}
+
+void R_Sun_ResetToDefaults (sun_t *s)
+{
+	if (!s)
+		return;
+	R_SetDefaultSunDirection (s->dir);
+	VectorSet (s->color, 1.f, 1.f, 1.f);
+	s->intensity = 1.f;
+	s->volumetric_intensity = q_max (0.f, r_fogvol_sun_scatter.value);
+	s->anisotropy = 0.f;
+	s->shadow_bias = 0.001f;
+	s->shadow_strength = CLAMP (0.f, r_fogvol_shadow_strength.value, 4.f);
+	s->shadow_distance = 0.f;
+	s->ray_decay = CLAMP (0.f, r_godrays_decay.value, 1.f);
+	s->ray_density = q_max (0.f, r_godrays_density.value);
+}
+
+void R_Sun_ApplyMapOverrides (sun_t *s, const char *worldspawn_entity_string)
+{
+	char key[128], value[4096];
+	const char *data;
+
+	if (!s || !worldspawn_entity_string)
+		return;
+
+	r_worldspawn_sun_presence.dir_defined = false;
+	r_worldspawn_sun_presence.color_defined = false;
+	r_worldspawn_sun_presence.intensity_defined = false;
+
+	data = COM_Parse (worldspawn_entity_string);
+	if (!data || com_token[0] != '{')
+		return;
+
+	while (1)
+	{
+		data = COM_Parse (data);
+		if (!data)
+			return;
+		if (com_token[0] == '}')
+			break;
+		if (com_token[0] == '_')
+			q_strlcpy (key, com_token + 1, sizeof (key));
+		else
+			q_strlcpy (key, com_token, sizeof (key));
+		while (key[0] && key[strlen (key) - 1] == ' ')
+			key[strlen (key) - 1] = 0;
+
+		data = COM_ParseEx (data, CPE_ALLOWTRUNC);
+		if (!data)
+			return;
+		q_strlcpy (value, com_token, sizeof (value));
+
+		if (!strcmp ("sun_mangle", key))
+		{
+			vec3_t ang;
+			if (sscanf (value, "%f %f %f", &ang[0], &ang[1], &ang[2]) == 3)
+			{
+				AngleVectors (ang, s->dir, NULL, NULL);
+				r_worldspawn_sun_presence.dir_defined = true;
+			}
+			continue;
+		}
+
+		if (!strcmp ("sunlight", key) || !strcmp ("sunlight2", key))
+		{
+			char *endptr;
+			float intensity = strtof (value, &endptr);
+			while (endptr && *endptr == ' ')
+				endptr++;
+			if (endptr && endptr != value && *endptr == '\0')
+			{
+				s->intensity = intensity;
+				r_worldspawn_sun_presence.intensity_defined = true;
+			}
+			continue;
+		}
+
+		if (!strcmp ("sunlight_color", key) || !strcmp ("sun_color", key) || !strcmp ("suncolour", key))
+		{
+			if (sscanf (value, "%f %f %f", &s->color[0], &s->color[1], &s->color[2]) == 3)
+				r_worldspawn_sun_presence.color_defined = true;
+			continue;
+		}
+	}
+}
+
+void R_Sun_Finalize (sun_t *s)
+{
+	if (!s)
+		return;
+	if (DotProduct (s->dir, s->dir) <= 1e-6f)
+		R_SetDefaultSunDirection (s->dir);
+	if (DotProduct (s->dir, s->dir) <= 1e-6f)
+		VectorSet (s->dir, 0.f, 0.f, -1.f);
+	else
+		VectorNormalize (s->dir);
+
+	s->color[0] = q_max (0.f, s->color[0]);
+	s->color[1] = q_max (0.f, s->color[1]);
+	s->color[2] = q_max (0.f, s->color[2]);
+	s->intensity = q_max (0.f, s->intensity);
+	s->volumetric_intensity = q_max (0.f, s->volumetric_intensity);
+	s->anisotropy = CLAMP (-0.99f, s->anisotropy, 0.99f);
+	s->shadow_bias = q_max (0.f, s->shadow_bias);
+	s->shadow_strength = CLAMP (0.f, s->shadow_strength, 4.f);
+	s->shadow_distance = q_max (0.f, s->shadow_distance);
+	s->ray_decay = CLAMP (0.f, s->ray_decay, 1.f);
+	s->ray_density = q_max (0.f, s->ray_density);
+}
+
+const sun_t* R_GetSun (void)
+{
+	return &r_sun_state;
+}
+
+void R_SetSun (const sun_t *src)
+{
+	if (!src)
+		return;
+	r_sun_state = *src;
+	R_Sun_Finalize (&r_sun_state);
 }
 
 qboolean R_WorldHasSun (void)
 {
-	return r_sun.enabled;
+	return r_worldspawn_has_sun;
 }
 
-qboolean R_GetSun (vec3_t dir, vec3_t origin, vec3_t color, float *intensity)
+void R_Sun_UpdateFromWorld (void)
 {
-	if (!r_sun.enabled)
-		return false;
+	sun_t sun;
 
-	if (dir)
-	{
-		if (DotProduct (r_sun.dir, r_sun.dir) > 1e-6f)
-			VectorCopy (r_sun.dir, dir);
-		else
-			VectorSet (dir, 0.f, 0.f, -1.f);
-	}
-	if (origin)
-		VectorCopy (r_sun.origin, origin);
-	if (color)
-		VectorCopy (r_sun.color, color);
-	if (intensity)
-		*intensity = r_sun.intensity;
-	return true;
-}
+	r_worldspawn_sun_presence.dir_defined = false;
+	r_worldspawn_sun_presence.color_defined = false;
+	r_worldspawn_sun_presence.intensity_defined = false;
+	R_Sun_ResetToDefaults (&sun);
+	if (cl.worldmodel)
+		R_Sun_ApplyMapOverrides (&sun, cl.worldmodel->entities);
+	R_Sun_Finalize (&sun);
+	R_SetSun (&sun);
 
-static void R_ApplyDefaultSunIfMissing (qmodel_t *world)
-{
-	vec3_t center;
-	vec3_t ang;
-
-	if (!world || r_sun.enabled || r_worldspawn_has_sun)
-		return;
-
-	center[0] = 0.5f * (world->mins[0] + world->maxs[0]);
-	center[1] = 0.5f * (world->mins[1] + world->maxs[1]);
-	center[2] = 0.5f * (world->mins[2] + world->maxs[2]);
-
-	VectorCopy (center, r_sun.origin);
-	r_sun.origin[2] += 128.0f;
-
-	ang[PITCH] = 45.0f;
-	ang[YAW] = 225.0f;
-	ang[ROLL] = 0.0f;
-
-	AngleVectors (ang, r_sun.dir, NULL, NULL);
-	if (VectorLength (r_sun.dir) < 0.001f)
-		VectorSet (r_sun.dir, 0.f, 0.f, -1.f);
-	else
-		VectorNormalize (r_sun.dir);
-
-	VectorSet (r_sun.color, 1.f, 1.f, 1.f);
-	r_sun.intensity = 1.f;
-	r_sun.enabled = true;
+	r_worldspawn_has_sun = r_worldspawn_sun_presence.dir_defined
+		|| r_worldspawn_sun_presence.color_defined
+		|| r_worldspawn_sun_presence.intensity_defined;
 }
 
 void R_NewGame (void)
@@ -754,12 +852,7 @@ static void R_ParseWorldspawn (void)
 {
 	char key[128], value[4096];
 	const char *data;
-	qboolean sun_dir_parsed = false;
-	qboolean sun_intensity_parsed = false;
-	qboolean sun_color_parsed = false;
-
 	map_fallbackalpha = r_wateralpha.value;
-	R_ResetSunState ();
 	map_wateralpha = (cl.worldmodel->contentstransparent&SURF_DRAWWATER)?r_wateralpha.value:1;
 	map_lavaalpha = 1.0f;
 	map_telealpha = (cl.worldmodel->contentstransparent&SURF_DRAWTELE)?r_telealpha.value:1;
@@ -792,44 +885,6 @@ static void R_ParseWorldspawn (void)
 		if (!strcmp("wateralpha", key))
 			map_wateralpha = atof(value);
 
-		if (!strcmp("sun_mangle", key))
-		{
-			vec3_t ang;
-			if (sscanf(value, "%f %f %f", &ang[0], &ang[1], &ang[2]) == 3)
-			{
-				AngleVectors (ang, r_sun.dir, NULL, NULL);
-				if (DotProduct (r_sun.dir, r_sun.dir) > 1e-6f)
-				{
-					VectorNormalize (r_sun.dir);
-					sun_dir_parsed = true;
-				}
-			}
-		}
-
-		if (!strcmp("sunlight", key))
-		{
-			char *endptr;
-			float intensity = strtof (value, &endptr);
-
-			while (endptr && *endptr == ' ')
-				endptr++;
-			if (endptr && endptr != value && *endptr == '\0')
-			{
-				r_sun.intensity = q_max (0.f, intensity);
-				sun_intensity_parsed = true;
-			}
-		}
-
-		if (!strcmp("sunlight_color", key) || !strcmp("sun_color", key) || !strcmp("suncolour", key))
-		{
-			vec3_t color;
-			if (sscanf(value, "%f %f %f", &color[0], &color[1], &color[2]) == 3)
-			{
-				r_sun.color[0] = q_max (0.f, color[0]);
-				r_sun.color[1] = q_max (0.f, color[1]);
-				r_sun.color[2] = q_max (0.f, color[2]);
-				sun_color_parsed = true;
-			}
 		}
 
 		if (!strcmp("telealpha", key))
@@ -840,11 +895,6 @@ static void R_ParseWorldspawn (void)
 
 	}
 
-	if (sun_dir_parsed || sun_intensity_parsed || sun_color_parsed)
-	{
-		r_worldspawn_has_sun = true;
-		r_sun.enabled = true;
-	}
 
 	map_fallbackalpha = CLAMP(0.f, map_fallbackalpha, 1.f);
 	map_wateralpha = CLAMP(0.f, map_wateralpha, 1.f);
@@ -877,8 +927,6 @@ void R_NewMap (void)
 	R_ReloadDecals ();
 	R_ClearDecals ();
 
-	R_ResetSunState ();
-
 	GL_BuildLightmaps ();
         GL_BuildBModelVertexBuffer ();
         GL_BuildBModelMarkBuffers ();
@@ -891,7 +939,7 @@ void R_NewMap (void)
         Sky_NewMap (); //johnfitz -- skybox in worldspawn
         Fog_NewMap (); //johnfitz -- global fog in worldspawn
         R_ParseWorldspawn (); //ericw -- wateralpha, telealpha, slimealpha in worldspawn
-        R_ApplyDefaultSunIfMissing (cl.worldmodel);
+        R_Sun_UpdateFromWorld ();
         R_ParseDlightEntities (); // persistent dlights from BSP entities
         R_FogVol_ParseEntities (); // fog volume entities from BSP
 

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -472,13 +472,24 @@ typedef struct gpuframedata_s {
         unsigned int    _padding2;
 } gpuframedata_t;
 
-typedef struct r_sun_s {
-	qboolean enabled;
-	vec3_t origin;
+typedef struct {
 	vec3_t dir;
 	vec3_t color;
 	float intensity;
-} r_sun_t;
+
+	// volumetrics
+	float volumetric_intensity;
+	float anisotropy;
+
+	// shadows
+	float shadow_bias;
+	float shadow_strength;
+	float shadow_distance;
+
+	// godrays
+	float ray_decay;
+	float ray_density;
+} sun_t;
 
 COMPILE_TIME_ASSERT (gpuframedata_std140_size, sizeof (gpuframedata_t) == 432);
 
@@ -493,10 +504,15 @@ extern gpulightbuffer_t r_lightbuffer;
 extern gpuframedata_t r_framedata;
 extern float r_lightstyle_framefrac;
 extern dlight_t *r_dlight_sources[DLIGHT_GPU_MAX];
-extern r_sun_t r_sun;
+extern sun_t r_sun_state;
 
 qboolean R_WorldHasSun (void);
-qboolean R_GetSun (vec3_t dir, vec3_t origin, vec3_t color, float *intensity);
+const sun_t* R_GetSun (void);
+void R_SetSun (const sun_t *src);
+void R_Sun_ResetToDefaults (sun_t *s);
+void R_Sun_ApplyMapOverrides (sun_t *s, const char *worldspawn_entity_string);
+void R_Sun_Finalize (sun_t *s);
+void R_Sun_UpdateFromWorld (void);
 
 void R_AnimateLight (void);
 void R_MarkSurfaces (void);

--- a/Quake/r_fogvol.c
+++ b/Quake/r_fogvol.c
@@ -293,10 +293,11 @@ enum
 	FOGVOL_U_LIGHT_SUBSAMPLE = 29,
 	FOGVOL_U_SUN_SCATTER = 30,
 	FOGVOL_U_SUN_COLOR = 31,
-	FOGVOL_U_COUNT = 32
+	FOGVOL_U_SUN_ANISOTROPY = 32,
+	FOGVOL_U_COUNT = 33
 };
 
-COMPILE_TIME_ASSERT (fogvol_uniform_location_max, FOGVOL_U_SUN_COLOR == 31);
+COMPILE_TIME_ASSERT (fogvol_uniform_location_max, FOGVOL_U_SUN_ANISOTROPY == 32);
 
 extern float skyflatcolor[3];
 
@@ -1954,10 +1955,11 @@ static void R_FogVol_SetShaderUniforms (int steps, int mode, qboolean use_halfre
 	vec3_t sun_color;
 	float sun_intensity;
 	float sun_scatter;
+	const sun_t *sun = R_GetSun ();
 	int shadow_samples;
 
 #if !defined(NDEBUG)
-	assert (FOGVOL_U_COUNT == 32);
+	assert (FOGVOL_U_COUNT == 33);
 #endif
 	GL_Uniform1iFunc (FOGVOL_U_STEPS, steps);
 	GL_Uniform1iFunc (FOGVOL_U_NOISE_ENABLED, r_fogvol_noise.value > 0.f ? 1 : 0);
@@ -1986,11 +1988,12 @@ static void R_FogVol_SetShaderUniforms (int steps, int mode, qboolean use_halfre
 	GL_Uniform1iFunc (FOGVOL_U_BLEND_MODE_DEFAULT, CLAMP (0, (int)Q_rint (r_fogvol_blendmode.value), 1));
 	GL_Uniform1iFunc (FOGVOL_U_LIGHT_ENABLED, fog_light_enabled ? 1 : 0);
 	shadow_samples = CLAMP (1, (int)Q_rint (r_fogvol_shadow_samples.value), 8);
-	if (r_fogvol_sun_dir.value > 0.f && R_GetSun (shadow_dir, NULL, NULL, NULL))
+	if (r_fogvol_sun_dir.value > 0.f && R_WorldHasSun ())
 	{
-		/* Convention: r_sun.dir points from scene toward the sun (light source).
+		/* Convention: sun->dir points from scene toward the sun (light source).
 		 * Fog shadow marching moves from sample point toward the blocker, so use
 		 * the same direction without flipping to keep shader/CPU conventions aligned. */
+		VectorCopy (sun->dir, shadow_dir);
 	}
 	else
 	{
@@ -2002,12 +2005,17 @@ static void R_FogVol_SetShaderUniforms (int steps, int mode, qboolean use_halfre
 		VectorNormalize (shadow_dir);
 	GL_Uniform1iFunc (FOGVOL_U_SHADOW_ENABLED, r_fogvol_shadow.value > 0.f ? 1 : 0);
 	GL_Uniform1iFunc (FOGVOL_U_SHADOW_SAMPLES, shadow_samples);
-	GL_Uniform1fFunc (FOGVOL_U_SHADOW_STRENGTH, CLAMP (0.f, r_fogvol_shadow_strength.value, 4.f));
+	GL_Uniform1fFunc (FOGVOL_U_SHADOW_STRENGTH, sun->shadow_strength);
 	GL_Uniform1fFunc (FOGVOL_U_SHADOW_JITTER, r_fogvol_shadow_jitter.value > 0.f ? 1.f : 0.f);
 	GL_Uniform3fFunc (FOGVOL_U_SHADOW_DIR, shadow_dir[0], shadow_dir[1], shadow_dir[2]);
 	GL_Uniform1iFunc (FOGVOL_U_LIGHTGRID_ENABLED, fog_lightgrid_enabled ? 1 : 0);
-	sun_scatter = q_max (0.f, r_fogvol_sun_scatter.value);
-	if (!R_GetSun (NULL, NULL, sun_color, &sun_intensity))
+	sun_scatter = sun->volumetric_intensity;
+	if (R_WorldHasSun ())
+	{
+		VectorCopy (sun->color, sun_color);
+		sun_intensity = sun->intensity;
+	}
+	else
 	{
 		VectorSet (sun_color, skyflatcolor[0], skyflatcolor[1], skyflatcolor[2]);
 		sun_intensity = 1.f;
@@ -2023,6 +2031,7 @@ static void R_FogVol_SetShaderUniforms (int steps, int mode, qboolean use_halfre
 	}
 	GL_Uniform1fFunc (FOGVOL_U_SUN_SCATTER, sun_scatter * q_max (0.f, sun_intensity));
 	GL_Uniform3fFunc (FOGVOL_U_SUN_COLOR, q_max (0.f, sun_color[0]), q_max (0.f, sun_color[1]), q_max (0.f, sun_color[2]));
+	GL_Uniform1fFunc (FOGVOL_U_SUN_ANISOTROPY, sun->anisotropy);
 }
 
 void R_FogVol_Render (void)

--- a/Quake/shaders/fogvol.frag
+++ b/Quake/shaders/fogvol.frag
@@ -115,6 +115,7 @@ layout(location=28) uniform int   FogHalfRes;
 layout(location=29) uniform int   FogLightSubsample;
 layout(location=30) uniform float FogSunScatter;
 layout(location=31) uniform vec3  FogSunColor;
+layout(location=32) uniform float FogSunAnisotropy;
 
 layout(location=0) out vec4 FragColor;
 
@@ -123,7 +124,6 @@ const float NOISE_SCALE_MIN  = 0.005;
 const float NOISE_SCALE_MAX  = 0.5;
 const float LUT_PERIOD       = 64.0;
 const float ANISO_G_LOCAL    = 0.5;
-const float ANISO_G_SUN      = 0.35;
 
 // ── helpers ────────────────────────────────────────────────────────────────
 
@@ -619,7 +619,7 @@ void main()
 		: 0.0;
 	// PERF: Precompute sun phase once per ray (viewDir and sunDir are constant).
 	float phaseSun      = (sunDirLenSq > 1e-6)
-		? AnisotropicPhase(clamp(dot(viewDir, sunDir), -1.0, 1.0), ANISO_G_SUN)
+		? AnisotropicPhase(clamp(dot(viewDir, sunDir), -1.0, 1.0), clamp(FogSunAnisotropy, -0.99, 0.99))
 		: 1.0;
 	float sunScatterStrength = max(FogSunScatter, 0.0);
 	vec3 sunScatterColor = max(FogSunColor, vec3(0.0));


### PR DESCRIPTION
### Motivation

- Provide a single source of truth for all sun-related parameters so every subsystem (fogvol, froxel/fog, godrays, shadows, frame uniforms, shaders) reads the same authoritative state.
- Preserve existing map-driven behavior by letting worldspawn keys override only the explicitly-present sun fields while falling back to engine defaults otherwise.
- Keep changes minimal and incremental so the renderer compiles at each step and existing shader uniform names stay stable where possible.

### Description

- Added the exact `sun_t` structure and a global instance `r_sun_state` to `Quake/glquake.h` and exposed the public API `R_GetSun`, `R_SetSun`, `R_Sun_ResetToDefaults`, `R_Sun_ApplyMapOverrides`, `R_Sun_Finalize`, and `R_Sun_UpdateFromWorld`.
- Implemented central sun management in `Quake/gl_rmisc.c` with defaults (`R_Sun_ResetToDefaults`), map override parsing for `sun_mangle`, `sunlight`/`sunlight2`, and `sunlight_color`/aliases (`R_Sun_ApplyMapOverrides`), presence bits tracking, normalization/clamping (`R_Sun_Finalize`), and world-update hook (`R_Sun_UpdateFromWorld`).
- Replaced ad-hoc sun consumers to read from the central API: frame uniforms in `Quake/gl_rmain.c` now source sun dir/color/intensity via `R_GetSun()`, godrays in `Quake/gl_rmain.c` use `sun->ray_density` and `sun->ray_decay` for defaults, and `Quake/r_fogvol.c` reads `sun->volumetric_intensity`, `sun->anisotropy`, and `sun->shadow_strength` and uploads them as uniforms.
- Minimized shader churn by keeping uniforms but adding `FogSunAnisotropy` to `Quake/shaders/fogvol.frag` and using it for the anisotropic phase; CPU-side now feeds the same uniform locations from `sun_t`.
- Safety and compatibility measures included: presence bits for map-defined fields so map values override defaults only when present, normalization of `dir`, clamping of intensities and anisotropy, and conservative defaults seeded from existing CVars where applicable.

### Testing

- Attempted an automated CMake configure/build (`cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug && cmake --build build -j4`), which failed during configure in this environment due to missing SDL2 CMake package files (`SDL2Config.cmake` / `sdl2-config.cmake`) so a full compile could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7815281f8832e83bafd5ff836221b)