### PR TITLE
Fix chance threshold behavior in Audio_PlayDefById

### DIFF
--- a/Quake/snd_dma.c
+++ b/Quake/snd_dma.c
@@ -1041,8 +1041,16 @@ audio_voice_handle_t Audio_PlayDefById (sound_def_id_t id, const audio_play_para
 		if (layer->sample_count <= 0)
 			continue;
 
-		if (layer->chance < 1.f && SND_RandomRange (0.f, 1.f) > layer->chance)
+		/* Edge-case intent: chance <= 0 never plays, chance >= 1 always plays. */
+		if (layer->chance <= 0.f)
 			continue;
+		if (layer->chance < 1.f)
+		{
+			const float chance_roll = (float) rand () / ((float) RAND_MAX + 1.f); /* [0, 1) */
+
+			if (!(chance_roll < layer->chance))
+				continue;
+		}
 
 		sample_index = (layer->sample_count == 1) ? 0 : rand () % layer->sample_count;
 		sample_sfx = layer->samples[sample_index].sfx;


### PR DESCRIPTION
### Motivation
- Ensure sound-def layer chance gating treats 0 and 1 as deterministic boundaries and uses strict `<` semantics for intermediate probabilities.

### Description
- In `Quake/snd_dma.c` replaced the previous `SND_RandomRange` check with explicit fast paths: skip when `layer->chance <= 0.f`, always pass when `layer->chance >= 1.f`, and for `0 < chance < 1` compute a single `rand()`-based float in `[0,1)` and continue unless `r < layer->chance`, and added an inline comment documenting the edge-case intent.

### Testing
- Ran `git diff --check` which reported no issues and the change was committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbace12eb8832eb5518daa152bbffb)