### PR TITLE
fogvol: blend froxel and list lighting without disabling light sources

### DIFF
--- a/Quake/r_fogvol.c
+++ b/Quake/r_fogvol.c
@@ -192,6 +192,17 @@ cvar_t r_fogvol_sun_scatter = { "r_fogvol_sun_scatter", "0", CVAR_ARCHIVE };
 cvar_t r_fogvol_sun_color = { "r_fogvol_sun_color", "0 0 0", CVAR_ARCHIVE };
 cvar_t r_fogvol_froxel = { "r_fogvol_froxel", "0", CVAR_ARCHIVE };
 cvar_t r_fogvol_froxel_parity = { "r_fogvol_froxel_parity", "0", CVAR_ARCHIVE };
+/* Source weighting policy for local fog lighting contributions.
+ * - r_fogvol_froxel_scale controls FogFroxelLightTex contribution when enabled.
+ * - r_fogvol_lightlist_scale controls per-volume FogLights list contribution.
+ * - r_fogvol_lightgrid_scale controls baked/static FogLightgrid contribution.
+ *
+ * Default policy keeps baked/static lighting fully visible even with froxel enabled,
+ * while splitting local-light energy evenly between froxel and explicit local lists
+ * to avoid double-counting when both carry overlapping lights. */
+cvar_t r_fogvol_froxel_scale = { "r_fogvol_froxel_scale", "1", CVAR_ARCHIVE };
+cvar_t r_fogvol_lightlist_scale = { "r_fogvol_lightlist_scale", "1", CVAR_ARCHIVE };
+cvar_t r_fogvol_lightgrid_scale = { "r_fogvol_lightgrid_scale", "1", CVAR_ARCHIVE };
 /* r_froxel_debug: 0=off, 1=froxel rgb at first hit, 2=max-energy heat */
 cvar_t r_froxel_debug = { "r_froxel_debug", "0", CVAR_ARCHIVE };
 
@@ -260,6 +271,9 @@ static const fogvol_cvar_reg_t fogvol_cvar_table[] = {
 	{&r_fogvol_sun_color, "lighting", "0 0 0"},
 	{&r_fogvol_froxel, "lighting", "0"},
 	{&r_fogvol_froxel_parity, "lighting", "0"},
+	{&r_fogvol_froxel_scale, "lighting", "1"},
+	{&r_fogvol_lightlist_scale, "lighting", "1"},
+	{&r_fogvol_lightgrid_scale, "lighting", "1"},
 	{&r_froxel_debug, "debug", "0"},
 };
 
@@ -305,10 +319,11 @@ enum
 	FOGVOL_U_FROXEL_PARAMS1 = 36,
 	FOGVOL_U_FROXEL_DEBUG = 37,
 	FOGVOL_U_FROXEL_PARITY_MODE = 38,
-	FOGVOL_U_COUNT = 39
+	FOGVOL_U_LIGHT_SOURCE_SCALES = 39,
+	FOGVOL_U_COUNT = 40
 };
 
-COMPILE_TIME_ASSERT (fogvol_uniform_location_max, FOGVOL_U_FROXEL_PARITY_MODE == 38);
+COMPILE_TIME_ASSERT (fogvol_uniform_location_max, FOGVOL_U_LIGHT_SOURCE_SCALES == 39);
 
 typedef struct froxel_state_s
 {
@@ -2442,7 +2457,7 @@ static void R_FogVol_SetShaderUniforms (int steps, int mode, qboolean use_halfre
 	int shadow_samples;
 
 #if !defined(NDEBUG)
-	assert (FOGVOL_U_COUNT == 39);
+	assert (FOGVOL_U_COUNT == 40);
 	assert (glwidth > 0);
 	assert (glheight > 0);
 	assert (view_w > 0.f);
@@ -2526,6 +2541,19 @@ static void R_FogVol_SetShaderUniforms (int steps, int mode, qboolean use_halfre
 		(float)q_max (1, r_froxel.dims[0]), (float)q_max (1, r_froxel.dims[1]), (float)q_max (1, r_froxel.dims[2]));
 	GL_Uniform1iFunc (FOGVOL_U_FROXEL_DEBUG, CLAMP (0, (int)Q_rint (r_froxel_debug.value), 2));
 	GL_Uniform1iFunc (FOGVOL_U_FROXEL_PARITY_MODE, r_fogvol_froxel_parity.value > 0.f ? 1 : 0);
+	/* Lighting-source policy for fog shading in shaders/fogvol.frag:
+	 *   X (froxel): sampled from FogFroxelLightTex.
+	 *   Y (local list): per-volume FogLights UBO iteration.
+	 *   Z (lightgrid): baked/static contribution from FogLightgrid probes.
+	 *
+	 * Shader normalizes X+Y only when both local-light sources are active to
+	 * avoid double-counting overlapping local lights; Z is additive by design so
+	 * static light injection remains visible with r_fogvol_froxel 1 and
+	 * r_fogvol_light 1 unless explicitly scaled down by policy cvars. */
+	GL_Uniform3fFunc (FOGVOL_U_LIGHT_SOURCE_SCALES,
+		q_max (0.f, r_fogvol_froxel_scale.value),
+		q_max (0.f, r_fogvol_lightlist_scale.value),
+		q_max (0.f, r_fogvol_lightgrid_scale.value));
 }
 
 void R_FogVol_Render (void)

--- a/Quake/shaders/fogvol.frag
+++ b/Quake/shaders/fogvol.frag
@@ -123,6 +123,7 @@ layout(location=35) uniform vec4  FogFroxelParams0; // x near, y far, z tanHalfF
 layout(location=36) uniform vec4  FogFroxelParams1; // x log(far/near), yzw dims
 layout(location=37) uniform int   FogFroxelDebug;
 layout(location=38) uniform int   FogFroxelParityMode; // 0: froxel perf fast path, 1: legacy per-light parity path
+layout(location=39) uniform vec3  FogLightSourceScales; // x: froxel, y: local light list, z: lightgrid/static
 
 layout(location=0) out vec4 FragColor;
 
@@ -656,8 +657,10 @@ void main()
 	FogLightList lightList = FogLightLists[clamp(FogVolumeIndex, 0, MAX_FOGVOLUMES - 1)];
 	int lightOffset     = max(lightList.offset_count.x, 0);
 	int lightCount      = clamp(lightList.offset_count.y, 0, MAX_FOGLIGHTS);
-	bool  doLights      = (FogLightEnabled != 0) && ((FogFroxelEnabled != 0) || (lightCount > 0));
-	bool  doLightgrid   = (FogLightgridEnabled != 0);
+	bool  doFroxelLights = (FogLightEnabled != 0) && (FogFroxelEnabled != 0) && (FogFroxelParityMode == 0) && (FogLightSourceScales.x > 0.0);
+	bool  doListLights   = (FogLightEnabled != 0) && (lightCount > 0) && (FogLightSourceScales.y > 0.0);
+	bool  doLights       = doFroxelLights || doListLights;
+	bool  doLightgrid    = (FogLightgridEnabled != 0) && (FogLightSourceScales.z > 0.0);
 
 	// FIX #8: Removed stepsTaken / edgeFadeSum / earlyTerminated  they were
 	// accumulated but never consumed, silently wasting ALU every iteration.
@@ -734,7 +737,7 @@ void main()
 			// probe data; explicit fog volume emissive remains handled separately
 			// by FogEmissiveEnabled/volume.extra.z below.
 			vec3 staticScatter = SampleFogLightgrid(p, volume);
-			stepScatter += staticScatter * (FogDLightScale * (1.0 - att));
+			stepScatter += staticScatter * (FogDLightScale * FogLightSourceScales.z * (1.0 - att));
 		}
 
 		// Froxel local-light contribution can run as a fast path; debug outputs remain
@@ -745,15 +748,17 @@ void main()
 			vec3 lightScatter = lightScatterPrev;
 			if (FogLightSubsample == 0 || (i & 1) == 0)
 			{
-				if (FogFroxelEnabled != 0 && FogFroxelParityMode == 0)
+				vec3 froxelScatter = vec3(0.0);
+				vec3 localScatter = vec3(0.0);
+				if (doFroxelLights)
 				{
-					// Fast path: froxel lighting is mutually exclusive with per-light UBO iteration.
-					// Froxel stores local light energy in world space; no extra local phase term needed here.
-					lightScatter = SampleFroxelLight(p) * FogDLightScale;
+					// Froxel lighting is blended with the per-volume light list.
+					// We normalize by active source weight sum to avoid double-counting
+					// when both represent the same local lights.
+					froxelScatter = SampleFroxelLight(p) * (FogDLightScale * FogLightSourceScales.x);
 				}
-				else
+				if (doListLights)
 				{
-					lightScatter = vec3(0.0);
 					for (int l = 0; l < MAX_FOGLIGHTS; ++l)
 					{
 						if (l >= lightCount) break;
@@ -767,9 +772,19 @@ void main()
 						if (atten < 1e-5) continue;
 						vec3 lightDir = (lightDist > 1e-5) ? (lightVec / lightDist) : vec3(0.0);
 						float phaseLocal = AnisotropicPhase(clamp(dot(viewDir, lightDir), -1.0, 1.0), ANISO_G_LOCAL);
-						lightScatter += FogLights[lightIndex].col_int.rgb * (atten * 0.75 * FogDLightScale * phaseLocal);
+						localScatter += FogLights[lightIndex].col_int.rgb * (atten * 0.75 * FogDLightScale * phaseLocal);
 					}
+					localScatter *= FogLightSourceScales.y;
 				}
+				if (doFroxelLights && doListLights)
+				{
+					float denom = max(FogLightSourceScales.x + FogLightSourceScales.y, 1e-4);
+					lightScatter = (froxelScatter + localScatter) / denom;
+				}
+				else if (doFroxelLights)
+					lightScatter = froxelScatter;
+				else
+					lightScatter = localScatter;
 				lightScatterPrev = lightScatter;
 			}
 			stepScatter += lightScatter * (1.0 - att);


### PR DESCRIPTION
### Motivation
- Fix the hard mutual-exclusion where enabling froxel lighting disabled the per-volume light list and ensure baked/static lights remain visible when froxel and per-volume lighting are both enabled.
- Provide an explicit, tunable policy for how froxel, per-volume (list) and lightgrid/static contributions are weighted to avoid double-counting and let users tune visual balance.

### Description
- In `Quake/shaders/fogvol.frag` add a new uniform `FogLightSourceScales` and replace the single `doLights` mutual-exclusion with `doFroxelLights` and `doListLights`, blending froxel and list contributions and normalizing only when both local-light sources are active; the lightgrid/static contribution is left additive but scaled by `FogLightSourceScales.z`.
- In `Quake/r_fogvol.c` introduce policy CVars `r_fogvol_froxel_scale`, `r_fogvol_lightlist_scale`, and `r_fogvol_lightgrid_scale`, register them, update the fogvol uniform enum with `FOGVOL_U_LIGHT_SOURCE_SCALES`, and upload the new `FOGVOL_U_LIGHT_SOURCE_SCALES` uniform in `R_FogVol_SetShaderUniforms` together with a comment describing the expected shader behavior.
- Preserve static-light injection behavior: `R_FogVol_BuildStaticLightInjection` still produces `r_fog_static_lights` and those static lights continue to enter the candidate/local-list path (static/lightgrid remains additive so it stays visible by default).

### Testing
- Attempted an automated build with `make -C Quake -j4`, which exercised the compile step but the environment is missing SDL2 tooling/headers (`sdl2-config` / `SDL.h`), so a full binary build could not be completed in this environment.
- Performed static/code-path validation by grepping and inspecting the modified shader and CPU-side uniform upload to confirm `FogLightSourceScales` is declared, uploaded, and used to scale/blend froxel, list, and lightgrid contributions; these checks succeeded.
- Verified by inspection that `R_FogVol_BuildStaticLightInjection` still populates `r_fog_static_lights` and static lights are still added to the candidate list path, supporting the guarantee that static lights remain visible with `r_fogvol_froxel 1` and `r_fogvol_light 1` unless scaled down by the new policy CVars.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa91ada5e0832e89f57c4a35d3157f)