### PR TITLE
Precompute godray shaft sample before volumetric raymarch loop

### DIFF
--- a/Quake/shaders/fogvol.frag
+++ b/Quake/shaders/fogvol.frag
@@ -715,6 +715,15 @@ void main()
 	}
 
 	int adaptiveSteps = int(stepCount); // adaptive, already capped at FogSteps
+	bool doGodrayCoupling = (FogGodrayCoupling != 0);
+	float shaftEnergyPre = 0.0;
+	if (doGodrayCoupling)
+	{
+		// Safe to precompute once: shaftUv depends only on screenUv, which is constant per pixel.
+		vec2 shaftUv = clamp(screenUv, vec2(0.0), vec2(1.0));
+		vec3 shafts = texture(FogGodrayShaftsTex, shaftUv).rgb;
+		shaftEnergyPre = max(shafts.r, max(shafts.g, shafts.b)) * max(FogGodrayShaftsParams.w, 0.0);
+	}
 	float sigmaEvenPrev = 0.0;
 	vec3 lightScatterPrev = vec3(0.0);
 	for (int i = 0; i < FogSteps; ++i)
@@ -755,13 +764,10 @@ void main()
 		// phaseSun is already precomputed per-ray (constant for all steps on same ray).
 		vec3  stepScatter = (1.0 - att) * (scatterColor * phaseSun + sunRadiance); // BUG-F-01 FIX: removed inner *transmittance (caused transmittance^2 weighting for sun term)
 		float godrayInject = 0.0;
-		if (FogGodrayCoupling != 0)
+		if (doGodrayCoupling)
 		{
-			vec2 shaftUv = clamp(screenUv, vec2(0.0), vec2(1.0));
-			vec3 shafts = texture(FogGodrayShaftsTex, shaftUv).rgb;
-			float shaftEnergy = max(shafts.r, max(shafts.g, shafts.b)) * max(FogGodrayShaftsParams.w, 0.0);
 			float depthGate = clamp(1.0 - (t / max(FogDepthParams.y, 1e-3)), 0.0, 1.0);
-			godrayInject = shaftEnergy * depthGate * max(FogGodrayShaftsParams.z, 0.0);
+			godrayInject = shaftEnergyPre * depthGate * max(FogGodrayShaftsParams.z, 0.0);
 			stepScatter += FogSunColor * FogSunScatter * (1.0 - att) * godrayInject;
 		}
 		if (doLightgrid)


### PR DESCRIPTION
### Motivation
- Reduce per-step cost in the volumetric fog raymarch loop by moving the expensive fog godray shaft texture sample out of the inner `for (i < FogSteps)` loop while preserving identical visual behavior.

### Description
- Added a per-pixel precomputation guarded by `doGodrayCoupling` that computes `shaftEnergyPre` from `texture(FogGodrayShaftsTex, clamp(screenUv, ...))` and scales it by `FogGodrayShaftsParams.w` once before the march loop, with a shader comment explaining safety because `screenUv` is constant per pixel; kept `FogGodrayShaftsParams.z`/`.w` semantics intact.
- Replaced the per-step texture fetch with depth-dependent gating/scaling that multiplies the precomputed `shaftEnergyPre` by the depth gate inside the loop (no behavioral change to the injection math).
- Left debug visualization `FogDebugMode == 9` unchanged so it still shows the direct shafts sample for debugging.

### Testing
- Inspected the patch and resulting file with `git diff -- Quake/shaders/fogvol.frag` which succeeded; the inserted precompute is present as expected. 
- Verified the modified code region with `nl -ba Quake/shaders/fogvol.frag | sed -n '706,782p'` and the debug path with `nl -ba Quake/shaders/fogvol.frag | sed -n '900,918p'`, both of which succeeded. 
- Committed the change with `git commit -m "Optimize fog godray shaft sampling in raymarch loop"` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aacf9c4800832e911bf86b551b0bbb)