### PR TITLE
Fix backend caps propagation and framegraph resource mapping validation

### DIFF
--- a/Quake/r_backend.c
+++ b/Quake/r_backend.c
@@ -18,6 +18,76 @@ static qboolean s_backend_active = false;
 
 cvar_t r_backend = { "r_backend", "OpenGL", CVAR_ARCHIVE };
 
+/*
+================
+R_Backend_ValidateContract
+
+Minimal "functional backend" contract:
+- must expose capability data via get_caps().
+- must support framegraph resource translation/validation callbacks.
+- must expose the legacy draw and viewport hooks used by current passes.
+- must populate framegraph resources each frame.
+
+Backends that fail this contract are rejected during registration/selection so
+runtime framegraph code can assert these callbacks are safe to use.
+================
+*/
+static qboolean R_Backend_ValidateContract (const IRenderBackend *backend, qboolean emit_warning)
+{
+	if (!backend)
+		return false;
+
+	if (!backend->get_caps
+		|| !backend->resolve_resource_id
+		|| !backend->is_resource_valid
+		|| !backend->bind_render_target
+		|| !backend->set_viewport
+		|| !backend->draw
+		|| !backend->populate_framegraph_resources)
+	{
+		if (emit_warning)
+		{
+			Con_Warning ("Renderer backend '%s' is missing required callbacks for functional operation.\n",
+				backend->name ? backend->name : "<unnamed>");
+		}
+		SDL_assert (!"Renderer backend contract violation");
+		return false;
+	}
+
+	return true;
+}
+
+static void R_Backend_ClearActiveCaps (void)
+{
+	memset (&s_active_backend_caps, 0, sizeof (s_active_backend_caps));
+}
+
+static qboolean R_Backend_RefreshActiveCaps (const IRenderBackend *backend, qboolean emit_warning)
+{
+	const RenderBackendCaps *caps;
+
+	R_Backend_ClearActiveCaps ();
+	if (!backend || !backend->get_caps)
+	{
+		if (emit_warning)
+			Con_Warning ("Renderer backend '%s' did not provide a caps callback.\n",
+				(backend && backend->name) ? backend->name : "<none>");
+		return false;
+	}
+
+	caps = backend->get_caps ();
+	if (!caps)
+	{
+		if (emit_warning)
+			Con_Warning ("Renderer backend '%s' returned null caps.\n",
+				backend->name ? backend->name : "<unnamed>");
+		return false;
+	}
+
+	s_active_backend_caps = *caps;
+	return true;
+}
+
 static const IRenderBackend *R_Backend_FindByName (const char *backend_name)
 {
 	int i;
@@ -65,6 +135,8 @@ void R_Backend_Register (const IRenderBackend *backend)
 
 	if (!backend || !backend->name || !backend->name[0])
 		return;
+	if (!R_Backend_ValidateContract (backend, true))
+		return;
 
 	for (i = 0; i < s_registered_backend_count; ++i)
 	{
@@ -95,6 +167,8 @@ qboolean R_Backend_Select (const char *backend_name)
 
 	if (!backend)
 		return false;
+	if (!R_Backend_ValidateContract (backend, true))
+		return false;
 
 	if (runtime_switch && (!backend->can_activate || !backend->can_activate (true)))
 	{
@@ -114,6 +188,8 @@ qboolean R_Backend_Select (const char *backend_name)
 	if (s_backend_active && previous && previous->shutdown)
 		previous->shutdown ();
 
+	R_Backend_ClearActiveCaps ();
+	s_backend_active = false;
 	s_active_backend = backend;
 	if (!backend->init || backend->init ())
 		activated = true;
@@ -128,6 +204,11 @@ qboolean R_Backend_Select (const char *backend_name)
 			Con_Warning ("Reverting renderer backend to '%s'.\n",
 				previous->name ? previous->name : "<unnamed>");
 			s_active_backend = previous;
+			if (!R_Backend_ValidateContract (previous, true))
+			{
+				s_active_backend = NULL;
+				return false;
+			}
 			if (!previous->init || previous->init ())
 				activated = true;
 		}
@@ -139,6 +220,18 @@ qboolean R_Backend_Select (const char *backend_name)
 			s_backend_active = false;
 			return false;
 		}
+	}
+
+	if (!R_Backend_RefreshActiveCaps (s_active_backend, true))
+	{
+		Con_Warning ("Renderer backend '%s' has no valid caps after activation.\n",
+			(s_active_backend && s_active_backend->name) ? s_active_backend->name : "<none>");
+		if (s_active_backend && s_active_backend->shutdown)
+			s_active_backend->shutdown ();
+		s_active_backend = NULL;
+		s_backend_active = false;
+		R_Backend_ClearActiveCaps ();
+		return false;
 	}
 
 	s_backend_active = true;
@@ -169,6 +262,7 @@ void R_Backend_Shutdown (void)
 	if (s_backend_active && s_active_backend && s_active_backend->shutdown)
 		s_active_backend->shutdown ();
 	s_backend_active = false;
+	R_Backend_ClearActiveCaps ();
 }
 
 void R_Backend_OnResize (int width, int height)
@@ -190,6 +284,11 @@ const RenderBackendCaps *R_Backend_GetCaps (void)
 {
 	if (!s_backend_initialized)
 		R_Backend_Init ();
+	if (s_backend_active && s_active_backend)
+	{
+		if (!R_Backend_RefreshActiveCaps (s_active_backend, false))
+			R_Backend_ClearActiveCaps ();
+	}
 	return &s_active_backend_caps;
 }
 

--- a/Quake/r_framegraph.c
+++ b/Quake/r_framegraph.c
@@ -53,24 +53,44 @@ static int FG_MoveSetupStagePassesToFront (void);
 static void FG_SortRuntimePassesTopologically (int first_pass, int pass_count);
 static void FG_ConsumeBackendTimerSamples (const IRenderBackend *backend);
 
-static qboolean FG_GetResourceSlotForBit (unsigned bit, render_backend_resource_slot_t *out_slot)
+typedef struct fg_resource_bit_mapping_s
 {
-	render_backend_resource_slot_t slot = R_BACKEND_RESOURCE_SLOT_NONE;
+	unsigned bit;
+	render_backend_resource_slot_t slot;
+	qboolean requires_backend_resource;
+} fg_resource_bit_mapping_t;
 
-	switch (bit)
+static const fg_resource_bit_mapping_t s_fg_resource_mappings[] = {
+	{ RENDER_RES_SCENE_COLOR, R_BACKEND_RESOURCE_SLOT_SCENE_COLOR, true },
+	{ RENDER_RES_SCENE_DEPTH, R_BACKEND_RESOURCE_SLOT_SCENE_DEPTH, true },
+	{ RENDER_RES_COMPOSITE_COLOR, R_BACKEND_RESOURCE_SLOT_COMPOSITE_COLOR, true },
+	{ RENDER_RES_COMPOSITE_DEPTH, R_BACKEND_RESOURCE_SLOT_COMPOSITE_DEPTH, true },
+	{ RENDER_RES_SHADOW_SUN_DEPTH, R_BACKEND_RESOURCE_SLOT_SHADOW_SUN_DEPTH, true },
+	{ RENDER_RES_VELOCITY, R_BACKEND_RESOURCE_SLOT_VELOCITY, true },
+	{ RENDER_RES_DECALS, R_BACKEND_RESOURCE_SLOT_NONE, false },
+	{ RENDER_RES_SSAO_FOG_STATE, R_BACKEND_RESOURCE_SLOT_NONE, false }
+};
+
+static const fg_resource_bit_mapping_t *FG_FindResourceMapping (unsigned bit)
+{
+	int i;
+
+	for (i = 0; i < (int)q_countof (s_fg_resource_mappings); ++i)
 	{
-	case RENDER_RES_SCENE_COLOR: slot = R_BACKEND_RESOURCE_SLOT_SCENE_COLOR; break;
-	case RENDER_RES_SCENE_DEPTH: slot = R_BACKEND_RESOURCE_SLOT_SCENE_DEPTH; break;
-	case RENDER_RES_COMPOSITE_COLOR: slot = R_BACKEND_RESOURCE_SLOT_COMPOSITE_COLOR; break;
-	case RENDER_RES_COMPOSITE_DEPTH: slot = R_BACKEND_RESOURCE_SLOT_COMPOSITE_DEPTH; break;
-	case RENDER_RES_SHADOW_SUN_DEPTH: slot = R_BACKEND_RESOURCE_SLOT_SHADOW_SUN_DEPTH; break;
-	case RENDER_RES_VELOCITY: slot = R_BACKEND_RESOURCE_SLOT_VELOCITY; break;
-	default:
-		return false;
+		if (s_fg_resource_mappings[i].bit == bit)
+			return &s_fg_resource_mappings[i];
 	}
 
+	return NULL;
+}
+
+static qboolean FG_GetResourceSlotForBit (unsigned bit, render_backend_resource_slot_t *out_slot)
+{
+	const fg_resource_bit_mapping_t *mapping = FG_FindResourceMapping (bit);
+	if (!mapping)
+		return false;
 	if (out_slot)
-		*out_slot = slot;
+		*out_slot = mapping->slot;
 	return true;
 }
 
@@ -632,16 +652,26 @@ static void FG_RunPass (int profile_slot, const RenderPassDesc *pass, RenderPass
 	for (bit = 1u; bit != 0; bit <<= 1)
 	{
 		qboolean read_required = true;
+		const fg_resource_bit_mapping_t *mapping;
 		render_backend_resource_slot_t slot;
 		const render_backend_resource_ref_t *resource_ref;
 		if ((pass->reads & bit) == 0)
 			continue;
+		mapping = FG_FindResourceMapping (bit);
+		if (!mapping)
+		{
+			Con_DWarning ("FrameGraph: pass '%s' uses unmapped resource bit 0x%x\n", pass->name, bit);
+			SDL_assert (!"FrameGraph pass uses unmapped resource bit");
+			continue;
+		}
 		if (bit == RENDER_RES_SHADOW_SUN_DEPTH)
 		{
 			/* Shadow-map reads are optional for passes that still run with shadows disabled. */
 			read_required = (ctx && ctx->frame_plan && ctx->frame_plan->run_shadowmaps);
 		}
 		if (!read_required)
+			continue;
+		if (!mapping->requires_backend_resource)
 			continue;
 		if (!FG_GetResourceSlotForBit (bit, &slot))
 			continue;


### PR DESCRIPTION
### Motivation
- Ensure `R_Backend_GetCaps()` and runtime framegraph code see the active backend's real, non‑stale capability set (timestamps, compute, etc.).
- Fail fast and give actionable diagnostics when a backend is missing callbacks needed for functional operation or when activation/transition yields no caps. 
- Prevent framegraph dependency validation from referencing unmapped or non-backend resources and make resource-slot mapping explicit.

### Description
- Add a minimal in-code backend contract and validator via `R_Backend_ValidateContract()` that asserts required callbacks (`get_caps`, `resolve_resource_id`, `is_resource_valid`, `bind_render_target`, `set_viewport`, `draw`, `populate_framegraph_resources`); registration/selection rejects violating backends.
- Introduce caps lifecycle helpers `R_Backend_ClearActiveCaps()` and `R_Backend_RefreshActiveCaps()` and wire them into backend selection, shutdown, and `R_Backend_GetCaps()` so the active `s_active_backend_caps` is refreshed/cleared on transitions.
- Add selection-time sanity checks so activation fails when caps are missing and previously active backends are validated before revert attempts.
- Expand framegraph resource mapping by adding `s_fg_resource_mappings[]`, `FG_FindResourceMapping()` and updated `FG_GetResourceSlotForBit()` so all `RENDER_RES_*` bits are covered, skip non-backend resources during validation, and assert/log on unmapped bits during pass read validation.

### Testing
- Attempted a local build with `make -C Quake -j2`, which failed in this environment due to missing SDL toolchain files (`sdl2-config` / `SDL.h`), so a full compile/test could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9122edde0832ea064eda19ed0bd81)