### PR TITLE
Clarify shared realtime light-collection architecture docs and naming

### DIFF
--- a/Quake/gl_dlight.c
+++ b/Quake/gl_dlight.c
@@ -20,15 +20,23 @@ void R_DrawDLightPass (void)
 	int count = 0;
 	float pp_debug_mode = 0.f;
 	entity_t **ents;
-	qboolean use_pp_world = R_PPdlights_WorldPathEnabled ();
+	qboolean use_shared_world_lights = R_PPdlights_WorldPathEnabled ();
 	unsigned int saved_numlights = r_framedata.numlights;
 	gpulightbuffer_t saved_lightbuffer = {0};
 	dlight_t *saved_sources[DLIGHT_GPU_MAX] = {0};
 
+	/*
+	 * Shared-light architecture:
+	 * - R_PPdlights_CollectFrame builds one frame list (dynamic + emissive).
+	 * - This pass consumes the world/surface subset and repacks it into the
+	 *   standard GPU light buffer expected by forward world shaders.
+	 * - Alias/model and froxel passes read the same collected list separately.
+	 */
+
 	if (r_framedata.numlights == 0 || !r_drawworld_cheatsafe)
 	{
 		/* Optional per-pixel world path can still feed lights even if legacy list is empty. */
-		if (!use_pp_world)
+		if (!use_shared_world_lights)
 			return;
 	}
 	if (CLAMP (0.f, r_ppdlights_world_scale.value, 4.f) <= 0.f)
@@ -40,7 +48,7 @@ void R_DrawDLightPass (void)
 	if (count <= 0)
 		return;
 
-	if (use_pp_world)
+	if (use_shared_world_lights)
 	{
 		int pp_count;
 		memcpy (&saved_lightbuffer, &r_lightbuffer, sizeof (saved_lightbuffer));
@@ -93,7 +101,7 @@ void R_DrawDLightPass (void)
 
 	GL_EndGroup ();
 
-	if (use_pp_world)
+	if (use_shared_world_lights)
 	{
 		r_framedata.numlights = saved_numlights;
 		memcpy (&r_lightbuffer, &saved_lightbuffer, sizeof (saved_lightbuffer));

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -4176,8 +4176,9 @@ void R_SetupView (void)
 
 
 	R_PushDlights ();
-	/* Optional per-pixel path consumes this shared list in later milestones.
-	 * Legacy lighting/rendering remains unchanged. */
+	/* Build one shared light-collection list for this frame; forward world/model
+	 * and froxel fog/GI passes consume it later. This is scene-light plumbing,
+	 * not a fullscreen postprocess lighting pass. */
 	R_PPdlights_CollectFrame ();
 
 	//johnfitz -- cheat-protect some draw modes

--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -1266,12 +1266,15 @@ R_DrawAliasModels
 void R_DrawAliasModels (entity_t **ents, int count)
 {
 	int i;
-	qboolean use_pp_models = R_PPdlights_ModelPathEnabled ();
+	qboolean use_shared_model_lights = R_PPdlights_ModelPathEnabled ();
 	unsigned int saved_numlights = r_framedata.numlights;
 	gpulightbuffer_t saved_lightbuffer = {0};
 	dlight_t *saved_sources[DLIGHT_GPU_MAX] = {0};
 
-	if (use_pp_models)
+	/* Shared-light architecture: consumes the same frame-collected list as
+	 * world dlights/froxel fog, but filtered for forward alias/model shading. */
+
+	if (use_shared_model_lights)
 	{
 		int pp_count;
 		memcpy (&saved_lightbuffer, &r_lightbuffer, sizeof (saved_lightbuffer));
@@ -1289,7 +1292,7 @@ void R_DrawAliasModels (entity_t **ents, int count)
 		R_DrawAliasModel_Real (ents[i], false);
 	R_FlushAliasInstances (false);
 
-	if (use_pp_models)
+	if (use_shared_model_lights)
 	{
 		r_framedata.numlights = saved_numlights;
 		memcpy (&r_lightbuffer, &saved_lightbuffer, sizeof (saved_lightbuffer));
@@ -1315,12 +1318,12 @@ R_DrawAliasModels_ShowTris
 void R_DrawAliasModels_ShowTris (entity_t **ents, int count)
 {
 	int i;
-	qboolean use_pp_models = R_PPdlights_ModelPathEnabled ();
+	qboolean use_shared_model_lights = R_PPdlights_ModelPathEnabled ();
 	unsigned int saved_numlights = r_framedata.numlights;
 	gpulightbuffer_t saved_lightbuffer = {0};
 	dlight_t *saved_sources[DLIGHT_GPU_MAX] = {0};
 
-	if (use_pp_models)
+	if (use_shared_model_lights)
 	{
 		int pp_count;
 		memcpy (&saved_lightbuffer, &r_lightbuffer, sizeof (saved_lightbuffer));
@@ -1335,7 +1338,7 @@ void R_DrawAliasModels_ShowTris (entity_t **ents, int count)
 		R_DrawAliasModel_Real (ents[i], true);
 	R_FlushAliasInstances (true);
 
-	if (use_pp_models)
+	if (use_shared_model_lights)
 	{
 		r_framedata.numlights = saved_numlights;
 		memcpy (&r_lightbuffer, &saved_lightbuffer, sizeof (saved_lightbuffer));

--- a/Quake/r_fogvol_froxel_runtime.c
+++ b/Quake/r_fogvol_froxel_runtime.c
@@ -645,6 +645,13 @@ static void R_Froxel_InjectPPDLights (void)
 	int light_count = 0;
 	int i;
 
+	/*
+	 * Shared-light architecture:
+	 * - Reads the frame list produced by R_PPdlights_CollectFrame.
+	 * - Consumes only volumetric-flagged lights for froxel fog injection.
+	 * - Optionally derives broad GI helper lights from the same source list.
+	 * World/model forward passes consume their own subsets independently.
+	 */
 	memset (&r_froxel_ppd_stats, 0, sizeof (r_froxel_ppd_stats));
 	if (!r_froxel.valid)
 		return;

--- a/Quake/r_realtimelight.c
+++ b/Quake/r_realtimelight.c
@@ -8,16 +8,21 @@
 extern cvar_t r_dlight_entities;
 
 cvar_t r_ppdlights = { "r_ppdlights", "0", CVAR_ARCHIVE };
+/* Forward world consumer toggle (shared frame-light list -> world dlight pass). */
 cvar_t r_ppdlights_world = { "r_ppdlights_world", "1", CVAR_ARCHIVE };
 cvar_t r_ppdlights_world_scale = { "r_ppdlights_world_scale", "1", CVAR_ARCHIVE };
-/* 0 = linear add, 1 = soft-add compression (default). */
+/* World forward-lighting response: 0 = linear add, 1 = soft-add compression (default). */
 cvar_t r_ppdlights_world_blend = { "r_ppdlights_world_blend", "1", CVAR_ARCHIVE };
-/* 0 = additive (GL_ONE,GL_ONE), 1 = screen-like (GL_ONE_MINUS_DST_COLOR,GL_ONE). */
+/* World blend op: 0 = additive (GL_ONE,GL_ONE), 1 = screen-like (GL_ONE_MINUS_DST_COLOR,GL_ONE). */
 cvar_t r_ppdlights_world_blendop = { "r_ppdlights_world_blendop", "0", CVAR_ARCHIVE };
+/* Forward alias/model consumer toggle (shared frame-light list -> alias lighting). */
 cvar_t r_ppdlights_models = { "r_ppdlights_models", "1", CVAR_ARCHIVE };
+/* Froxel fog consumer toggle (shared frame-light list -> volumetric injection). */
 cvar_t r_ppdlights_fog = { "r_ppdlights_fog", "0", CVAR_ARCHIVE };
 cvar_t r_ppdlights_fog_debug = { "r_ppdlights_fog_debug", "0", CVAR_NONE };
+/* Per-frame fog consumer budget from the shared frame-light list. */
 cvar_t r_ppdlights_fog_budget = { "r_ppdlights_fog_budget", "32", CVAR_ARCHIVE };
+/* Optional GI helper that derives broad bounce from shared frame lights. */
 cvar_t r_ppdlights_gi = { "r_ppdlights_gi", "0", CVAR_ARCHIVE };
 cvar_t r_ppdlights_gi_debug = { "r_ppdlights_gi_debug", "0", CVAR_NONE };
 cvar_t r_ppdlights_gi_budget = { "r_ppdlights_gi_budget", "8", CVAR_ARCHIVE };
@@ -324,6 +329,12 @@ void R_PPdlights_CollectFrame (void)
 	if (!collect_enabled)
 		return;
 
+	/*
+	 * Architecture: this is the sole frame-level gather point.
+	 * We merge dynamic + emissive contributors once, then downstream passes
+	 * (world forward lights, alias/model forward lights, froxel fog/GI) each
+	 * consume filtered views of this same array in their own pass budgets.
+	 */
 	active = DLightPool_GetActiveList (&active_count);
 	if (active && active_count > 0)
 	{

--- a/Quake/r_realtimelight.h
+++ b/Quake/r_realtimelight.h
@@ -2,14 +2,17 @@
 #define R_REALTIMELIGHT_H
 
 /*
- * Optional per-pixel realtime lighting scaffold.
+ * Shared realtime light collection for forward surface + volumetric consumers.
  *
- * Intended data flow (incremental rollout):
- * 1) Collect runtime lights on CPU from existing dlight/emissive/GI sources.
- * 2) Upload a shared GPU-friendly light list once per frame.
- * 3) Reuse the same list for world/model surface lighting and froxel/fog injection.
+ * Frame flow:
+ * 1) Collect runtime lights on CPU from existing dlight/emissive sources.
+ * 2) Cache one shared frame light list.
+ * 3) Fan the same list out to each consumer:
+ *    - forward world dlight pass
+ *    - forward alias/model pass
+ *    - froxel fog + GI injection
  *
- * Milestone 1 intentionally adds only type/cvar scaffolding with no behavior change.
+ * This is not a fullscreen postprocess pass; it is shared scene-light plumbing.
  */
 
 typedef enum rl_light_type_e


### PR DESCRIPTION
### Motivation
- The realtime lighting feature is a shared per-frame light collection consumed by multiple forward renderer passes and should be documented as scene-light plumbing rather than a fullscreen postprocess step.
- Clarify cvar semantics so per-consumer toggles/budgets (world, models, fog, GI) are easier to understand and maintain.

### Description
- Rewrote module header docs in `r_realtimelight.h` to describe the shared frame light list and its consumers (`world`/`models`/`froxel`), and clarified that this is not a fullscreen postprocess pass. 
- Added explanatory architecture comments around `R_PPdlights_CollectFrame`, `R_DrawDLightPass`, and `R_Froxel_InjectPPDLights` to document the gather-once / consume-many data flow and per-pass consumers. 
- Updated inline cvar comments in `r_realtimelight.c` to describe per-consumer toggles and budgets and refined help text wording for world blend/ops. 
- Renamed local variables for clarity at consumer sites (`use_pp_world` -> `use_shared_world_lights`, `use_pp_models` -> `use_shared_model_lights`) and added short comments at `gl_rmain.c` and `r_alias.c` to keep terminology consistent.

### Testing
- Ran `git -C /workspace/ironwail diff --check` which reported no whitespace/patch errors (success). 
- Verified working tree state with `git -C /workspace/ironwail status --short` (success). 
- Inspected the commit with `git -C /workspace/ironwail show --stat --oneline HEAD` to confirm the intended file changes were recorded (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c50382f7b4832e843d3e87e959fbd9)