### PR TITLE
Add missing LIGHT_TILES defines to world.frag to fix GLSL compile error

### DIFF
--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -18,6 +18,9 @@ vec3 ApplyFog(vec3 clr, vec3 p)
 }
 
 #define MAX_LIGHTS    64
+#define LIGHT_TILES_X 32
+#define LIGHT_TILES_Y 16
+#define LIGHT_TILES_Z 32
 
 struct Light
 {


### PR DESCRIPTION
### Motivation
- Fix GLSL compilation failures complaining about undefined variables `LIGHT_TILES_X`, `LIGHT_TILES_Y`, and `LIGHT_TILES_Z` in the `world` fragment shader used by `ComputeLightTileCoord`.

### Description
- Add `#define LIGHT_TILES_X 32`, `#define LIGHT_TILES_Y 16`, and `#define LIGHT_TILES_Z 32` to `Quake/shaders/world.frag` so the fragment shader has the same light-tile constants as other shader stages.

### Testing
- Located usages with `rg` and updated the shader, then attempted to configure and build with `cmake -S /workspace/ironwail -B /workspace/ironwail/build && cmake --build /workspace/ironwail/build -j2`, which failed at configure due to a missing SDL2 development package so full build validation could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a871426758832e94c005e094b27535)