### PR TITLE
Tighten linear data texture name matching for blue-noise assets

### DIFF
--- a/Quake/gl_texmgr.c
+++ b/Quake/gl_texmgr.c
@@ -777,7 +777,8 @@ static qboolean TexMgr_IsLinearDataTextureName (const char *name)
 		return true;
 	if (strstr (lower, "depth") || strstr (lower, "velocity"))
 		return true;
-	if (strstr (lower, "ssao") || strstr (lower, "noise") || strstr (lower, "blue"))
+	/* Avoid broad color words (e.g. "blue"): albedo textures often include them but should remain sRGB. */
+	if (strstr (lower, "ssao") || strstr (lower, "noise") || strstr (lower, "blue_noise") || strstr (lower, "bluenoise") || strstr (lower, "_bn"))
 		return true;
 	if (strstr (lower, "lut"))
 		return true;


### PR DESCRIPTION
### Motivation
- Prevent misclassification of color/albedo textures as linear data by removing a broad `"blue"` substring check and replacing it with explicit blue-noise/data tokens used for non-color textures.

### Description
- Update `TexMgr_IsLinearDataTextureName` in `Quake/gl_texmgr.c` to remove the generic `strstr(lower, "blue")` check and add explicit checks for `"blue_noise"`, `"bluenoise"`, and `"_bn"`, while preserving existing checks for lightmaps, normals, roughness/metalness, AO, height/depth/velocity, and LUTs, and add a short comment explaining why broad color words are unsafe.

### Testing
- Performed static grep validations (`rg`) to confirm the updated tokens are present and no other broad color-name substrings are used in `TexMgr_IsLinearDataTextureName`, and the checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7f684d834832e93395bd2858707db)