### PR TITLE
Fix fog volume depth reprojection sampling collapse

### DIFF
--- a/Quake/shaders/fogvol.frag
+++ b/Quake/shaders/fogvol.frag
@@ -384,12 +384,16 @@ float InterleavedGradientNoise(vec2 p)
 
 void main()
 {
-	ivec2 screenPixel = ivec2(floor(gl_FragCoord.xy * FogDepthScale));
+	/* Reproject fog-target pixels into native depth-space using pixel centers.
+	 * This avoids depth quantization/collapse when fog runs at half resolution
+	 * or under dynamic viewport scaling. */
+	vec2 screenPos = gl_FragCoord.xy * FogDepthScale;
+	ivec2 screenPixel = ivec2(floor(screenPos));
 	ivec2 depthSize = textureSize(SceneDepth, 0);
 	screenPixel = clamp(screenPixel, ivec2(0), max(depthSize - ivec2(1), ivec2(0)));
-	vec2 screenPos = vec2(screenPixel) + vec2(0.5);
+	screenPos = vec2(screenPixel) + vec2(0.5);
 	vec2 screenUv = screenPos * FogViewportParams.zw;
-	vec2 viewUv = (screenPos - FogViewParams.xy) * FogViewParams.zw;
+	vec2 viewUv = ScreenUvToViewUv(screenUv);
 	vec3 scene = texture(SceneColor, screenUv).rgb;
 
 	if (FogCheckerboard != 0)


### PR DESCRIPTION
### Motivation
- Debug screenshots showed the fog-volume pass depth collapsing (breaking volumetric depth and producing artifacts), so the shader needs correct reprojection from fog-target pixels into native depth-space.

### Description
- Adjusted `Quake/shaders/fogvol.frag` to reproject fog-target pixels using pixel centers (`screenPos = gl_FragCoord.xy * FogDepthScale` then `screenPixel = ivec2(floor(screenPos))`) and replaced the inline view-UV math with `ScreenUvToViewUv(screenUv)` to keep viewport math consistent and avoid depth quantization/collapse.

### Testing
- Ran `make -C Quake -j4` to validate build, but it could not complete in this environment due to missing SDL toolchain (`sdl2-config` / `SDL.h`), so no full binary build was produced; the shader change is self-contained and small so it is expected to be compile-time neutral on the C side.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c40e51acc0832e80164c53a6d495ca)