### PR TITLE
Use sRGB EOTF helper in WAD pixel linearization

### DIFF
--- a/Quake/gl_texmgr.c
+++ b/Quake/gl_texmgr.c
@@ -863,7 +863,9 @@ static void TexMgr_LinearizeWadPixels (gltexture_t *glt, unsigned *data)
 	{
 		for (int c = 0; c < 3; ++c)
 		{
-			float linear = powf (bytes[c] * (1.0f / 255.0f), 2.2f) * 255.0f + 0.5f;
+			/* WAD pixels are decoded with the sRGB EOTF on purpose, not a gamma 2.2 approximation. */
+			float s = bytes[c] * (1.0f / 255.0f);
+			float linear = TexMgr_SRGBToLinear (s) * 255.0f + 0.5f;
 			if (linear < 0.0f)
 				linear = 0.0f;
 			else if (linear > 255.0f)


### PR DESCRIPTION
### Motivation
- Replace the prior gamma-2.2 approximation with the proper sRGB EOTF when linearizing pixels from WAD sources to produce more correct linear color values.  

### Description
- In `Quake/gl_texmgr.c` the `TexMgr_LinearizeWadPixels` loop replaces `powf(bytes[c] * (1.0f / 255.0f), 2.2f)` with `float s = bytes[c] * (1.0f / 255.0f);` followed by `float linear = TexMgr_SRGBToLinear(s) * 255.0f + 0.5f;`, preserves the `WADFILENAME` guard, and adds a comment explaining the use of the sRGB EOTF.  

### Testing
- Ran `git diff --check` which reported clean results.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7eff44488832e9d17c73dc03733d5)