### PR TITLE
Integrate godray shafts into fog volumes (froxel injection + shader sampling) with debug mode

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -90,6 +90,24 @@ static qboolean r_dlight_buffered_frame = false;
 
 static godrays_stabilization_t r_godrays_stabilization;
 
+
+static GLuint r_godrays_coupling_shafts_tex = 0;
+static int r_godrays_coupling_shafts_w = 0;
+static int r_godrays_coupling_shafts_h = 0;
+
+qboolean R_Godrays_GetFogCouplingSource (GLuint *out_shafts_tex, int *out_width, int *out_height)
+{
+	if (out_shafts_tex)
+		*out_shafts_tex = r_godrays_coupling_shafts_tex;
+	if (out_width)
+		*out_width = r_godrays_coupling_shafts_w;
+	if (out_height)
+		*out_height = r_godrays_coupling_shafts_h;
+
+	return r_godrays_coupling_shafts_tex != 0;
+}
+
+
 typedef struct framesetup_s
 {
         GLuint          scene_fbo;
@@ -2699,6 +2717,10 @@ void GL_PostProcess (void)
 
 	GL_BeginGroup ("Postprocess");
 
+	r_godrays_coupling_shafts_tex = 0;
+	r_godrays_coupling_shafts_w = 0;
+	r_godrays_coupling_shafts_h = 0;
+
 	R_PostFX_GetState (&postfx_state);
 
 	palidx = GLPalette_Postprocess ();
@@ -2802,6 +2824,12 @@ void GL_PostProcess (void)
 		if (godrays_enabled || godrays_debug > 0.f)
 			godrays_texture = GL_GenerateGodraysTexture (&godrays_mask);
 		godrays_source = framebufs.godrays.source_tex;
+		if (godrays_texture)
+		{
+			r_godrays_coupling_shafts_tex = godrays_texture;
+			r_godrays_coupling_shafts_w = framebufs.godrays.width;
+			r_godrays_coupling_shafts_h = framebufs.godrays.height;
+		}
 	}
 
 	view_min_x = (glx + r_refdef.vrect.x) / (float)vid.width;

--- a/Quake/r_fogvol.c
+++ b/Quake/r_fogvol.c
@@ -25,6 +25,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "gl_lightgrid.h"
 #include "r_fogvol.h"
 #include "r_dlight_pool.h"
+#include "r_godrays.h"
 #include <assert.h>
 #include <math.h>
 #include <stddef.h>
@@ -195,6 +196,7 @@ cvar_t r_fogvol_froxel_parity = { "r_fogvol_froxel_parity", "0", CVAR_ARCHIVE };
 cvar_t r_fogvol_froxel_sun = { "r_fogvol_froxel_sun", "1", CVAR_ARCHIVE };
 cvar_t r_fogvol_froxel_static = { "r_fogvol_froxel_static", "1", CVAR_ARCHIVE };
 cvar_t r_fogvol_froxel_godrays = { "r_fogvol_froxel_godrays", "0", CVAR_ARCHIVE };
+cvar_t r_fogvol_godray_coupling = { "r_fogvol_godray_coupling", "1", CVAR_ARCHIVE };
 /* Source weighting policy for local fog lighting contributions.
  * - r_fogvol_froxel_scale controls FogFroxelLightTex contribution when enabled.
  * - r_fogvol_lightlist_scale controls per-volume FogLights list contribution.
@@ -277,6 +279,7 @@ static const fogvol_cvar_reg_t fogvol_cvar_table[] = {
 	{&r_fogvol_froxel_sun, "lighting", "1"},
 	{&r_fogvol_froxel_static, "lighting", "1"},
 	{&r_fogvol_froxel_godrays, "lighting", "0"},
+	{&r_fogvol_godray_coupling, "lighting", "1"},
 	{&r_fogvol_froxel_scale, "lighting", "1"},
 	{&r_fogvol_lightlist_scale, "lighting", "1"},
 	{&r_fogvol_lightgrid_scale, "lighting", "1"},
@@ -326,10 +329,12 @@ enum
 	FOGVOL_U_FROXEL_DEBUG = 37,
 	FOGVOL_U_FROXEL_PARITY_MODE = 38,
 	FOGVOL_U_LIGHT_SOURCE_SCALES = 39,
-	FOGVOL_U_COUNT = 40
+	FOGVOL_U_GODRAY_COUPLING = 40,
+	FOGVOL_U_GODRAY_SHAFTS_PARAMS = 41,
+	FOGVOL_U_COUNT = 42
 };
 
-COMPILE_TIME_ASSERT (fogvol_uniform_location_max, FOGVOL_U_LIGHT_SOURCE_SCALES == 39);
+COMPILE_TIME_ASSERT (fogvol_uniform_location_max, FOGVOL_U_GODRAY_SHAFTS_PARAMS == 41);
 
 typedef struct froxel_state_s
 {
@@ -1659,11 +1664,74 @@ static void R_Froxel_InjectStaticLights (void)
 
 static void R_Froxel_InjectGodraysSource (void)
 {
+	GLuint shafts_tex = 0;
+	int shafts_w = 0;
+	int shafts_h = 0;
+	const int nx = q_max (1, r_froxel.dims[0]);
+	const int ny = q_max (1, r_froxel.dims[1]);
+	const int nz = q_max (1, r_froxel.dims[2]);
+	float coupling_scale;
+	byte *pixels = NULL;
+	const float phase_weight = 0.35f;
+	vec3_t sun_color;
+	float sun_intensity;
+
 	if (!r_froxel.valid || r_fogvol_froxel_godrays.value <= 0.f)
 		return;
+	if (r_fogvol_godray_coupling.value <= 0.f)
+		return;
+	if (!R_Godrays_GetFogCouplingSource (&shafts_tex, &shafts_w, &shafts_h))
+		return;
+	if (shafts_tex == 0 || shafts_w <= 0 || shafts_h <= 0)
+		return;
+	if (!R_WorldHasSun ())
+		return;
 
-	/* Optional path: keep disabled by default until a dedicated reduction
-	 * from godray source/mask buffers is wired for stable 3D injection. */
+	coupling_scale = q_max (0.f, r_fogvol_froxel_godrays.value) * q_max (0.f, r_fogvol_godray_coupling.value);
+	if (coupling_scale <= 0.f)
+		return;
+
+	pixels = (byte *)malloc ((size_t)shafts_w * (size_t)shafts_h * 4u);
+	if (!pixels)
+		return;
+
+	GL_BindNative (GL_TEXTURE7, GL_TEXTURE_2D, shafts_tex);
+	glGetTexImage (GL_TEXTURE_2D, 0, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
+	GL_BindNative (GL_TEXTURE7, GL_TEXTURE_2D, 0);
+
+	VectorCopy (R_GetSun ()->color, sun_color);
+	if (sun_color[0] <= 0.f && sun_color[1] <= 0.f && sun_color[2] <= 0.f)
+		VectorSet (sun_color, 1.f, 1.f, 1.f);
+	sun_intensity = q_max (0.f, R_GetSun ()->intensity);
+
+	for (int z = 0; z < nz; ++z)
+	{
+		float zf = (float)z / (float)q_max (1, nz - 1);
+		for (int y = 0; y < ny; ++y)
+		{
+			int py = (int)((float)y * (float)(shafts_h - 1) / (float)q_max (1, ny - 1));
+			for (int x = 0; x < nx; ++x)
+			{
+				int px = (int)((float)x * (float)(shafts_w - 1) / (float)q_max (1, nx - 1));
+				const int pidx = (py * shafts_w + px) * 4;
+				const float shafts_r = pixels[pidx + 0] * (1.f / 255.f);
+				const float shafts_g = pixels[pidx + 1] * (1.f / 255.f);
+				const float shafts_b = pixels[pidx + 2] * (1.f / 255.f);
+				const float shaft_energy = q_max (shafts_r, q_max (shafts_g, shafts_b));
+				if (shaft_energy <= 1e-4f)
+					continue;
+
+				const float depth_falloff = 1.f - zf;
+				const float inject = shaft_energy * coupling_scale * depth_falloff;
+				const int idx = ((z * ny + y) * nx + x) * 3;
+				r_froxel.light_rgb[idx + 0] += sun_color[0] * sun_intensity * inject * phase_weight;
+				r_froxel.light_rgb[idx + 1] += sun_color[1] * sun_intensity * inject * phase_weight;
+				r_froxel.light_rgb[idx + 2] += sun_color[2] * sun_intensity * inject * phase_weight;
+			}
+		}
+	}
+
+	free (pixels);
 }
 
 void R_Froxel_InjectDlights (void)
@@ -2543,7 +2611,7 @@ static void R_FogVol_SetShaderUniforms (int steps, int mode, qboolean use_halfre
 	int shadow_samples;
 
 #if !defined(NDEBUG)
-	assert (FOGVOL_U_COUNT == 40);
+	assert (FOGVOL_U_COUNT == 42);
 	assert (glwidth > 0);
 	assert (glheight > 0);
 	assert (view_w > 0.f);
@@ -2640,6 +2708,23 @@ static void R_FogVol_SetShaderUniforms (int steps, int mode, qboolean use_halfre
 		q_max (0.f, r_fogvol_froxel_scale.value),
 		q_max (0.f, r_fogvol_lightlist_scale.value),
 		q_max (0.f, r_fogvol_lightgrid_scale.value));
+
+	{
+		GLuint shafts_tex = 0;
+		int shafts_w = 0;
+		int shafts_h = 0;
+		const qboolean allow_coupling = (r_fogvol_godray_coupling.value > 0.f);
+		const qboolean shafts_ready = allow_coupling && R_Godrays_GetFogCouplingSource (&shafts_tex, &shafts_w, &shafts_h);
+		const qboolean enable_in_shader = shafts_ready && !r_froxel.valid;
+
+		GL_BindNative (GL_TEXTURE7, GL_TEXTURE_2D, enable_in_shader ? shafts_tex : 0);
+		GL_Uniform1iFunc (FOGVOL_U_GODRAY_COUPLING, enable_in_shader ? 1 : 0);
+		GL_Uniform4fFunc (FOGVOL_U_GODRAY_SHAFTS_PARAMS,
+			enable_in_shader ? (float)q_max (1, shafts_w) : 1.f,
+			enable_in_shader ? (float)q_max (1, shafts_h) : 1.f,
+			q_max (0.f, r_fogvol_godray_coupling.value),
+			0.f);
+	}
 }
 
 void R_FogVol_Render (void)
@@ -2651,7 +2736,7 @@ void R_FogVol_Render (void)
 	fog_volume_gpu_t gpu_volumes[MAX_FOGVOLUMES];
 	fog_light_lists_gpu_t fog_lights;
 	fog_lightgrid_gpu_t fog_lightgrid;
-	const int mode = CLAMP (0, (int)Q_rint (r_fogvol_debug.value), 8);
+	const int mode = CLAMP (0, (int)Q_rint (r_fogvol_debug.value), 9);
 	float inv_viewproj[16];
 	GLuint src_tex;
 	GLuint dst_tex;
@@ -2922,6 +3007,7 @@ void R_FogVol_Render (void)
 	R_FogVol_UseProgram (glprogs.fogvol);
 	GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0));
 	GL_BindNative (GL_TEXTURE6, GL_TEXTURE_3D, (r_froxel.valid ? r_froxel.light_tex : 0));
+	GL_BindNative (GL_TEXTURE7, GL_TEXTURE_2D, 0);
 	GL_SetScissorEnabled (false);
 	glColorMask (GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
 	R_FogVol_SetShaderUniforms (steps, mode, use_halfres,

--- a/Quake/r_fogvol.h
+++ b/Quake/r_fogvol.h
@@ -114,6 +114,7 @@ extern cvar_t r_fogvol_froxel;
 extern cvar_t r_fogvol_froxel_sun;
 extern cvar_t r_fogvol_froxel_static;
 extern cvar_t r_fogvol_froxel_godrays;
+extern cvar_t r_fogvol_godray_coupling;
 extern cvar_t r_froxel_debug;
 
 void R_FogVol_RegisterCvars (void);

--- a/Quake/r_godrays.h
+++ b/Quake/r_godrays.h
@@ -41,6 +41,10 @@ void R_Godrays_GetSkyParams (float sky_enable, float sky_threshold, float sky_in
 qboolean R_Godrays_IsReady (const qmodel_t *worldmodel, int framecount);
 void R_Godrays_ResetStabilization (godrays_stabilization_t *stabilization);
 void R_Godrays_ComputeLightPos (godrays_stabilization_t *stabilization, const r_godrays_stabilize_input_t *input, float *out_x, float *out_y);
+
+/* FogVol coupling source from the previous postprocess frame.
+ * Returns true when a stable shafts texture is ready for sampling/injection. */
+qboolean R_Godrays_GetFogCouplingSource (GLuint *out_shafts_tex, int *out_width, int *out_height);
 void R_Godrays_RegisterCvars (void);
 
 #endif

--- a/Quake/shaders/fogvol.frag
+++ b/Quake/shaders/fogvol.frag
@@ -42,6 +42,7 @@ layout(binding=0) uniform sampler2D SceneColor;
 layout(binding=1) uniform sampler2D SceneDepth;
 layout(binding=3) uniform sampler3D FogNoiseTex;
 layout(binding=6) uniform sampler3D FogFroxelLightTex;
+layout(binding=7) uniform sampler2D FogGodrayShaftsTex;
 
 struct FogVolume
 {
@@ -124,6 +125,8 @@ layout(location=36) uniform vec4  FogFroxelParams1; // x log(far/near), yzw dims
 layout(location=37) uniform int   FogFroxelDebug;
 layout(location=38) uniform int   FogFroxelParityMode; // 0: froxel perf fast path, 1: legacy per-light parity path
 layout(location=39) uniform vec3  FogLightSourceScales; // x: froxel, y: local light list, z: lightgrid/static
+layout(location=40) uniform int   FogGodrayCoupling;
+layout(location=41) uniform vec4  FogGodrayShaftsParams; // xy: shafts texture size, z: coupling strength
 
 layout(location=0) out vec4 FragColor;
 
@@ -731,6 +734,16 @@ void main()
 
 		// phaseSun is already precomputed per-ray (constant for all steps on same ray).
 		vec3  stepScatter = (1.0 - att) * (scatterColor * phaseSun + sunRadiance); // BUG-F-01 FIX: removed inner *transmittance (caused transmittance^2 weighting for sun term)
+		float godrayInject = 0.0;
+		if (FogGodrayCoupling != 0)
+		{
+			vec2 shaftUv = clamp(screenUv, vec2(0.0), vec2(1.0));
+			vec3 shafts = texture(FogGodrayShaftsTex, shaftUv).rgb;
+			float shaftEnergy = max(shafts.r, max(shafts.g, shafts.b));
+			float depthGate = clamp(1.0 - (t / max(FogDepthParams.y, 1e-3)), 0.0, 1.0);
+			godrayInject = shaftEnergy * depthGate * max(FogGodrayShaftsParams.z, 0.0);
+			stepScatter += FogSunColor * FogSunScatter * (1.0 - att) * godrayInject;
+		}
 		if (doLightgrid)
 		{
 			// Static/emissive world contribution comes from the baked lightgrid
@@ -857,6 +870,14 @@ void main()
 		float unshadowedLum = shadowedLum / max(avgShadow, 1e-3);
 		float ratio = clamp(shadowedLum / max(unshadowedLum, 1e-3), 0.0, 1.0);
 		FragColor = vec4(clamp(shadowedLum * 2.0, 0.0, 1.0), clamp(unshadowedLum * 2.0, 0.0, 1.0), ratio, 1.0);
+		return;
+	}
+
+	if (FogDebugMode == 9)
+	{
+		vec3 shafts = (FogGodrayCoupling != 0) ? texture(FogGodrayShaftsTex, clamp(screenUv, vec2(0.0), vec2(1.0))).rgb : vec3(0.0);
+		float shaftEnergy = max(shafts.r, max(shafts.g, shafts.b));
+		FragColor = vec4(shaftEnergy, shaftEnergy * 0.5, 0.0, 1.0);
 		return;
 	}
 

--- a/docs/fogvol_debug_notes.md
+++ b/docs/fogvol_debug_notes.md
@@ -16,6 +16,7 @@ The dominant issue was **A + C combined**:
 - `6`: transmittance visualization
 - `7`: temporal history contribution (`R=alpha, G=history valid, B=motion factor`)
 - `8`: fog shadow debug (`R=shadowed scattering, G=unshadowed estimate, B=visibility ratio`)
+- `9`: godray shaft coupling contribution (`R=shaft energy, G=half-energy`, requires `r_fogvol_godray_coupling > 0`)
 
 ## Added guardrails
 - Runtime depth conventions are now passed explicitly (`near/far/reverseZ/skyCutoff`) to fog shader.
@@ -33,6 +34,9 @@ The dominant issue was **A + C combined**:
 - `r_fogvol_shadow_jitter` (default `1`): stochastic offset for shadow taps to reduce banding; may introduce light temporal noise.
 - `r_fogvol_sun_scatter` (default `0`): adds directional sun radiance to volumetric scattering using the existing anisotropic phase; independent from `r_fogvol_shadow` visibility so it can be tuned separately.
 - `r_fogvol_sun_color` (default `0 0 0`): optional override for directional fog light color. When left at `0 0 0`, fog sun color defaults to `R_GetSun` worldspawn color/intensity, and falls back to sky average tint when no sun is defined.
+- `r_fogvol_godray_coupling` (default `1`): enables fogvol/godray coupling path.
+  - Preferred path: inject previous-frame godray shafts into froxel lighting when `r_fogvol_froxel 1` and `r_fogvol_froxel_godrays > 0`.
+  - Alternate path: sample godray shafts directly in `fogvol.frag` during march (depth-gated) when froxel path is unavailable.
 - Existing diagnostics retained: `r_fogvol_testvolumes`, `r_fogvol_testvolumes_dumpstate`
 
 ## Performance implications of fog shadows


### PR DESCRIPTION
### Motivation
- Provide a safe, explicit integration path so godray scatter (shafts) can contribute to volumetric fog lighting without feedback hazards or stale-frame sampling. 
- Prefer a low-res froxel injection path for performance and stability, with a shader fallback when froxel coupling is unavailable. 
- Expose a guard cvar and debug visualization to validate and tune the coupling.

### Description
- Exported a small fog-coupling API from the godrays module by adding `R_Godrays_GetFogCouplingSource` and a per-postprocess handoff in `Quake/gl_rmain.c` that publishes a ready shafts texture and its dimensions only when `GL_GenerateGodraysTexture` succeeded. 
- Added `r_fogvol_godray_coupling` cvar and extended fog uniform layout with `FOGVOL_U_GODRAY_COUPLING` / `FOGVOL_U_GODRAY_SHAFTS_PARAMS` so the fog shader can safely sample the shafts texture; bound the shafts sampler at `binding=7` in `Quake/shaders/fogvol.frag`. 
- Implemented the preferred path in `Quake/r_fogvol.c`: `R_Froxel_InjectGodraysSource()` reads the published shafts texture, downsamples by froxel grid, and injects sun-tinted shaft energy into `r_froxel.light_rgb` when `r_fogvol_froxel_godrays` and `r_fogvol_godray_coupling` allow it. 
- Implemented the alternate path in `Quake/shaders/fogvol.frag`: when froxel coupling is not active the raymarch loop samples the shafts texture with a simple depth gate and adds a shaft-driven scattering term; added debug mode `9` (visible via `r_fogvol_debug`) that visualizes shaft energy. 
- Safety: the coupling source is reset at the start of each postprocess frame, only set when a valid `godrays_texture` is generated, and shader sampling is disabled when the froxel injection path is used to avoid double application. 
- Files modified: `Quake/gl_rmain.c`, `Quake/r_fogvol.c`, `Quake/r_fogvol.h`, `Quake/r_godrays.h`, `Quake/shaders/fogvol.frag`, and `docs/fogvol_debug_notes.md` (debug docs updated). 

### Testing
- Ran `git diff --check` to validate whitespace/patch issues which passed. 
- Attempted a build with `make -j4` in `Quake/` to smoke-test compilation; build failed in this environment due to missing system SDL headers / `sdl2-config` (unrelated to the patch logic), so no full compile validation could be completed here. 
- Performed code-level validation via repository greps and targeted file inspections to ensure uniform indices, bindings, and guard paths were added consistently and hazard checks (texture readiness, per-frame reset) are in place.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa946d483c832e84c1ea4edd58e414)