### PR TITLE
Add .sndshd syntax manifest and reference README

### DIFF
--- a/Quake/sounddefs/README_sounddefs.md
+++ b/Quake/sounddefs/README_sounddefs.md
@@ -1,0 +1,21 @@
+# SoundDef Syntax Reference
+
+Die Datei `syntax_manifest.json` ist die **Single Source of Truth** für die `.sndshd`-Sprache.
+
+## Inhalt des Manifests
+
+- unterstützte Tokens und Bool-Literale
+- Top-Level-`sound`-Block inkl. erlaubter Definition-Properties
+- `layer`-Block inkl. Layer-Properties
+- Werttypen (`int`, `float`, `bool`, `path`, `enum`, `range`)
+- Parser-/Runtime-Constraints (inkl. Grenzwerte und Symbol-Limits)
+- gültige Beispieldefinitionen aus `demo_debug.sndshd`
+
+## Kurzregel zur Blockstruktur
+
+Innerhalb eines `sound`-Blocks gilt:
+
+- entweder impliziter Layer über Top-Level-Layer-Keys (`sample`, `bus`, `volume`, …)
+- oder explizite `layer { ... }`-Blöcke
+
+Eine Mischung beider Formen in derselben Definition ist ungültig.

--- a/Quake/sounddefs/syntax_manifest.json
+++ b/Quake/sounddefs/syntax_manifest.json
@@ -1,0 +1,143 @@
+{
+  "version": "1.0.0",
+  "tokens": {
+    "top_level_keyword": "sound",
+    "layer_keyword": "layer",
+    "block_delimiters": ["{", "}"],
+    "comments": ["// line comment", "/* block comment */"],
+    "boolean_literals": [
+      "true",
+      "false",
+      "yes",
+      "no",
+      "on",
+      "off",
+      "1",
+      "0"
+    ]
+  },
+  "sound_block": {
+    "syntax": "sound <name> { <sound properties and/or layer data> }",
+    "properties": {
+      "priority": {
+        "value_type": "int",
+        "constraints": ["range:0..255"]
+      },
+      "max_instances": {
+        "value_type": "int",
+        "constraints": ["range:0..MAX_CHANNELS"]
+      },
+      "spatialize": {
+        "value_type": "bool"
+      },
+      "doppler": {
+        "value_type": "bool"
+      },
+      "lowpass_by_distance": {
+        "value_type": "bool"
+      },
+      "reverb_send": {
+        "value_type": "float",
+        "constraints": ["range:0..1"]
+      }
+    }
+  },
+  "layer_block": {
+    "syntax": "layer { <layer properties> }",
+    "properties": {
+      "sample": {
+        "value_type": "path",
+        "multiplicity": "repeatable",
+        "constraints": ["1..SOUNDDEF_MAX_SAMPLES_PER_LAYER entries per layer"]
+      },
+      "bus": {
+        "value_type": "enum",
+        "enum_values": ["sfx", "ui", "ambient", "music"]
+      },
+      "volume": {
+        "value_type": "float",
+        "constraints": ["range:0..4"]
+      },
+      "volume_random": {
+        "value_type": "range",
+        "element_type": "float",
+        "arity": 2,
+        "constraints": ["min>=0", "max<=4", "min<=max"]
+      },
+      "pitch": {
+        "value_type": "float",
+        "constraints": ["range:(0..8]"]
+      },
+      "pitch_random": {
+        "value_type": "range",
+        "element_type": "float",
+        "arity": 2,
+        "constraints": ["min>0", "max<=8", "min<=max"]
+      },
+      "loop": {
+        "value_type": "bool"
+      },
+      "chance": {
+        "value_type": "float",
+        "constraints": ["range:0..1"]
+      },
+      "delay_ms": {
+        "value_type": "int",
+        "constraints": ["range:[0..INT_MAX]"]
+      },
+      "start_offset_ms": {
+        "value_type": "int",
+        "constraints": ["range:[0..INT_MAX]"]
+      }
+    }
+  },
+  "value_types": {
+    "int": {
+      "description": "Base-10 integer token parsed via strtol."
+    },
+    "float": {
+      "description": "Finite floating-point token parsed via strtod."
+    },
+    "bool": {
+      "description": "One of the accepted boolean literals listed in tokens.boolean_literals."
+    },
+    "path": {
+      "description": "Unquoted asset-relative path token.",
+      "constraints": ["token length < MAX_QPATH"]
+    },
+    "enum": {
+      "description": "Case-insensitive symbol that must resolve to a known runtime enum."
+    },
+    "range": {
+      "description": "Two scalar tokens (min, max) consumed in order."
+    }
+  },
+  "constraints": {
+    "mixing_rule": "Top-level layer keys (sample/bus/volume/volume_random/pitch/pitch_random/loop/chance/delay_ms/start_offset_ms) are mutually exclusive with explicit layer {} blocks within the same sound block.",
+    "layer_count_limit": "Each sound definition must contain 1..SOUNDDEF_MAX_LAYERS layers after parsing.",
+    "sample_count_limit": "Each layer must contain 1..SOUNDDEF_MAX_SAMPLES_PER_LAYER samples after parsing.",
+    "runtime_validated_ranges": {
+      "priority": "0..255",
+      "max_instances": "0..MAX_CHANNELS",
+      "reverb_send": "0..1",
+      "volume": "0..4",
+      "pitch": ">0 && <=8",
+      "chance": "0..1",
+      "delay_ms": ">=0",
+      "start_offset_ms": ">=0"
+    }
+  },
+  "examples": {
+    "implicit_single_layer": "sound debug/ui_cycle { priority 240 max_instances 4 spatialize false doppler false lowpass_by_distance false reverb_send 0.05 sample misc/menu1.wav sample misc/menu2.wav sample misc/menu3.wav bus ui volume 0.80 volume_random 0.70 1.00 pitch 1.00 pitch_random 0.92 1.10 loop false chance 1.00 delay_ms 0 start_offset_ms 0 }",
+    "explicit_multi_layer": "sound debug/spatial_kitchen_sink { priority 208 max_instances 1 spatialize true doppler true lowpass_by_distance true reverb_send 0.70 layer { sample weapons/rocket1i.wav sample weapons/grenade.wav bus sfx volume 1.00 volume_random 0.85 1.15 pitch 0.95 pitch_random 0.85 1.05 loop false chance 1.00 delay_ms 0 start_offset_ms 0 } layer { sample ambience/thunder1.wav bus ambient volume 0.30 volume_random 1.00 1.00 pitch 0.75 pitch_random 1.00 1.00 loop false chance 0.65 delay_ms 120 start_offset_ms 180 } }"
+  },
+  "valid_examples": {
+    "source": "Quake/sounddefs/demo_debug.sndshd",
+    "definitions": [
+      "debug/ui_cycle",
+      "debug/spatial_kitchen_sink",
+      "debug/ambient_loop",
+      "debug/music_loop"
+    ]
+  }
+}


### PR DESCRIPTION
### Motivation

- Provide a single machine-readable specification for the `.sndshd` sound-definition language to make tooling and documentation consistent. 
- Capture the grammar and top-level versus layer semantics implemented by the parser (`sounddef_parser.c`) including the implicit-vs-explicit layer mixing rule. 
- Document runtime validation bounds and symbolic limits enforced by the runtime (`sounddef_registry.c`) so validators can reflect actual engine constraints.

### Description

- Add `Quake/sounddefs/syntax_manifest.json` which documents `version`, `tokens`, `sound_block.properties`, `layer_block.properties`, `value_types`, `constraints`, `examples`, and `valid_examples` that reference `Quake/sounddefs/demo_debug.sndshd`. 
- Encode parser-derived keys and structure: top-level `sound <name> { ... }`, def-keys (`priority`, `max_instances`, `spatialize`, `doppler`, `lowpass_by_distance`, `reverb_send`) and layer-keys (`sample`, `bus`, `volume`, `volume_random`, `pitch`, `pitch_random`, `loop`, `chance`, `delay_ms`, `start_offset_ms`). 
- Record runtime validation ranges and symbolic limits (e.g. `priority: 0..255`, `max_instances: 0..MAX_CHANNELS`, `reverb_send: 0..1`, `volume: 0..4`, `pitch: >0 && <=8`, `chance: 0..1`, `delay_ms`/`start_offset_ms: >=0`, and `SOUNDDEF_MAX_LAYERS`/`SOUNDDEF_MAX_SAMPLES_PER_LAYER`). 
- Add `Quake/sounddefs/README_sounddefs.md` that points to `syntax_manifest.json` as the single source of truth and summarizes the implicit-vs-explicit layer rule.

### Testing

- The manifest JSON was validated with `jq` (`jq empty Quake/sounddefs/syntax_manifest.json`) and the check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daee953d08832e996310af76fe6ddb)