### PR TITLE
Fix WAV cue loop parsing to prevent infinite lift sound loops

### DIFF
--- a/Quake/snd_mem.c
+++ b/Quake/snd_mem.c
@@ -525,9 +525,12 @@ wavinfo_t GetWavinfo (const char *name, byte *wav, int wavlength)
 	FindChunk("cue ");
 	if (data_p)
 	{
+		qboolean has_valid_loop = false;
+		int cue_loopstart = -1;
+
 		data_p += 32;
-		info.loopstart = GetLittleLong();
-	//	Con_Printf("loopstart=%d\n", sfx->loopstart);
+		cue_loopstart = GetLittleLong();
+	//	Con_Printf("loopstart=%d\n", cue_loopstart);
 
 	// if the next chunk is a LIST chunk, look for a cue length marker
 		FindNextChunk ("LIST");
@@ -537,10 +540,18 @@ wavinfo_t GetWavinfo (const char *name, byte *wav, int wavlength)
 			{	// this is not a proper parse, but it works with cooledit...
 				data_p += 24;
 				i = GetLittleLong();	// samples in loop
-				info.samples = info.loopstart + i;
+				if (cue_loopstart >= 0 && i > 0)
+				{
+					info.loopstart = cue_loopstart;
+					info.samples = info.loopstart + i;
+					has_valid_loop = true;
+				}
 		//		Con_Printf("looped length: %i\n", i);
 			}
 		}
+
+		if (!has_valid_loop)
+			info.loopstart = -1;
 	}
 	else
 		info.loopstart = -1;


### PR DESCRIPTION
### Motivation
- Prevent one-shot movement sounds (e.g. lifts/platforms) being mis-detected as looping due to partial/invalid WAV cue metadata.
- Make loop detection in the WAV parser stricter so only fully-specified cue + LIST/mark data enable looping.

### Description
- Tightened loop parsing in `GetWavinfo` so a sound is marked looping only when both a valid cue loop start and a positive `LIST/mark` loop length are present, otherwise `info.loopstart` is set to `-1`.
- Changes made to `Quake/snd_mem.c` around the cue/LIST handling to validate `cue_loopstart` and loop length before assigning `info.loopstart` and `info.samples`.

### Testing
- Ran `git diff --check` to verify there are no whitespace/patch issues and it passed.
- Attempted the Windows MSBuild from the AGENTS.md but the MSBuild binary was not available in this environment so the build could not be run here.
- Attempted the PowerShell-based local smoke test but PowerShell is not available in this container so the runtime smoke test was not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4f3adbd9c832ebfd567abd86a2d5f)