### PR TITLE
Render teleport FBM shader output in linear space

### DIFF
--- a/Quake/shaders/teleport_fbm.frag
+++ b/Quake/shaders/teleport_fbm.frag
@@ -71,17 +71,6 @@ float fbm(vec3 x)
     return t;
 }
 
-float sRGBencode(float c)
-{
-    return c > 0.0031308 ? (1.055 * pow(c, 1.0 / 2.4) - 0.055) : (12.92 * c);
-}
-
-vec3 sRGBencode(vec3 c)
-{
-    c = clamp(c, 0.0, 1.0);
-    return vec3(sRGBencode(c.x), sRGBencode(c.y), sRGBencode(c.z));
-}
-
 // --- Main --------------------------------------------------------------------
 
 void main()
@@ -136,8 +125,6 @@ void main()
 
     color = 1.0 - exp(-1.2 * sqrt(color * color * color));
     color *= 1.0 - dot(uv, uv) * 0.2;
-    color = sRGBencode(color);
-
     float alpha = clamp(max(max(color.r, color.g), color.b), 0.0, 1.0);
     fragColor = vec4(color, alpha);
 }


### PR DESCRIPTION
### Motivation
- Ensure the teleporter FBM shader emits linear RGB instead of performing an sRGB encode in-shader so it matches other world/water HDR rendering paths.
- Remove unused sRGB helper routines to avoid redundant color-space transforms and simplify linear-domain tuning.
- Keep color/intensity adjustments in linear space (exposure/intensity parameters) rather than via gamma encodes in the shader.

### Description
- Deleted the `sRGBencode(float)` and `sRGBencode(vec3)` helper functions from `Quake/shaders/teleport_fbm.frag`.
- Removed the `color = sRGBencode(color);` call so `fragColor.rgb` is now written in linear RGB.
- Verified that `glprogs.teleport` is created alongside other world/water programs in `Quake/gl_shaders.c` and is selected in the same water draw path in `Quake/r_world.c`, so the shader remains on the same linear HDR render targets.
- Changes committed with a concise commit message reflecting the linear-space output.

### Testing
- Ran repository searches with `rg` to confirm removal of `sRGBencode` usage and to verify `glprogs.teleport` program wiring, which succeeded.
- Ran `git diff --check` and `git status --short` to validate no whitespace errors and staged changes, which succeeded.
- Committed the modified file using `git commit`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7f0ba018c832e99c1da48ee6ded83)