### PR TITLE
docs: refresh material parser capability note in mat_material.h

### DIFF
--- a/Quake/mat_material.h
+++ b/Quake/mat_material.h
@@ -260,10 +260,24 @@ typedef struct material_s
 } material_t;
 
 // Developer note:
-// Supported directives: qer_editorimage, surfaceparm, emissive, bloom, godray, emissive_scale,
-// bloom_scale, godray_scale, emissiveScale, bloomScale, godrayScale, and a single stage block
-// with map + rgbGen identity.
-// To add new surfaceparms, extend mat_surfaceparm_table in mat_material_parse.c and map to flags.
+// Material parsing supports top-level and stage blocks as implemented by ParseMaterialBlock
+// and ParseStageBlock in Quake/mat_material_parse.c.
+//
+// Capability snapshot (see keyword table/docs for exact coverage):
+// - Implemented: core top-level metadata/flags (qer_editorimage, surfaceparm, polygonOffset,
+//   emissive/bloom/godray + *_scale) and core stage features (map/clampmap, depthWrite,
+//   stage emissive/bloom/godray + *Scale).
+// - Partial: selected classic directives such as cull, sort, animMap, rgbGen/alphaGen,
+//   blendFunc, depthFunc, tcGen, and tcMod.
+// - Deferred (known unimplemented): skyParms, fogParms, deformVertexes, q3map_*, alphaFunc.
+//
+// Extension/status references:
+// - Canonical status map: mat_material_keyword_table in Quake/mat_material.c.
+// - Authoring guide: docs/how2use-materials.md.
+// - Particle constraints: docs/particle_material_contract.md.
+//
+// Warning: parser coverage evolves over time; always treat mat_material_keyword_table as the
+// canonical source of directive support status.
 
 typedef struct texture_s texture_t;
 


### PR DESCRIPTION
### Motivation
- The old developer note next to `material_t` was out of sync with the parser and understated supported directives, so it needed replacement with an accurate, maintainable summary. 
- The project exposes canonical extension points via `ParseMaterialBlock`/`ParseStageBlock` and a keyword table, so the note should point readers at those locations.

### Description
- Replaced the legacy developer note in `Quake/mat_material.h` with a concise capability snapshot aligned to `ParseMaterialBlock` and `ParseStageBlock` in `Quake/mat_material_parse.c`. 
- Split directive support into explicit levels (`Implemented`, `Partial`, `Deferred`) and enumerated representative directives to match current parser behavior. 
- Added references to the canonical status table (`mat_material_keyword_table` in `Quake/mat_material.c`) and the documentation files `docs/how2use-materials.md` and `docs/particle_material_contract.md`, plus a warning that the keyword table is the authoritative source.

### Testing
- Ran `git diff -- Quake/mat_material.h` to verify the textual change and it reported the expected insertions and deletions (success). 
- Ran `git status --short` to confirm the working tree update and the change was staged/committed (success). 
- Printed relevant file regions with `nl -ba ... | sed -n ...` to validate the new note and corroborating parser/keyword locations in `Quake/mat_material_parse.c` and `Quake/mat_material.c` (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c29c3eac28832e896123b017ed4e0d)