### PR TITLE
Add optional stage normal/spec/ORM material directives

### DIFF
--- a/Quake/mat_material.c
+++ b/Quake/mat_material.c
@@ -119,6 +119,12 @@ static const material_keyword_def_t mat_material_keyword_table[] =
 	{ "alphaFunc", MATERIAL_KEYWORD_SCOPE_STAGE, MATERIAL_KEYWORD_STATUS_KNOWN_UNIMPLEMENTED, "Q3 alpha test (deferred; non-MVP)." },
 	{ "tcGen", MATERIAL_KEYWORD_SCOPE_STAGE, MATERIAL_KEYWORD_STATUS_PARTIAL, "Modes: base/environment/lightmap." },
 	{ "tcMod", MATERIAL_KEYWORD_SCOPE_STAGE, MATERIAL_KEYWORD_STATUS_PARTIAL, "Types: scroll/scale/rotate/turb/stretch." },
+	{ "normalMap", MATERIAL_KEYWORD_SCOPE_STAGE, MATERIAL_KEYWORD_STATUS_IMPLEMENTED, "Optional per-stage normal texture path." },
+	{ "specularMap", MATERIAL_KEYWORD_SCOPE_STAGE, MATERIAL_KEYWORD_STATUS_IMPLEMENTED, "Optional per-stage specular texture path." },
+	{ "ormMap", MATERIAL_KEYWORD_SCOPE_STAGE, MATERIAL_KEYWORD_STATUS_IMPLEMENTED, "Optional per-stage occlusion/roughness/metallic texture path." },
+	{ "normalScale", MATERIAL_KEYWORD_SCOPE_STAGE, MATERIAL_KEYWORD_STATUS_IMPLEMENTED, "Optional per-stage normal scaling factor (default 1)." },
+	{ "specPower", MATERIAL_KEYWORD_SCOPE_STAGE, MATERIAL_KEYWORD_STATUS_IMPLEMENTED, "Optional per-stage specular power scalar (default 1)." },
+	{ "specIntensity", MATERIAL_KEYWORD_SCOPE_STAGE, MATERIAL_KEYWORD_STATUS_IMPLEMENTED, "Optional per-stage specular intensity scalar (default 1)." },
 	{ "emissive", MATERIAL_KEYWORD_SCOPE_STAGE, MATERIAL_KEYWORD_STATUS_IMPLEMENTED, "Stage-level emissive toggle." },
 	{ "bloom", MATERIAL_KEYWORD_SCOPE_STAGE, MATERIAL_KEYWORD_STATUS_IMPLEMENTED, "Stage-level bloom toggle." },
 	{ "emissiveScale", MATERIAL_KEYWORD_SCOPE_STAGE, MATERIAL_KEYWORD_STATUS_IMPLEMENTED, "Stage-level emissive scale." },
@@ -170,6 +176,21 @@ static void Material_FreeStageData (material_stage_t *stage)
 		Z_Free (stage->map_path);
 		stage->map_path = NULL;
 	}
+	if (stage->normal_map_path)
+	{
+		Z_Free (stage->normal_map_path);
+		stage->normal_map_path = NULL;
+	}
+	if (stage->specular_map_path)
+	{
+		Z_Free (stage->specular_map_path);
+		stage->specular_map_path = NULL;
+	}
+	if (stage->orm_map_path)
+	{
+		Z_Free (stage->orm_map_path);
+		stage->orm_map_path = NULL;
+	}
 	if (stage->anim_map_frames)
 	{
 		size_t j;
@@ -198,6 +219,9 @@ static void Material_FreeMaterial (material_t *material)
 		   are owned by stages[0] and already freed above. Clear the pointers
 		   to prevent any accidental use-after-free. */
 		material->stage0.map_path = NULL;
+		material->stage0.normal_map_path = NULL;
+		material->stage0.specular_map_path = NULL;
+		material->stage0.orm_map_path = NULL;
 		material->stage0.anim_map_frames = NULL;
 	}
 	else
@@ -1409,10 +1433,22 @@ void Material_Print (const material_t *material)
 		Con_Printf ("  polygon offset: off\n");
 	Con_Printf ("  emissive: %s (scale %.2f)\n", material->emissive_enable ? "on" : "off", material->emissive_scale);
 	Con_Printf ("  bloom: %s (scale %.2f)\n", material->bloom_enable ? "on" : "off", material->bloom_scale);
-	if (material->stage0.map_path || material->stage0.map_type != MAT_MAP_MAP)
+	if (material->stage0.map_path
+		|| material->stage0.map_type != MAT_MAP_MAP
+		|| material->stage0.normal_map_path
+		|| material->stage0.specular_map_path
+		|| material->stage0.orm_map_path
+		|| material->stage0.normal_scale != 1.f
+		|| material->stage0.spec_power != 1.f
+		|| material->stage0.spec_intensity != 1.f)
 	{
 		const char *map_name = map_names[q_min ((int)material->stage0.map_type, (int)countof (map_names) - 1)];
 		Con_Printf ("  stage0 map: %s (%s)\n", material->stage0.map_path ? material->stage0.map_path : "<builtin>", map_name);
+		Con_Printf ("  stage0 normal map: %s\n", material->stage0.normal_map_path ? material->stage0.normal_map_path : "<none>");
+		Con_Printf ("  stage0 specular map: %s\n", material->stage0.specular_map_path ? material->stage0.specular_map_path : "<none>");
+		Con_Printf ("  stage0 orm map: %s\n", material->stage0.orm_map_path ? material->stage0.orm_map_path : "<none>");
+		Con_Printf ("  stage0 normal/spec: normalScale %.2f specPower %.2f specIntensity %.2f\n",
+			material->stage0.normal_scale, material->stage0.spec_power, material->stage0.spec_intensity);
 		Con_Printf ("  stage0 blend: %s\n", blend_names[q_min ((int)material->stage0.blend_mode, (int)countof (blend_names) - 1)]);
 		Con_Printf ("  stage0 depth: %s (write %s)\n",
 			depth_names[q_min ((int)material->stage0.depth_func, (int)countof (depth_names) - 1)],

--- a/Quake/mat_material.h
+++ b/Quake/mat_material.h
@@ -204,6 +204,12 @@ typedef struct mat_material_stage_s
 	qboolean		bloom_scale_set;
 	qboolean		godray_scale_set;
 	char		*map_path;
+	char		*normal_map_path;
+	char		*specular_map_path;
+	char		*orm_map_path;
+	float			normal_scale;
+	float			spec_power;
+	float			spec_intensity;
 	mat_rgbgen_t	rgbgen;
 	mat_alphagen_t	alphagen;
 	float		const_color[3];

--- a/Quake/mat_material_parse.c
+++ b/Quake/mat_material_parse.c
@@ -946,6 +946,9 @@ static const char *ParseStageBlock (const char *data, material_t *material, size
 	stage.blend_src = GL_ONE;
 	stage.blend_dst = GL_ZERO;
 	stage.tcgen = MAT_TCGEN_BASE;
+	stage.normal_scale = 1.f;
+	stage.spec_power = 1.f;
+	stage.spec_intensity = 1.f;
 	stage.anim_map_fps = 0.f;
 	stage.anim_map_frame = 0;
 	stage.texmatrix_time_bucket = -1;
@@ -1014,6 +1017,57 @@ static const char *ParseStageBlock (const char *data, material_t *material, size
 			}
 			stage.map_type = MAT_MAP_CLAMPMAP;
 			stage.map_path = Material_DupString (value);
+			continue;
+		}
+		if (!q_strcasecmp (com_token, "normalMap"))
+		{
+			Material_MarkKeywordSeen ("normalMap", MATERIAL_KEYWORD_SCOPE_STAGE);
+			if (!ParseIdentExpected (&data, &value, state, "normal map path"))
+			{
+				valid = false;
+				data = SkipUnknownBlockOrLine (data, true, state);
+				break;
+			}
+			if (stage.normal_map_path)
+			{
+				Z_Free (stage.normal_map_path);
+				stage.normal_map_path = NULL;
+			}
+			stage.normal_map_path = Material_DupString (value);
+			continue;
+		}
+		if (!q_strcasecmp (com_token, "specularMap"))
+		{
+			Material_MarkKeywordSeen ("specularMap", MATERIAL_KEYWORD_SCOPE_STAGE);
+			if (!ParseIdentExpected (&data, &value, state, "specular map path"))
+			{
+				valid = false;
+				data = SkipUnknownBlockOrLine (data, true, state);
+				break;
+			}
+			if (stage.specular_map_path)
+			{
+				Z_Free (stage.specular_map_path);
+				stage.specular_map_path = NULL;
+			}
+			stage.specular_map_path = Material_DupString (value);
+			continue;
+		}
+		if (!q_strcasecmp (com_token, "ormMap"))
+		{
+			Material_MarkKeywordSeen ("ormMap", MATERIAL_KEYWORD_SCOPE_STAGE);
+			if (!ParseIdentExpected (&data, &value, state, "orm map path"))
+			{
+				valid = false;
+				data = SkipUnknownBlockOrLine (data, true, state);
+				break;
+			}
+			if (stage.orm_map_path)
+			{
+				Z_Free (stage.orm_map_path);
+				stage.orm_map_path = NULL;
+			}
+			stage.orm_map_path = Material_DupString (value);
 			continue;
 		}
 		if (!q_strcasecmp (com_token, "rgbGen"))
@@ -1648,6 +1702,54 @@ static const char *ParseStageBlock (const char *data, material_t *material, size
 			Material_ValidateFiniteFloat (state, "godrayScale", scale, 1.f, &validated_scale);
 			stage.godray_scale = CLAMP (0.f, validated_scale, MATERIAL_SCALE_MAX);
 			stage.godray_scale_set = true;
+			continue;
+		}
+		if (!q_strcasecmp (com_token, "normalScale"))
+		{
+			Material_MarkKeywordSeen ("normalScale", MATERIAL_KEYWORD_SCOPE_STAGE);
+			float value_scale;
+			float validated_scale = 1.f;
+
+			if (!ParseFloat (&data, &value_scale, state))
+			{
+				data = ResyncMaterialBlock (data, state);
+				break;
+			}
+
+			Material_ValidateFiniteFloat (state, "normalScale", value_scale, 1.f, &validated_scale);
+			stage.normal_scale = CLAMP (0.f, validated_scale, MATERIAL_SCALE_MAX);
+			continue;
+		}
+		if (!q_strcasecmp (com_token, "specPower"))
+		{
+			Material_MarkKeywordSeen ("specPower", MATERIAL_KEYWORD_SCOPE_STAGE);
+			float value_scale;
+			float validated_scale = 1.f;
+
+			if (!ParseFloat (&data, &value_scale, state))
+			{
+				data = ResyncMaterialBlock (data, state);
+				break;
+			}
+
+			Material_ValidateFiniteFloat (state, "specPower", value_scale, 1.f, &validated_scale);
+			stage.spec_power = CLAMP (0.f, validated_scale, MATERIAL_SCALE_MAX);
+			continue;
+		}
+		if (!q_strcasecmp (com_token, "specIntensity"))
+		{
+			Material_MarkKeywordSeen ("specIntensity", MATERIAL_KEYWORD_SCOPE_STAGE);
+			float value_scale;
+			float validated_scale = 1.f;
+
+			if (!ParseFloat (&data, &value_scale, state))
+			{
+				data = ResyncMaterialBlock (data, state);
+				break;
+			}
+
+			Material_ValidateFiniteFloat (state, "specIntensity", value_scale, 1.f, &validated_scale);
+			stage.spec_intensity = CLAMP (0.f, validated_scale, MATERIAL_SCALE_MAX);
 			continue;
 		}
 


### PR DESCRIPTION
### Motivation
- Add optional per-stage normal/specular/ORM support and simple scalar controls so materials can carry normal, specular and ORM textures and tuning values without changing existing material behaviour.

### Description
- Extended `material_stage_t` in `Quake/mat_material.h` with optional path pointers `normal_map_path`, `specular_map_path`, `orm_map_path` and scalar controls `normal_scale`, `spec_power`, and `spec_intensity` initialized to neutral defaults.
- Updated `ParseStageBlock` in `Quake/mat_material_parse.c` to initialize the new scalars to `1.0` and to parse/store the new directives `normalMap`, `specularMap`, `ormMap`, `normalScale`, `specPower`, and `specIntensity` using existing validation helpers and `Material_MarkKeywordSeen`.
- Registered the new directives in `mat_material_keyword_table` in `Quake/mat_material.c` with `MATERIAL_KEYWORD_STATUS_IMPLEMENTED` and concise notes.
- Added cleanup for the new per-stage string allocations in `Material_FreeStageData` and cleared the `stage0` alias pointers in `Material_FreeMaterial` when `stages[]` owns allocations.
- Exposed the new per-stage values in `Material_Print` for debugging and broadened the `stage0` print condition so the new fields are shown even when `map` is not present.
- All new fields default to neutral values (null paths and `1.0` scalars) so existing materials render unchanged when directives are absent.

### Testing
- Attempted an automated build with `make -j4`, which failed because no Makefile is present in this environment (no successful build executed).
- No other automated tests were available or executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c532111f88832eb253fda088147cf4)