### PR TITLE
docs: standardize particle material contract language and add reciprocal links

### DIFF
--- a/docs/how2use-materials.md
+++ b/docs/how2use-materials.md
@@ -4,6 +4,10 @@ Ironwail loads material definitions from `materials/*.material` through the
 material pipeline. These definitions are used for texture metadata and selected
 render-stage behavior (including particle material integration).
 
+For the particle-stage compatibility contract (MVP scope + strict/tolerant
+policy), see
+[`docs/particle_material_contract.md`](./particle_material_contract.md).
+
 ## Console workflow
 
 1. **List loaded materials**

--- a/docs/particle_material_contract.md
+++ b/docs/particle_material_contract.md
@@ -1,36 +1,41 @@
 # Particle Shader Contract (MVP)
 
-Diese Spezifikation beschreibt den **MVP-Partikel-Shader-Vertrag** auf Basis von `mat_material.h/.c`.
+This specification describes the **MVP particle shader contract** based on
+`mat_material.h/.c`.
 
-## 1) Vertragsumfang pro Stage
+Related docs:
+- Parser + API overview: [`docs/how2use-materials.md`](./how2use-materials.md)
 
-Eine Stage ist für den Partikelpfad klassifiziert als:
+## 1) Contract scope per stage
+
+A stage is classified for the particle path as:
 
 - `MAT_PARTICLE_STAGE_SUPPORTED`
 - `MAT_PARTICLE_STAGE_SKIPPED`
 - `MAT_PARTICLE_STAGE_HARD_FAIL`
 
-Die Bewertung erfolgt mit `Material_ClassifyParticleStage(stage, policy, reason, reason_size)`.
+Classification is performed with
+`Material_ClassifyParticleStage(stage, policy, reason, reason_size)`.
 
-### Erlaubte `map`-Typen
+### Allowed `map` types
 
 - `map <path>` (`MAT_MAP_MAP`)
 - `clampmap <path>` (`MAT_MAP_CLAMPMAP`)
 - `map $whiteimage` (`MAT_MAP_WHITE`)
 - `map $blackimage` (`MAT_MAP_BLACK`)
 
-Nicht erlaubt im Partikel-MVP:
+Not allowed in the particle MVP:
 
 - `map $lightmap` (`MAT_MAP_LIGHTMAP`)
 
-### Erlaubte `rgbGen`/`alphaGen`
+### Allowed `rgbGen`/`alphaGen`
 
 - `identity`
 - `vertex`
 - `const`
 - `wave`
 
-### Erlaubte `tcMod`
+### Allowed `tcMod`
 
 - `scroll`
 - `scale`
@@ -38,63 +43,68 @@ Nicht erlaubt im Partikel-MVP:
 - `turb`
 - `stretch`
 
-Zusätzlich gilt:
+Additionally:
 
-- `tcGen` muss `base` sein.
-- Mehr als `countof(stage->tcmods)` ist ein Hard-Fail (inkonsistente Stage-Daten).
+- `tcGen` must be `base`.
+- More than `countof(stage->tcmods)` is a hard fail (inconsistent stage data).
 
-### Erlaubte Blend-Modi
+### Allowed blend modes
 
 - `replace`
 - `alpha` (`blend`)
 - `add`
 - `mult` (`filter`)
 - `premult`
-- `custom` nur mit gültigen `blend_src`/`blend_dst` Faktoren.
+- `custom` only with valid `blend_src`/`blend_dst` factors.
 
 ## 2) MVP-Subset (Quad/Sprite)
 
-Der MVP umfasst die Features, die direkt im Partikel-Rendering sinnvoll sind:
+The MVP includes features that are directly useful for particle rendering:
 
-- Quad/Sprite-Stage mit einer unterstützten `map`/`clampmap`.
-- `animMap` (FPS + Frame-Liste).
-- UV-Modulation über `tcMod`: `scroll`, `scale`, `rotate`, `turb`, `stretch`.
-- Farb-/Alpha-Modulation über `rgbGen`/`alphaGen`: `identity`, `vertex`, `const`, `wave`.
-- Blending über die oben definierten Modi.
+- Quad/sprite stage with a supported `map`/`clampmap`.
+- `animMap` (FPS + frame list).
+- UV modulation via `tcMod`: `scroll`, `scale`, `rotate`, `turb`, `stretch`.
+- Color/alpha modulation via `rgbGen`/`alphaGen`: `identity`, `vertex`, `const`,
+  `wave`.
+- Blending using the modes listed above.
 
-Bewusst außerhalb des MVP (deferred):
+Intentionally outside the MVP (deferred):
 
 - `alphaFunc`
 - `tcGen environment/lightmap`
-- nicht unterstützte `tcMod`-Typen
-- sonstige Stage-Direktiven außerhalb der obigen Liste
+- unsupported `tcMod` types
+- other stage directives outside the list above
 
 ## 3) Policy: tolerant vs. strict
 
-`r_particles_material_strict` steuert das Verhalten für **nicht unterstützte, aber syntaktisch valide** Stage-Features:
+`r_particles_material_strict` controls behavior for **unsupported but
+syntactically valid** stage features:
 
 - `r_particles_material_strict 0` (tolerant):
-  - Ergebnis: `MAT_PARTICLE_STAGE_SKIPPED`
-  - Fallback: Stage wird verworfen, Renderer nutzt sichere Standard-Partikelpfade.
+  - Result: `MAT_PARTICLE_STAGE_SKIPPED`
+  - Fallback: the stage is discarded; the renderer uses safe default particle
+    paths.
 - `r_particles_material_strict 1` (strict):
-  - Ergebnis: `MAT_PARTICLE_STAGE_HARD_FAIL`
-  - Fallback: Shader-/Stage-Kandidat gilt als nicht nutzbar für den Partikelpfad.
+  - Result: `MAT_PARTICLE_STAGE_HARD_FAIL`
+  - Fallback: the shader/stage candidate is treated as unusable for the
+    particle path.
 
-Unabhängig von strict/tolerant bleiben **inkonsistente Daten** Hard-Fail:
+Independent of strict/tolerant policy, **inconsistent data** is always hard
+fail:
 
-- fehlende Stage (`NULL`)
+- missing stage (`NULL`)
 - `tcMod` overflow
-- `blendFunc` custom mit ungültigen Faktoren
+- `blendFunc` custom with invalid factors
 
-## 4) Akzeptanzkriterien und Tests
+## 4) Acceptance criteria and tests
 
-Für jede Stage muss eindeutig klassifiziert sein:
+Each stage must be classified unambiguously as:
 
 - supported
 - skipped
 - hard-fail
 
-### Testmatrix (Soll-Verhalten)
+### Test matrix (expected behavior)
 
 1. `map textures/particles/smoke` + `rgbGen vertex` + `alphaGen wave` + `tcMod scroll` → **supported**
 2. `map $whiteimage` + `blendFunc add` → **supported**
@@ -104,16 +114,27 @@ Für jede Stage muss eindeutig klassifiziert sein:
 4. `tcGen environment`:
    - tolerant → **skipped**
    - strict → **hard-fail**
-5. `tcMod transform` (nicht MVP):
+5. `tcMod transform` (not in MVP):
    - tolerant → **skipped**
    - strict → **hard-fail**
-6. `blendFunc GL_ONE ???` mit ungültigem Faktor-Parsing → **hard-fail**
+6. `blendFunc GL_ONE ???` with invalid factor parsing → **hard-fail**
 7. `stage == NULL` → **hard-fail**
 8. `tcmod_count > countof(tcmods)` → **hard-fail**
 
-### Dokumentierter Fallback
+### Documented fallback
 
-Wenn eine Stage nicht unterstützt wird, ist der Fallback deterministisch:
+If a stage is unsupported, fallback behavior is deterministic:
 
-- tolerant: Stage skippen und auf sichere Partikel-Defaults degradieren.
-- strict: Stage als Hard-Fail markieren und nicht als MVP-kompatibel akzeptieren.
+- tolerant: skip the stage and degrade to safe particle defaults.
+- strict: mark the stage as hard fail and do not accept it as MVP-compatible.
+
+## 5) Last updated against parser behavior
+
+This contract was cross-checked against current parser/implementation behavior
+in:
+
+- `Quake/mat_material_parse.c`
+- `Quake/mat_material.c`
+
+For parser/API usage details, see
+[`docs/how2use-materials.md`](./how2use-materials.md).


### PR DESCRIPTION
### Motivation
- Standardize documentation language by translating the particle material contract to English to make the contract accessible to the repo's broader audience. 
- Ensure docs navigation and developer flow remain aligned by adding reciprocal links between material usage docs and the particle contract. 
- Make it explicit which parser/implementation sources the contract was validated against to help future maintainers keep docs in sync with behavior.

### Description
- Translated `docs/particle_material_contract.md` from German to English and normalized section headings, policy text, acceptance criteria, and test matrix. 
- Added a reciprocal cross-link from `docs/how2use-materials.md` to `docs/particle_material_contract.md` and a link back from the particle contract to `docs/how2use-materials.md`. 
- Added a new "Last updated against parser behavior" section in `docs/particle_material_contract.md` referencing `Quake/mat_material_parse.c` and `Quake/mat_material.c`. 
- Fixed several minor wording and consistency issues (e.g., `tcMod`/`tcGen` wording, blend mode phrasing, and test matrix entries) to keep contract and implementation docs aligned. 

### Testing
- Ran `git diff --check` to validate whitespace and trivial diff issues, which reported no problems.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c29c61cd7c832e9cebba7ed1bc3cf7)