### PR TITLE
Gate froxel injection by fog lighting + add froxel debug counters and shader bypass

### DIFF
--- a/Quake/r_fogvol.c
+++ b/Quake/r_fogvol.c
@@ -1566,6 +1566,9 @@ void R_Froxel_InjectDlights (void)
 {
 	const dlight_t *const *active;
 	int active_count = 0;
+	int injected_count = 0;
+	int nonzero_voxels = 0;
+	double aggregate_energy = 0.0;
 
 	if (!r_froxel.valid)
 		return;
@@ -1585,6 +1588,7 @@ void R_Froxel_InjectDlights (void)
 			if (!dl || !CL_DlightIsActive (dl) || dl->radius <= 0.f)
 				continue;
 			R_Froxel_InjectOneLight (dl->origin, dl->radius, dl->color, 1.f);
+			injected_count++;
 		}
 	}
 
@@ -1594,6 +1598,27 @@ void R_Froxel_InjectDlights (void)
 		if (!CL_DlightIsActive (dl) || dl->radius <= 0.f)
 			continue;
 		R_Froxel_InjectOneLight (dl->origin, dl->radius, dl->color, 1.f);
+		injected_count++;
+	}
+
+	if (r_froxel_debug.value > 0.f)
+	{
+		const int voxel_count = r_froxel.dims[0] * r_froxel.dims[1] * r_froxel.dims[2];
+		for (int i = 0; i < voxel_count; ++i)
+		{
+			const float r = r_froxel.light_rgb[i * 3 + 0];
+			const float g = r_froxel.light_rgb[i * 3 + 1];
+			const float b = r_froxel.light_rgb[i * 3 + 2];
+			const float peak = q_max (r, q_max (g, b));
+			if (peak <= 1e-6f)
+				continue;
+			nonzero_voxels++;
+			aggregate_energy += peak;
+		}
+		Con_Printf ("FROXEL inject: lights=%d nonzero_voxels=%d aggregate_energy=%.3f\n",
+			injected_count,
+			nonzero_voxels,
+			aggregate_energy);
 	}
 
 	if (((r_fogvol_inject_debug.value > 0.f) || (r_fogvol_debug.value >= 7.f))
@@ -1604,6 +1629,48 @@ void R_Froxel_InjectDlights (void)
 			(unsigned long long)r_froxel_tested_froxels_before,
 			(unsigned long long)r_froxel_tested_froxels_after,
 			ratio);
+	}
+}
+
+static int R_Froxel_CountInjectableDlights (void)
+{
+	const dlight_t *const *active;
+	int active_count = 0;
+	int count = 0;
+
+	active = DLightPool_GetActiveList (&active_count);
+	if (active)
+	{
+		for (int i = 0; i < active_count; ++i)
+		{
+			const dlight_t *dl = active[i];
+			if (!dl || !CL_DlightIsActive (dl) || dl->radius <= 0.f)
+				continue;
+			count++;
+		}
+	}
+
+	for (int i = 0; i < r_num_fog_dlights; ++i)
+	{
+		const dlight_t *dl = &r_fog_dlights[i];
+		if (!CL_DlightIsActive (dl) || dl->radius <= 0.f)
+			continue;
+		count++;
+	}
+
+	return count;
+}
+
+static void R_FogVol_WarnFroxelLightingConfig (void)
+{
+	static qboolean warned = false;
+
+	if (warned)
+		return;
+	if (r_fogvol_froxel.value > 0.f && r_fogvol_light.value <= 0.f)
+	{
+		Con_Printf ("Warning: r_fogvol_froxel=1 while r_fogvol_light=0. Froxel injection is disabled in this mode and cannot provide performance wins.\n");
+		warned = true;
 	}
 }
 
@@ -1621,6 +1688,7 @@ void R_Froxel_EndFrame (void)
 void R_FogVol_Init (void)
 {
 	memset (&r_froxel, 0, sizeof (r_froxel));
+	R_FogVol_WarnFroxelLightingConfig ();
 }
 
 void R_FogVol_Clear (void)
@@ -2510,6 +2578,11 @@ void R_FogVol_Render (void)
 	int frame_candidate_count = 0;
 	qboolean has_fog_bounds = false;
 	const qboolean light_stats_enabled = r_fogvol_light_stats.value > 0.f;
+	const qboolean froxel_light_enabled = r_fogvol_light.value > 0.f;
+	const int froxel_dlight_count = froxel_light_enabled ? R_Froxel_CountInjectableDlights () : 0;
+	const qboolean run_froxel_injection = froxel_light_enabled && froxel_dlight_count > 0;
+
+	R_FogVol_WarnFroxelLightingConfig ();
 
 	/* Per-frame validity: only expose a fogvol composite texture after this
 	 * frame actually produced one. */
@@ -2575,9 +2648,16 @@ void R_FogVol_Render (void)
 	}
 	steps = CLAMP (8, steps, q_max (8, (int)Q_rint (r_fogvol_maxsteps.value)));
 
-	R_Froxel_BeginFrame (depth_near, depth_far);
-	R_Froxel_InjectDlights ();
-	R_Froxel_EndFrame ();
+	if (run_froxel_injection)
+	{
+		R_Froxel_BeginFrame (depth_near, depth_far);
+		R_Froxel_InjectDlights ();
+		R_Froxel_EndFrame ();
+	}
+	else
+	{
+		r_froxel.valid = false;
+	}
 
 	memset (&fog_lights, 0, sizeof (fog_lights));
 	memset (&light_stats, 0, sizeof (light_stats));

--- a/Quake/shaders/fogvol.frag
+++ b/Quake/shaders/fogvol.frag
@@ -746,21 +746,30 @@ void main()
 			vec3 lightScatter = lightScatterPrev;
 			if (FogLightSubsample == 0 || (i & 1) == 0)
 			{
-				lightScatter = vec3(0.0);
-				for (int l = 0; l < MAX_FOGLIGHTS; ++l)
+				vec3 froxelLight = SampleFroxelLight(p);
+				float froxelEnergy = max(froxelLight.r, max(froxelLight.g, froxelLight.b));
+				if (FogFroxelEnabled != 0 && froxelEnergy <= 1e-4)
 				{
-					if (l >= lightCount) break;
-					int lightIndex = lightOffset + l;
-					if (lightIndex >= MAX_FOGVOLUMES * MAX_FOGLIGHTS) break;
-					vec3 lightVec = FogLights[lightIndex].pos_rad.xyz - p;
-					float lightDist = length(lightVec);
-					float radius = max(FogLights[lightIndex].pos_rad.w, 1e-3);
-					float atten = clamp(1.0 - lightDist / radius, 0.0, 1.0);
-					atten *= atten;
-					if (atten < 1e-5) continue;
-					vec3 lightDir = (lightDist > 1e-5) ? (lightVec / lightDist) : vec3(0.0);
-					float phaseLocal = AnisotropicPhase(clamp(dot(viewDir, lightDir), -1.0, 1.0), ANISO_G_LOCAL);
-					lightScatter += FogLights[lightIndex].col_int.rgb * (atten * 0.75 * FogDLightScale * phaseLocal);
+					lightScatter = vec3(0.0);
+				}
+				else
+				{
+					lightScatter = vec3(0.0);
+					for (int l = 0; l < MAX_FOGLIGHTS; ++l)
+					{
+						if (l >= lightCount) break;
+						int lightIndex = lightOffset + l;
+						if (lightIndex >= MAX_FOGVOLUMES * MAX_FOGLIGHTS) break;
+						vec3 lightVec = FogLights[lightIndex].pos_rad.xyz - p;
+						float lightDist = length(lightVec);
+						float radius = max(FogLights[lightIndex].pos_rad.w, 1e-3);
+						float atten = clamp(1.0 - lightDist / radius, 0.0, 1.0);
+						atten *= atten;
+						if (atten < 1e-5) continue;
+						vec3 lightDir = (lightDist > 1e-5) ? (lightVec / lightDist) : vec3(0.0);
+						float phaseLocal = AnisotropicPhase(clamp(dot(viewDir, lightDir), -1.0, 1.0), ANISO_G_LOCAL);
+						lightScatter += FogLights[lightIndex].col_int.rgb * (atten * 0.75 * FogDLightScale * phaseLocal);
+					}
 				}
 				lightScatterPrev = lightScatter;
 			}

--- a/docs/fogvol_debug_notes.md
+++ b/docs/fogvol_debug_notes.md
@@ -40,3 +40,17 @@ The dominant issue was **A + C combined**:
 - Recommended baseline: keep `r_fogvol_shadow_samples=2` for gameplay, use `4` for captures, and avoid `8` unless fog coverage is limited.
 - If performance is tight, first reduce `r_fogvol_shadow_samples`, then disable jitter, and finally disable `r_fogvol_shadow`.
 - Directional sun radiance adds only a few ALU ops per fog step and no extra texture taps; it is effectively free compared to shadow marching. Keep `r_fogvol_sun_scatter=0` for exact legacy output.
+
+## Froxel lighting validation checklist
+1. Enable fog lighting before profiling froxel work:
+   - `r_fogvol_light 1`
+   - `r_fogvol_froxel 1`
+2. Ensure there are active dynamic lights intersecting fog volumes (weapon flashes, explosions, scripted dlights, or fog-only dlights).
+3. Turn on froxel diagnostics and confirm injection activity:
+   - `r_froxel_debug 1` (visualize first-hit froxel RGB)
+   - Check console for `FROXEL inject: lights=... nonzero_voxels=... aggregate_energy=...`.
+4. Compare with heat/debug mode:
+   - `r_froxel_debug 2` (max-energy heat view)
+   - If mode 1/2 shows little-to-no signal and counters stay near zero, froxel acceleration will not help in that scene.
+5. Verify configuration sanity:
+   - If `r_fogvol_froxel=1` while `r_fogvol_light=0`, froxel injection is intentionally skipped and cannot provide performance wins.


### PR DESCRIPTION
### Motivation
- Avoid wasting CPU/GPU work by running froxel setup/injection/upload when fog lighting is disabled or there are no injectable dynamic/fog dlights.  
- Give developers runtime visibility into whether froxel injection actually populated any voxels so they can validate when froxel acceleration can help.  
- Short-circuit per-step local-light math in the fog shader when the sampled froxel energy is effectively zero to avoid useless work.  
- Clarify configuration pitfalls in docs and warn at startup when froxel is enabled but fog lighting is disabled.

### Description
- Gate CPU froxel pipeline calls so `R_Froxel_BeginFrame`/`R_Froxel_InjectDlights`/`R_Froxel_EndFrame` only run when `r_fogvol_light > 0` and at least one injectable dlight exists, otherwise `r_froxel.valid` is cleared for the frame (changes in `Quake/r_fogvol.c`).
- Added `R_Froxel_CountInjectableDlights()` helper and a one-time `R_FogVol_WarnFroxelLightingConfig()` warning that logs when `r_fogvol_froxel=1` but `r_fogvol_light=0` (calls placed in init and render paths).  
- Instrumented `R_Froxel_InjectDlights()` to count injected lights, count nonzero froxel voxels, and accumulate a simple aggregate energy metric, and print `"FROXEL inject: lights=... nonzero_voxels=... aggregate_energy=..."` when `r_froxel_debug > 0` (in `Quake/r_fogvol.c`).
- In `Quake/shaders/fogvol.frag` kept the existing `doLights` mutual exclusion but added an early froxel bypass: sample the froxel (`SampleFroxelLight(p)`), compute `froxelEnergy = max(r,g,b)` and if `FogFroxelEnabled != 0 && froxelEnergy <= 1e-4` skip the per-light loop to avoid unnecessary math; otherwise run the existing local-light accumulation path.  
- Updated `docs/fogvol_debug_notes.md` with a `Froxel lighting validation checklist` explaining how to enable/verify froxel injection, toggle `r_froxel_debug` modes, and sanity-check the `r_fogvol_froxel`/`r_fogvol_light` configuration.

### Testing
- Ran repository text checks (`rg`/`sed`/file inspection) to verify the inserted logic and new log text appears in the expected locations and updated docs include the checklist, which succeeded.  
- Attempted `make -j4` at repo root which failed because there is no top-level make target, which is expected for this repo layout.  
- Attempted `make -j4` inside `Quake/` to validate compilation of the modified C/shader files but the environment lacks SDL2 development headers/tools (`sdl2-config`, `SDL.h`), so a full build was not possible in this container; source-level diff and local textual checks were used to validate the changes instead.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa2ebce708832ead75fb908e555d68)