### PR TITLE
Validate async API arguments in job submission and FS_AsyncRead

### DIFF
--- a/Quake/async.c
+++ b/Quake/async.c
@@ -89,6 +89,9 @@ JobHandle *Jobs_Submit (jobs_func_t func, void *userdata)
 	JobHandle *handle;
 	jobnode_t *node;
 
+	if (!func)
+		Sys_Error ("Jobs_Submit: NULL function");
+
 	handle = (JobHandle *) calloc (1, sizeof (*handle));
 	if (!handle)
 		Sys_Error ("Jobs_Submit: out of memory");
@@ -194,6 +197,9 @@ static void Jobs_LogQueueStats (const char *reason)
 void Jobs_SubmitDetached (jobs_func_t func, void *userdata)
 {
 	jobnode_t *node;
+
+	if (!func)
+		Sys_Error ("Jobs_SubmitDetached: NULL function");
 
 	if (!Host_AsyncEnabled () || jobs_num_threads <= 0)
 	{
@@ -447,6 +453,13 @@ fs_asyncread_handle_t FS_AsyncRead (const char *path, fs_async_cb cb, void *user
 	fs_asyncread_handle_t handle;
 	fs_job_t *job;
 	handle.id = 0;
+
+	if (!path || !path[0] || !cb)
+	{
+		if (cb)
+			cb (user, NULL, 0, -1);
+		return handle;
+	}
 
 	if (!Host_AsyncFSEnabled ())
 	{


### PR DESCRIPTION
### Motivation
- Catch programmer errors early by failing fast when invalid job functions are submitted to the jobs system.
- Make `FS_AsyncRead` behavior deterministic across both async-enabled and sync-fallback paths when callers provide invalid arguments.

### Description
- Added a fail-fast check in `Jobs_Submit` that calls `Sys_Error("Jobs_Submit: NULL function")` when `func == NULL` before any allocation or execution.
- Added the same fail-fast check in `Jobs_SubmitDetached` as `Sys_Error("Jobs_SubmitDetached: NULL function")` to keep detached submissions consistent.
- Added argument validation at the top of `FS_AsyncRead` that checks `path` and `cb`; on invalid input it returns a zero `fs_asyncread_handle_t` and, if `cb` is non-NULL, invokes `cb(user, NULL, 0, -1)` before returning.
- The `FS_AsyncRead` check runs prior to branching into async vs sync behavior so the failure semantics are consistent regardless of whether async I/O is enabled.

### Testing
- Ran a repository diff (`git diff -- Quake/async.c`) to verify the intended changes were applied successfully.
- Attempted to build the Quake subdirectory with `make -C Quake -j2` but the build failed due to missing SDL2 tooling/headers (`sdl2-config` and `SDL.h`).
- Attempted a top-level `make -j2` which is not applicable in this workspace layout and reported no top-level Makefile; no further automated tests were run due to the missing SDL2 dependencies.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a82212d9a8832e808c604cef05ea10)