### PR TITLE
Unify SkyVis ambient contract for world, models, and fog

### DIFF
--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -502,10 +502,10 @@ typedef struct gpuframedata_s {
         vec4_t          lightgrid_params; // x: enabled, yzw: unused
         vec4_t          dlight_params;  // x: style, y: debug view, z: pass selector, w: padding
         vec4_t          colorspace_params; // x: debug mode, y: manual gamma, z: output sRGB, w: unused
-        vec4_t          shader_params;  // x: shader debug, y: tcgen debug, z: legacy sun visibility, w: skyvis scale
+        vec4_t          shader_params;  // x: shader debug, y: tcgen debug, z: legacy sun visibility, w: ambient-sky scale
         vec4_t          sun_dir_enabled; // xyz: sun dir (scene->sun), w: enabled
         vec4_t          sun_color_intensity; // rgb: sun color, w: intensity
-        vec4_t          skyvis_tint;    // rgb: sky tint, w: cap
+        vec4_t          skyvis_tint;    // Shared ambient-sky contract: rgb tint + w cap (world/alias/fog)
         unsigned int    numlights;
         unsigned int    prev_frame_valid;
         unsigned int    _padding1;

--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -25,6 +25,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "quakedef.h"
 #include "../common/lightgrid.h"
 #include "r_realtimelight.h"
+#include "r_skyvis.h"
 
 extern cvar_t gl_overbright_models, gl_fullbrights, r_lerpmodels, r_lerpmove, r_model_halflambert; //johnfitz
 extern cvar_t scr_fov, cl_gun_fovscale, cl_gun_x, cl_gun_y, cl_gun_z;
@@ -79,6 +80,8 @@ typedef struct aliasinstance_s {
 	float		_pad1;
 	vec3_t		staticlightdir;
 	float		_pad2;
+	float		skyvisibility;
+	float		_pad3[3];
 	int32_t		pose1;
 	int32_t		pose2;
 	float		blend;
@@ -105,13 +108,17 @@ struct ibuf_s {
 		float	half_lambert;
 		float	dlight_debug_models;
 		float	dlight_directional_mix;
+		float	pp_dlight_model_enable;
+		float	pp_dlight_model_debug;
+		float	ambient_sky_params[4]; // x: enabled, y: scale, z: debug, w: unused
+		float	ambient_sky_tint[4];   // rgb: tint, w: cap
 		float	_pad1[3];
 	} global;
 	aliasinstance_t inst[MAX_ALIAS_INSTANCES];
 } ibuf;
 
 COMPILE_TIME_ASSERT (alias_global_size_matches_std430, sizeof (ibuf.global) % 16 == 0);
-COMPILE_TIME_ASSERT (alias_instance_size_matches_std430, sizeof (aliasinstance_t) == 224);
+COMPILE_TIME_ASSERT (alias_instance_size_matches_std430, sizeof (aliasinstance_t) == 240);
 
 static qboolean r_lightgrid_debug_sample_reported = false;
 static const qmodel_t *r_lightgrid_debug_last_world = NULL;
@@ -789,7 +796,17 @@ ibuf.global.dither = r_framedata.dither[0];
 ibuf.global.half_lambert = CLAMP (0.f, r_model_halflambert.value, 1.f);
 ibuf.global.dlight_debug_models = 0.f;
 ibuf.global.dlight_directional_mix = CLAMP (0.f, r_dlight_models_directional.value, 1.f);
-ibuf.global._pad1[0] = use_pp_models ? 1.f : 0.f;
+ibuf.global.pp_dlight_model_enable = use_pp_models ? 1.f : 0.f;
+ibuf.global.pp_dlight_model_debug = 0.f;
+ibuf.global.ambient_sky_params[0] = (r_skyvis.value > 0.f && R_SkyVis_Active ()) ? 1.f : 0.f;
+ibuf.global.ambient_sky_params[1] = R_SkyVis_GetResolvedScale ();
+ibuf.global.ambient_sky_params[2] = (r_skyvis_debug.value >= 2.f) ? 1.f : 0.f;
+ibuf.global.ambient_sky_params[3] = 0.f;
+ibuf.global.ambient_sky_tint[0] = r_framedata.skyvis_tint[0];
+ibuf.global.ambient_sky_tint[1] = r_framedata.skyvis_tint[1];
+ibuf.global.ambient_sky_tint[2] = r_framedata.skyvis_tint[2];
+ibuf.global.ambient_sky_tint[3] = r_framedata.skyvis_tint[3];
+ibuf.global._pad1[0] = 0.f;
 ibuf.global._pad1[1] = 0.f;
 ibuf.global._pad1[2] = 0.f;
 
@@ -1057,6 +1074,7 @@ static void R_DrawAliasModel_Real (entity_t *e, qboolean showtris)
 	float		fovscale = 1.0f;
 	float		model_matrix[16];
 	aliasinstance_t	*instance;
+	float		skyvisibility = 0.f;
 
 	//
 	// setup pose/lerp data -- do it first so we don't miss updates due to culling
@@ -1119,6 +1137,8 @@ static void R_DrawAliasModel_Real (entity_t *e, qboolean showtris)
         //
 	rs_aliaspolys += paliashdr->numtris;
 	R_SetupAliasLighting (e);
+	if (r_skyvis.value > 0.f && R_SkyVis_Active ())
+		skyvisibility = CLAMP (0.f, R_SkyVis_Sample (lerpdata.origin), 1.f);
 
 	//
 	// draw it
@@ -1192,9 +1212,13 @@ static void R_DrawAliasModel_Real (entity_t *e, qboolean showtris)
         VectorCopy (e->lightcache.dlightcolor, instance->dlightcolor);
         VectorCopy (e->lightcache.dlightdir, instance->dlightdir);
         VectorCopy (e->lightcache.staticlightdir, instance->staticlightdir);
+	instance->skyvisibility = skyvisibility;
         instance->_pad0 = 0.f;
         instance->_pad1 = 0.f;
         instance->_pad2 = 0.f;
+	instance->_pad3[0] = 0.f;
+	instance->_pad3[1] = 0.f;
+	instance->_pad3[2] = 0.f;
         instance->alpha = entalpha;
         if (e == &cl.viewent)
                 instance->flags |= ALIAS_INSTANCE_FLAG_NO_MOTION_BLUR | ALIAS_INSTANCE_FLAG_VIEWMODEL;

--- a/Quake/r_fogvol.c
+++ b/Quake/r_fogvol.c
@@ -5,6 +5,7 @@
 #include "r_dlight_pool.h"
 #include "r_godrays.h"
 #include "r_realtimelight.h"
+#include "r_skyvis.h"
 #include <math.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -655,6 +656,9 @@ static void R_FogVol_FillGPUVolume (const fog_volume_t *v, fog_volume_gpu_t *gpu
 	gpu->params2[0] = v->edgeSoftness;
 	gpu->params2[1] = v->heightScale;
 	gpu->params2[2] = v->falloff;
+	gpu->params2[3] = 0.f;
+	if (r_skyvis.value > 0.f && R_SkyVis_Active ())
+		gpu->params2[3] = CLAMP (0.f, R_SkyVis_Sample (v->sphereCenter), 1.f);
 }
 
 static void R_FogVol_UploadVolumeRange (const fog_volume_t *volumes, int count)
@@ -1044,4 +1048,3 @@ void R_FogVol_DrawDebug2D (void)
 void R_FogVol_LogEndFrameState (void)
 {
 }
-

--- a/Quake/shaders/alias.frag
+++ b/Quake/shaders/alias.frag
@@ -7,6 +7,8 @@ struct InstanceData
 	vec4	DLightColor; // xyz=DLightColor
 	vec4	DLightDir;   // xyz=dominant dlight direction
 	vec4	StaticLightDir; // xyz=dominant static light direction
+	float	SkyVisibility;
+	vec3	_PadSky;
 	int		Pose1;
 	int		Pose2;
 	float	Blend;
@@ -27,7 +29,9 @@ layout(std430, binding=1) restrict readonly buffer AliasFrameBlock
 	float	DLightDirectionalMix;
 	float	PPDLightModelEnable;
 	float	PPDLightModelDebug;
-	float	_Pad1;
+	vec4	AmbientSkyParams; // x: enabled, y: scale, z: debug mode, w: unused
+	vec4	AmbientSkyTint;   // rgb: tint, w: cap
+	float	_Pad1[3];
 	InstanceData instances[];
 } AliasFrameBuffer;
 
@@ -141,6 +145,7 @@ layout(location=5) flat in int in_flags;
 layout(location=6) in vec3 in_normal;
 layout(location=7) in float in_dlight_vis;
 layout(location=8) in vec3 in_dlight_color;
+layout(location=9) in float in_sky_visibility;
 
 #define OUT_COLOR out_fragcolor
 #if OIT
@@ -462,6 +467,24 @@ void main()
 			sun_shadow = SampleSunShadow(world_pos);
 			result.rgb += albedo * ShadowSunColorIntensity.rgb * ShadowSunColorIntensity.a
 				* ndotl * max(ShadowSunVisibility, 0.0) * sun_shadow;
+		}
+	}
+
+	{
+		float sky_enable = clamp(AliasFrameBuffer.AmbientSkyParams.x, 0.0, 1.0);
+		float sky_scale = max(AliasFrameBuffer.AmbientSkyParams.y, 0.0);
+		float sky_visibility = clamp(in_sky_visibility, 0.0, 1.0);
+		float sky_upness = clamp(world_nor.z * 0.5 + 0.5, 0.0, 1.0);
+		float sky_room = 1.0 - 0.6 * max(max(lit_color.r, lit_color.g), lit_color.b);
+		vec3 sky_ambient = AliasFrameBuffer.AmbientSkyTint.rgb
+			* (sky_enable * sky_scale * mix(0.2, 1.0, sky_upness) * sky_visibility * max(sky_room, 0.0));
+		sky_ambient = min(sky_ambient, vec3(max(AliasFrameBuffer.AmbientSkyTint.a, 0.0)));
+		result.rgb += max(min(sky_ambient, vec3(1.0) - result.rgb), vec3(0.0));
+
+		if (AliasFrameBuffer.AmbientSkyParams.z > 0.5)
+		{
+			float sky_luma = clamp(dot(sky_ambient, vec3(0.2126, 0.7152, 0.0722)) * 8.0, 0.0, 1.0);
+			result.rgb = vec3(sky_visibility, sky_luma, 0.0);
 		}
 	}
 

--- a/Quake/shaders/alias.vert
+++ b/Quake/shaders/alias.vert
@@ -7,6 +7,8 @@ struct InstanceData
 	vec4	DLightColor; // xyz=DLightColor
 	vec4	DLightDir;   // xyz=dominant dlight direction
 	vec4	StaticLightDir; // xyz=dominant static light direction
+	float	SkyVisibility;
+	vec3	_PadSky;
 	int		Pose1;
 	int		Pose2;
 	float	Blend;
@@ -27,7 +29,9 @@ layout(std430, binding=1) restrict readonly buffer AliasFrameBlock
 	float	DLightDirectionalMix;
 	float	PPDLightModelEnable;
 	float	PPDLightModelDebug;
-	float	_Pad1;
+	vec4	AmbientSkyParams; // x: enabled, y: scale, z: debug mode, w: unused
+	vec4	AmbientSkyTint;   // rgb: tint, w: cap
+	float	_Pad1[3];
 	InstanceData instances[];
 } AliasFrameBuffer;
 
@@ -100,6 +104,7 @@ layout(location=5) flat out int out_flags;
 layout(location=6) out vec3 out_normal;
 layout(location=7) out float out_dlight_vis;
 layout(location=8) out vec3 out_dlight_color;
+layout(location=9) out float out_sky_visibility;
 
 const int ALIAS_FLAG_VIEWMODEL = 2;
 
@@ -158,4 +163,5 @@ void main()
 	out_dlight_vis = clamp(dot(litDlight, vec3(0.2126, 0.7152, 0.0722)), 0.0, 1.0);
 	out_dlight_color = litDlight;
 	out_normal = world_normal;
+	out_sky_visibility = clamp(inst.SkyVisibility, 0.0, 1.0);
 }

--- a/Quake/shaders/fogvol.frag
+++ b/Quake/shaders/fogvol.frag
@@ -467,6 +467,13 @@ void main()
 	float transmittance = 1.0;
 	float tau = 0.0;
 	float ambientWeight = clamp(FogClusterParams.x, 0.0, 1.0);
+	float ambientSkyVis = clamp(volume.params2.w, 0.0, 1.0);
+	float ambientSkyMod = 1.0;
+	if (AmbientSkyEnabled() > 0.5)
+	{
+		float skyRoom = 1.0 - clamp(max(max(volume.color_density.r, volume.color_density.g), volume.color_density.b) * 0.6, 0.0, 1.0);
+		ambientSkyMod = clamp(AmbientSkyScale() * ambientSkyVis * max(skyRoom, 0.0), 0.0, 1.0);
+	}
 	// Keep ambient contribution capped so lit scattering remains dominant.
 	float lightContrast = clamp(FogLightSourceScales.w, 0.5, 4.0);
 	float extinctionRelief = clamp(FogClusterParams.w, 0.0, 0.95);
@@ -502,7 +509,8 @@ void main()
 
 		vec3 scattering = vec3(0.0);
 		// Keep only a small unlit baseline so lighting and shadows dominate.
-		scattering += volume.color_density.rgb * min(ambientWeight, 0.15);
+		vec3 ambientTint = mix(vec3(1.0), AmbientSkyTint(), clamp(ambientSkyMod, 0.0, 1.0));
+		scattering += volume.color_density.rgb * ambientTint * min(ambientWeight, 0.15);
 		scattering += froxelScatter;
 		scattering += sunScatter;
 		scattering += emissiveScatter;
@@ -549,6 +557,11 @@ void main()
 		FragColor = vec4(vec3(clamp(transmittance, 0.0, 1.0)), 1.0);
 		return;
 	}
+	if (AmbientSkyDebugEnabled() > 0.5)
+	{
+		FragColor = vec4(vec3(ambientSkyVis), 1.0);
+		return;
+	}
 	if (FogFroxelDebug != 0)
 	{
 		vec3 uvw;
@@ -593,4 +606,3 @@ void main()
 
 	FragColor = vec4(outColor, 1.0 - transmittance);
 }
-

--- a/Quake/shaders/frame_uniforms.glsl
+++ b/Quake/shaders/frame_uniforms.glsl
@@ -46,10 +46,10 @@ layout(std140, binding=0) uniform FrameDataUBO
     vec4    LightgridParams;    // 320
     vec4    DLightParams;       // 336
     vec4    ColorSpaceParams;   // 352
-    vec4    ShaderParams;       // 368  x: shader debug, y: tcgen debug, z: legacy sun visibility, w: skyvis scale
+    vec4    ShaderParams;       // 368  x: shader debug, y: tcgen debug, z: legacy sun visibility, w: ambient-sky scale
     vec4    SunDirEnabled;  // 384  xyz: scene->sun direction, w: enabled
     vec4    SunColorIntensity; // 400 rgb: sun color, w: intensity
-    vec4    SkyVisTint;     // 416 rgb: sky tint, w: cap
+    vec4    SkyVisTint;     // 416 shared ambient-sky contract: rgb tint, w cap
 
     //  Global params  offset 432
     // NOTE: These members must stay layout-compatible with gpuframedata_t
@@ -62,6 +62,39 @@ layout(std140, binding=0) uniform FrameDataUBO
     uint    _Pad1;          // 424
     uint    _Pad2;          // 428
 };                          // Total: 432 bytes
+
+float AmbientSkyEnabled()
+{
+    return (LightgridParams.z > 0.5) ? 1.0 : 0.0;
+}
+
+float AmbientSkyDebugEnabled()
+{
+    return (LightgridParams.w > 0.5) ? 1.0 : 0.0;
+}
+
+float AmbientSkyScale()
+{
+    return max(ShaderParams.w, 0.0);
+}
+
+vec3 AmbientSkyTint()
+{
+    return max(SkyVisTint.rgb, vec3(0.0));
+}
+
+float AmbientSkyCap()
+{
+    return max(SkyVisTint.a, 0.0);
+}
+
+vec3 AmbientSkyDiffuse(float visibility, float upness, float room)
+{
+    float sky = AmbientSkyEnabled() * AmbientSkyScale() * clamp(visibility, 0.0, 1.0)
+        * mix(0.2, 1.0, clamp(upness, 0.0, 1.0)) * max(room, 0.0);
+    vec3 diffuse = AmbientSkyTint() * sky;
+    return min(diffuse, vec3(AmbientSkyCap()));
+}
 
 
 #endif // FRAME_UNIFORMS_GLSL

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -688,11 +688,9 @@ void main()
 		 * indoor scenes (double attenuation). Keep world static lighting authored. */
 		vec3 total_light    = clamped_static + in_bmodel_relight;
 		float sky_visibility = clamp(in_skyvisibility, 0.0, 1.0);
-		float skyvis_enable = (LightgridParams.z > 0.5) ? 1.0 : 0.0;
 		float sky_upness = clamp(surface_normal.z * 0.5 + 0.5, 0.0, 1.0);
 		float sky_room = 1.0 - 0.6 * max(max(clamped_static.r, clamped_static.g), clamped_static.b);
-		vec3 sky_diffuse = SkyVisTint.rgb * (skyvis_enable * ShaderParams.w * mix(0.2, 1.0, sky_upness) * sky_visibility * max(sky_room, 0.0));
-		sky_diffuse = min(sky_diffuse, vec3(SkyVisTint.a));
+		vec3 sky_diffuse = AmbientSkyDiffuse(sky_visibility, sky_upness, sky_room);
 		total_light += max(min(sky_diffuse, 1.0 - total_light), 0.0);
 
 		// Dynamic lights


### PR DESCRIPTION
### Motivation
- Provide a single, well-documented ambient-sky contract so world, model (alias), and volumetric fog shading share the same SkyVis-driven ambient behavior and parameters.
- Make model and fog ambient lighting track the same SkyVis regime as world surfaces so lighting feels consistent across surfaces, entities, and volumes.
- Keep the change low-cost when SkyVis is disabled and expose debug parity so developers can verify alignment between world/models/fog.

### Description
- Added shared helpers and a documented ambient-sky contract to the frame UBO include: `FrameDataUBO` helpers in `Quake/shaders/frame_uniforms.glsl` (`AmbientSkyEnabled`, `AmbientSkyDebugEnabled`, `AmbientSkyScale`, `AmbientSkyTint`, `AmbientSkyCap`, `AmbientSkyDiffuse`) and clarified the `skyvis_tint` comment in `Quake/glquake.h` so world/alias/fog consume the same contract.
- Switched world skylight to use the shared helper by replacing inline SkyVis math with `AmbientSkyDiffuse(...)` in `Quake/shaders/world.frag` so world lighting follows the unified contract.
- Extended alias model GPU data and CPU upload path in `Quake/r_alias.c` to carry a per-instance `skyvisibility` and per-frame ambient-sky params/tint, sampled SkyVis on the CPU (`R_SkyVis_Sample`) and uploaded to the alias SSBO.
- Propagated SkyVis data into alias shaders (`Quake/shaders/alias.vert` / `alias.frag`) and added a lightweight SkyVis-compatible ambient term (scale/tint/cap + per-model visibility proxy) to `alias.frag`, plus a model debug view when SkyVis debug is active.
- Added a SkyVis proxy for fog volumes on the CPU by writing a sampled value into `fog_volume_gpu_t.params2[3]` in `Quake/r_fogvol.c`, and used that proxy in `Quake/shaders/fogvol.frag` to modulate the fog ambient tint/weight under the same ambient-sky contract; also added a fog debug visualization for SkyVis proxy.
- All new runtime behavior is gated behind the existing `r_skyvis*` controls (`r_skyvis`, `r_skyvis_debug`, `r_skyvis_scale`, `r_skyvis_cap`) and falls back to a no-op path when SkyVis is disabled.

### Testing
- Attempted a full build with `make -C Quake -j4`; the build failed in this environment due to missing SDL2 tooling/headers (`sdl2-config` not found and `SDL.h` missing), so no binary test could be produced.
- No additional automated tests were available in this environment; shader logic changes were implemented following the shared UBO layout so runtime shader upload should be layout-compatible when built in a full dev environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c29e73a35c832eb2dd309e9d9c0a14)