### PR TITLE
fogvol: add optional per-light occlusion (cheap depth test + cone trace)

### DIFF
--- a/Quake/r_fogvol.c
+++ b/Quake/r_fogvol.c
@@ -212,6 +212,11 @@ cvar_t r_fogvol_shadow = { "r_fogvol_shadow", "1", CVAR_ARCHIVE };
 cvar_t r_fogvol_shadow_samples = { "r_fogvol_shadow_samples", "2", CVAR_ARCHIVE };
 cvar_t r_fogvol_shadow_strength = { "r_fogvol_shadow_strength", "0.8", CVAR_ARCHIVE };
 cvar_t r_fogvol_shadow_jitter = { "r_fogvol_shadow_jitter", "1", CVAR_ARCHIVE };
+/* Per-local-light occlusion term in fogvol.frag:
+ * 0=off, 1=cheap signed depth test along light ray, 2=multi-tap depth cone trace.
+ * Mode 2 is automatically downgraded to mode 1 when shadow marching is disabled
+ * because there is no additional shadow context to justify the extra taps. */
+cvar_t r_fogvol_local_occlusion = { "r_fogvol_local_occlusion", "0", CVAR_ARCHIVE };
 cvar_t r_fogvol_sun_dir = { "r_fogvol_sun_dir", "1", CVAR_ARCHIVE };
 cvar_t r_fogvol_sun_scatter = { "r_fogvol_sun_scatter", "0", CVAR_ARCHIVE };
 cvar_t r_fogvol_sun_color = { "r_fogvol_sun_color", "0 0 0", CVAR_ARCHIVE };
@@ -304,6 +309,7 @@ static const fogvol_cvar_reg_t fogvol_cvar_table[] = {
 	{&r_fogvol_shadow_samples, "lighting", "2"},
 	{&r_fogvol_shadow_strength, "lighting", "0.8"},
 	{&r_fogvol_shadow_jitter, "lighting", "1"},
+	{&r_fogvol_local_occlusion, "lighting", "0"},
 	{&r_fogvol_sun_dir, "lighting", "1"},
 	{&r_fogvol_sun_scatter, "lighting", "0"},
 	{&r_fogvol_sun_color, "lighting", "0 0 0"},
@@ -374,10 +380,12 @@ enum
 	FOGVOL_U_GODRAY_COUPLING = 41,
 	FOGVOL_U_GODRAY_SHAFTS_PARAMS = 42,
 	FOGVOL_U_FROXEL_TEMPORAL_PARAMS = 43,
-	FOGVOL_U_COUNT = 44
+	FOGVOL_U_LOCAL_OCCLUSION_MODE = 44,
+	FOGVOL_U_LOCAL_OCCLUSION_PARAMS = 45,
+	FOGVOL_U_COUNT = 46
 };
 
-COMPILE_TIME_ASSERT (fogvol_uniform_location_max, FOGVOL_U_FROXEL_TEMPORAL_PARAMS == 43);
+COMPILE_TIME_ASSERT (fogvol_uniform_location_max, FOGVOL_U_LOCAL_OCCLUSION_PARAMS == 45);
 
 typedef struct froxel_state_s
 {
@@ -3082,7 +3090,7 @@ static void R_FogVol_SetShaderUniforms (int steps, int mode, qboolean use_halfre
 	int shadow_samples;
 
 #if !defined(NDEBUG)
-	assert (FOGVOL_U_COUNT == 44);
+	assert (FOGVOL_U_COUNT == 46);
 	assert (glwidth > 0);
 	assert (glheight > 0);
 	assert (view_w > 0.f);
@@ -3188,7 +3196,24 @@ static void R_FogVol_SetShaderUniforms (int steps, int mode, qboolean use_halfre
 		q_max (0.f, r_fogvol_froxel_scale.value),
 		q_max (0.f, r_fogvol_lightlist_scale.value),
 		q_max (0.f, r_fogvol_lightgrid_scale.value));
-	GL_Uniform1iFunc (FOGVOL_U_LIGHTING_MODE, (int)R_FogVol_LightingMode ());
+	{
+		const fogvol_lighting_mode_t lighting_mode = R_FogVol_LightingMode ();
+		int local_occlusion_mode = CLAMP (0, (int)Q_rint (r_fogvol_local_occlusion.value), 2);
+
+		/* Local-light occlusion only applies when the shader evaluates explicit
+		 * FogLights list contribution (lighting_mode 1 or 3). Make this explicit
+		 * in CPU-side uniform plumbing so mode interactions are deterministic. */
+		if (!(lighting_mode == FOGVOL_LIGHTING_RAYMARCH || lighting_mode == FOGVOL_LIGHTING_FROXEL_PLUS_DETAIL))
+			local_occlusion_mode = 0;
+		if (local_occlusion_mode >= 2 && r_fogvol_shadow.value <= 0.f)
+			local_occlusion_mode = 1;
+
+		GL_Uniform1iFunc (FOGVOL_U_LIGHTING_MODE, (int)lighting_mode);
+		GL_Uniform1iFunc (FOGVOL_U_LOCAL_OCCLUSION_MODE, local_occlusion_mode);
+		/* x: depth-thickness tolerance in world units, y: cone radius scale,
+		 * z: max trace distance scale (relative to light distance), w: reserved. */
+		GL_Uniform4fFunc (FOGVOL_U_LOCAL_OCCLUSION_PARAMS, 8.f, 0.035f, 1.f, 0.f);
+	}
 
 	{
 		GLuint shafts_tex = 0;

--- a/Quake/shaders/fogvol.frag
+++ b/Quake/shaders/fogvol.frag
@@ -129,6 +129,8 @@ layout(location=40) uniform int   FogLightingMode; // 0=off, 1=raymarch, 2=froxe
 layout(location=41) uniform int   FogGodrayCoupling;
 layout(location=42) uniform vec4  FogGodrayShaftsParams; // xy: shafts texture size, z: coupling strength, w: froxel godray scale
 layout(location=43) uniform vec4  FogFroxelTemporalParams; // x: alpha, y: reject threshold, z: camera delta, w: prev valid
+layout(location=44) uniform int   FogLocalOcclusionMode; // 0=off, 1=cheap signed depth test, 2=multi-tap depth cone trace
+layout(location=45) uniform vec4  FogLocalOcclusionParams; // x depth thickness, y cone scale, z max dist scale, w reserved
 
 layout(location=0) out vec4 FragColor;
 
@@ -256,6 +258,64 @@ bool IsSkyDepth(float depth)
 
 // FIX #4: Accept viewUv so the NDC x/y is correct for every pixel, not just
 // the screen centre.  Original had clip.xy hardcoded to (0,0).
+float LinearEyeDepth(float depth, vec2 viewUv);
+
+vec2 ScreenUvToViewUv(vec2 screenUv)
+{
+	vec2 screenPos = screenUv * FogViewportParams.xy;
+	return (screenPos - FogViewParams.xy) * FogViewParams.zw;
+}
+
+vec2 ProjectWorldToScreenUv(vec3 worldPos)
+{
+	vec4 clip = ViewProj * vec4(worldPos, 1.0);
+	if (abs(clip.w) < 1e-6)
+		return vec2(-1.0);
+	vec2 ndc = clip.xy / clip.w;
+	return ndc * 0.5 + 0.5;
+}
+
+float LocalLightOcclusionTap(vec3 probePos, float probeViewDist, float thickness)
+{
+	vec2 uv = ProjectWorldToScreenUv(probePos);
+	if (uv.x <= 0.0 || uv.x >= 1.0 || uv.y <= 0.0 || uv.y >= 1.0)
+		return 1.0;
+	float depth = texture(SceneDepth, uv).r;
+	if (IsSkyDepth(depth))
+		return 1.0;
+	float sceneViewDist = LinearEyeDepth(depth, ScreenUvToViewUv(uv));
+	return (sceneViewDist + thickness >= probeViewDist) ? 1.0 : 0.0;
+}
+
+float EstimateLocalLightOcclusion(vec3 samplePos, vec3 lightPos, float lightDist)
+{
+	if (FogLocalOcclusionMode <= 0 || lightDist <= 1e-3)
+		return 1.0;
+
+	vec3 dir = (lightPos - samplePos) / lightDist;
+	float maxDist = lightDist * max(FogLocalOcclusionParams.z, 0.0);
+	if (FogLocalOcclusionMode == 1)
+	{
+		float t = min(maxDist, lightDist * 0.6);
+		vec3 probePos = samplePos + dir * t;
+		float probeViewDist = length(probePos - FogCameraPosWS);
+		return LocalLightOcclusionTap(probePos, probeViewDist, max(FogLocalOcclusionParams.x, 0.0));
+	}
+
+	float vis = 1.0;
+	const int kTapCount = 4;
+	for (int s = 0; s < kTapCount; ++s)
+	{
+		float t = min(maxDist, lightDist * (float(s + 1) / float(kTapCount + 1)));
+		vec3 probePos = samplePos + dir * t;
+		float probeViewDist = length(probePos - FogCameraPosWS);
+		float cone = max(FogLocalOcclusionParams.y, 0.0) * t;
+		float thickness = max(FogLocalOcclusionParams.x, 0.0) + cone;
+		vis *= LocalLightOcclusionTap(probePos, probeViewDist, thickness);
+	}
+	return vis;
+}
+
 float LinearEyeDepth(float depth, vec2 viewUv)
 {
 	float ndcDepth = DepthToNdcZ(depth);
@@ -811,7 +871,8 @@ void main()
 						if (atten < 1e-5) continue;
 						vec3 lightDir = (lightDist > 1e-5) ? (lightVec / lightDist) : vec3(0.0);
 						float phaseLocal = AnisotropicPhase(clamp(dot(viewDir, lightDir), -1.0, 1.0), ANISO_G_LOCAL);
-						localScatter += FogLights[lightIndex].col_int.rgb * (atten * 0.75 * FogDLightScale * phaseLocal);
+						float localOcclusion = EstimateLocalLightOcclusion(p, FogLights[lightIndex].pos_rad.xyz, lightDist);
+						localScatter += FogLights[lightIndex].col_int.rgb * (atten * 0.75 * FogDLightScale * phaseLocal * localOcclusion);
 					}
 					localScatter *= FogLightSourceScales.y;
 					if (doListLightsDetail)

--- a/docs/fogvol_debug_notes.md
+++ b/docs/fogvol_debug_notes.md
@@ -34,6 +34,14 @@ The dominant issue was **A + C combined**:
 - `r_fogvol_shadow_jitter` (default `1`): stochastic offset for shadow taps to reduce banding; may introduce light temporal noise.
 - `r_fogvol_sun_scatter` (default `0`): adds directional sun radiance to volumetric scattering using the existing anisotropic phase; independent from `r_fogvol_shadow` visibility so it can be tuned separately.
 - `r_fogvol_sun_color` (default `0 0 0`): optional override for directional fog light color. When left at `0 0 0`, fog sun color defaults to `R_GetSun` worldspawn color/intensity, and falls back to sky average tint when no sun is defined.
+- `r_fogvol_local_occlusion` (default `0`): optional per-local-light fog occlusion term for light-list shading (`FogLights` loop in `fogvol.frag`).
+  - `0`: disabled (legacy behavior, fastest).
+  - `1`: cheap signed depth test (single projected depth probe along sample→light ray).
+  - `2`: multi-tap depth cone trace (higher quality, higher cost).
+  - Interaction with `r_fogvol_lighting_mode` is explicit in CPU uniform setup:
+    - Active only when local light-list shading runs (`mode 1` raymarch or `mode 3` froxel+detail).
+    - Forced to `0` in pure froxel mode (`mode 2`) and lighting off (`mode 0`).
+    - Mode `2` is downgraded to mode `1` when `r_fogvol_shadow 0`.
 - `r_fogvol_godray_coupling` (default `1`): enables fogvol/godray coupling path.
   - Preferred path: inject previous-frame godray shafts into froxel lighting when `r_fogvol_froxel 1` and `r_fogvol_froxel_godrays > 0`.
   - Alternate path: sample godray shafts directly in `fogvol.frag` during march (depth-gated) when froxel path is unavailable.
@@ -58,3 +66,9 @@ The dominant issue was **A + C combined**:
    - If mode 1/2 shows little-to-no signal and counters stay near zero, froxel acceleration will not help in that scene.
 5. Verify configuration sanity:
    - If `r_fogvol_froxel=1` while `r_fogvol_light=0`, froxel injection is intentionally skipped and cannot provide performance wins.
+
+## Local-light occlusion quality/performance trade-offs
+- `r_fogvol_local_occlusion 0`: no added depth work in local-light path; use as baseline for perf captures.
+- `r_fogvol_local_occlusion 1`: adds one depth sample + one depth reconstruction per contributing light at each marched fog step. This is the recommended low-cost default when you need basic blocker awareness near geometry edges.
+- `r_fogvol_local_occlusion 2`: adds multiple projected depth taps per contributing light for a cone-like blocker test. This reduces false positives/negatives from a single depth sample, but cost scales with both light count and fog step count; reserve for capture-quality settings or scenes with few active local lights.
+- Since cost multiplies with local light-list evaluation, prefer `r_fogvol_lighting_mode 2` (pure froxel) for performance-sensitive gameplay and use modes `1`/`3` when local occlusion detail is important.


### PR DESCRIPTION
### Motivation
- Reduce obvious false lighting from local per-volume lights by giving the FogLights loop an optional per-light occlusion term that can cheaply detect blockers in screen-space and optionally use a higher-quality cone trace when shadow data exists. 
- Provide a tunable, explicit interaction with the existing `r_fogvol_lighting_mode` so quality/perf trade-offs are deterministic.

### Description
- Introduce a new cvar `r_fogvol_local_occlusion` (`0=off`, `1=cheap signed depth test`, `2=multi-tap depth cone trace`) and register it in the fogvol cvar table in `Quake/r_fogvol.c`.
- Add two new shader uniforms (`FogLocalOcclusionMode` and `FogLocalOcclusionParams`) and grow the fogvol uniform enum/count to accommodate them, with CPU plumbing in `R_FogVol_SetShaderUniforms` that clamps and explicitly gates the occlusion mode based on `R_FogVol_LightingMode()` and `r_fogvol_shadow`.
- Extend `Quake/shaders/fogvol.frag` with helper functions and an estimator: a single projected depth probe path (cheap) and a multi-tap cone-style trace (higher quality) that sample `SceneDepth` and use `LinearEyeDepth` to compare scene depth vs probe depth; apply the resulting occlusion multiplier inside the `FogLights` loop when accumulating `localScatter`.
- Update `docs/fogvol_debug_notes.md` to describe the new cvar, expected mode interactions with `r_fogvol_lighting_mode`, and quality/performance trade-offs for modes 0/1/2.

### Testing
- Ran repository checks: `git diff --check` succeeded with no whitespace errors.
- Performed source-level validation: grepped/inspected the modified shader/uniform plumbing and confirmed `EstimateLocalLightOcclusion` is invoked in the `FogLights` loop and new uniforms are set in `R_FogVol_SetShaderUniforms`.
- Attempted a local build invocation (`cmake --build build -j2`) but no `build/` directory exists in this environment, so no compile-time shader+binary validation was performed.
- Changes were committed (`fogvol: add optional local-light occlusion modes`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aaddf134d4832e8f8cffaffa38517e)