### PR TITLE
Refine fogvol availability vs global-fog replacement gates

### DIFF
--- a/Quake/gl_fog.c
+++ b/Quake/gl_fog.c
@@ -311,10 +311,11 @@ void Fog_SetupFrame (void)
 	const float SphericalCorrection = 0.85f; // compensate higher perceived density with spherical fog
 	const float DensityScale = ExpAdjustment * SphericalCorrection / 96.0f;
 	float density = Fog_GetDensity() * DensityScale;
-	qboolean fogvol_global = R_FogVol_CanRenderGlobal ();
+	qboolean fogvol_global_active = R_FogVol_CanRenderGlobal ();
 	memcpy(r_framedata.fogdata, Fog_GetColor(), 3 * sizeof(float));
 	memcpy(r_framedata.skyfogdata, r_framedata.fogdata, 3 * sizeof(float));
-	r_framedata.fogdata[3] = fogvol_global ? 0.f : density * density;
+	/* Keep analytic global fog only when volumetric global replacement is not active. */
+	r_framedata.fogdata[3] = fogvol_global_active ? 0.f : density * density;
 	r_framedata.skyfogdata[3] = density > 0.f ? CLAMP (0.f, skyfog, 1.f) : 0.f;
 }
 

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -4694,7 +4694,7 @@ void R_WarpScaleView (void)
 	needwarpscale = r_refdef.scale != 1 || water_warp;
 	fbodest = GL_NeedsPostprocess () ? framebufs.composite.fbo : 0;
 	need_depth_resolve = (fbodest == framebufs.composite.fbo)
-		&& (R_DoFEnabled () || r_ssao.value > 0.f || r_ssao_debug.value > 0.f || r_fogvol.value > 0.f
+		&& (R_DoFEnabled () || r_ssao.value > 0.f || r_ssao_debug.value > 0.f || R_FogVol_ShouldAffectPostFX ()
 			|| (R_Godrays_IsReady (cl.worldmodel, r_framecount) && (r_godrays.value > 0.f || r_godrays_debug.value > 0.f || r_godrays_debug_source.value > 0.f)));
 
 	if (msaa)

--- a/Quake/r_fogvol.c
+++ b/Quake/r_fogvol.c
@@ -1724,8 +1724,6 @@ qboolean R_FogVol_IsEnabledForFrame (void)
 {
 	if (r_fogvol.value <= 0.f)
 		return false;
-	if (Fog_GetDensity () <= 0.f)
-		return false;
 	if (!glprogs.fogvol)
 		return false;
 	if (framebufs.composite.color_tex == 0 || framebufs.fogvol.color_tex[0] == 0)
@@ -1748,12 +1746,22 @@ qboolean R_FogVol_HasValidComposite (void)
 
 qboolean R_FogVol_ShouldAffectPostFX (void)
 {
+	/* PostFX should reserve volumetric integration/composite paths whenever
+	 * fogvol rendering is available this frame, even if classic global fog
+	 * density is currently zero. */
 	return R_FogVol_IsEnabledForFrame ();
 }
 
 qboolean R_FogVol_CanRenderGlobal (void)
 {
-	return R_FogVol_IsEnabledForFrame ();
+	if (!R_FogVol_IsEnabledForFrame ())
+		return false;
+	if (r_fogvol_globalfog.value <= 0.f)
+		return false;
+	if (Fog_GetDensity () <= 0.f)
+		return false;
+
+	return true;
 }
 
 /* Returns the fogvol composite texture that was rendered this frame.

--- a/Quake/r_fogvol.h
+++ b/Quake/r_fogvol.h
@@ -113,12 +113,13 @@ void R_FogVol_ClearHistory (void);
 void R_FogVol_LogEndFrameState (void);
 void R_FogVol_InjectIntoGrid (froxel_grid_t *grid, const fog_volume_t *vols, int num);
 qboolean R_FogVol_ProjectAABBToScreenRect (const fog_volume_t *v, int *x0, int *y0, int *x1, int *y1, qboolean fullres);
-/* Feature-level gate: fogvol is enabled by cvar and all global render resources/programs are ready this frame. */
+/* FogVol rendering-availability gate: volumetric resources/programs + r_fogvol are ready this frame. */
 qboolean R_FogVol_IsEnabledForFrame (void);
 /* Output-level gate: fogvol produced a valid composite texture this frame (safe to sample now). */
 qboolean R_FogVol_HasValidComposite (void);
-/* PostFX gate: fogvol should contribute to postprocess passes this frame. */
+/* PostFX gate: volumetric output may be produced this frame (not tied to global fog density). */
 qboolean R_FogVol_ShouldAffectPostFX (void);
+/* Global-replacement gate: volumetric global fog is eligible this frame (includes classic fog density + r_fogvol_globalfog). */
 qboolean R_FogVol_CanRenderGlobal (void);
 /*
  * FogVol Composite Contract (for CPU + shader users):


### PR DESCRIPTION
### Motivation
- Separate the notion of "fogvol rendering availability" from "volumetric global-fog replacement" so postprocess and scene-effect gates reserve resources when rendering is possible even if classic fog density is zero. 
- Preserve the strictness of the composite-valid check so shaders/sample paths that require a produced composite still only sample when per-frame output is valid. 

### Description
- Updated `R_FogVol_IsEnabledForFrame()` in `Quake/r_fogvol.c` to act as a rendering-availability gate (requires `r_fogvol`, program/resources and framebuffers) and removed the `Fog_GetDensity() > 0` check. 
- Implemented a separate global-replacement gate in `R_FogVol_CanRenderGlobal()` which requires `R_FogVol_IsEnabledForFrame()`, `r_fogvol_globalfog > 0` and `Fog_GetDensity() > 0`. 
- Aligned `R_FogVol_ShouldAffectPostFX()` to reflect volumetric rendering availability by returning `R_FogVol_IsEnabledForFrame()`. 
- Adjusted `Fog_SetupFrame()` in `Quake/gl_fog.c` so analytic global fog is suppressed only when `R_FogVol_CanRenderGlobal()` indicates volumetric global fog replacement is active. 
- Replaced a raw `r_fogvol` check in the depth-resolve gating inside `R_WarpScaleView()` (`Quake/gl_rmain.c`) with `R_FogVol_ShouldAffectPostFX()` so depth-resolve decisions use the availability gate. 
- Updated API comments in `Quake/r_fogvol.h` to document the split semantics (availability, output validity, postfx, and global replacement). 

### Testing
- Ran code inspection/searches with `rg` to verify updated call sites and function uses, which confirmed `R_FogVol_ShouldAffectPostFX()` and `R_FogVol_CanRenderGlobal()` were used where expected and header comments were updated (succeeded). 
- Attempted to configure/build with `cmake -S . -B build` to validate compilation, but configuration failed in this environment due to a missing `SDL2` CMake package (`SDL2Config.cmake` / `sdl2-config.cmake` not found), so a full compile could not be performed (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8250b9c7c832e9679e2723a598201)