### PR TITLE
Per-Tile Light-Index-Listen für World-DLight-Pass mit Shader-Fallback

### DIFF
--- a/Quake/gl_dlight.c
+++ b/Quake/gl_dlight.c
@@ -87,12 +87,7 @@ void R_DrawDLightPass (void)
 
 	r_framedata.dlight_params[2] = 1.f;
 	r_framedata.dlight_params[3] = pp_debug_mode;
-	{
-		GLuint buf;
-		GLbyte *ofs;
-		GL_Upload (GL_UNIFORM_BUFFER, &r_framedata, sizeof (r_framedata), &buf, &ofs);
-		GL_BindBufferRange (GL_UNIFORM_BUFFER, 0, buf, (GLintptr)ofs, sizeof (r_framedata));
-	}
+	R_UploadFrameData ();
 
 	{
 		const float world_scale = CLAMP (0.f, r_ppdlights_world_scale.value, 4.f);
@@ -106,12 +101,7 @@ void R_DrawDLightPass (void)
 
 	r_framedata.dlight_params[2] = 0.f;
 	r_framedata.dlight_params[3] = 0.f;
-	{
-		GLuint buf;
-		GLbyte *ofs;
-		GL_Upload (GL_UNIFORM_BUFFER, &r_framedata, sizeof (r_framedata), &buf, &ofs);
-		GL_BindBufferRange (GL_UNIFORM_BUFFER, 0, buf, (GLintptr)ofs, sizeof (r_framedata));
-	}
+	R_UploadFrameData ();
 
 	GL_EndGroup ();
 

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -117,6 +117,150 @@ static GLuint r_godrays_coupling_shafts_tex = 0;
 static int r_godrays_coupling_shafts_w = 0;
 static int r_godrays_coupling_shafts_h = 0;
 
+typedef struct light_tile_entry_s
+{
+	unsigned int	offset;
+	unsigned int	count;
+} light_tile_entry_t;
+
+#define LIGHT_TILE_COUNT (LIGHT_TILES_X * LIGHT_TILES_Y * LIGHT_TILES_Z)
+#define LIGHT_TILE_INDEX_CAPACITY (LIGHT_TILE_COUNT * 8)
+
+static light_tile_entry_t r_light_tiles[LIGHT_TILE_COUNT];
+static unsigned int r_light_tile_indices[LIGHT_TILE_INDEX_CAPACITY];
+static int r_light_tile_index_count = 0;
+static int r_light_tile_used_count = 0;
+static float r_light_tile_avg_lights = 0.f;
+static qboolean r_light_tile_ready = false;
+
+static int R_LightTileIndex (int tx, int ty, int tz)
+{
+	return tz * (LIGHT_TILES_X * LIGHT_TILES_Y) + ty * LIGHT_TILES_X + tx;
+}
+
+static int R_LightTileCoordFromDepth (float depth)
+{
+	const float z = q_max (depth, 1e-6f);
+	const float tzf = CLAMP (0.f, log2f (z) * r_framedata.zparams[0] + r_framedata.zparams[1], (float)(LIGHT_TILES_Z - 1));
+	return (int)tzf;
+}
+
+static qboolean R_BuildLightTileLists (void)
+{
+	typedef struct light_tile_light_range_s
+	{
+		unsigned char tx0, tx1, ty0, ty1, tz0, tz1;
+		qboolean valid;
+	} light_tile_light_range_t;
+	light_tile_light_range_t light_ranges[DLIGHT_GPU_MAX];
+	unsigned int tile_counts[LIGHT_TILE_COUNT];
+	unsigned int tile_offsets[LIGHT_TILE_COUNT];
+	unsigned int running = 0;
+	int i, tx, ty, tz;
+
+	memset (r_light_tiles, 0, sizeof (r_light_tiles));
+	memset (r_light_tile_indices, 0, sizeof (r_light_tile_indices));
+	memset (light_ranges, 0, sizeof (light_ranges));
+	memset (tile_counts, 0, sizeof (tile_counts));
+	memset (tile_offsets, 0, sizeof (tile_offsets));
+	r_light_tile_index_count = 0;
+	r_light_tile_used_count = 0;
+	r_light_tile_avg_lights = 0.f;
+	r_light_tile_ready = false;
+
+	if (r_ppdlights_world_tiles.value <= 0.f || r_framedata.numlights == 0)
+		return false;
+
+	for (i = 0; i < (int)r_framedata.numlights; ++i)
+	{
+		const gpulight_t *l = &r_lightbuffer.lights[i];
+		const float radius = q_max (l->radius, 1.f);
+		const float clip_x = r_matviewproj[0] * l->pos[0] + r_matviewproj[4] * l->pos[1] + r_matviewproj[8] * l->pos[2] + r_matviewproj[12];
+		const float clip_y = r_matviewproj[1] * l->pos[0] + r_matviewproj[5] * l->pos[1] + r_matviewproj[9] * l->pos[2] + r_matviewproj[13];
+		const float clip_w = r_matviewproj[3] * l->pos[0] + r_matviewproj[7] * l->pos[1] + r_matviewproj[11] * l->pos[2] + r_matviewproj[15];
+		const float view_z = r_matview[2] * l->pos[0] + r_matview[6] * l->pos[1] + r_matview[10] * l->pos[2] + r_matview[14];
+		const float view_depth = -view_z;
+		const float depth_near = q_max (view_depth - radius, 1e-4f);
+		const float depth_far = view_depth + radius;
+		const float ndc_x = clip_x / q_max (fabsf (clip_w), 1e-6f);
+		const float ndc_y = clip_y / q_max (fabsf (clip_w), 1e-6f);
+		const float extent_x = fabsf (r_matproj[0]) * radius / depth_near;
+		const float extent_y = fabsf (r_matproj[5]) * radius / depth_near;
+		const float min_x = ndc_x - extent_x;
+		const float max_x = ndc_x + extent_x;
+		const float min_y = ndc_y - extent_y;
+		const float max_y = ndc_y + extent_y;
+		const float tile_fx0 = CLAMP (0.f, (min_x * 0.5f + 0.5f) * LIGHT_TILES_X, (float)(LIGHT_TILES_X - 1));
+		const float tile_fx1 = CLAMP (0.f, (max_x * 0.5f + 0.5f) * LIGHT_TILES_X, (float)(LIGHT_TILES_X - 1));
+		const float tile_fy0 = CLAMP (0.f, (min_y * 0.5f + 0.5f) * LIGHT_TILES_Y, (float)(LIGHT_TILES_Y - 1));
+		const float tile_fy1 = CLAMP (0.f, (max_y * 0.5f + 0.5f) * LIGHT_TILES_Y, (float)(LIGHT_TILES_Y - 1));
+		light_tile_light_range_t *range = &light_ranges[i];
+
+		if (clip_w <= 1e-5f || depth_far <= 1e-5f)
+			continue;
+
+		range->tx0 = (unsigned char)tile_fx0;
+		range->tx1 = (unsigned char)tile_fx1;
+		range->ty0 = (unsigned char)tile_fy0;
+		range->ty1 = (unsigned char)tile_fy1;
+		range->tz0 = (unsigned char)R_LightTileCoordFromDepth (depth_near);
+		range->tz1 = (unsigned char)R_LightTileCoordFromDepth (q_max (depth_far, depth_near));
+		range->valid = true;
+
+		for (tz = range->tz0; tz <= range->tz1; ++tz)
+			for (ty = range->ty0; ty <= range->ty1; ++ty)
+				for (tx = range->tx0; tx <= range->tx1; ++tx)
+					tile_counts[R_LightTileIndex (tx, ty, tz)]++;
+	}
+
+	for (i = 0; i < LIGHT_TILE_COUNT; ++i)
+	{
+		r_light_tiles[i].offset = running;
+		r_light_tiles[i].count = tile_counts[i];
+		tile_offsets[i] = running;
+		running += tile_counts[i];
+	}
+
+	if (running == 0 || running > LIGHT_TILE_INDEX_CAPACITY)
+	{
+		if (running > LIGHT_TILE_INDEX_CAPACITY && r_ppdlights_debug.value >= 1.f && (r_framecount % 60) == 0)
+			Con_DWarning ("r_ppdlights_world_tiles: overflow (%u > %u), fallback to global loop\n", running, LIGHT_TILE_INDEX_CAPACITY);
+		return false;
+	}
+
+	for (i = 0; i < (int)r_framedata.numlights; ++i)
+	{
+		const light_tile_light_range_t *range = &light_ranges[i];
+		if (!range->valid)
+			continue;
+		for (tz = range->tz0; tz <= range->tz1; ++tz)
+			for (ty = range->ty0; ty <= range->ty1; ++ty)
+				for (tx = range->tx0; tx <= range->tx1; ++tx)
+				{
+					const int tile = R_LightTileIndex (tx, ty, tz);
+					const unsigned int write_index = tile_offsets[tile]++;
+					r_light_tile_indices[write_index] = (unsigned int)i;
+				}
+	}
+
+	r_light_tile_index_count = (int)running;
+	for (i = 0; i < LIGHT_TILE_COUNT; ++i)
+	{
+		if (r_light_tiles[i].count > 0)
+			r_light_tile_used_count++;
+	}
+	r_light_tile_avg_lights = (float)r_light_tile_index_count / (float)LIGHT_TILE_COUNT;
+	r_light_tile_ready = true;
+
+	if (r_ppdlights_world_tiles_debug.value > 0.f && (r_framecount % 60) == 0)
+	{
+		Con_DPrintf ("r_ppdlights_world_tiles: lights=%u refs=%d tiles=%d/%d avg=%.2f\n",
+			r_framedata.numlights, r_light_tile_index_count, r_light_tile_used_count, LIGHT_TILE_COUNT, r_light_tile_avg_lights);
+	}
+
+	return true;
+}
+
 qboolean R_Godrays_GetFogCouplingSource (GLuint *out_shafts_tex, int *out_width, int *out_height)
 {
 	if (out_shafts_tex)
@@ -4183,10 +4327,22 @@ void R_UploadFrameData (void)
 	GLuint	buf;
 	GLbyte* ofs;
 	size_t	size;
+	qboolean tile_ready;
+
+	tile_ready = R_BuildLightTileLists ();
+	r_framedata.dlight_params[2] = tile_ready ? 1.f : 0.f;
 
 	size = sizeof (r_lightbuffer.lightstyles) + sizeof (r_lightbuffer.lights[0]) * q_max (r_framedata.numlights, 1); // avoid zero-length array
 	GL_Upload (GL_SHADER_STORAGE_BUFFER, &r_lightbuffer, size, &buf, &ofs);
 	GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 0, buf, (GLintptr)ofs, size);
+
+	size = sizeof (r_light_tiles);
+	GL_Upload (GL_SHADER_STORAGE_BUFFER, &r_light_tiles, size, &buf, &ofs);
+	GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 9, buf, (GLintptr)ofs, size);
+
+	size = sizeof (r_light_tile_indices[0]) * q_max (r_light_tile_index_count, 1);
+	GL_Upload (GL_SHADER_STORAGE_BUFFER, &r_light_tile_indices, size, &buf, &ofs);
+	GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 10, buf, (GLintptr)ofs, size);
 
 	GL_Upload (GL_UNIFORM_BUFFER, &r_framedata, sizeof (r_framedata), &buf, &ofs);
 	GL_BindBufferRange (GL_UNIFORM_BUFFER, 0, buf, (GLintptr)ofs, sizeof (r_framedata));

--- a/Quake/r_realtimelight.c
+++ b/Quake/r_realtimelight.c
@@ -14,6 +14,8 @@ cvar_t r_ppdlights_world_scale = { "r_ppdlights_world_scale", "1", CVAR_ARCHIVE 
 /* World-light shaping controls, applied in shader before additive blend. */
 cvar_t r_ppdlights_world_luma_clamp = { "r_ppdlights_world_luma_clamp", "1.0", CVAR_ARCHIVE };
 cvar_t r_ppdlights_world_soft_knee = { "r_ppdlights_world_soft_knee", "1.0", CVAR_ARCHIVE };
+cvar_t r_ppdlights_world_tiles = { "r_ppdlights_world_tiles", "1", CVAR_ARCHIVE };
+cvar_t r_ppdlights_world_tiles_debug = { "r_ppdlights_world_tiles_debug", "0", CVAR_NONE };
 /* Experimental fixed-function blend op override for world dlight pass. */
 cvar_t r_experimental_ppdlights_world_blendop = { "r_experimental_ppdlights_world_blendop", "0", CVAR_ARCHIVE };
 /* Forward alias/model consumer toggle (shared frame-light list -> alias lighting). */
@@ -474,6 +476,8 @@ void R_PPdlights_RegisterCvars (void)
 	Cvar_RegisterVariable (&r_ppdlights_world_scale);
 	Cvar_RegisterVariable (&r_ppdlights_world_luma_clamp);
 	Cvar_RegisterVariable (&r_ppdlights_world_soft_knee);
+	Cvar_RegisterVariable (&r_ppdlights_world_tiles);
+	Cvar_RegisterVariable (&r_ppdlights_world_tiles_debug);
 	Cvar_RegisterVariable (&r_experimental_ppdlights_world_blendop);
 	Cvar_RegisterVariable (&r_ppdlights_models);
 	Cvar_RegisterVariable (&r_ppdlights_fog);

--- a/Quake/r_realtimelight.h
+++ b/Quake/r_realtimelight.h
@@ -87,6 +87,8 @@ extern cvar_t r_ppdlights_world;
 extern cvar_t r_ppdlights_world_scale;
 extern cvar_t r_ppdlights_world_luma_clamp;
 extern cvar_t r_ppdlights_world_soft_knee;
+extern cvar_t r_ppdlights_world_tiles;
+extern cvar_t r_ppdlights_world_tiles_debug;
 extern cvar_t r_experimental_ppdlights_world_blendop;
 extern cvar_t r_ppdlights_models;
 extern cvar_t r_ppdlights_fog;

--- a/Quake/shaders/world_dlight.frag
+++ b/Quake/shaders/world_dlight.frag
@@ -76,6 +76,16 @@ layout(std430, binding=0) restrict readonly buffer LightBuffer
 	Light   Lights[];
 };
 
+layout(std430, binding=9) restrict readonly buffer LightTileBuffer
+{
+	uvec2 LightTileRanges[];
+};
+
+layout(std430, binding=10) restrict readonly buffer LightTileIndexBuffer
+{
+	uint LightTileIndices[];
+};
+
 layout(location=0) flat in uint in_flags;
 layout(location=1) flat in float in_alpha;
 layout(location=2) in vec3 in_pos;
@@ -210,6 +220,9 @@ void main()
 	vec3 rim_dlight_accum = vec3(0.0);
 	float debug_attenuation = 0.0;
 	float debug_affected_count = 0.0;
+	uvec3 tile_coord = ComputeLightTileCoord(in_coord, in_depth);
+	uint tile_index = tile_coord.z * uint(LIGHT_TILES_X * LIGHT_TILES_Y) + tile_coord.y * uint(LIGHT_TILES_X) + tile_coord.x;
+	bool use_tile_lists = (DLightParams.z > 0.5);
 	if (NumLights > 0u)
 	{
 		const float core_boost = 0.0;
@@ -217,9 +230,20 @@ void main()
 		const float knee = 0.0;
 		const float ndotl_mix = 1.0;
 		const float saturation_chop = 0.0;
-
-		for (uint light_index = 0u; light_index < NumLights; light_index++)
+		uint light_begin = 0u;
+		uint light_end = NumLights;
+		if (use_tile_lists)
 		{
+			uvec2 tile_range = LightTileRanges[tile_index];
+			light_begin = tile_range.x;
+			light_end = tile_range.x + tile_range.y;
+		}
+
+		for (uint light_iter = light_begin; light_iter < light_end; light_iter++)
+		{
+			uint light_index = use_tile_lists ? LightTileIndices[light_iter] : light_iter;
+			if (light_index >= NumLights)
+				continue;
 			Light l = Lights[light_index];
 
 			float rad = l.radius;
@@ -296,7 +320,8 @@ void main()
 	{
 		if (pp_debug_mode == 1)
 		{
-			float count_norm = debug_affected_count / max(float(NumLights), 1.0);
+			float debug_denom = use_tile_lists ? max(float(LightTileRanges[tile_index].y), 1.0) : max(float(NumLights), 1.0);
+			float count_norm = debug_affected_count / debug_denom;
 			color = vec3(clamp(count_norm, 0.0, 1.0));
 		}
 		else if (pp_debug_mode == 2)


### PR DESCRIPTION
### Motivation
- Reduziere die Per-Fragment-Kosten des globalen `for (light_index < NumLights)`-Loops in `world_dlight.frag` durch gezielte Iteration nur über die Lichtliste der Tile des aktuellen Fragments.
- Biete einen robusten Fallback auf das bestehende globale Verhalten, falls die Tile-Buffers nicht bereit sind oder überlaufen.

### Description
- Implementiert ein CPU-seitiges Tile-Index-Format (`offset/count` pro Tile) und eine globale Indexliste in `Quake/gl_rmain.c` inklusive `R_BuildLightTileLists()`; neue in-memory Arrays: `r_light_tiles` und `r_light_tile_indices` sowie helpers `R_LightTileIndex` und `R_LightTileCoordFromDepth`.
- Uploadet und bindet die neuen SSBOs pro Frame in `R_UploadFrameData()` (`binding=9` für Tile-Ranges, `binding=10` für Indexliste) und setzt `r_framedata.dlight_params[2]` als Laufzeit-Flag für Shader-Fallback.
- Passt den Fragment-Shader `Quake/shaders/world_dlight.frag` so an, dass er, falls `DLightParams.z` (Tile-Feature-Flag) gesetzt ist, nur über die Tile-Range iteriert und ansonsten sicher auf den globalen `NumLights`-Loop zurückfällt; Debug-Mode rechnet jetzt korrekt mit Tile-Counts.
- Fügt zwei neue CVars hinzu und registriert sie in `r_realtimelight`: `r_ppdlights_world_tiles` (Feature-Flag) und `r_ppdlights_world_tiles_debug` (periodische Statistik-Ausgabe); sorgt dafür, dass die World-DLight-Pass-Upload-Logik (`gl_dlight.c`) `R_UploadFrameData()` nutzt, damit Light-/Tile-Daten synchron sind.

### Testing
- `git diff --check` wurde ausgeführt und zeigte keine Probleme (erfolgreich).
- Ein automatisierter Windows-Runtime-Smoke-Start (`powershell.exe` Start-Process) wurde in dieser Linux-Umgebung versucht und schlug fehl, da `powershell.exe` nicht vorhanden ist, deswegen kein lokaler engine smoke möglich war (fehlgeschlagen).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d513bc3188832eb99eb73b3dcffd85)