### PR TITLE
GL backend: implement descriptor & dynamic-state binding and migrate sprite pass

### DIFF
--- a/Quake/gl_backend.c
+++ b/Quake/gl_backend.c
@@ -588,14 +588,23 @@ static void GLBackend_BindPipeline (const RenderBackendPipelineDesc *pipeline)
 {
 	if (!pipeline)
 		return;
+	if (pipeline->pipeline_id != 0u)
+		GL_UseProgram ((GLuint)pipeline->pipeline_id);
 	GLBackend_SetPipelineState (pipeline->state_bits);
 }
 
 static void GLBackend_SetDynamicState (const RenderBackendDynamicState *dynamic_state)
 {
-	/* GL backend still uses legacy packed state bits. Keep dynamic-state path
-	 * available for callsite migration while preserving current behavior. */
-	(void)dynamic_state;
+	unsigned state_bits;
+
+	if (!dynamic_state)
+		return;
+
+	state_bits = 0u;
+	state_bits |= dynamic_state->blend_state & GLS_MASK_BLEND;
+	state_bits |= dynamic_state->depth_state & (GLS_NO_ZTEST | GLS_NO_ZWRITE);
+	state_bits |= dynamic_state->raster_state & (GLS_MASK_CULL | GLS_MASK_ATTRIBS | GLS_MASK_INSTANCED_ATTRIBS);
+	GLBackend_SetPipelineState (state_bits);
 }
 
 static void GLBackend_BindDescriptors (const RenderBackendDescriptorBinding *bindings, unsigned count)
@@ -620,7 +629,12 @@ static void GLBackend_BindDescriptors (const RenderBackendDescriptorBinding *bin
 				Con_DWarning ("GL descriptor bind out of range: type=%u slot=%u max_textures=%u\n",
 					(unsigned)binding->type, binding->slot, max_textures);
 				SDL_assert (!"GL descriptor texture/sampler slot out of range");
+				break;
 			}
+			if (binding->type == R_BACKEND_DESCRIPTOR_TEXTURE)
+				GL_BindNative (GL_TEXTURE0 + binding->slot, GL_TEXTURE_2D, (GLuint)binding->resource_id);
+			else if (GL_BindSamplerFunc)
+				GL_BindSamplerFunc (binding->slot, (GLuint)binding->resource_id);
 			break;
 		case R_BACKEND_DESCRIPTOR_UNIFORM_BUFFER:
 			if (max_ubos > 0u && binding->slot >= max_ubos)
@@ -629,6 +643,14 @@ static void GLBackend_BindDescriptors (const RenderBackendDescriptorBinding *bin
 					binding->slot, max_ubos);
 				SDL_assert (!"GL descriptor UBO slot out of range");
 			}
+			if (binding->range == 0u)
+			{
+				Con_DWarning ("GL descriptor UBO binding requires range > 0 (slot=%u resource=%u)\n",
+					binding->slot, binding->resource_id);
+				SDL_assert (!"GL descriptor UBO binding missing range");
+				break;
+			}
+			GL_BindBufferRange (GL_UNIFORM_BUFFER, binding->slot, (GLuint)binding->resource_id, (GLintptr)binding->offset, (GLsizeiptr)binding->range);
 			break;
 		case R_BACKEND_DESCRIPTOR_STORAGE_BUFFER:
 			if (max_ssbos > 0u && binding->slot >= max_ssbos)
@@ -637,6 +659,14 @@ static void GLBackend_BindDescriptors (const RenderBackendDescriptorBinding *bin
 					binding->slot, max_ssbos);
 				SDL_assert (!"GL descriptor SSBO slot out of range");
 			}
+			if (binding->range == 0u)
+			{
+				Con_DWarning ("GL descriptor SSBO binding requires range > 0 (slot=%u resource=%u)\n",
+					binding->slot, binding->resource_id);
+				SDL_assert (!"GL descriptor SSBO binding missing range");
+				break;
+			}
+			GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, binding->slot, (GLuint)binding->resource_id, (GLintptr)binding->offset, (GLsizeiptr)binding->range);
 			break;
 		default:
 			Con_DWarning ("GL descriptor bind has unknown descriptor type=%u (slot=%u)\n",

--- a/Quake/r_sprite.c
+++ b/Quake/r_sprite.c
@@ -154,25 +154,30 @@ static void R_FlushSpriteInstances (void)
 		GL_PolygonOffset (OFFSET_DECAL);
 
 	dither = (softemu == SOFTEMU_COARSE && !showtris);
-	GL_UseProgram (glprogs.sprites[dither]);
 
 	{
 		const unsigned state = showtris
 			? (GLS_BLEND_OPAQUE | GLS_NO_ZWRITE | GLS_CULL_BACK | GLS_ATTRIBS(2))
 			: (GLS_BLEND_OPAQUE | GLS_CULL_BACK | GLS_ATTRIBS(2));
+		RenderBackendDescriptorBinding descriptor;
 		RenderBackendPipelineDesc pipeline_desc;
 		RenderBackendDynamicState dynamic_state;
+		const gltexture_t *draw_texture = showtris ? whitetexture : batchtexture;
 		memset (&pipeline_desc, 0, sizeof (pipeline_desc));
 		memset (&dynamic_state, 0, sizeof (dynamic_state));
+		memset (&descriptor, 0, sizeof (descriptor));
+		pipeline_desc.pipeline_id = glprogs.sprites[dither];
 		pipeline_desc.state_bits = state;
 		dynamic_state.blend_state = state;
 		dynamic_state.depth_state = state;
 		dynamic_state.raster_state = state;
+		descriptor.type = R_BACKEND_DESCRIPTOR_TEXTURE;
+		descriptor.slot = 0u;
+		descriptor.resource_id = draw_texture->texnum;
 		R_Backend_BindPipeline (&pipeline_desc);
 		R_Backend_SetDynamicState (&dynamic_state);
+		R_Backend_BindDescriptors (&descriptor, 1u);
 	}
-
-	GL_Bind (GL_TEXTURE0, showtris ? whitetexture : batchtexture);
 
 	GL_Upload (GL_ARRAY_BUFFER, batchverts, sizeof(batchverts[0]) * 4 * numbatchquads, &buf, &ofs);
 	GL_BindBuffer (GL_ARRAY_BUFFER, buf);


### PR DESCRIPTION
### Motivation

- Move GL backend toward the backend-neutral pipeline/descriptor/dynamic-state API by implementing actual descriptor binding and translating dynamic state into the existing legacy GL state path. 
- Provide a concrete migration example by converting one rendering pass (sprites) from direct GL calls to the new backend APIs as a template for other passes.

### Description

- Wire `pipeline_id` into `GLBackend_BindPipeline` so program objects in `RenderBackendPipelineDesc` are bound via `GL_UseProgram` before applying state bits. 
- Implement `GLBackend_SetDynamicState` to translate `RenderBackendDynamicState` fields (`blend_state`, `depth_state`, `raster_state`) into legacy `GLS_*` state bits and apply them via `GLBackend_SetPipelineState`. 
- Implement `GLBackend_BindDescriptors` to perform real bindings: textures via `GL_BindNative`, samplers via `GL_BindSamplerFunc` (when available), and UBO/SSBO ranges via `GL_BindBufferRange`, with range validation and diagnostic warnings/asserts for invalid bindings. 
- Migrate the sprite pass (`R_FlushSpriteInstances` in `r_sprite.c`) to use `R_Backend_BindPipeline`, `R_Backend_SetDynamicState`, `R_Backend_BindDescriptors`, and existing `R_Backend_DrawIndexed` instead of direct `GL_UseProgram`/`GL_Bind`, providing a template for further pass migrations.

### Testing

- Ran `python3 python/check_no_raw_gl_calls.py`, which passed. 
- Ran `python3 python/check_no_legacy_pipeline_state_calls.py`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da297bd718832ea2c9c4232cf9eb8d)