### PR TITLE
Harden godrays sky-source depth detection

### DIFF
--- a/Quake/shaders/godrays_source_sky.frag
+++ b/Quake/shaders/godrays_source_sky.frag
@@ -13,14 +13,31 @@ float BrightPartMask(vec3 color, float threshold, float knee)
 	return mask;
 }
 
+float SkyDepthMask(float depth)
+{
+	/*
+	 * Be tolerant about depth convention: some pipelines can expose regular or
+	 * reversed depth depending on runtime capabilities/state.  Accept either
+	 * sky extreme near the far plane so source debug remains
+	 * visible instead of going fully black on convention mismatches.
+	 */
+	const float edgeEpsilon = 0.003;
+	float cpuCutoff = clamp(SkyParams.x, 0.0, 1.0);
+	float reversedLike = step(depth, min(cpuCutoff + edgeEpsilon, 1.0));
+	float regularLike = step(max(cpuCutoff - edgeEpsilon, 0.0), depth);
+	float nearZero = step(depth, edgeEpsilon);
+	float nearOne = step(1.0 - edgeEpsilon, depth);
+
+	if (SkyParams.z > 0.5)
+		return clamp(max(reversedLike, nearOne), 0.0, 1.0);
+	return clamp(max(regularLike, nearZero), 0.0, 1.0);
+}
+
 void main()
 {
 	ivec2 coord = ivec2(gl_FragCoord.xy);
 	float depth = texelFetch(DepthTexture, coord, 0).r;
-	bool isSky = (SkyParams.z > 0.5) ? (depth <= SkyParams.x) : (depth >= SkyParams.x);
-	float mask = 0.0;
-	if (isSky)
-		mask = BrightPartMask(SkyTint.rgb, SkyParams.w, SkyMaskParams.x);
+	float mask = SkyDepthMask(depth) * BrightPartMask(SkyTint.rgb, SkyParams.w, SkyMaskParams.x);
 	vec3 color = SkyTint.rgb * SkyParams.y * mask;
 	outColor = vec4(color, mask);
 }


### PR DESCRIPTION
### Motivation
- The godrays sky-source shader relied on a single depth-convention branch, which could reject all sky pixels when the runtime depth convention disagreed with the CPU-provided flag, making `r_godrays_debug_source` appear black.
- The goal was to make sky-source detection tolerant of reversed/regular depth conventions while keeping detection constrained to sky-like depth regions.

### Description
- Replaced the brittle `isSky` boolean in `Quake/shaders/godrays_source_sky.frag` with a new helper `SkyDepthMask(float depth)` which tolerantly detects sky pixels across depth-convention mismatch scenarios.
- `SkyDepthMask` uses a small `edgeEpsilon` and checks both the expected cutoff branch (from `SkyParams.x`/`SkyParams.z`) and a guarded far-plane/near-plane fallback (`nearZero`/`nearOne`) to remain visible when conventions differ.
- The shader now computes `mask` as `SkyDepthMask(depth) * BrightPartMask(...)`, simplifying the main flow and keeping brightness-based masking intact.
- The change is localized to the godrays sky source shader and does not alter CPU-side uniforms or other rendering paths.

### Testing
- Ran a build attempt with `make -C Quake -j2` as an automated validation step, which exercised the updated shader file, but the build failed in this environment due to missing SDL2 development tools/headers (`sdl2-config` / `SDL.h`).
- Because of the missing dependencies the runtime/shader validation could not be completed here; the change is shader-local and should be exercised by an in-tree build or runtime test on a system with SDL2 installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7fa7183ec832eb92a1cc09fe68dbe)