### PR TITLE
Make DRS cooldown windows configurable via cvars

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -567,6 +567,8 @@ cvar_t	r_drs_min_scale = { "r_drs_min_scale", "1", CVAR_ARCHIVE };
 cvar_t	r_drs_max_scale = { "r_drs_max_scale", "4", CVAR_ARCHIVE };
 cvar_t	r_drs_step_up = { "r_drs_step_up", "1", CVAR_ARCHIVE };
 cvar_t	r_drs_step_down = { "r_drs_step_down", "1", CVAR_ARCHIVE };
+cvar_t	r_drs_cooldown_after_down = { "r_drs_cooldown_after_down", "8", CVAR_ARCHIVE };
+cvar_t	r_drs_cooldown_after_up = { "r_drs_cooldown_after_up", "2", CVAR_ARCHIVE };
 cvar_t	r_drs_hysteresis_ms = { "r_drs_hysteresis_ms", "0.5", CVAR_ARCHIVE };
 cvar_t	r_drs_filter_alpha = { "r_drs_filter_alpha", "0.25", CVAR_ARCHIVE };
 cvar_t	r_drs_debug = { "r_drs_debug", "0", CVAR_NONE };
@@ -636,6 +638,8 @@ static void R_UpdateDynamicResolutionScale (void)
 	int max_scale;
 	int step_up;
 	int step_down;
+	int cooldown_after_down;
+	int cooldown_after_up;
 	int current_scale;
 	int new_scale;
 	int debug_level;
@@ -665,6 +669,8 @@ static void R_UpdateDynamicResolutionScale (void)
 	max_scale = R_GetDRSMaxScale (min_scale);
 	step_up = CLAMP (1, (int)Q_rint (r_drs_step_up.value), 8);
 	step_down = CLAMP (1, (int)Q_rint (r_drs_step_down.value), 8);
+	cooldown_after_down = CLAMP (0, (int)Q_rint (r_drs_cooldown_after_down.value), 120);
+	cooldown_after_up = CLAMP (0, (int)Q_rint (r_drs_cooldown_after_up.value), 120);
 	debug_level = (int)Q_rint (r_drs_debug.value);
 
 	if (!r_drs_state.initialized)
@@ -690,7 +696,7 @@ static void R_UpdateDynamicResolutionScale (void)
 	if (r_drs_state.filtered_ms > target_ms + hysteresis_ms)
 	{
 		new_scale = q_min (max_scale, current_scale + step_down);
-		r_drs_state.upscale_cooldown = 8;
+		r_drs_state.upscale_cooldown = cooldown_after_down;
 	}
 	else if (r_drs_state.filtered_ms < target_ms - hysteresis_ms)
 	{
@@ -699,7 +705,7 @@ static void R_UpdateDynamicResolutionScale (void)
 		else
 		{
 			new_scale = q_max (min_scale, current_scale - step_up);
-			r_drs_state.upscale_cooldown = 2;
+			r_drs_state.upscale_cooldown = cooldown_after_up;
 		}
 	}
 	else if (r_drs_state.upscale_cooldown > 0)

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -646,6 +646,8 @@ Cvar_RegisterVariable (&r_vignette);
 	Cvar_RegisterVariable (&r_drs_max_scale);
 	Cvar_RegisterVariable (&r_drs_step_up);
 	Cvar_RegisterVariable (&r_drs_step_down);
+	Cvar_RegisterVariable (&r_drs_cooldown_after_down);
+	Cvar_RegisterVariable (&r_drs_cooldown_after_up);
 	Cvar_RegisterVariable (&r_drs_hysteresis_ms);
 	Cvar_RegisterVariable (&r_drs_filter_alpha);
 	Cvar_RegisterVariable (&r_drs_debug);

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -140,6 +140,8 @@ extern	cvar_t	r_drs_min_scale;
 extern	cvar_t	r_drs_max_scale;
 extern	cvar_t	r_drs_step_up;
 extern	cvar_t	r_drs_step_down;
+extern	cvar_t	r_drs_cooldown_after_down;
+extern	cvar_t	r_drs_cooldown_after_up;
 extern	cvar_t	r_drs_hysteresis_ms;
 extern	cvar_t	r_drs_filter_alpha;
 extern	cvar_t	r_drs_debug;


### PR DESCRIPTION
### Motivation
- Allow tuning of dynamic resolution cooldowns without changing source by exposing the two hardcoded cooldown values as cvars. 
- Keep existing behavior for users by preserving the previous defaults so there is no regression unless tuned.

### Description
- Add two new cvars `r_drs_cooldown_after_down` (default `8`) and `r_drs_cooldown_after_up` (default `2`) next to the other `r_drs_*` declarations in `Quake/gl_rmain.c` and declare them in `Quake/glquake.h`.
- Replace the hardcoded `8` and `2` assignments in `R_UpdateDynamicResolutionScale` with the new cvar-driven values and clamp them with `CLAMP(0, ..., 120)` before use.
- Register the new cvars in `Quake/gl_rmisc.c` alongside the other DRS variables so they are available at runtime.

### Testing
- Ran `git diff --check` and the workspace reported no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3a1118a08832e809a374805792818)