### PR TITLE
Report and track tcMod overflow in material parser and particle classification

### DIFF
--- a/Quake/mat_material.c
+++ b/Quake/mat_material.c
@@ -1141,6 +1141,12 @@ mat_particle_stage_support_t Material_ClassifyParticleStage (const material_stag
 			q_strlcpy (reason, "tcMod count overflow", reason_size);
 		return MAT_PARTICLE_STAGE_HARD_FAIL;
 	}
+	if (stage->tcmod_overflow)
+	{
+		if (reason && reason_size)
+			q_strlcpy (reason, "tcMod limit exceeded", reason_size);
+		return MAT_PARTICLE_STAGE_HARD_FAIL;
+	}
 
 	for (i = 0; i < stage->tcmod_count; ++i)
 	{

--- a/Quake/mat_material.h
+++ b/Quake/mat_material.h
@@ -219,6 +219,7 @@ typedef struct mat_material_stage_s
 	mat_map_type_t		map_type;
 	mat_tcgen_t		tcgen;
 	int			tcmod_count;
+	qboolean		tcmod_overflow;
 	mat_tcmod_t		tcmods[4];
 	float			anim_map_fps;
 	char			**anim_map_frames;

--- a/Quake/mat_material_parse.c
+++ b/Quake/mat_material_parse.c
@@ -580,13 +580,13 @@ static qboolean Material_ParseTcGen (const char *token, mat_tcgen_t *out)
 	return false;
 }
 
-static void Material_PushTcMod (material_stage_t *stage, mat_tcmod_type_t type, const float *args, int arg_count)
+static qboolean Material_PushTcMod (material_stage_t *stage, mat_tcmod_type_t type, const float *args, int arg_count)
 {
 	mat_tcmod_t mod;
 	int i;
 
 	if (!stage || stage->tcmod_count >= (int)countof (stage->tcmods))
-		return;
+		return false;
 
 	memset (&mod, 0, sizeof (mod));
 	mod.type = type;
@@ -594,6 +594,7 @@ static void Material_PushTcMod (material_stage_t *stage, mat_tcmod_type_t type, 
 		mod.args[i] = args[i];
 
 	stage->tcmods[stage->tcmod_count++] = mod;
+	return true;
 }
 
 static qboolean ExpectToken (const char **data, const char *token, mat_material_parse_state_t *state)
@@ -1388,7 +1389,13 @@ static const char *ParseStageBlock (const char *data, material_t *material, size
 					break;
 				}
 				Material_ValidateTcModArgs (state, "tcMod scroll", scroll, scroll_defaults, 2);
-				Material_PushTcMod (&stage, MAT_TCMOD_SCROLL, scroll, 2);
+				if (!Material_PushTcMod (&stage, MAT_TCMOD_SCROLL, scroll, 2))
+				{
+					Material_WarnMaterial (state, "tcMod limit exceeded; ignoring extra modifiers");
+					stage.tcmod_overflow = true;
+					if (r_particles_material_strict.value > 0.f)
+						valid = false;
+				}
 				continue;
 			}
 			if (!q_strcasecmp (value, "scale"))
@@ -1402,7 +1409,13 @@ static const char *ParseStageBlock (const char *data, material_t *material, size
 					break;
 				}
 				Material_ValidateTcModArgs (state, "tcMod scale", scale, scale_defaults, 2);
-				Material_PushTcMod (&stage, MAT_TCMOD_SCALE, scale, 2);
+				if (!Material_PushTcMod (&stage, MAT_TCMOD_SCALE, scale, 2))
+				{
+					Material_WarnMaterial (state, "tcMod limit exceeded; ignoring extra modifiers");
+					stage.tcmod_overflow = true;
+					if (r_particles_material_strict.value > 0.f)
+						valid = false;
+				}
 				continue;
 			}
 			if (!q_strcasecmp (value, "rotate"))
@@ -1416,7 +1429,13 @@ static const char *ParseStageBlock (const char *data, material_t *material, size
 					break;
 				}
 				Material_ValidateTcModArgs (state, "tcMod rotate", &deg_per_sec, &rotate_default, 1);
-				Material_PushTcMod (&stage, MAT_TCMOD_ROTATE, &deg_per_sec, 1);
+				if (!Material_PushTcMod (&stage, MAT_TCMOD_ROTATE, &deg_per_sec, 1))
+				{
+					Material_WarnMaterial (state, "tcMod limit exceeded; ignoring extra modifiers");
+					stage.tcmod_overflow = true;
+					if (r_particles_material_strict.value > 0.f)
+						valid = false;
+				}
 				continue;
 			}
 			if (!q_strcasecmp (value, "turb"))
@@ -1430,7 +1449,13 @@ static const char *ParseStageBlock (const char *data, material_t *material, size
 					break;
 				}
 				Material_ValidateTcModArgs (state, "tcMod turb", turb, turb_defaults, 4);
-				Material_PushTcMod (&stage, MAT_TCMOD_TURB, turb, 4);
+				if (!Material_PushTcMod (&stage, MAT_TCMOD_TURB, turb, 4))
+				{
+					Material_WarnMaterial (state, "tcMod limit exceeded; ignoring extra modifiers");
+					stage.tcmod_overflow = true;
+					if (r_particles_material_strict.value > 0.f)
+						valid = false;
+				}
 				continue;
 			}
 			if (!q_strcasecmp (value, "stretch"))
@@ -1444,7 +1469,13 @@ static const char *ParseStageBlock (const char *data, material_t *material, size
 					break;
 				}
 				Material_ValidateTcModArgs (state, "tcMod stretch", stretch, stretch_defaults, 4);
-				Material_PushTcMod (&stage, MAT_TCMOD_STRETCH, stretch, 4);
+				if (!Material_PushTcMod (&stage, MAT_TCMOD_STRETCH, stretch, 4))
+				{
+					Material_WarnMaterial (state, "tcMod limit exceeded; ignoring extra modifiers");
+					stage.tcmod_overflow = true;
+					if (r_particles_material_strict.value > 0.f)
+						valid = false;
+				}
 				continue;
 			}
 			Material_ReportUnknownToken (value, MATERIAL_KEYWORD_SCOPE_STAGE, material->name,

--- a/docs/particle_material_contract.md
+++ b/docs/particle_material_contract.md
@@ -41,7 +41,8 @@ Nicht erlaubt im Partikel-MVP:
 Zusätzlich gilt:
 
 - `tcGen` muss `base` sein.
-- Mehr als `countof(stage->tcmods)` ist ein Hard-Fail (inkonsistente Stage-Daten).
+- Mehr als `countof(stage->tcmods)` wird beim Parsen verworfen, als `tcmod_overflow` markiert
+  und als Hard-Fail klassifiziert.
 
 ### Erlaubte Blend-Modi
 
@@ -83,7 +84,7 @@ Bewusst außerhalb des MVP (deferred):
 Unabhängig von strict/tolerant bleiben **inkonsistente Daten** Hard-Fail:
 
 - fehlende Stage (`NULL`)
-- `tcMod` overflow
+- `tcMod` overflow (`tcmod_overflow`, inkl. Warnung: `tcMod limit exceeded; ignoring extra modifiers`)
 - `blendFunc` custom mit ungültigen Faktoren
 
 ## 4) Akzeptanzkriterien und Tests
@@ -109,7 +110,7 @@ Für jede Stage muss eindeutig klassifiziert sein:
    - strict → **hard-fail**
 6. `blendFunc GL_ONE ???` mit ungültigem Faktor-Parsing → **hard-fail**
 7. `stage == NULL` → **hard-fail**
-8. `tcmod_count > countof(tcmods)` → **hard-fail**
+8. mehr als 4 `tcMod`-Direktiven in einer Stage (Overflow-Flag gesetzt) → **hard-fail**
 
 ### Dokumentierter Fallback
 


### PR DESCRIPTION
### Motivation

- The material parser previously dropped excess `tcMod` entries silently, losing visibility into overflow and causing inconsistent stage data handling for particle classification. 
- Parsing should emit a warning and record overflow in stage metadata so `Material_ClassifyParticleStage` can make deterministic tolerant/strict decisions.

### Description

- Change `Material_PushTcMod` (`Quake/mat_material_parse.c`) to return `qboolean` success/failure so callers can detect when a `tcMod` could not be stored. 
- At each `tcMod` parse site (`scroll`, `scale`, `rotate`, `turb`, `stretch`) the parser now emits `Material_WarnMaterial(state, "tcMod limit exceeded; ignoring extra modifiers")`, sets `stage.tcmod_overflow = true`, and marks the stage invalid when `r_particles_material_strict` is enabled. 
- Add `tcmod_overflow` to `material_stage_t` (`Quake/mat_material.h`) so overflow is recorded in the stage structure. 
- Update `Material_ClassifyParticleStage` (`Quake/mat_material.c`) to treat `tcmod_overflow` as a hard-fail reason (`"tcMod limit exceeded"`) during classification. 
- Update `docs/particle_material_contract.md` to document that excess `tcMod` entries are discarded, warned about, flagged via `tcmod_overflow`, and classified as a hard-fail.

### Testing

- Verified code locations with `rg` to ensure all `tcMod` parse sites and classification checks were updated to use `Material_PushTcMod` return value and `tcmod_overflow`. 
- Attempted to build with `make -j4` in `Quake/`, but the build could not complete in this environment due to missing SDL2 development tooling (`sdl2-config` and `SDL.h`), so a full compile/test was not run. 
- Local grep/inspection confirms the new warning text `"tcMod limit exceeded; ignoring extra modifiers"`, the `tcmod_overflow` field, and the classification branch were added successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c29c800fe4832ea1b3509e08052b4f)