### PR TITLE
renderer: migrate pass state mutations to cached backend wrappers

### DIFF
--- a/Quake/include/gl_backend.h
+++ b/Quake/include/gl_backend.h
@@ -19,6 +19,15 @@ unsigned short GL_Backend_RegisterNamedResource (render_backend_resource_type_t 
 void GL_Backend_UnregisterResourceBySlot (render_backend_resource_slot_t slot);
 void GL_Backend_UnregisterNamedResource (gl_backend_resource_key_t key);
 unsigned GL_Backend_ResolveOpaqueResource (unsigned short opaque_id);
+void GL_Backend_ResetStateCache (void);
+void GL_Backend_SetViewportCached (int x, int y, int width, int height);
+void GL_Backend_SetColorMaskCached (int r, int g, int b, int a);
+void GL_Backend_SetDepthMaskCached (int enabled);
+void GL_Backend_SetDepthFuncCached (unsigned func);
+void GL_Backend_SetStencilTestCached (qboolean enabled);
+void GL_Backend_SetStencilMaskCached (unsigned mask);
+void GL_Backend_SetStencilFuncCached (unsigned func, int ref, unsigned mask);
+void GL_Backend_SetStencilOpCached (unsigned sfail, unsigned dpfail, unsigned dppass);
 const IRenderBackend *GL_Backend_GetInterface (void);
 void GL_Backend_Register (void);
 

--- a/Quake/src/render/gl_backend.c
+++ b/Quake/src/render/gl_backend.c
@@ -45,6 +45,29 @@ static gl_backend_timer_pass_t s_timer_passes[R_BACKEND_MAX_PROFILE_SLOTS];
 static RenderBackendCaps s_gl_backend_caps;
 static int s_legacy_pass_resource_fallback_frame = -1;
 static gl_proc_address_loader_t s_gl_proc_loader = NULL;
+static struct gl_backend_state_cache_s
+{
+	qboolean viewport_valid;
+	GLint viewport[4];
+	qboolean color_mask_valid;
+	GLboolean color_mask[4];
+	qboolean depth_mask_valid;
+	GLboolean depth_mask;
+	qboolean depth_func_valid;
+	GLenum depth_func;
+	qboolean stencil_test_valid;
+	qboolean stencil_test_enabled;
+	qboolean stencil_mask_valid;
+	GLuint stencil_mask;
+	qboolean stencil_func_valid;
+	GLenum stencil_func;
+	GLint stencil_ref;
+	GLuint stencil_value_mask;
+	qboolean stencil_op_valid;
+	GLenum stencil_op_sfail;
+	GLenum stencil_op_dpfail;
+	GLenum stencil_op_dppass;
+} s_gl_state_cache;
 static struct gl_backend_resource_table_s
 {
 	struct gl_backend_resource_entry_s
@@ -59,6 +82,125 @@ static struct gl_backend_resource_table_s
 	unsigned short next_opaque_id;
 	unsigned short count;
 } s_gl_resources;
+
+void GL_Backend_ResetStateCache (void)
+{
+	memset (&s_gl_state_cache, 0, sizeof (s_gl_state_cache));
+}
+
+void GL_Backend_SetViewportCached (int x, int y, int width, int height)
+{
+	if (!s_gl_state_cache.viewport_valid
+		|| s_gl_state_cache.viewport[0] != x
+		|| s_gl_state_cache.viewport[1] != y
+		|| s_gl_state_cache.viewport[2] != width
+		|| s_gl_state_cache.viewport[3] != height)
+	{
+		glViewport (x, y, width, height);
+		s_gl_state_cache.viewport[0] = x;
+		s_gl_state_cache.viewport[1] = y;
+		s_gl_state_cache.viewport[2] = width;
+		s_gl_state_cache.viewport[3] = height;
+		s_gl_state_cache.viewport_valid = true;
+	}
+}
+
+void GL_Backend_SetColorMaskCached (int r, int g, int b, int a)
+{
+	const GLboolean nr = r ? GL_TRUE : GL_FALSE;
+	const GLboolean ng = g ? GL_TRUE : GL_FALSE;
+	const GLboolean nb = b ? GL_TRUE : GL_FALSE;
+	const GLboolean na = a ? GL_TRUE : GL_FALSE;
+
+	if (!s_gl_state_cache.color_mask_valid
+		|| s_gl_state_cache.color_mask[0] != nr
+		|| s_gl_state_cache.color_mask[1] != ng
+		|| s_gl_state_cache.color_mask[2] != nb
+		|| s_gl_state_cache.color_mask[3] != na)
+	{
+		glColorMask (nr, ng, nb, na);
+		s_gl_state_cache.color_mask[0] = nr;
+		s_gl_state_cache.color_mask[1] = ng;
+		s_gl_state_cache.color_mask[2] = nb;
+		s_gl_state_cache.color_mask[3] = na;
+		s_gl_state_cache.color_mask_valid = true;
+	}
+}
+
+void GL_Backend_SetDepthMaskCached (int enabled)
+{
+	const GLboolean mask = enabled ? GL_TRUE : GL_FALSE;
+
+	if (!s_gl_state_cache.depth_mask_valid || s_gl_state_cache.depth_mask != mask)
+	{
+		glDepthMask (mask);
+		s_gl_state_cache.depth_mask = mask;
+		s_gl_state_cache.depth_mask_valid = true;
+	}
+}
+
+void GL_Backend_SetDepthFuncCached (unsigned func)
+{
+	if (!s_gl_state_cache.depth_func_valid || s_gl_state_cache.depth_func != (GLenum)func)
+	{
+		glDepthFunc ((GLenum)func);
+		s_gl_state_cache.depth_func = (GLenum)func;
+		s_gl_state_cache.depth_func_valid = true;
+	}
+}
+
+void GL_Backend_SetStencilTestCached (qboolean enabled)
+{
+	if (!s_gl_state_cache.stencil_test_valid || s_gl_state_cache.stencil_test_enabled != enabled)
+	{
+		if (enabled)
+			glEnable (GL_STENCIL_TEST);
+		else
+			glDisable (GL_STENCIL_TEST);
+		s_gl_state_cache.stencil_test_enabled = enabled;
+		s_gl_state_cache.stencil_test_valid = true;
+	}
+}
+
+void GL_Backend_SetStencilMaskCached (unsigned mask)
+{
+	if (!s_gl_state_cache.stencil_mask_valid || s_gl_state_cache.stencil_mask != (GLuint)mask)
+	{
+		glStencilMask ((GLuint)mask);
+		s_gl_state_cache.stencil_mask = (GLuint)mask;
+		s_gl_state_cache.stencil_mask_valid = true;
+	}
+}
+
+void GL_Backend_SetStencilFuncCached (unsigned func, int ref, unsigned mask)
+{
+	if (!s_gl_state_cache.stencil_func_valid
+		|| s_gl_state_cache.stencil_func != (GLenum)func
+		|| s_gl_state_cache.stencil_ref != (GLint)ref
+		|| s_gl_state_cache.stencil_value_mask != (GLuint)mask)
+	{
+		glStencilFunc ((GLenum)func, (GLint)ref, (GLuint)mask);
+		s_gl_state_cache.stencil_func = (GLenum)func;
+		s_gl_state_cache.stencil_ref = (GLint)ref;
+		s_gl_state_cache.stencil_value_mask = (GLuint)mask;
+		s_gl_state_cache.stencil_func_valid = true;
+	}
+}
+
+void GL_Backend_SetStencilOpCached (unsigned sfail, unsigned dpfail, unsigned dppass)
+{
+	if (!s_gl_state_cache.stencil_op_valid
+		|| s_gl_state_cache.stencil_op_sfail != (GLenum)sfail
+		|| s_gl_state_cache.stencil_op_dpfail != (GLenum)dpfail
+		|| s_gl_state_cache.stencil_op_dppass != (GLenum)dppass)
+	{
+		glStencilOp ((GLenum)sfail, (GLenum)dpfail, (GLenum)dppass);
+		s_gl_state_cache.stencil_op_sfail = (GLenum)sfail;
+		s_gl_state_cache.stencil_op_dpfail = (GLenum)dpfail;
+		s_gl_state_cache.stencil_op_dppass = (GLenum)dppass;
+		s_gl_state_cache.stencil_op_valid = true;
+	}
+}
 
 void GL_Backend_SetProcAddressLoader (gl_proc_address_loader_t loader)
 {
@@ -110,6 +252,7 @@ void GL_Backend_ResetResources (void)
 {
 	memset (&s_gl_resources, 0, sizeof (s_gl_resources));
 	s_gl_resources.next_opaque_id = 1u;
+	GL_Backend_ResetStateCache ();
 }
 
 static unsigned short GLBackend_RegisterResourceInternal (render_backend_resource_type_t type, render_backend_resource_slot_t slot, gl_backend_resource_key_t key, render_backend_resource_lifetime_t lifetime, unsigned native_id)
@@ -461,6 +604,31 @@ static void GLBackend_ResourceBarrier (const RenderGraphResourceHandle *resource
 
 static void GLBackend_ValidatePassState (const char *pass_name, qboolean before_pass)
 {
+	typedef struct gl_backend_pass_contract_s
+	{
+		const char *name;
+		qboolean expect_depth_test;
+		qboolean expect_depth_write;
+		qboolean expect_blend;
+		qboolean expect_cull;
+		qboolean expect_stencil_test;
+		qboolean expect_scissor_test;
+	} gl_backend_pass_contract_t;
+	static const gl_backend_pass_contract_t contracts[] = {
+		{"Setup view", true, true, false, true, false, false},
+		{"Shadow maps", true, true, false, true, false, false},
+		{"Render scene", true, true, false, true, false, false},
+		{"Warp/resolve", false, false, false, false, false, false},
+		{"Capture fog handoff", false, false, true, false, false, false},
+		{"Postprocess", false, false, false, false, false, false},
+		{"Draw viewmodel", true, true, false, true, false, false},
+		{"Polyblend", false, false, true, false, false, false},
+		{"Store previous frame", false, false, false, false, false, false},
+		{"Update decals", true, true, true, true, false, false},
+		{NULL, false, false, false, false, false, false}
+	};
+	const gl_backend_pass_contract_t *contract = NULL;
+	unsigned i;
 	GLenum err;
 
 	if (r_gl_state_validate.value <= 0.f)
@@ -473,8 +641,34 @@ static void GLBackend_ValidatePassState (const char *pass_name, qboolean before_
 	{
 		GLint draw_fbo = 0;
 		GLint viewport[4] = {0};
+		GLint scissor_box[4] = {0};
+		GLboolean depth_test = GL_FALSE;
+		GLboolean blend = GL_FALSE;
+		GLboolean cull = GL_FALSE;
+		GLboolean stencil_test = GL_FALSE;
+		GLboolean scissor_test = GL_FALSE;
+		GLboolean depth_write = GL_FALSE;
+		GLboolean color_mask[4] = {GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE};
 		glGetIntegerv (GL_DRAW_FRAMEBUFFER_BINDING, &draw_fbo);
 		glGetIntegerv (GL_VIEWPORT, viewport);
+		glGetIntegerv (GL_SCISSOR_BOX, scissor_box);
+		glGetBooleanv (GL_DEPTH_TEST, &depth_test);
+		glGetBooleanv (GL_BLEND, &blend);
+		glGetBooleanv (GL_CULL_FACE, &cull);
+		glGetBooleanv (GL_STENCIL_TEST, &stencil_test);
+		glGetBooleanv (GL_SCISSOR_TEST, &scissor_test);
+		glGetBooleanv (GL_DEPTH_WRITEMASK, &depth_write);
+		glGetBooleanv (GL_COLOR_WRITEMASK, color_mask);
+
+		for (i = 0; contracts[i].name; ++i)
+		{
+			if (!q_strcasecmp (pass_name ? pass_name : "", contracts[i].name))
+			{
+				contract = &contracts[i];
+				break;
+			}
+		}
+
 		if (viewport[2] <= 0 || viewport[3] <= 0)
 			Con_Warning ("FrameGraph %s(%s): invalid viewport %d %d %d %d\n",
 				before_pass ? "before" : "after",
@@ -487,6 +681,39 @@ static void GLBackend_ValidatePassState (const char *pass_name, qboolean before_
 				Con_Warning ("FrameGraph %s(%s): incomplete FBO %d status=0x%x\n",
 					before_pass ? "before" : "after",
 					pass_name, draw_fbo, (unsigned)status);
+		}
+
+		if (contract)
+		{
+			if ((depth_test != GL_FALSE) != contract->expect_depth_test
+				|| (depth_write != GL_FALSE) != contract->expect_depth_write
+				|| (blend != GL_FALSE) != contract->expect_blend
+				|| (cull != GL_FALSE) != contract->expect_cull
+				|| (stencil_test != GL_FALSE) != contract->expect_stencil_test
+				|| (scissor_test != GL_FALSE) != contract->expect_scissor_test)
+			{
+				Con_Warning ("FrameGraph %s(%s): state contract mismatch exp[d=%d dw=%d b=%d c=%d s=%d sc=%d] got[d=%d dw=%d b=%d c=%d s=%d sc=%d] vp=[%d %d %d %d] scissor=[%d %d %d %d] colormask=[%d %d %d %d]\n",
+					before_pass ? "before" : "after",
+					pass_name,
+					contract->expect_depth_test ? 1 : 0,
+					contract->expect_depth_write ? 1 : 0,
+					contract->expect_blend ? 1 : 0,
+					contract->expect_cull ? 1 : 0,
+					contract->expect_stencil_test ? 1 : 0,
+					contract->expect_scissor_test ? 1 : 0,
+					depth_test != GL_FALSE ? 1 : 0,
+					depth_write != GL_FALSE ? 1 : 0,
+					blend != GL_FALSE ? 1 : 0,
+					cull != GL_FALSE ? 1 : 0,
+					stencil_test != GL_FALSE ? 1 : 0,
+					scissor_test != GL_FALSE ? 1 : 0,
+					viewport[0], viewport[1], viewport[2], viewport[3],
+					scissor_box[0], scissor_box[1], scissor_box[2], scissor_box[3],
+					color_mask[0] != GL_FALSE ? 1 : 0,
+					color_mask[1] != GL_FALSE ? 1 : 0,
+					color_mask[2] != GL_FALSE ? 1 : 0,
+					color_mask[3] != GL_FALSE ? 1 : 0);
+			}
 		}
 	}
 
@@ -675,7 +902,7 @@ static void GLBackend_BindRenderTarget (const RenderGraphResourceHandle *resourc
 
 static void GLBackend_SetViewport (int x, int y, int width, int height)
 {
-	glViewport (x, y, width, height);
+	GL_Backend_SetViewportCached (x, y, width, height);
 }
 
 static void GLBackend_SetScissor (qboolean enabled, int x, int y, int width, int height)
@@ -973,6 +1200,7 @@ static qboolean GLBackend_HasRequiredPassCallbacks (void)
 static qboolean GLBackend_Init (void)
 {
 	GL_Backend_ResetResources ();
+	GL_Backend_ResetStateCache ();
 	return true;
 }
 
@@ -1006,6 +1234,7 @@ static void GLBackend_BeginFrame (void)
 		GLBackend_DetectCaps ();
 	}
 
+	GL_Backend_ResetStateCache ();
 	GL_BackendBeginFrame ();
 }
 

--- a/Quake/src/render/gl_oit.c
+++ b/Quake/src/render/gl_oit.c
@@ -1,5 +1,6 @@
 #include "quakedef.h"
 #include "glquake.h"
+#include "gl_backend.h"
 
 #include "gl_oit.h"
 
@@ -18,10 +19,10 @@ void R_BeginTranslucency (void)
 		GL_ClearBufferfvFunc (GL_COLOR, 0, zeroes);
 		GL_ClearBufferfvFunc (GL_COLOR, 1, ones);
 
-		glEnable (GL_STENCIL_TEST);
-		glStencilMask (2);
-		glStencilFunc (GL_ALWAYS, 2, 2);
-		glStencilOp (GL_KEEP, GL_KEEP, GL_REPLACE);
+		GL_Backend_SetStencilTestCached (true);
+		GL_Backend_SetStencilMaskCached (2);
+		GL_Backend_SetStencilFuncCached (GL_ALWAYS, 2, 2);
+		GL_Backend_SetStencilOpCached (GL_KEEP, GL_KEEP, GL_REPLACE);
 	}
 }
 
@@ -38,8 +39,8 @@ void R_EndTranslucency (void)
 			glReadBuffer (GL_COLOR_ATTACHMENT0);
 		}
 
-		glStencilFunc (GL_EQUAL, 2, 2);
-		glStencilOp (GL_KEEP, GL_KEEP, GL_KEEP);
+		GL_Backend_SetStencilFuncCached (GL_EQUAL, 2, 2);
+		GL_Backend_SetStencilOpCached (GL_KEEP, GL_KEEP, GL_KEEP);
 
 		GL_UseProgram (glprogs.oit_resolve[framebufs.scene.samples > 1]);
 		{
@@ -63,11 +64,10 @@ void R_EndTranslucency (void)
 
 		R_Backend_Draw (R_BACKEND_PRIMITIVE_TRIANGLES, 0, 3);
 
-		glDisable (GL_STENCIL_TEST);
+		GL_Backend_SetStencilTestCached (false);
 
 		GL_EndGroup ();
 	}
 
 	GL_EndGroup ();
 }
-

--- a/Quake/src/render/gl_rmain.c
+++ b/Quake/src/render/gl_rmain.c
@@ -1764,8 +1764,8 @@ static void GL_BloomExtractLevel (int level, GLuint source_tex, GLuint mask_tex,
 
 	GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.bloom.extract_fbo[level]);
 	GL_SetScissorEnabled (false);
-	glColorMask (GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
-	glViewport (0, 0, width, height);
+	GL_Backend_SetColorMaskCached (GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+	R_Backend_SetViewport (0, 0, width, height);
 	GL_ClearBufferfvFunc (GL_COLOR, 0, clear_color);
 	GL_UseProgram (glprogs.bloom_extract);
 	{
@@ -1803,8 +1803,8 @@ static GLuint GL_BloomBlurLevel (int level, int passes, float radius_scale)
 
 		GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.bloom.pingpong_fbo[level][target_index]);
 		GL_SetScissorEnabled (false);
-		glColorMask (GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
-		glViewport (0, 0, width, height);
+		GL_Backend_SetColorMaskCached (GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+		R_Backend_SetViewport (0, 0, width, height);
 		GL_ClearBufferfvFunc (GL_COLOR, 0, clear_color);
 		GL_UseProgram (glprogs.bloom_blur);
 		{
@@ -1890,8 +1890,8 @@ static GLuint GL_GenerateBloomTexture (GLuint mask_tex)
 
 	GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.bloom.extract_fbo[0]);
 	GL_SetScissorEnabled (false);
-	glColorMask (GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
-	glViewport (0, 0, framebufs.bloom.width[0], framebufs.bloom.height[0]);
+	GL_Backend_SetColorMaskCached (GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+	R_Backend_SetViewport (0, 0, framebufs.bloom.width[0], framebufs.bloom.height[0]);
 	GL_ClearBufferfvFunc (GL_COLOR, 0, clear_color);
 	GL_UseProgram (glprogs.bloom_combine);
 	{
@@ -2155,8 +2155,8 @@ static GLuint GL_GenerateSSAOTexture (float view_min_x, float view_min_y, float 
 	}
 	// SSAO FIX: Reset viewport/scissor/color mask per pass to avoid banding from stale state.
 	GL_SetScissorEnabled (false);
-	glColorMask (GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
-	glViewport (0, 0, width, height);
+	GL_Backend_SetColorMaskCached (GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+	R_Backend_SetViewport (0, 0, width, height);
 	{
 		const float clear[4] = { 1.f, 1.f, 1.f, 1.f };
 		GL_ClearBufferfvFunc (GL_COLOR, 0, clear);
@@ -2248,8 +2248,8 @@ static GLuint GL_GenerateSSAOTexture (float view_min_x, float view_min_y, float 
 		GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.ssao.blur_fbo[index]);
 		GL_LogErrorIfDeveloper ("SSAO blur bind FBO");
 		GL_SetScissorEnabled (false);
-		glColorMask (GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
-		glViewport (0, 0, width, height);
+		GL_Backend_SetColorMaskCached (GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+		R_Backend_SetViewport (0, 0, width, height);
 		GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, framebufs.ssao.ao_tex[index]);
 		GL_Uniform4fFunc (2, 1.f, 0.f, 0.f, 0.f);
 		R_Backend_Draw (R_BACKEND_PRIMITIVE_TRIANGLES, 0, 3);
@@ -2257,7 +2257,7 @@ static GLuint GL_GenerateSSAOTexture (float view_min_x, float view_min_y, float 
 
 		GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.ssao.ao_fbo[index]);
 		GL_SetScissorEnabled (false);
-		glColorMask (GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+		GL_Backend_SetColorMaskCached (GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
 		GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, framebufs.ssao.blur_tex[index]);
 		GL_Uniform4fFunc (2, 0.f, 1.f, 0.f, 0.f);
 		R_Backend_Draw (R_BACKEND_PRIMITIVE_TRIANGLES, 0, 3);
@@ -2374,7 +2374,7 @@ static void GL_GenerateGodraysSource (qboolean draw_sky, qboolean draw_brush)
 
 	GL_BeginGroup ("Godrays source");
 	GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.godrays.source_fbo);
-	glViewport (0, 0, width, height);
+	R_Backend_SetViewport (0, 0, width, height);
 	{
 		const float zero[4] = { 0.f, 0.f, 0.f, 0.f };
 		GL_ClearBufferfvFunc (GL_COLOR, 0, zero);
@@ -2523,7 +2523,7 @@ static GLuint GL_GenerateGodraysTexture (GLuint *out_mask)
 
 	GL_BeginGroup ("Godrays scatter");
 	GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.godrays.shafts_fbo);
-	glViewport (0, 0, width, height);
+	R_Backend_SetViewport (0, 0, width, height);
 	{
 		const float zero[4] = { 0.f, 0.f, 0.f, 0.f };
 		GL_ClearBufferfvFunc (GL_COLOR, 0, zero);
@@ -2540,7 +2540,7 @@ static GLuint GL_GenerateGodraysTexture (GLuint *out_mask)
 
 			GL_BeginGroup ("Godrays mask (sky)");
 			GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.godrays.mask_fbo);
-			glViewport (0, 0, width, height);
+			R_Backend_SetViewport (0, 0, width, height);
 			{
 				const float zero[4] = { 0.f, 0.f, 0.f, 0.f };
 				GL_ClearBufferfvFunc (GL_COLOR, 0, zero);
@@ -2569,7 +2569,7 @@ static GLuint GL_GenerateGodraysTexture (GLuint *out_mask)
 
 			GL_BeginGroup ("Godrays scatter (sky)");
 			GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.godrays.shafts_fbo);
-			glViewport (0, 0, width, height);
+			R_Backend_SetViewport (0, 0, width, height);
 			GL_UseProgram (glprogs.godrays);
 			{
 				const unsigned state = GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0);
@@ -2600,7 +2600,7 @@ static GLuint GL_GenerateGodraysTexture (GLuint *out_mask)
 
 			GL_BeginGroup ("Godrays mask (brush)");
 			GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.godrays.mask_fbo);
-			glViewport (0, 0, width, height);
+			R_Backend_SetViewport (0, 0, width, height);
 			{
 				const float zero[4] = { 0.f, 0.f, 0.f, 0.f };
 				GL_ClearBufferfvFunc (GL_COLOR, 0, zero);
@@ -2629,7 +2629,7 @@ static GLuint GL_GenerateGodraysTexture (GLuint *out_mask)
 
 			GL_BeginGroup ("Godrays scatter (brush)");
 			GL_BindFramebufferFunc (GL_FRAMEBUFFER, framebufs.godrays.shafts_fbo);
-			glViewport (0, 0, width, height);
+			R_Backend_SetViewport (0, 0, width, height);
 			GL_UseProgram (glprogs.godrays);
 			{
 				const unsigned state = (first_pass ? GLS_BLEND_OPAQUE : GLS_BLEND_ADD) | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS (0);
@@ -3405,7 +3405,7 @@ void GL_PostProcess (const RenderGraphResourceHandle *resources)
 
 	GL_BindFramebufferFunc (GL_FRAMEBUFFER, 0);
 	GL_SetScissorEnabled (false);
-	glColorMask (GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+	GL_Backend_SetColorMaskCached (GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
 	R_Backend_SetViewport (glx, gly, glwidth, glheight);
 	{
 		int debug_mode = (int)Q_rint (CLAMP (0.f, r_debug_colorspace.value, 4.f));
@@ -4351,7 +4351,7 @@ void R_SetupGL (void)
 			glDrawBuffer (GL_BACK);
 			glReadBuffer (GL_BACK);
 		}
-		glViewport (glx + r_refdef.vrect.x, gly + glheight - r_refdef.vrect.y - r_refdef.vrect.height, r_refdef.vrect.width, r_refdef.vrect.height);
+		R_Backend_SetViewport (glx + r_refdef.vrect.x, gly + glheight - r_refdef.vrect.y - r_refdef.vrect.height, r_refdef.vrect.width, r_refdef.vrect.height);
 	}
 	else
 	{
@@ -4371,7 +4371,7 @@ void R_SetupGL (void)
 			glDrawBuffer (GL_COLOR_ATTACHMENT0);
 			glReadBuffer (GL_COLOR_ATTACHMENT0);
 		}
-		glViewport (0, 0, scene_width, scene_height);
+		R_Backend_SetViewport (0, 0, scene_width, scene_height);
 	}
 }
 
@@ -4400,7 +4400,7 @@ void R_Clear (void)
 		R_Backend_BindPipeline (&pipeline_desc);
 		R_Backend_SetDynamicState (&dynamic_state);
 	}
-	glStencilMask (~0u);
+	GL_Backend_SetStencilMaskCached (~0u);
 	glClear (clearbits);
 }
 
@@ -4908,25 +4908,25 @@ void R_DrawViewModel (void)
 
 	GL_BeginGroup ("View model");
 	GL_SetScissorEnabled (false);
-	glColorMask (GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+	GL_Backend_SetColorMaskCached (GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
 
 	/* Viewmodel is rendered after postprocess to keep it out of blur/DoF/SSAO/bloom.
 	 * Reinitialize depth so world depth cannot clip the weapon while preserving
 	 * correct self-occlusion inside the model.
 	 * The alias shader applies the final tonemap/overbright finish for the weapon. */
-	glDepthMask (GL_TRUE);
+	GL_Backend_SetDepthMaskCached (GL_TRUE);
 	if (gl_clipcontrol_able)
 		glClearDepth (0.0);
 	else
 		glClearDepth (1.0);
 	glClear (GL_DEPTH_BUFFER_BIT);
-	glDepthFunc (restore_depth_func);
+	GL_Backend_SetDepthFuncCached ((unsigned)restore_depth_func);
 
 	// hack the depth range to prevent view model from poking into walls
 	GL_DepthRange (ZRANGE_VIEWMODEL);
 	R_DrawAliasModels (&e, 1);
 	GL_DepthRange (ZRANGE_FULL);
-	glDepthFunc (restore_depth_func);
+	GL_Backend_SetDepthFuncCached ((unsigned)restore_depth_func);
 
 	GL_EndGroup ();
 }
@@ -5904,7 +5904,7 @@ void R_WarpScaleView (const RenderGraphResourceHandle *resources)
 		glDrawBuffer (GL_COLOR_ATTACHMENT0);
 		glReadBuffer (GL_COLOR_ATTACHMENT0);
 		GL_SetScissorEnabled (false);
-		glColorMask (GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+		GL_Backend_SetColorMaskCached (GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
 		GL_ClearBufferfvFunc (GL_COLOR, 0, clear_color);
 		GL_ClearBufferfvFunc (GL_DEPTH, 0, &clear_depth);
 	}
@@ -5996,7 +5996,7 @@ void R_WarpScaleView (const RenderGraphResourceHandle *resources)
 		glDrawBuffer (GL_BACK);
 		glReadBuffer (GL_BACK);
 	}
-	glViewport (srcx, srcy, r_refdef.vrect.width, r_refdef.vrect.height);
+	R_Backend_SetViewport (srcx, srcy, r_refdef.vrect.width, r_refdef.vrect.height);
 
 	if (!needwarpscale)
 	{

--- a/Quake/src/render/gl_shadow_runtime.c
+++ b/Quake/src/render/gl_shadow_runtime.c
@@ -1,5 +1,6 @@
 #include "quakedef.h"
 #include "glquake.h"
+#include "gl_backend.h"
 
 #include "gl_backend.h"
 #include "gl_shadow.h"
@@ -1093,7 +1094,7 @@ static void R_RenderSunShadowMap (void)
 		}
 
 		GL_FramebufferTextureLayerFunc (GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, framebufs.shadow.sun_depth_tex, 0, cascade);
-		glViewport (0, 0, framebufs.shadow.sun_size, framebufs.shadow.sun_size);
+		R_Backend_SetViewport (0, 0, framebufs.shadow.sun_size, framebufs.shadow.sun_size);
 		glClear (GL_DEPTH_BUFFER_BIT);
 
 		R_Shadow_SetCasterState (&r_shadow_state, r_shadow_state.sun_viewproj[cascade], false, dummy, 1.f);
@@ -1164,7 +1165,7 @@ static void R_RenderDLightShadowMaps (void)
 			}
 
 			GL_FramebufferTextureLayerFunc (GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, framebufs.shadow.dlight_depth_tex, 0, layer);
-			glViewport (0, 0, framebufs.shadow.dlight_size, framebufs.shadow.dlight_size);
+			R_Backend_SetViewport (0, 0, framebufs.shadow.dlight_size, framebufs.shadow.dlight_size);
 			glClear (GL_DEPTH_BUFFER_BIT);
 
 			R_Shadow_SetCasterState (&r_shadow_state, r_shadow_state.dlight_viewproj[slot][face], true, *light, (*light)[3]);
@@ -1246,10 +1247,10 @@ void R_Shadow_RenderMaps (entity_t **shadow_visedicts, int numshadowedicts)
 		GL_ClipControlFunc (GL_LOWER_LEFT, GL_NEGATIVE_ONE_TO_ONE);
 		clip_depth_mode_changed = true;
 	}
-	glDepthFunc (GL_LEQUAL);
+	GL_Backend_SetDepthFuncCached (GL_LEQUAL);
 	glClearDepth (1.0);
-	glDepthMask (GL_TRUE);
-	glColorMask (GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
+	GL_Backend_SetDepthMaskCached (GL_TRUE);
+	GL_Backend_SetColorMaskCached (GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
 
 	GL_BeginGroup ("Shadow maps");
 	if (profile_enabled && have_query_api && want_sun_shadow)
@@ -1273,7 +1274,7 @@ void R_Shadow_RenderMaps (entity_t **shadow_visedicts, int numshadowedicts)
 		GL_EndQueryFunc (GL_TIME_ELAPSED);
 	GL_EndGroup ();
 
-	glColorMask (GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+	GL_Backend_SetColorMaskCached (GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
 	{
 		RenderBackendPipelineDesc pipeline_desc;
 		RenderBackendDynamicState dynamic_state;
@@ -1290,12 +1291,12 @@ void R_Shadow_RenderMaps (entity_t **shadow_visedicts, int numshadowedicts)
 		GL_ClipControlFunc (GL_LOWER_LEFT, GL_ZERO_TO_ONE);
 	if (gl_clipcontrol_able)
 	{
-		glDepthFunc (GL_GEQUAL);
+		GL_Backend_SetDepthFuncCached (GL_GEQUAL);
 		glClearDepth (0.0);
 	}
 	else
 	{
-		glDepthFunc (GL_LEQUAL);
+		GL_Backend_SetDepthFuncCached (GL_LEQUAL);
 		glClearDepth (1.0);
 	}
 	if (marked_for_shadow)
@@ -1364,4 +1365,3 @@ void R_Shadow_RenderMaps (entity_t **shadow_visedicts, int numshadowedicts)
 
 	r_shadow_state.valid = (want_sun_shadow || want_dlight_shadows);
 }
-

--- a/Quake/src/render/gl_sky.c
+++ b/Quake/src/render/gl_sky.c
@@ -24,6 +24,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "quakedef.h"
 #include "glquake.h"
+#include "gl_backend.h"
 
 extern	int	rs_skypolys; //for r_speeds readout
 extern	int rs_skypasses; //for r_speeds readout
@@ -791,21 +792,21 @@ void Sky_DrawSky (void)
 	}
 	else if (skybox)
 	{
-		glEnable (GL_STENCIL_TEST);
-		glStencilMask (1);
-		glStencilFunc (GL_ALWAYS, 1, 1);
-		glStencilOp (GL_KEEP, GL_KEEP, GL_REPLACE);
-		glColorMask (GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
+		GL_Backend_SetStencilTestCached (true);
+		GL_Backend_SetStencilMaskCached (1);
+		GL_Backend_SetStencilFuncCached (GL_ALWAYS, 1, 1);
+		GL_Backend_SetStencilOpCached (GL_KEEP, GL_KEEP, GL_REPLACE);
+		GL_Backend_SetColorMaskCached (GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
 
 		R_DrawBrushModels_SkyStencil (ents, count);
 
-		glStencilFunc (GL_EQUAL, 1, 1);
-		glStencilOp (GL_KEEP, GL_KEEP, GL_KEEP);
-		glColorMask (GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+		GL_Backend_SetStencilFuncCached (GL_EQUAL, 1, 1);
+		GL_Backend_SetStencilOpCached (GL_KEEP, GL_KEEP, GL_KEEP);
+		GL_Backend_SetColorMaskCached (GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
 
 		Sky_DrawSkyBox ();
 
-		glDisable (GL_STENCIL_TEST);
+		GL_Backend_SetStencilTestCached (false);
 	}
 	else
 	{
@@ -849,4 +850,3 @@ void Sky_SetupFrame (void)
         r_framedata.wind[2] = -dist * cp * cy;
         r_framedata.wind[3] = phase;
 }
-

--- a/docs/renderer_backend_review.md
+++ b/docs/renderer_backend_review.md
@@ -192,6 +192,15 @@ Reviewed against the current framegraph/backend split and the still-GL-heavy exe
 - Replace direct framebuffer/draw/state calls with backend wrapper equivalents.
 - Keep OpenGL behavior identical.
 
+#### Phase-1 migration note (April 20, 2026)
+- Completed wrapper migration for direct state mutations in:
+  - `Quake/src/render/gl_rmain.c`
+  - `Quake/src/render/gl_sky.c`
+  - `Quake/src/render/gl_oit.c`
+  - `Quake/src/render/gl_shadow_runtime.c`
+- Added cached backend wrappers for viewport/color/depth/stencil state in `gl_backend` to reduce redundant driver calls.
+- Remaining intentional exceptions (not migrated yet) are direct framebuffer attachment/read-draw-buffer operations that still depend on legacy FBO plumbing semantics; these are deferred until pass-local render-target contracts are fully explicit.
+
 ### Phase 2: Pass baselines and explicit state objects
 - Targets: `r_framegraph.h/c`, backend interface, `gl_backend.c`
 - Introduce pass baseline descriptors (depth/stencil/blend/raster/viewport/scissor).
@@ -240,4 +249,3 @@ Reviewed against the current framegraph/backend split and the still-GL-heavy exe
 6. Must-fix before serious Vulkan/DX12: state ownership, resource transitions, pass contracts, submission abstraction.
 7. Incremental path viability: **yes**, if GL remains first-class during phased migration.
 8. Confidence: **medium-high** for architecture-level findings; **medium** for runtime-correctness edge cases without exhaustive runtime tracing.
-


### PR DESCRIPTION
### Motivation
- Reduce scattered direct `gl*` state mutations and centralize state changes through the backend seam to make the framegraph/backends safer to migrate to non-GL APIs. 
- Avoid redundant driver calls by introducing a backend state cache for frequent per-pass state (viewport, color/depth masks, depth func, stencil). 
- Improve runtime diagnostics by validating per-pass minimal state contracts (depth/blend/cull/stencil/scissor) and emitting expected vs actual snapshots for `r_gl_state_validate`. 

### Description
- Added cached GL state wrapper API declarations in `Quake/include/gl_backend.h` and implemented a state cache and cached setters in `Quake/src/render/gl_backend.c` (`GL_Backend_ResetStateCache`, `GL_Backend_SetViewportCached`, `GL_Backend_SetColorMaskCached`, `GL_Backend_SetDepthMaskCached`, `GL_Backend_SetDepthFuncCached`, `GL_Backend_SetStencilTestCached`, `GL_Backend_SetStencilMaskCached`, `GL_Backend_SetStencilFuncCached`, `GL_Backend_SetStencilOpCached`).
- Hooked state-cache lifecycle to backend init/frame/resource reset by calling `GL_Backend_ResetStateCache` from `GLBackend_Init`, `GLBackend_BeginFrame`, and `GL_Backend_ResetResources` to avoid stale assumptions across resizes/frames. 
- Replaced direct state mutations in pass code with backend wrappers in the following files: `Quake/src/render/gl_rmain.c`, `Quake/src/render/gl_sky.c`, `Quake/src/render/gl_oit.c`, and `Quake/src/render/gl_shadow_runtime.c` (viewport calls were routed to `R_Backend_SetViewport` where appropriate, and color/depth/stencil mutations routed to new `GL_Backend_*Cached` wrappers). 
- Extended `GLBackend_ValidatePassState` in `gl_backend.c` with a small per-pass contract table and runtime checks that emit `Con_Warning` with expected vs actual state and snapshots of viewport/scissor/colormask when `r_gl_state_validate` is enabled. 
- Documented the Phase-1 migration progress and the intentional remaining legacy exceptions in `docs/renderer_backend_review.md`.

### Testing
- Ran `python python/check_no_legacy_pipeline_state_calls.py` and it passed. 
- Ran `python python/check_no_raw_gl_calls.py` which reported failures due to the script expecting legacy file locations (path/layout mismatch), not due to the introduced wrapper changes. 
- Ran `python python/check_framegraph_pass_contracts.py` which failed because the script expects `Quake/r_passes.c` at a different path (environment/path mismatch); the new pass-contract checks exist in `GLBackend_ValidatePassState` and will emit warnings at runtime when `r_gl_state_validate` is enabled.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5fd2b1210832eb4d5b8ed285f0f4d)