### PR TITLE
Render: make framegraph pass fallback and resource validation backend-agnostic

### DIFF
--- a/Quake/gl_backend.c
+++ b/Quake/gl_backend.c
@@ -125,6 +125,7 @@ static void GLBackend_DetectCaps (void)
 	memset (&s_gl_backend_caps, 0, sizeof (s_gl_backend_caps));
 	s_gl_backend_caps.supports_timestamps = GLBackend_HasTimestampQueries ();
 	s_gl_backend_caps.supports_compute = (GL_DispatchComputeFunc != NULL);
+	s_gl_backend_caps.supports_legacy_pass_fallbacks = true;
 	s_gl_backend_caps.supports_bindless = gl_bindless_able;
 	s_gl_backend_caps.shader_model = 50u;
 	s_gl_backend_caps.max_msaa_samples = (framebufs.max_samples > 0) ? (unsigned)framebufs.max_samples : 1u;

--- a/Quake/r_backend.c
+++ b/Quake/r_backend.c
@@ -15,8 +15,26 @@ static RenderBackendCaps s_active_backend_caps;
 static qboolean s_backend_initialized = false;
 static qboolean s_applying_backend_cvar = false;
 static qboolean s_backend_active = false;
+static qboolean s_backend_audit_cmd_registered = false;
 
 cvar_t r_backend = { "r_backend", "OpenGL", CVAR_ARCHIVE };
+
+/*
+================
+R_Backend_WrapperAudit_f
+
+Tracks high-value legacy wrappers still in heavy use so migration work can be
+planned around backend-neutral pipeline/descriptors/dynamic-state APIs.
+================
+*/
+static void R_Backend_WrapperAudit_f (void)
+{
+	Con_Printf ("Renderer wrapper migration priorities:\n");
+	Con_Printf ("  P0: R_Backend_SetPipelineState (most draw-path callsites; migrate material/decal/particle state to pipeline + dynamic state)\n");
+	Con_Printf ("  P1: direct glDraw*/GL_Draw* callsites (route through R_Backend_Draw/descriptor-driven draw plans)\n");
+	Con_Printf ("  P2: bind-time texture/program glue in legacy passes (move to descriptor sets + explicit pipeline binding)\n");
+	Con_Printf ("  P3: optional compute/dispatch paths (already abstracted via R_Backend_Dispatch where available)\n");
+}
 
 /*
 ================
@@ -247,6 +265,11 @@ void R_Backend_Init (void)
 	s_backend_initialized = true;
 	Cvar_RegisterVariable (&r_backend);
 	Cvar_SetCallback (&r_backend, R_Backend_Changed_f);
+	if (!s_backend_audit_cmd_registered)
+	{
+		Cmd_AddCommand ("r_backend_wrapper_audit", R_Backend_WrapperAudit_f);
+		s_backend_audit_cmd_registered = true;
+	}
 
 	GL_Backend_Register ();
 

--- a/Quake/r_framegraph.c
+++ b/Quake/r_framegraph.c
@@ -181,11 +181,89 @@ static void FG_EmitPassBarriers (const RenderPassDesc *pass, RenderPassContext *
 		R_Backend_ResourceBarrier (ctx->resources, barriers, barrier_count);
 }
 
+static qboolean FG_ValidatePassResourceDecls (const RenderPassDesc *pass_desc, qboolean emit_warning)
+{
+	unsigned bit;
+	unsigned i;
+
+	if (!pass_desc)
+		return false;
+
+	for (bit = 1u; bit != 0; bit <<= 1)
+	{
+		const fg_resource_bit_mapping_t *mapping;
+		if (((pass_desc->reads | pass_desc->writes) & bit) == 0u)
+			continue;
+		mapping = FG_FindResourceMapping (bit);
+		if (!mapping)
+		{
+			if (emit_warning)
+				Con_Warning ("FrameGraph: pass '%s' uses unmapped resource bit 0x%x\n",
+					pass_desc->name ? pass_desc->name : "<unnamed>", bit);
+			SDL_assert (!"FrameGraph pass uses unmapped resource bit");
+			return false;
+		}
+	}
+
+	if (pass_desc->color_attachments && pass_desc->num_color_attachments > 0)
+	{
+		for (i = 0; i < pass_desc->num_color_attachments; ++i)
+		{
+			unsigned resource_bit = pass_desc->color_attachments[i].resource_bit;
+			const fg_resource_bit_mapping_t *mapping = FG_FindResourceMapping (resource_bit);
+
+			if (!mapping || !mapping->requires_backend_resource || mapping->slot == R_BACKEND_RESOURCE_SLOT_NONE)
+			{
+				if (emit_warning)
+					Con_Warning ("FrameGraph: pass '%s' color attachment[%u] does not map to backend resource\n",
+						pass_desc->name ? pass_desc->name : "<unnamed>", i);
+				SDL_assert (!"FrameGraph pass attachment requires backend resource mapping");
+				return false;
+			}
+			if ((pass_desc->writes & resource_bit) == 0u)
+			{
+				if (emit_warning)
+					Con_Warning ("FrameGraph: pass '%s' color attachment[%u] must be declared in writes mask\n",
+						pass_desc->name ? pass_desc->name : "<unnamed>", i);
+				SDL_assert (!"FrameGraph pass attachment must be declared in writes mask");
+				return false;
+			}
+		}
+	}
+
+	if (pass_desc->depth_attachment)
+	{
+		unsigned resource_bit = pass_desc->depth_attachment->resource_bit;
+		const fg_resource_bit_mapping_t *mapping = FG_FindResourceMapping (resource_bit);
+
+		if (!mapping || !mapping->requires_backend_resource || mapping->slot == R_BACKEND_RESOURCE_SLOT_NONE)
+		{
+			if (emit_warning)
+				Con_Warning ("FrameGraph: pass '%s' depth attachment does not map to backend resource\n",
+					pass_desc->name ? pass_desc->name : "<unnamed>");
+			SDL_assert (!"FrameGraph pass depth attachment requires backend resource mapping");
+			return false;
+		}
+		if ((pass_desc->writes & resource_bit) == 0u)
+		{
+			if (emit_warning)
+				Con_Warning ("FrameGraph: pass '%s' depth attachment must be declared in writes mask\n",
+					pass_desc->name ? pass_desc->name : "<unnamed>");
+			SDL_assert (!"FrameGraph pass depth attachment must be declared in writes mask");
+			return false;
+		}
+	}
+
+	return true;
+}
+
 static qboolean FG_AddRuntimePassInternal (const RenderPassDesc *pass_desc)
 {
 	int profile_slot;
 
 	if (!pass_desc || !pass_desc->name || !pass_desc->execute)
+		return false;
+	if (!FG_ValidatePassResourceDecls (pass_desc, true))
 		return false;
 	if (s_runtime_pass_count >= FG_MAX_RUNTIME_PASSES)
 	{
@@ -740,6 +818,8 @@ static void FG_RunPass (int profile_slot, const RenderPassDesc *pass, RenderPass
 		return;
 	if (pass->enabled && !pass->enabled (ctx))
 		return;
+	if (!FG_ValidatePassResourceDecls (pass, false))
+		return;
 
 	for (bit = 1u; bit != 0; bit <<= 1)
 	{
@@ -798,6 +878,12 @@ static void FG_RunPass (int profile_slot, const RenderPassDesc *pass, RenderPass
 			if (!FG_GetResourceSlotForBit (pass->color_attachments[i].resource_bit, &slot))
 				continue;
 			color_attachments[i].resource = R_FrameGraph_GetResourceRef (ctx->resources, slot);
+			if (!color_attachments[i].resource || (ctx->backend && ctx->backend->is_resource_valid
+				&& !ctx->backend->is_resource_valid (ctx->resources, color_attachments[i].resource)))
+			{
+				Con_DWarning ("FrameGraph: pass '%s' color attachment[%u] resolved invalid resource\n", pass->name, i);
+				SDL_assert (!"FrameGraph pass color attachment resolved invalid resource");
+			}
 			color_attachments[i].load_op = pass->color_attachments[i].load_op;
 			color_attachments[i].store_op = pass->color_attachments[i].store_op;
 		}
@@ -811,6 +897,12 @@ static void FG_RunPass (int profile_slot, const RenderPassDesc *pass, RenderPass
 		if (FG_GetResourceSlotForBit (pass->depth_attachment->resource_bit, &depth_slot))
 		{
 			depth_attachment.resource = R_FrameGraph_GetResourceRef (ctx->resources, depth_slot);
+			if (!depth_attachment.resource || (ctx->backend && ctx->backend->is_resource_valid
+				&& !ctx->backend->is_resource_valid (ctx->resources, depth_attachment.resource)))
+			{
+				Con_DWarning ("FrameGraph: pass '%s' depth attachment resolved invalid resource\n", pass->name);
+				SDL_assert (!"FrameGraph pass depth attachment resolved invalid resource");
+			}
 			depth_attachment.load_op = pass->depth_attachment->load_op;
 			depth_attachment.store_op = pass->depth_attachment->store_op;
 			has_depth_attachment = true;

--- a/Quake/r_framegraph.h
+++ b/Quake/r_framegraph.h
@@ -20,6 +20,7 @@ typedef struct render_backend_caps_s
 {
 	qboolean supports_timestamps;
 	qboolean supports_compute;
+	qboolean supports_legacy_pass_fallbacks;
 	unsigned msaa_mode_mask;
 	unsigned max_msaa_samples;
 	unsigned shader_model;

--- a/Quake/r_passes.c
+++ b/Quake/r_passes.c
@@ -30,10 +30,14 @@ static qboolean R_FG_PassWhenStorePrevEnabled (const RenderPassContext *ctx)
 	return ctx && ctx->frame_plan && ctx->frame_plan->run_store_prev;
 }
 
-static qboolean R_Pass_IsOpenGLBackend (const RenderPassContext *ctx)
+static qboolean R_Pass_AllowLegacyFallback (const RenderPassContext *ctx)
 {
-	return ctx && ctx->backend && ctx->backend->name
-		&& !q_strcasecmp (ctx->backend->name, "OpenGL");
+	const RenderBackendCaps *caps = R_Backend_GetCaps ();
+
+	if (!ctx || !ctx->backend)
+		return true;
+
+	return caps && caps->supports_legacy_pass_fallbacks;
 }
 
 void R_Pass_SetupView (RenderPassContext *ctx)
@@ -44,8 +48,8 @@ void R_Pass_SetupView (RenderPassContext *ctx)
 		return;
 	}
 
-	/* Legacy fallback: keep OpenGL framegraph path working. */
-	if (!ctx || R_Pass_IsOpenGLBackend (ctx))
+	/* Compatibility fallback: backend opt-in via capability contract. */
+	if (R_Pass_AllowLegacyFallback (ctx))
 		R_SetupView ();
 }
 
@@ -57,7 +61,7 @@ void R_Pass_RenderShadowMaps (RenderPassContext *ctx)
 		return;
 	}
 
-	if (!ctx || R_Pass_IsOpenGLBackend (ctx))
+	if (R_Pass_AllowLegacyFallback (ctx))
 		R_RenderShadowMaps ();
 }
 
@@ -69,7 +73,7 @@ void R_Pass_RenderScene (RenderPassContext *ctx)
 		return;
 	}
 
-	if (!ctx || R_Pass_IsOpenGLBackend (ctx))
+	if (R_Pass_AllowLegacyFallback (ctx))
 		R_RenderScene (ctx ? ctx->resources : NULL);
 }
 
@@ -81,7 +85,7 @@ void R_Pass_WarpResolve (RenderPassContext *ctx)
 		return;
 	}
 
-	if (!ctx || R_Pass_IsOpenGLBackend (ctx))
+	if (R_Pass_AllowLegacyFallback (ctx))
 		R_WarpScaleView (ctx ? ctx->resources : NULL);
 }
 
@@ -93,7 +97,7 @@ void R_Pass_PostProcess (RenderPassContext *ctx)
 		return;
 	}
 
-	if (!ctx || R_Pass_IsOpenGLBackend (ctx))
+	if (R_Pass_AllowLegacyFallback (ctx))
 		GL_PostProcess (ctx ? ctx->resources : NULL);
 }
 
@@ -105,7 +109,7 @@ void R_Pass_DrawViewmodel (RenderPassContext *ctx)
 		return;
 	}
 
-	if (!ctx || R_Pass_IsOpenGLBackend (ctx))
+	if (R_Pass_AllowLegacyFallback (ctx))
 		R_DrawViewModel ();
 }
 
@@ -117,7 +121,7 @@ void R_Pass_DrawPolyblend (RenderPassContext *ctx)
 		return;
 	}
 
-	if (!ctx || R_Pass_IsOpenGLBackend (ctx))
+	if (R_Pass_AllowLegacyFallback (ctx))
 		V_PolyBlend ();
 }
 

--- a/docs/render_backend_readiness_checklist.md
+++ b/docs/render_backend_readiness_checklist.md
@@ -1,0 +1,35 @@
+# Render Backend Bring-Up Readiness Checklist
+
+This checklist is the Phase 3 baseline for bringing up a second renderer backend (stubbed or full) without pass-graph orchestration changes.
+
+## 1) Registration + selection contract
+
+- [ ] Backend registers with a unique `IRenderBackend.name`.
+- [ ] `get_caps`, `resolve_resource_id`, `is_resource_valid`, `bind_render_target`, `set_viewport`, `draw`, and `populate_framegraph_resources` are implemented (required contract).
+- [ ] `can_activate` reports startup/runtime viability correctly.
+- [ ] Backend can be selected via `r_backend`.
+
+## 2) Pass execution contract
+
+- [ ] New backend either implements per-pass callbacks (`pass_setup_view`, `pass_render_scene`, etc.) **or** explicitly opts into legacy fallback behavior with `RenderBackendCaps.supports_legacy_pass_fallbacks`.
+- [ ] `begin_pass_ex`/`end_pass_ex` are wired (or legacy `begin_pass`/`end_pass` are intentionally used as a compatibility bridge).
+- [ ] `resource_barrier` handles shader-write/read hazards where relevant.
+
+## 3) Resource declarations + validation
+
+- [ ] All `RenderPassDesc` read/write resource bits are mapped in framegraph resource mapping.
+- [ ] Attachment resources are backend-resolvable and also declared in pass `writes` masks.
+- [ ] Non-backend handoff resources (state-only edges like fog handoff) stay declared in read/write masks for ordering, even when they do not resolve to backend objects.
+
+## 4) Wrapper migration priority (OpenGL debt burn-down)
+
+- [ ] `R_Backend_SetPipelineState` high-frequency callsites reduced in favor of `bind_pipeline` + `set_dynamic_state`.
+- [ ] Direct `glDraw*`/`GL_Draw*` hot paths migrated to `R_Backend_Draw` + descriptor binding.
+- [ ] Per-pass texture/program binding logic migrated to `bind_descriptors`-style data flow.
+- [ ] Compute-capable paths use `R_Backend_Dispatch` and explicit barriers.
+
+## 5) Smoke + diagnostics
+
+- [ ] `r_backend_wrapper_audit` command prints migration priorities.
+- [ ] Framegraph debug validation (`r_framegraph_debug`, `r_gl_state_validate`) reports no attachment/resource declaration warnings.
+- [ ] Frame launches and scene render complete with expected pass timings.


### PR DESCRIPTION
### Motivation

- Remove hard-coded OpenGL backend-name checks from pass orchestration so fallback behavior is governed by backend capability contracts. 
- Normalize and validate pass-declared resources in backend-neutral terms so attachments and non-texture handoffs are consistently resolvable. 
- Provide lightweight tools and documentation to prioritize conversion of legacy GL wrappers and to prepare for adding a second backend implementation.

### Description

- Added `RenderBackendCaps.supports_legacy_pass_fallbacks` and marked the OpenGL backend as opting into legacy pass fallbacks (GL sets the flag to `true`).
- Replaced explicit "OpenGL" name checks with `R_Pass_AllowLegacyFallback()` that gates legacy fallbacks by the backend capability instead of the backend name, affecting setup/shadow/scene/warp/postprocess/viewmodel/polyblend pass fallbacks.
- Introduced `FG_ValidatePassResourceDecls()` to validate pass `reads`/`writes` masks and attachment declarations during pass registration and before execution, rejecting unmapped bits and ensuring attachments map to backend-resolvable resources and are declared in `writes` where required.
- Strengthened runtime resolution checks to warn/assert when color/depth attachments resolve to invalid backend resources during pass execution.
- Added `r_backend_wrapper_audit` command that prints migration priorities for wrapper debt (pipeline state, direct draw hot paths, descriptor migration, compute/barrier follow-up).
- Added `docs/render_backend_readiness_checklist.md` providing a concrete readiness checklist for bringing up a second renderer backend.

### Testing

- Ran static check `git diff --check`, which produced no warnings or whitespace errors (success).
- Attempted an automated smoke launch via PowerShell (`pwsh`) in this environment, but `pwsh` is not available here so the runtime smoke could not be executed (failed due to missing runtime in CI environment).
- No platform builds or runtime render validation were performed in this environment; recommend running the documented local smoke tests from `C:\Quake\rerelease` and a Windows Release build as described in the repository `AGENTS.md` for full verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d922177818832eb9740bb734739a81)