### PR TITLE
bot_ai: compute item reachability once during item selection

### DIFF
--- a/Quake/bot_ai.c
+++ b/Quake/bot_ai.c
@@ -547,7 +547,7 @@ static qboolean BotAI_ItemPotentiallyReachable (bot_state_t *bot, edict_t *self,
 	return tr.fraction >= 1.f;
 }
 
-static float BotAI_ItemScore (bot_state_t *bot, edict_t *self, edict_t *item, const char *classname, qboolean enemy_visible, float dist)
+static float BotAI_ItemScore (bot_state_t *bot, edict_t *self, edict_t *item, const char *classname, qboolean enemy_visible, float dist, qboolean item_reachable)
 {
 	bot_item_type_t item_type;
 	float score = -1.f;
@@ -633,7 +633,7 @@ static float BotAI_ItemScore (bot_state_t *bot, edict_t *self, edict_t *item, co
 	score -= dist * 0.05f;
 	if (enemy_visible && item_type != BOT_ITEM_HEALTH && item_type != BOT_ITEM_POWERUP)
 		score *= 0.65f;
-	if (!BotAI_ItemPotentiallyReachable (bot, self, item))
+	if (!item_reachable)
 		score *= 0.2f;
 	if (bot->state == BOT_STATE_RETREAT && item_type == BOT_ITEM_HEALTH)
 		score += 80.f;
@@ -658,6 +658,7 @@ static edict_t *BotAI_FindBestItem (bot_state_t *bot, edict_t *self, qboolean en
 		vec3_t delta;
 		float dist;
 		float score;
+		qboolean item_reachable;
 
 		if (!item || item->free)
 			continue;
@@ -683,9 +684,10 @@ static edict_t *BotAI_FindBestItem (bot_state_t *bot, edict_t *self, qboolean en
 		if (dist > 2200.f)
 			continue;
 
-		score = BotAI_ItemScore (bot, self, item, classname, enemy_visible, dist);
-		if (!BotAI_ItemPotentiallyReachable (bot, self, item))
+		item_reachable = BotAI_ItemPotentiallyReachable (bot, self, item);
+		if (!item_reachable)
 			continue;
+		score = BotAI_ItemScore (bot, self, item, classname, enemy_visible, dist, item_reachable);
 		if (score > best_score)
 		{
 			best_score = score;


### PR DESCRIPTION
### Motivation

- Avoid redundant and potentially expensive reachability probes during item selection by computing item reachability once per candidate and separating reachability from scoring.
- Make `BotAI_ItemScore` consume precomputed reachability so scoring logic does not itself call path/reach checks.

### Description

- Changed the signature of `BotAI_ItemScore` to accept an extra `qboolean item_reachable` parameter and use that instead of calling `BotAI_ItemPotentiallyReachable` inside the scorer.
- Updated `BotAI_FindBestItem` to compute `item_reachable = BotAI_ItemPotentiallyReachable(bot, self, item)` once per item, skip items that are unreachable, and pass the flag into `BotAI_ItemScore`.
- Removed the duplicate reachability call that previously ran after scoring; the optional per-bot transient cache was not added in this change.

### Testing

- Ran `git diff --check` to validate no whitespace/patch issues, which completed successfully.
- Verified the working tree with `git status --short` and committed the change successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4ea398bcc832e92cb7fd46f53c670)