### PR TITLE
fogvol: honor lighting mode uniforms in scattering composition

### DIFF
--- a/Quake/r_fogvol.c
+++ b/Quake/r_fogvol.c
@@ -920,6 +920,10 @@ static void R_FogVol_SetShaderUniforms (int steps, int mode, qboolean use_halfre
 	float shadow_contrast = CLAMP (0.5f, r_fogvol_shadow_contrast.value, 4.f);
 	float extinction_relief = CLAMP (0.f, r_fogvol_light_extinction_relief.value, 0.95f);
 	float emissive_floor = 0.f;
+	qboolean light_enabled = false;
+	qboolean light_has_froxel = false;
+	qboolean light_has_sun = false;
+	qboolean light_has_emissive = false;
 	float debug_dlight_scale = 1.f;
 	float debug_sun_scale = 0.f;
 	float debug_emissive_scale = 0.f;
@@ -982,6 +986,14 @@ static void R_FogVol_SetShaderUniforms (int steps, int mode, qboolean use_halfre
 		light_scale_dlight = q_max (light_scale_dlight, 3.0f);
 		light_contrast = q_max (light_contrast, 1.0f);
 	}
+	lighting_mode = CLAMP (0, mode, 2);
+	light_has_froxel = (mode > 0 && (froxel_ready || force_froxel_debug) && light_scale_dlight > 0.f);
+	light_has_sun = (mode > 0 && shadow_enabled && light_scale_sun > 0.f);
+	light_has_emissive = (mode > 1 && r_fogvol_emissive.value > 0.f && light_scale_emissive > 0.f);
+	if (lighting_mode == 1)
+		light_enabled = (light_has_froxel || light_has_sun);
+	else if (lighting_mode >= 2)
+		light_enabled = (light_has_froxel || light_has_sun || light_has_emissive);
 
 	GL_Uniform1iFunc (FOGVOL_U_STEPS, q_max (8, steps));
 	GL_Uniform1iFunc (FOGVOL_U_NOISE_ENABLED, r_fogvol_noise.value > 0.f ? 1 : 0);
@@ -1002,7 +1014,7 @@ static void R_FogVol_SetShaderUniforms (int steps, int mode, qboolean use_halfre
 	GL_Uniform4fFunc (FOGVOL_U_DENSITY_PARAMS, fog_density, sigma_max, noise_scale, noise_bias);
 	GL_Uniform1iFunc (FOGVOL_U_EMISSIVE_ENABLED, r_fogvol_emissive.value > 0.f ? 1 : 0);
 	GL_Uniform1iFunc (FOGVOL_U_BLEND_MODE_DEFAULT, CLAMP (0, (int)Q_rint (r_fogvol_blendmode.value), 1));
-	GL_Uniform1iFunc (FOGVOL_U_LIGHT_ENABLED, 0);
+	GL_Uniform1iFunc (FOGVOL_U_LIGHT_ENABLED, light_enabled ? 1 : 0);
 	GL_Uniform1iFunc (FOGVOL_U_SHADOW_ENABLED, shadow_enabled ? 1 : 0);
 	GL_Uniform1iFunc (FOGVOL_U_SHADOW_SAMPLES, shadow_enabled ? 1 : 0);
 	GL_Uniform1fFunc (FOGVOL_U_SHADOW_STRENGTH, CLAMP (0.f, r_fogvol_shadow_strength.value, 4.f));

--- a/Quake/shaders/fogvol.frag
+++ b/Quake/shaders/fogvol.frag
@@ -596,8 +596,20 @@ void main()
 	float ambientWeight = clamp(FogClusterParams.x, 0.0, 1.0);
 	float ambientSkyVis = clamp(volume.params2.w, 0.0, 1.0);
 	float ambientSkyMod = 1.0;
-	bool noFogLights = (FogLightSourceScales.x <= 1e-4 && FogLightSourceScales.y <= 1e-4 && FogLightSourceScales.z <= 1e-4);
+	bool lightingEnabled = (FogLightEnabled != 0);
+	int lightingMode = clamp(FogLightingMode, 0, 2);
+	bool modeFroxelOnly = (lightingMode == 1);
+	bool modeMixedDetail = (lightingMode >= 2);
 	float ambientClamp = 0.15;
+	float ambientMin = 0.0;
+	bool hasActiveLightingTerms = false;
+	if (lightingEnabled)
+	{
+		if (modeFroxelOnly)
+			hasActiveLightingTerms = (FogLightSourceScales.x > 1e-4 || FogLightSourceScales.y > 1e-4);
+		else if (modeMixedDetail)
+			hasActiveLightingTerms = (FogLightSourceScales.x > 1e-4 || FogLightSourceScales.y > 1e-4 || FogLightSourceScales.z > 1e-4);
+	}
 	if (AmbientSkyEnabled() > 0.5)
 	{
 		float skyRoom = 1.0 - clamp(max(max(volume.color_density.r, volume.color_density.g), volume.color_density.b) * 0.6, 0.0, 1.0);
@@ -614,12 +626,19 @@ void main()
 		/* Keep global medium extinction-dominant; large ambient values flatten
 		 * depth cues into a fullscreen veil, especially when config overrides
 		 * push r_fogvol_light_ambient far above default. */
-		ambientClamp = noFogLights ? 0.0 : 0.04;
+		ambientClamp = hasActiveLightingTerms ? 0.04 : 0.0;
 		/* When fog lighting is disabled (r_fogvol_light 0), suppress ambient
 		 * in-scatter for global fog so distance extinction remains visible
 		 * instead of collapsing into a flat fullscreen veil. */
-		if (noFogLights)
+		if (!hasActiveLightingTerms)
 			ambientWeight = 0.0;
+	}
+	else if (!hasActiveLightingTerms && lightingMode == 0)
+	{
+		/* Unlit mode keeps a minimal baseline so fog remains readable
+		 * without forcing a broad ambient tint. */
+		ambientClamp = min(ambientClamp, 0.05);
+		ambientMin = 0.01;
 	}
 
 	for (int i = 0; i < FogSteps; ++i)
@@ -638,12 +657,17 @@ void main()
 		if (!IsFiniteFloat(sigma) || sigma <= 1e-6)
 			continue;
 
-		vec3 froxelScatter = SampleFroxelLight(p) * max(FogLightSourceScales.x, 0.0);
-		froxelScatter = pow(max(froxelScatter, vec3(0.0)), vec3(1.0 / max(lightContrast, 0.5)));
-		froxelScatter *= lightContrast;
-		vec3 sunScatter = SampleSunScatter(p, viewDir);
+		vec3 froxelScatter = vec3(0.0);
+		vec3 sunScatter = vec3(0.0);
 		vec3 emissiveScatter = vec3(0.0);
-		if (FogEmissiveEnabled != 0)
+		if (lightingEnabled && lightingMode > 0)
+		{
+			froxelScatter = SampleFroxelLight(p) * max(FogLightSourceScales.x, 0.0);
+			froxelScatter = pow(max(froxelScatter, vec3(0.0)), vec3(1.0 / max(lightContrast, 0.5)));
+			froxelScatter *= lightContrast;
+			sunScatter = SampleSunScatter(p, viewDir);
+		}
+		if (lightingEnabled && modeMixedDetail && FogEmissiveEnabled != 0)
 		{
 			float emissiveStrength = max(volume.misc.w, 0.0) * max(FogLightSourceScales.z, 0.0);
 			emissiveStrength = max(emissiveStrength, max(FogClusterParams.z, 0.0));
@@ -651,13 +675,16 @@ void main()
 				emissiveScatter = volume.color_density.rgb * emissiveStrength;
 		}
 
-		vec3 scattering = vec3(0.0);
-		// Keep only a small unlit baseline so lighting and shadows dominate.
 		vec3 ambientTint = mix(vec3(1.0), AmbientSkyTint(), clamp(ambientSkyMod, 0.0, 1.0));
-		scattering += volume.color_density.rgb * ambientTint * min(ambientWeight, ambientClamp);
-		scattering += froxelScatter;
-		scattering += sunScatter;
-		scattering += emissiveScatter;
+		float ambientTerm = clamp(min(ambientWeight, ambientClamp), ambientMin, ambientClamp);
+		vec3 scattering = volume.color_density.rgb * ambientTint * ambientTerm;
+		if (lightingEnabled)
+		{
+			if (modeFroxelOnly)
+				scattering += froxelScatter + sunScatter;
+			else if (modeMixedDetail)
+				scattering += froxelScatter + sunScatter + emissiveScatter;
+		}
 
 		float lightLuma = dot(max(froxelScatter + sunScatter + emissiveScatter, vec3(0.0)), vec3(0.2126, 0.7152, 0.0722));
 		float relief = extinctionRelief * clamp(lightLuma * 0.75, 0.0, 1.0);
@@ -701,6 +728,21 @@ void main()
 	if (FogDebugMode == 6)
 	{
 		FragColor = vec4(vec3(clamp(transmittance, 0.0, 1.0)), 1.0);
+		return;
+	}
+	if (FogDebugMode == 7)
+	{
+		vec3 modeColor = vec3(0.15, 0.15, 0.15);
+		if (FogLightEnabled != 0)
+		{
+			if (FogLightingMode == 1)
+				modeColor = vec3(0.1, 0.35, 1.0);
+			else if (FogLightingMode >= 2)
+				modeColor = vec3(0.1, 0.9, 0.25);
+			else
+				modeColor = vec3(1.0, 0.5, 0.1);
+		}
+		FragColor = vec4(modeColor, 1.0);
 		return;
 	}
 	if (AmbientSkyDebugEnabled() > 0.5)


### PR DESCRIPTION
### Motivation
- Make shader scattering follow the runtime lighting-mode uniforms so fog lighting behaves predictably for lighting-off, froxel-only and mixed/detail modes.
- Ensure the CPU-side uniform setup drives the same branches the shader uses so disabled lighting truly short-circuits expensive contributions.

### Description
- In `Quake/shaders/fogvol.frag` branch scattering in `main()` by `FogLightingMode` and `FogLightEnabled`, implementing: mode 0 = extinction/minimal ambient, mode 1 = froxel (+ optional sun), mode 2 = froxel + sun + emissive detail.
- Short-circuit froxel/sun/emissive sampling when `FogLightEnabled == 0` and avoid forcing a broad ambient tint when no active lighting terms exist, while keeping camera-follow global-fog safeguards.
- Add `FogDebugMode == 7` debug visualization to color pixels by active lighting mode for quick visual validation.
- In `Quake/r_fogvol.c` compute `lighting_mode` and per-mode availability (`froxel`, `sun`, `emissive`) and set `FOGVOL_U_LIGHT_ENABLED` accordingly so CPU uniforms map 1:1 to shader branches.

### Testing
- Ran `git diff --check` which passed with no whitespace errors.
- Verified CPU->shader uniform names/locations via repository grep and code inspection to confirm `FOGVOL_U_LIGHTING_MODE`/`FOGVOL_U_LIGHT_ENABLED` are set to match shader branches.
- Attempted the Windows smoke-launch command from AGENTS notes but the PowerShell executable path was unavailable in this environment, so an executable run was not performed (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4e543dd44832e9fbfe9620a57304b)