### PR TITLE
Framegraph: use BeginPassEx + descriptors and resource barriers

### DIFF
--- a/Quake/gl_backend.c
+++ b/Quake/gl_backend.c
@@ -191,6 +191,42 @@ static void GLBackend_EndPass (void)
 	GL_EndGroup ();
 }
 
+static void GLBackend_BeginPassEx (const RenderBackendPassDesc *pass_desc)
+{
+	GLBackend_BeginPass ((pass_desc && pass_desc->name) ? pass_desc->name : "<unnamed>");
+}
+
+static void GLBackend_EndPassEx (void)
+{
+	GLBackend_EndPass ();
+}
+
+static void GLBackend_ResourceBarrier (const RenderGraphResourceHandle *resources, const RenderBackendResourceBarrier *barriers, unsigned count)
+{
+	unsigned i;
+	qboolean needs_memory_barrier = false;
+	(void)resources;
+
+	if (!barriers || count == 0u)
+		return;
+
+	for (i = 0; i < count; ++i)
+	{
+		if (!barriers[i].resource)
+			continue;
+		if (barriers[i].before == R_BACKEND_RESOURCE_STATE_SHADER_WRITE
+			|| barriers[i].after == R_BACKEND_RESOURCE_STATE_SHADER_READ
+			|| barriers[i].after == R_BACKEND_RESOURCE_STATE_SHADER_WRITE)
+		{
+			needs_memory_barrier = true;
+			break;
+		}
+	}
+
+	if (needs_memory_barrier && GL_MemoryBarrierFunc)
+		GL_MemoryBarrierFunc (GL_FRAMEBUFFER_BARRIER_BIT | GL_TEXTURE_FETCH_BARRIER_BIT | GL_SHADER_IMAGE_ACCESS_BARRIER_BIT);
+}
+
 static void GLBackend_ValidatePassState (const char *pass_name, qboolean before_pass)
 {
 	GLenum err;
@@ -539,9 +575,9 @@ void GL_Backend_Register (void)
 		GLBackend_Shutdown,
 		GLBackend_OnResize,
 		GLBackend_CanActivate,
-		NULL,
-		NULL,
-		NULL,
+		GLBackend_BeginPassEx,
+		GLBackend_EndPassEx,
+		GLBackend_ResourceBarrier,
 		NULL,
 		NULL,
 		NULL,

--- a/Quake/r_decals.c
+++ b/Quake/r_decals.c
@@ -1277,14 +1277,14 @@ static void R_Decals_ExecFrameGraphPass (RenderPassContext *ctx)
 }
 
 static const RenderPassDesc s_decals_framegraph_pass = {
-	"Update decals",
-	RENDER_RES_NONE,
-	RENDER_RES_DECALS,
-	0,
-	FG_PASS_OUTPUT_KEEP,
-	FG_PASS_VIEWPORT_KEEP,
-	NULL,
-	R_Decals_ExecFrameGraphPass
+	.name = "Update decals",
+	.reads = RENDER_RES_NONE,
+	.writes = RENDER_RES_DECALS,
+	.side_effects = 0,
+	.output_target = FG_PASS_OUTPUT_KEEP,
+	.viewport_mode = FG_PASS_VIEWPORT_KEEP,
+	.enabled = NULL,
+	.execute = R_Decals_ExecFrameGraphPass
 };
 
 void R_Decals_RegisterFrameGraphPasses (void)

--- a/Quake/r_framegraph.c
+++ b/Quake/r_framegraph.c
@@ -70,6 +70,7 @@ static const fg_resource_bit_mapping_t s_fg_resource_mappings[] = {
 	{ RENDER_RES_DECALS, R_BACKEND_RESOURCE_SLOT_NONE, false },
 	{ RENDER_RES_SSAO_FOG_STATE, R_BACKEND_RESOURCE_SLOT_NONE, false }
 };
+static render_backend_resource_state_t s_resource_states[q_countof (s_fg_resource_mappings)];
 
 static const fg_resource_bit_mapping_t *FG_FindResourceMapping (unsigned bit)
 {
@@ -92,6 +93,92 @@ static qboolean FG_GetResourceSlotForBit (unsigned bit, render_backend_resource_
 	if (out_slot)
 		*out_slot = mapping->slot;
 	return true;
+}
+
+static int FG_FindResourceMappingIndex (unsigned bit)
+{
+	int i;
+	for (i = 0; i < (int)q_countof (s_fg_resource_mappings); ++i)
+	{
+		if (s_fg_resource_mappings[i].bit == bit)
+			return i;
+	}
+	return -1;
+}
+
+static render_backend_resource_state_t FG_GetWriteStateForBit (unsigned bit)
+{
+	switch (bit)
+	{
+	case RENDER_RES_SCENE_DEPTH:
+	case RENDER_RES_COMPOSITE_DEPTH:
+	case RENDER_RES_SHADOW_SUN_DEPTH:
+		return R_BACKEND_RESOURCE_STATE_DEPTH_ATTACHMENT;
+	default:
+		return R_BACKEND_RESOURCE_STATE_COLOR_ATTACHMENT;
+	}
+}
+
+static void FG_ResetResourceStates (void)
+{
+	memset (s_resource_states, 0, sizeof (s_resource_states));
+}
+
+static void FG_EmitPassBarriers (const RenderPassDesc *pass, RenderPassContext *ctx)
+{
+	RenderBackendResourceBarrier barriers[16];
+	unsigned barrier_count = 0;
+	unsigned bit;
+
+	if (!pass || !ctx || !ctx->resources)
+		return;
+
+	for (bit = 1u; bit != 0; bit <<= 1)
+	{
+		render_backend_resource_state_t desired_state = R_BACKEND_RESOURCE_STATE_UNKNOWN;
+		const fg_resource_bit_mapping_t *mapping;
+		const render_backend_resource_ref_t *resource_ref;
+		int mapping_index;
+		render_backend_resource_state_t before_state;
+
+		if (((pass->reads | pass->writes) & bit) == 0u)
+			continue;
+
+		mapping = FG_FindResourceMapping (bit);
+		if (!mapping || !mapping->requires_backend_resource)
+			continue;
+
+		if ((pass->writes & bit) != 0u)
+			desired_state = FG_GetWriteStateForBit (bit);
+		else if ((pass->reads & bit) != 0u)
+			desired_state = R_BACKEND_RESOURCE_STATE_SHADER_READ;
+
+		if (desired_state == R_BACKEND_RESOURCE_STATE_UNKNOWN)
+			continue;
+
+		resource_ref = R_FrameGraph_GetResourceRef (ctx->resources, mapping->slot);
+		if (!resource_ref || (ctx->backend && ctx->backend->is_resource_valid
+			&& !ctx->backend->is_resource_valid (ctx->resources, resource_ref)))
+			continue;
+
+		mapping_index = FG_FindResourceMappingIndex (bit);
+		if (mapping_index < 0)
+			continue;
+		before_state = s_resource_states[mapping_index];
+		if (before_state == desired_state)
+			continue;
+
+		if (barrier_count >= q_countof (barriers))
+			break;
+		barriers[barrier_count].resource = resource_ref;
+		barriers[barrier_count].before = before_state;
+		barriers[barrier_count].after = desired_state;
+		s_resource_states[mapping_index] = desired_state;
+		barrier_count++;
+	}
+
+	if (barrier_count > 0)
+		R_Backend_ResourceBarrier (ctx->resources, barriers, barrier_count);
 }
 
 static qboolean FG_AddRuntimePassInternal (const RenderPassDesc *pass_desc)
@@ -643,6 +730,11 @@ static void FG_RunPass (int profile_slot, const RenderPassDesc *pass, RenderPass
 	double cpu_start;
 	double cpu_ms;
 	unsigned bit;
+	RenderBackendPassAttachmentDesc color_attachments[4];
+	RenderBackendPassAttachmentDesc depth_attachment;
+	RenderBackendPassDesc backend_pass_desc;
+	qboolean has_depth_attachment = false;
+	qboolean has_legacy_validation = false;
 
 	if (!pass || !ctx)
 		return;
@@ -687,10 +779,54 @@ static void FG_RunPass (int profile_slot, const RenderPassDesc *pass, RenderPass
 
 	FG_ApplyPassOutputBinding (pass, ctx);
 
-	if (ctx->backend && ctx->backend->validate_pass_state)
+	memset (color_attachments, 0, sizeof (color_attachments));
+	memset (&depth_attachment, 0, sizeof (depth_attachment));
+	memset (&backend_pass_desc, 0, sizeof (backend_pass_desc));
+	backend_pass_desc.name = pass->name;
+	backend_pass_desc.resources = ctx->resources;
+	backend_pass_desc.backbuffer = (pass->output_target == FG_PASS_OUTPUT_BACKBUFFER);
+
+	if (pass->color_attachments && pass->num_color_attachments > 0)
+	{
+		unsigned i;
+		unsigned color_count = pass->num_color_attachments;
+		if (color_count > q_countof (color_attachments))
+			color_count = q_countof (color_attachments);
+		for (i = 0; i < color_count; ++i)
+		{
+			render_backend_resource_slot_t slot = R_BACKEND_RESOURCE_SLOT_NONE;
+			if (!FG_GetResourceSlotForBit (pass->color_attachments[i].resource_bit, &slot))
+				continue;
+			color_attachments[i].resource = R_FrameGraph_GetResourceRef (ctx->resources, slot);
+			color_attachments[i].load_op = pass->color_attachments[i].load_op;
+			color_attachments[i].store_op = pass->color_attachments[i].store_op;
+		}
+		backend_pass_desc.color_attachments = color_attachments;
+		backend_pass_desc.num_color_attachments = color_count;
+	}
+
+	if (pass->depth_attachment)
+	{
+		render_backend_resource_slot_t depth_slot = R_BACKEND_RESOURCE_SLOT_NONE;
+		if (FG_GetResourceSlotForBit (pass->depth_attachment->resource_bit, &depth_slot))
+		{
+			depth_attachment.resource = R_FrameGraph_GetResourceRef (ctx->resources, depth_slot);
+			depth_attachment.load_op = pass->depth_attachment->load_op;
+			depth_attachment.store_op = pass->depth_attachment->store_op;
+			has_depth_attachment = true;
+		}
+	}
+
+	if (has_depth_attachment)
+		backend_pass_desc.depth_attachment = &depth_attachment;
+
+	FG_EmitPassBarriers (pass, ctx);
+
+	has_legacy_validation = (ctx->backend && ctx->backend->validate_pass_state
+		&& !ctx->backend->begin_pass_ex);
+	if (has_legacy_validation)
 		ctx->backend->validate_pass_state (pass->name, true);
-	if (ctx->backend && ctx->backend->begin_pass)
-		ctx->backend->begin_pass (pass->name);
+	R_Backend_BeginPassEx (&backend_pass_desc);
 	if (ctx->frame_plan && ctx->frame_plan->run_gpu_timers && ctx->backend && ctx->backend->begin_timer)
 		ctx->backend->begin_timer (profile_slot);
 
@@ -702,9 +838,8 @@ static void FG_RunPass (int profile_slot, const RenderPassDesc *pass, RenderPass
 
 	if (ctx->frame_plan && ctx->frame_plan->run_gpu_timers && ctx->backend && ctx->backend->end_timer)
 		ctx->backend->end_timer (profile_slot);
-	if (ctx->backend && ctx->backend->end_pass)
-		ctx->backend->end_pass ();
-	if (ctx->backend && ctx->backend->validate_pass_state)
+	R_Backend_EndPassEx ();
+	if (has_legacy_validation)
 		ctx->backend->validate_pass_state (pass->name, false);
 }
 
@@ -825,6 +960,7 @@ void R_FrameGraph_RenderView (void)
 		&& pass_ctx.backend && pass_ctx.backend->resolve_timers)
 		pass_ctx.backend->resolve_timers ();
 	FG_ConsumeBackendTimerSamples (pass_ctx.backend);
+	FG_ResetResourceStates ();
 
 	/* Setup-stage passes run before plan build so frame state is current. */
 	setup_pass_count = FG_MoveSetupStagePassesToFront ();

--- a/Quake/r_framegraph.h
+++ b/Quake/r_framegraph.h
@@ -178,6 +178,13 @@ typedef struct render_backend_descriptor_binding_s
 	unsigned range;
 } RenderBackendDescriptorBinding;
 
+typedef struct fg_pass_attachment_config_s
+{
+	unsigned resource_bit;
+	render_backend_load_op_t load_op;
+	render_backend_store_op_t store_op;
+} FGPassAttachmentConfig;
+
 typedef struct render_pass_context_s RenderPassContext;
 
 typedef struct i_render_backend_s
@@ -237,6 +244,9 @@ typedef struct render_pass_desc_s
 	unsigned char viewport_mode;
 	qboolean (*enabled)(const RenderPassContext *ctx);
 	void (*execute)(RenderPassContext *ctx);
+	const FGPassAttachmentConfig *color_attachments;
+	unsigned char num_color_attachments;
+	const FGPassAttachmentConfig *depth_attachment;
 	unsigned char stage;
 	unsigned char stats_channel;
 } RenderPassDesc;

--- a/Quake/r_passes.c
+++ b/Quake/r_passes.c
@@ -135,117 +135,149 @@ static void R_Pass_StorePrevFrame (RenderPassContext *ctx)
 	R_StorePrevFrameState ();
 }
 
+static const FGPassAttachmentConfig s_scene_color_attachments[] = {
+	{ RENDER_RES_SCENE_COLOR, R_BACKEND_LOAD_OP_CLEAR, R_BACKEND_STORE_OP_STORE }
+};
+
+static const FGPassAttachmentConfig s_scene_depth_attachment = {
+	RENDER_RES_SCENE_DEPTH,
+	R_BACKEND_LOAD_OP_CLEAR,
+	R_BACKEND_STORE_OP_STORE
+};
+
+static const FGPassAttachmentConfig s_warp_color_attachments[] = {
+	{ RENDER_RES_COMPOSITE_COLOR, R_BACKEND_LOAD_OP_CLEAR, R_BACKEND_STORE_OP_STORE }
+};
+
+static const FGPassAttachmentConfig s_warp_depth_attachment = {
+	RENDER_RES_COMPOSITE_DEPTH,
+	R_BACKEND_LOAD_OP_CLEAR,
+	R_BACKEND_STORE_OP_STORE
+};
+
+static const FGPassAttachmentConfig s_postprocess_color_attachments[] = {
+	{ RENDER_RES_COMPOSITE_COLOR, R_BACKEND_LOAD_OP_LOAD, R_BACKEND_STORE_OP_STORE }
+};
+
 static const RenderPassDesc s_setup_view_framegraph_pass = {
-	"Setup view",
-	RENDER_RES_NONE,
-	RENDER_RES_NONE,
-	1u << 0,
-	FG_PASS_OUTPUT_KEEP,
-	FG_PASS_VIEWPORT_KEEP,
-	NULL,
-	R_Pass_SetupView,
-	FG_PASS_STAGE_SETUP,
-	FG_PASS_STATS_SETUP
+	.name = "Setup view",
+	.reads = RENDER_RES_NONE,
+	.writes = RENDER_RES_NONE,
+	.side_effects = 1u << 0,
+	.output_target = FG_PASS_OUTPUT_KEEP,
+	.viewport_mode = FG_PASS_VIEWPORT_KEEP,
+	.enabled = NULL,
+	.execute = R_Pass_SetupView,
+	.stage = FG_PASS_STAGE_SETUP,
+	.stats_channel = FG_PASS_STATS_SETUP
 };
 
 static const RenderPassDesc s_shadowmaps_framegraph_pass = {
-	"Shadow maps",
-	RENDER_RES_NONE,
-	RENDER_RES_SHADOW_SUN_DEPTH,
-	0,
-	FG_PASS_OUTPUT_KEEP,
-	FG_PASS_VIEWPORT_KEEP,
-	R_FG_PassWhenShadowEnabled,
-	R_Pass_RenderShadowMaps,
-	FG_PASS_STAGE_MAIN,
-	FG_PASS_STATS_SHADOW
+	.name = "Shadow maps",
+	.reads = RENDER_RES_NONE,
+	.writes = RENDER_RES_SHADOW_SUN_DEPTH,
+	.side_effects = 0,
+	.output_target = FG_PASS_OUTPUT_KEEP,
+	.viewport_mode = FG_PASS_VIEWPORT_KEEP,
+	.enabled = R_FG_PassWhenShadowEnabled,
+	.execute = R_Pass_RenderShadowMaps,
+	.stage = FG_PASS_STAGE_MAIN,
+	.stats_channel = FG_PASS_STATS_SHADOW
 };
 
 static const RenderPassDesc s_scene_framegraph_pass = {
-	"Render scene",
-	RENDER_RES_DECALS | RENDER_RES_SHADOW_SUN_DEPTH,
-	RENDER_RES_SCENE_COLOR | RENDER_RES_SCENE_DEPTH | RENDER_RES_VELOCITY,
-	0,
-	FG_PASS_OUTPUT_AUTO_SCENE,
-	FG_PASS_VIEWPORT_VIEW_RECT_SCALED,
-	NULL,
-	R_Pass_RenderScene,
-	FG_PASS_STAGE_MAIN,
-	FG_PASS_STATS_SCENE
+	.name = "Render scene",
+	.reads = RENDER_RES_DECALS | RENDER_RES_SHADOW_SUN_DEPTH,
+	.writes = RENDER_RES_SCENE_COLOR | RENDER_RES_SCENE_DEPTH | RENDER_RES_VELOCITY,
+	.side_effects = 0,
+	.output_target = FG_PASS_OUTPUT_AUTO_SCENE,
+	.viewport_mode = FG_PASS_VIEWPORT_VIEW_RECT_SCALED,
+	.enabled = NULL,
+	.execute = R_Pass_RenderScene,
+	.color_attachments = s_scene_color_attachments,
+	.num_color_attachments = 1,
+	.depth_attachment = &s_scene_depth_attachment,
+	.stage = FG_PASS_STAGE_MAIN,
+	.stats_channel = FG_PASS_STATS_SCENE
 };
 
 static const RenderPassDesc s_warp_resolve_framegraph_pass = {
-	"Warp/resolve",
-	RENDER_RES_SCENE_COLOR | RENDER_RES_SCENE_DEPTH,
-	RENDER_RES_COMPOSITE_COLOR | RENDER_RES_COMPOSITE_DEPTH,
-	1u << 0,
-	FG_PASS_OUTPUT_AUTO_WARP,
-	FG_PASS_VIEWPORT_VIEW_RECT,
-	NULL,
-	R_Pass_WarpResolve,
-	FG_PASS_STAGE_MAIN,
-	FG_PASS_STATS_WARP
+	.name = "Warp/resolve",
+	.reads = RENDER_RES_SCENE_COLOR | RENDER_RES_SCENE_DEPTH,
+	.writes = RENDER_RES_COMPOSITE_COLOR | RENDER_RES_COMPOSITE_DEPTH,
+	.side_effects = 1u << 0,
+	.output_target = FG_PASS_OUTPUT_AUTO_WARP,
+	.viewport_mode = FG_PASS_VIEWPORT_VIEW_RECT,
+	.enabled = NULL,
+	.execute = R_Pass_WarpResolve,
+	.color_attachments = s_warp_color_attachments,
+	.num_color_attachments = 1,
+	.depth_attachment = &s_warp_depth_attachment,
+	.stage = FG_PASS_STAGE_MAIN,
+	.stats_channel = FG_PASS_STATS_WARP
 };
 
 static const RenderPassDesc s_ssao_fog_handoff_framegraph_pass = {
-	"Capture fog handoff",
-	RENDER_RES_NONE,
-	RENDER_RES_SSAO_FOG_STATE,
-	0,
-	FG_PASS_OUTPUT_KEEP,
-	FG_PASS_VIEWPORT_KEEP,
-	NULL,
-	R_Pass_CaptureSSAOFogHandoff
+	.name = "Capture fog handoff",
+	.reads = RENDER_RES_NONE,
+	.writes = RENDER_RES_SSAO_FOG_STATE,
+	.side_effects = 0,
+	.output_target = FG_PASS_OUTPUT_KEEP,
+	.viewport_mode = FG_PASS_VIEWPORT_KEEP,
+	.enabled = NULL,
+	.execute = R_Pass_CaptureSSAOFogHandoff
 };
 
 static const RenderPassDesc s_postprocess_framegraph_pass = {
-	"Postprocess",
-	RENDER_RES_COMPOSITE_COLOR | RENDER_RES_COMPOSITE_DEPTH | RENDER_RES_SSAO_FOG_STATE,
-	RENDER_RES_COMPOSITE_COLOR,
-	1u << 0,
-	FG_PASS_OUTPUT_BACKBUFFER,
-	FG_PASS_VIEWPORT_FULL_WINDOW,
-	R_FG_PassWhenPostprocessEnabled,
-	R_Pass_PostProcess,
-	FG_PASS_STAGE_MAIN,
-	FG_PASS_STATS_POST
+	.name = "Postprocess",
+	.reads = RENDER_RES_COMPOSITE_COLOR | RENDER_RES_COMPOSITE_DEPTH | RENDER_RES_SSAO_FOG_STATE,
+	.writes = RENDER_RES_COMPOSITE_COLOR,
+	.side_effects = 1u << 0,
+	.output_target = FG_PASS_OUTPUT_BACKBUFFER,
+	.viewport_mode = FG_PASS_VIEWPORT_FULL_WINDOW,
+	.enabled = R_FG_PassWhenPostprocessEnabled,
+	.execute = R_Pass_PostProcess,
+	.color_attachments = s_postprocess_color_attachments,
+	.num_color_attachments = 1,
+	.stage = FG_PASS_STAGE_MAIN,
+	.stats_channel = FG_PASS_STATS_POST
 };
 
 static const RenderPassDesc s_viewmodel_framegraph_pass = {
-	"Draw viewmodel",
-	RENDER_RES_COMPOSITE_COLOR,
-	RENDER_RES_COMPOSITE_COLOR,
-	1u << 0,
-	FG_PASS_OUTPUT_BACKBUFFER,
-	FG_PASS_VIEWPORT_VIEW_RECT,
-	R_FG_PassWhenViewmodelEnabled,
-	R_Pass_DrawViewmodel,
-	FG_PASS_STAGE_MAIN,
-	FG_PASS_STATS_OVERLAY
+	.name = "Draw viewmodel",
+	.reads = RENDER_RES_COMPOSITE_COLOR,
+	.writes = RENDER_RES_COMPOSITE_COLOR,
+	.side_effects = 1u << 0,
+	.output_target = FG_PASS_OUTPUT_BACKBUFFER,
+	.viewport_mode = FG_PASS_VIEWPORT_VIEW_RECT,
+	.enabled = R_FG_PassWhenViewmodelEnabled,
+	.execute = R_Pass_DrawViewmodel,
+	.stage = FG_PASS_STAGE_MAIN,
+	.stats_channel = FG_PASS_STATS_OVERLAY
 };
 
 static const RenderPassDesc s_polyblend_framegraph_pass = {
-	"Polyblend",
-	RENDER_RES_COMPOSITE_COLOR,
-	RENDER_RES_COMPOSITE_COLOR,
-	1u << 0,
-	FG_PASS_OUTPUT_BACKBUFFER,
-	FG_PASS_VIEWPORT_VIEW_RECT,
-	R_FG_PassWhenPolyblendEnabled,
-	R_Pass_DrawPolyblend,
-	FG_PASS_STAGE_MAIN,
-	FG_PASS_STATS_OVERLAY
+	.name = "Polyblend",
+	.reads = RENDER_RES_COMPOSITE_COLOR,
+	.writes = RENDER_RES_COMPOSITE_COLOR,
+	.side_effects = 1u << 0,
+	.output_target = FG_PASS_OUTPUT_BACKBUFFER,
+	.viewport_mode = FG_PASS_VIEWPORT_VIEW_RECT,
+	.enabled = R_FG_PassWhenPolyblendEnabled,
+	.execute = R_Pass_DrawPolyblend,
+	.stage = FG_PASS_STAGE_MAIN,
+	.stats_channel = FG_PASS_STATS_OVERLAY
 };
 
 static const RenderPassDesc s_storeprev_framegraph_pass = {
-	"Store previous frame",
-	RENDER_RES_COMPOSITE_COLOR | RENDER_RES_SCENE_DEPTH,
-	RENDER_RES_NONE,
-	1u << 0,
-	FG_PASS_OUTPUT_KEEP,
-	FG_PASS_VIEWPORT_KEEP,
-	R_FG_PassWhenStorePrevEnabled,
-	R_Pass_StorePrevFrame
+	.name = "Store previous frame",
+	.reads = RENDER_RES_COMPOSITE_COLOR | RENDER_RES_SCENE_DEPTH,
+	.writes = RENDER_RES_NONE,
+	.side_effects = 1u << 0,
+	.output_target = FG_PASS_OUTPUT_KEEP,
+	.viewport_mode = FG_PASS_VIEWPORT_KEEP,
+	.enabled = R_FG_PassWhenStorePrevEnabled,
+	.execute = R_Pass_StorePrevFrame
 };
 
 void R_RegisterFrameGraphPasses (void)


### PR DESCRIPTION
### Motivation
- Move framegraph pass execution to backend-generic Ex/descriptor-aware APIs as the primary path while keeping legacy OpenGL hooks as optional compatibility.
- Provide explicit per-pass attachment metadata (color/depth load/store) so backends can perform correct load/store behavior instead of relying on autobind heuristics.
- Emit explicit resource barriers at pass boundaries to make implicit transitions explicit and portable across backends.

### Description
- Added `FGPassAttachmentConfig` and extended `RenderPassDesc` with `color_attachments`, `num_color_attachments`, and `depth_attachment` to carry per-pass attachment metadata. (file: `Quake/r_framegraph.h`)
- Construct `RenderBackendPassDesc` in `FG_RunPass`, populate attachment descriptors, and call `R_Backend_BeginPassEx` / `R_Backend_EndPassEx` as the primary execution path; legacy `validate_pass_state` is invoked only as a compatibility fallback when `begin_pass_ex` is not present. (file: `Quake/r_framegraph.c`)
- Track per-frame resource states and emit barriers at pass boundaries via a new `FG_EmitPassBarriers` helper that calls `R_Backend_ResourceBarrier` with `RenderBackendResourceBarrier` entries. (file: `Quake/r_framegraph.c`)
- Added OpenGL backend compatibility implementations: `GLBackend_BeginPassEx`, `GLBackend_EndPassEx`, and `GLBackend_ResourceBarrier` and wired them into the `IRenderBackend` registration so existing GL path remains functional. (file: `Quake/gl_backend.c`)
- Added attachment metadata for key passes (scene, warp/resolve, postprocess) and converted pass declarations to designated-initializer style so new fields are explicit and safe; updated decals pass similarly. (files: `Quake/r_passes.c`, `Quake/r_decals.c`)
- Small utility helpers added: `FG_FindResourceMappingIndex`, `FG_GetWriteStateForBit`, and `FG_ResetResourceStates` to support barrier logic. (file: `Quake/r_framegraph.c`)

### Testing
- Ran `make -j4` from the repository root which failed because there is no top-level Makefile in this container (no build attempted). Result: failure (no targets).
- Ran `make -j4` from `Quake/` to exercise a local build, which failed due to missing SDL development tooling (`sdl2-config` / `SDL.h`) in the environment, so a full compile could not complete; no binary produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d914dace00832e8f1de83c8104e2a3)