### PR TITLE
fogvol: gate froxel injection on r_fogvol_froxel

### DIFF
--- a/Quake/r_fogvol.c
+++ b/Quake/r_fogvol.c
@@ -1669,7 +1669,7 @@ static void R_FogVol_WarnFroxelLightingConfig (void)
 		return;
 	if (r_fogvol_froxel.value > 0.f && r_fogvol_light.value <= 0.f)
 	{
-		Con_Printf ("Warning: r_fogvol_froxel=1 while r_fogvol_light=0. Froxel injection is disabled in this mode and cannot provide performance wins.\n");
+		Con_Printf ("Warning: r_fogvol_froxel>0 requires r_fogvol_light>0 for froxel dlight injection; with r_fogvol_light<=0, froxel lighting is skipped.\n");
 		warned = true;
 	}
 }
@@ -2578,9 +2578,9 @@ void R_FogVol_Render (void)
 	int frame_candidate_count = 0;
 	qboolean has_fog_bounds = false;
 	const qboolean light_stats_enabled = r_fogvol_light_stats.value > 0.f;
-	const qboolean froxel_light_enabled = r_fogvol_light.value > 0.f;
-	const int froxel_dlight_count = froxel_light_enabled ? R_Froxel_CountInjectableDlights () : 0;
-	const qboolean run_froxel_injection = froxel_light_enabled && froxel_dlight_count > 0;
+	const qboolean froxel_injection_enabled = (r_fogvol_froxel.value > 0.f) && (r_fogvol_light.value > 0.f);
+	const int froxel_dlight_count = froxel_injection_enabled ? R_Froxel_CountInjectableDlights () : 0;
+	const qboolean run_froxel_injection = froxel_injection_enabled && froxel_dlight_count > 0;
 
 	R_FogVol_WarnFroxelLightingConfig ();
 


### PR DESCRIPTION
### Motivation
- Prevent froxel dlight injection from running when `r_fogvol_froxel` is disabled even if `r_fogvol_light` is set, making the runtime gating explicit and predictable.
- Ensure warning text and runtime predicates match actual behavior so users aren't misled about when froxel injection will run.

### Description
- Changed the runtime predicate in `R_FogVol_Render` to compute `froxel_injection_enabled` from both `r_fogvol_froxel.value > 0.f` and `r_fogvol_light.value > 0.f` and then derive `froxel_dlight_count` and `run_froxel_injection` from that predicate in `Quake/r_fogvol.c`.
- Kept the froxel pipeline calls `R_Froxel_BeginFrame`, `R_Froxel_InjectDlights`, and `R_Froxel_EndFrame` behind the corrected `run_froxel_injection` gate and preserved the else path that invalidates `r_froxel.valid` when injection is skipped.
- Updated `R_FogVol_WarnFroxelLightingConfig()` messaging to reflect the new gating semantics (`r_fogvol_froxel>0 requires r_fogvol_light>0`).
- Left `FOGVOL_U_FROXEL_ENABLED` behavior unchanged so it still reflects froxel resource validity via `(r_froxel.valid && r_froxel.light_tex)`.

### Testing
- Ran `rg -n "run_froxel_injection|R_Froxel_BeginFrame|R_Froxel_InjectDlights|R_Froxel_EndFrame|FOGVOL_U_FROXEL_ENABLED" Quake/r_fogvol.c` to verify the updated references, which succeeded.
- Inspected changes with `git diff -- Quake/r_fogvol.c`, which showed the predicate and warning text updates and succeeded.
- Verified repository state with `git status --short` and created the commit with `git commit -m "fogvol: gate froxel injection on r_fogvol_froxel"`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa902e8730832ebb51054f6b9dbd90)