### PR TITLE
world: drive specular params from material stage data

### DIFF
--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -403,21 +403,21 @@ typedef struct bmodel_bindless_gpu_call_s {
 	GLfloat		alpha;
 	GLfloat		_pad0;
 	GLfloat		polygon_offset[2];
-	GLfloat		_pad1[2];
+	GLfloat		specular[2]; /* x = intensity, y = exponent */
 	GLfloat		stage_color[4];
 	GLuint64	texture;
 	GLuint64	fullbright;
 	GLuint64	emissive;
-	GLuint64	_pad2;
+	GLuint64	specular_map;
 } bmodel_bindless_gpu_call_t;
 
 typedef struct bmodel_bound_gpu_call_s {
 	GLuint		flags;
 	GLuint		tcgen;
 	GLfloat		alpha;
-	GLfloat		_pad0;
+	GLint		spec_mode;
 	GLfloat		polygon_offset[2];
-	GLfloat		_pad1[2];
+	GLfloat		specular[2]; /* x = intensity, y = exponent */
 	GLfloat		stage_color[4];
 	GLint		baseinstance;
 	GLint		padding[3];
@@ -440,7 +440,7 @@ static union {
 	} bindless;
 	struct {
 		bmodel_bound_gpu_call_t		params[MAX_BMODEL_DRAWS];
-		gltexture_t					*textures[MAX_BMODEL_DRAWS][4];
+		gltexture_t					*textures[MAX_BMODEL_DRAWS][5];
 	} bound;
 } bmodel_calls;
 static bmodel_gpu_call_remap_t		bmodel_call_remap[MAX_BMODEL_DRAWS];
@@ -765,6 +765,7 @@ static void R_FlushBModelCalls (void)
 			GL_BindTextures (0, 2, bmodel_calls.bound.textures[i]);
 			GL_Bind (GL_TEXTURE4, bmodel_calls.bound.textures[i][2]);
 			GL_Bind (GL_TEXTURE5, bmodel_calls.bound.textures[i][3]);
+			GL_Bind (GL_TEXTURE6, bmodel_calls.bound.textures[i][4]);
 			GL_DrawElementsIndirectFunc (GL_TRIANGLES, GL_UNSIGNED_INT, (const byte *)(dstcmdofs + i * sizeof (bmodel_draw_indirect_t)));
 		}
 	}
@@ -906,11 +907,11 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
 		call->flags = flags;
 		call->tcgen = TCGEN_BASE;
 		call->alpha = alpha;
-		call->_pad0 = 0.f;
+		call->spec_mode = 0;
 		call->polygon_offset[0] = polygon_offset_factor;
 		call->polygon_offset[1] = polygon_offset_units;
-		call->_pad1[0] = 0.f;
-		call->_pad1[1] = 0.f;
+		call->specular[0] = 0.4f;
+		call->specular[1] = 16.f;
 		call->stage_color[0] = 1.f;
 		call->stage_color[1] = 1.f;
 		call->stage_color[2] = 1.f;
@@ -918,7 +919,7 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
 		call->texture = tx ? tx->bindless_handle : greytexture->bindless_handle;
 		call->fullbright = fb ? fb->bindless_handle : blacktexture->bindless_handle;
 		call->emissive = em ? em->bindless_handle : blacktexture->bindless_handle;
-		call->_pad2 = 0;
+		call->specular_map = whitetexture->bindless_handle;
 	}
 	else
 	{
@@ -927,11 +928,11 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
 		call->flags = flags;
 		call->tcgen = TCGEN_BASE;
 		call->alpha = alpha;
-		call->_pad0 = 0.f;
+		call->spec_mode = 0;
 		call->polygon_offset[0] = polygon_offset_factor;
 		call->polygon_offset[1] = polygon_offset_units;
-		call->_pad1[0] = 0.f;
-		call->_pad1[1] = 0.f;
+		call->specular[0] = 0.4f;
+		call->specular[1] = 16.f;
 		call->stage_color[0] = 1.f;
 		call->stage_color[1] = 1.f;
 		call->stage_color[2] = 1.f;
@@ -944,6 +945,7 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
 		textures[1] = fb ? fb : blacktexture;
 		textures[2] = em ? em : blacktexture;
 		textures[3] = greytexture;
+		textures[4] = whitetexture;
 	}
 
 	SDL_assert (num_instances > 0);
@@ -954,9 +956,9 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
 	++num_bmodel_calls;
 }
 
-static void R_AddBModelCallWithTextures (int index, int first_instance, int num_instances, gltexture_t *tx, gltexture_t *fb, gltexture_t *em, gltexture_t *nm,
+static void R_AddBModelCallWithTextures (int index, int first_instance, int num_instances, gltexture_t *tx, gltexture_t *fb, gltexture_t *em, gltexture_t *nm, gltexture_t *sm,
 	tcgen_mode_t tcgen, qboolean zfix, float polygon_offset_factor, float polygon_offset_units, float alpha_override, unsigned extra_flags,
-	const vec4_t stage_color)
+	const vec4_t stage_color, float spec_intensity, float spec_exponent, int spec_mode)
 {
 	GLuint flags;
 	float alpha;
@@ -968,6 +970,7 @@ static void R_AddBModelCallWithTextures (int index, int first_instance, int num_
 	fb = R_SanitizeGLTexture (fb, "shaderstage", "fullbright");
 	em = R_SanitizeGLTexture (em, "shaderstage", "emissive");
 	nm = R_SanitizeGLTexture (nm, "shaderstage", "normal");
+	sm = R_SanitizeGLTexture (sm, "shaderstage", "specular");
 
 	flags = zfix | ((fb != NULL) << 1) | (r_fullbright_cheatsafe ? CALLFLAG_NOLIGHTMAP : 0u) | extra_flags;
 	if (em != NULL && (extra_flags & CALLFLAG_MAT_EMISSIVE))
@@ -981,11 +984,11 @@ static void R_AddBModelCallWithTextures (int index, int first_instance, int num_
 		call->flags = flags;
 		call->tcgen = tcgen;
 		call->alpha = alpha;
-		call->_pad0 = 0.f;
+		call->spec_mode = spec_mode;
 		call->polygon_offset[0] = polygon_offset_factor;
 		call->polygon_offset[1] = polygon_offset_units;
-		call->_pad1[0] = 0.f;
-		call->_pad1[1] = 0.f;
+		call->specular[0] = spec_intensity;
+		call->specular[1] = spec_exponent;
 		call->stage_color[0] = stage_color ? stage_color[0] : 1.f;
 		call->stage_color[1] = stage_color ? stage_color[1] : 1.f;
 		call->stage_color[2] = stage_color ? stage_color[2] : 1.f;
@@ -993,7 +996,7 @@ static void R_AddBModelCallWithTextures (int index, int first_instance, int num_
 		call->texture = tx ? tx->bindless_handle : greytexture->bindless_handle;
 		call->fullbright = fb ? fb->bindless_handle : blacktexture->bindless_handle;
 		call->emissive = em ? em->bindless_handle : blacktexture->bindless_handle;
-		call->_pad2 = 0;
+		call->specular_map = sm ? sm->bindless_handle : whitetexture->bindless_handle;
 	}
 	else
 	{
@@ -1002,11 +1005,11 @@ static void R_AddBModelCallWithTextures (int index, int first_instance, int num_
 		call->flags = flags;
 		call->tcgen = tcgen;
 		call->alpha = alpha;
-		call->_pad0 = 0.f;
+		call->spec_mode = spec_mode;
 		call->polygon_offset[0] = polygon_offset_factor;
 		call->polygon_offset[1] = polygon_offset_units;
-		call->_pad1[0] = 0.f;
-		call->_pad1[1] = 0.f;
+		call->specular[0] = spec_intensity;
+		call->specular[1] = spec_exponent;
 		call->stage_color[0] = stage_color ? stage_color[0] : 1.f;
 		call->stage_color[1] = stage_color ? stage_color[1] : 1.f;
 		call->stage_color[2] = stage_color ? stage_color[2] : 1.f;
@@ -1019,6 +1022,7 @@ static void R_AddBModelCallWithTextures (int index, int first_instance, int num_
 		textures[1] = fb ? fb : blacktexture;
 		textures[2] = em ? em : blacktexture;
 		textures[3] = nm ? nm : greytexture;
+		textures[4] = sm ? sm : whitetexture;
 	}
 
 	SDL_assert (num_instances > 0);
@@ -1191,6 +1195,27 @@ static gltexture_t *R_FindStageNormalTexture (const qmodel_t *model, const mater
 	return TexMgr_FindTexture ((qmodel_t *)model, stage->normal_map_path);
 }
 
+static gltexture_t *R_FindStageSpecularTexture (const qmodel_t *model, const material_stage_t *stage, int *out_mode)
+{
+	if (out_mode)
+		*out_mode = 0;
+	if (!stage)
+		return NULL;
+	if (stage->specular_map_path && stage->specular_map_path[0])
+	{
+		if (out_mode)
+			*out_mode = 1; /* dedicated spec map: red = intensity */
+		return TexMgr_FindTexture ((qmodel_t *)model, stage->specular_map_path);
+	}
+	if (stage->orm_map_path && stage->orm_map_path[0])
+	{
+		if (out_mode)
+			*out_mode = 2; /* ORM alpha = roughness */
+		return TexMgr_FindTexture ((qmodel_t *)model, stage->orm_map_path);
+	}
+	return NULL;
+}
+
 static qboolean R_StageUsesLightmap (const material_stage_t *stage, size_t stage_index)
 {
 	if (!stage)
@@ -1331,6 +1356,7 @@ static void R_DrawBrushModels_MaterialStages (entity_t **ents, int count, brushp
 	GL_Bind (GL_TEXTURE2, r_fullbright_cheatsafe ? greytexture : lightmap_texture);
 	GL_Bind (GL_TEXTURE3, (r_lightingdir.value > 0.f && lightmap_dir_texture) ? lightmap_dir_texture : greytexture);
 	GL_Bind (GL_TEXTURE5, greytexture);
+	GL_Bind (GL_TEXTURE6, whitetexture);
 
 	GL_Upload (GL_SHADER_STORAGE_BUFFER, bmodel_instances, sizeof (bmodel_instances[0]) * totalinst, &buf, &ofs);
 	GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 2, buf, (GLintptr)ofs, sizeof (bmodel_instances[0]) * totalinst);
@@ -1410,6 +1436,7 @@ static void R_DrawBrushModels_MaterialStages (entity_t **ents, int count, brushp
 				gltexture_t *fb = NULL;
 				gltexture_t *em = NULL;
 				gltexture_t *nm = NULL;
+				gltexture_t *sm = NULL;
 				vec4_t stage_color;
 				unsigned extra_flags = mat_call_flags | R_StageOutputCallFlags (stage);
 				unsigned stage_state;
@@ -1417,6 +1444,9 @@ static void R_DrawBrushModels_MaterialStages (entity_t **ents, int count, brushp
 				qboolean blend_changed;
 				qboolean uses_lightmap;
 				qboolean stage_is_base = (stage_index == 0 && R_StageIsOpaqueBase (material));
+				float spec_intensity = 0.4f;
+				float spec_exponent = 16.f;
+				int spec_mode = 0;
 
 				if (stage_is_base)
 					continue;
@@ -1445,6 +1475,9 @@ static void R_DrawBrushModels_MaterialStages (entity_t **ents, int count, brushp
 						fb = NULL;
 				}
 				nm = R_FindStageNormalTexture (model, stage);
+				sm = R_FindStageSpecularTexture (model, stage, &spec_mode);
+				spec_intensity = 0.4f * q_max (stage->spec_intensity, 0.f);
+				spec_exponent = q_max (1.f, 16.f * stage->spec_power);
 
 				uses_lightmap = R_StageUsesLightmap (stage, stage_index);
 				if (!uses_lightmap || !model->lightdata)
@@ -1488,8 +1521,9 @@ static void R_DrawBrushModels_MaterialStages (entity_t **ents, int count, brushp
 
 					R_GetPolygonOffsetValues (material, use_polygon_offset, &polygon_offset_factor, &polygon_offset_units);
 					R_AddBModelCallWithTextures (model->firstcmd + j, baseinst, numinst,
-						stage_tex, fb, em, nm, R_ResolveStageTcGen (stage),
-						use_polygon_offset, polygon_offset_factor, polygon_offset_units, -1.f, extra_flags, stage_color);
+						stage_tex, fb, em, nm, sm, R_ResolveStageTcGen (stage),
+						use_polygon_offset, polygon_offset_factor, polygon_offset_units, -1.f, extra_flags,
+						stage_color, spec_intensity, spec_exponent, spec_mode);
 				}
 			}
 		}
@@ -1542,6 +1576,7 @@ static void R_DrawBrushModels_GodrayStages (entity_t **ents, int count)
 	GL_Bind (GL_TEXTURE2, r_fullbright_cheatsafe ? greytexture : lightmap_texture);
 	GL_Bind (GL_TEXTURE3, (r_lightingdir.value > 0.f && lightmap_dir_texture) ? lightmap_dir_texture : greytexture);
 	GL_Bind (GL_TEXTURE5, greytexture);
+	GL_Bind (GL_TEXTURE6, whitetexture);
 
 	GL_Upload (GL_SHADER_STORAGE_BUFFER, bmodel_instances, sizeof (bmodel_instances[0]) * totalinst, &buf, &ofs);
 	GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 2, buf, (GLintptr)ofs, sizeof (bmodel_instances[0]) * totalinst);
@@ -1657,8 +1692,9 @@ static void R_DrawBrushModels_GodrayStages (entity_t **ents, int count)
 
 					R_GetPolygonOffsetValues (material, use_polygon_offset, &polygon_offset_factor, &polygon_offset_units);
 					R_AddBModelCallWithTextures (model->firstcmd + j, baseinst, numinst,
-						stage_tex, fb, em, R_FindStageNormalTexture (model, stage), R_ResolveStageTcGen (stage),
-						use_polygon_offset, polygon_offset_factor, polygon_offset_units, -1.f, extra_flags, stage_color);
+						stage_tex, fb, em, R_FindStageNormalTexture (model, stage), NULL, R_ResolveStageTcGen (stage),
+						use_polygon_offset, polygon_offset_factor, polygon_offset_units, -1.f, extra_flags,
+						stage_color, 0.4f, 16.f, 0);
 				}
 			}
 		}
@@ -1816,6 +1852,7 @@ GL_UseProgram (program);
 	GL_Bind (GL_TEXTURE2, r_fullbright_cheatsafe ? greytexture : lightmap_texture);
 	GL_Bind (GL_TEXTURE3, (r_lightingdir.value > 0.f && lightmap_dir_texture) ? lightmap_dir_texture : greytexture);
 	GL_Bind (GL_TEXTURE5, greytexture);
+	GL_Bind (GL_TEXTURE6, whitetexture);
 }
 else if (pass == BP_SHADOW_SUN || pass == BP_SHADOW_DLIGHT)
 {
@@ -2063,6 +2100,7 @@ void R_DrawBrushModels_Water (entity_t **ents, int count, qboolean translucent)
 	GL_Bind (GL_TEXTURE2, r_fullbright_cheatsafe ? greytexture : lightmap_texture);
 	GL_Bind (GL_TEXTURE3, (r_lightingdir.value > 0.f && lightmap_dir_texture) ? lightmap_dir_texture : greytexture);
 	GL_Bind (GL_TEXTURE5, greytexture);
+	GL_Bind (GL_TEXTURE6, whitetexture);
 
 	GL_Upload (GL_SHADER_STORAGE_BUFFER, bmodel_instances, sizeof(bmodel_instances[0]) * totalinst, &buf, &ofs);
 	GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 2, buf, (GLintptr)ofs, sizeof(bmodel_instances[0]) * totalinst);

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -4,7 +4,8 @@
 	layout(binding=0) uniform sampler2D Tex;
 	layout(binding=1) uniform sampler2D FullbrightTex;
 	layout(binding=4) uniform sampler2D EmissiveTex;
-layout(binding=5) uniform sampler2D NormalTex;
+	layout(binding=5) uniform sampler2D NormalTex;
+	layout(binding=6) uniform sampler2D SpecularTex;
 #endif
 layout(binding=2) uniform sampler2D LMTex;
 layout(binding=3) uniform sampler2D LMTexDir;
@@ -78,16 +79,18 @@ struct Call
 	uint	flags;
 	uint	tcgen;
 	float	wateralpha;
-	float	_pad0;
+	int		spec_mode;
 	vec2	polygon_offset;
+	vec2	specular;
 	vec4	stage_color;
 #if BINDLESS
 	uvec2	txhandle;
 	uvec2	fbhandle;
 	uvec2	emhandle;
+	uvec2	smhandle;
 #else
 	int		baseinstance;
-	int		padding;
+	int		padding[3];
 #endif
 };
 
@@ -167,7 +170,7 @@ layout(location=7)  flat in vec4  in_styles;
 layout(location=8)  flat in float in_lmofs;
 #if BINDLESS
 	layout(location=9)  flat in uvec4 in_samplers0;
-	layout(location=10) flat in uvec2 in_samplers1;
+	layout(location=10) flat in uvec4 in_samplers1;
 #endif
 layout(location=11) noperspective in vec4 in_curr_clip;
 layout(location=12) noperspective in vec4 in_prev_clip;
@@ -178,6 +181,7 @@ layout(location=16) in float in_skyvisibility;
 layout(location=17) flat in vec4 in_stage_color;
 layout(location=18) flat in uint in_tcgen;
 layout(location=19) flat in vec3 in_bmodel_relight;
+layout(location=20) flat in vec4 in_specular;
 
 // Utility: ALU-only 16x16 Bayer matrix
 float bayer01(ivec2 coord)
@@ -468,6 +472,7 @@ void main()
 {
 	vec3 fullbright = vec3(0.0);
 	vec3 emissive   = vec3(0.0);
+	float spec_map_value = 1.0;
 	vec2 uv = in_uv;
 
 #if MODE == 2
@@ -499,11 +504,22 @@ void main()
 		sampler2D EmissiveSampler = sampler2D(in_samplers1.xy);
 		emissive = texture(EmissiveSampler, uv).rgb;
 	}
+	if (in_specular.z > 0.5)
+	{
+		sampler2D SpecSampler = sampler2D(in_samplers1.zw);
+		vec4 spec_sample = texture(SpecSampler, uv);
+		spec_map_value = (in_specular.z > 1.5) ? (1.0 - spec_sample.a) : spec_sample.r;
+	}
 #else
 	if ((in_flags & CF_USE_FULLBRIGHT) != 0u)
 		fullbright = texture(FullbrightTex, uv).rgb;
 	if ((in_flags & CF_USE_EMISSIVE) != 0u)
 		emissive = texture(EmissiveTex, uv).rgb;
+	if (in_specular.z > 0.5)
+	{
+		vec4 spec_sample = texture(SpecularTex, uv);
+		spec_map_value = (in_specular.z > 1.5) ? (1.0 - spec_sample.a) : spec_sample.r;
+	}
 #endif
 
 #if DITHER >= 2
@@ -778,9 +794,12 @@ void main()
 						float h2  = ndoth * ndoth;
 						float h4  = h2 * h2;
 						float h8  = h4 * h4;
-						float h16 = h8 * h8;
-						float spec = h16 * ndotl;
-						specular_light += light_contrib * spec * 0.4; // SPECULAR_SCALE=0.4
+						float h16 = h8 * h8; // legacy x^16 baseline
+						float spec_exp = max(in_specular.y, 1.0);
+						float legacy_to_exp = pow(max(h16, 0.0), spec_exp * (1.0 / 16.0));
+						float spec = legacy_to_exp * ndotl;
+						float spec_scale = max(in_specular.x, 0.0) * clamp(spec_map_value, 0.0, 1.0);
+						specular_light += light_contrib * spec * spec_scale;
 					}
 				}
 			}

--- a/Quake/shaders/world.vert
+++ b/Quake/shaders/world.vert
@@ -46,16 +46,18 @@ struct Call
 	uint	flags;
 	uint	tcgen;
 	float	wateralpha;
-	float	_pad0;
+	int		spec_mode;
 	vec2	polygon_offset;
+	vec2	specular; // x=intensity y=exponent
 	vec4	stage_color;
 #if BINDLESS
 	uvec2	txhandle;
 	uvec2	fbhandle;
 	uvec2	emhandle;
+	uvec2	smhandle;
 #else
 	int		baseinstance;
-	int		padding;
+	int		padding[3];
 #endif
 };
 
@@ -151,7 +153,7 @@ layout(location=7)  flat out vec4  out_styles;
 layout(location=8)  flat out float out_lmofs;
 #if BINDLESS
 	layout(location=9)  flat out uvec4 out_samplers0;
-	layout(location=10) flat out uvec2 out_samplers1;
+	layout(location=10) flat out uvec4 out_samplers1;
 #endif
 layout(location=11) noperspective out vec4 out_curr_clip;
 layout(location=12) noperspective out vec4 out_prev_clip;
@@ -162,6 +164,7 @@ layout(location=16) out float out_skyvisibility;
 layout(location=17) flat out vec4 out_stage_color;
 layout(location=18) flat out uint out_tcgen;
 layout(location=19) flat out vec3 out_bmodel_relight;
+layout(location=20) flat out vec4 out_specular; // x=intensity y=exponent z=mode
 
 vec2 ComputeEnvUV(vec3 world_pos, vec3 world_normal)
 {
@@ -265,6 +268,7 @@ void main()
 	out_lmofs       = in_lmofs;
 	out_stage_color = call.stage_color;
 	out_tcgen       = call.tcgen;
+	out_specular    = vec4(call.specular, float(call.spec_mode), 0.0);
 
 #if BINDLESS
 	out_samplers0.xy = call.txhandle;
@@ -272,5 +276,6 @@ void main()
 	// This is a known-safe pattern on most drivers.
 	out_samplers0.zw = ((call.flags & CF_USE_FULLBRIGHT) != 0u) ? call.fbhandle : call.txhandle;
 	out_samplers1.xy = call.emhandle;
+	out_samplers1.zw = call.smhandle;
 #endif
 }


### PR DESCRIPTION
### Motivation

- Replace hardcoded specular scale/power in `world.frag` with per-material/per-stage parameters so materials can control specular intensity/exponent and optionally supply a spec/ORM map while preserving legacy visuals by default.

### Description

- Add per-draw-call specular payload fields to CPU-side call structs (`bmodel_bindless_gpu_call_t` / `bmodel_bound_gpu_call_t`) including `specular` (intensity, exponent) and a `specular_map` handle and a small `spec_mode` flag; extend bound texture slot array to carry the extra map (`textures[][5]`).
- Thread specular values through draw call creation by extending `R_AddBModelCallWithTextures` signature, initializing defaults (`0.4` intensity, `16` exponent) and passing `spec_intensity`, `spec_exponent`, and `spec_mode` derived from stage data.
- Add `R_FindStageSpecularTexture` to select either a dedicated `specularMap` (mode 1) or an `ormMap` (mode 2) and set `spec_mode` accordingly, leaving legacy fallback when none provided.
- Expose new fields in the vertex payloads (`world.vert`) and fragment inputs (`world.frag`), add a bound sampler slot `binding=6` / `GL_TEXTURE6` for non-bindless paths, sample the optional spec/ORM texture in `world.frag`, and compute dynamic-light specular using the passed `in_specular` intensity/exponent and map modulation while keeping legacy results when no overrides are present.

### Testing

- Ran `make -C /workspace/ironwail/Quake -j2` to sanity-check integration; the build process emitted many dependency errors due to missing SDL tooling/headers (`sdl2-config`, `SDL.h`) in the environment so a full compile/test could not be completed.
- Also attempted `make -C /workspace/ironwail -j2` which failed immediately because no top-level `Makefile` is present in the workspace.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c54a7029ac832e99383e8da4cdb9b2)