### PR TITLE
Fix fog volume static light TEX_SPECIAL check

### DIFF
--- a/Quake/r_fogvol.c
+++ b/Quake/r_fogvol.c
@@ -1330,7 +1330,7 @@ static void R_FogVol_BuildStaticLightInjection (void)
 			continue;
 		if (!surf->texinfo || surf->texinfo->texnum < 0 || surf->texinfo->texnum >= model->numtextures)
 			continue;
-		if (!model->textures[surf->texinfo->texnum] || (model->textures[surf->texinfo->texnum]->flags & TEX_SPECIAL))
+		if (!model->textures[surf->texinfo->texnum] || (surf->texinfo->flags & TEX_SPECIAL))
 			continue;
 		if (!R_FogVol_TryGetSurfaceLightSample (model, surf, color))
 			continue;


### PR DESCRIPTION
### Motivation
- Resolve a compile error C2039 in `R_FogVol_BuildStaticLightInjection` by addressing an incorrect member access: `texture_s` does not have a `flags` field so the original check caused the build to fail.

### Description
- Replace the `texture_t` flags check with the `mtexinfo_t` flags check by changing `(model->textures[surf->texinfo->texnum]->flags & TEX_SPECIAL)` to `(surf->texinfo->flags & TEX_SPECIAL)` in `Quake/r_fogvol.c`.

### Testing
- Inspected and verified the file change with `git diff` and reviewed the updated lines with `nl`/`sed`, which succeeded; no compile was run as part of this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7893c4110832eba1464520d61411e)