### PR TITLE
SSAO: add fogvol-valid handoff and deterministic suppression policy with debug source

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -403,7 +403,7 @@ cvar_t	r_ssao_blur_radius = { "r_ssao_blur_radius", "2", CVAR_ARCHIVE };
 cvar_t	r_ssao_blur_sigma = { "r_ssao_blur_sigma", "2.0", CVAR_ARCHIVE };
 cvar_t	r_ssao_blur_bilateral = { "r_ssao_blur_bilateral", "1", CVAR_ARCHIVE };
 cvar_t	r_ssao_halfres = { "r_ssao_halfres", "1", CVAR_ARCHIVE };
-// r_ssao_debug modes: 0 off, 1 raw AO, 2 AO*fog, 3 fog factor, 4 depth raw, 5 view-space Z, 6 view-space position, 7 normals, 8 noise, 9 sample hit ratio, 10 AO raw, 11 blur debug, 12 AO mask, 13 fog transmittance, 14 fog-damped AO.
+// r_ssao_debug modes: 0 off, 1 raw AO, 2 AO*fog, 3 fog factor, 4 depth raw, 5 view-space Z, 6 view-space position, 7 normals, 8 noise, 9 sample hit ratio, 10 AO raw, 11 blur debug, 12 AO mask, 13 fog transmittance+source, 14 fog-damped AO.
 cvar_t	r_ssao_debug = { "r_ssao_debug", "0", CVAR_ARCHIVE };
 cvar_t	r_ssao_debug_far = { "r_ssao_debug_far", "4096", CVAR_ARCHIVE };
 cvar_t	r_ssao_reversedz_mode = { "r_ssao_reversedz_mode", "0", CVAR_ARCHIVE };
@@ -2205,12 +2205,25 @@ static float GL_UpdateAutoExposure (void)
 }
 
 
-static void GL_PostProcess_SetMediumScatterUniforms (void)
+static void GL_PostProcess_SetMediumScatterUniforms (const r_ssao_fog_state_t *fog_state)
 {
-	medium_scatter_source_t medium = GL_GetMediumScatterSource ();
+	medium_scatter_source_t medium = { 0, 0.f };
+	float fogvol_valid = 0.f;
+	float transmittance_policy = (float)R_SSAO_FOG_TRANS_GLOBAL_ONLY;
+
+	if (fog_state)
+	{
+		fogvol_valid = fog_state->fogvol_valid ? 1.f : 0.f;
+		transmittance_policy = (float)fog_state->transmittance_policy;
+	}
+
+	/* Framegraph fog handoff captures whether FogVol composite is valid for this
+	 * frame; only sample the medium texture when that handoff says it's ready. */
+	if (fogvol_valid > 0.5f)
+		medium = GL_GetMediumScatterSource ();
 
 	GL_BindNative (GL_TEXTURE10, GL_TEXTURE_2D, medium.texture);
-	GL_Uniform4fFunc (27, medium.valid, 0.f, 0.f, 0.f);
+	GL_Uniform4fFunc (27, medium.valid, transmittance_policy, 0.f, 0.f);
 }
 
 static float GL_ComputeEffectiveBloomIntensity (float bloom_base, float bloom_boost)
@@ -2506,7 +2519,7 @@ void GL_PostProcess (const RenderGraphResourceHandle *resources)
 	/* Bind medium scatter/transmittance texture at slot 10 for SSAO suppression
 	 * in postprocess.frag. The current implementation sources FogVol composite via
 	 * GL_GetMediumScatterSource(), preserving validity gating and stale-handle safety. */
-	GL_PostProcess_SetMediumScatterUniforms ();
+	GL_PostProcess_SetMediumScatterUniforms (&r_ssao_fog_state);
 	GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 0, gl_palette_buffer[palidx], 0, 256 * sizeof (GLuint));
 	{
 		float post_contrast = CLAMP (0.8f, r_color_contrast.value, 1.2f);
@@ -5127,12 +5140,14 @@ static const RenderPassDesc s_fogvol_framegraph_pass_noshadow = {
 static void R_FG_ExecSSAOFogHandoff (RenderPassContext *ctx)
 {
 	(void)ctx;
+	/* Capture both global fog parameters and fogvol composite validity so
+	 * postprocess SSAO suppression uses deterministic source selection. */
 	R_SSAO_CaptureFogState (&r_framedata, &r_ssao_fog_state);
 }
 
 static const RenderPassDesc s_ssao_fog_handoff_framegraph_pass = {
 	"Capture fog handoff",
-	/* Captures CPU-side fog state into SSAO handoff data; no framebuffer read required. */
+	/* Captures CPU-side global fog + fogvol availability into SSAO handoff data. */
 	RENDER_RES_NONE,
 	RENDER_RES_SSAO_FOG_STATE,
 	0,
@@ -5320,4 +5335,3 @@ void R_RenderView (void)
 			rs_dynamiclightmaps);
 	//johnfitz
 }
-

--- a/Quake/r_ssao.c
+++ b/Quake/r_ssao.c
@@ -81,6 +81,11 @@ void R_SSAO_CaptureFogState (const gpuframedata_t *framedata, r_ssao_fog_state_t
 	if (!out_state)
 		return;
 
+	out_state->fogvol_valid = R_FogVol_HasValidComposite ();
+	out_state->transmittance_policy = out_state->fogvol_valid
+		? R_SSAO_FOG_TRANS_FOGVOL_OR_GLOBAL
+		: R_SSAO_FOG_TRANS_GLOBAL_ONLY;
+
 	if (!R_FogVol_GetGlobalFogState (color, &density))
 	{
 		VectorClear (out_state->color);

--- a/Quake/r_ssao.h
+++ b/Quake/r_ssao.h
@@ -7,7 +7,15 @@ typedef struct r_ssao_fog_state_s
 {
 	float color[3];
 	float density;
+	qboolean fogvol_valid;
+	int transmittance_policy;
 } r_ssao_fog_state_t;
+
+typedef enum r_ssao_fog_transmittance_policy_e
+{
+	R_SSAO_FOG_TRANS_GLOBAL_ONLY = 0,
+	R_SSAO_FOG_TRANS_FOGVOL_OR_GLOBAL = 1
+} r_ssao_fog_transmittance_policy_t;
 
 float R_SSAO_SanitizeValue (float value, float fallback, float minval, float maxval);
 void R_SSAO_CaptureFogState (const gpuframedata_t *framedata, r_ssao_fog_state_t *out_state);

--- a/Quake/shaders/postprocess.frag
+++ b/Quake/shaders/postprocess.frag
@@ -150,6 +150,7 @@ layout(location=25) uniform vec4 DamageDVParams0; // x: trauma, y: strength, z: 
 layout(location=26) uniform vec4 DamageDVParams1; // x: time, y: quality, z: debug, w: unused
 // Volumetric fog params for SSAO suppression.
 // x: fogvol active flag (1.0 = fogvol texture is bound and valid, 0.0 = inactive)
+// y: transmittance source policy (0=global only, 1=fogvol preferred with global fallback)
 layout(location=27) uniform vec4 FogVolParams;
 
 const int MOTION_MAX_SAMPLES = 64;
@@ -257,6 +258,25 @@ float FogVolTransmittance(vec2 uv)
                 return 1.0; // fogvol inactive — no suppression
         float fogDensity = texture(FogVolTexture, uv).a; // 0=no fog, 1=full fog
         return clamp(1.0 - fogDensity, 0.0, 1.0);
+}
+
+// Deterministic SSAO suppression source selection:
+//  - Policy 1 + valid fogvol -> use fogvol transmittance.
+//  - Otherwise              -> use global fog transmittance fallback.
+// outSource: 1=global, 2=fogvol.
+float SelectSuppressionTransmittance(vec2 uv, float depth, out float outSource)
+{
+        float policy = floor(FogVolParams.y + 0.5);
+        bool fogvolValid = FogVolParams.x > 0.5;
+        bool useFogVol = (policy >= 1.0) && fogvolValid;
+        if (useFogVol)
+        {
+                outSource = 2.0;
+                return FogVolTransmittance(uv);
+        }
+
+        outSource = 1.0;
+        return FogTransmittanceFromGlobalFog(depth);
 }
 
 float SampleSSAO(vec2 uv, DepthSamplingInfo info, float centerDepth, bool useDepth)
@@ -591,25 +611,14 @@ void main()
                                 float ssaoFogStrength = clamp(SSAOParams.w, 0.0, 1.0);
                                 float ssaoFogPower = max(SSAOBlurParams.w, 0.01);
                                 float fogTransmittance = 1.0;
+                                float fogSource = 0.0;
                                 if (ssaoUseDepth)
                                 {
                                         float fogStrength = clamp(PostFXParams4.z, 0.0, 1.0);
                                         float underwaterTransmittance = 1.0;
                                         if (fogStrength > 0.0)
                                                 underwaterTransmittance = FogTransmittanceFromDepth(ssaoCenterDepth, fogStrength);
-					/* When volumetric fog is active, use the fogvol transmittance
-					 * buffer as the authoritative medium signal. Mixing the
-					 * legacy global-fog transmittance here over-suppresses SSAO
-					 * because fogvol density uses different units. */
-					float globalTransmittance = (FogVolParams.x < 0.5)
-						? FogTransmittanceFromGlobalFog(ssaoCenterDepth)
-						: 1.0;
-                                        // Volumetric fog transmittance: sample the fogvol composite buffer
-                                        // directly. This correctly handles spatial noise variation and
-                                        // color variation that FogTransmittanceFromGlobalFog cannot model.
-                                        // Take the minimum (most suppressing) of classical and volumetric fog.
-                                        float fogvolTransmittance = FogVolTransmittance(uv);
-                                        fogTransmittance = min(globalTransmittance, fogvolTransmittance) * underwaterTransmittance;
+                                        fogTransmittance = SelectSuppressionTransmittance(uv, ssaoCenterDepth, fogSource) * underwaterTransmittance;
                                 }
                                 float aoFogMask = pow(clamp(fogTransmittance, 0.0, 1.0), ssaoFogPower);
                                 float aoFogged = mix(1.0, ao, aoFogMask);
@@ -621,7 +630,12 @@ void main()
                                 }
                                 else if (ssaoDebugMode == 13)
                                 {
-                                        color.rgb = vec3(fogTransmittance);
+                                        vec3 sourceTint = vec3(0.0);
+                                        if (fogSource > 1.5)
+                                                sourceTint = vec3(0.15, 0.50, 1.0); // fogvol source
+                                        else if (fogSource > 0.5)
+                                                sourceTint = vec3(1.0, 0.45, 0.1); // global source
+                                        color.rgb = mix(vec3(fogTransmittance), sourceTint, 0.75);
                                 }
                                 else if (ssaoDebugMode == 14)
                                 {


### PR DESCRIPTION
### Motivation
- Make SSAO/postprocess fog damping deterministic by explicitly capturing whether the fog-volume composite is valid and encoding a transmittance source policy, so fogvol vs global fog selection is stable across frames.
- Avoid mixing legacy global-fog and volumetric fog transmittance heuristics that caused inconsistent suppression and tuning difficulty.

### Description
- Extend `r_ssao_fog_state_t` in `Quake/r_ssao.h` with `fogvol_valid` and `transmittance_policy` and add the `R_SSAO_FOG_TRANS_*` enum to represent source policy.
- Populate the new fields in `R_SSAO_CaptureFogState` in `Quake/r_ssao.c` so the framegraph handoff records both global fog params and fogvol composite availability.
- Change `GL_PostProcess_SetMediumScatterUniforms` in `Quake/gl_rmain.c` to accept the captured `r_ssao_fog_state_t`, gate sampling of the medium texture on the handoff validity flag, and send the selected `transmittance_policy` through `FogVolParams.y`.
- Replace the previous mixed suppression logic in `Quake/shaders/postprocess.frag` with a single documented selection function `SelectSuppressionTransmittance` that prefers fogvol transmittance when policy + validity allow, otherwise falls back to global fog, and update SSAO debug mode `13` to tint the output to indicate the active suppression source.

### Testing
- Attempted to configure and build with `cmake -S . -B build && cmake --build build -j4` in this environment; configuration failed due to missing SDL2 package files (`SDL2Config.cmake` / `sdl2-config.cmake`), so a full compile could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2a1a59ea0832e870496ec881fcb10)