### PR TITLE
Make additive world dlight the default; add shader luma‑clamp/soft‑knee and experimental blend-op cvar

### DIFF
--- a/Quake/gl_dlight.c
+++ b/Quake/gl_dlight.c
@@ -5,14 +5,15 @@
 
 extern cvar_t r_lighting_debug_view;
 
-static void R_SetDlightConfig (GLuint program, float scale, float blend_mode)
+static void R_SetDlightConfig (GLuint program, float scale, float luma_clamp, float soft_knee)
 {
 	if (!program)
 		return;
 
 	GL_UseProgram (program);
 	GL_Uniform1fFunc (0, scale);
-	GL_Uniform1fFunc (1, blend_mode);
+	GL_Uniform1fFunc (1, luma_clamp);
+	GL_Uniform1fFunc (2, soft_knee);
 }
 
 void R_DrawDLightPass (void)
@@ -77,7 +78,7 @@ void R_DrawDLightPass (void)
 				consumer_stats.rejected[RL_REJECT_LOCAL_BUDGET]);
 		}
 
-		pp_debug_mode = CLAMP (0.f, r_ppdlights_debug_mode.value, 4.f);
+		pp_debug_mode = CLAMP (0.f, r_ppdlights_debug_mode.value, 6.f);
 		if (pp_debug_mode > 0.f && r_ppdlights_debug.value >= 1.f && (r_framecount % 60) == 0)
 			Con_DPrintf ("r_ppdlights_world: debug mode %.0f active\n", pp_debug_mode);
 	}
@@ -94,10 +95,11 @@ void R_DrawDLightPass (void)
 	}
 
 	{
-		const float blend_mode = CLAMP (0.f, (float)Q_rint (r_ppdlights_world_blend.value), 1.f);
 		const float world_scale = CLAMP (0.f, r_ppdlights_world_scale.value, 4.f);
-		R_SetDlightConfig (glprogs.world_dlight[0], world_scale, blend_mode);
-		R_SetDlightConfig (glprogs.world_dlight[1], world_scale, blend_mode);
+		const float luma_clamp = CLAMP (0.f, r_ppdlights_world_luma_clamp.value, 16.f);
+		const float soft_knee = CLAMP (0.05f, r_ppdlights_world_soft_knee.value, 8.f);
+		R_SetDlightConfig (glprogs.world_dlight[0], world_scale, luma_clamp, soft_knee);
+		R_SetDlightConfig (glprogs.world_dlight[1], world_scale, luma_clamp, soft_knee);
 	}
 
 	R_DrawBrushModels_DLights (ents, count);

--- a/Quake/r_realtimelight.c
+++ b/Quake/r_realtimelight.c
@@ -11,10 +11,11 @@ cvar_t r_ppdlights = { "r_ppdlights", "0", CVAR_ARCHIVE };
 /* Forward world consumer toggle (shared frame-light list -> world dlight pass). */
 cvar_t r_ppdlights_world = { "r_ppdlights_world", "1", CVAR_ARCHIVE };
 cvar_t r_ppdlights_world_scale = { "r_ppdlights_world_scale", "1", CVAR_ARCHIVE };
-/* World forward-lighting response: 0 = linear add, 1 = soft-add compression (default). */
-cvar_t r_ppdlights_world_blend = { "r_ppdlights_world_blend", "1", CVAR_ARCHIVE };
-/* World blend op: 0 = additive (GL_ONE,GL_ONE), 1 = screen-like (GL_ONE_MINUS_DST_COLOR,GL_ONE). */
-cvar_t r_ppdlights_world_blendop = { "r_ppdlights_world_blendop", "0", CVAR_ARCHIVE };
+/* World-light shaping controls, applied in shader before additive blend. */
+cvar_t r_ppdlights_world_luma_clamp = { "r_ppdlights_world_luma_clamp", "1.0", CVAR_ARCHIVE };
+cvar_t r_ppdlights_world_soft_knee = { "r_ppdlights_world_soft_knee", "1.0", CVAR_ARCHIVE };
+/* Experimental fixed-function blend op override for world dlight pass. */
+cvar_t r_experimental_ppdlights_world_blendop = { "r_experimental_ppdlights_world_blendop", "0", CVAR_ARCHIVE };
 /* Forward alias/model consumer toggle (shared frame-light list -> alias lighting). */
 cvar_t r_ppdlights_models = { "r_ppdlights_models", "1", CVAR_ARCHIVE };
 /* Froxel fog consumer toggle (shared frame-light list -> volumetric injection). */
@@ -27,7 +28,8 @@ cvar_t r_ppdlights_gi = { "r_ppdlights_gi", "0", CVAR_ARCHIVE };
 cvar_t r_ppdlights_gi_debug = { "r_ppdlights_gi_debug", "0", CVAR_NONE };
 cvar_t r_ppdlights_gi_budget = { "r_ppdlights_gi_budget", "8", CVAR_ARCHIVE };
 cvar_t r_ppdlights_debug = { "r_ppdlights_debug", "0", CVAR_NONE };
-/* World dlight debug views: 0=off, 1=affected count, 2=attenuation, 3=raw, 4=new/legacy split. */
+/* World dlight debug views: 0=off, 1=affected count, 2=attenuation, 3=raw light, 4=new/legacy split,
+ * 5=pre-compression contribution, 6=post-compression contribution. */
 cvar_t r_ppdlights_debug_mode = { "r_ppdlights_dbgmode", "0", CVAR_ARCHIVE };
 cvar_t r_ppdlights_emissive = { "r_ppdlights_emissive", "0", CVAR_ARCHIVE };
 cvar_t r_ppdlights_emissive_debug = { "r_ppdlights_emissive_debug", "0", CVAR_NONE };
@@ -62,6 +64,18 @@ static void R_PPdlights_DebugModeCompat_f (void)
 	}
 
 	Cvar_SetValueQuick (&r_ppdlights_debug_mode, Q_atof (Cmd_Argv (1)));
+}
+
+static void R_PPdlights_WorldBlendOpCompat_f (void)
+{
+	if (Cmd_Argc () <= 1)
+	{
+		Con_Printf ("\"r_ppdlights_world_blendop\" is deprecated; use \"r_experimental_ppdlights_world_blendop\" (current %.0f)\n",
+			r_experimental_ppdlights_world_blendop.value);
+		return;
+	}
+
+	Cvar_SetValueQuick (&r_experimental_ppdlights_world_blendop, Q_atof (Cmd_Argv (1)));
 }
 
 /* Backward compatibility for temporary milestone cvar names. */
@@ -395,8 +409,9 @@ void R_PPdlights_RegisterCvars (void)
 	Cvar_RegisterVariable (&r_ppdlights);
 	Cvar_RegisterVariable (&r_ppdlights_world);
 	Cvar_RegisterVariable (&r_ppdlights_world_scale);
-	Cvar_RegisterVariable (&r_ppdlights_world_blend);
-	Cvar_RegisterVariable (&r_ppdlights_world_blendop);
+	Cvar_RegisterVariable (&r_ppdlights_world_luma_clamp);
+	Cvar_RegisterVariable (&r_ppdlights_world_soft_knee);
+	Cvar_RegisterVariable (&r_experimental_ppdlights_world_blendop);
 	Cvar_RegisterVariable (&r_ppdlights_models);
 	Cvar_RegisterVariable (&r_ppdlights_fog);
 	Cvar_RegisterVariable (&r_ppdlights_fog_debug);
@@ -410,6 +425,7 @@ void R_PPdlights_RegisterCvars (void)
 	Cvar_RegisterVariable (&r_ppdlights_emissive_debug);
 	Cmd_AddCommand ("r_ppdlights_stats", R_PPdlights_Stats_f);
 	Cmd_AddCommand ("r_ppdlights_debug_mode", R_PPdlights_DebugModeCompat_f);
+	Cmd_AddCommand ("r_ppdlights_world_blendop", R_PPdlights_WorldBlendOpCompat_f);
 	Cmd_AddCommand ("r_ppd_emissive", R_PPdlights_EmissiveShortAlias_f);
 	Cmd_AddCommand ("r_ppd_emisdbg", R_PPdlights_EmissiveDebugShortAlias_f);
 	Cmd_AddCommand ("r_ppdlights_participation", R_PPdlights_Participation_f);

--- a/Quake/r_realtimelight.h
+++ b/Quake/r_realtimelight.h
@@ -84,8 +84,9 @@ typedef struct rl_consumer_stats_s
 extern cvar_t r_ppdlights;
 extern cvar_t r_ppdlights_world;
 extern cvar_t r_ppdlights_world_scale;
-extern cvar_t r_ppdlights_world_blend;
-extern cvar_t r_ppdlights_world_blendop;
+extern cvar_t r_ppdlights_world_luma_clamp;
+extern cvar_t r_ppdlights_world_soft_knee;
+extern cvar_t r_experimental_ppdlights_world_blendop;
 extern cvar_t r_ppdlights_models;
 extern cvar_t r_ppdlights_fog;
 extern cvar_t r_ppdlights_fog_debug;

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -1774,7 +1774,7 @@ static void R_DrawBrushModels_Real (entity_t **ents, int count, brushpass_t pass
         state = GLS_CULL_BACK | GLS_ATTRIBS(6);
         if (pass == BP_DLIGHT_SOLID || pass == BP_DLIGHT_ALPHA)
         {
-                int blendop = CLAMP (0, (int)Q_rint (r_ppdlights_world_blendop.value), 1);
+                int blendop = CLAMP (0, (int)Q_rint (r_experimental_ppdlights_world_blendop.value), 1);
                 state |= ((blendop == 1) ? GLS_BLEND_SCREEN : GLS_BLEND_ADD) | GLS_NO_ZWRITE;
         }
         else if (pass == BP_SHADOW_SUN || pass == BP_SHADOW_DLIGHT)

--- a/Quake/shaders/world_dlight.frag
+++ b/Quake/shaders/world_dlight.frag
@@ -15,7 +15,8 @@ layout(binding=8) uniform samplerCubeArray DLightShadowTex;
 #endif
 
 layout(location=0) uniform float DLightScale;
-layout(location=1) uniform float DLightBlendMode; // 0=linear add, 1=soft-add
+layout(location=1) uniform float DLightLumaClamp;
+layout(location=2) uniform float DLightSoftKnee;
 
 layout(location=30) uniform mat4 ShadowSunViewProj;
 layout(location=34) uniform vec4 ShadowEnableDebug;   // x=enabled, y=sun, z=dlight, w=debug mode
@@ -42,6 +43,18 @@ vec3 SanitizeColor(vec3 color)
 		SanitizeScalar(color.x),
 		SanitizeScalar(color.y),
 		SanitizeScalar(color.z));
+}
+
+vec3 ApplyLumaClamp(vec3 color, float lumaClamp)
+{
+	float max_luma = max(lumaClamp, 0.0);
+	if (max_luma <= 0.0)
+		return vec3(0.0);
+
+	float luma = dot(color, vec3(0.299, 0.587, 0.114));
+	if (luma <= max_luma || luma <= 1e-6)
+		return color;
+	return color * (max_luma / luma);
 }
 
 #define MAX_LIGHTS    64
@@ -265,13 +278,11 @@ void main()
 	 */
 	vec3 contrib_raw = SanitizeColor(dynamic_light * DLightScale);
 	vec3 contrib_legacy_raw = SanitizeColor(dynamic_light_legacy * DLightScale);
-	vec3 contrib_linear = clamp(contrib_raw, 0.0, 1.0);
-	vec3 contrib_legacy_linear = clamp(contrib_legacy_raw, 0.0, 1.0);
-	vec3 contrib_soft = clamp(contrib_raw / (vec3(1.0) + contrib_raw), 0.0, 1.0);
-	vec3 contrib_legacy_soft = clamp(contrib_legacy_raw / (vec3(1.0) + contrib_legacy_raw), 0.0, 1.0);
-	float blend_mode = clamp(DLightBlendMode, 0.0, 1.0);
-	vec3 contrib = mix(contrib_linear, contrib_soft, blend_mode);
-	vec3 contrib_legacy = mix(contrib_legacy_linear, contrib_legacy_soft, blend_mode);
+	vec3 contrib_clamped = ApplyLumaClamp(contrib_raw, DLightLumaClamp);
+	vec3 contrib_legacy_clamped = ApplyLumaClamp(contrib_legacy_raw, DLightLumaClamp);
+	float soft_knee = max(DLightSoftKnee, 1e-4);
+	vec3 contrib = clamp(contrib_clamped / (vec3(soft_knee) + contrib_clamped), 0.0, 1.0);
+	vec3 contrib_legacy = clamp(contrib_legacy_clamped / (vec3(soft_knee) + contrib_legacy_clamped), 0.0, 1.0);
 	/* BUGFIX: keep full material response in RT-lighting. Luma-mixing the albedo
 	 * washed out texture contrast and made light look "painted on". */
 	vec3 color = albedo * contrib;
@@ -302,6 +313,14 @@ void main()
 			/* Debug hook: split the new shaping model against a legacy-style approximation. */
 			float split = mod(floor(gl_FragCoord.x / 16.0), 2.0);
 			color = (split < 1.0) ? (albedo * contrib) : (albedo * contrib_legacy);
+		}
+		else if (pp_debug_mode == 5)
+		{
+			color = clamp(contrib_raw, 0.0, 1.0);
+		}
+		else if (pp_debug_mode == 6)
+		{
+			color = contrib;
 		}
 	}
 


### PR DESCRIPTION
### Motivation
- Make the additive fixed-function blend path the canonical default for world dynamic lights and gate non-additive/screen blend ops behind an explicit experimental cvar so accidental user configuration doesn't change the canonical rendering path.
- Provide per-scene tunable controls for light shaping in the shader (luminance clamp and a soft-knee compressor) so scene balance can be adjusted without changing GPU blend equations.
- Add shader debug visualizations for raw and compressed light contributions to make tuning these controls practical.
- Preserve a compatibility hook for the old blend-op name so existing configs/scripts can be migrated without breaking.

### Description
- Replaced the old world blend scalar/override with shader-driven shaping controls by introducing `r_ppdlights_world_luma_clamp` and `r_ppdlights_world_soft_knee` and exporting them via the realtime-light interface (`r_realtimelight.h` / `r_realtimelight.c`).
- Made the fixed-function world dlight blend-op override explicitly experimental by adding `r_experimental_ppdlights_world_blendop` and using it in place of the old `r_ppdlights_world_blendop` selection in `r_world.c`, keeping additive as the default (`GLS_BLEND_ADD`).
- Wired the new uniforms from `gl_dlight.c` into the world dlight programs by extending `R_SetDlightConfig` to send `luma_clamp` and `soft_knee` uniforms and by clamping their ranges before upload.
- Implemented shader-side luminance clamp and soft-knee compression in `shaders/world_dlight.frag` via a new `ApplyLumaClamp` helper and replacing the previous linear/soft mix with a single compressive response that uses the configured soft-knee; added debug visualization modes for pre-compression and post-compression outputs.
- Extended the `r_ppdlights` debug mode range and added a small compatibility command so `r_ppdlights_world_blendop` forwards to the new experimental cvar name.

### Testing
- Attempted an automated build with `make -C Quake -j4`, but the build environment is missing SDL2 tooling/headers (`sdl2-config` / `SDL.h`), so a full native build could not complete and the compilation failed due to missing system dependencies.
- No additional automated unit tests exist for these rendering tuning changes, and shader runtime validation was not performed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c51320cd64832eab8abb5cf08eab2a)