### PR TITLE
Use ceil division for scene render sizing

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -737,8 +737,8 @@ static void R_UpdateSceneSizeState (void)
 	if (r_drs.value > 0.f)
 		requested_scale = R_ClampDRSScale (requested_scale);
 
-	int scene_width = q_max (1, base_scene_width / requested_scale);
-	int scene_height = q_max (1, base_scene_height / requested_scale);
+	int scene_width = (base_scene_width + requested_scale - 1) / requested_scale;
+	int scene_height = (base_scene_height + requested_scale - 1) / requested_scale;
 	qboolean size_changed;
 	qboolean scale_changed;
 
@@ -5292,8 +5292,11 @@ void R_WarpScaleView (const RenderGraphResourceHandle *resources)
 
 	GL_BeginGroup ("Warp/scale view");
 
-	/* Canonical scene-size path renders directly into size-matched scene textures,
-	 * so warp/upscale should sample the full source texture range. */
+	/* Canonical scene-size path renders directly into size-matched scene textures.
+	 * Scene dimensions now use ceil(base/scale), so srcw/srch may not be exact
+	 * floor divisions of the view rect, but they are still the authoritative
+	 * allocated/rendered source bounds. Sampling the full [0,1] UV range and
+	 * blitting [0,srcw) x [0,srch) therefore remains in-bounds. */
 	smax = 1.f;
 	tmax = 1.f;
 


### PR DESCRIPTION
### Motivation
- Ensure scene render targets are sized with ceiling division so reduced-resolution targets fully cover the view rect when base dimensions are not divisible by the requested scale.
- Validate callers (notably `R_WarpScaleView` and framebuffer blits) to avoid any out-of-bounds sampling assumptions after switching to ceil-sized scene targets.

### Description
- Replace floor-style `q_max(1, base / requested_scale)` with ceil division `(base + requested_scale - 1) / requested_scale` for `scene_width` and `scene_height` in `R_UpdateSceneSizeState` (`Quake/gl_rmain.c`).
- Add a clarifying comment in `R_WarpScaleView` that explains scene dimensions are now computed with ceil division and that sampling the full [0,1] UV range and blitting `[0,srcw) x [0,srch)` remains in-bounds.
- Reviewed call sites that reference scene dimensions (notably `R_WarpScaleView` blits/viewports and framegraph viewport setup) and found no code changes required to handle the ceil-sized values.

### Testing
- Attempted a local build with `make -C Quake -j2`, which failed to complete in this environment due to missing SDL2 development tools/headers (`sdl2-config` / `SDL.h`).
- Performed automated static inspection (`rg`) of `R_GetSceneRenderWidth`, `R_WarpScaleView`, and related viewport/blit code to confirm no out-of-bounds assumptions were present; inspection did not indicate further code changes were necessary.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3a1108c68832eaacb262608cb8706)