### PR TITLE
Initialize DRS postfx guard before postfx feature gating

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -2748,6 +2748,10 @@ void GL_PostProcess (const RenderGraphResourceHandle *resources)
 		postfx_lut_strength = 0.f;
 	}
 
+	inv_scale = 1.f / (float)q_max (1, R_GetSceneRenderScale ());
+	scaled_scene = (R_GetSceneRenderScale () != 1);
+	drs_postfx_guard = scaled_scene || (r_drs.value > 0.f);
+
 	godrays_enabled = (!drs_postfx_guard
 		&& r_godrays.value > 0.f
 		&& R_GodraysMediumEnabled ()
@@ -2781,9 +2785,6 @@ void GL_PostProcess (const RenderGraphResourceHandle *resources)
 	view_min_y = (gly + glheight - r_refdef.vrect.y - r_refdef.vrect.height) / (float)R_GetNativeRenderHeight ();
 	view_max_x = view_min_x + r_refdef.vrect.width / (float)R_GetNativeRenderWidth ();
 	view_max_y = view_min_y + r_refdef.vrect.height / (float)R_GetNativeRenderHeight ();
-	inv_scale = 1.f / (float)q_max (1, R_GetSceneRenderScale ());
-	scaled_scene = (R_GetSceneRenderScale () != 1);
-	drs_postfx_guard = scaled_scene || (r_drs.value > 0.f);
 
 	ssao_texture = GL_GenerateSSAOTexture (view_min_x, view_min_y, view_max_x, view_max_y);
 	/* Keep SSAO intensity aligned with the cvar's intended tuning range.


### PR DESCRIPTION
### Motivation
- Ensure `drs_postfx_guard` (and its inputs `inv_scale` / `scaled_scene`) is computed before any postfx feature-gating logic reads it so godrays, motion blur and DoF decisions do not depend on an uninitialized or later-updated value.

### Description
- Move initialization of `inv_scale`, `scaled_scene`, and `drs_postfx_guard` earlier in `GL_PostProcess` immediately after LUT selection so the guard is established prior to postfx gating.
- Remove the later duplicate initialization and keep subsequent godrays, motion blur, and DoF gating logic unchanged so they read the already-initialized `drs_postfx_guard`.

### Testing
- Ran `rg -n "drs_postfx_guard|godrays_enabled =|motion_strength =|dof_enabled =" Quake/gl_rmain.c` to verify the guard is now initialized before the godrays, motion blur, and DoF checks.
- Inspected the modified region with `sed -n '2728,2985p' Quake/gl_rmain.c` and `nl -ba Quake/gl_rmain.c | sed -n '2740,2980p'` to confirm the new ordering and that there are no other regressions in the surrounding flow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3a3ae04bc832e9ed9026ce38dc1ff)