### PR TITLE
Free previous stage.map_path before reassigning in map/clampmap handlers

### DIFF
--- a/Quake/mat_material_parse.c
+++ b/Quake/mat_material_parse.c
@@ -973,6 +973,11 @@ static const char *ParseStageBlock (const char *data, material_t *material, size
 				data = SkipUnknownBlockOrLine (data, true, state);
 				break;
 			}
+			if (stage.map_path)
+			{
+				Z_Free (stage.map_path);
+				stage.map_path = NULL;
+			}
 			if (!q_strcasecmp (value, "$lightmap"))
 			{
 				stage.map_type = MAT_MAP_LIGHTMAP;
@@ -1000,6 +1005,11 @@ static const char *ParseStageBlock (const char *data, material_t *material, size
 				valid = false;
 				data = SkipUnknownBlockOrLine (data, true, state);
 				break;
+			}
+			if (stage.map_path)
+			{
+				Z_Free (stage.map_path);
+				stage.map_path = NULL;
 			}
 			stage.map_type = MAT_MAP_CLAMPMAP;
 			stage.map_path = Material_DupString (value);


### PR DESCRIPTION
### Motivation
- Prevent stale allocations and memory leaks when a `map` or `clampmap` directive overrides a previously-set `stage.map_path` within the same stage block.
- Ensure ownership and cleanup semantics match `Material_FreeStageData` which frees `map_path` and sets it to `NULL`.
- Make built-in map tokens (`$lightmap`, `$whiteimage`/`$white`, `$blackimage`/`$black`) also clear any prior `map_path` when selected.

### Description
- Added a defensive cleanup in the `map` handler to `Z_Free(stage.map_path)` and set `stage.map_path = NULL` before processing the new token.
- Added the same cleanup in the `clampmap` handler before assigning `stage.map_path = Material_DupString(value)`.
- Left ownership behavior consistent with `Material_FreeStageData` by freeing then nulling the pointer instead of leaking or leaving stale pointers.

### Testing
- Located relevant branches with `rg` to confirm the change targets the correct `map`/`clampmap` handlers and inspected context with `nl`, which showed the inserted cleanup lines as expected; these inspections succeeded.
- Verified the produced patch/diff shows the new `Z_Free`/NULL assignments in both handlers; the diff inspection succeeded.
- The file update/apply step completed successfully; no runtime or compile-time tests were executed in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c29c2c5a44832e8d82eadd5b332e9a)