### PR TITLE
Add runtime per-cell sky visibility grid and unify skylight into world shading

### DIFF
--- a/Linux/CodeBlocks/QuakeSpasm-SDL2.cbp
+++ b/Linux/CodeBlocks/QuakeSpasm-SDL2.cbp
@@ -129,6 +129,9 @@
 		<Unit filename="../../Quake/gl_rmisc.c">
 			<Option compilerVar="CC" />
 		</Unit>
+		<Unit filename="../../Quake/r_skyvis.c">
+			<Option compilerVar="CC" />
+		</Unit>
 		<Unit filename="../../Quake/gl_screen.c">
 			<Option compilerVar="CC" />
 		</Unit>

--- a/Quake/Makefile
+++ b/Quake/Makefile
@@ -225,6 +225,7 @@ GLOBJS = \
 	gl_fog.o \
 	gl_rmisc.o \
 	r_postfx.o \
+	r_skyvis.o \
 	r_realtimelight.o \
 	r_part.o \
 	r_world.o \

--- a/Quake/gl_model.h
+++ b/Quake/gl_model.h
@@ -142,6 +142,7 @@ typedef struct glvert_s {
 	vec3_t		pos;
 	vec3_t		normal;
 	vec3_t		lightgrid;
+	float		skyvisibility;
 	float		st[4];
 	float		lmofs;
 	unsigned	styles;

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -27,6 +27,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "r_framegraph.h"
 #include "r_fogvol.h"
 #include "r_godrays.h"
+#include "r_skyvis.h"
 #include "r_ssao.h"
 #include "r_tonemap.h"
 #include "r_quality.h"
@@ -3568,8 +3569,8 @@ void R_SetupView (void)
         r_framedata.lightmap_params[3] = r_lightstyle_framefrac;
         r_framedata.lightgrid_params[0] = R_LightgridEnabled () ? 1.f : 0.f;
         r_framedata.lightgrid_params[1] = (r_lightgrid_debug.value >= 2.f) ? 1.f : 0.f;
-        r_framedata.lightgrid_params[2] = 0.f;
-        r_framedata.lightgrid_params[3] = 0.f;
+        r_framedata.lightgrid_params[2] = (r_skyvis.value > 0.f && R_SkyVis_Active ()) ? 1.f : 0.f;
+        r_framedata.lightgrid_params[3] = (r_skyvis_debug.value >= 2.f) ? 1.f : 0.f;
         r_framedata.dlight_params[0] = 1.f;
         r_framedata.dlight_params[1] = 0.f;
         r_framedata.dlight_params[2] = 0.f;
@@ -3580,7 +3581,7 @@ void R_SetupView (void)
         r_framedata.colorspace_params[3] = CLAMP (0.f, r_lighting_debug_view.value, 9.f);
         r_framedata.shader_params[0] = r_material_debug.value;
         r_framedata.shader_params[1] = r_tcgen_debug.value;
-        r_framedata.shader_params[2] = CLAMP (0.f, r_sun_visibility.value, 1.f);
+        r_framedata.shader_params[2] = R_SkyVis_GetResolvedScale ();
         r_framedata.shader_params[3] = 0.f;
 
 	{
@@ -3596,6 +3597,18 @@ void R_SetupView (void)
 		r_framedata.sun_color_intensity[1] = sun->color[1];
 		r_framedata.sun_color_intensity[2] = sun->color[2];
 		r_framedata.sun_color_intensity[3] = sun->intensity;
+	}
+
+	{
+		vec3_t skyvis_tint = {0.f, 0.f, 0.f};
+
+		if (r_skyvis.value > 0.f && R_SkyVis_Active ())
+			R_SkyVis_GetTint (skyvis_tint);
+
+		r_framedata.skyvis_tint[0] = skyvis_tint[0];
+		r_framedata.skyvis_tint[1] = skyvis_tint[1];
+		r_framedata.skyvis_tint[2] = skyvis_tint[2];
+		r_framedata.skyvis_tint[3] = R_SkyVis_GetResolvedCap ();
 	}
 
 	double prev_delta = cl.time - r_prev_frame_time;
@@ -5255,6 +5268,5 @@ void R_RenderView (void)
 			rs_dynamiclightmaps);
 	//johnfitz
 }
-
 
 

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -32,6 +32,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "r_godrays.h"
 #include "r_fogvol.h"
 #include "r_realtimelight.h"
+#include "r_skyvis.h"
 
 //johnfitz -- new cvars
 extern cvar_t r_clearcolor;
@@ -449,6 +450,7 @@ void R_Init (void)
         Cmd_AddCommand ("r_showbboxes_filter_clear", R_ShowbboxesFilterClear_f);
 
         Lightgrid_Init ();
+        R_SkyVis_Init ();
         Material_Init ();
 
 Cvar_RegisterVariable (&r_norefresh);
@@ -1002,6 +1004,7 @@ void R_NewMap (void)
 	R_ClearDecals ();
 
 	GL_BuildLightmaps ();
+	R_SkyVis_NewMap ();
         GL_BuildBModelVertexBuffer ();
         GL_BuildBModelMarkBuffers ();
         //ericw -- no longer load alias models into a VBO here, it's done in Mod_LoadAliasModel

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -502,9 +502,10 @@ typedef struct gpuframedata_s {
         vec4_t          lightgrid_params; // x: enabled, yzw: unused
         vec4_t          dlight_params;  // x: style, y: debug view, z: pass selector, w: padding
         vec4_t          colorspace_params; // x: debug mode, y: manual gamma, z: output sRGB, w: unused
-        vec4_t          shader_params;  // x: shader debug, y: tcgen debug, z: sun visibility attenuation, w: unused
+        vec4_t          shader_params;  // x: shader debug, y: tcgen debug, z: skyvis scale, w: unused
         vec4_t          sun_dir_enabled; // xyz: sun dir (scene->sun), w: enabled
         vec4_t          sun_color_intensity; // rgb: sun color, w: intensity
+        vec4_t          skyvis_tint;    // rgb: sky tint, w: cap
         unsigned int    numlights;
         unsigned int    prev_frame_valid;
         unsigned int    _padding1;
@@ -530,7 +531,7 @@ typedef struct {
 	float ray_density;
 } sun_t;
 
-COMPILE_TIME_ASSERT (gpuframedata_std140_size, sizeof (gpuframedata_t) == 432);
+COMPILE_TIME_ASSERT (gpuframedata_std140_size, sizeof (gpuframedata_t) == 448);
 
 typedef enum
 {

--- a/Quake/r_brush.c
+++ b/Quake/r_brush.c
@@ -26,6 +26,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "quakedef.h"
 #include "gl_lightgrid.h"
+#include "r_skyvis.h"
 
 extern cvar_t gl_fullbrights, gl_overbright; //johnfitz
 extern cvar_t r_lightmap_mipmaps;
@@ -917,6 +918,7 @@ void GL_BuildBModelVertexBuffer (void)
                                         {
                                                 VectorSet (vert->lightgrid, 1.f, 1.f, 1.f);
                                         }
+					vert->skyvisibility = R_SkyVis_Sample (vec);
                                 }
 
                                 s = DotProduct (vec, fa->texinfo->vecs[0]) + fa->texinfo->vecs[0][3] * useofs;

--- a/Quake/r_skyvis.c
+++ b/Quake/r_skyvis.c
@@ -1,0 +1,435 @@
+#include "quakedef.h"
+#include "render.h"
+#include "gl_model.h"
+#include "glquake.h"
+#include "r_skyvis.h"
+
+extern cvar_t r_sun_visibility;
+extern float skyflatcolor[3];
+
+#define SKYVIS_MAX_CELLS 524288u
+#define SKYVIS_TRACE_DIST_MAX 16384.f
+
+typedef struct skyvis_grid_s {
+	vec3_t mins;
+	vec3_t spacing;
+	vec3_t maxs;
+	int size[3];
+	float *values;
+	unsigned int total_cells;
+	unsigned int valid_cells;
+	float average_visibility;
+	qboolean used_lightgrid_header;
+	qboolean has_sky_surfaces;
+} skyvis_grid_t;
+
+/* Chosen reuse strategy: keep sky visibility in a sibling runtime cache instead
+ * of overloading authored RGB lightgrid probes. This reuses lightgrid bounds/
+ * spacing when a BSPX octree exists, but still works on classic maps with no
+ * BSPX payload and keeps the new scalar visibility data zero-safe. */
+static skyvis_grid_t r_skyvis_grid;
+
+cvar_t r_skyvis = { "r_skyvis", "1", CVAR_ARCHIVE };
+cvar_t r_skyvis_debug = { "r_skyvis_debug", "0", CVAR_NONE };
+/* Compatibility note: -1 keeps legacy r_sun_visibility tuning but routes it
+ * through the new sky-visibility skylight path instead of the old global hack. */
+cvar_t r_skyvis_scale = { "r_skyvis_scale", "-1", CVAR_ARCHIVE };
+cvar_t r_skyvis_cap = { "r_skyvis_cap", "0.25", CVAR_ARCHIVE };
+cvar_t r_skyvis_spacing_xy = { "r_skyvis_spacing_xy", "128", CVAR_ARCHIVE };
+cvar_t r_skyvis_spacing_z = { "r_skyvis_spacing_z", "96", CVAR_ARCHIVE };
+cvar_t r_skyvis_rays = { "r_skyvis_rays", "7", CVAR_ARCHIVE };
+
+static const vec4_t skyvis_raydirs[] = {
+	{  0.00f,  0.00f, 1.00f, 1.00f },
+	{  0.45f,  0.00f, 1.00f, 0.82f },
+	{ -0.45f,  0.00f, 1.00f, 0.82f },
+	{  0.00f,  0.45f, 1.00f, 0.82f },
+	{  0.00f, -0.45f, 1.00f, 0.82f },
+	{  0.20f,  0.20f, 1.00f, 0.94f },
+	{ -0.20f, -0.20f, 1.00f, 0.94f }
+};
+
+static float R_SkyVis_Lerp (float a, float b, float t)
+{
+	return a + (b - a) * t;
+}
+
+static void R_SkyVis_ResetGrid (void)
+{
+	q_free (r_skyvis_grid.values);
+	memset (&r_skyvis_grid, 0, sizeof (r_skyvis_grid));
+}
+
+void R_SkyVis_Clear (void)
+{
+	R_SkyVis_ResetGrid ();
+}
+
+void R_SkyVis_Shutdown (void)
+{
+	R_SkyVis_ResetGrid ();
+}
+
+static qboolean R_SkyVis_WorldHasSky (const qmodel_t *world)
+{
+	int i;
+
+	if (!world)
+		return false;
+
+	for (i = 0; i < world->numsurfaces; i++)
+		if (world->surfaces[i].flags & SURF_DRAWSKY)
+			return true;
+
+	return false;
+}
+
+static qboolean R_SkyVis_AdjustPointForLeaf (qmodel_t *world, vec3_t point)
+{
+	mleaf_t *leaf = NULL;
+	int i;
+
+	for (i = 0; i < 8; i++)
+	{
+		leaf = Mod_PointInLeaf (point, world);
+		if (!leaf || leaf->contents != CONTENTS_SOLID)
+			return true;
+		point[2] += 1.f;
+	}
+
+	return leaf && leaf->contents != CONTENTS_SOLID;
+}
+
+static qboolean R_SkyVis_TraceToSky (qmodel_t *world, const vec3_t start, const vec3_t dir, float trace_dist)
+{
+	trace_t trace;
+	vec3_t start_copy;
+	vec3_t end;
+	int step;
+
+	VectorCopy (start, start_copy);
+	VectorMA (start, trace_dist, dir, end);
+	memset (&trace, 0, sizeof (trace));
+	trace.fraction = 1.f;
+	trace.allsolid = true;
+	VectorCopy (end, trace.endpos);
+
+	SV_RecursiveHullCheck (&world->hulls[0], world->hulls[0].firstclipnode, 0.f, 1.f, start_copy, end, &trace);
+	if (trace.startsolid || trace.allsolid || trace.fraction < 1.f)
+		return false;
+
+	for (step = 1; step <= 8; step++)
+	{
+		vec3_t probe;
+		mleaf_t *leaf;
+		float t = (float)step / 8.f;
+		VectorLerp (start, end, t, probe);
+		leaf = Mod_PointInLeaf (probe, world);
+		if (leaf && leaf->contents == CONTENTS_SKY)
+			return true;
+	}
+
+	{
+		mleaf_t *leaf = Mod_PointInLeaf (end, world);
+		return leaf && leaf->contents == CONTENTS_SKY;
+	}
+}
+
+static float R_SkyVis_PointVisibility (qmodel_t *world, const vec3_t pos, float trace_dist)
+{
+	float weighted_visible = 0.f;
+	float weighted_total = 0.f;
+	int ray_count = CLAMP (1, (int)r_skyvis_rays.value, (int)(sizeof (skyvis_raydirs) / sizeof (skyvis_raydirs[0])));
+	int i;
+
+	for (i = 0; i < ray_count; i++)
+	{
+		vec3_t dir = { skyvis_raydirs[i][0], skyvis_raydirs[i][1], skyvis_raydirs[i][2] };
+		float weight = skyvis_raydirs[i][3];
+		VectorNormalize (dir);
+		weighted_total += weight;
+		if (R_SkyVis_TraceToSky (world, pos, dir, trace_dist))
+			weighted_visible += weight;
+	}
+
+	if (weighted_total <= 0.f)
+		return 0.f;
+
+	return weighted_visible / weighted_total;
+}
+
+static float R_SkyVis_EvaluateCell (qmodel_t *world, const vec3_t cell_center, const vec3_t spacing, float trace_dist, qboolean *out_valid)
+{
+	vec3_t sample_points[3];
+	float accum = 0.f;
+	int valid = 0;
+	int i;
+	const float zofs = spacing[2] * 0.35f;
+
+	VectorCopy (cell_center, sample_points[0]);
+	VectorCopy (cell_center, sample_points[1]);
+	VectorCopy (cell_center, sample_points[2]);
+	sample_points[1][2] += zofs;
+	sample_points[2][2] -= zofs;
+
+	for (i = 0; i < 3; i++)
+	{
+		vec3_t adjusted;
+		mleaf_t *leaf;
+		VectorCopy (sample_points[i], adjusted);
+		if (!R_SkyVis_AdjustPointForLeaf (world, adjusted))
+			continue;
+		leaf = Mod_PointInLeaf (adjusted, world);
+		if (!leaf || leaf->contents == CONTENTS_SOLID)
+			continue;
+		accum += R_SkyVis_PointVisibility (world, adjusted, trace_dist);
+		valid++;
+	}
+
+	if (out_valid)
+		*out_valid = (valid > 0);
+	if (!valid)
+		return 0.f;
+
+	accum /= (float)valid;
+	accum = CLAMP (0.f, accum, 1.f);
+	return accum * accum;
+}
+
+static void R_SkyVis_InitGeneratedGrid (skyvis_grid_t *grid, const qmodel_t *world)
+{
+	vec3_t mins, maxs, spacing;
+	unsigned int total_cells;
+	int i;
+
+	if (world->lightgrid_octree)
+	{
+		const lightgrid_octree_header_t *header = &world->lightgrid_octree->header;
+		VectorCopy (header->grid_mins, mins);
+		VectorCopy (header->grid_dist, spacing);
+		for (i = 0; i < 3; i++)
+		{
+			spacing[i] = q_max (1.f, spacing[i]);
+			grid->size[i] = q_max (1, header->grid_size[i]);
+			maxs[i] = mins[i] + spacing[i] * (float)(grid->size[i] - 1);
+		}
+		grid->used_lightgrid_header = true;
+	}
+	else
+	{
+		spacing[0] = spacing[1] = q_max (32.f, r_skyvis_spacing_xy.value);
+		spacing[2] = q_max (32.f, r_skyvis_spacing_z.value);
+		for (i = 0; i < 3; i++)
+		{
+			mins[i] = floorf (world->mins[i] / spacing[i]) * spacing[i];
+			maxs[i] = ceilf (world->maxs[i] / spacing[i]) * spacing[i];
+		}
+		grid->used_lightgrid_header = false;
+	}
+
+	for (;;)
+	{
+		total_cells = 1u;
+		for (i = 0; i < 3; i++)
+		{
+			float extent = q_max (0.f, maxs[i] - mins[i]);
+			grid->size[i] = q_max (1, (int)floorf (extent / spacing[i] + 0.5f) + 1);
+			total_cells *= (unsigned int)grid->size[i];
+		}
+		if (total_cells <= SKYVIS_MAX_CELLS)
+			break;
+		spacing[0] *= 2.f;
+		spacing[1] *= 2.f;
+		spacing[2] *= 2.f;
+		grid->used_lightgrid_header = false;
+		if (r_skyvis_debug.value > 0.f)
+			Con_Printf ("r_skyvis: increasing spacing to %.0f %.0f %.0f to cap grid size\n", spacing[0], spacing[1], spacing[2]);
+	}
+
+	VectorCopy (mins, grid->mins);
+	VectorCopy (maxs, grid->maxs);
+	VectorCopy (spacing, grid->spacing);
+	grid->total_cells = total_cells;
+}
+
+static void R_SkyVis_LogStats (const skyvis_grid_t *grid)
+{
+	Con_Printf ("r_skyvis: %ux%ux%u cells spacing=(%.0f %.0f %.0f) total=%u valid=%u avg=%.3f source=%s\n",
+		(unsigned int)grid->size[0], (unsigned int)grid->size[1], (unsigned int)grid->size[2],
+		grid->spacing[0], grid->spacing[1], grid->spacing[2],
+		grid->total_cells, grid->valid_cells, grid->average_visibility,
+		grid->used_lightgrid_header ? "lightgrid header" : "runtime spacing");
+}
+
+void R_SkyVis_NewMap (void)
+{
+	qmodel_t *world = cl.worldmodel;
+	float trace_dist;
+	unsigned int index;
+	unsigned int valid_cells = 0;
+	float vis_sum = 0.f;
+
+	R_SkyVis_ResetGrid ();
+	if (!world || world->type != mod_brush)
+		return;
+
+	r_skyvis_grid.has_sky_surfaces = R_SkyVis_WorldHasSky (world);
+	if (!r_skyvis_grid.has_sky_surfaces)
+	{
+		Con_Printf ("r_skyvis: map has no sky surfaces, unified skylight will remain disabled\n");
+		return;
+	}
+
+	R_SkyVis_InitGeneratedGrid (&r_skyvis_grid, world);
+	if (!r_skyvis_grid.total_cells)
+		return;
+
+	r_skyvis_grid.values = (float *)q_malloc (sizeof (*r_skyvis_grid.values) * r_skyvis_grid.total_cells);
+	if (!r_skyvis_grid.values)
+	{
+		Con_Warning ("r_skyvis: failed to allocate %u cells, unified skylight disabled\n", r_skyvis_grid.total_cells);
+		R_SkyVis_ResetGrid ();
+		return;
+	}
+
+	memset (r_skyvis_grid.values, 0, sizeof (*r_skyvis_grid.values) * r_skyvis_grid.total_cells);
+	trace_dist = q_min (SKYVIS_TRACE_DIST_MAX, VectorLength (world->maxs) + VectorLength (world->mins) + 4096.f);
+	trace_dist = q_max (4096.f, trace_dist);
+
+	for (index = 0; index < r_skyvis_grid.total_cells; index++)
+	{
+		int cell[3];
+		vec3_t center;
+		qboolean cell_valid = false;
+		float vis;
+
+		cell[0] = index % r_skyvis_grid.size[0];
+		cell[1] = (index / r_skyvis_grid.size[0]) % r_skyvis_grid.size[1];
+		cell[2] = index / (r_skyvis_grid.size[0] * r_skyvis_grid.size[1]);
+		center[0] = r_skyvis_grid.mins[0] + r_skyvis_grid.spacing[0] * (float)cell[0];
+		center[1] = r_skyvis_grid.mins[1] + r_skyvis_grid.spacing[1] * (float)cell[1];
+		center[2] = r_skyvis_grid.mins[2] + r_skyvis_grid.spacing[2] * (float)cell[2];
+
+		vis = R_SkyVis_EvaluateCell (world, center, r_skyvis_grid.spacing, trace_dist, &cell_valid);
+		r_skyvis_grid.values[index] = CLAMP (0.f, vis, 1.f);
+		if (cell_valid)
+		{
+			valid_cells++;
+			vis_sum += r_skyvis_grid.values[index];
+		}
+	}
+
+	r_skyvis_grid.valid_cells = valid_cells;
+	r_skyvis_grid.average_visibility = valid_cells ? (vis_sum / (float)valid_cells) : 0.f;
+	R_SkyVis_LogStats (&r_skyvis_grid);
+	if (!valid_cells || r_skyvis_grid.average_visibility <= 0.f)
+		Con_Warning ("r_skyvis: generated all-zero visibility, unified skylight fallback is zero\n");
+	else if (r_skyvis_debug.value > 0.f)
+		Con_Printf ("r_skyvis: legacy global sky/fill attenuation replaced by sky-visibility skylight\n");
+}
+
+qboolean R_SkyVis_Active (void)
+{
+	return r_skyvis_grid.values != NULL && r_skyvis_grid.total_cells > 0 && r_skyvis_grid.valid_cells > 0;
+}
+
+static float R_SkyVis_FetchCell (int x, int y, int z)
+{
+	size_t index;
+
+	x = CLAMP (0, x, r_skyvis_grid.size[0] - 1);
+	y = CLAMP (0, y, r_skyvis_grid.size[1] - 1);
+	z = CLAMP (0, z, r_skyvis_grid.size[2] - 1);
+	index = ((size_t)z * (size_t)r_skyvis_grid.size[1] + (size_t)y) * (size_t)r_skyvis_grid.size[0] + (size_t)x;
+	return r_skyvis_grid.values[index];
+}
+
+float R_SkyVis_Sample (const vec3_t pos)
+{
+	vec3_t local;
+	int base[3];
+	vec3_t frac;
+	float c000, c100, c010, c110, c001, c101, c011, c111;
+	float c00, c10, c01, c11, c0, c1;
+	int i;
+
+	if (!R_SkyVis_Active ())
+		return 0.f;
+
+	for (i = 0; i < 3; i++)
+	{
+		local[i] = (pos[i] - r_skyvis_grid.mins[i]) / r_skyvis_grid.spacing[i];
+		base[i] = (int)floorf (local[i]);
+		frac[i] = local[i] - (float)base[i];
+		if (base[i] < 0 || base[i] >= r_skyvis_grid.size[i])
+			return 0.f;
+	}
+
+	c000 = R_SkyVis_FetchCell (base[0],     base[1],     base[2]);
+	c100 = R_SkyVis_FetchCell (base[0] + 1, base[1],     base[2]);
+	c010 = R_SkyVis_FetchCell (base[0],     base[1] + 1, base[2]);
+	c110 = R_SkyVis_FetchCell (base[0] + 1, base[1] + 1, base[2]);
+	c001 = R_SkyVis_FetchCell (base[0],     base[1],     base[2] + 1);
+	c101 = R_SkyVis_FetchCell (base[0] + 1, base[1],     base[2] + 1);
+	c011 = R_SkyVis_FetchCell (base[0],     base[1] + 1, base[2] + 1);
+	c111 = R_SkyVis_FetchCell (base[0] + 1, base[1] + 1, base[2] + 1);
+
+	c00 = R_SkyVis_Lerp (c000, c100, frac[0]);
+	c10 = R_SkyVis_Lerp (c010, c110, frac[0]);
+	c01 = R_SkyVis_Lerp (c001, c101, frac[0]);
+	c11 = R_SkyVis_Lerp (c011, c111, frac[0]);
+	c0 = R_SkyVis_Lerp (c00, c10, frac[1]);
+	c1 = R_SkyVis_Lerp (c01, c11, frac[1]);
+	return CLAMP (0.f, R_SkyVis_Lerp (c0, c1, frac[2]), 1.f);
+}
+
+void R_SkyVis_GetTint (vec3_t out_tint)
+{
+	vec3_t sky_tint;
+	const sun_t *sun = R_GetSun ();
+	float len;
+
+	VectorCopy (skyflatcolor, sky_tint);
+	len = VectorLength (sky_tint);
+	if (len < 1e-4f)
+		VectorSet (sky_tint, 0.5f, 0.55f, 0.6f);
+
+	if (sun && R_WorldHasSun ())
+	{
+		vec3_t sun_tint;
+		VectorCopy (sun->color, sun_tint);
+		if (VectorLength (sun_tint) > 1e-4f)
+		{
+			VectorNormalize (sun_tint);
+			for (int i = 0; i < 3; i++)
+				sky_tint[i] = sky_tint[i] * 0.7f + sun_tint[i] * 0.3f;
+		}
+	}
+
+	for (int i = 0; i < 3; i++)
+		out_tint[i] = CLAMP (0.f, sky_tint[i], 1.f);
+}
+
+float R_SkyVis_GetResolvedScale (void)
+{
+	float scale = r_skyvis_scale.value;
+	if (scale < 0.f)
+		scale = r_sun_visibility.value;
+	return CLAMP (0.f, scale, 1.f);
+}
+
+float R_SkyVis_GetResolvedCap (void)
+{
+	return CLAMP (0.f, r_skyvis_cap.value, 1.f);
+}
+
+void R_SkyVis_Init (void)
+{
+	Cvar_RegisterVariable (&r_skyvis);
+	Cvar_RegisterVariable (&r_skyvis_debug);
+	Cvar_RegisterVariable (&r_skyvis_scale);
+	Cvar_RegisterVariable (&r_skyvis_cap);
+	Cvar_RegisterVariable (&r_skyvis_spacing_xy);
+	Cvar_RegisterVariable (&r_skyvis_spacing_z);
+	Cvar_RegisterVariable (&r_skyvis_rays);
+}

--- a/Quake/r_skyvis.h
+++ b/Quake/r_skyvis.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "quakedef.h"
+
+extern cvar_t r_skyvis;
+extern cvar_t r_skyvis_debug;
+extern cvar_t r_skyvis_scale;
+extern cvar_t r_skyvis_cap;
+extern cvar_t r_skyvis_spacing_xy;
+extern cvar_t r_skyvis_spacing_z;
+extern cvar_t r_skyvis_rays;
+
+void R_SkyVis_Init (void);
+void R_SkyVis_Shutdown (void);
+void R_SkyVis_Clear (void);
+void R_SkyVis_NewMap (void);
+qboolean R_SkyVis_Active (void);
+float R_SkyVis_Sample (const vec3_t pos);
+void R_SkyVis_GetTint (vec3_t out_tint);
+float R_SkyVis_GetResolvedScale (void);
+float R_SkyVis_GetResolvedCap (void);

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -733,11 +733,12 @@ static void R_FlushBModelCalls (void)
 	GL_BindBuffer (GL_ARRAY_BUFFER, gl_bmodel_vbo);
 	GL_BindBuffer (GL_DRAW_INDIRECT_BUFFER, cmdbuf);
 	GL_VertexAttribPointerFunc (0, 3, GL_FLOAT, GL_FALSE, sizeof (glvert_t), (void *) offsetof (glvert_t, pos));
-        GL_VertexAttribPointerFunc (1, 4, GL_FLOAT, GL_FALSE, sizeof (glvert_t), (void *) offsetof (glvert_t, st));
-        GL_VertexAttribPointerFunc (2, 1, GL_FLOAT, GL_FALSE, sizeof (glvert_t), (void *) offsetof (glvert_t, lmofs));
-        GL_VertexAttribIPointerFunc (3, 4, GL_UNSIGNED_BYTE, sizeof (glvert_t), (void *) offsetof (glvert_t, styles));
-        GL_VertexAttribPointerFunc (4, 3, GL_FLOAT, GL_FALSE, sizeof (glvert_t), (void *) offsetof (glvert_t, normal));
-        GL_VertexAttribPointerFunc (5, 3, GL_FLOAT, GL_FALSE, sizeof (glvert_t), (void *) offsetof (glvert_t, lightgrid));
+	GL_VertexAttribPointerFunc (1, 4, GL_FLOAT, GL_FALSE, sizeof (glvert_t), (void *) offsetof (glvert_t, st));
+	GL_VertexAttribPointerFunc (2, 1, GL_FLOAT, GL_FALSE, sizeof (glvert_t), (void *) offsetof (glvert_t, lmofs));
+	GL_VertexAttribIPointerFunc (3, 4, GL_UNSIGNED_BYTE, sizeof (glvert_t), (void *) offsetof (glvert_t, styles));
+	GL_VertexAttribPointerFunc (4, 3, GL_FLOAT, GL_FALSE, sizeof (glvert_t), (void *) offsetof (glvert_t, normal));
+	GL_VertexAttribPointerFunc (5, 3, GL_FLOAT, GL_FALSE, sizeof (glvert_t), (void *) offsetof (glvert_t, lightgrid));
+	GL_VertexAttribPointerFunc (6, 1, GL_FLOAT, GL_FALSE, sizeof (glvert_t), (void *) offsetof (glvert_t, skyvisibility));
 
 	if (gl_bindless_able)
 	{

--- a/Quake/shaders/frame_uniforms.glsl
+++ b/Quake/shaders/frame_uniforms.glsl
@@ -46,11 +46,12 @@ layout(std140, binding=0) uniform FrameDataUBO
     vec4    LightgridParams;    // 320
     vec4    DLightParams;       // 336
     vec4    ColorSpaceParams;   // 352
-    vec4    ShaderParams;       // 368  x: shader debug, y: tcgen debug, z: sun visibility attenuation, w: unused
+    vec4    ShaderParams;       // 368  x: shader debug, y: tcgen debug, z: skyvis scale, w: unused
     vec4    SunDirEnabled;  // 384  xyz: scene->sun direction, w: enabled
     vec4    SunColorIntensity; // 400 rgb: sun color, w: intensity
+    vec4    SkyVisTint;     // 416 rgb: sky tint, w: cap
 
-    //  Global params  offset 416
+    //  Global params  offset 432
     // NOTE: These members must stay layout-compatible with gpuframedata_t
     // their expected offsets.
 

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -172,9 +172,10 @@ layout(location=11) noperspective in vec4 in_curr_clip;
 layout(location=12) noperspective in vec4 in_prev_clip;
 layout(location=13) in vec3 in_normal;
 layout(location=14) in vec3 in_lightgrid;
-layout(location=15) flat in vec4 in_stage_color;
-layout(location=16) flat in uint in_tcgen;
-layout(location=17) flat in vec3 in_bmodel_relight;
+layout(location=15) in float in_skyvisibility;
+layout(location=16) flat in vec4 in_stage_color;
+layout(location=17) flat in uint in_tcgen;
+layout(location=18) flat in vec3 in_bmodel_relight;
 
 // Utility: ALU-only 16x16 Bayer matrix
 float bayer01(ivec2 coord)
@@ -651,6 +652,16 @@ void main()
 			return;
 		}
 
+		if (LightgridParams.w > 0.5)
+		{
+			float skyvis_debug = clamp(in_skyvisibility, 0.0, 1.0);
+			OUT_COLOR = vec4(vec3(skyvis_debug), 1.0);
+#if !OIT
+			out_velocity = vec4(0.0);
+#endif
+			return;
+		}
+
 		// Directional lightmap
 		if (LightmapParams.z > 0.5)
 		{
@@ -673,6 +684,12 @@ void main()
 
 		vec3 clamped_static = clamp(static_light, 0.0, 1.0);
 		vec3 total_light    = clamped_static * lightgrid + in_bmodel_relight;
+		float sky_visibility = clamp(in_skyvisibility, 0.0, 1.0);
+		float sky_upness = clamp(surface_normal.z * 0.5 + 0.5, 0.0, 1.0);
+		float sky_room = 1.0 - 0.6 * max(max(clamped_static.r, clamped_static.g), clamped_static.b);
+		vec3 sky_diffuse = SkyVisTint.rgb * (ShaderParams.z * mix(0.2, 1.0, sky_upness) * sky_visibility * max(sky_room, 0.0));
+		sky_diffuse = min(sky_diffuse, vec3(SkyVisTint.a));
+		total_light += max(min(sky_diffuse, 1.0 - total_light), 0.0);
 
 		// Dynamic lights
 		if (!additive_dlights && NumLights > 0u)
@@ -764,28 +781,23 @@ void main()
 			float ndotl = max(dot(surface_normal, sun_to_surface), 0.0);
 			if (ndotl > 0.0)
 			{
-				/* Minimal stopgap visibility: sky surfaces always receive full sun,
-				 * non-sky surfaces get a conservative attenuation from ShaderParams.z
-				 * (driven by cvar r_sun_visibility, clamped to [0,1] on CPU). */
-				float sun_visibility = ((in_flags & CF_MAT_SKY) != 0u) ? 1.0 : ShaderParams.z;
 				float sun_shadow = SampleSunShadow(in_pos);
-				vec3 sun_contrib = SunColorIntensity.rgb * SunColorIntensity.a * ndotl * sun_visibility * sun_shadow;
+				vec3 sun_contrib = SunColorIntensity.rgb * SunColorIntensity.a * ndotl * sun_shadow;
 				total_light += max(min(sun_contrib, 1.0 - total_light), 0.0);
 				if (rim_factor > 1e-5 && RimLightParams1.z > 0.0)
 				{
 					float rim_shadow = (RimLightParams0.w > 0.5) ? sun_shadow : 1.0;
 					float sun_back = max(dot(-surface_normal, sun_to_surface), 0.0);
 					rim_sun_accum += SunColorIntensity.rgb * SunColorIntensity.a
-						* sun_visibility * rim_shadow * mix(0.35, 1.0, sun_back);
+						* rim_shadow * mix(0.35, 1.0, sun_back);
 				}
 			}
 			else if (rim_factor > 1e-5 && RimLightParams1.z > 0.0)
 			{
-				float sun_visibility = ((in_flags & CF_MAT_SKY) != 0u) ? 1.0 : ShaderParams.z;
 				float rim_shadow = (RimLightParams0.w > 0.5) ? SampleSunShadow(in_pos) : 1.0;
 				float sun_back = max(dot(-surface_normal, sun_to_surface), 0.0);
 				rim_sun_accum += SunColorIntensity.rgb * SunColorIntensity.a
-					* sun_visibility * rim_shadow * mix(0.35, 1.0, sun_back);
+					* rim_shadow * mix(0.35, 1.0, sun_back);
 			}
 		}
 
@@ -857,7 +869,7 @@ void main()
 		}
 		else if (lighting_debug_view == 6)
 		{
-			debug_rgb = clamp(in_lightgrid, 0.0, 1.0);
+			debug_rgb = vec3(clamp(in_skyvisibility, 0.0, 1.0));
 		}
 		else if (lighting_debug_view == 7)
 		{

--- a/Quake/shaders/world.vert
+++ b/Quake/shaders/world.vert
@@ -132,6 +132,7 @@ layout(location=2) in float  in_lmofs;
 layout(location=3) in ivec4  in_styles;
 layout(location=4) in vec3   in_normal;
 layout(location=5) in vec3   in_lightgrid;
+layout(location=6) in float  in_skyvisibility;
 
 // Vertex outputs
 layout(location=0)  flat out uint  out_flags;
@@ -155,9 +156,10 @@ layout(location=11) noperspective out vec4 out_curr_clip;
 layout(location=12) noperspective out vec4 out_prev_clip;
 layout(location=13) out vec3 out_normal;
 layout(location=14) out vec3 out_lightgrid;
-layout(location=15) flat out vec4 out_stage_color;
-layout(location=16) flat out uint out_tcgen;
-layout(location=17) flat out vec3 out_bmodel_relight;
+layout(location=15) out float out_skyvisibility;
+layout(location=16) flat out vec4 out_stage_color;
+layout(location=17) flat out uint out_tcgen;
+layout(location=18) flat out vec3 out_bmodel_relight;
 
 vec2 ComputeEnvUV(vec3 world_pos, vec3 world_normal)
 {
@@ -212,6 +214,7 @@ void main()
 	// consistent results. normalize() still required — non-uniform scale possible.
 	out_normal    = normalize(world_normal);
 	out_lightgrid = in_lightgrid;
+	out_skyvisibility = in_skyvisibility;
 	out_bmodel_relight = vec3(instance.pad0, instance.pad1, instance.pad2);
 
 	// UV selection

--- a/Windows/VisualStudio/ironwail.vcxproj
+++ b/Windows/VisualStudio/ironwail.vcxproj
@@ -263,6 +263,7 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
     <ClCompile Include="..\..\Quake\gl_shadow_runtime.c" />
     <ClCompile Include="..\..\Quake\gl_rmain.c" />
     <ClCompile Include="..\..\Quake\gl_rmisc.c" />
+    <ClCompile Include="..\..\Quake\r_skyvis.c" />
     <ClCompile Include="..\..\Quake\r_decals.c" />
     <ClCompile Include="..\..\Quake\gl_screen.c" />
     <ClCompile Include="..\..\Quake\gl_shaders.c" />

--- a/Windows/VisualStudio/ironwail.vcxproj.filters
+++ b/Windows/VisualStudio/ironwail.vcxproj.filters
@@ -90,6 +90,9 @@
     <ClCompile Include="..\..\Quake\gl_rmisc.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Quake\r_skyvis.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\Quake\r_decals.c">
       <Filter>Source Files</Filter>
     </ClCompile>


### PR DESCRIPTION
### Motivation
- Replace legacy global "sun/sky ambient" heuristic (the `r_sun_visibility` attenuation hack) with a single authoritative skylight path driven by runtime per-lightgrid-cell sky visibility so the engine does not double-light surfaces.
- Provide a conservative, zero-cost-per-frame, runtime cache that works on classic maps without BSPX lightgrid lumps and reuses existing lightgrid placement/addressing where possible.
- Bake the scalar visibility into world VBO vertices for a production-ready, low-runtime-cost v1 integration and keep indoor areas dark while giving conservative skylight to outdoor shadowed areas.

### Description
- Added a new runtime skylight subsystem in `Quake/r_skyvis.c` / `Quake/r_skyvis.h` that builds a scalar `skyvis` grid at map load using either the BSPX lightgrid header (when present) or generated spacing (`r_skyvis_spacing_xy`, `r_skyvis_spacing_z`) and stores one float per cell in [0..1].
- Chose a sibling runtime cache approach (not overloading authored RGB lightgrid data); the implementation reuses grid bounds/spacing and addressing when a `lightgrid_octree` exists and falls back safely to generated spacing when absent (documented in code comments).
- Hooked map-time precompute into `R_NewMap()` (`Quake/gl_rmisc.c`) so the grid is generated before `GL_BuildBModelVertexBuffer()`; the grid sampling uses 3 sample points per cell and a small set of upward-hemisphere traces via `SV_RecursiveHullCheck()` / `Mod_PointInLeaf()` to conservatively determine sky reachability.
- Baked a single `float skyvisibility` into the world vertex format by adding the field to `glvert_t` (`Quake/gl_model.h`) and writing sampled values during `GL_BuildBModelVertexBuffer()` in `Quake/r_brush.c`.
- Exposed the attribute to the GPU draw path (`Quake/r_world.c`) and threaded it through `Quake/shaders/world.vert` as `out_skyvisibility` and into `Quake/shaders/world.frag` as `in_skyvisibility` where it now modulates a single unified sky diffuse term (`skyDiffuse *= sky_visibility`-style), with conservative shaping, tinting and a cap provided via the frame UBO.
- Replaced the old non-sky-surface `r_sun_visibility` attenuation usage inside the sun branch of `world.frag`; `r_sun_visibility` is now optionally re-used as compatibility tuning via the new `r_skyvis_scale` logic rather than as a separate implemention path.
- Added shader/frame-uniform support (`SkyVisTint`) and extended `gpuframedata_t`/std140 size accordingly (`Quake/shaders/frame_uniforms.glsl`, `Quake/glquake.h`, `Quake/gl_rmain.c`) to pass the tint and cap to shaders.
- Added runtime cvars and debug controls: `r_skyvis`, `r_skyvis_debug`, `r_skyvis_scale`, `r_skyvis_cap`, `r_skyvis_spacing_xy`, `r_skyvis_spacing_z`, and `r_skyvis_rays`.
- Added grayscale debug visualization (shader debug view) and console logging of grid stats; maps with no sky or failed generation produce all-zero visibility so skylight contribution is disabled as a safe fallback.
- Project/build files updated to include the new source: `Quake/Makefile`, Windows/CodeBlocks project entries and Visual Studio filters.

### Testing
- Per-file compile/syntax checks were run with `cc -IQuake -I. -IWindows/SDL2/include -fsyntax-only` for modified files (`r_skyvis.c`, `r_brush.c`, `gl_rmain.c`, `gl_rmisc.c`, `r_world.c`) and the full set of modified sources; these checks succeeded in this environment after adding a minimal include shim for SDL (success).
- Performed `git diff --check` to validate whitespace/patch issues (passed).
- Attempted a full engine build with `make -C Quake -j4` in this environment but it cannot complete here due to missing SDL2 build tooling (`sdl2-config` / system SDL2 headers), so a full linkable binary was not produced in this container (expected environment limitation).
- Tests summary: compile-time checks for the modified units passed; full project build could not be completed here due to missing external dev dependencies (SDL2), so in-engine runtime validation (map loads, visual checks) should be performed in a normal dev environment as the next step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c13b6e64a0832eba42cd8b7ae18fbd)