### PR TITLE
Track outstanding async read IDs to prevent wrap-around collisions

### DIFF
--- a/Quake/async.c
+++ b/Quake/async.c
@@ -262,7 +262,13 @@ typedef struct fs_canceled_id_s {
 	struct fs_canceled_id_s *next;
 } fs_canceled_id_t;
 
+typedef struct fs_outstanding_id_s {
+	unsigned int id;
+	struct fs_outstanding_id_s *next;
+} fs_outstanding_id_t;
+
 static fs_canceled_id_t *fs_canceled_ids;
+static fs_outstanding_id_t *fs_outstanding_ids;
 
 #define FS_RECENT_COMPLETED_CAPACITY 64
 #define FS_CANCELED_PRUNE_GENERATIONS 4
@@ -297,6 +303,48 @@ static qboolean FS_HasCompletionIdLocked (unsigned int id)
 	return false;
 }
 
+static qboolean FS_HasOutstandingIdLocked (unsigned int id)
+{
+	fs_outstanding_id_t *entry = fs_outstanding_ids;
+	while (entry)
+	{
+		if (entry->id == id)
+			return true;
+		entry = entry->next;
+	}
+
+	return false;
+}
+
+static void FS_AddOutstandingIdLocked (unsigned int id)
+{
+	fs_outstanding_id_t *entry = (fs_outstanding_id_t *) calloc (1, sizeof (*entry));
+	if (!entry)
+		Sys_Error ("FS_AddOutstandingIdLocked: out of memory");
+
+	entry->id = id;
+	entry->next = fs_outstanding_ids;
+	fs_outstanding_ids = entry;
+}
+
+static qboolean FS_RemoveOutstandingIdLocked (unsigned int id)
+{
+	fs_outstanding_id_t **cursor = &fs_outstanding_ids;
+	while (*cursor)
+	{
+		fs_outstanding_id_t *entry = *cursor;
+		if (entry->id == id)
+		{
+			*cursor = entry->next;
+			free (entry);
+			return true;
+		}
+		cursor = &entry->next;
+	}
+
+	return false;
+}
+
 static unsigned int FS_AllocAsyncReadIdLocked (void)
 {
 	unsigned int candidate = fs_next_id;
@@ -307,7 +355,9 @@ static unsigned int FS_AllocAsyncReadIdLocked (void)
 		if (candidate == 0)
 			candidate = 1;
 
-		if (!FS_HasCompletionIdLocked (candidate) && !FS_HasCanceledIdLocked (candidate))
+		if (!FS_HasOutstandingIdLocked (candidate)
+			&& !FS_HasCanceledIdLocked (candidate)
+			&& !FS_HasCompletionIdLocked (candidate))
 			break;
 
 		candidate++;
@@ -465,6 +515,7 @@ fs_asyncread_handle_t FS_AsyncRead (const char *path, fs_async_cb cb, void *user
 
 	SDL_LockMutex (fs_mutex);
 	job->id = FS_AllocAsyncReadIdLocked ();
+	FS_AddOutstandingIdLocked (job->id);
 	job->generation = fs_generation;
 	SDL_UnlockMutex (fs_mutex);
 
@@ -543,6 +594,7 @@ void FS_PumpAsyncCompletions (void)
 		FS_RecordCompletionIdLocked (list->id);
 		canceled = FS_TakeCanceledIdLocked (list->id);
 		stale = list->generation != fs_generation;
+		FS_RemoveOutstandingIdLocked (list->id);
 		SDL_UnlockMutex (fs_mutex);
 
 		if (!canceled && !stale)
@@ -564,6 +616,7 @@ void Jobs_Shutdown (void)
 	jobnode_t *node;
 	fs_completion_t *comp;
 	fs_canceled_id_t *canceled;
+	fs_outstanding_id_t *outstanding;
 
 	if (!jobs_mutex)
 		return;
@@ -613,6 +666,18 @@ void Jobs_Shutdown (void)
 		fs_canceled_id_t *next = canceled->next;
 		free (canceled);
 		canceled = next;
+	}
+
+	SDL_LockMutex (fs_mutex);
+	outstanding = fs_outstanding_ids;
+	fs_outstanding_ids = NULL;
+	SDL_UnlockMutex (fs_mutex);
+
+	while (outstanding)
+	{
+		fs_outstanding_id_t *next = outstanding->next;
+		free (outstanding);
+		outstanding = next;
 	}
 
 	while ((node = jobs_head) != NULL)


### PR DESCRIPTION
### Motivation
- Prevent allocation of async read IDs that collide with IDs currently queued, in-flight, or recently canceled when `fs_next_id` wraps.
- Guarantee uniqueness across the queued completion list, in-flight (outstanding) requests, and the canceled/recent-completed windows to avoid suppressed or misrouted completions.

### Description
- Add a new linked-list `fs_outstanding_id_t` and global `fs_outstanding_ids` guarded by `fs_mutex` to track IDs from allocation until consumption.
- Implement helper functions `FS_HasOutstandingIdLocked`, `FS_AddOutstandingIdLocked`, and `FS_RemoveOutstandingIdLocked` and use them in allocation and completion paths.
- Update `FS_AllocAsyncReadIdLocked` to reject candidates present in the outstanding set, canceled set, or completion queue by checking `FS_HasOutstandingIdLocked`, `FS_HasCanceledIdLocked`, and `FS_HasCompletionIdLocked`.
- Mark IDs outstanding in `FS_AsyncRead` immediately after allocation with `FS_AddOutstandingIdLocked`, remove them in `FS_PumpAsyncCompletions` via `FS_RemoveOutstandingIdLocked` after completion handling, and free outstanding nodes during `Jobs_Shutdown`.

### Testing
- Inspected the resulting diff to verify the ID lifecycle updates in `FS_AllocAsyncReadIdLocked`, `FS_AsyncRead`, and `FS_PumpAsyncCompletions` and that shutdown frees outstanding nodes (inspection succeeded).
- Attempted an automated build with `cmake --build build -j2`, but there was no `build/` directory in the environment so a build was not performed.
- No additional automated tests were available or executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8221fc4b0832ea959f1b84c32c66b)