### PR TITLE
Fix sky shader CallBuffer layout for bindless stride update

### DIFF
--- a/Quake/shaders/sky_cubemap.vert
+++ b/Quake/shaders/sky_cubemap.vert
@@ -21,16 +21,19 @@ struct Call
 	uint	flags;
 	uint	tcgen;
 	float	wateralpha;
-	float	_pad0;
+	int		spec_mode;
 	vec2	polygon_offset;
+	vec2	specular; // x=intensity y=exponent
 	vec4	stage_color;
 #if BINDLESS
 	uvec2	txhandle;
 	uvec2	fbhandle;
 	uvec2	emhandle;
+	uvec2	nmhandle;
+	uvec2	smhandle;
 #else
 	int		baseinstance;
-	int		padding;
+	int		padding[3];
 #endif // BINDLESS
 };
 const uint

--- a/Quake/shaders/sky_layers.vert
+++ b/Quake/shaders/sky_layers.vert
@@ -21,16 +21,19 @@ struct Call
 	uint	flags;
 	uint	tcgen;
 	float	wateralpha;
-	float	_pad0;
+	int		spec_mode;
 	vec2	polygon_offset;
+	vec2	specular; // x=intensity y=exponent
 	vec4	stage_color;
 #if BINDLESS
 	uvec2	txhandle;
 	uvec2	fbhandle;
 	uvec2	emhandle;
+	uvec2	nmhandle;
+	uvec2	smhandle;
 #else
 	int		baseinstance;
-	int		padding;
+	int		padding[3];
 #endif // BINDLESS
 };
 const uint

--- a/Quake/shaders/skystencil.vert
+++ b/Quake/shaders/skystencil.vert
@@ -21,16 +21,19 @@ struct Call
 	uint	flags;
 	uint	tcgen;
 	float	wateralpha;
-	float	_pad0;
+	int		spec_mode;
 	vec2	polygon_offset;
+	vec2	specular; // x=intensity y=exponent
 	vec4	stage_color;
 #if BINDLESS
 	uvec2	txhandle;
 	uvec2	fbhandle;
 	uvec2	emhandle;
+	uvec2	nmhandle;
+	uvec2	smhandle;
 #else
 	int		baseinstance;
-	int		padding;
+	int		padding[3];
 #endif // BINDLESS
 };
 const uint


### PR DESCRIPTION
### Motivation
- The CPU-side `bmodel_bindless_gpu_call_t` struct was changed to 96 bytes, but the `Call` definitions in sky shaders still used the old 80-byte layout, causing wrong indexing of `call_data[DRAW_ID]` in bindless mode.
- This could make sky draws after the first read incorrect flags/handles when using bindless draws, so the shader `Call` layout must match the CPU struct/std430 stride.

### Description
- Update `Call` struct in `Quake/shaders/sky_layers.vert`, `Quake/shaders/sky_cubemap.vert`, and `Quake/shaders/skystencil.vert` to match the CPU-side layout and std430 packing.
- Add `spec_mode` and `specular` members in the same positions as `bmodel_bindless_gpu_call_t` and include the missing bindless handles `nmhandle` and `smhandle`.
- Expand the non-bindless side padding to `padding[3]` to preserve alignment with the bound-call CPU struct.

### Testing
- Ran `git diff --check` to validate no whitespace/format issues, which completed with no problems.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c565848030832e8ce34f1462674a6e)