### PR TITLE
Fix global fog rendering: force native-res global fog and skip sky depth in shader

### DIFF
--- a/Quake/r_fogvol.c
+++ b/Quake/r_fogvol.c
@@ -902,10 +902,11 @@ void R_FogVol_Render (void)
 	if (r_fogvol_debug_froxel_random.value > 0.f)
 		use_halfres = false;
 
-	/* Global (camera-following) fog covers the whole view. Rendering that path in
-	 * halfres turns the full scene into an upscaled fog pass. Keep it native-res
-	 * by ping-ponging between composite and finalcopy instead. */
-	if (use_halfres && r_fogvol_global_active && r_fogvolume_count == 1)
+	/* Global (camera-following) fog always covers the full view. Rendering any
+	 * frame that includes this path in halfres makes the baseline medium read
+	 * like a post-process overlay instead of volumetric depth. Keep all global
+	 * fog frames native-res by ping-ponging between composite and finalcopy. */
+	if (use_halfres && r_fogvol_global_active)
 	{
 		use_halfres = false;
 		use_native_pingpong = true;

--- a/Quake/shaders/fogvol.frag
+++ b/Quake/shaders/fogvol.frag
@@ -155,6 +155,14 @@ float DepthToNdcZ(float depth)
 	return depth * 2.0 - 1.0;
 }
 
+bool IsSkyDepthSample(float depth)
+{
+	float cutoff = FogDepthParams.w;
+	if (FogDepthParams.z > 0.5)
+		return depth <= cutoff;
+	return depth >= cutoff;
+}
+
 vec2 ScreenUvToViewUv(vec2 screenUv)
 {
 	vec2 screenPos = screenUv * FogViewportParams.xy;
@@ -405,6 +413,11 @@ void main()
 	}
 
 	float depth = texelFetch(SceneDepth, screenPixel, 0).r;
+	if (IsSkyDepthSample(depth))
+	{
+		FragColor = vec4(scene, 0.0);
+		return;
+	}
 	vec3 worldPos;
 	if (!ReconstructWorldPos(viewUv, depth, worldPos))
 	{


### PR DESCRIPTION
### Motivation
- The scene-reported symptom (fog appearing "glued" to world textures like a post-process) was traced to the global fog path rendering at half resolution and the shader not rejecting clear/sky depth samples before raymarching.
- Making global fog always render native-resolution when active preserves volumetric depth cues and prevents the upscaled overlay look.
- Early rejection of sky/clear-depth samples in the shader prevents invalid world-position reconstruction and false raymarch inputs.

### Description
- Changed `R_FogVol_Render` (`Quake/r_fogvol.c`) to disable `use_halfres` whenever `r_fogvol_global_active` is true and enable the native ping-pong path, with a clarifying comment about why global fog must be native-res (preserves the original ping-pong behavior).
- Added `IsSkyDepthSample` and an early `if (IsSkyDepthSample(depth))` return to `Quake/shaders/fogvol.frag` so clear/sky depth samples are excluded before `ReconstructWorldPos` and raymarching.
- Kept the existing ping-pong upscaling/blit behavior and preserved prior safeguards to avoid changing cvar semantics beyond the quality/hardening fixes.

### Testing
- Attempted an automated build with `make -C Quake -j4`, which failed in this environment due to missing SDL development tooling (`sdl2-config` / `SDL.h`), so a full compile/test could not be completed here (build failed).
- Verified changes locally in the repository by static inspection and grep searches for the new symbols and updated control flow (`IsSkyDepthSample`, `r_fogvol_global_active` condition), and committed the source edits successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c40b7e1e70832e86d3d49ad84a798e)