### PR TITLE
Harden async read handle ID allocation

### DIFF
--- a/Quake/async.c
+++ b/Quake/async.c
@@ -263,6 +263,11 @@ typedef struct fs_canceled_id_s {
 
 static fs_canceled_id_t *fs_canceled_ids;
 
+/*
+ * Async read handle invariant (under fs_mutex): id 0 is reserved as an invalid
+ * sentinel and is never issued to callers.
+ */
+
 static qboolean FS_HasCanceledIdLocked (unsigned int id)
 {
 	fs_canceled_id_t *entry = fs_canceled_ids;
@@ -274,6 +279,42 @@ static qboolean FS_HasCanceledIdLocked (unsigned int id)
 	}
 
 	return false;
+}
+
+static qboolean FS_HasCompletionIdLocked (unsigned int id)
+{
+	fs_completion_t *comp = fs_comp_head;
+	while (comp)
+	{
+		if (comp->id == id)
+			return true;
+		comp = comp->next;
+	}
+
+	return false;
+}
+
+static unsigned int FS_AllocAsyncReadIdLocked (void)
+{
+	unsigned int candidate = fs_next_id;
+
+	for (;;)
+	{
+		/* id 0 is reserved and never issued as a valid async handle. */
+		if (candidate == 0)
+			candidate = 1;
+
+		if (!FS_HasCompletionIdLocked (candidate) && !FS_HasCanceledIdLocked (candidate))
+			break;
+
+		candidate++;
+	}
+
+	fs_next_id = candidate + 1;
+	if (fs_next_id == 0)
+		fs_next_id = 1;
+
+	return candidate;
 }
 
 static qboolean FS_TakeCanceledIdLocked (unsigned int id)
@@ -376,7 +417,7 @@ fs_asyncread_handle_t FS_AsyncRead (const char *path, fs_async_cb cb, void *user
 	job->user = user;
 
 	SDL_LockMutex (fs_mutex);
-	job->id = fs_next_id++;
+	job->id = FS_AllocAsyncReadIdLocked ();
 	job->generation = fs_generation;
 	SDL_UnlockMutex (fs_mutex);
 


### PR DESCRIPTION
### Motivation
- Prevent issuance of `0` as a valid async read handle by centralizing allocation checks and documenting the invariant. 
- Avoid subtle ID reuse/collision between pending completions and cancellation tracking while IDs remain in bookkeeping lists. 

### Description
- Added a comment documenting the invariant that `0` is reserved and never issued as a valid async handle (`fs_mutex` protected). 
- Introduced `FS_HasCompletionIdLocked` to detect IDs currently present in the completion queue. 
- Added `FS_AllocAsyncReadIdLocked`, a small allocator that runs under `fs_mutex` and selects the next safe ID while skipping `0`, checking pending completions and canceled IDs, and advancing `fs_next_id` with wrap-around protection. 
- Switched `FS_AsyncRead` to call `FS_AllocAsyncReadIdLocked` while holding `fs_mutex` instead of incrementing `fs_next_id` inline. 

### Testing
- Ran `make -j2` at the repository root and it failed with "No targets specified and no makefile found", so no build verification was performed. 
- No repository-specific automated tests were available to exercise the async FS paths during this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7fe3f6218832ea7d44a3e39ba865f)