### PR TITLE
render: harden backend activation and add lifecycle hooks

### DIFF
--- a/Quake/gl_backend.c
+++ b/Quake/gl_backend.c
@@ -399,10 +399,34 @@ static void GLBackend_Finish (void)
 	glFinish ();
 }
 
+static qboolean GLBackend_Init (void)
+{
+	return true;
+}
+
+static void GLBackend_Shutdown (void)
+{
+}
+
+static void GLBackend_OnResize (int width, int height)
+{
+	(void)width;
+	(void)height;
+}
+
+static qboolean GLBackend_CanActivate (qboolean runtime_switch)
+{
+	return !runtime_switch;
+}
+
 void GL_Backend_Register (void)
 {
 	static const IRenderBackend gl_backend = {
 		"OpenGL",
+		GLBackend_Init,
+		GLBackend_Shutdown,
+		GLBackend_OnResize,
+		GLBackend_CanActivate,
 		GLBackend_BeginPass,
 		GLBackend_EndPass,
 		GLBackend_ValidatePassState,

--- a/Quake/gl_vidsdl.c
+++ b/Quake/gl_vidsdl.c
@@ -635,6 +635,7 @@ static void VID_UpdateWindowMetrics (int *out_depthbits, int *out_stencilbits)
 	vid.numpages = 2;
 
 	VID_RecalcInterfaceSize ();
+	R_Backend_OnResize (vid.width, vid.height);
 
 	if (SDL_GL_GetAttribute (SDL_GL_DEPTH_SIZE, out_depthbits) == -1)
 		*out_depthbits = 0;
@@ -1600,6 +1601,7 @@ void	VID_Shutdown (void)
 {
 	if (vid_initialized)
 	{
+		R_Backend_Shutdown ();
 		Lightgrid_Shutdown ();
 		VID_FreeMouseCursors();
 		SDL_GL_DeleteContext(gl_context);

--- a/Quake/r_backend.c
+++ b/Quake/r_backend.c
@@ -13,6 +13,7 @@ static int s_registered_backend_count = 0;
 static const IRenderBackend *s_active_backend = NULL;
 static qboolean s_backend_initialized = false;
 static qboolean s_applying_backend_cvar = false;
+static qboolean s_backend_active = false;
 
 cvar_t r_backend = { "r_backend", "OpenGL", CVAR_ARCHIVE };
 
@@ -50,7 +51,7 @@ static void R_Backend_Changed_f (cvar_t *var)
 
 	if (!R_Backend_Select (var->string))
 	{
-		Con_Warning ("Renderer backend '%s' not found; keeping '%s'\n",
+		Con_Warning ("Renderer backend change to '%s' rejected; keeping '%s'\n",
 			var->string,
 			(s_active_backend && s_active_backend->name) ? s_active_backend->name : "<none>");
 		R_Backend_ApplySelectionToCvar ();
@@ -87,11 +88,60 @@ void R_Backend_Register (const IRenderBackend *backend)
 qboolean R_Backend_Select (const char *backend_name)
 {
 	const IRenderBackend *backend = R_Backend_FindByName (backend_name);
+	const IRenderBackend *previous = s_active_backend;
+	const qboolean runtime_switch = s_backend_active && previous && backend && (previous != backend);
+	qboolean activated = false;
 
 	if (!backend)
 		return false;
 
+	if (runtime_switch && (!backend->can_activate || !backend->can_activate (true)))
+	{
+		Con_Warning (
+			"Renderer backend '%s' cannot be activated at runtime; set r_backend and restart the engine.\n",
+			backend->name ? backend->name : "<unnamed>");
+		return false;
+	}
+
+	if (backend->can_activate && !backend->can_activate (false))
+	{
+		Con_Warning ("Renderer backend '%s' is not ready for activation.\n",
+			backend->name ? backend->name : "<unnamed>");
+		return false;
+	}
+
+	if (s_backend_active && previous && previous->shutdown)
+		previous->shutdown ();
+
 	s_active_backend = backend;
+	if (!backend->init || backend->init ())
+		activated = true;
+
+	if (!activated)
+	{
+		Con_Warning ("Renderer backend '%s' failed to activate.\n",
+			backend->name ? backend->name : "<unnamed>");
+
+		if (previous && previous != backend)
+		{
+			Con_Warning ("Reverting renderer backend to '%s'.\n",
+				previous->name ? previous->name : "<unnamed>");
+			s_active_backend = previous;
+			if (!previous->init || previous->init ())
+				activated = true;
+		}
+
+		if (!activated)
+		{
+			Con_Warning ("Failed to restore previous renderer backend; no active backend available.\n");
+			s_active_backend = NULL;
+			s_backend_active = false;
+			return false;
+		}
+	}
+
+	s_backend_active = true;
+	R_Backend_ApplySelectionToCvar ();
 	return true;
 }
 
@@ -111,6 +161,21 @@ void R_Backend_Init (void)
 
 	if (!R_Backend_Select (r_backend.string))
 		R_Backend_ApplySelectionToCvar ();
+}
+
+void R_Backend_Shutdown (void)
+{
+	if (s_backend_active && s_active_backend && s_active_backend->shutdown)
+		s_active_backend->shutdown ();
+	s_backend_active = false;
+}
+
+void R_Backend_OnResize (int width, int height)
+{
+	const IRenderBackend *backend = R_GetRenderBackend ();
+
+	if (backend && backend->on_resize)
+		backend->on_resize (width, height);
 }
 
 const IRenderBackend *R_GetRenderBackend (void)

--- a/Quake/r_framegraph.h
+++ b/Quake/r_framegraph.h
@@ -75,6 +75,10 @@ typedef struct render_pass_context_s RenderPassContext;
 typedef struct i_render_backend_s
 {
 	const char *name;
+	qboolean (*init)(void);
+	void (*shutdown)(void);
+	void (*on_resize)(int width, int height);
+	qboolean (*can_activate)(qboolean runtime_switch);
 	void (*begin_pass)(const char *name);
 	void (*end_pass)(void);
 	void (*validate_pass_state)(const char *pass_name, qboolean before_pass);
@@ -123,8 +127,10 @@ void R_FrameGraph_ResetPasses (void);
 qboolean R_FrameGraph_AddPass (const RenderPassDesc *pass_desc);
 void R_FrameGraph_RenderView (void);
 void R_Backend_Init (void);
+void R_Backend_Shutdown (void);
 void R_Backend_Register (const IRenderBackend *backend);
 qboolean R_Backend_Select (const char *backend_name);
+void R_Backend_OnResize (int width, int height);
 const IRenderBackend *R_GetRenderBackend (void);
 const render_backend_resource_ref_t *R_FrameGraph_GetResourceRef (const RenderGraphResourceHandle *resources, render_backend_resource_slot_t slot);
 unsigned R_FrameGraph_ResolveResourceBySlot (const RenderGraphResourceHandle *resources, render_backend_resource_slot_t slot);


### PR DESCRIPTION
### Motivation
- Add explicit lifecycle and readiness hooks so render backends can prepare, teardown, and respond to resizes safely at runtime.
- Prevent unsafe runtime backend switches by validating readiness and clearly requiring a restart when a backend cannot be activated live.
- Ensure the `r_backend` cvar is only persisted after a backend has been successfully activated.
- Provide a recovery path that reverts to the previous backend if activation of the new backend fails.

### Description
- Extend `IRenderBackend` in `r_framegraph.h` with `init`, `shutdown`, `on_resize`, and `can_activate` callbacks and expose `R_Backend_Shutdown` and `R_Backend_OnResize` APIs.
- Rework `R_Backend_Select` in `r_backend.c` to validate `can_activate`, reject unsupported runtime switches with a clear warning, call `shutdown` on the previous backend, call `init` on the new backend, persist `r_backend` only after successful activation, and attempt rollback to the previous backend on failure.
- Add `R_Backend_Shutdown` and `R_Backend_OnResize` implementations and wire `R_Backend_OnResize` into `VID_UpdateWindowMetrics` and `R_Backend_Shutdown` into `VID_Shutdown` in `gl_vidsdl.c`.
- Implement OpenGL backend stubs in `gl_backend.c` for the new callbacks and disallow runtime activation by returning false from the runtime `can_activate` path.
- Update cvar change messaging to clearly indicate when a requested change was rejected rather than just missing.

### Testing
- Ran `make -C Quake -j4` in the container to exercise the build after changes and it failed due to missing system SDL tooling (`sdl2-config`) and headers (`SDL.h`), so full compilation/integration verification could not complete in this environment.
- No other automated tests were run; the change compiles locally in a full dev environment should be validated (build + smoke run) per repo `AGENTS.md` instructions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8d7c95d14832e8f8e018e67fe00c5)