### PR TITLE
Make ref_vk/ref_dx12 independent no-op backends (remove GL forwarding)

### DIFF
--- a/Quake/r_backend.c
+++ b/Quake/r_backend.c
@@ -35,7 +35,6 @@ static qboolean s_backend_audit_cmd_registered = false;
 static qboolean s_backend_vulkan_status_cmd_registered = false;
 static qboolean s_backend_dx12_status_cmd_registered = false;
 static qboolean s_warned_deprecated_builtin_register = false;
-static qboolean s_warned_vulkan_wrapper_runtime = false;
 static int s_missing_resource_warn_frame[R_BACKEND_RESOURCE_SLOT_COUNT];
 static void *s_plugin_libs[R_BACKEND_MAX_PLUGIN_LIBS];
 static int s_plugin_lib_count = 0;
@@ -1047,7 +1046,7 @@ static void R_Backend_VulkanStatus_f (void)
 	else
 	{
 		Con_Printf ("  source: non-stub backend is currently registered for 'Vulkan' (likely ref_vk plugin).\n");
-		Con_Printf ("  note: current ref_vk is a compatibility wrapper that forwards to OpenGL; native Vulkan rendering is not implemented yet.\n");
+		Con_Printf ("  note: current ref_vk backend is an independent placeholder with activation blocked until native Vulkan implementation lands.\n");
 	}
 }
 
@@ -1135,6 +1134,7 @@ static void R_Backend_DX12Status_f (void)
 	else
 	{
 		Con_Printf ("  source: non-stub backend is currently registered for 'DX12' (likely ref_dx12 plugin).\n");
+		Con_Printf ("  note: current ref_dx12 backend is an independent placeholder with activation blocked until native DX12 implementation lands.\n");
 	}
 }
 
@@ -1262,15 +1262,6 @@ qboolean R_Backend_Select (const char *backend_name)
 
 	s_backend_active = true;
 	R_Backend_ApplySelectionToCvar ();
-	if (s_active_backend
-		&& s_active_backend->name
-		&& !q_strcasecmp (s_active_backend->name, "Vulkan")
-		&& s_active_backend != &s_vulkan_stub_backend
-		&& !s_warned_vulkan_wrapper_runtime)
-	{
-		Con_Warning ("'Vulkan' currently routes through ref_vk compatibility wrapper (OpenGL forwarding), not a native Vulkan renderer.\n");
-		s_warned_vulkan_wrapper_runtime = true;
-	}
 	return true;
 }
 
@@ -1333,7 +1324,6 @@ void R_Backend_Shutdown (void)
 	s_registered_backend_count = 0;
 	s_active_backend = NULL;
 	s_backend_initialized = false;
-	s_warned_vulkan_wrapper_runtime = false;
 	s_command_encoder_recording = false;
 	s_command_encoder_frame = -1;
 	memset (&s_last_populated_resources, 0, sizeof (s_last_populated_resources));

--- a/Quake/ref_dx12_plugin.c
+++ b/Quake/ref_dx12_plugin.c
@@ -1,85 +1,78 @@
 #include "renderer_plugin.h"
 
-static const IRenderBackend *s_dx12_source = NULL;
+static const RenderBackendCaps s_dx12_caps = {
+	false, /* supports_timestamps */
+	false, /* supports_compute */
+	false, /* supports_draw_instanced */
+	false, /* supports_draw_indirect */
+	false, /* supports_multi_draw_indirect */
+	false, /* supports_memory_barrier */
+	false, /* supports_legacy_pass_fallbacks */
+	0u,    /* msaa_mode_mask */
+	1u,    /* max_msaa_samples */
+	0u,    /* shader_model */
+	false, /* supports_bindless */
+	0u,    /* max_textures */
+	0u,    /* max_samplers */
+	0u,    /* max_ubos */
+	0u     /* max_ssbos */
+};
 
-static const IRenderBackend *DX12_Source (void)
-{
-	return s_dx12_source;
-}
-
-static qboolean DX12_Init (void)
-{
-	const IRenderBackend *b = DX12_Source ();
-	if (!b || !b->init)
-		return false;
-	return b->init ();
-}
-
-static void DX12_Shutdown (void)
-{
-	const IRenderBackend *b = DX12_Source ();
-	if (b && b->shutdown)
-		b->shutdown ();
-}
-
-static void DX12_OnResize (int width, int height)
-{
-	const IRenderBackend *b = DX12_Source ();
-	if (b && b->on_resize)
-		b->on_resize (width, height);
-}
+static qboolean DX12_Init (void) { return false; }
+static void DX12_Shutdown (void) {}
+static void DX12_OnResize (int width, int height) { (void)width; (void)height; }
 
 static qboolean DX12_CanActivate (qboolean runtime_switch)
 {
 	(void)runtime_switch;
-	return DX12_Source () != NULL;
+	return false;
 }
 
-static void DX12_BeginFrame (void) { const IRenderBackend *b = DX12_Source (); if (b && b->begin_frame) b->begin_frame (); }
-static void DX12_EndFrame (void) { const IRenderBackend *b = DX12_Source (); if (b && b->end_frame) b->end_frame (); }
-static void DX12_Present (void) { const IRenderBackend *b = DX12_Source (); if (b && b->present) b->present (); }
-static void DX12_BeginPassEx (const RenderBackendPassDesc *pass_desc) { const IRenderBackend *b = DX12_Source (); if (b && b->begin_pass_ex) b->begin_pass_ex (pass_desc); }
-static void DX12_EndPassEx (void) { const IRenderBackend *b = DX12_Source (); if (b && b->end_pass_ex) b->end_pass_ex (); }
-static void DX12_ResourceBarrier (const RenderGraphResourceHandle *resources, const RenderBackendResourceBarrier *barriers, unsigned count) { const IRenderBackend *b = DX12_Source (); if (b && b->resource_barrier) b->resource_barrier (resources, barriers, count); }
-static void DX12_BindPipeline (const RenderBackendPipelineDesc *pipeline) { const IRenderBackend *b = DX12_Source (); if (b && b->bind_pipeline) b->bind_pipeline (pipeline); }
-static void DX12_SetDynamicState (const RenderBackendDynamicState *dynamic_state) { const IRenderBackend *b = DX12_Source (); if (b && b->set_dynamic_state) b->set_dynamic_state (dynamic_state); }
-static void DX12_BindDescriptors (const RenderBackendDescriptorBinding *bindings, unsigned count) { const IRenderBackend *b = DX12_Source (); if (b && b->bind_descriptors) b->bind_descriptors (bindings, count); }
-static void DX12_PassSetupView (RenderPassContext *ctx) { const IRenderBackend *b = DX12_Source (); if (b && b->pass_setup_view) b->pass_setup_view (ctx); }
-static void DX12_PassShadowmaps (RenderPassContext *ctx) { const IRenderBackend *b = DX12_Source (); if (b && b->pass_shadowmaps) b->pass_shadowmaps (ctx); }
-static void DX12_PassRenderScene (RenderPassContext *ctx) { const IRenderBackend *b = DX12_Source (); if (b && b->pass_render_scene) b->pass_render_scene (ctx); }
-static void DX12_PassWarpResolve (RenderPassContext *ctx) { const IRenderBackend *b = DX12_Source (); if (b && b->pass_warp_resolve) b->pass_warp_resolve (ctx); }
-static void DX12_PassPostprocess (RenderPassContext *ctx) { const IRenderBackend *b = DX12_Source (); if (b && b->pass_postprocess) b->pass_postprocess (ctx); }
-static void DX12_PassOverlayViewmodel (RenderPassContext *ctx) { const IRenderBackend *b = DX12_Source (); if (b && b->pass_overlay_viewmodel) b->pass_overlay_viewmodel (ctx); }
-static void DX12_PassOverlayPolyblend (RenderPassContext *ctx) { const IRenderBackend *b = DX12_Source (); if (b && b->pass_overlay_polyblend) b->pass_overlay_polyblend (ctx); }
-static void DX12_BeginPass (const char *name) { const IRenderBackend *b = DX12_Source (); if (b && b->begin_pass) b->begin_pass (name); }
-static void DX12_EndPass (void) { const IRenderBackend *b = DX12_Source (); if (b && b->end_pass) b->end_pass (); }
-static void DX12_ValidatePassState (const char *pass_name, qboolean before_pass) { const IRenderBackend *b = DX12_Source (); if (b && b->validate_pass_state) b->validate_pass_state (pass_name, before_pass); }
-static void DX12_BeginTimer (int pass_id) { const IRenderBackend *b = DX12_Source (); if (b && b->begin_timer) b->begin_timer (pass_id); }
-static void DX12_EndTimer (int pass_id) { const IRenderBackend *b = DX12_Source (); if (b && b->end_timer) b->end_timer (pass_id); }
-static void DX12_ResolveTimers (void) { const IRenderBackend *b = DX12_Source (); if (b && b->resolve_timers) b->resolve_timers (); }
-static qboolean DX12_ConsumeTimerSample (int pass_id, double *out_gpu_ms) { const IRenderBackend *b = DX12_Source (); return (b && b->consume_timer_sample) ? b->consume_timer_sample (pass_id, out_gpu_ms) : false; }
-static const RenderBackendCaps *DX12_GetCaps (void) { const IRenderBackend *b = DX12_Source (); return (b && b->get_caps) ? b->get_caps () : NULL; }
-static unsigned DX12_ResolveResourceId (const RenderGraphResourceHandle *resources, const render_backend_resource_ref_t *resource) { const IRenderBackend *b = DX12_Source (); return (b && b->resolve_resource_id) ? b->resolve_resource_id (resources, resource) : 0u; }
-static qboolean DX12_IsResourceValid (const RenderGraphResourceHandle *resources, const render_backend_resource_ref_t *resource) { const IRenderBackend *b = DX12_Source (); return (b && b->is_resource_valid) ? b->is_resource_valid (resources, resource) : false; }
-static void DX12_BindRenderTarget (const RenderGraphResourceHandle *resources, const render_backend_resource_ref_t *resource, qboolean backbuffer) { const IRenderBackend *b = DX12_Source (); if (b && b->bind_render_target) b->bind_render_target (resources, resource, backbuffer); }
-static void DX12_SetViewport (int x, int y, int width, int height) { const IRenderBackend *b = DX12_Source (); if (b && b->set_viewport) b->set_viewport (x, y, width, height); }
-static void DX12_SetScissor (qboolean enabled, int x, int y, int width, int height) { const IRenderBackend *b = DX12_Source (); if (b && b->set_scissor) b->set_scissor (enabled, x, y, width, height); }
-static void DX12_SetPipelineState (unsigned state_bits) { const IRenderBackend *b = DX12_Source (); if (b && b->set_pipeline_state) b->set_pipeline_state (state_bits); }
-static void DX12_Draw (render_backend_primitive_t primitive, int first, int count) { const IRenderBackend *b = DX12_Source (); if (b && b->draw) b->draw (primitive, first, count); }
-static void DX12_DrawIndexed (render_backend_primitive_t primitive, render_backend_index_type_t index_type, int count, intptr_t index_offset_bytes) { const IRenderBackend *b = DX12_Source (); if (b && b->draw_indexed) b->draw_indexed (primitive, index_type, count, index_offset_bytes); }
-static void DX12_DrawInstanced (render_backend_primitive_t primitive, int first, int count, int instance_count) { const IRenderBackend *b = DX12_Source (); if (b && b->draw_instanced) b->draw_instanced (primitive, first, count, instance_count); }
-static void DX12_DrawIndexedInstanced (render_backend_primitive_t primitive, render_backend_index_type_t index_type, int count, intptr_t index_offset_bytes, int instance_count) { const IRenderBackend *b = DX12_Source (); if (b && b->draw_indexed_instanced) b->draw_indexed_instanced (primitive, index_type, count, index_offset_bytes, instance_count); }
-static void DX12_DrawIndexedIndirect (render_backend_primitive_t primitive, render_backend_index_type_t index_type, intptr_t indirect_offset_bytes) { const IRenderBackend *b = DX12_Source (); if (b && b->draw_indexed_indirect) b->draw_indexed_indirect (primitive, index_type, indirect_offset_bytes); }
-static void DX12_MultiDrawIndexedIndirect (render_backend_primitive_t primitive, render_backend_index_type_t index_type, intptr_t indirect_offset_bytes, int draw_count, int stride_bytes) { const IRenderBackend *b = DX12_Source (); if (b && b->multi_draw_indexed_indirect) b->multi_draw_indexed_indirect (primitive, index_type, indirect_offset_bytes, draw_count, stride_bytes); }
-static void DX12_Dispatch (unsigned group_x, unsigned group_y, unsigned group_z) { const IRenderBackend *b = DX12_Source (); if (b && b->dispatch) b->dispatch (group_x, group_y, group_z); }
-static void DX12_MemoryBarrier (unsigned barrier_bits) { const IRenderBackend *b = DX12_Source (); if (b && b->memory_barrier) b->memory_barrier (barrier_bits); }
-static void DX12_SetBlendFactors (render_blend_factor_t src, render_blend_factor_t dst) { const IRenderBackend *b = DX12_Source (); if (b && b->set_blend_factors) b->set_blend_factors (src, dst); }
-static void DX12_SetDepthFunc (render_backend_depth_func_t depth_func) { const IRenderBackend *b = DX12_Source (); if (b && b->set_depth_func) b->set_depth_func (depth_func); }
-static unsigned DX12_CreatePostFXLUTTexture (void) { const IRenderBackend *b = DX12_Source (); return (b && b->create_postfx_lut_texture) ? b->create_postfx_lut_texture () : 0u; }
-static void DX12_ConfigurePostFXLUTTexture (unsigned texture_id) { const IRenderBackend *b = DX12_Source (); if (b && b->configure_postfx_lut_texture) b->configure_postfx_lut_texture (texture_id); }
-static void DX12_Finish (void) { const IRenderBackend *b = DX12_Source (); if (b && b->finish) b->finish (); }
-static void DX12_PopulateFramegraphResources (RenderGraphResourceHandle *out_handles) { const IRenderBackend *b = DX12_Source (); if (b && b->populate_framegraph_resources) b->populate_framegraph_resources (out_handles); }
-static int DX12_GetSceneSampleCount (void) { const IRenderBackend *b = DX12_Source (); return (b && b->get_scene_sample_count) ? b->get_scene_sample_count () : 1; }
+static void DX12_BeginFrame (void) {}
+static void DX12_EndFrame (void) {}
+static void DX12_Present (void) {}
+static void DX12_BeginPassEx (const RenderBackendPassDesc *pass_desc) { (void)pass_desc; }
+static void DX12_EndPassEx (void) {}
+static void DX12_ResourceBarrier (const RenderGraphResourceHandle *resources, const RenderBackendResourceBarrier *barriers, unsigned count) { (void)resources; (void)barriers; (void)count; }
+static void DX12_BindPipeline (const RenderBackendPipelineDesc *pipeline) { (void)pipeline; }
+static void DX12_SetDynamicState (const RenderBackendDynamicState *dynamic_state) { (void)dynamic_state; }
+static void DX12_BindDescriptors (const RenderBackendDescriptorBinding *bindings, unsigned count) { (void)bindings; (void)count; }
+static void DX12_PassSetupView (RenderPassContext *ctx) { (void)ctx; }
+static void DX12_PassShadowmaps (RenderPassContext *ctx) { (void)ctx; }
+static void DX12_PassRenderScene (RenderPassContext *ctx) { (void)ctx; }
+static void DX12_PassWarpResolve (RenderPassContext *ctx) { (void)ctx; }
+static void DX12_PassPostprocess (RenderPassContext *ctx) { (void)ctx; }
+static void DX12_PassOverlayViewmodel (RenderPassContext *ctx) { (void)ctx; }
+static void DX12_PassOverlayPolyblend (RenderPassContext *ctx) { (void)ctx; }
+static void DX12_BeginPass (const char *name) { (void)name; }
+static void DX12_EndPass (void) {}
+static void DX12_ValidatePassState (const char *pass_name, qboolean before_pass) { (void)pass_name; (void)before_pass; }
+static void DX12_BeginTimer (int pass_id) { (void)pass_id; }
+static void DX12_EndTimer (int pass_id) { (void)pass_id; }
+static void DX12_ResolveTimers (void) {}
+static qboolean DX12_ConsumeTimerSample (int pass_id, double *out_gpu_ms) { (void)pass_id; (void)out_gpu_ms; return false; }
+static const RenderBackendCaps *DX12_GetCaps (void) { return &s_dx12_caps; }
+static unsigned DX12_ResolveResourceId (const RenderGraphResourceHandle *resources, const render_backend_resource_ref_t *resource) { (void)resources; (void)resource; return 0u; }
+static qboolean DX12_IsResourceValid (const RenderGraphResourceHandle *resources, const render_backend_resource_ref_t *resource) { (void)resources; (void)resource; return false; }
+static void DX12_BindRenderTarget (const RenderGraphResourceHandle *resources, const render_backend_resource_ref_t *resource, qboolean backbuffer) { (void)resources; (void)resource; (void)backbuffer; }
+static void DX12_SetViewport (int x, int y, int width, int height) { (void)x; (void)y; (void)width; (void)height; }
+static void DX12_SetScissor (qboolean enabled, int x, int y, int width, int height) { (void)enabled; (void)x; (void)y; (void)width; (void)height; }
+static void DX12_SetPipelineState (unsigned state_bits) { (void)state_bits; }
+static void DX12_Draw (render_backend_primitive_t primitive, int first, int count) { (void)primitive; (void)first; (void)count; }
+static void DX12_DrawIndexed (render_backend_primitive_t primitive, render_backend_index_type_t index_type, int count, intptr_t index_offset_bytes) { (void)primitive; (void)index_type; (void)count; (void)index_offset_bytes; }
+static void DX12_DrawInstanced (render_backend_primitive_t primitive, int first, int count, int instance_count) { (void)primitive; (void)first; (void)count; (void)instance_count; }
+static void DX12_DrawIndexedInstanced (render_backend_primitive_t primitive, render_backend_index_type_t index_type, int count, intptr_t index_offset_bytes, int instance_count) { (void)primitive; (void)index_type; (void)count; (void)index_offset_bytes; (void)instance_count; }
+static void DX12_DrawIndexedIndirect (render_backend_primitive_t primitive, render_backend_index_type_t index_type, intptr_t indirect_offset_bytes) { (void)primitive; (void)index_type; (void)indirect_offset_bytes; }
+static void DX12_MultiDrawIndexedIndirect (render_backend_primitive_t primitive, render_backend_index_type_t index_type, intptr_t indirect_offset_bytes, int draw_count, int stride_bytes) { (void)primitive; (void)index_type; (void)indirect_offset_bytes; (void)draw_count; (void)stride_bytes; }
+static void DX12_Dispatch (unsigned group_x, unsigned group_y, unsigned group_z) { (void)group_x; (void)group_y; (void)group_z; }
+static void DX12_MemoryBarrier (unsigned barrier_bits) { (void)barrier_bits; }
+static void DX12_SetBlendFactors (render_blend_factor_t src, render_blend_factor_t dst) { (void)src; (void)dst; }
+static void DX12_SetDepthFunc (render_backend_depth_func_t depth_func) { (void)depth_func; }
+static unsigned DX12_CreatePostFXLUTTexture (void) { return 0u; }
+static void DX12_ConfigurePostFXLUTTexture (unsigned texture_id) { (void)texture_id; }
+static void DX12_Finish (void) {}
+static void DX12_PopulateFramegraphResources (RenderGraphResourceHandle *out_handles) { if (out_handles) memset (out_handles, 0, sizeof (*out_handles)); }
+static int DX12_GetSceneSampleCount (void) { return 1; }
 
 static const IRenderBackend s_ref_dx12_backend = {
 	"DX12",
@@ -138,10 +131,9 @@ static qboolean IW_RendererRefDX12_Register (const iw_renderer_plugin_host_api_t
 {
 	if (!host_api || host_api->struct_size < IW_RENDERER_PLUGIN_HOST_API_V2_SIZE)
 		return false;
-	if (!host_api->register_backend || !host_api->builtin_opengl_backend)
+	if (!host_api->register_backend)
 		return false;
 
-	s_dx12_source = host_api->builtin_opengl_backend;
 	return host_api->register_backend (&s_ref_dx12_backend);
 }
 

--- a/Quake/ref_vk_plugin.c
+++ b/Quake/ref_vk_plugin.c
@@ -1,85 +1,78 @@
 #include "renderer_plugin.h"
 
-static const IRenderBackend *s_vk_source = NULL;
+static const RenderBackendCaps s_vk_caps = {
+	false, /* supports_timestamps */
+	false, /* supports_compute */
+	false, /* supports_draw_instanced */
+	false, /* supports_draw_indirect */
+	false, /* supports_multi_draw_indirect */
+	false, /* supports_memory_barrier */
+	false, /* supports_legacy_pass_fallbacks */
+	0u,    /* msaa_mode_mask */
+	1u,    /* max_msaa_samples */
+	0u,    /* shader_model */
+	false, /* supports_bindless */
+	0u,    /* max_textures */
+	0u,    /* max_samplers */
+	0u,    /* max_ubos */
+	0u     /* max_ssbos */
+};
 
-static const IRenderBackend *VK_Source (void)
-{
-	return s_vk_source;
-}
-
-static qboolean VK_Init (void)
-{
-	const IRenderBackend *b = VK_Source ();
-	if (!b || !b->init)
-		return false;
-	return b->init ();
-}
-
-static void VK_Shutdown (void)
-{
-	const IRenderBackend *b = VK_Source ();
-	if (b && b->shutdown)
-		b->shutdown ();
-}
-
-static void VK_OnResize (int width, int height)
-{
-	const IRenderBackend *b = VK_Source ();
-	if (b && b->on_resize)
-		b->on_resize (width, height);
-}
+static qboolean VK_Init (void) { return false; }
+static void VK_Shutdown (void) {}
+static void VK_OnResize (int width, int height) { (void)width; (void)height; }
 
 static qboolean VK_CanActivate (qboolean runtime_switch)
 {
 	(void)runtime_switch;
-	return VK_Source () != NULL;
+	return false;
 }
 
-static void VK_BeginFrame (void) { const IRenderBackend *b = VK_Source (); if (b && b->begin_frame) b->begin_frame (); }
-static void VK_EndFrame (void) { const IRenderBackend *b = VK_Source (); if (b && b->end_frame) b->end_frame (); }
-static void VK_Present (void) { const IRenderBackend *b = VK_Source (); if (b && b->present) b->present (); }
-static void VK_BeginPassEx (const RenderBackendPassDesc *pass_desc) { const IRenderBackend *b = VK_Source (); if (b && b->begin_pass_ex) b->begin_pass_ex (pass_desc); }
-static void VK_EndPassEx (void) { const IRenderBackend *b = VK_Source (); if (b && b->end_pass_ex) b->end_pass_ex (); }
-static void VK_ResourceBarrier (const RenderGraphResourceHandle *resources, const RenderBackendResourceBarrier *barriers, unsigned count) { const IRenderBackend *b = VK_Source (); if (b && b->resource_barrier) b->resource_barrier (resources, barriers, count); }
-static void VK_BindPipeline (const RenderBackendPipelineDesc *pipeline) { const IRenderBackend *b = VK_Source (); if (b && b->bind_pipeline) b->bind_pipeline (pipeline); }
-static void VK_SetDynamicState (const RenderBackendDynamicState *dynamic_state) { const IRenderBackend *b = VK_Source (); if (b && b->set_dynamic_state) b->set_dynamic_state (dynamic_state); }
-static void VK_BindDescriptors (const RenderBackendDescriptorBinding *bindings, unsigned count) { const IRenderBackend *b = VK_Source (); if (b && b->bind_descriptors) b->bind_descriptors (bindings, count); }
-static void VK_PassSetupView (RenderPassContext *ctx) { const IRenderBackend *b = VK_Source (); if (b && b->pass_setup_view) b->pass_setup_view (ctx); }
-static void VK_PassShadowmaps (RenderPassContext *ctx) { const IRenderBackend *b = VK_Source (); if (b && b->pass_shadowmaps) b->pass_shadowmaps (ctx); }
-static void VK_PassRenderScene (RenderPassContext *ctx) { const IRenderBackend *b = VK_Source (); if (b && b->pass_render_scene) b->pass_render_scene (ctx); }
-static void VK_PassWarpResolve (RenderPassContext *ctx) { const IRenderBackend *b = VK_Source (); if (b && b->pass_warp_resolve) b->pass_warp_resolve (ctx); }
-static void VK_PassPostprocess (RenderPassContext *ctx) { const IRenderBackend *b = VK_Source (); if (b && b->pass_postprocess) b->pass_postprocess (ctx); }
-static void VK_PassOverlayViewmodel (RenderPassContext *ctx) { const IRenderBackend *b = VK_Source (); if (b && b->pass_overlay_viewmodel) b->pass_overlay_viewmodel (ctx); }
-static void VK_PassOverlayPolyblend (RenderPassContext *ctx) { const IRenderBackend *b = VK_Source (); if (b && b->pass_overlay_polyblend) b->pass_overlay_polyblend (ctx); }
-static void VK_BeginPass (const char *name) { const IRenderBackend *b = VK_Source (); if (b && b->begin_pass) b->begin_pass (name); }
-static void VK_EndPass (void) { const IRenderBackend *b = VK_Source (); if (b && b->end_pass) b->end_pass (); }
-static void VK_ValidatePassState (const char *pass_name, qboolean before_pass) { const IRenderBackend *b = VK_Source (); if (b && b->validate_pass_state) b->validate_pass_state (pass_name, before_pass); }
-static void VK_BeginTimer (int pass_id) { const IRenderBackend *b = VK_Source (); if (b && b->begin_timer) b->begin_timer (pass_id); }
-static void VK_EndTimer (int pass_id) { const IRenderBackend *b = VK_Source (); if (b && b->end_timer) b->end_timer (pass_id); }
-static void VK_ResolveTimers (void) { const IRenderBackend *b = VK_Source (); if (b && b->resolve_timers) b->resolve_timers (); }
-static qboolean VK_ConsumeTimerSample (int pass_id, double *out_gpu_ms) { const IRenderBackend *b = VK_Source (); return (b && b->consume_timer_sample) ? b->consume_timer_sample (pass_id, out_gpu_ms) : false; }
-static const RenderBackendCaps *VK_GetCaps (void) { const IRenderBackend *b = VK_Source (); return (b && b->get_caps) ? b->get_caps () : NULL; }
-static unsigned VK_ResolveResourceId (const RenderGraphResourceHandle *resources, const render_backend_resource_ref_t *resource) { const IRenderBackend *b = VK_Source (); return (b && b->resolve_resource_id) ? b->resolve_resource_id (resources, resource) : 0u; }
-static qboolean VK_IsResourceValid (const RenderGraphResourceHandle *resources, const render_backend_resource_ref_t *resource) { const IRenderBackend *b = VK_Source (); return (b && b->is_resource_valid) ? b->is_resource_valid (resources, resource) : false; }
-static void VK_BindRenderTarget (const RenderGraphResourceHandle *resources, const render_backend_resource_ref_t *resource, qboolean backbuffer) { const IRenderBackend *b = VK_Source (); if (b && b->bind_render_target) b->bind_render_target (resources, resource, backbuffer); }
-static void VK_SetViewport (int x, int y, int width, int height) { const IRenderBackend *b = VK_Source (); if (b && b->set_viewport) b->set_viewport (x, y, width, height); }
-static void VK_SetScissor (qboolean enabled, int x, int y, int width, int height) { const IRenderBackend *b = VK_Source (); if (b && b->set_scissor) b->set_scissor (enabled, x, y, width, height); }
-static void VK_SetPipelineState (unsigned state_bits) { const IRenderBackend *b = VK_Source (); if (b && b->set_pipeline_state) b->set_pipeline_state (state_bits); }
-static void VK_Draw (render_backend_primitive_t primitive, int first, int count) { const IRenderBackend *b = VK_Source (); if (b && b->draw) b->draw (primitive, first, count); }
-static void VK_DrawIndexed (render_backend_primitive_t primitive, render_backend_index_type_t index_type, int count, intptr_t index_offset_bytes) { const IRenderBackend *b = VK_Source (); if (b && b->draw_indexed) b->draw_indexed (primitive, index_type, count, index_offset_bytes); }
-static void VK_DrawInstanced (render_backend_primitive_t primitive, int first, int count, int instance_count) { const IRenderBackend *b = VK_Source (); if (b && b->draw_instanced) b->draw_instanced (primitive, first, count, instance_count); }
-static void VK_DrawIndexedInstanced (render_backend_primitive_t primitive, render_backend_index_type_t index_type, int count, intptr_t index_offset_bytes, int instance_count) { const IRenderBackend *b = VK_Source (); if (b && b->draw_indexed_instanced) b->draw_indexed_instanced (primitive, index_type, count, index_offset_bytes, instance_count); }
-static void VK_DrawIndexedIndirect (render_backend_primitive_t primitive, render_backend_index_type_t index_type, intptr_t indirect_offset_bytes) { const IRenderBackend *b = VK_Source (); if (b && b->draw_indexed_indirect) b->draw_indexed_indirect (primitive, index_type, indirect_offset_bytes); }
-static void VK_MultiDrawIndexedIndirect (render_backend_primitive_t primitive, render_backend_index_type_t index_type, intptr_t indirect_offset_bytes, int draw_count, int stride_bytes) { const IRenderBackend *b = VK_Source (); if (b && b->multi_draw_indexed_indirect) b->multi_draw_indexed_indirect (primitive, index_type, indirect_offset_bytes, draw_count, stride_bytes); }
-static void VK_Dispatch (unsigned group_x, unsigned group_y, unsigned group_z) { const IRenderBackend *b = VK_Source (); if (b && b->dispatch) b->dispatch (group_x, group_y, group_z); }
-static void VK_MemoryBarrier (unsigned barrier_bits) { const IRenderBackend *b = VK_Source (); if (b && b->memory_barrier) b->memory_barrier (barrier_bits); }
-static void VK_SetBlendFactors (render_blend_factor_t src, render_blend_factor_t dst) { const IRenderBackend *b = VK_Source (); if (b && b->set_blend_factors) b->set_blend_factors (src, dst); }
-static void VK_SetDepthFunc (render_backend_depth_func_t depth_func) { const IRenderBackend *b = VK_Source (); if (b && b->set_depth_func) b->set_depth_func (depth_func); }
-static unsigned VK_CreatePostFXLUTTexture (void) { const IRenderBackend *b = VK_Source (); return (b && b->create_postfx_lut_texture) ? b->create_postfx_lut_texture () : 0u; }
-static void VK_ConfigurePostFXLUTTexture (unsigned texture_id) { const IRenderBackend *b = VK_Source (); if (b && b->configure_postfx_lut_texture) b->configure_postfx_lut_texture (texture_id); }
-static void VK_Finish (void) { const IRenderBackend *b = VK_Source (); if (b && b->finish) b->finish (); }
-static void VK_PopulateFramegraphResources (RenderGraphResourceHandle *out_handles) { const IRenderBackend *b = VK_Source (); if (b && b->populate_framegraph_resources) b->populate_framegraph_resources (out_handles); }
-static int VK_GetSceneSampleCount (void) { const IRenderBackend *b = VK_Source (); return (b && b->get_scene_sample_count) ? b->get_scene_sample_count () : 1; }
+static void VK_BeginFrame (void) {}
+static void VK_EndFrame (void) {}
+static void VK_Present (void) {}
+static void VK_BeginPassEx (const RenderBackendPassDesc *pass_desc) { (void)pass_desc; }
+static void VK_EndPassEx (void) {}
+static void VK_ResourceBarrier (const RenderGraphResourceHandle *resources, const RenderBackendResourceBarrier *barriers, unsigned count) { (void)resources; (void)barriers; (void)count; }
+static void VK_BindPipeline (const RenderBackendPipelineDesc *pipeline) { (void)pipeline; }
+static void VK_SetDynamicState (const RenderBackendDynamicState *dynamic_state) { (void)dynamic_state; }
+static void VK_BindDescriptors (const RenderBackendDescriptorBinding *bindings, unsigned count) { (void)bindings; (void)count; }
+static void VK_PassSetupView (RenderPassContext *ctx) { (void)ctx; }
+static void VK_PassShadowmaps (RenderPassContext *ctx) { (void)ctx; }
+static void VK_PassRenderScene (RenderPassContext *ctx) { (void)ctx; }
+static void VK_PassWarpResolve (RenderPassContext *ctx) { (void)ctx; }
+static void VK_PassPostprocess (RenderPassContext *ctx) { (void)ctx; }
+static void VK_PassOverlayViewmodel (RenderPassContext *ctx) { (void)ctx; }
+static void VK_PassOverlayPolyblend (RenderPassContext *ctx) { (void)ctx; }
+static void VK_BeginPass (const char *name) { (void)name; }
+static void VK_EndPass (void) {}
+static void VK_ValidatePassState (const char *pass_name, qboolean before_pass) { (void)pass_name; (void)before_pass; }
+static void VK_BeginTimer (int pass_id) { (void)pass_id; }
+static void VK_EndTimer (int pass_id) { (void)pass_id; }
+static void VK_ResolveTimers (void) {}
+static qboolean VK_ConsumeTimerSample (int pass_id, double *out_gpu_ms) { (void)pass_id; (void)out_gpu_ms; return false; }
+static const RenderBackendCaps *VK_GetCaps (void) { return &s_vk_caps; }
+static unsigned VK_ResolveResourceId (const RenderGraphResourceHandle *resources, const render_backend_resource_ref_t *resource) { (void)resources; (void)resource; return 0u; }
+static qboolean VK_IsResourceValid (const RenderGraphResourceHandle *resources, const render_backend_resource_ref_t *resource) { (void)resources; (void)resource; return false; }
+static void VK_BindRenderTarget (const RenderGraphResourceHandle *resources, const render_backend_resource_ref_t *resource, qboolean backbuffer) { (void)resources; (void)resource; (void)backbuffer; }
+static void VK_SetViewport (int x, int y, int width, int height) { (void)x; (void)y; (void)width; (void)height; }
+static void VK_SetScissor (qboolean enabled, int x, int y, int width, int height) { (void)enabled; (void)x; (void)y; (void)width; (void)height; }
+static void VK_SetPipelineState (unsigned state_bits) { (void)state_bits; }
+static void VK_Draw (render_backend_primitive_t primitive, int first, int count) { (void)primitive; (void)first; (void)count; }
+static void VK_DrawIndexed (render_backend_primitive_t primitive, render_backend_index_type_t index_type, int count, intptr_t index_offset_bytes) { (void)primitive; (void)index_type; (void)count; (void)index_offset_bytes; }
+static void VK_DrawInstanced (render_backend_primitive_t primitive, int first, int count, int instance_count) { (void)primitive; (void)first; (void)count; (void)instance_count; }
+static void VK_DrawIndexedInstanced (render_backend_primitive_t primitive, render_backend_index_type_t index_type, int count, intptr_t index_offset_bytes, int instance_count) { (void)primitive; (void)index_type; (void)count; (void)index_offset_bytes; (void)instance_count; }
+static void VK_DrawIndexedIndirect (render_backend_primitive_t primitive, render_backend_index_type_t index_type, intptr_t indirect_offset_bytes) { (void)primitive; (void)index_type; (void)indirect_offset_bytes; }
+static void VK_MultiDrawIndexedIndirect (render_backend_primitive_t primitive, render_backend_index_type_t index_type, intptr_t indirect_offset_bytes, int draw_count, int stride_bytes) { (void)primitive; (void)index_type; (void)indirect_offset_bytes; (void)draw_count; (void)stride_bytes; }
+static void VK_Dispatch (unsigned group_x, unsigned group_y, unsigned group_z) { (void)group_x; (void)group_y; (void)group_z; }
+static void VK_MemoryBarrier (unsigned barrier_bits) { (void)barrier_bits; }
+static void VK_SetBlendFactors (render_blend_factor_t src, render_blend_factor_t dst) { (void)src; (void)dst; }
+static void VK_SetDepthFunc (render_backend_depth_func_t depth_func) { (void)depth_func; }
+static unsigned VK_CreatePostFXLUTTexture (void) { return 0u; }
+static void VK_ConfigurePostFXLUTTexture (unsigned texture_id) { (void)texture_id; }
+static void VK_Finish (void) {}
+static void VK_PopulateFramegraphResources (RenderGraphResourceHandle *out_handles) { if (out_handles) memset (out_handles, 0, sizeof (*out_handles)); }
+static int VK_GetSceneSampleCount (void) { return 1; }
 
 static const IRenderBackend s_ref_vk_backend = {
 	"Vulkan",
@@ -138,10 +131,9 @@ static qboolean IW_RendererRefVK_Register (const iw_renderer_plugin_host_api_t *
 {
 	if (!host_api || host_api->struct_size < IW_RENDERER_PLUGIN_HOST_API_V2_SIZE)
 		return false;
-	if (!host_api->register_backend || !host_api->builtin_opengl_backend)
+	if (!host_api->register_backend)
 		return false;
 
-	s_vk_source = host_api->builtin_opengl_backend;
 	return host_api->register_backend (&s_ref_vk_backend);
 }
 


### PR DESCRIPTION
### Motivation
- Prevent selecting `r_backend_api vk` or `dx12` from accidentally routing into OpenGL codepaths by decoupling the plugin wrappers from the host `builtin_opengl_backend` fallback. 
- Provide minimal, safe placeholder backends that explicitly block activation until native implementations are available.

### Description
- Converted `ref_vk` and `ref_dx12` to independent placeholder backends by removing assignment/use of `host_api->builtin_opengl_backend` and no longer forwarding into the GL backend.
- Implemented explicit not-implemented behavior: `init` returns `false`, `can_activate` returns `false`, `get_caps` returns a backend-local `RenderBackendCaps` with legacy fallbacks disabled, and `populate_framegraph_resources` zeroes the output safely; all other callbacks are safe no-ops.
- Updated registration checks so `IW_RendererRef*_Register` only requires `host_api->register_backend` (no GL backend dependency), and updated `r_backend` status messaging in `Quake/r_backend.c` to describe these plugins as independent placeholders (removed the warning path that assumed GL forwarding).

### Testing
- Ran `git diff --check` to validate whitespace/patch issues and it succeeded.
- Committed changes successfully (`git commit`), and verified files updated (`git status` / repository checks).
- Attempted the Windows smoke-launch command via `powershell.exe` but it could not run in this Linux container (`powershell.exe: command not found`), so no runtime smoke test was executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da234dcd6c832ebf296d694071d3b5)