### PR TITLE
Fix R_ParseWorldspawn stray brace and add missing r_fogvol_sun_scatter extern

### DIFF
--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -885,14 +885,11 @@ static void R_ParseWorldspawn (void)
 		if (!strcmp("wateralpha", key))
 			map_wateralpha = atof(value);
 
-		}
-
 		if (!strcmp("telealpha", key))
 			map_telealpha = atof(value);
 
 		if (!strcmp("slimealpha", key))
 			map_slimealpha = atof(value);
-
 	}
 
 

--- a/Quake/r_fogvol.h
+++ b/Quake/r_fogvol.h
@@ -98,6 +98,7 @@ extern cvar_t r_fogvol_shadow;
 extern cvar_t r_fogvol_shadow_samples;
 extern cvar_t r_fogvol_shadow_strength;
 extern cvar_t r_fogvol_shadow_jitter;
+extern cvar_t r_fogvol_sun_scatter;
 
 void R_FogVol_RegisterCvars (void);
 void R_FogVol_Init (void);


### PR DESCRIPTION
### Motivation
- Resolve MSVC compile failures caused by a prematurely closed parsing block in `R_ParseWorldspawn` and an undeclared reference to the fog-volume cvar `r_fogvol_sun_scatter` used by sun setup code.

### Description
- Remove the stray/misplaced closing brace in `Quake/gl_rmisc.c` so the worldspawn parsing loop is not prematurely terminated and parser/type errors are avoided. 
- Add the missing `extern cvar_t r_fogvol_sun_scatter;` declaration to `Quake/r_fogvol.h` so `gl_rmisc.c` can reference `r_fogvol_sun_scatter.value` without an undeclared identifier error.

### Testing
- Attempted an automated build with `make -j4` in `Quake/`, but the build could not be completed in this environment because `sdl2-config` and `SDL.h` are not available, so full compilation validation could not be run (build failed due to missing SDL2 development files).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7876c2248832e8581cf100d82e388)