### PR TITLE
Update docs to match current engine shader, SSAO, and async systems

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,21 @@
+# Ironwail docs index
+
+This directory tracks engine-facing implementation notes and feature references.
+
+## Current runtime feature docs
+- `EMISSIVE_MAPS.md` — emissive/glow map naming and behavior.
+- `async_threading.md` — async worker model and controlling CVars.
+- `bspx_lumps.md` — BSPX lump handling status.
+- `how2use-q3-shaders.md` — current material shader workflow/API (legacy filename).
+- `shadow_mapping.md` — shadow mapping runtime behavior and tuning CVars.
+- `ssao.md` — SSAO conventions, debug modes, and controls.
+
+## Design/debug notes
+- `fogvol_debug_notes.md`
+- `particle_debug_mvp.md`
+- `particle_shader_contract.md`
+- `q3p_phase0_particle_mapping.md`
+
+The design/debug notes are intentionally implementation-oriented snapshots. They
+may describe rollout phases, experiments, or diagnostics rather than user-facing
+commands.

--- a/docs/async_threading.md
+++ b/docs/async_threading.md
@@ -1,18 +1,28 @@
 # Async threading ownership rules
 
-- OpenGL uploads and all `gl*` calls remain on the main/render thread.
-- File I/O can run in the background worker through `FS_AsyncRead`; callbacks are pumped on the main thread via `FS_PumpAsyncCompletions()`.
-- Sound asset preparation can run in worker jobs (`Jobs_Submit`), while cache commit stays on the main thread.
+- OpenGL uploads and all `gl*` calls stay on the main/render thread.
+- File I/O can run in background workers through `FS_AsyncRead`; completion
+  callbacks are pumped on the main thread via `FS_PumpAsyncCompletions()`.
+- Sound asset preparation can run in worker jobs (`Jobs_Submit`), while cache
+  commit remains on the main thread.
 
 ## CVars
 
-- `host_async` (default `0`): master toggle for background jobs.
+Core toggles:
+- `host_async` (default `0`): master async enable.
 - `host_async_fs` (default `0`): enables async filesystem reads.
-- `host_async_assets` (default `0`): enables async asset staging (currently sound pilot path).
+- `host_async_assets` (default `0`): enables async asset staging paths.
+
+Worker/pending queue controls:
+- `host_async_workers` (default `1`): worker thread count (clamped to CPU count).
+- `host_async_max_pending` (default `128`): max queued jobs before overflow policy.
+- `host_async_overflow_policy` (default `sync`): overflow strategy.
+- `host_async_overflow_block_ms` (default `2`): block time used by blocking policy.
 
 ## Testing hints
 
-1. Baseline: keep all CVars at `0` and verify behavior matches single-thread path.
-2. Enable `host_async 1; host_async_fs 1; host_async_assets 1`.
-3. Switch maps quickly and trigger repeated weapon/fire sounds.
-4. Watch for regressions and check `developer 1` logging if additional diagnostics are added.
+1. Baseline: keep all async CVars at defaults and verify single-thread behavior.
+2. Enable async path, e.g.:
+   `host_async 1; host_async_fs 1; host_async_assets 1; host_async_workers 2`
+3. Stress map changes and repeated sound triggers.
+4. Watch for regressions and use `developer 1` logging if extra diagnostics are enabled.

--- a/docs/how2use-q3-shaders.md
+++ b/docs/how2use-q3-shaders.md
@@ -1,94 +1,78 @@
-# Working with Quake III Shader Files in Ironwail
+# Working with Material Shader Files in Ironwail
 
-Ironwail now ships with a lightweight Quake III shader parser. This document explains how to load shader definition files at runtime, inspect the parsed data, and use the new C API from engine code.
+> Note: this file keeps its historical filename, but the runtime feature is now the
+> **material shader system** implemented in `mat_shader.*` (not the old `q3shader_*`
+> console/API names).
+
+Ironwail loads shader definitions from `scripts/*.shader` through the material
+shader pipeline. These definitions are used for texture metadata and selected
+render-stage behavior (including particle material integration).
 
 ## Console workflow
 
-1. **Load shader files**
+1. **List loaded shader materials**
 
    ```
-   q3shader_load scripts/common.shader
+   shaderlist
    ```
 
-   * The command accepts one or more relative paths (use forward slashes).
-   * Each invocation reports how many shader blocks were successfully parsed.
+   Optional argument: `shaderlist <limit>` to clamp printed rows.
 
-   To pull in *every* `scripts/*.shader` file that is visible through the Quake filesystem, run:
-
-   ```
-   q3shader_loadall
-   ```
-
-   * Searches PAKs and loose directories in priority order (mods override base content).
-   * Loads every `scripts/*.shader` it encounters, even when multiple paths share the same filename, so base content stays available for later overrides.
-   * Prints a summary of how many files succeeded versus failed and the total shader count discovered.
-
-2. **List the currently loaded shaders**
+2. **Inspect one material**
 
    ```
-   q3shader_list
+   shaderprint textures/common/nodraw
    ```
 
-   * Displays every shader name and the number of stages the parser discovered for that entry.
+   Prints source file, surface/render/content flags, emissive/bloom/godray
+   settings, and stage details.
 
-3. **Inspect a single shader**
-
-   ```
-   q3shader_info textures/common/nodraw
-   ```
-
-   The command prints:
-
-   * Source file the definition came from.
-   * Cull mode and decoded `surfaceparm` flags.
-   * Metadata such as `qer_editorimage`, transparency, and light parameters when present.
-   * Stage-by-stage details (maps, animMap rate, blend/alpha configuration, tcMods, etc.).
-
-4. **Clear all parsed shader data**
+3. **Reload all material shaders**
 
    ```
-   q3shader_clear
+   r_reloadshaders 1
    ```
 
-   * Useful when reloading a modified `.shader` file while developing content.
+   Setting this cvar triggers a full reload and then resets the cvar to `0`.
+
+4. **Developer-only parser fuzzing**
+
+   ```
+   shaderfuzz
+   ```
+
+   Or set `r_matshader_fuzz 1` for callback-based fuzz runs.
+
+## Relevant CVars
+
+- `r_shaders` (`1`): master enable for loading and applying material shaders.
+- `r_shader_debug` (`0`): runtime shader debug toggle.
+- `r_matshader_debug_parse` (`0`): print parser debug information.
+- `r_matshader_report` (`0`): write markdown parser support report during load.
+- `r_particles_shader_strict` (`0`): strict compatibility policy for particle
+  stage support.
 
 ## C API overview
 
-Include `q3shader.h` to access the parser programmatically. Key helpers:
+Include `mat_shader.h` for public APIs.
 
-* `int Q3Shader_LoadFile(const char *path);`
-  * Parses a `.shader` file and merges/replaces entries in the registry.
-* `int Q3Shader_LoadAll(int *files_loaded, int *files_failed);`
-  * Enumerates `scripts/*.shader` across the virtual filesystem.
-  * Returns the number of shader definitions parsed and optionally reports the number of files that succeeded/failed.
-* `void Q3Shader_Clear(void);`
-  * Empties the registry.
-* `size_t Q3Shader_Count(void);`
-  * Returns the number of loaded shaders. Iterate with `Q3Shader_GetByIndex`.
-* `const q3shader_t *Q3Shader_Find(const char *name);`
-  * Fetches a shader definition by name (case-insensitive).
-* `void Q3Shader_DescribeSurfaceParms(const q3shader_t *shader, char *buffer, size_t bufsize);`
-  * Converts the surface parameter bit-mask into a readable string.
-* Stage helpers such as `Q3ShaderStage_Count`, `Q3ShaderStage_GetMap`, `Q3ShaderStage_GetAnimMapCount`, and `Q3ShaderStage_GetTcModCount` expose render-stage data.
+- Lifecycle/load:
+  - `void Mat_Shader_Init(void);`
+  - `void Mat_Shader_Reload(void);`
+  - `void Mat_Shader_Shutdown(void);`
+- Registry/query:
+  - `size_t Mat_Shader_Count(void);`
+  - `const shader_material_t *Mat_Shader_GetByIndex(size_t index);`
+  - `const shader_material_t *Mat_Shader_Find(const char *name);`
+  - `const shader_material_t *Mat_Shader_FindForTextureName(const char *texname, const char *mapname);`
+- Texture integration:
+  - `void Mat_Shader_ApplyToTexture(texture_t *tex, const char *mapname);`
+  - `unsigned int Mat_Shader_GetTextureFlags(const shader_material_t *material);`
+- Debug/introspection:
+  - `void Mat_Shader_Print(const shader_material_t *material);`
 
-### Sample iteration code
+## Current support scope
 
-```c
-for (size_t i = 0; i < Q3Shader_Count(); ++i) {
-    const q3shader_t *shader = Q3Shader_GetByIndex(i);
-    Con_Printf("%s has %zu stage(s)\n", shader->name, Q3ShaderStage_Count(shader));
-
-    for (size_t s = 0; s < Q3ShaderStage_Count(shader); ++s) {
-        const q3shader_stage_t *stage = Q3Shader_GetStage(shader, s);
-        const char *map = Q3ShaderStage_GetMap(stage);
-        if (map)
-            Con_Printf("  stage %zu map: %s\n", s + 1, map);
-    }
-}
-```
-
-## Notes and limitations
-
-* The parser is designed for Quake III style syntax, including nested stage blocks, `surfaceparm` directives, `animMap`, `tcMod`, and blend instructions. Unknown directives are still stored in the directive lists so nothing is lost.
-* Definitions loaded later replace earlier entries that share the same shader name, mirroring idTech 3 behaviour.
-* Shader data lives in zone memory and is released automatically during `q3shader_clear` or engine shutdown.
+The parser currently focuses on a practical subset (for engine needs), including
+material-level directives and stage fields used by Ironwail. Unknown tokens are
+tracked and summarized in parser reporting instead of aborting load.

--- a/docs/ssao.md
+++ b/docs/ssao.md
@@ -1,63 +1,58 @@
-# SSAO Debugging & Conventions
+# SSAO Debugging & Current Conventions
 
 ## View-space conventions
 - Ironwail uses a **+X forward** view-space (camera looks down +X).
-- SSAO comparisons operate in view-space using `viewPos.x` as depth.
-- Depth is reconstructed via inverse projection from NDC.
-- Reverse-Z is supported (see below) with a single source of truth in the SSAO shaders.
+- SSAO depth comparisons operate in view-space via `viewPos.x`.
+- Depth is reconstructed from NDC using inverse projection.
 
 ## Reverse-Z handling
-- `u_depthParams.z` indicates reverse-Z.
-- `u_reversedZMode` supports validation:
-  - `0`: default
-  - `1`: invert raw depth (before NDC)
-  - `2`: invert NDC
-- Debug mode 1/2/3 should remain monotonic when toggling these.
+- `u_depthParams.z` carries reverse-Z state.
+- `r_ssao_reversedz_mode` can override decode mode for diagnostics:
+  - `0`: default path
+  - `1`: invert raw depth before NDC mapping
+  - `2`: invert NDC depth
 
-## AO resolution mapping
-- The SSAO pass can run at full or half resolution.
-- AO UVs are derived from AO buffer size, while depth sampling is derived from screen size.
-- AO pixels are mapped to integer screen texels via `texelFetch` to avoid half-res UV drift and banding.
+## Resolution behavior
+- SSAO can run half-res (`r_ssao_halfres 1`) or full-res.
+- AO texels map to integer screen-depth texels via `texelFetch` to avoid
+  half-res UV drift/banding.
+- `r_ssao_force_fullres 1` forces full-res path while keeping other settings.
 
 ## Debug modes (`r_ssao_debug`)
 - `0`: off
-- `1`: depth raw (0..1)
-- `2`: view-space Z (linearized)
-- `3`: view-space position length (reconstructed)
-- `4`: normals (reconstructed)
-- `5`: noise/rotation
-- `6`: sample hit ratio (valid samples / total)
-- `7`: AO raw (pre-blur)
-- `8`: blur debug (raw vs blur + depth weight)
-- `9`: AO mask (occlusion where applied)
+- `1`: raw AO
+- `2`: AO * fog
+- `3`: fog factor
+- `4`: depth raw
+- `5`: view-space Z
+- `6`: reconstructed view-space position
+- `7`: reconstructed normals
+- `8`: noise/rotation visualization
+- `9`: sample hit ratio
+- `10`: AO raw (pre-blur)
+- `11`: blur debug
+- `12`: AO mask
+- `13`: fog transmittance
+- `14`: fog-damped AO
 
-## Noise controls
-- `r_ssao_noise` toggles per-pixel rotation.
-- `r_ssao_noise_mode` selects noise source (`1`=IGN hash, `2`=noise texture).
-- `r_ssao_freeze_noise` freezes the noise seed for debugging.
-- `r_ssao_noise_scale` scales the noise tiling frequency.
+## Key controls
+- Core: `r_ssao`, `r_ssao_radius`, `r_ssao_intensity`, `r_ssao_bias`,
+  `r_ssao_power`, `r_ssao_min`, `r_ssao_samples`.
+- Blur: `r_ssao_blur`, `r_ssao_blur_radius`, `r_ssao_blur_sigma`,
+  `r_ssao_blur_bilateral`.
+- Quality: `r_ssao_halfres`, `r_ssao_force_fullres`, `r_ssao_format`,
+  `r_ssao_upscale_nearest`.
+- Noise: `r_ssao_noise`, `r_ssao_noise_mode`, `r_ssao_noise_scale`,
+  `r_ssao_freeze_noise`.
+- Normals: `r_ssao_normalsource` (`0` neighbor reconstruction, `1` derivative).
+- Fog coupling: `r_ssao_fog_strength`, `r_ssao_fog_power`.
+- Safety/validation: `r_ssao_max_distance`, `r_ssao_validate`, `r_ssao_debug_far`.
 
-## Format + blur controls
-- `r_ssao_format` selects AO target precision (`0`=R8, `1`=R16F).
-- `r_ssao_blur_bilateral` toggles depth-aware blur weighting.
-- `r_ssao_upscale_nearest` toggles nearest-neighbor AO upsampling (diagnostic).
+## Quick verification matrix
+1. `r_ssao 1; r_ssao_halfres 0/1`
+2. `r_ssao_noise 0/1; r_ssao_normalsource 0/1`
+3. `r_ssao_reversedz_mode 0/1/2`
+4. Sweep debug modes `4`, `5`, `7`, `9`, `10`, `11`, `14` for stability.
 
-## Normal source
-- `r_ssao_normalsource 0`: neighbor-based reconstruction from depth.
-- `r_ssao_normalsource 1`: derivative-based reconstruction (for comparison).
-
-## Test matrix
-<!--
-SSAO_TEST_MATRIX
-Maps: e1m1, start
-Resolutions: 1080p, 1440p
-Toggles:
-  r_ssao_halfres 0/1
-  r_ssao_noise 0/1
-  r_ssao_normalsource 0/1
-  r_ssao_reversedz_mode 0/1/2
-Expect: no stripes/banding; debug views are stable.
--->
-
-## Changelog
-- SSAO: fix half-res depth sampling by snapping to integer depth texels; add upscaling toggle + expanded debug views.
+Expected: no striping/banding regressions, stable debug outputs, and monotonic
+reversed-Z diagnostic modes.


### PR DESCRIPTION
### Motivation

- Align the engine-facing documentation in `docs/` with the current runtime implementation and naming (material shader system, SSAO runtime controls, and async worker behavior).
- Replace outdated references to legacy console/API names and clarify which documents are runtime references versus design/debug notes.

### Description

- Add `docs/README.md` as an index that classifies current runtime feature docs and design/debug notes.
- Rewrite `docs/how2use-q3-shaders.md` to document the current material shader pipeline (`mat_shader.*`), the active console commands (`shaderlist`, `shaderprint`, `r_reloadshaders`, `shaderfuzz`), relevant CVars, and the public `mat_shader.h` API surface.
- Update `docs/ssao.md` to list the current `r_ssao_debug` mapping (0–14), reverse-Z handling, full/half-res behavior, and the active SSAO CVars and verification steps.
- Expand `docs/async_threading.md` with worker/queue controls (`host_async_workers`, `host_async_max_pending`, overflow policy CVars) and updated testing guidance; perform minor wording/format cleanups in those files.

### Testing

- Ran a Python token cross-check that extracts backticked identifiers from the updated docs and verifies each identifier is present in the codebase (`Quake`/`common`), and the script reported no missing symbol references.
- Performed targeted `ripgrep` checks to confirm referenced CVars and public API symbols appear in engine sources, with results matching the documentation updates.
- No engine source code was modified; this change is documentation-only and the automated validations above passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aae2b6d180832eae84631b31d846e7)