### PR TITLE
Reset froxel texture/CPU resources during fogvol and framebuffer teardown

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -912,6 +912,7 @@ void GL_DeleteFrameBuffers (void)
 	GL_DeleteFramebuffersFunc (2, framebufs.fogvol.history_fbo);
 	GL_DeleteFramebuffersFunc (2, framebufs.fogvol.composite_fbo);
 	GL_DeleteFramebuffersFunc (1, &framebufs.fogvol.finalcopy_fbo);
+	R_Froxel_ResetResources ();
 	GL_DeleteFramebuffersFunc (1, &framebufs.autoexposure.fbo);
 	GL_AutoExposureDeletePBOs ();
 	GL_DeleteFramebuffersFunc (1, &framebufs.bloom.extract_fbo);

--- a/Quake/r_fogvol.c
+++ b/Quake/r_fogvol.c
@@ -349,6 +349,7 @@ void R_FogVol_ClearHistory (void)
 	r_fogvol_history_width = 0;
 	r_fogvol_history_height = 0;
 	r_fogvol_composite_valid = false;
+	R_Froxel_ResetResources ();
 
 	if (!framebufs.fogvol.history_fbo[0] || !framebufs.fogvol.history_fbo[1])
 		return;
@@ -1443,6 +1444,18 @@ static void R_Froxel_FreeCPUBuffer (void)
 		free (r_froxel.light_rgb);
 		r_froxel.light_rgb = NULL;
 	}
+}
+
+void R_Froxel_ResetResources (void)
+{
+	if (r_froxel.light_tex)
+		glDeleteTextures (1, &r_froxel.light_tex);
+	r_froxel.light_tex = 0;
+	R_Froxel_FreeCPUBuffer ();
+	r_froxel.dims[0] = 0;
+	r_froxel.dims[1] = 0;
+	r_froxel.dims[2] = 0;
+	r_froxel.valid = false;
 }
 
 static qboolean R_Froxel_EnsureResources (int nx, int ny, int nz)

--- a/Quake/r_fogvol.h
+++ b/Quake/r_fogvol.h
@@ -126,6 +126,7 @@ void R_FogVol_LogEndFrameState (void);
 void R_Froxel_BeginFrame (float near_clip, float far_clip);
 void R_Froxel_InjectDlights (void);
 void R_Froxel_EndFrame (void);
+void R_Froxel_ResetResources (void);
 void R_FogVol_InjectIntoGrid (froxel_grid_t *grid, const fog_volume_t *vols, int num);
 qboolean R_FogVol_ProjectAABBToScreenRect (const fog_volume_t *v, int *x0, int *y0, int *x1, int *y1, qboolean fullres);
 /* FogVol rendering-availability gate: volumetric resources/programs + r_fogvol are ready this frame. */


### PR DESCRIPTION
### Motivation

- Ensure froxel GPU/CPU resources are reliably released when the renderer context or fog history is torn down to avoid stale GL objects and to force regeneration on next use.

### Description

- Added `R_Froxel_ResetResources()` in `Quake/r_fogvol.c` which deletes `r_froxel.light_tex` via `glDeleteTextures` when non-zero, sets `r_froxel.light_tex = 0`, calls the existing `R_Froxel_FreeCPUBuffer()` to free `r_froxel.light_rgb`, clears `r_froxel.dims[]`, and sets `r_froxel.valid = false`.
- Call `R_Froxel_ResetResources()` from `R_FogVol_ClearHistory()` so froxel resources are invalidated during fog history/vid restart paths.
- Call `R_Froxel_ResetResources()` from `GL_DeleteFrameBuffers()` in `Quake/gl_rmain.c` so framebuffer teardown also clears froxel resources.
- Exported the new function in `Quake/r_fogvol.h`; `R_Froxel_EnsureResources()` will regenerate the texture/buffer as needed after a reset.

### Testing

- Attempted an automated configure/build with `cmake -S . -B build && cmake --build build -j2`, but configuration failed due to a missing `SDL2` CMake package in this environment, so a full build could not be validated.
- No other automated tests were available or run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a82fe3151c832e9fa26c4292c16b7c)