### PR TITLE
Clarify renderer backend maturity and enforce stub fallback

### DIFF
--- a/Quake/include/r_backend.h
+++ b/Quake/include/r_backend.h
@@ -21,6 +21,24 @@ typedef struct render_backend_surface_info_s
 	qboolean needs_postprocess;
 } RenderBackendSurfaceInfo;
 
+typedef enum render_backend_runtime_status_e
+{
+	R_BACKEND_RUNTIME_IMPLEMENTED = 0,
+	R_BACKEND_RUNTIME_EXPERIMENTAL,
+	R_BACKEND_RUNTIME_STUB
+} render_backend_runtime_status_t;
+
+typedef struct render_backend_milestones_s
+{
+	qboolean init_ready;
+	qboolean pass_callbacks_ready;
+	qboolean present_ready;
+	qboolean resource_translation_ready;
+} RenderBackendMilestones;
+
+render_backend_runtime_status_t R_Backend_GetRuntimeStatusForName (const char *backend_name);
+const char *R_Backend_GetRuntimeStatusLabel (render_backend_runtime_status_t status);
+qboolean R_Backend_GetMilestonesForName (const char *backend_name, RenderBackendMilestones *out_milestones);
 void R_Backend_QuerySurfaceInfo (RenderBackendSurfaceInfo *out_info);
 
 #endif

--- a/Quake/src/render/r_backend.c
+++ b/Quake/src/render/r_backend.c
@@ -29,6 +29,7 @@ static const char *s_ref_dx12_plugin_filename = "ref_dx12.so";
 static const IRenderBackend *s_registered_backends[R_BACKEND_MAX_REGISTERED];
 static int s_registered_backend_count = 0;
 static const IRenderBackend *s_active_backend = NULL;
+static const IRenderBackend *s_gl_backend = NULL;
 static RenderBackendCaps s_active_backend_caps;
 static qboolean s_backend_initialized = false;
 static qboolean s_applying_backend_cvar = false;
@@ -63,6 +64,11 @@ static qboolean R_Backend_Host_IsTransientResourceAlive (unsigned int resource_i
 static qboolean R_Backend_Host_GetShaderMetadata (unsigned int shader_id, iw_renderer_host_shader_metadata_t *out_metadata);
 static qboolean R_Backend_Host_GetPipelineMetadata (unsigned int pipeline_id, iw_renderer_host_pipeline_metadata_t *out_metadata);
 static qboolean R_Backend_ValidatePluginHostApi (const iw_renderer_plugin_host_api_t *host_api, qboolean emit_warning);
+static qboolean R_VulkanStub_Init (void);
+static qboolean R_VulkanStub_HasRequiredPassCallbacks (void);
+static void R_VulkanStub_Present (void);
+static unsigned R_VulkanStub_ResolveResourceId (const RenderGraphResourceHandle *resources, const render_backend_resource_ref_t *resource);
+static qboolean R_VulkanStub_IsResourceValid (const RenderGraphResourceHandle *resources, const render_backend_resource_ref_t *resource);
 
 static const iw_renderer_plugin_surface_services_t s_plugin_surface_services = {
 	sizeof (iw_renderer_plugin_surface_services_t),
@@ -466,6 +472,78 @@ static const char *R_Backend_CanonicalNameToApi (const char *backend_name)
 		return "dx12";
 
 	return backend_name;
+}
+
+static render_backend_runtime_status_t R_Backend_GetRuntimeStatusForBackend (const IRenderBackend *backend)
+{
+	if (!backend)
+		return R_BACKEND_RUNTIME_STUB;
+
+	if ((backend->init == R_VulkanStub_Init
+		&& backend->present == R_VulkanStub_Present
+		&& backend->resolve_resource_id == R_VulkanStub_ResolveResourceId
+		&& backend->is_resource_valid == R_VulkanStub_IsResourceValid)
+		&& (backend->name && (!q_strcasecmp (backend->name, "Vulkan") || !q_strcasecmp (backend->name, "DX12"))))
+		return R_BACKEND_RUNTIME_STUB;
+
+	if (backend->name && !q_strcasecmp (backend->name, "OpenGL"))
+		return R_BACKEND_RUNTIME_IMPLEMENTED;
+
+	return R_BACKEND_RUNTIME_EXPERIMENTAL;
+}
+
+const char *R_Backend_GetRuntimeStatusLabel (render_backend_runtime_status_t status)
+{
+	switch (status)
+	{
+	case R_BACKEND_RUNTIME_IMPLEMENTED: return "implemented";
+	case R_BACKEND_RUNTIME_EXPERIMENTAL: return "experimental";
+	case R_BACKEND_RUNTIME_STUB: return "stub";
+	default: return "unknown";
+	}
+}
+
+qboolean R_Backend_GetMilestonesForName (const char *backend_name, RenderBackendMilestones *out_milestones)
+{
+	const IRenderBackend *backend = R_Backend_FindByName (backend_name);
+
+	if (!out_milestones || !backend)
+		return false;
+
+	memset (out_milestones, 0, sizeof (*out_milestones));
+	out_milestones->init_ready = (backend->init != NULL && backend->init != R_VulkanStub_Init);
+	out_milestones->pass_callbacks_ready = (backend->has_required_pass_callbacks != NULL
+		&& backend->has_required_pass_callbacks != R_VulkanStub_HasRequiredPassCallbacks);
+	out_milestones->present_ready = (backend->present != NULL && backend->present != R_VulkanStub_Present);
+	out_milestones->resource_translation_ready = (backend->resolve_resource_id != NULL
+		&& backend->is_resource_valid != NULL
+		&& backend->resolve_resource_id != R_VulkanStub_ResolveResourceId
+		&& backend->is_resource_valid != R_VulkanStub_IsResourceValid);
+
+	if (backend->name && !q_strcasecmp (backend->name, "OpenGL"))
+	{
+		out_milestones->init_ready = true;
+		out_milestones->pass_callbacks_ready = true;
+		out_milestones->present_ready = true;
+		out_milestones->resource_translation_ready = true;
+	}
+
+	return true;
+}
+
+render_backend_runtime_status_t R_Backend_GetRuntimeStatusForName (const char *backend_name)
+{
+	return R_Backend_GetRuntimeStatusForBackend (R_Backend_FindByName (backend_name));
+}
+
+static void R_Backend_PrintApiHelp (void)
+{
+	Con_Printf ("r_backend_api help: gl=%s, vulkan=%s, dx12=%s\n",
+		R_Backend_GetRuntimeStatusLabel (R_Backend_GetRuntimeStatusForName ("OpenGL")),
+		R_Backend_GetRuntimeStatusLabel (R_Backend_GetRuntimeStatusForName ("Vulkan")),
+		R_Backend_GetRuntimeStatusLabel (R_Backend_GetRuntimeStatusForName ("DX12")));
+	Con_Printf ("  gl: production path.\n");
+	Con_Printf ("  vulkan/dx12: bring-up paths; see *_status commands for milestone detail.\n");
 }
 
 static qboolean R_Backend_RegisterViaHostApi (const IRenderBackend *backend);
@@ -941,11 +1019,17 @@ static void R_Backend_Changed_f (cvar_t *var)
 static void R_Backend_ApiChanged_f (cvar_t *var)
 {
 	const char *canonical_name;
+	render_backend_runtime_status_t status;
 
 	if (!var || s_applying_backend_api_cvar)
 		return;
 
 	canonical_name = R_Backend_ApiToCanonicalName (var->string);
+	status = R_Backend_GetRuntimeStatusForName (canonical_name);
+	Con_Printf ("r_backend_api '%s' -> backend '%s' (%s)\n",
+		var->string,
+		canonical_name ? canonical_name : "<unknown>",
+		R_Backend_GetRuntimeStatusLabel (status));
 	if (!R_Backend_Select (canonical_name))
 	{
 		Con_Warning ("Renderer backend API change to '%s' rejected; keeping '%s'\n",
@@ -1103,6 +1187,17 @@ static void R_Backend_VulkanStatus_f (void)
 	Con_Printf ("  registration: %s\n", is_stub ? "stub backend registered" : "plugin/backend override registered");
 	Con_Printf ("  activation gate: startup=%s runtime=%s\n", can_start ? "allowed" : "blocked", can_runtime ? "allowed" : "blocked");
 	Con_Printf ("  active backend: %s\n", (s_active_backend && s_active_backend->name) ? s_active_backend->name : "<none>");
+	{
+		RenderBackendMilestones milestones;
+		if (R_Backend_GetMilestonesForName ("Vulkan", &milestones))
+		{
+			Con_Printf ("  milestones: init=%s pass_callbacks=%s present=%s resource_translation=%s\n",
+				milestones.init_ready ? "yes" : "no",
+				milestones.pass_callbacks_ready ? "yes" : "no",
+				milestones.present_ready ? "yes" : "no",
+				milestones.resource_translation_ready ? "yes" : "no");
+		}
+	}
 	if (is_stub)
 	{
 		Con_Printf ("  implemented callbacks: contract no-op stubs only.\n");
@@ -1195,6 +1290,17 @@ static void R_Backend_DX12Status_f (void)
 	Con_Printf ("  registration: %s\n", is_stub ? "stub backend registered" : "plugin/backend override registered");
 	Con_Printf ("  activation gate: startup=%s runtime=%s\n", can_start ? "allowed" : "blocked", can_runtime ? "allowed" : "blocked");
 	Con_Printf ("  active backend: %s\n", (s_active_backend && s_active_backend->name) ? s_active_backend->name : "<none>");
+	{
+		RenderBackendMilestones milestones;
+		if (R_Backend_GetMilestonesForName ("DX12", &milestones))
+		{
+			Con_Printf ("  milestones: init=%s pass_callbacks=%s present=%s resource_translation=%s\n",
+				milestones.init_ready ? "yes" : "no",
+				milestones.pass_callbacks_ready ? "yes" : "no",
+				milestones.present_ready ? "yes" : "no",
+				milestones.resource_translation_ready ? "yes" : "no");
+		}
+	}
 	if (is_stub)
 	{
 		Con_Printf ("  implemented callbacks: contract no-op stubs only.\n");
@@ -1226,6 +1332,8 @@ static qboolean R_Backend_RegisterViaHostApi (const IRenderBackend *backend)
 			s_registered_backends[i] = backend;
 			if (s_active_backend && !q_strcasecmp (s_active_backend->name, backend->name))
 				s_active_backend = backend;
+			if (!q_strcasecmp (backend->name, "OpenGL"))
+				s_gl_backend = backend;
 			return true;
 		}
 	}
@@ -1241,6 +1349,8 @@ static qboolean R_Backend_RegisterViaHostApi (const IRenderBackend *backend)
 	s_registered_backends[s_registered_backend_count++] = backend;
 	if (!s_active_backend)
 		s_active_backend = backend;
+	if (!q_strcasecmp (backend->name, "OpenGL"))
+		s_gl_backend = backend;
 	return true;
 }
 
@@ -1255,11 +1365,21 @@ qboolean R_Backend_Select (const char *backend_name)
 	const IRenderBackend *previous = s_active_backend;
 	const qboolean runtime_switch = s_backend_active && previous && backend && (previous != backend);
 	qboolean activated = false;
+	const render_backend_runtime_status_t status = R_Backend_GetRuntimeStatusForBackend (backend);
 
 	if (!backend)
 		return false;
 	if (!R_Backend_ValidateContract (backend, true))
 		return false;
+	if (status == R_BACKEND_RUNTIME_STUB)
+	{
+		Con_Warning ("Renderer backend '%s' is a stub backend and cannot be selected.\n",
+			backend->name ? backend->name : "<unnamed>");
+		Con_Warning ("Fallback to OpenGL requested.\n");
+		if (s_gl_backend && backend != s_gl_backend)
+			return R_Backend_Select (s_gl_backend->name);
+		return false;
+	}
 
 	if (runtime_switch && (!backend->can_activate || !backend->can_activate (true)))
 	{
@@ -1271,8 +1391,9 @@ qboolean R_Backend_Select (const char *backend_name)
 
 	if (backend->can_activate && !backend->can_activate (false))
 	{
-		Con_Warning ("Renderer backend '%s' is not ready for activation.\n",
-			backend->name ? backend->name : "<unnamed>");
+		Con_Warning ("Renderer backend '%s' is %s and not ready for activation.\n",
+			backend->name ? backend->name : "<unnamed>",
+			R_Backend_GetRuntimeStatusLabel (status));
 		if (backend->name && !q_strcasecmp (backend->name, "Vulkan"))
 			Con_Warning ("Use command 'r_backend_vulkan_status' for detailed bring-up status.\n");
 		if (backend->name && !q_strcasecmp (backend->name, "DX12"))
@@ -1350,6 +1471,7 @@ void R_Backend_Init (void)
 	Cvar_RegisterVariable (&r_backend_api);
 	Cvar_SetCallback (&r_backend, R_Backend_Changed_f);
 	Cvar_SetCallback (&r_backend_api, R_Backend_ApiChanged_f);
+	R_Backend_PrintApiHelp ();
 	if (!s_backend_audit_cmd_registered)
 	{
 		Cmd_AddCommand ("r_backend_wrapper_audit", R_Backend_WrapperAudit_f);
@@ -1393,6 +1515,7 @@ void R_Backend_Shutdown (void)
 	}
 	s_registered_backend_count = 0;
 	s_active_backend = NULL;
+	s_gl_backend = NULL;
 	s_backend_initialized = false;
 	s_command_encoder_recording = false;
 	s_command_encoder_frame = -1;

--- a/Quake/src/render/ref_dx12_plugin.c
+++ b/Quake/src/render/ref_dx12_plugin.c
@@ -141,6 +141,8 @@ static qboolean IW_RendererRefDX12_Register (const iw_renderer_plugin_host_api_t
 	if (!host_api->register_backend)
 		return false;
 
+	Con_Printf ("[ref_dx12] capability banner: STUB backend loaded (experimental bring-up only).\n");
+	Con_Printf ("[ref_dx12] milestones: init=no pass_callbacks=no present=no resource_translation=no\n");
 	return host_api->register_backend (&s_ref_dx12_backend);
 }
 

--- a/Quake/src/render/ref_vk_plugin.c
+++ b/Quake/src/render/ref_vk_plugin.c
@@ -141,6 +141,8 @@ static qboolean IW_RendererRefVK_Register (const iw_renderer_plugin_host_api_t *
 	if (!host_api->register_backend)
 		return false;
 
+	Con_Printf ("[ref_vk] capability banner: STUB backend loaded (experimental bring-up only).\n");
+	Con_Printf ("[ref_vk] milestones: init=no pass_callbacks=no present=no resource_translation=no\n");
 	return host_api->register_backend (&s_ref_vk_backend);
 }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ This directory tracks engine-facing implementation notes, feature references, an
 - `particle_debug_mvp.md`
 - `particle_material_contract.md`
 - `q3p_phase0_particle_mapping.md`
+- `developer_renderer_backends.md` - backend runtime status, stub policy, and milestone criteria for Vulkan/DX12 bring-up.
 
 The design/debug notes are intentionally implementation-oriented snapshots. They
 may describe rollout phases, experiments, or diagnostics rather than user-facing

--- a/docs/developer_renderer_backends.md
+++ b/docs/developer_renderer_backends.md
@@ -1,0 +1,42 @@
+# Developer renderer backend maturity guide
+
+This project currently exposes three `r_backend_api` values:
+
+- `gl` -> `OpenGL` (**implemented**)
+- `vulkan` -> `Vulkan` (**experimental** or **stub**, depending on loaded plugin/backend)
+- `dx12` -> `DX12` (**experimental** or **stub**, depending on loaded plugin/backend)
+
+## Runtime status model
+
+Runtime status labels are intentionally simple:
+
+- `implemented`: production path expected to work end-to-end.
+- `experimental`: non-stub backend is wired in, but activation/readiness can still be blocked.
+- `stub`: placeholder backend; selection is blocked and engine falls back to OpenGL.
+
+The console prints a compact help line at backend init:
+
+- `r_backend_api help: gl=..., vulkan=..., dx12=...`
+
+When `r_backend_api` is changed at runtime, it also logs the resolved backend and current runtime status.
+
+## Stub selection policy
+
+Stub backends are rejected early during `R_Backend_Select()` with explicit diagnostics.
+When this happens, the engine forces fallback selection to OpenGL so users do not stay on a non-functional renderer path.
+
+## Backend maturity milestones
+
+A backend should only be considered production-ready when these milestones are all `yes`:
+
+1. `init`: backend can initialize successfully.
+2. `pass_callbacks`: backend provides required pass callback implementation.
+3. `present`: backend can present frames.
+4. `resource_translation`: backend resolves/validates framegraph resources.
+
+The status commands (`r_backend_vulkan_status`, `r_backend_dx12_status`) now print milestone values directly.
+
+## Important user-facing expectation
+
+Presence of a backend name (`Vulkan`/`DX12`) in logs or plugin discovery is **not** equivalent to production readiness.
+Only the runtime status plus milestone output should be used as readiness signals.


### PR DESCRIPTION
### Motivation

- Prevent users from mistaking discovered or plugin-registered backends (Vulkan/DX12) as production-ready by exposing a clear runtime status model and milestone checklist. 
- Fail fast and give actionable diagnostics when a stub backend is selected so the engine does not remain on a non-functional renderer path. 

### Description

- Add a small backend maturity interface in `Quake/include/r_backend.h`: `render_backend_runtime_status_t`, `RenderBackendMilestones`, and query APIs `R_Backend_GetRuntimeStatusForName`, `R_Backend_GetRuntimeStatusLabel`, and `R_Backend_GetMilestonesForName`.
- Implement runtime-status and milestone logic in `Quake/src/render/r_backend.c`, including `R_Backend_GetRuntimeStatusForBackend`, `R_Backend_GetMilestonesForName`, and a `R_Backend_PrintApiHelp` banner printed at init and on `r_backend_api` changes.
- Block selection of stub backends early in `R_Backend_Select()` with clear `Con_Warning` output and an automatic fallback attempt to the tracked OpenGL backend (`s_gl_backend`).
- Extend `r_backend_vulkan_status` and `r_backend_dx12_status` to include milestone output (`init`, `pass_callbacks`, `present`, `resource_translation`).
- Add visible capability banners to `Quake/src/render/ref_vk_plugin.c` and `Quake/src/render/ref_dx12_plugin.c` so the plugins announce their stub/bring-up status at load-time.
- Add developer documentation `docs/developer_renderer_backends.md` and link it from `docs/README.md` to explain the runtime status model and milestone expectations.

### Testing

- Ran repository checks: `git diff --check` and `git status --short`, both reported no issues.
- Verified code compiles locally was not performed due to the project's Windows smoke-run workflow targeting `C:\Quake\rerelease\ironwail.exe`, so no binary smoke test was executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e613306378832eb9b9c1afac1780dc)