### PR TITLE
Harden save-thread init/shutdown in host_cmd.c

### DIFF
--- a/Quake/host_cmd.c
+++ b/Quake/host_cmd.c
@@ -2310,11 +2310,17 @@ void Host_ShutdownSave (void)
 	SDL_DestroyCond (save_pending_condition);
 	save_pending_condition = NULL;
 
+	SDL_DestroyMutex (save_mutex);
+	save_mutex = NULL;
+
 	SaveData_Clear (&save_data);
 }
 
 void Host_WaitForSaveThread (void)
 {
+	if (!save_mutex || !save_finished_condition)
+		return;
+
 	SDL_LockMutex (save_mutex);
 	while (save_pending)
 		SDL_CondWait (save_finished_condition, save_mutex);
@@ -2324,6 +2330,10 @@ void Host_WaitForSaveThread (void)
 qboolean Host_IsSaving (void)
 {
 	qboolean saving;
+
+	if (!save_mutex || !save_finished_condition)
+		return false;
+
 	SDL_LockMutex (save_mutex);
 	saving = save_pending;
 	SDL_UnlockMutex (save_mutex);
@@ -2392,9 +2402,39 @@ static int Host_BackgroundSave (void *param)
 static void Host_InitSaveThread (void)
 {
 	save_mutex = SDL_CreateMutex ();
+	if (!save_mutex)
+		Sys_Error ("Host_InitSaveThread: couldn't create save mutex: %s", SDL_GetError ());
+
 	save_finished_condition = SDL_CreateCond ();
+	if (!save_finished_condition)
+	{
+		SDL_DestroyMutex (save_mutex);
+		save_mutex = NULL;
+		Sys_Error ("Host_InitSaveThread: couldn't create save finished condition: %s", SDL_GetError ());
+	}
+
 	save_pending_condition = SDL_CreateCond ();
+	if (!save_pending_condition)
+	{
+		SDL_DestroyCond (save_finished_condition);
+		save_finished_condition = NULL;
+		SDL_DestroyMutex (save_mutex);
+		save_mutex = NULL;
+		Sys_Error ("Host_InitSaveThread: couldn't create save pending condition: %s", SDL_GetError ());
+	}
+
 	save_thread = SDL_CreateThread (Host_BackgroundSave, "SaveThread", &save_data);
+	if (!save_thread)
+	{
+		SDL_DestroyCond (save_pending_condition);
+		save_pending_condition = NULL;
+		SDL_DestroyCond (save_finished_condition);
+		save_finished_condition = NULL;
+		SDL_DestroyMutex (save_mutex);
+		save_mutex = NULL;
+		Sys_Error ("Host_InitSaveThread: couldn't create save thread: %s", SDL_GetError ());
+	}
+
 	SaveData_Init (&save_data);
 }
 


### PR DESCRIPTION
### Motivation
- Prevent NULL derefs and undefined behavior when save-thread primitives fail to initialize by validating each SDL primitive creation and failing fast like other engine paths using `Sys_Error`.
- Ensure shutdown fully tears down synchronization primitives so subsequent startup/shutdown ordering is robust.

### Description
- Added checks in `Host_InitSaveThread` to verify `SDL_CreateMutex`, both `SDL_CreateCond` calls, and `SDL_CreateThread` succeeded and perform partial cleanup before calling `Sys_Error` with `SDL_GetError()` on failure.
- Added cleanup in `Host_ShutdownSave` to `SDL_DestroyMutex(save_mutex)` and set `save_mutex = NULL` after condition variables are destroyed.
- Added guards in `Host_WaitForSaveThread` and `Host_IsSaving` to safely no-op or return `false` when `save_mutex` or `save_finished_condition` are not initialized.
- Preserved existing `SaveData_Init`/`SaveData_Clear` usage and ensured resources are nulled after destruction.

### Testing
- Ran `make -C Quake -j2` which could not complete due to missing SDL development tooling/headers (missing `sdl2-config` / `SDL.h`) so a full build was not possible; this prevented compile-time verification of the changes.
- Running `make -j2` at the repo root reported no targets and exited; no automated tests were executed successfully due to the environment limitations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a82211ee0c832e8d487daf19adbfb1)