### PR TITLE
Keep alias/static model lighting linear on CPU

### DIFF
--- a/Quake/gl_rlight.c
+++ b/Quake/gl_rlight.c
@@ -1303,7 +1303,9 @@ qboolean R_EntityStaticLight (entity_t *e, vec3_t out_color255, entity_lightinfo
                 {
                         float L = out_color255[i] * (1.0f / 256.0f);
                         L = fminf (L, 1.0f);
-                        info->static_color[i] = powf (L, 1.0f / 2.2f);
+                        // Keep entity static_color in linear space. Alias/world
+                        // paths are display-encoded once in postprocess.frag.
+                        info->static_color[i] = L;
                 }
                 info->intensity = intensity;
                 info->used_lightgrid = used_lightgrid;

--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -488,7 +488,8 @@ void R_SetupAliasLighting (entity_t     *e)
 		{
 			float L = pre_total[i] * (1.0f / 256.0f);
 			L = fminf(L, 1.0f);
-			L = powf(L, 1.0f / 2.2f);
+			// Keep alias lighting in linear space; final display encoding happens
+			// in the postprocess path (LinearToSRGB in postprocess.frag).
 			post_total[i] = L;
 		}
 


### PR DESCRIPTION
### Motivation
- Remove premature display (gamma/sRGB) encoding performed per-channel in the alias and entity-static-light code paths to avoid double conversion and to keep lighting math in linear space.
- Ensure a single conversion point remains in the postprocess path (`LinearToSRGB` in `postprocess.frag`) so postprocessing and blending operate on linear colors.

### Description
- Removed the `powf(L, 1.0f / 2.2f)` encode from the alias lighting accumulation in `Quake/r_alias.c` so `post_total`, `ambientcolor`, `dlightcolor` and `lightcolor` remain linear.
- Removed the `powf(L, 1.0f / 2.2f)` encode from `R_EntityStaticLight` in `Quake/gl_rlight.c` so `info->static_color` is stored in linear space.
- Added inline comments at both change sites documenting that final display encoding is applied in the postprocess shader (`LinearToSRGB`), preventing accidental double-encoding.

### Testing
- Ran `git diff --check` to ensure no whitespace/patch issues and it succeeded.
- Searched the tree with `rg` for the removed `powf(..., 1.0f / 2.2f)` patterns and for updated assignment sites to verify the two changes were applied.
- Changes were committed and the repo status shows `Quake/r_alias.c` and `Quake/gl_rlight.c` modified as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7f001670c832eb68fbfae515f56d6)