### PR TITLE
Fix `resetcfg` scoping and add debug-only reset self-test

### DIFF
--- a/Quake/src/core/cvar.c
+++ b/Quake/src/core/cvar.c
@@ -65,6 +65,12 @@ static void Cvar_AddToHashMap (cvar_t *var)
 
 void Cvar_Reset (const char *name); //johnfitz
 
+#if !defined(NDEBUG)
+static cvar_t cvar_resetcfg_test_archive = {"_cvar_resetcfg_test_archive", "10", CVAR_ARCHIVE};
+static cvar_t cvar_resetcfg_test_none = {"_cvar_resetcfg_test_none", "20", CVAR_NONE};
+static cvar_t cvar_resetcfg_test_notify = {"_cvar_resetcfg_test_notify", "30", CVAR_NOTIFY};
+#endif
+
 /*
 ============
 Cvar_List_f -- johnfitz
@@ -249,6 +255,11 @@ void Cvar_ResetAll_f (void)
 /*
 ============
 Cvar_ResetCfg_f -- QuakeSpasm
+
+Reset only CVAR_ARCHIVE vars to their defaults.
+Expected behavior:
+- CVAR_ARCHIVE vars are reset.
+- non-archived vars are left untouched.
 ============
 */
 void Cvar_ResetCfg_f (void)
@@ -256,9 +267,43 @@ void Cvar_ResetCfg_f (void)
 	int i;
 
 	for (i = 0; i < cvar_count; i++)
+	{
 		if (cvar_list[i]->flags & CVAR_ARCHIVE)
 			Cvar_Reset (cvar_list[i]->name);
+	}
 }
+
+#if !defined(NDEBUG)
+static void Cvar_ResetCfg_SelfTest_f (void)
+{
+	qboolean ok = true;
+
+	Cvar_SetQuick (&cvar_resetcfg_test_archive, "11");
+	Cvar_SetQuick (&cvar_resetcfg_test_none, "21");
+	Cvar_SetQuick (&cvar_resetcfg_test_notify, "31");
+
+	Cvar_ResetCfg_f ();
+
+	if (strcmp (cvar_resetcfg_test_archive.string, cvar_resetcfg_test_archive.default_string) != 0)
+	{
+		Con_Printf ("resetcfg_selftest: FAIL archived var was not reset\n");
+		ok = false;
+	}
+	if (strcmp (cvar_resetcfg_test_none.string, "21") != 0)
+	{
+		Con_Printf ("resetcfg_selftest: FAIL non-archived var changed\n");
+		ok = false;
+	}
+	if (strcmp (cvar_resetcfg_test_notify.string, "31") != 0)
+	{
+		Con_Printf ("resetcfg_selftest: FAIL notify-only var changed\n");
+		ok = false;
+	}
+
+	if (ok)
+		Con_Printf ("resetcfg_selftest: PASS\n");
+}
+#endif
 
 //==============================================================================
 //
@@ -282,6 +327,12 @@ void Cvar_Init (void)
 	Cmd_AddCommand ("reset", Cvar_Reset_f);
 	Cmd_AddCommand ("resetall", Cvar_ResetAll_f);
 	Cmd_AddCommand ("resetcfg", Cvar_ResetCfg_f);
+#if !defined(NDEBUG)
+	Cvar_RegisterVariable (&cvar_resetcfg_test_archive);
+	Cvar_RegisterVariable (&cvar_resetcfg_test_none);
+	Cvar_RegisterVariable (&cvar_resetcfg_test_notify);
+	Cmd_AddCommand ("resetcfg_selftest", Cvar_ResetCfg_SelfTest_f);
+#endif
 }
 
 //==============================================================================


### PR DESCRIPTION
### Motivation

- Make `Cvar_ResetCfg_f` behavior explicit so only `CVAR_ARCHIVE` variables are reset and avoid accidental side-effects from ambiguous scoping. 
- Add an inexpensive debug-only self-test to catch regressions in `resetcfg` behavior during development. 

### Description

- Add explicit braces around the loop body in `Cvar_ResetCfg_f` so the `CVAR_ARCHIVE` filter clearly scopes the call to `Cvar_Reset`. 
- Document the expected behavior directly above `Cvar_ResetCfg_f` indicating that only `CVAR_ARCHIVE` vars are reset and non-archived vars remain unchanged. 
- Add three debug-only test variables (`_cvar_resetcfg_test_archive`, `_cvar_resetcfg_test_none`, `_cvar_resetcfg_test_notify`) under `#if !defined(NDEBUG)`. 
- Implement a debug-only console command `resetcfg_selftest` (compiled only in non-NDEBUG builds) that sets the three test cvars, runs `Cvar_ResetCfg_f`, and prints PASS/FAIL based on the expected outcomes, and register the test cvars and command in `Cvar_Init`.

### Testing

- Ran static checks and diffs to validate the edit (`git diff --check`) which reported no issues. 
- Verified locations and context of changes with code searches (`rg`) and file inspection (`sed`/`nl`) to confirm the new test cvars, self-test function, and command registration are present. 
- No binary/runtime smoke test was executed because the target runtime binary was not available in this environment; the self-test is available for use in non-`NDEBUG` builds to perform an in-engine verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e60d14f0ac832eb5e42916c577a66b)