### PR TITLE
Fix shader include `#line` directives for broader GLSL driver compatibility

### DIFF
--- a/Quake/gl_shaders.c
+++ b/Quake/gl_shaders.c
@@ -592,13 +592,16 @@ static char *GL_LoadShaderFile_Internal (const char *path, int depth, const char
                                         included = GL_LoadShaderFile_Internal (full_path, depth + 1, include_stack, include_stack_size);
                                         if (included)
                                         {
-                                                q_snprintf (linebuf, sizeof (linebuf), "#line 1 \"%s\"\n", full_path);
-                                                APPEND_STR (linebuf, strlen (linebuf));
-                                                APPEND_STR (included, strlen (included));
-                                                if (line_end && (result_len == 0 || result[result_len - 1] != '\n'))
-                                                        APPEND_STR ("\n", 1);
-                                                q_snprintf (linebuf, sizeof (linebuf), "#line %d \"%s\"\n", parent_line + 1, path);
-                                                APPEND_STR (linebuf, strlen (linebuf));
+							/* GLSL #line accepts only numeric source IDs (not quoted paths).
+							 * Use the single-argument form for broad driver compatibility.
+							 */
+							q_snprintf (linebuf, sizeof (linebuf), "#line 1\n");
+							APPEND_STR (linebuf, strlen (linebuf));
+							APPEND_STR (included, strlen (included));
+							if (line_end && (result_len == 0 || result[result_len - 1] != '\n'))
+								APPEND_STR ("\n", 1);
+							q_snprintf (linebuf, sizeof (linebuf), "#line %d\n", parent_line + 1);
+							APPEND_STR (linebuf, strlen (linebuf));
                                         }
 
                                         cursor = line_end ? line_end + 1 : cursor + line_len;


### PR DESCRIPTION
### Motivation
- Some GLSL drivers reject C-style `#line` directives with quoted file paths, causing shader compilation failures; the change aims to improve compatibility by emitting numeric-only `#line` directives when expanding `#include`d shader sources.

### Description
- Replace emitted `#line 1 "path"` / `#line <n> "path"` sequences with numeric-only `#line 1\n` and `#line <n>\n` in `GL_LoadShaderFile_Internal`, and add a short comment explaining the compatibility rationale in `Quake/gl_shaders.c`.

### Testing
- Attempted to run `glslangValidator` on the fragment shader but the tool was not available in the environment; no validation performed.
- Ran `cmake -S . -B build` which failed due to missing `SDL2` CMake package files so the project could not be configured.
- Ran `cc -fsyntax-only -IQuake -I. Quake/gl_shaders.c` which failed due to missing SDL headers (`SDL_endian.h`), so a full compile could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a78c0ce574832e80c99bd40b871b0f)