### PR TITLE
Fix MSAA no-warp blit to resolve color only

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -5188,12 +5188,7 @@ void R_WarpScaleView (const RenderGraphResourceHandle *resources)
 				glDrawBuffer (GL_COLOR_ATTACHMENT0);
 			else
 				glDrawBuffer (GL_BACK);
-			{
-				GLbitfield mask = GL_COLOR_BUFFER_BIT;
-				if (need_depth_resolve)
-					mask |= GL_DEPTH_BUFFER_BIT;
-				GL_BlitFramebufferFunc (0, 0, srcw, srch, srcx, srcy, srcx + srcw, srcy + srch, mask, GL_NEAREST);
-			}
+			GL_BlitFramebufferFunc (0, 0, srcw, srch, srcx, srcy, srcx + srcw, srcy + srch, GL_COLOR_BUFFER_BIT, GL_NEAREST);
 		}
 	}
 


### PR DESCRIPTION
### Motivation
- The MSAA + no-warp blit path used a mask that could include `GL_DEPTH_BUFFER_BIT` while reading from `resolved_scene_fbo`, but `resolved_scene_fbo` is created without a depth attachment so depth cannot/should not be sourced from it.

### Description
- In `R_WarpScaleView` (MSAA && !needwarpscale branch) replace the conditional mask with an unconditional `GL_COLOR_BUFFER_BIT` so the blit from `resolved_scene_fbo` only copies color and leaves depth resolution to the dedicated `need_depth_resolve` block that reads from `scene_fbo`.

### Testing
- Performed static checks with `rg -n "resolved_scene_fbo|GL_DEPTH_BUFFER_BIT" Quake/gl_rmain.c` and inspected the relevant region with `nl -ba Quake/gl_rmain.c | sed -n '5158,5230p'`, confirming no `GL_DEPTH_BUFFER_BIT` is used when `resolved_scene_fbo` is bound for read and the standalone depth-resolve remains intact and targeted at `scene_fbo`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c325f359ac832e8669e8dcf1ef6768)