### PR TITLE
Use accurate sRGB->linear conversion in fog volume surface light sampling

### DIFF
--- a/Quake/r_fogvol.c
+++ b/Quake/r_fogvol.c
@@ -1241,6 +1241,13 @@ static int R_FogVol_BuildFrameLightBroadphase (const fogvol_visible_volume_t *vi
 	return candidate_count;
 }
 
+static float R_FogVol_SRGBToLinear (float c)
+{
+	if (c <= 0.04045f)
+		return c / 12.92f;
+	return powf ((c + 0.055f) / 1.055f, 2.4f);
+}
+
 static qboolean R_FogVol_TryGetSurfaceLightSample (const qmodel_t *model, const msurface_t *surf, vec3_t out_rgb)
 {
 	const byte *samples;
@@ -1299,9 +1306,9 @@ static qboolean R_FogVol_TryGetSurfaceLightSample (const qmodel_t *model, const 
 	out_rgb[2] = q_max (0.f, accum[2] * (1.f / 255.f));
 	if (!q_strcasecmp (r_lightmap_colorspace.string, "srgb"))
 	{
-		out_rgb[0] = powf (q_max (out_rgb[0], 0.f), 2.2f);
-		out_rgb[1] = powf (q_max (out_rgb[1], 0.f), 2.2f);
-		out_rgb[2] = powf (q_max (out_rgb[2], 0.f), 2.2f);
+		out_rgb[0] = R_FogVol_SRGBToLinear (out_rgb[0]);
+		out_rgb[1] = R_FogVol_SRGBToLinear (out_rgb[1]);
+		out_rgb[2] = R_FogVol_SRGBToLinear (out_rgb[2]);
 	}
 	return (out_rgb[0] > 0.f || out_rgb[1] > 0.f || out_rgb[2] > 0.f);
 }


### PR DESCRIPTION
### Motivation
- Ensure correct linearization of sampled lightmap texel values for fog-volume light injection by replacing the ad-hoc gamma approximation with the standard sRGB transfer function and only applying it when `r_lightmap_colorspace == "srgb"`.

### Description
- Added `R_FogVol_SRGBToLinear` that implements the sRGB transfer function (threshold `0.04045`, divide by `12.92`, otherwise `((c + 0.055)/1.055)^2.4`) and replaced the three per-channel `powf(..., 2.2f)` calls in `R_FogVol_TryGetSurfaceLightSample` with calls to this helper in `Quake/r_fogvol.c`.

### Testing
- Ran `rg` to verify the new helper and that the old `powf(..., 2.2f)` usage was removed, inspected the `git diff` for the file change, and committed the patch; all checks and commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7f0132800832e8f909839084fb999)