### PR TITLE
Use channel start time for duplicate-SFX jitter end-time calculation

### DIFF
--- a/Quake/snd_dma.c
+++ b/Quake/snd_dma.c
@@ -969,7 +969,8 @@ static audio_voice_handle_t SND_PlaySfxInternal (sfx_t *sfx, const audio_play_pa
 			if (skip > 0)
 				skip = rand() % skip;
 			target_chan->pos += (float) skip;
-			target_chan->end = SND_CalcChannelEndTime (paintedtime, target_chan, sc);
+			// Recalculate from the channel's actual start so delayed voices keep their delay.
+			target_chan->end = SND_CalcChannelEndTime (target_chan->start, target_chan, sc);
 			break;
 		}
 	}


### PR DESCRIPTION
### Motivation
- Fix a timing bug where duplicate-SFX jitter recalculated a channel's `end` from `paintedtime`, which could ignore a previously applied `delay_ms` and shorten delayed voices.

### Description
- Replace the duplicate-sfx jitter end-time call to use `SND_CalcChannelEndTime(target_chan->start, target_chan, sc)` instead of using `paintedtime` so the end time is derived from the channel's actual start.
- Add a brief inline comment explaining that `target_chan->start` is required to preserve delayed voices.
- Confirmed that `delay_ms` is applied to `target_chan->start` before the end-time calculation so the delay remains effective.

### Testing
- Searched and inspected occurrences with `rg` and verified the targeted block; the search succeeded.
- Reviewed the file diff with `git diff -- Quake/snd_dma.c` and inspected the modified lines with `nl -ba Quake/snd_dma.c | sed -n '944,982p'`; both checks succeeded and show the intended change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbf654748c832eb5a967c6e64ac6a8)