### PR TITLE
framegraph: skip optional shadow read validation when shadows are off

### DIFF
--- a/Quake/r_framegraph.c
+++ b/Quake/r_framegraph.c
@@ -631,9 +631,17 @@ static void FG_RunPass (int profile_slot, const RenderPassDesc *pass, RenderPass
 
 	for (bit = 1u; bit != 0; bit <<= 1)
 	{
+		qboolean read_required = true;
 		render_backend_resource_slot_t slot;
 		const render_backend_resource_ref_t *resource_ref;
 		if ((pass->reads & bit) == 0)
+			continue;
+		if (bit == RENDER_RES_SHADOW_SUN_DEPTH)
+		{
+			/* Shadow-map reads are optional for passes that still run with shadows disabled. */
+			read_required = (ctx && ctx->frame_plan && ctx->frame_plan->run_shadowmaps);
+		}
+		if (!read_required)
 			continue;
 		if (!FG_GetResourceSlotForBit (bit, &slot))
 			continue;


### PR DESCRIPTION
### Motivation
- `FG_RunPass` currently treats all declared backend-backed reads as required which causes assertions when `RENDER_RES_SHADOW_SUN_DEPTH` is declared but shadow maps are intentionally disabled or unavailable at runtime.

### Description
- In `FG_RunPass` add a `read_required` guard and special-case `RENDER_RES_SHADOW_SUN_DEPTH` so the read-validation is skipped unless `ctx->frame_plan->run_shadowmaps` is true, preventing false-positive asserts while keeping strict validation for other resources.

### Testing
- Ran `git diff --check` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8fb437278832e899dee29f46fbbfb)