### PR TITLE
Add DRS responsiveness presets and inline config help

### DIFF
--- a/Misc/pak/default.cfg
+++ b/Misc/pak/default.cfg
@@ -106,6 +106,21 @@ bind	RTRIGGER	+attack
 //
 // default cvars
 //
+// Dynamic resolution scaling (DRS) quick presets and help:
+//   r_drs_min_scale / r_drs_max_scale: DRS range (1=full res, 2=half, 3=third, 4=quarter).
+//   r_drs_step_up / r_drs_step_down: amount to raise/lower scale when adapting.
+//   r_drs_cooldown_after_down / r_drs_cooldown_after_up: frames to wait before opposite direction changes.
+//   r_drs_guard_mode: 0=off, 1=guard against rapid oscillation near min/max scale.
+//
+// Preset command path (responsiveness):
+alias drs_resp_low "r_drs_step_up 1; r_drs_step_down 1; r_drs_cooldown_after_down 12; r_drs_cooldown_after_up 4; r_drs_hysteresis_ms 0.7; echo DRS responsiveness: low (stable, slower reactions)"
+alias drs_resp_medium "r_drs_step_up 1; r_drs_step_down 1; r_drs_cooldown_after_down 8; r_drs_cooldown_after_up 2; r_drs_hysteresis_ms 0.5; echo DRS responsiveness: medium (balanced)"
+alias drs_resp_high "r_drs_step_up 1; r_drs_step_down 2; r_drs_cooldown_after_down 4; r_drs_cooldown_after_up 1; r_drs_hysteresis_ms 0.25; echo DRS responsiveness: high (fast reactions)"
+//
+// Practical example target profile:
+//   60 FPS with moderate stability (good general default)
+alias drs_profile_60_moderate "r_drs 1; r_drs_target_fps 60; r_drs_target_ms 0; r_drs_min_scale 1; r_drs_max_scale 3; r_drs_guard_mode 1; drs_resp_medium; echo DRS profile: 60 FPS moderate stability"
+
 gamma 			0.95
 contrast 		1.2
 volume 			0.7

--- a/Quake/default_cfg.h
+++ b/Quake/default_cfg.h
@@ -82,6 +82,11 @@ static const char default_cfg[] =
 "bind LTRIGGER +jump\n"
 "bind RTRIGGER +attack\n"
 
+"alias drs_resp_low \"r_drs_step_up 1; r_drs_step_down 1; r_drs_cooldown_after_down 12; r_drs_cooldown_after_up 4; r_drs_hysteresis_ms 0.7; echo DRS responsiveness: low (stable, slower reactions)\"\n"
+"alias drs_resp_medium \"r_drs_step_up 1; r_drs_step_down 1; r_drs_cooldown_after_down 8; r_drs_cooldown_after_up 2; r_drs_hysteresis_ms 0.5; echo DRS responsiveness: medium (balanced)\"\n"
+"alias drs_resp_high \"r_drs_step_up 1; r_drs_step_down 2; r_drs_cooldown_after_down 4; r_drs_cooldown_after_up 1; r_drs_hysteresis_ms 0.25; echo DRS responsiveness: high (fast reactions)\"\n"
+"alias drs_profile_60_moderate \"r_drs 1; r_drs_target_fps 60; r_drs_target_ms 0; r_drs_min_scale 1; r_drs_max_scale 3; r_drs_guard_mode 1; drs_resp_medium; echo DRS profile: 60 FPS moderate stability\"\n"
+
 "gamma 0.95\n"
 "contrast 1.2\n"
 "volume 0.7\n"


### PR DESCRIPTION
### Motivation
- Make Dynamic Resolution Scaling (DRS) cvars discoverable and easier to tune by adding concise help text where users edit/configure cvars. 
- Provide quick, reusable responsiveness presets so users can switch DRS behavior (low/medium/high) without memorizing multiple cvar tweaks.
- Ship a practical example profile that targets a common goal (60 FPS) with a moderate stability tradeoff.

### Description
- Added inline help comments describing `r_drs_min_scale` / `r_drs_max_scale`, `r_drs_step_up` / `r_drs_step_down`, `r_drs_cooldown_after_down` / `r_drs_cooldown_after_up`, and `r_drs_guard_mode` to `Misc/pak/default.cfg` so guidance appears in the packaged config.
- Introduced three responsiveness aliases: `drs_resp_low`, `drs_resp_medium`, and `drs_resp_high` that set sensible `r_drs_*` tuning values for stability vs reaction speed.
- Added a practical example alias `drs_profile_60_moderate` which enables DRS and targets `60` FPS with `r_drs_guard_mode 1` and the medium responsiveness preset.
- Mirrored the same alias entries into `Quake/default_cfg.h` so the built-in default config used at build/runtime stays in sync with the packaged config.

### Testing
- Inspected the resulting diffs with `git diff` to confirm the expected insertions in `Misc/pak/default.cfg` and `Quake/default_cfg.h`, and the inspection succeeded.
- Printed relevant file ranges with `nl`/`sed` to verify alias lines and comments appear at the intended locations, and the output matched expectations.
- Searched for `r_drs_` references with `rg` to ensure referenced cvars exist in code, and the search succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3bbfe495c832e879e09fe08144f7d)