### PR TITLE
Validate sounddef integer token bounds before cast

### DIFF
--- a/Quake/sounddef_parser.c
+++ b/Quake/sounddef_parser.c
@@ -1,6 +1,8 @@
 #include "quakedef.h"
 #include "sounddef.h"
 #include "miniz.h"
+#include <errno.h>
+#include <limits.h>
 
 typedef struct sounddef_parse_state_s
 {
@@ -203,8 +205,12 @@ static qboolean SoundDef_ParseIntToken (const char *token, int *out_value)
 	if (!token || !token[0] || !out_value)
 		return false;
 
+	errno = 0;
 	value = strtol (token, &end, 10);
-	if (!end || *end)
+	if (end == token || !end || *end)
+		return false;
+
+	if (errno == ERANGE || value < INT_MIN || value > INT_MAX)
 		return false;
 
 	*out_value = (int) value;


### PR DESCRIPTION
### Motivation

- Prevent undefined behavior from casting out-of-range `long` values to `int` when parsing sounddef integer properties by enforcing bounds and conversion success.

### Description

- Added includes for `<errno.h>` and `<limits.h>` to support range and error checks. 
- Reset `errno` and use `strtol` result checks to reject inputs where no digits were parsed or trailing garbage remains by checking `end == token` and `*end`.
- Reject `strtol` overflow/underflow (`errno == ERANGE`) and values outside `INT_MIN..INT_MAX` before casting to `int` and return `false` on failure. 
- Kept failure behavior consistent so callers continue to follow existing property-specific parse error paths.

### Testing

- Ran `git diff -- Quake/sounddef_parser.c` to verify the code delta and it succeeded. 
- Ran `git status --short` to confirm a clean staged state and it succeeded. 
- Attempted the Windows runtime smoke command using `powershell.exe` to launch `C:\Quake\rerelease\ironwail.exe` but it could not be executed in this environment (`powershell.exe: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccf937d2d8832ebcffabdbc0cdcd7f)