### PR TITLE
sounddef: reject non-finite float tokens during parse

### DIFF
--- a/Quake/sounddef_parser.c
+++ b/Quake/sounddef_parser.c
@@ -1,6 +1,7 @@
 #include "quakedef.h"
 #include "sounddef.h"
 #include "miniz.h"
+#include <math.h>
 
 typedef struct sounddef_parse_state_s
 {
@@ -21,6 +22,7 @@ static const char *SoundDef_SkipBlockContents (const char *cursor, sounddef_pars
 static qboolean SoundDef_ParseBoolToken (const char *token, qboolean *out_value);
 static qboolean SoundDef_ParseIntToken (const char *token, int *out_value);
 static qboolean SoundDef_ParseFloatToken (const char *token, float *out_value);
+static qboolean SoundDef_IsFinite (float value);
 static qboolean SoundDef_IsTopLevelLayerKey (const char *token);
 static qboolean SoundDef_ParseLayerProperty (const char *key, sound_def_layer_desc_t *layer, const char **cursor, sounddef_parse_state_t *state);
 static qboolean SoundDef_ParseDefProperty (const char *key, sound_def_desc_t *desc, const char **cursor, sounddef_parse_state_t *state);
@@ -222,9 +224,20 @@ static qboolean SoundDef_ParseFloatToken (const char *token, float *out_value)
 	value = (float) strtod (token, &end);
 	if (!end || *end)
 		return false;
+	if (!SoundDef_IsFinite (value))
+		return false;
 
 	*out_value = value;
 	return true;
+}
+
+static qboolean SoundDef_IsFinite (float value)
+{
+#if defined(_MSC_VER)
+	return _finite (value) != 0;
+#else
+	return isfinite (value);
+#endif
 }
 
 static qboolean SoundDef_IsTopLevelLayerKey (const char *token)


### PR DESCRIPTION
### Motivation
- Prevent NaN/±Inf values from being accepted by the sounddef parser to avoid propagating invalid numeric values into runtime volume/pitch/chance/etc.

### Description
- Added `#include <math.h>` for portable `isfinite` availability and declared a small helper `SoundDef_IsFinite` that uses `_finite` on MSVC and `isfinite` elsewhere.
- Hardened `SoundDef_ParseFloatToken` to call `SoundDef_IsFinite` after `strtod` and reject non-finite results before assigning to `*out_value`, while preserving the existing token-format checks (`!end || *end`).

### Testing
- No automated tests were executed for this targeted parser hardening change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccf7630314832ea806e964f45da405)