### PR TITLE
Backend resource registry for GL handles with explicit lifetime domains

### DIFF
--- a/Quake/gl_backend.c
+++ b/Quake/gl_backend.c
@@ -20,7 +20,8 @@
 
 enum
 {
-	GL_BACKEND_TIMER_QUERY_RING = 3
+	GL_BACKEND_TIMER_QUERY_RING = 3,
+	GL_BACKEND_MAX_RESOURCES = 128
 };
 
 typedef struct gl_backend_timer_slot_s
@@ -44,6 +45,20 @@ static gl_backend_timer_pass_t s_timer_passes[R_BACKEND_MAX_PROFILE_SLOTS];
 static RenderBackendCaps s_gl_backend_caps;
 static int s_legacy_pass_resource_fallback_frame = -1;
 static gl_proc_address_loader_t s_gl_proc_loader = NULL;
+static struct gl_backend_resource_table_s
+{
+	struct gl_backend_resource_entry_s
+	{
+		unsigned short opaque_id;
+		unsigned native_id;
+		unsigned char type;
+		unsigned char lifetime;
+		unsigned short slot;
+		unsigned short key;
+	} entries[GL_BACKEND_MAX_RESOURCES];
+	unsigned short next_opaque_id;
+	unsigned short count;
+} s_gl_resources;
 
 void GL_Backend_SetProcAddressLoader (gl_proc_address_loader_t loader)
 {
@@ -57,65 +72,162 @@ void *GL_Backend_GetProcAddress (const char *name)
 	return s_gl_proc_loader (name);
 }
 
-static unsigned short GLBackend_RegisterResource (RenderGraphResourceHandle *handles, render_backend_resource_type_t type, render_backend_resource_slot_t slot, render_backend_resource_lifetime_t lifetime, unsigned native_id)
-{
-	unsigned index;
-	unsigned short resource_id;
+static unsigned GLBackend_ResolveResourceOpaqueId (const RenderGraphResourceHandle *resources, unsigned short opaque_id);
 
-	if (!handles || type == R_BACKEND_RESOURCE_NONE || slot <= R_BACKEND_RESOURCE_SLOT_NONE || slot >= R_BACKEND_RESOURCE_SLOT_COUNT)
-		return 0u;
-	if (handles->registry_count >= (unsigned char)Q_COUNTOF (handles->registry))
-		return 0u;
-
-	index = (unsigned)handles->registry_count;
-	resource_id = (unsigned short)(index + 1u);
-	handles->registry[index].resource_id = resource_id;
-	handles->registry[index].native_id = native_id;
-	handles->registry[index].type = (unsigned char)type;
-	handles->registry[index].lifetime = (unsigned char)lifetime;
-	handles->registry[index].slot = (unsigned short)slot;
-	handles->registry_count++;
-
-	handles->slot_resource_ids[slot] = resource_id;
-	handles->refs[slot].type = (unsigned char)type;
-	handles->refs[slot].slot = (unsigned short)slot; /* Compatibility path while slot enums are still in use. */
-	handles->refs[slot].opaque_id = resource_id;
-	return resource_id;
-}
-
-static unsigned GLBackend_ResolveResourceOpaqueId (const RenderGraphResourceHandle *resources, unsigned short opaque_id)
+static int GLBackend_FindResourceIndexBySlot (render_backend_resource_slot_t slot)
 {
 	unsigned i;
 
-	if (!resources || opaque_id == 0u)
+	if (slot <= R_BACKEND_RESOURCE_SLOT_NONE || slot >= R_BACKEND_RESOURCE_SLOT_COUNT)
+		return -1;
+
+	for (i = 0; i < s_gl_resources.count; ++i)
+	{
+		if (s_gl_resources.entries[i].slot == (unsigned short)slot)
+			return (int)i;
+	}
+
+	return -1;
+}
+
+static int GLBackend_FindResourceIndexByKey (gl_backend_resource_key_t key)
+{
+	unsigned index;
+
+	if (key <= GL_BACKEND_RESOURCE_KEY_NONE)
+		return -1;
+
+	for (index = 0; index < s_gl_resources.count; ++index)
+	{
+		if (s_gl_resources.entries[index].key == (unsigned short)key)
+			return (int)index;
+	}
+
+	return -1;
+}
+
+void GL_Backend_ResetResources (void)
+{
+	memset (&s_gl_resources, 0, sizeof (s_gl_resources));
+	s_gl_resources.next_opaque_id = 1u;
+}
+
+static unsigned short GLBackend_RegisterResourceInternal (render_backend_resource_type_t type, render_backend_resource_slot_t slot, gl_backend_resource_key_t key, render_backend_resource_lifetime_t lifetime, unsigned native_id)
+{
+	unsigned short opaque_id;
+	int index;
+
+	if (type == R_BACKEND_RESOURCE_NONE || native_id == 0u)
 		return 0u;
 
-	for (i = 0; i < (unsigned)resources->registry_count; ++i)
+	index = (slot > R_BACKEND_RESOURCE_SLOT_NONE) ? GLBackend_FindResourceIndexBySlot (slot) : GLBackend_FindResourceIndexByKey (key);
+	if (index < 0)
 	{
-		if (resources->registry[i].resource_id == opaque_id)
-			return resources->registry[i].native_id;
+		if (s_gl_resources.count >= GL_BACKEND_MAX_RESOURCES)
+			return 0u;
+		index = (int)s_gl_resources.count++;
+		memset (&s_gl_resources.entries[index], 0, sizeof (s_gl_resources.entries[index]));
+		opaque_id = s_gl_resources.next_opaque_id++;
+		if (opaque_id == 0u)
+			opaque_id = s_gl_resources.next_opaque_id++;
+		s_gl_resources.entries[index].opaque_id = opaque_id;
+	}
+
+	s_gl_resources.entries[index].native_id = native_id;
+	s_gl_resources.entries[index].type = (unsigned char)type;
+	s_gl_resources.entries[index].lifetime = (unsigned char)lifetime;
+	s_gl_resources.entries[index].slot = (unsigned short)slot;
+	s_gl_resources.entries[index].key = (unsigned short)key;
+	return s_gl_resources.entries[index].opaque_id;
+}
+
+unsigned short GL_Backend_RegisterResource (render_backend_resource_type_t type, render_backend_resource_slot_t slot, render_backend_resource_lifetime_t lifetime, unsigned native_id)
+{
+	return GLBackend_RegisterResourceInternal (type, slot, GL_BACKEND_RESOURCE_KEY_NONE, lifetime, native_id);
+}
+
+unsigned short GL_Backend_RegisterNamedResource (render_backend_resource_type_t type, gl_backend_resource_key_t key, render_backend_resource_lifetime_t lifetime, unsigned native_id)
+{
+	return GLBackend_RegisterResourceInternal (type, R_BACKEND_RESOURCE_SLOT_NONE, key, lifetime, native_id);
+}
+
+void GL_Backend_UnregisterResourceBySlot (render_backend_resource_slot_t slot)
+{
+	int index = GLBackend_FindResourceIndexBySlot (slot);
+
+	if (index < 0)
+		return;
+
+	s_gl_resources.entries[index] = s_gl_resources.entries[s_gl_resources.count - 1];
+	s_gl_resources.count--;
+}
+
+void GL_Backend_UnregisterNamedResource (gl_backend_resource_key_t key)
+{
+	int index = GLBackend_FindResourceIndexByKey (key);
+
+	if (index < 0)
+		return;
+
+	s_gl_resources.entries[index] = s_gl_resources.entries[s_gl_resources.count - 1];
+	s_gl_resources.count--;
+}
+
+unsigned GL_Backend_ResolveOpaqueResource (unsigned short opaque_id)
+{
+	unsigned i;
+
+	if (opaque_id == 0u)
+		return 0u;
+
+	for (i = 0; i < s_gl_resources.count; ++i)
+	{
+		if (s_gl_resources.entries[i].opaque_id == opaque_id)
+			return s_gl_resources.entries[i].native_id;
 	}
 
 	return 0u;
 }
 
+static unsigned GLBackend_ResolveResourceOpaqueId (const RenderGraphResourceHandle *resources, unsigned short opaque_id)
+{
+	(void)resources;
+	return GL_Backend_ResolveOpaqueResource (opaque_id);
+}
+
 static void GLBackend_PopulateFrameGraphResources (RenderGraphResourceHandle *out_handles)
 {
+	unsigned i;
+
 	if (!out_handles)
 		return;
 
-	GLBackend_RegisterResource (out_handles, R_BACKEND_RESOURCE_FRAMEBUFFER, R_BACKEND_RESOURCE_SLOT_SCENE_FBO, R_BACKEND_RESOURCE_LIFETIME_FRAME, framebufs.scene.fbo);
-	GLBackend_RegisterResource (out_handles, R_BACKEND_RESOURCE_TEXTURE, R_BACKEND_RESOURCE_SLOT_SCENE_COLOR, R_BACKEND_RESOURCE_LIFETIME_FRAME, framebufs.scene.color_tex);
-	GLBackend_RegisterResource (out_handles, R_BACKEND_RESOURCE_TEXTURE, R_BACKEND_RESOURCE_SLOT_SCENE_VELOCITY, R_BACKEND_RESOURCE_LIFETIME_FRAME, framebufs.scene.velocity_tex);
-	GLBackend_RegisterResource (out_handles, R_BACKEND_RESOURCE_TEXTURE, R_BACKEND_RESOURCE_SLOT_SCENE_DEPTH, R_BACKEND_RESOURCE_LIFETIME_FRAME, framebufs.scene.depth_stencil_tex);
-	GLBackend_RegisterResource (out_handles, R_BACKEND_RESOURCE_FRAMEBUFFER, R_BACKEND_RESOURCE_SLOT_RESOLVED_SCENE_FBO, R_BACKEND_RESOURCE_LIFETIME_FRAME, framebufs.resolved_scene.fbo);
-	GLBackend_RegisterResource (out_handles, R_BACKEND_RESOURCE_TEXTURE, R_BACKEND_RESOURCE_SLOT_RESOLVED_SCENE_COLOR, R_BACKEND_RESOURCE_LIFETIME_FRAME, framebufs.resolved_scene.color_tex);
-	GLBackend_RegisterResource (out_handles, R_BACKEND_RESOURCE_TEXTURE, R_BACKEND_RESOURCE_SLOT_RESOLVED_SCENE_VELOCITY, R_BACKEND_RESOURCE_LIFETIME_FRAME, framebufs.resolved_scene.velocity_tex);
-	GLBackend_RegisterResource (out_handles, R_BACKEND_RESOURCE_FRAMEBUFFER, R_BACKEND_RESOURCE_SLOT_COMPOSITE_FBO, R_BACKEND_RESOURCE_LIFETIME_FRAME, framebufs.composite.fbo);
-	GLBackend_RegisterResource (out_handles, R_BACKEND_RESOURCE_TEXTURE, R_BACKEND_RESOURCE_SLOT_COMPOSITE_COLOR, R_BACKEND_RESOURCE_LIFETIME_FRAME, framebufs.composite.color_tex);
-	GLBackend_RegisterResource (out_handles, R_BACKEND_RESOURCE_TEXTURE, R_BACKEND_RESOURCE_SLOT_COMPOSITE_DEPTH, R_BACKEND_RESOURCE_LIFETIME_FRAME, framebufs.composite.depth_stencil_tex);
-	GLBackend_RegisterResource (out_handles, R_BACKEND_RESOURCE_TEXTURE, R_BACKEND_RESOURCE_SLOT_SHADOW_SUN_DEPTH, R_BACKEND_RESOURCE_LIFETIME_PERSISTENT, framebufs.shadow.sun_depth_tex);
-	GLBackend_RegisterResource (out_handles, R_BACKEND_RESOURCE_TEXTURE, R_BACKEND_RESOURCE_SLOT_VELOCITY, R_BACKEND_RESOURCE_LIFETIME_FRAME, (framebufs.scene.samples > 1) ? framebufs.resolved_scene.velocity_tex : framebufs.scene.velocity_tex);
+	for (i = 0; i < s_gl_resources.count; ++i)
+	{
+		const struct gl_backend_resource_entry_s *entry = &s_gl_resources.entries[i];
+		unsigned registry_index;
+		render_backend_resource_slot_t slot;
+
+		if (entry->slot <= R_BACKEND_RESOURCE_SLOT_NONE || entry->slot >= R_BACKEND_RESOURCE_SLOT_COUNT)
+			continue;
+		if (entry->opaque_id == 0u || entry->native_id == 0u || entry->type == R_BACKEND_RESOURCE_NONE)
+			continue;
+		if (out_handles->registry_count >= (unsigned char)Q_COUNTOF (out_handles->registry))
+			break;
+
+		slot = (render_backend_resource_slot_t)entry->slot;
+		registry_index = out_handles->registry_count++;
+		out_handles->registry[registry_index].resource_id = entry->opaque_id;
+		out_handles->registry[registry_index].native_id = entry->native_id;
+		out_handles->registry[registry_index].type = entry->type;
+		out_handles->registry[registry_index].lifetime = entry->lifetime;
+		out_handles->registry[registry_index].slot = entry->slot;
+
+		out_handles->slot_resource_ids[slot] = entry->opaque_id;
+		out_handles->refs[slot].type = entry->type;
+		out_handles->refs[slot].slot = entry->slot;
+		out_handles->refs[slot].opaque_id = entry->opaque_id;
+	}
 }
 
 static int GLBackend_GetSceneSampleCount (void)
@@ -860,11 +972,13 @@ static qboolean GLBackend_HasRequiredPassCallbacks (void)
 
 static qboolean GLBackend_Init (void)
 {
+	GL_Backend_ResetResources ();
 	return true;
 }
 
 static void GLBackend_Shutdown (void)
 {
+	GL_Backend_ResetResources ();
 }
 
 static void GLBackend_OnResize (int width, int height)

--- a/Quake/gl_backend.h
+++ b/Quake/gl_backend.h
@@ -5,8 +5,20 @@
 
 typedef void *(*gl_proc_address_loader_t)(const char *name);
 
+typedef enum gl_backend_resource_key_e
+{
+	GL_BACKEND_RESOURCE_KEY_NONE = 0,
+	GL_BACKEND_RESOURCE_KEY_GLOBAL_VAO
+} gl_backend_resource_key_t;
+
 void GL_Backend_SetProcAddressLoader (gl_proc_address_loader_t loader);
 void *GL_Backend_GetProcAddress (const char *name);
+void GL_Backend_ResetResources (void);
+unsigned short GL_Backend_RegisterResource (render_backend_resource_type_t type, render_backend_resource_slot_t slot, render_backend_resource_lifetime_t lifetime, unsigned native_id);
+unsigned short GL_Backend_RegisterNamedResource (render_backend_resource_type_t type, gl_backend_resource_key_t key, render_backend_resource_lifetime_t lifetime, unsigned native_id);
+void GL_Backend_UnregisterResourceBySlot (render_backend_resource_slot_t slot);
+void GL_Backend_UnregisterNamedResource (gl_backend_resource_key_t key);
+unsigned GL_Backend_ResolveOpaqueResource (unsigned short opaque_id);
 const IRenderBackend *GL_Backend_GetInterface (void);
 void GL_Backend_Register (void);
 

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -37,6 +37,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "gl_shadow.h"
 #include "gl_shadow_runtime.h"
 #include "gl_lightgrid.h"
+#include "gl_backend.h"
 #include "mat_material.h"
 #include <float.h>
 #include <math.h>
@@ -1345,6 +1346,41 @@ static qboolean GL_ValidateSimpleFramebuffer (GLuint fbo, const char* name)
 static qboolean GL_AutoExposurePBOAvailable (void);
 static void GL_AutoExposureDeletePBOs (void);
 static void GL_AutoExposureInitPBOs (void);
+static void GL_RegisterFrameGraphResourceSlots (void);
+static void GL_UnregisterFrameGraphResourceSlots (void);
+
+static void GL_RegisterFrameGraphResourceSlots (void)
+{
+	unsigned velocity_tex = (framebufs.scene.samples > 1) ? framebufs.resolved_scene.velocity_tex : framebufs.scene.velocity_tex;
+
+	GL_Backend_RegisterResource (R_BACKEND_RESOURCE_FRAMEBUFFER, R_BACKEND_RESOURCE_SLOT_SCENE_FBO, R_BACKEND_RESOURCE_LIFETIME_FRAME, framebufs.scene.fbo);
+	GL_Backend_RegisterResource (R_BACKEND_RESOURCE_TEXTURE, R_BACKEND_RESOURCE_SLOT_SCENE_COLOR, R_BACKEND_RESOURCE_LIFETIME_FRAME, framebufs.scene.color_tex);
+	GL_Backend_RegisterResource (R_BACKEND_RESOURCE_TEXTURE, R_BACKEND_RESOURCE_SLOT_SCENE_VELOCITY, R_BACKEND_RESOURCE_LIFETIME_FRAME, framebufs.scene.velocity_tex);
+	GL_Backend_RegisterResource (R_BACKEND_RESOURCE_TEXTURE, R_BACKEND_RESOURCE_SLOT_SCENE_DEPTH, R_BACKEND_RESOURCE_LIFETIME_FRAME, framebufs.scene.depth_stencil_tex);
+	GL_Backend_RegisterResource (R_BACKEND_RESOURCE_FRAMEBUFFER, R_BACKEND_RESOURCE_SLOT_RESOLVED_SCENE_FBO, R_BACKEND_RESOURCE_LIFETIME_FRAME, framebufs.resolved_scene.fbo);
+	GL_Backend_RegisterResource (R_BACKEND_RESOURCE_TEXTURE, R_BACKEND_RESOURCE_SLOT_RESOLVED_SCENE_COLOR, R_BACKEND_RESOURCE_LIFETIME_FRAME, framebufs.resolved_scene.color_tex);
+	GL_Backend_RegisterResource (R_BACKEND_RESOURCE_TEXTURE, R_BACKEND_RESOURCE_SLOT_RESOLVED_SCENE_VELOCITY, R_BACKEND_RESOURCE_LIFETIME_FRAME, framebufs.resolved_scene.velocity_tex);
+	GL_Backend_RegisterResource (R_BACKEND_RESOURCE_FRAMEBUFFER, R_BACKEND_RESOURCE_SLOT_COMPOSITE_FBO, R_BACKEND_RESOURCE_LIFETIME_FRAME, framebufs.composite.fbo);
+	GL_Backend_RegisterResource (R_BACKEND_RESOURCE_TEXTURE, R_BACKEND_RESOURCE_SLOT_COMPOSITE_COLOR, R_BACKEND_RESOURCE_LIFETIME_FRAME, framebufs.composite.color_tex);
+	GL_Backend_RegisterResource (R_BACKEND_RESOURCE_TEXTURE, R_BACKEND_RESOURCE_SLOT_COMPOSITE_DEPTH, R_BACKEND_RESOURCE_LIFETIME_FRAME, framebufs.composite.depth_stencil_tex);
+	GL_Backend_RegisterResource (R_BACKEND_RESOURCE_TEXTURE, R_BACKEND_RESOURCE_SLOT_VELOCITY, R_BACKEND_RESOURCE_LIFETIME_FRAME, velocity_tex);
+}
+
+static void GL_UnregisterFrameGraphResourceSlots (void)
+{
+	GL_Backend_UnregisterResourceBySlot (R_BACKEND_RESOURCE_SLOT_SCENE_FBO);
+	GL_Backend_UnregisterResourceBySlot (R_BACKEND_RESOURCE_SLOT_SCENE_COLOR);
+	GL_Backend_UnregisterResourceBySlot (R_BACKEND_RESOURCE_SLOT_SCENE_VELOCITY);
+	GL_Backend_UnregisterResourceBySlot (R_BACKEND_RESOURCE_SLOT_SCENE_DEPTH);
+	GL_Backend_UnregisterResourceBySlot (R_BACKEND_RESOURCE_SLOT_RESOLVED_SCENE_FBO);
+	GL_Backend_UnregisterResourceBySlot (R_BACKEND_RESOURCE_SLOT_RESOLVED_SCENE_COLOR);
+	GL_Backend_UnregisterResourceBySlot (R_BACKEND_RESOURCE_SLOT_RESOLVED_SCENE_VELOCITY);
+	GL_Backend_UnregisterResourceBySlot (R_BACKEND_RESOURCE_SLOT_COMPOSITE_FBO);
+	GL_Backend_UnregisterResourceBySlot (R_BACKEND_RESOURCE_SLOT_COMPOSITE_COLOR);
+	GL_Backend_UnregisterResourceBySlot (R_BACKEND_RESOURCE_SLOT_COMPOSITE_DEPTH);
+	GL_Backend_UnregisterResourceBySlot (R_BACKEND_RESOURCE_SLOT_SHADOW_SUN_DEPTH);
+	GL_Backend_UnregisterResourceBySlot (R_BACKEND_RESOURCE_SLOT_VELOCITY);
+}
 
 /*
 =============
@@ -1520,6 +1556,7 @@ void GL_CreateFrameBuffers (void)
 
         GL_BindFramebufferFunc (GL_FRAMEBUFFER, 0);
         GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, 0);
+	GL_RegisterFrameGraphResourceSlots ();
 }
 
 /*
@@ -1529,6 +1566,8 @@ GL_DeleteFrameBuffers
 */
 void GL_DeleteFrameBuffers (void)
 {
+	GL_UnregisterFrameGraphResourceSlots ();
+
 	R_Shadow_DeleteFrameBuffers ();
 	GL_DeleteFramebuffersFunc (1, &framebufs.resolved_scene.fbo);
 	GL_DeleteFramebuffersFunc (1, &framebufs.oit.fbo_composite);
@@ -5957,3 +5996,4 @@ void R_RenderView (void)
 }
 
 
+	GL_UnregisterFrameGraphResourceSlots ();

--- a/Quake/gl_shadow_runtime.c
+++ b/Quake/gl_shadow_runtime.c
@@ -1,6 +1,7 @@
 #include "quakedef.h"
 #include "glquake.h"
 
+#include "gl_backend.h"
 #include "gl_shadow.h"
 #include "gl_shadow_runtime.h"
 
@@ -591,6 +592,7 @@ void R_Shadow_CreateFrameBuffers (void)
 		GL_DeleteNativeTexture (framebufs.shadow.dlight_depth_tex);
 		framebufs.shadow.dlight_depth_tex = 0;
 		framebufs.shadow.available = true;
+		GL_Backend_RegisterResource (R_BACKEND_RESOURCE_TEXTURE, R_BACKEND_RESOURCE_SLOT_SHADOW_SUN_DEPTH, R_BACKEND_RESOURCE_LIFETIME_LEVEL, framebufs.shadow.sun_depth_tex);
 		return;
 	}
 	if (r_shadow_log.value > 0.f)
@@ -598,6 +600,7 @@ void R_Shadow_CreateFrameBuffers (void)
 			dlight_size, dlight_size, SHADOW_DLIGHT_MAX * SHADOW_DLIGHT_FACES);
 
 	framebufs.shadow.available = true;
+	GL_Backend_RegisterResource (R_BACKEND_RESOURCE_TEXTURE, R_BACKEND_RESOURCE_SLOT_SHADOW_SUN_DEPTH, R_BACKEND_RESOURCE_LIFETIME_LEVEL, framebufs.shadow.sun_depth_tex);
 }
 
 void R_Shadow_DeleteFrameBuffers (void)
@@ -611,6 +614,7 @@ void R_Shadow_DeleteFrameBuffers (void)
 	framebufs.shadow.dlight_depth_tex = 0;
 	framebufs.shadow.dlight_fbo = 0;
 	framebufs.shadow.available = false;
+	GL_Backend_UnregisterResourceBySlot (R_BACKEND_RESOURCE_SLOT_SHADOW_SUN_DEPTH);
 	r_shadow_draw_cache.valid = false;
 }
 

--- a/Quake/gl_vidsdl.c
+++ b/Quake/gl_vidsdl.c
@@ -105,6 +105,7 @@ unsigned glstate;
 GLint ssbo_align;
 GLint ubo_align;
 static GLuint globalvao;
+static unsigned short globalvao_resource_id;
 
 #define QGL_DEFINE_FUNC(ret, name, args) ret (APIENTRYP GL_##name##Func) args = NULL;
 QGL_ALL_FUNCTIONS(QGL_DEFINE_FUNC)
@@ -1492,6 +1493,7 @@ static void GL_Init (void)
 
 	GL_GenVertexArraysFunc (1, &globalvao);
 	GL_BindVertexArrayFunc (globalvao);
+	globalvao_resource_id = GL_Backend_RegisterNamedResource (R_BACKEND_RESOURCE_BUFFER, GL_BACKEND_RESOURCE_KEY_GLOBAL_VAO, R_BACKEND_RESOURCE_LIFETIME_DEVICE, globalvao);
 
 	glGetIntegerv (GL_SHADER_STORAGE_BUFFER_OFFSET_ALIGNMENT, &ssbo_align);
 	glGetIntegerv (GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT, &ubo_align);
@@ -1634,6 +1636,11 @@ void	VID_Shutdown (void)
 {
 	if (vid_initialized)
 	{
+		if (globalvao_resource_id)
+		{
+			GL_Backend_UnregisterNamedResource (GL_BACKEND_RESOURCE_KEY_GLOBAL_VAO);
+			globalvao_resource_id = 0;
+		}
 		R_Backend_Shutdown ();
 		Lightgrid_Shutdown ();
 		VID_FreeMouseCursors();

--- a/Quake/render_api.h
+++ b/Quake/render_api.h
@@ -136,6 +136,8 @@ typedef enum render_backend_resource_state_e
 typedef enum render_backend_resource_lifetime_e
 {
 	R_BACKEND_RESOURCE_LIFETIME_FRAME = 0,
+	R_BACKEND_RESOURCE_LIFETIME_LEVEL,
+	R_BACKEND_RESOURCE_LIFETIME_DEVICE,
 	R_BACKEND_RESOURCE_LIFETIME_PERSISTENT
 } render_backend_resource_lifetime_t;
 


### PR DESCRIPTION
### Motivation
- Decouple native GL handles from framegraph/renderer consumers by introducing a backend-owned registry keyed by opaque IDs and explicit lifetime domains to make ownership and lifetime transitions explicit.
- Move registration/unregistration of major GL resources (framebuffers, shadow maps, global VAO) behind backend APIs so native handles remain private to `gl_backend` internals.

### Description
- Add `R_BACKEND_RESOURCE_LIFETIME_LEVEL` and `R_BACKEND_RESOURCE_LIFETIME_DEVICE` to `render_api.h` and expand the `RenderGraphResourceHandle` population to accept backend-provided entries.
- Implement a backend resource table in `gl_backend.c` (`s_gl_resources`) with APIs added to `gl_backend.h`: `GL_Backend_ResetResources`, `GL_Backend_RegisterResource`, `GL_Backend_RegisterNamedResource`, `GL_Backend_UnregisterResourceBySlot`, `GL_Backend_UnregisterNamedResource`, and `GL_Backend_ResolveOpaqueResource`, and a capacity constant `GL_BACKEND_MAX_RESOURCES`.
- Replace the hardcoded `framebufs` enumeration inside backend framegraph population with table-driven population that emits opaque resource IDs and native IDs from the backend registry, keeping native GL handles private to the backend.
- Register/unregister framebuffer/texture slots from `GL_CreateFrameBuffers`/`GL_DeleteFrameBuffers` via `GL_Backend_RegisterResource`/`GL_Backend_UnregisterResourceBySlot`, hook shadow sun-depth registration/unregistration into `R_Shadow_CreateFrameBuffers`/`R_Shadow_DeleteFrameBuffers`, and register the global VAO as a named device-lifetime resource (unregister on shutdown).
- Ensure backend init/shutdown clear the resource table so resource ownership is reset across backend lifecycle transitions.

### Testing
- Ran `make -C Quake -j4` to validate build after changes; the build in this container could not complete due to missing SDL development files (`sdl2-config` / `SDL.h`), so a full compile validation was not possible here (observed many header-not-found errors reported by the build).
- No additional automated unit tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da2acf437c832e8bb993c5608bcafb)