### PR TITLE
Replace volatile sound-job completion flag with SDL atomics

### DIFF
--- a/Quake/snd_mem.c
+++ b/Quake/snd_mem.c
@@ -99,7 +99,12 @@ typedef struct pending_snd_job_s
 	byte *decoded;
 	int decoded_bytes;
 	int status;
-	volatile int done;
+	/*
+	 * Producer/consumer handoff between async file/decode worker threads and
+	 * the main thread: workers publish status/data, then set done atomically;
+	 * main thread must only consume shared fields after observing done.
+	 */
+	SDL_atomic_t done;
 	struct pending_snd_job_s *next;
 } pending_snd_job_t;
 
@@ -156,7 +161,7 @@ static void S_LoadSoundDecodeJob (void *userdata)
 	if (job->info.channels != 1 || (job->info.width != 1 && job->info.width != 2))
 	{
 		job->status = -1;
-		job->done = 1;
+		SDL_AtomicSet (&job->done, 1);
 		return;
 	}
 
@@ -165,7 +170,7 @@ static void S_LoadSoundDecodeJob (void *userdata)
 	if (outcount <= 0)
 	{
 		job->status = -1;
-		job->done = 1;
+		SDL_AtomicSet (&job->done, 1);
 		return;
 	}
 
@@ -196,7 +201,7 @@ static void S_LoadSoundDecodeJob (void *userdata)
 	}
 
 	job->status = 0;
-	job->done = 1;
+	SDL_AtomicSet (&job->done, 1);
 }
 
 static void S_AsyncReadComplete (void *user, uint8_t *data, size_t len, int status)
@@ -207,7 +212,7 @@ static void S_AsyncReadComplete (void *user, uint8_t *data, size_t len, int stat
 	if (status != 0 || !data)
 	{
 		job->status = -1;
-		job->done = 1;
+		SDL_AtomicSet (&job->done, 1);
 		return;
 	}
 	Jobs_SubmitDetached (S_LoadSoundDecodeJob, job);
@@ -218,7 +223,7 @@ static sfxcache_t *S_CommitPendingSound (pending_snd_job_t *job)
 	sfxcache_t *sc;
 	pending_snd_job_t **pp;
 
-	if (!job->done)
+	if (!SDL_AtomicGet (&job->done))
 		return NULL;
 
 	pp = &pending_snd_jobs;
@@ -283,7 +288,7 @@ sfxcache_t *S_LoadSound (sfx_t *s)
 	job = S_FindPendingSoundJob (s);
 	if (job)
 	{
-		if (!job->done)
+		if (!SDL_AtomicGet (&job->done))
 			return NULL;
 		sc = S_CommitPendingSound (job);
 		if (sc)


### PR DESCRIPTION
### Motivation
- `volatile int done` did not provide required atomicity or memory-ordering guarantees for the producer/consumer handoff between async worker threads and the main thread.
- Use of an explicit atomic type ensures proper publication of decoded data/status from worker threads to the main thread.

### Description
- Replaced `pending_snd_job_t.done` from `volatile int` to `SDL_atomic_t` and added a comment describing the producer/consumer publication model.
- Worker-side completion paths (`S_LoadSoundDecodeJob`, `S_AsyncReadComplete`) now publish completion using `SDL_AtomicSet(&job->done, 1)`.
- Main-thread polling sites (`S_CommitPendingSound`, `S_LoadSound`) now observe completion using `SDL_AtomicGet(&job->done)` before consuming shared fields.
- Adjusted code to preserve the requirement that other shared fields (`status`, `decoded`, `info`, etc.) are only read after completion is observed.

### Testing
- Attempted to configure the project with `cmake -S . -B build`, but configuration failed due to missing SDL2 development package (`SDL2Config.cmake` / `sdl2-config.cmake` not found). (Failure)
- Attempted `make -j2` at the top level but the repository layout produced no top-level Makefile targets to build. (No build performed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7fd4b78a4832e86764219e1ee2823)