### PR TITLE
Add bindless normal/spec handles to bmodel call layout and shader bindings

### DIFF
--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -401,13 +401,14 @@ typedef struct bmodel_bindless_gpu_call_s {
 	GLuint		flags;
 	GLuint		tcgen;
 	GLfloat		alpha;
-	GLfloat		_pad0;
+	GLint		spec_mode;
 	GLfloat		polygon_offset[2];
 	GLfloat		specular[2]; /* x = intensity, y = exponent */
 	GLfloat		stage_color[4];
 	GLuint64	texture;
 	GLuint64	fullbright;
 	GLuint64	emissive;
+	GLuint64	normal_map;
 	GLuint64	specular_map;
 } bmodel_bindless_gpu_call_t;
 
@@ -429,9 +430,13 @@ typedef struct bmodel_gpu_call_remap_s {
 } bmodel_gpu_call_remap_t;
 
 COMPILE_TIME_ASSERT (bmodel_instance_std430_size, sizeof (bmodel_gpu_instance_t) == 112);
-COMPILE_TIME_ASSERT (bmodel_bindless_call_std430_size, sizeof (bmodel_bindless_gpu_call_t) == 80);
+COMPILE_TIME_ASSERT (bmodel_bindless_call_std430_size, sizeof (bmodel_bindless_gpu_call_t) == 96);
 COMPILE_TIME_ASSERT (bmodel_bound_call_std430_size, sizeof (bmodel_bound_gpu_call_t) == 64);
 COMPILE_TIME_ASSERT (bmodel_call_remap_std430_size, sizeof (bmodel_gpu_call_remap_t) == 8);
+COMPILE_TIME_ASSERT (bmodel_bindless_call_spec_mode_offset, offsetof (bmodel_bindless_gpu_call_t, spec_mode) == 12);
+COMPILE_TIME_ASSERT (bmodel_bindless_call_normal_map_offset, offsetof (bmodel_bindless_gpu_call_t, normal_map) == 80);
+COMPILE_TIME_ASSERT (bmodel_bindless_call_spec_map_offset, offsetof (bmodel_bindless_gpu_call_t, specular_map) == 88);
+COMPILE_TIME_ASSERT (bmodel_bound_call_spec_mode_offset, offsetof (bmodel_bound_gpu_call_t, spec_mode) == 12);
 
 static bmodel_gpu_instance_t		bmodel_instances[MAX_VISEDICTS + 1]; // +1 for worldspawn
 static union {
@@ -446,6 +451,18 @@ static union {
 static bmodel_gpu_call_remap_t		bmodel_call_remap[MAX_BMODEL_DRAWS];
 static int							num_bmodel_calls;
 static GLuint						bmodel_batch_program;
+
+enum
+{
+	BMODEL_TEX_SLOT_BASE = 0,
+	BMODEL_TEX_SLOT_FULLBRIGHT,
+	BMODEL_TEX_SLOT_EMISSIVE,
+	BMODEL_TEX_SLOT_NORMAL,
+	BMODEL_TEX_SLOT_SPECULAR_OR_ORM,
+	BMODEL_TEX_SLOT_COUNT
+};
+
+COMPILE_TIME_ASSERT (bmodel_bound_texture_slot_count, BMODEL_TEX_SLOT_COUNT == 5);
 
 static void R_GetPolygonOffsetValues (const material_t *material, qboolean use_offset,
 	float *factor, float *units)
@@ -763,9 +780,9 @@ static void R_FlushBModelCalls (void)
 		{
 			GL_Uniform1iFunc (0, i);
 			GL_BindTextures (0, 2, bmodel_calls.bound.textures[i]);
-			GL_Bind (GL_TEXTURE4, bmodel_calls.bound.textures[i][2]);
-			GL_Bind (GL_TEXTURE5, bmodel_calls.bound.textures[i][3]);
-			GL_Bind (GL_TEXTURE6, bmodel_calls.bound.textures[i][4]);
+			GL_Bind (GL_TEXTURE4, bmodel_calls.bound.textures[i][BMODEL_TEX_SLOT_EMISSIVE]);
+			GL_Bind (GL_TEXTURE5, bmodel_calls.bound.textures[i][BMODEL_TEX_SLOT_NORMAL]);
+			GL_Bind (GL_TEXTURE6, bmodel_calls.bound.textures[i][BMODEL_TEX_SLOT_SPECULAR_OR_ORM]);
 			GL_DrawElementsIndirectFunc (GL_TRIANGLES, GL_UNSIGNED_INT, (const byte *)(dstcmdofs + i * sizeof (bmodel_draw_indirect_t)));
 		}
 	}
@@ -919,6 +936,7 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
 		call->texture = tx ? tx->bindless_handle : greytexture->bindless_handle;
 		call->fullbright = fb ? fb->bindless_handle : blacktexture->bindless_handle;
 		call->emissive = em ? em->bindless_handle : blacktexture->bindless_handle;
+		call->normal_map = greytexture->bindless_handle;
 		call->specular_map = whitetexture->bindless_handle;
 	}
 	else
@@ -941,11 +959,11 @@ static void R_AddBModelCall (int index, int first_instance, int num_instances, t
 		call->padding[0] = 0;
 		call->padding[1] = 0;
 		call->padding[2] = 0;
-		textures[0] = tx ? tx : greytexture;
-		textures[1] = fb ? fb : blacktexture;
-		textures[2] = em ? em : blacktexture;
-		textures[3] = greytexture;
-		textures[4] = whitetexture;
+		textures[BMODEL_TEX_SLOT_BASE] = tx ? tx : greytexture;
+		textures[BMODEL_TEX_SLOT_FULLBRIGHT] = fb ? fb : blacktexture;
+		textures[BMODEL_TEX_SLOT_EMISSIVE] = em ? em : blacktexture;
+		textures[BMODEL_TEX_SLOT_NORMAL] = greytexture;
+		textures[BMODEL_TEX_SLOT_SPECULAR_OR_ORM] = whitetexture;
 	}
 
 	SDL_assert (num_instances > 0);
@@ -971,6 +989,8 @@ static void R_AddBModelCallWithTextures (int index, int first_instance, int num_
 	em = R_SanitizeGLTexture (em, "shaderstage", "emissive");
 	nm = R_SanitizeGLTexture (nm, "shaderstage", "normal");
 	sm = R_SanitizeGLTexture (sm, "shaderstage", "specular");
+	if (!sm)
+		spec_mode = 0;
 
 	flags = zfix | ((fb != NULL) << 1) | (r_fullbright_cheatsafe ? CALLFLAG_NOLIGHTMAP : 0u) | extra_flags;
 	if (em != NULL && (extra_flags & CALLFLAG_MAT_EMISSIVE))
@@ -996,6 +1016,7 @@ static void R_AddBModelCallWithTextures (int index, int first_instance, int num_
 		call->texture = tx ? tx->bindless_handle : greytexture->bindless_handle;
 		call->fullbright = fb ? fb->bindless_handle : blacktexture->bindless_handle;
 		call->emissive = em ? em->bindless_handle : blacktexture->bindless_handle;
+		call->normal_map = nm ? nm->bindless_handle : greytexture->bindless_handle;
 		call->specular_map = sm ? sm->bindless_handle : whitetexture->bindless_handle;
 	}
 	else
@@ -1018,11 +1039,11 @@ static void R_AddBModelCallWithTextures (int index, int first_instance, int num_
 		call->padding[0] = 0;
 		call->padding[1] = 0;
 		call->padding[2] = 0;
-		textures[0] = tx ? tx : greytexture;
-		textures[1] = fb ? fb : blacktexture;
-		textures[2] = em ? em : blacktexture;
-		textures[3] = nm ? nm : greytexture;
-		textures[4] = sm ? sm : whitetexture;
+		textures[BMODEL_TEX_SLOT_BASE] = tx ? tx : greytexture;
+		textures[BMODEL_TEX_SLOT_FULLBRIGHT] = fb ? fb : blacktexture;
+		textures[BMODEL_TEX_SLOT_EMISSIVE] = em ? em : blacktexture;
+		textures[BMODEL_TEX_SLOT_NORMAL] = nm ? nm : greytexture;
+		textures[BMODEL_TEX_SLOT_SPECULAR_OR_ORM] = sm ? sm : whitetexture;
 	}
 
 	SDL_assert (num_instances > 0);

--- a/Quake/shaders/water.vert
+++ b/Quake/shaders/water.vert
@@ -21,16 +21,19 @@ struct Call
 	uint	flags;
 	uint	tcgen;
 	float	wateralpha;
-	float	_pad0;
+	int		spec_mode;
 	vec2	polygon_offset;
+	vec2	specular;
 	vec4	stage_color;
 #if BINDLESS
 	uvec2	txhandle;
 	uvec2	fbhandle;
 	uvec2	emhandle;
+	uvec2	nmhandle;
+	uvec2	smhandle;
 #else
 	int		baseinstance;
-	int		padding;
+	int		padding[3];
 #endif // BINDLESS
 };
 const uint

--- a/Quake/shaders/world.frag
+++ b/Quake/shaders/world.frag
@@ -87,6 +87,7 @@ struct Call
 	uvec2	txhandle;
 	uvec2	fbhandle;
 	uvec2	emhandle;
+	uvec2	nmhandle;
 	uvec2	smhandle;
 #else
 	int		baseinstance;
@@ -171,17 +172,18 @@ layout(location=8)  flat in float in_lmofs;
 #if BINDLESS
 	layout(location=9)  flat in uvec4 in_samplers0;
 	layout(location=10) flat in uvec4 in_samplers1;
+	layout(location=11) flat in uvec4 in_samplers2;
 #endif
-layout(location=11) noperspective in vec4 in_curr_clip;
-layout(location=12) noperspective in vec4 in_prev_clip;
-layout(location=13) in vec3 in_normal;
-layout(location=14) in vec4 in_tangent;
-layout(location=15) in vec3 in_lightgrid;
-layout(location=16) in float in_skyvisibility;
-layout(location=17) flat in vec4 in_stage_color;
-layout(location=18) flat in uint in_tcgen;
-layout(location=19) flat in vec3 in_bmodel_relight;
-layout(location=20) flat in vec4 in_specular;
+layout(location=12) noperspective in vec4 in_curr_clip;
+layout(location=13) noperspective in vec4 in_prev_clip;
+layout(location=14) in vec3 in_normal;
+layout(location=15) in vec4 in_tangent;
+layout(location=16) in vec3 in_lightgrid;
+layout(location=17) in float in_skyvisibility;
+layout(location=18) flat in vec4 in_stage_color;
+layout(location=19) flat in uint in_tcgen;
+layout(location=20) flat in vec3 in_bmodel_relight;
+layout(location=21) flat in vec4 in_specular;
 
 // Utility: ALU-only 16x16 Bayer matrix
 float bayer01(ivec2 coord)
@@ -494,6 +496,7 @@ void main()
 	// Sample textures
 #if BINDLESS
 	sampler2D Tex = sampler2D(in_samplers0.xy);
+	sampler2D NormalSampler = sampler2D(in_samplers1.zw);
 	if ((in_flags & CF_USE_FULLBRIGHT) != 0u)
 	{
 		sampler2D FullbrightTex = sampler2D(in_samplers0.zw);
@@ -506,7 +509,7 @@ void main()
 	}
 	if (in_specular.z > 0.5)
 	{
-		sampler2D SpecSampler = sampler2D(in_samplers1.zw);
+		sampler2D SpecSampler = sampler2D(in_samplers2.xy);
 		vec4 spec_sample = texture(SpecSampler, uv);
 		spec_map_value = (in_specular.z > 1.5) ? (1.0 - spec_sample.a) : spec_sample.r;
 	}
@@ -601,7 +604,11 @@ void main()
 		vec3 geom_normal = surface_normal;
 		vec3 tangent = in_tangent.xyz;
 		float tlen = length(tangent);
+#if BINDLESS
+		vec3 sampled_n = texture(NormalSampler, in_uv).xyz * 2.0 - 1.0;
+#else
 		vec3 sampled_n = texture(NormalTex, in_uv).xyz * 2.0 - 1.0;
+#endif
 		bool has_nm = dot(sampled_n.xy, sampled_n.xy) > 1e-5;
 		if (tlen > 1e-5 && has_nm)
 		{

--- a/Quake/shaders/world.vert
+++ b/Quake/shaders/world.vert
@@ -54,6 +54,7 @@ struct Call
 	uvec2	txhandle;
 	uvec2	fbhandle;
 	uvec2	emhandle;
+	uvec2	nmhandle;
 	uvec2	smhandle;
 #else
 	int		baseinstance;
@@ -154,17 +155,18 @@ layout(location=8)  flat out float out_lmofs;
 #if BINDLESS
 	layout(location=9)  flat out uvec4 out_samplers0;
 	layout(location=10) flat out uvec4 out_samplers1;
+	layout(location=11) flat out uvec4 out_samplers2;
 #endif
-layout(location=11) noperspective out vec4 out_curr_clip;
-layout(location=12) noperspective out vec4 out_prev_clip;
-layout(location=13) out vec3 out_normal;
-layout(location=14) out vec4 out_tangent;
-layout(location=15) out vec3 out_lightgrid;
-layout(location=16) out float out_skyvisibility;
-layout(location=17) flat out vec4 out_stage_color;
-layout(location=18) flat out uint out_tcgen;
-layout(location=19) flat out vec3 out_bmodel_relight;
-layout(location=20) flat out vec4 out_specular; // x=intensity y=exponent z=mode
+layout(location=12) noperspective out vec4 out_curr_clip;
+layout(location=13) noperspective out vec4 out_prev_clip;
+layout(location=14) out vec3 out_normal;
+layout(location=15) out vec4 out_tangent;
+layout(location=16) out vec3 out_lightgrid;
+layout(location=17) out float out_skyvisibility;
+layout(location=18) flat out vec4 out_stage_color;
+layout(location=19) flat out uint out_tcgen;
+layout(location=20) flat out vec3 out_bmodel_relight;
+layout(location=21) flat out vec4 out_specular; // x=intensity y=exponent z=mode
 
 vec2 ComputeEnvUV(vec3 world_pos, vec3 world_normal)
 {
@@ -276,6 +278,8 @@ void main()
 	// This is a known-safe pattern on most drivers.
 	out_samplers0.zw = ((call.flags & CF_USE_FULLBRIGHT) != 0u) ? call.fbhandle : call.txhandle;
 	out_samplers1.xy = call.emhandle;
-	out_samplers1.zw = call.smhandle;
+	out_samplers1.zw = call.nmhandle;
+	out_samplers2.xy = call.smhandle;
+	out_samplers2.zw = uvec2(0u);
 #endif
 }

--- a/Quake/shaders/world_dlight.vert
+++ b/Quake/shaders/world_dlight.vert
@@ -36,16 +36,19 @@ struct Call
         uint    flags;
         uint    tcgen;
         float   wateralpha;
-        float   _pad0;
+        int     spec_mode;
         vec2    polygon_offset;
+        vec2    specular;
         vec4    stage_color;
 #if BINDLESS
         uvec2   txhandle;
         uvec2   fbhandle;
         uvec2   emhandle;
+        uvec2   nmhandle;
+        uvec2   smhandle;
 #else
-        int             baseinstance;
-        int             padding;
+        int     baseinstance;
+        int     padding[3];
 #endif // BINDLESS
 };
 const uint

--- a/Quake/shaders/world_shadow.vert
+++ b/Quake/shaders/world_shadow.vert
@@ -16,16 +16,19 @@ struct Call
 	uint flags;
 	uint tcgen;
 	float wateralpha;
-	float _pad0;
+	int spec_mode;
 	vec2 polygon_offset;
+	vec2 specular;
 	vec4 stage_color;
 #if BINDLESS
 	uvec2 txhandle;
 	uvec2 fbhandle;
 	uvec2 emhandle;
+	uvec2 nmhandle;
+	uvec2 smhandle;
 #else
 	int baseinstance;
-	int padding;
+	int padding[3];
 #endif
 };
 


### PR DESCRIPTION
### Motivation
- Enable per-draw bindless delivery of normal and specular (or ORM) maps for bmodel draws while keeping old-materials rendering identical by providing neutral defaults and strict layout checks.

### Description
- Extended `bmodel_bindless_gpu_call_t` to include `spec_mode`, `normal_map`, and `specular_map` members and added compile-time `COMPILE_TIME_ASSERT` checks for struct size and key offsets to detect CPU/GPU std430 mismatches.
- Introduced `BMODEL_TEX_SLOT_*` enum and a slot-count assertion and updated the non-bindless (bound) path to use explicit slots for BASE/FULLBRIGHT/EMISSIVE/NORMAL/SPECULAR_OR_ORM.
- Updated bmodel call setup to assign safe defaults for missing maps (grey normal, white spec/ORM, black emissive) and added a guard to clear `spec_mode` when no spec/ORM map is present.
- Mirrored the call-struct layout changes in shader `Call` definitions used by world rendering (`world.vert`, `world.frag`, `world_dlight.vert`, `world_shadow.vert`, `water.vert`) and extended the bindless sampler varyings to carry normal + spec handles; switched bindless normal/spec sampling to the new handles.

### Testing
- Attempted an automated build with `make -C Quake -j4`, which could not complete in this environment because SDL2 tooling/headers are unavailable (`sdl2-config` / `SDL.h` missing), so no successful compile/run verification was possible.
- Source-level checks performed: updated files compiled logically by static edits and were committed to local tree; runtime shader/driver validation was not performed due to the build environment limitation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c54c0ebc5c832ea1ca25c25ee0cf74)