### PR TITLE
Optimize froxel light injection by bounding per-light froxel traversal

### DIFF
--- a/Quake/r_fogvol.c
+++ b/Quake/r_fogvol.c
@@ -329,6 +329,8 @@ typedef struct froxel_state_s
 } froxel_state_t;
 
 static froxel_state_t r_froxel;
+static uint64_t r_froxel_tested_froxels_before = 0;
+static uint64_t r_froxel_tested_froxels_after = 0;
 
 extern float skyflatcolor[3];
 
@@ -1507,18 +1509,74 @@ void R_Froxel_BeginFrame (float near_clip, float far_clip)
 static void R_Froxel_InjectOneLight (const vec3_t origin, float radius, const vec3_t color, float intensity)
 {
 	int nx = r_froxel.dims[0], ny = r_froxel.dims[1], nz = r_froxel.dims[2];
+	vec3_t rel;
+	const float radius2 = radius * radius;
+	const float near_clip = r_froxel.near_clip;
+	const float far_clip = r_froxel.far_clip;
+	const float inv_log_far_near = 1.f / q_max (r_froxel.log_far_near, 1e-6f);
+	const qboolean inject_debug = (r_fogvol_inject_debug.value > 0.f) || (r_fogvol_debug.value >= 7.f);
+	float cx, cy, cz;
+	float zmin_depth, zmax_depth;
+	float zf_min, zf_max;
+	int z0, z1;
 
 	if (!r_froxel.valid || radius <= 0.f)
 		return;
 
-	for (int z = 0; z < nz; ++z)
+	if (inject_debug)
+		r_froxel_tested_froxels_before += (uint64_t)nx * (uint64_t)ny * (uint64_t)nz;
+
+	VectorSubtract (origin, r_refdef.vieworg, rel);
+	cx = DotProduct (rel, vright);
+	cy = DotProduct (rel, vup);
+	cz = DotProduct (rel, vpn);
+
+	zmin_depth = q_max (near_clip, cz - radius);
+	zmax_depth = q_min (far_clip, cz + radius);
+	if (zmax_depth < zmin_depth)
+		return;
+
+	zf_min = logf (q_max (zmin_depth, near_clip) / near_clip) * inv_log_far_near;
+	zf_max = logf (q_max (zmax_depth, near_clip) / near_clip) * inv_log_far_near;
+	z0 = CLAMP (0, (int)floorf (zf_min * (float)nz - 0.5f), nz - 1);
+	z1 = CLAMP (0, (int)ceilf (zf_max * (float)nz - 0.5f), nz - 1);
+	if (z1 < z0)
+		return;
+
+	for (int z = z0; z <= z1; ++z)
 	{
 		float zf = ((float)z + 0.5f) / (float)nz;
 		float zv = r_froxel.near_clip * expf (r_froxel.log_far_near * zf);
 		float half_w = q_max (1e-3f, zv * r_froxel.tan_half_fov_x);
 		float half_h = q_max (1e-3f, zv * r_froxel.tan_half_fov_y);
-		for (int y = 0; y < ny; ++y)
-		for (int x = 0; x < nx; ++x)
+		float dz = zv - cz;
+		float cross2 = radius2 - dz * dz;
+		float cross;
+		float min_xf, max_xf, min_yf, max_yf;
+		int x0, x1, y0, y1;
+
+		if (cross2 <= 0.f)
+			continue;
+
+		cross = sqrtf (cross2);
+		min_xf = (cx - cross) / half_w;
+		max_xf = (cx + cross) / half_w;
+		min_yf = (cy - cross) / half_h;
+		max_yf = (cy + cross) / half_h;
+
+		x0 = CLAMP (0, (int)ceilf (((min_xf + 1.f) * 0.5f) * (float)nx - 0.5f), nx - 1);
+		x1 = CLAMP (0, (int)floorf (((max_xf + 1.f) * 0.5f) * (float)nx - 0.5f), nx - 1);
+		y0 = CLAMP (0, (int)ceilf (((min_yf + 1.f) * 0.5f) * (float)ny - 0.5f), ny - 1);
+		y1 = CLAMP (0, (int)floorf (((max_yf + 1.f) * 0.5f) * (float)ny - 0.5f), ny - 1);
+
+		if (x1 < x0 || y1 < y0)
+			continue;
+
+		if (inject_debug)
+			r_froxel_tested_froxels_after += (uint64_t)(x1 - x0 + 1) * (uint64_t)(y1 - y0 + 1);
+
+		for (int y = y0; y <= y1; ++y)
+		for (int x = x0; x <= x1; ++x)
 		{
 			float xf = (((float)x + 0.5f) / (float)nx) * 2.f - 1.f;
 			float yf = (((float)y + 0.5f) / (float)ny) * 2.f - 1.f;
@@ -1557,6 +1615,12 @@ void R_Froxel_InjectDlights (void)
 	if (!r_froxel.valid)
 		return;
 
+	if ((r_fogvol_inject_debug.value > 0.f) || (r_fogvol_debug.value >= 7.f))
+	{
+		r_froxel_tested_froxels_before = 0;
+		r_froxel_tested_froxels_after = 0;
+	}
+
 	active = DLightPool_GetActiveList (&active_count);
 	if (active)
 	{
@@ -1575,6 +1639,16 @@ void R_Froxel_InjectDlights (void)
 		if (!CL_DlightIsActive (dl) || dl->radius <= 0.f)
 			continue;
 		R_Froxel_InjectOneLight (dl->origin, dl->radius, dl->color, 1.f);
+	}
+
+	if (((r_fogvol_inject_debug.value > 0.f) || (r_fogvol_debug.value >= 7.f))
+		&& r_froxel_tested_froxels_before > 0)
+	{
+		double ratio = (double)r_froxel_tested_froxels_after / (double)r_froxel_tested_froxels_before;
+		Con_DPrintf ("FROXEL inject tested_froxels before=%llu after=%llu ratio=%.3f\n",
+			(unsigned long long)r_froxel_tested_froxels_before,
+			(unsigned long long)r_froxel_tested_froxels_after,
+			ratio);
 	}
 }
 


### PR DESCRIPTION
### Motivation

- Reduce the cost of froxel light injection by avoiding a full 3D-grid scan per light and instead limit work to a conservative froxel-space AABB computed per light. 

### Description

- Compute the light center once in view space by subtracting `r_refdef.vieworg` and projecting into camera axes (`cx`, `cy`, `cz`) and precompute `radius2` for cheap sphere math. 
- Derive a conservative z-slice range `z0..z1` using the existing froxel logarithmic depth mapping (`near_clip`, `far_clip`, `log_far_near`) so only relevant depth slices are visited. 
- For each z-slice in the range, compute the sphere cross-section, project to normalized device x/y extents, clamp to `[0..nx-1]` and `[0..ny-1]`, then iterate only the bounded `x0..x1` / `y0..y1` region instead of the entire grid. 
- Preserve the original attenuation/existing distance evaluation math for visual parity and keep behavior unchanged except for traversal. 
- Add debug counters `r_froxel_tested_froxels_before` and `r_froxel_tested_froxels_after` and a summary `Con_DPrintf` log to report `before`, `after`, and `ratio`, gated behind the existing debug controls (`r_fogvol_inject_debug` or `r_fogvol_debug >= 7`).

### Testing

- Attempted `make -j4` at the repository root but no top-level build target was present so no build was performed. 
- Attempted `make -j4` in `Quake/` to validate compilation but the build failed due to missing SDL2 development tools/headers (`sdl2-config`, `SDL.h`), so compilation could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a83011fac4832ebe41994875d3ea9d)