### PR TITLE
Framegraph: map resource bits to backend slots and validate pass reads

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -5738,7 +5738,7 @@ static void R_FG_ExecWarpResolve (RenderPassContext *ctx)
 static const RenderPassDesc s_warp_resolve_framegraph_pass = {
 	"Warp/resolve",
 	RENDER_RES_SCENE_COLOR | RENDER_RES_SCENE_DEPTH,
-	RENDER_RES_COMPOSITE_COLOR | RENDER_RES_SCENE_DEPTH,
+	RENDER_RES_COMPOSITE_COLOR | RENDER_RES_COMPOSITE_DEPTH,
 	1u << 0,
 	FG_PASS_OUTPUT_AUTO_WARP,
 	FG_PASS_VIEWPORT_VIEW_RECT,
@@ -5750,24 +5750,39 @@ static const RenderPassDesc s_warp_resolve_framegraph_pass = {
 
 static qboolean R_FG_HasResources (const RenderPassContext *ctx, unsigned required)
 {
-	unsigned available = RENDER_RES_NONE;
+	unsigned mask;
 	const RenderGraphResourceHandle *resources = ctx ? ctx->resources : NULL;
 
 	if (!resources)
 		return false;
 
-	if (R_FrameGraph_HasResourceBySlot (resources, R_BACKEND_RESOURCE_SLOT_SCENE_FBO))
-		available |= RENDER_RES_SCENE_COLOR;
-	if (R_FrameGraph_HasResourceBySlot (resources, R_BACKEND_RESOURCE_SLOT_SCENE_DEPTH))
-		available |= RENDER_RES_SCENE_DEPTH;
-	if (R_FrameGraph_HasResourceBySlot (resources, R_BACKEND_RESOURCE_SLOT_COMPOSITE_FBO))
-		available |= RENDER_RES_COMPOSITE_COLOR;
-	if (R_FrameGraph_HasResourceBySlot (resources, R_BACKEND_RESOURCE_SLOT_SHADOW_SUN_DEPTH))
-		available |= RENDER_RES_SHADOW_SUN_DEPTH;
-	if (R_FrameGraph_HasResourceBySlot (resources, R_BACKEND_RESOURCE_SLOT_VELOCITY))
-		available |= RENDER_RES_VELOCITY;
+	for (mask = 1u; mask != 0; mask <<= 1)
+	{
+		render_backend_resource_slot_t slot = R_BACKEND_RESOURCE_SLOT_NONE;
+		if ((required & mask) == 0)
+			continue;
 
-	return (available & required) == required;
+		switch (mask)
+		{
+		case RENDER_RES_SCENE_COLOR: slot = R_BACKEND_RESOURCE_SLOT_SCENE_COLOR; break;
+		case RENDER_RES_SCENE_DEPTH: slot = R_BACKEND_RESOURCE_SLOT_SCENE_DEPTH; break;
+		case RENDER_RES_COMPOSITE_COLOR: slot = R_BACKEND_RESOURCE_SLOT_COMPOSITE_COLOR; break;
+		case RENDER_RES_COMPOSITE_DEPTH: slot = R_BACKEND_RESOURCE_SLOT_COMPOSITE_DEPTH; break;
+		case RENDER_RES_SHADOW_SUN_DEPTH: slot = R_BACKEND_RESOURCE_SLOT_SHADOW_SUN_DEPTH; break;
+		case RENDER_RES_VELOCITY: slot = R_BACKEND_RESOURCE_SLOT_VELOCITY; break;
+		case RENDER_RES_DECALS:
+		case RENDER_RES_SSAO_FOG_STATE:
+			/* Internal logical framegraph resources; no backend slot backing. */
+			continue;
+		default:
+			return false;
+		}
+
+		if (!R_FrameGraph_HasResourceBySlot (resources, slot))
+			return false;
+	}
+
+	return true;
 }
 
 static void R_FG_ExecSSAOFogHandoff (RenderPassContext *ctx)
@@ -5793,7 +5808,7 @@ static qboolean R_FG_PassWhenPostprocessEnabled (const RenderPassContext *ctx)
 {
 	return ctx && ctx->frame_plan
 		&& ctx->frame_plan->run_postprocess
-		&& R_FG_HasResources (ctx, RENDER_RES_COMPOSITE_COLOR | RENDER_RES_SCENE_DEPTH);
+		&& R_FG_HasResources (ctx, RENDER_RES_COMPOSITE_COLOR | RENDER_RES_COMPOSITE_DEPTH);
 }
 
 static void R_FG_ExecPostprocess (RenderPassContext *ctx)
@@ -5803,7 +5818,7 @@ static void R_FG_ExecPostprocess (RenderPassContext *ctx)
 
 static const RenderPassDesc s_postprocess_framegraph_pass = {
 	"Postprocess",
-	RENDER_RES_COMPOSITE_COLOR | RENDER_RES_SCENE_DEPTH | RENDER_RES_SSAO_FOG_STATE,
+	RENDER_RES_COMPOSITE_COLOR | RENDER_RES_COMPOSITE_DEPTH | RENDER_RES_SSAO_FOG_STATE,
 	RENDER_RES_COMPOSITE_COLOR,
 	1u << 0,
 	FG_PASS_OUTPUT_BACKBUFFER,

--- a/Quake/r_framegraph.c
+++ b/Quake/r_framegraph.c
@@ -53,6 +53,27 @@ static int FG_MoveSetupStagePassesToFront (void);
 static void FG_SortRuntimePassesTopologically (int first_pass, int pass_count);
 static void FG_ConsumeBackendTimerSamples (const IRenderBackend *backend);
 
+static qboolean FG_GetResourceSlotForBit (unsigned bit, render_backend_resource_slot_t *out_slot)
+{
+	render_backend_resource_slot_t slot = R_BACKEND_RESOURCE_SLOT_NONE;
+
+	switch (bit)
+	{
+	case RENDER_RES_SCENE_COLOR: slot = R_BACKEND_RESOURCE_SLOT_SCENE_COLOR; break;
+	case RENDER_RES_SCENE_DEPTH: slot = R_BACKEND_RESOURCE_SLOT_SCENE_DEPTH; break;
+	case RENDER_RES_COMPOSITE_COLOR: slot = R_BACKEND_RESOURCE_SLOT_COMPOSITE_COLOR; break;
+	case RENDER_RES_COMPOSITE_DEPTH: slot = R_BACKEND_RESOURCE_SLOT_COMPOSITE_DEPTH; break;
+	case RENDER_RES_SHADOW_SUN_DEPTH: slot = R_BACKEND_RESOURCE_SLOT_SHADOW_SUN_DEPTH; break;
+	case RENDER_RES_VELOCITY: slot = R_BACKEND_RESOURCE_SLOT_VELOCITY; break;
+	default:
+		return false;
+	}
+
+	if (out_slot)
+		*out_slot = slot;
+	return true;
+}
+
 static qboolean FG_AddRuntimePassInternal (const RenderPassDesc *pass_desc)
 {
 	int profile_slot;
@@ -601,11 +622,30 @@ static void FG_RunPass (int profile_slot, const RenderPassDesc *pass, RenderPass
 {
 	double cpu_start;
 	double cpu_ms;
+	unsigned bit;
 
 	if (!pass || !ctx)
 		return;
 	if (pass->enabled && !pass->enabled (ctx))
 		return;
+
+	for (bit = 1u; bit != 0; bit <<= 1)
+	{
+		render_backend_resource_slot_t slot;
+		const render_backend_resource_ref_t *resource_ref;
+		if ((pass->reads & bit) == 0)
+			continue;
+		if (!FG_GetResourceSlotForBit (bit, &slot))
+			continue;
+
+		resource_ref = R_FrameGraph_GetResourceRef (ctx->resources, slot);
+		if (!ctx->backend || !ctx->backend->is_resource_valid || !resource_ref
+			|| !ctx->backend->is_resource_valid (ctx->resources, resource_ref))
+		{
+			Con_DWarning ("FrameGraph: pass '%s' read slot %d resolved invalid resource\n", pass->name, (int)slot);
+			SDL_assert (!"FrameGraph pass declares read dependency on invalid resource");
+		}
+	}
 
 	FG_ApplyPassOutputBinding (pass, ctx);
 

--- a/Quake/r_framegraph.h
+++ b/Quake/r_framegraph.h
@@ -36,10 +36,11 @@ typedef enum render_graph_resource_bits_e
 	RENDER_RES_SCENE_COLOR = 1u << 0,
 	RENDER_RES_SCENE_DEPTH = 1u << 1,
 	RENDER_RES_COMPOSITE_COLOR = 1u << 2,
-	RENDER_RES_SHADOW_SUN_DEPTH = 1u << 3,
-	RENDER_RES_VELOCITY = 1u << 4,
-	RENDER_RES_DECALS = 1u << 5,
-	RENDER_RES_SSAO_FOG_STATE = 1u << 6
+	RENDER_RES_COMPOSITE_DEPTH = 1u << 3,
+	RENDER_RES_SHADOW_SUN_DEPTH = 1u << 4,
+	RENDER_RES_VELOCITY = 1u << 5,
+	RENDER_RES_DECALS = 1u << 6,
+	RENDER_RES_SSAO_FOG_STATE = 1u << 7
 } render_graph_resource_bits_t;
 
 typedef enum fg_pass_output_target_e


### PR DESCRIPTION
### Motivation

- Eliminate incorrect inference that a framebuffer existence implies its backing textures are ready by resolving each `RENDER_RES_*` bit to the exact backend slot. 
- Make pass read contracts explicit so passes don't silently read invalid / missing resources at runtime. 
- Surface debug failures early during framegraph execution when a pass claims a read but the resolved backend resource is invalid.

### Description

- Map each `RENDER_RES_*` bit to a concrete backend slot in `R_FG_HasResources` and check `R_FrameGraph_HasResourceBySlot` for that slot instead of inferring availability from FBO presence (changes in `Quake/gl_rmain.c`).
- Introduced a new resource bit `RENDER_RES_COMPOSITE_DEPTH` in `Quake/r_framegraph.h` so composite depth can be expressed and checked independently. 
- Updated pass masks and enable checks that previously relied on the FBO-implies-color shortcut to use `RENDER_RES_COMPOSITE_DEPTH` where appropriate (warp/resolve and postprocess modifications in `Quake/gl_rmain.c`).
- Added run-time validation in `FG_RunPass` (in `Quake/r_framegraph.c`) that resolves each declared read bit to a backend slot and calls the backend `is_resource_valid` hook; invalid resolved reads emit `Con_DWarning` and trigger an `SDL_assert` to aid debugging.

### Testing

- Ran `git diff --check` to verify no whitespace/conflict markers, which completed with no issues. 
- Attempted the recommended Windows timed smoke-launch command via `powershell.exe` but it failed in this environment with `powershell.exe: command not found`, so runtime smoke tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8f476be74832e8cde69a0e0058d8d)