### PR TITLE
Add backend callbacks for surface metrics and scene/postprocess predicates

### DIFF
--- a/Quake/gl_backend.c
+++ b/Quake/gl_backend.c
@@ -123,6 +123,35 @@ static int GLBackend_GetSceneSampleCount (void)
 	return framebufs.scene.samples;
 }
 
+static qboolean GLBackend_QuerySurfaceMetrics (RenderBackendSurfaceMetrics *out_metrics)
+{
+	if (!out_metrics)
+		return false;
+
+	memset (out_metrics, 0, sizeof (*out_metrics));
+	out_metrics->surface_x = glx;
+	out_metrics->surface_y = gly;
+	out_metrics->surface_width = (glwidth > 0) ? glwidth : q_max (1, vid.width);
+	out_metrics->surface_height = (glheight > 0) ? glheight : q_max (1, vid.height);
+	out_metrics->view_x = out_metrics->surface_x + r_refdef.vrect.x;
+	out_metrics->view_y = out_metrics->surface_y + out_metrics->surface_height - r_refdef.vrect.y - r_refdef.vrect.height;
+	out_metrics->view_width = q_max (1, r_refdef.vrect.width);
+	out_metrics->view_height = q_max (1, r_refdef.vrect.height);
+	out_metrics->scene_width = q_max (1, R_GetSceneRenderWidth ());
+	out_metrics->scene_height = q_max (1, R_GetSceneRenderHeight ());
+	return true;
+}
+
+static qboolean GLBackend_NeedsSceneEffects (void)
+{
+	return GL_NeedsSceneEffects ();
+}
+
+static qboolean GLBackend_NeedsPostprocess (void)
+{
+	return GL_NeedsPostprocess ();
+}
+
 static qboolean GLBackend_HasTimestampQueries (void)
 {
 	return (GL_GenQueriesFunc && GL_DeleteQueriesFunc
@@ -896,6 +925,9 @@ static const IRenderBackend s_gl_backend = {
 	GLBackend_CreatePostFXLUTTexture,
 	GLBackend_ConfigurePostFXLUTTexture,
 	GLBackend_Finish,
+	GLBackend_QuerySurfaceMetrics,
+	GLBackend_NeedsSceneEffects,
+	GLBackend_NeedsPostprocess,
 	GLBackend_PopulateFrameGraphResources,
 	GLBackend_GetSceneSampleCount
 };

--- a/Quake/r_backend.c
+++ b/Quake/r_backend.c
@@ -51,14 +51,6 @@ static qboolean s_warned_host_resource_registration_unimplemented = false;
 static qboolean s_warned_host_shader_metadata_unimplemented = false;
 static qboolean s_warned_host_pipeline_metadata_unimplemented = false;
 
-/* GL-facing globals/functions remain implemented in OpenGL files, but are
- * accessed through backend-neutral wrappers from this translation unit. */
-extern int glx, gly, glwidth, glheight;
-extern qboolean GL_NeedsSceneEffects (void);
-extern qboolean GL_NeedsPostprocess (void);
-extern int R_GetSceneRenderWidth (void);
-extern int R_GetSceneRenderHeight (void);
-
 static qboolean R_Backend_Host_GetSurfaceInfo (iw_renderer_host_surface_info_t *out_info);
 static qboolean R_Backend_Host_ResolveResourceBySlot (render_backend_resource_slot_t slot, iw_renderer_host_resource_handle_t *out_handle);
 static qboolean R_Backend_Host_ResolveResourceByRef (const render_backend_resource_ref_t *ref, iw_renderer_host_resource_handle_t *out_handle);
@@ -251,24 +243,49 @@ static qboolean R_Backend_FillHostResourceHandleFromRef (const RenderGraphResour
 
 void R_Backend_QuerySurfaceInfo (RenderBackendSurfaceInfo *out_info)
 {
+	const IRenderBackend *backend = R_GetRenderBackend ();
+	RenderBackendSurfaceMetrics metrics;
+	qboolean has_metrics = false;
+
 	if (!out_info)
 		return;
 
 	memset (out_info, 0, sizeof (*out_info));
-	out_info->surface_x = glx;
-	out_info->surface_y = gly;
-	out_info->surface_width = (glwidth > 0) ? glwidth : q_max (1, vid.width);
-	out_info->surface_height = (glheight > 0) ? glheight : q_max (1, vid.height);
-	out_info->view_x = out_info->surface_x + r_refdef.vrect.x;
-	out_info->view_y = out_info->surface_y + out_info->surface_height - r_refdef.vrect.y - r_refdef.vrect.height;
-	out_info->view_width = q_max (1, r_refdef.vrect.width);
-	out_info->view_height = q_max (1, r_refdef.vrect.height);
-	out_info->scene_width = q_max (1, R_GetSceneRenderWidth ());
-	out_info->scene_height = q_max (1, R_GetSceneRenderHeight ());
+	memset (&metrics, 0, sizeof (metrics));
+	if (backend && backend->query_surface_metrics)
+		has_metrics = backend->query_surface_metrics (&metrics);
+
+	if (has_metrics)
+	{
+		out_info->surface_x = metrics.surface_x;
+		out_info->surface_y = metrics.surface_y;
+		out_info->surface_width = q_max (1, metrics.surface_width);
+		out_info->surface_height = q_max (1, metrics.surface_height);
+		out_info->view_x = metrics.view_x;
+		out_info->view_y = metrics.view_y;
+		out_info->view_width = q_max (1, metrics.view_width);
+		out_info->view_height = q_max (1, metrics.view_height);
+		out_info->scene_width = q_max (1, metrics.scene_width);
+		out_info->scene_height = q_max (1, metrics.scene_height);
+	}
+	else
+	{
+		out_info->surface_x = 0;
+		out_info->surface_y = 0;
+		out_info->surface_width = q_max (1, vid.width);
+		out_info->surface_height = q_max (1, vid.height);
+		out_info->view_x = out_info->surface_x + r_refdef.vrect.x;
+		out_info->view_y = out_info->surface_y + out_info->surface_height - r_refdef.vrect.y - r_refdef.vrect.height;
+		out_info->view_width = q_max (1, r_refdef.vrect.width);
+		out_info->view_height = q_max (1, r_refdef.vrect.height);
+		out_info->scene_width = out_info->view_width;
+		out_info->scene_height = out_info->view_height;
+	}
+
 	out_info->scene_samples = (unsigned)q_max (1, R_Backend_GetSceneSampleCount ());
 	out_info->frame_index = (unsigned)q_max (0, r_framecount);
-	out_info->needs_scene_effects = GL_NeedsSceneEffects ();
-	out_info->needs_postprocess = GL_NeedsPostprocess ();
+	out_info->needs_scene_effects = (backend && backend->needs_scene_effects) ? backend->needs_scene_effects () : false;
+	out_info->needs_postprocess = (backend && backend->needs_postprocess) ? backend->needs_postprocess () : false;
 }
 
 static void R_Backend_ValidateFrameGraphResourceRegistry (const RenderGraphResourceHandle *resources)
@@ -988,6 +1005,9 @@ static void R_VulkanStub_SetDepthFunc (render_backend_depth_func_t depth_func) {
 static unsigned R_VulkanStub_CreatePostFXLUTTexture (void) { return 0u; }
 static void R_VulkanStub_ConfigurePostFXLUTTexture (unsigned texture_id) { (void)texture_id; }
 static void R_VulkanStub_Finish (void) {}
+static qboolean R_VulkanStub_QuerySurfaceMetrics (RenderBackendSurfaceMetrics *out_metrics) { (void)out_metrics; return false; }
+static qboolean R_VulkanStub_NeedsSceneEffects (void) { return false; }
+static qboolean R_VulkanStub_NeedsPostprocess (void) { return false; }
 static void R_VulkanStub_PopulateFrameGraphResources (RenderGraphResourceHandle *out_handles) { (void)out_handles; }
 static int R_VulkanStub_GetSceneSampleCount (void) { return 1; }
 
@@ -1041,6 +1061,9 @@ static const IRenderBackend s_vulkan_stub_backend = {
 	R_VulkanStub_CreatePostFXLUTTexture,
 	R_VulkanStub_ConfigurePostFXLUTTexture,
 	R_VulkanStub_Finish,
+	R_VulkanStub_QuerySurfaceMetrics,
+	R_VulkanStub_NeedsSceneEffects,
+	R_VulkanStub_NeedsPostprocess,
 	R_VulkanStub_PopulateFrameGraphResources,
 	R_VulkanStub_GetSceneSampleCount
 };
@@ -1130,6 +1153,9 @@ static const IRenderBackend s_dx12_stub_backend = {
 	R_VulkanStub_CreatePostFXLUTTexture,
 	R_VulkanStub_ConfigurePostFXLUTTexture,
 	R_VulkanStub_Finish,
+	R_VulkanStub_QuerySurfaceMetrics,
+	R_VulkanStub_NeedsSceneEffects,
+	R_VulkanStub_NeedsPostprocess,
 	R_VulkanStub_PopulateFrameGraphResources,
 	R_VulkanStub_GetSceneSampleCount
 };

--- a/Quake/ref_dx12_plugin.c
+++ b/Quake/ref_dx12_plugin.c
@@ -71,6 +71,9 @@ static void DX12_SetDepthFunc (render_backend_depth_func_t depth_func) { (void)d
 static unsigned DX12_CreatePostFXLUTTexture (void) { return 0u; }
 static void DX12_ConfigurePostFXLUTTexture (unsigned texture_id) { (void)texture_id; }
 static void DX12_Finish (void) {}
+static qboolean DX12_QuerySurfaceMetrics (RenderBackendSurfaceMetrics *out_metrics) { (void)out_metrics; return false; }
+static qboolean DX12_NeedsSceneEffects (void) { return false; }
+static qboolean DX12_NeedsPostprocess (void) { return false; }
 static void DX12_PopulateFramegraphResources (RenderGraphResourceHandle *out_handles) { if (out_handles) memset (out_handles, 0, sizeof (*out_handles)); }
 static int DX12_GetSceneSampleCount (void) { return 1; }
 
@@ -124,6 +127,9 @@ static const IRenderBackend s_ref_dx12_backend = {
 	DX12_CreatePostFXLUTTexture,
 	DX12_ConfigurePostFXLUTTexture,
 	DX12_Finish,
+	DX12_QuerySurfaceMetrics,
+	DX12_NeedsSceneEffects,
+	DX12_NeedsPostprocess,
 	DX12_PopulateFramegraphResources,
 	DX12_GetSceneSampleCount
 };

--- a/Quake/ref_gl_plugin.c
+++ b/Quake/ref_gl_plugin.c
@@ -79,6 +79,9 @@ static void REFGL_SetDepthFunc (render_backend_depth_func_t depth_func) { const 
 static unsigned REFGL_CreatePostFXLUTTexture (void) { const IRenderBackend *b = REFGL_Source (); return (b && b->create_postfx_lut_texture) ? b->create_postfx_lut_texture () : 0u; }
 static void REFGL_ConfigurePostFXLUTTexture (unsigned texture_id) { const IRenderBackend *b = REFGL_Source (); if (b && b->configure_postfx_lut_texture) b->configure_postfx_lut_texture (texture_id); }
 static void REFGL_Finish (void) { const IRenderBackend *b = REFGL_Source (); if (b && b->finish) b->finish (); }
+static qboolean REFGL_QuerySurfaceMetrics (RenderBackendSurfaceMetrics *out_metrics) { const IRenderBackend *b = REFGL_Source (); return (b && b->query_surface_metrics) ? b->query_surface_metrics (out_metrics) : false; }
+static qboolean REFGL_NeedsSceneEffects (void) { const IRenderBackend *b = REFGL_Source (); return (b && b->needs_scene_effects) ? b->needs_scene_effects () : false; }
+static qboolean REFGL_NeedsPostprocess (void) { const IRenderBackend *b = REFGL_Source (); return (b && b->needs_postprocess) ? b->needs_postprocess () : false; }
 static void REFGL_PopulateFramegraphResources (RenderGraphResourceHandle *out_handles) { const IRenderBackend *b = REFGL_Source (); if (b && b->populate_framegraph_resources) b->populate_framegraph_resources (out_handles); }
 static int REFGL_GetSceneSampleCount (void) { const IRenderBackend *b = REFGL_Source (); return (b && b->get_scene_sample_count) ? b->get_scene_sample_count () : 1; }
 
@@ -132,6 +135,9 @@ static const IRenderBackend s_ref_gl_backend = {
 	REFGL_CreatePostFXLUTTexture,
 	REFGL_ConfigurePostFXLUTTexture,
 	REFGL_Finish,
+	REFGL_QuerySurfaceMetrics,
+	REFGL_NeedsSceneEffects,
+	REFGL_NeedsPostprocess,
 	REFGL_PopulateFramegraphResources,
 	REFGL_GetSceneSampleCount
 };

--- a/Quake/ref_vk_plugin.c
+++ b/Quake/ref_vk_plugin.c
@@ -71,6 +71,9 @@ static void VK_SetDepthFunc (render_backend_depth_func_t depth_func) { (void)dep
 static unsigned VK_CreatePostFXLUTTexture (void) { return 0u; }
 static void VK_ConfigurePostFXLUTTexture (unsigned texture_id) { (void)texture_id; }
 static void VK_Finish (void) {}
+static qboolean VK_QuerySurfaceMetrics (RenderBackendSurfaceMetrics *out_metrics) { (void)out_metrics; return false; }
+static qboolean VK_NeedsSceneEffects (void) { return false; }
+static qboolean VK_NeedsPostprocess (void) { return false; }
 static void VK_PopulateFramegraphResources (RenderGraphResourceHandle *out_handles) { if (out_handles) memset (out_handles, 0, sizeof (*out_handles)); }
 static int VK_GetSceneSampleCount (void) { return 1; }
 
@@ -124,6 +127,9 @@ static const IRenderBackend s_ref_vk_backend = {
 	VK_CreatePostFXLUTTexture,
 	VK_ConfigurePostFXLUTTexture,
 	VK_Finish,
+	VK_QuerySurfaceMetrics,
+	VK_NeedsSceneEffects,
+	VK_NeedsPostprocess,
 	VK_PopulateFramegraphResources,
 	VK_GetSceneSampleCount
 };

--- a/Quake/render_api.h
+++ b/Quake/render_api.h
@@ -239,6 +239,20 @@ typedef struct render_backend_draw_packet_s
 	unsigned flags;
 } RenderBackendDrawPacket;
 
+typedef struct render_backend_surface_metrics_s
+{
+	int surface_x;
+	int surface_y;
+	int surface_width;
+	int surface_height;
+	int view_x;
+	int view_y;
+	int view_width;
+	int view_height;
+	int scene_width;
+	int scene_height;
+} RenderBackendSurfaceMetrics;
+
 typedef struct render_pass_context_s RenderPassContext;
 
 typedef struct i_render_backend_s
@@ -292,6 +306,9 @@ typedef struct i_render_backend_s
 	unsigned (*create_postfx_lut_texture)(void);
 	void (*configure_postfx_lut_texture)(unsigned texture_id);
 	void (*finish)(void);
+	qboolean (*query_surface_metrics)(RenderBackendSurfaceMetrics *out_metrics);
+	qboolean (*needs_scene_effects)(void);
+	qboolean (*needs_postprocess)(void);
 	void (*populate_framegraph_resources)(RenderGraphResourceHandle *out_handles);
 	int (*get_scene_sample_count)(void);
 } IRenderBackend;


### PR DESCRIPTION
### Motivation
- Decouple `r_backend.c` from direct OpenGL globals/functions by letting the active backend provide surface/view/scene metrics and effect need predicates via the backend interface.
- Allow non-GL backends (Vulkan/DX12 or plugin-supplied) to supply the same window/view/scene sizing and postprocess decisions so framegraph planning and host-plugin surface queries become backend-neutral.

### Description
- Added `RenderBackendSurfaceMetrics` and three new `IRenderBackend` callbacks: `query_surface_metrics`, `needs_scene_effects`, and `needs_postprocess` in `Quake/render_api.h`.
- Implemented the callbacks in the OpenGL backend (`Quake/gl_backend.c`) with `GLBackend_QuerySurfaceMetrics`, `GLBackend_NeedsSceneEffects`, and `GLBackend_NeedsPostprocess`, and wired them into the GL backend vtable.
- Updated `R_Backend_QuerySurfaceInfo` in `Quake/r_backend.c` to call the active backend's `query_surface_metrics` and `needs_*` callbacks, and added a safe backend-neutral fallback when callbacks are absent.
- Added forwarding wrappers in `Quake/ref_gl_plugin.c` so plugin-hosted GL backends forward the new callbacks.
- Added no-op implementations for the new callbacks in the Vulkan/DX12 plugin placeholders and the stub backends to keep the interface compile-safe across backends.

### Testing
- Attempted a full build with `cmake -S . -B build && cmake --build build -j2`, which failed in this environment due to a missing SDL2 CMake package (environment dependency), so no successful binary build was produced.
- Quick repository checks (search/grep) and local compilation gating edits were exercised during the change to ensure symbol usage was updated (no automated unit tests were run in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da2683fdcc832ea5b4e15c5d06db4b)