### PR TITLE
Refactor dynamic light evaluation to return canonical color/radius

### DIFF
--- a/Quake/gl_dlight.c
+++ b/Quake/gl_dlight.c
@@ -84,8 +84,9 @@ void R_DrawDLightPass (void)
 
 	{
 		const float blend_mode = CLAMP (0.f, (float)Q_rint (r_ppdlights_world_blend.value), 1.f);
-		R_SetDlightConfig (glprogs.world_dlight[0], 1.f, blend_mode);
-		R_SetDlightConfig (glprogs.world_dlight[1], 1.f, blend_mode);
+		const float world_scale = CLAMP (0.f, r_ppdlights_world_scale.value, 4.f);
+		R_SetDlightConfig (glprogs.world_dlight[0], world_scale, blend_mode);
+		R_SetDlightConfig (glprogs.world_dlight[1], world_scale, blend_mode);
 	}
 
 	R_DrawBrushModels_DLights (ents, count);

--- a/Quake/gl_rlight.c
+++ b/Quake/gl_rlight.c
@@ -87,7 +87,6 @@ void R_EvaluateDLightForRender (const dlight_t *l, float *out_radius, vec3_t out
 	float radius;
 	float radius_scale = 1.f;
 	float energy_scale = 1.f;
-	float world_dlight_scale = 1.f;
 	const vec3_t *temp;
 
 	if (!l)
@@ -148,10 +147,6 @@ void R_EvaluateDLightForRender (const dlight_t *l, float *out_radius, vec3_t out
 		out_color[0] *= 1.0f + colorshift;
 		out_color[1] *= 1.0f - colorshift;
 	}
-
-	/* Global dynamic-light output gain used by world/fog/model receive paths. */
-	world_dlight_scale = CLAMP (0.f, r_ppdlights_world_scale.value, 4.f);
-	VectorScale (out_color, world_dlight_scale, out_color);
 
 	if (out_radius)
 		*out_radius = radius;


### PR DESCRIPTION
### Motivation
- Prevent the world-only control `r_ppdlights_world_scale` from being baked into the canonical dynamic-light output so model/fog/froxel consumers that reuse the evaluation don't get unintended world scaling.

### Description
- Remove world-scale multiplication from `R_EvaluateDLightForRender` so it returns canonical `radius` and `color` only (file: `Quake/gl_rlight.c`).
- Apply `r_ppdlights_world_scale` in the world forward-light path by passing a `world_scale` into `R_SetDlightConfig` (sets `DLightScale`) inside `R_DrawDLightPass` (file: `Quake/gl_dlight.c`).
- Leave model and fog/froxel code paths unchanged so they continue to use their own local scaling (no global bake-in), and preserve downstream brightness behavior.
- Changed files: `Quake/gl_rlight.c`, `Quake/gl_dlight.c`.

### Testing
- Ran targeted text searches to verify callsites and the presence/absence of `r_ppdlights_world_scale` in evaluation and world-path config; those checks succeeded via `rg` searches.
- Attempted to build the whole tree with `make -j4` from repository root, which did not run because no top-level target was specified (failed). 
- Attempted to build under `Quake/` with `make -j4`, which failed in this environment due to missing SDL development tools (`sdl2-config` / `SDL.h`), so a full compile verification could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c506757374832e8272ac0151521176)