### PR TITLE
Centralize Warp/Resolve/FBO fallback resolution and add table-driven CVar registration and docs

### DIFF
--- a/Quake/src/render/gl_rmain.c
+++ b/Quake/src/render/gl_rmain.c
@@ -5822,6 +5822,56 @@ void R_RenderScene (const RenderGraphResourceHandle *resources)
 	R_ShowLightgridDebug ();
 }
 
+typedef struct r_warpscale_resources_s
+{
+	GLuint scene_fbo;
+	GLuint scene_color_tex;
+	GLuint scene_velocity_tex;
+	GLuint resolved_scene_fbo;
+	GLuint resolved_scene_color_tex;
+	GLuint resolved_scene_velocity_tex;
+	GLuint composite_fbo;
+	int scene_samples;
+	qboolean msaa;
+} r_warpscale_resources_t;
+
+static void R_ResolveWarpScaleResources (const RenderGraphResourceHandle *resources, r_warpscale_resources_t *resolved)
+{
+	memset (resolved, 0, sizeof (*resolved));
+
+	resolved->scene_fbo = (GLuint)R_FrameGraph_ResolveRequiredResourceBySlot (resources, R_BACKEND_RESOURCE_SLOT_SCENE_FBO, "Warp/resolve");
+	resolved->scene_color_tex = (GLuint)R_FrameGraph_ResolveRequiredResourceBySlot (resources, R_BACKEND_RESOURCE_SLOT_SCENE_COLOR, "Warp/resolve");
+	resolved->scene_velocity_tex = (GLuint)R_FrameGraph_ResolveRequiredResourceBySlot (resources, R_BACKEND_RESOURCE_SLOT_SCENE_VELOCITY, "Warp/resolve");
+	resolved->composite_fbo = (GLuint)R_FrameGraph_ResolveRequiredResourceBySlot (resources, R_BACKEND_RESOURCE_SLOT_COMPOSITE_FBO, "Warp/resolve");
+	resolved->scene_samples = R_Backend_GetSceneSampleCount ();
+	if (resolved->scene_samples <= 0)
+		resolved->scene_samples = framebufs.scene.samples;
+	resolved->msaa = resolved->scene_samples > 1;
+
+	if (!resolved->scene_fbo)
+		resolved->scene_fbo = framebufs.scene.fbo;
+	if (!resolved->scene_color_tex)
+		resolved->scene_color_tex = framebufs.scene.color_tex;
+	if (!resolved->scene_velocity_tex)
+		resolved->scene_velocity_tex = framebufs.scene.velocity_tex;
+	if (!resolved->composite_fbo)
+		resolved->composite_fbo = framebufs.composite.fbo;
+
+	if (resolved->msaa)
+	{
+		resolved->resolved_scene_fbo = (GLuint)R_FrameGraph_ResolveRequiredResourceBySlot (resources, R_BACKEND_RESOURCE_SLOT_RESOLVED_SCENE_FBO, "Warp/resolve");
+		resolved->resolved_scene_color_tex = (GLuint)R_FrameGraph_ResolveRequiredResourceBySlot (resources, R_BACKEND_RESOURCE_SLOT_RESOLVED_SCENE_COLOR, "Warp/resolve");
+		resolved->resolved_scene_velocity_tex = (GLuint)R_FrameGraph_ResolveRequiredResourceBySlot (resources, R_BACKEND_RESOURCE_SLOT_RESOLVED_SCENE_VELOCITY, "Warp/resolve");
+	}
+
+	if (!resolved->resolved_scene_fbo)
+		resolved->resolved_scene_fbo = framebufs.resolved_scene.fbo;
+	if (!resolved->resolved_scene_color_tex)
+		resolved->resolved_scene_color_tex = framebufs.resolved_scene.color_tex;
+	if (!resolved->resolved_scene_velocity_tex)
+		resolved->resolved_scene_velocity_tex = framebufs.resolved_scene.velocity_tex;
+}
+
 /*
 ================
 R_WarpScaleView
@@ -5836,17 +5886,7 @@ void R_WarpScaleView (const RenderGraphResourceHandle *resources)
 {
 	int srcx, srcy, srcw, srch;
 	float smax, tmax;
-	GLuint scene_fbo = (GLuint)R_FrameGraph_ResolveRequiredResourceBySlot (resources, R_BACKEND_RESOURCE_SLOT_SCENE_FBO, "Warp/resolve");
-	GLuint scene_color_tex = (GLuint)R_FrameGraph_ResolveRequiredResourceBySlot (resources, R_BACKEND_RESOURCE_SLOT_SCENE_COLOR, "Warp/resolve");
-	GLuint scene_velocity_tex = (GLuint)R_FrameGraph_ResolveRequiredResourceBySlot (resources, R_BACKEND_RESOURCE_SLOT_SCENE_VELOCITY, "Warp/resolve");
-	GLuint resolved_scene_fbo = 0;
-	GLuint resolved_scene_color_tex = 0;
-	GLuint resolved_scene_velocity_tex = 0;
-	GLuint composite_fbo = (GLuint)R_FrameGraph_ResolveRequiredResourceBySlot (resources, R_BACKEND_RESOURCE_SLOT_COMPOSITE_FBO, "Warp/resolve");
-	int scene_samples = R_Backend_GetSceneSampleCount ();
-	if (scene_samples <= 0)
-		scene_samples = framebufs.scene.samples;
-	qboolean msaa = scene_samples > 1;
+	r_warpscale_resources_t resolved;
 	qboolean needwarpscale;
 	qboolean need_depth_resolve;
 	qboolean force_blit_upscale;
@@ -5858,26 +5898,7 @@ void R_WarpScaleView (const RenderGraphResourceHandle *resources)
 	GLuint fbodest;
 	double t;
 
-	if (!scene_fbo)
-		scene_fbo = framebufs.scene.fbo;
-	if (!scene_color_tex)
-		scene_color_tex = framebufs.scene.color_tex;
-	if (!scene_velocity_tex)
-		scene_velocity_tex = framebufs.scene.velocity_tex;
-	if (msaa)
-	{
-		resolved_scene_fbo = (GLuint)R_FrameGraph_ResolveRequiredResourceBySlot (resources, R_BACKEND_RESOURCE_SLOT_RESOLVED_SCENE_FBO, "Warp/resolve");
-		resolved_scene_color_tex = (GLuint)R_FrameGraph_ResolveRequiredResourceBySlot (resources, R_BACKEND_RESOURCE_SLOT_RESOLVED_SCENE_COLOR, "Warp/resolve");
-		resolved_scene_velocity_tex = (GLuint)R_FrameGraph_ResolveRequiredResourceBySlot (resources, R_BACKEND_RESOURCE_SLOT_RESOLVED_SCENE_VELOCITY, "Warp/resolve");
-	}
-	if (!resolved_scene_fbo)
-		resolved_scene_fbo = framebufs.resolved_scene.fbo;
-	if (!resolved_scene_color_tex)
-		resolved_scene_color_tex = framebufs.resolved_scene.color_tex;
-	if (!resolved_scene_velocity_tex)
-		resolved_scene_velocity_tex = framebufs.resolved_scene.velocity_tex;
-	if (!composite_fbo)
-		composite_fbo = framebufs.composite.fbo;
+	R_ResolveWarpScaleResources (resources, &resolved);
 
 	R_GetFramePlanDecisions (&needs_scene_effects, &needs_postprocess);
 	if (!needs_scene_effects)
@@ -5890,17 +5911,17 @@ void R_WarpScaleView (const RenderGraphResourceHandle *resources)
 
 	force_blit_upscale = (R_GetSceneRenderScale () != 1) || (r_drs.value > 0.f);
 	needwarpscale = water_warp && !force_blit_upscale;
-	fbodest = needs_postprocess ? composite_fbo : 0;
+	fbodest = needs_postprocess ? resolved.composite_fbo : 0;
 	effective_dof_enabled = R_PostFX_DoFEnabledEffective ();
 	effective_ssao_enabled = ((r_ssao.value > 0.f && r_ssao_intensity.value > 0.f) || r_ssao_debug.value > 0.f);
 	effective_godrays_preview = R_PostFX_GodraysPreviewEnabledEffective ();
-	need_depth_resolve = (fbodest == composite_fbo)
+	need_depth_resolve = (fbodest == resolved.composite_fbo)
 		&& (effective_dof_enabled || effective_ssao_enabled || effective_godrays_preview);
-	if (fbodest == composite_fbo)
+	if (fbodest == resolved.composite_fbo)
 	{
 		const float clear_color[4] = { 0.f, 0.f, 0.f, 1.f };
 		const float clear_depth = 1.f;
-		GL_BindFramebufferFunc (GL_FRAMEBUFFER, composite_fbo);
+		GL_BindFramebufferFunc (GL_FRAMEBUFFER, resolved.composite_fbo);
 		glDrawBuffer (GL_COLOR_ATTACHMENT0);
 		glReadBuffer (GL_COLOR_ATTACHMENT0);
 		GL_SetScissorEnabled (false);
@@ -5909,18 +5930,18 @@ void R_WarpScaleView (const RenderGraphResourceHandle *resources)
 		GL_ClearBufferfvFunc (GL_DEPTH, 0, &clear_depth);
 	}
 
-	if (msaa)
+	if (resolved.msaa)
 	{
 		GL_BeginGroup ("MSAA resolve");
 
-		GL_BindFramebufferFunc (GL_READ_FRAMEBUFFER, scene_fbo);
-		GL_BindFramebufferFunc (GL_DRAW_FRAMEBUFFER, resolved_scene_fbo);
+		GL_BindFramebufferFunc (GL_READ_FRAMEBUFFER, resolved.scene_fbo);
+		GL_BindFramebufferFunc (GL_DRAW_FRAMEBUFFER, resolved.resolved_scene_fbo);
 
 		glReadBuffer (GL_COLOR_ATTACHMENT0);
 		glDrawBuffer (GL_COLOR_ATTACHMENT0);
 		GL_BlitFramebufferFunc (0, 0, srcw, srch, 0, 0, srcw, srch, GL_COLOR_BUFFER_BIT, GL_NEAREST);
 
-		if (scene_velocity_tex && resolved_scene_velocity_tex)
+		if (resolved.scene_velocity_tex && resolved.resolved_scene_velocity_tex)
 		{
 			glReadBuffer (GL_COLOR_ATTACHMENT1);
 			glDrawBuffer (GL_COLOR_ATTACHMENT1);
@@ -5933,7 +5954,7 @@ void R_WarpScaleView (const RenderGraphResourceHandle *resources)
 		{
 			int dstw = force_blit_upscale ? r_refdef.vrect.width : srcw;
 			int dsth = force_blit_upscale ? r_refdef.vrect.height : srch;
-			GL_BindFramebufferFunc (GL_READ_FRAMEBUFFER, resolved_scene_fbo);
+			GL_BindFramebufferFunc (GL_READ_FRAMEBUFFER, resolved.resolved_scene_fbo);
 			glReadBuffer (GL_COLOR_ATTACHMENT0);
 			GL_BindFramebufferFunc (GL_DRAW_FRAMEBUFFER, fbodest);
 			if (fbodest)
@@ -5954,18 +5975,18 @@ void R_WarpScaleView (const RenderGraphResourceHandle *resources)
 		int dstw = (R_GetSceneRenderScale () != 1) ? r_refdef.vrect.width : srcw;
 		int dsth = (R_GetSceneRenderScale () != 1) ? r_refdef.vrect.height : srch;
 
-		GL_BindFramebufferFunc (GL_READ_FRAMEBUFFER, scene_fbo);
+		GL_BindFramebufferFunc (GL_READ_FRAMEBUFFER, resolved.scene_fbo);
 		glReadBuffer (GL_COLOR_ATTACHMENT0);
-		GL_BindFramebufferFunc (GL_DRAW_FRAMEBUFFER, composite_fbo);
+		GL_BindFramebufferFunc (GL_DRAW_FRAMEBUFFER, resolved.composite_fbo);
 		glDrawBuffer (GL_COLOR_ATTACHMENT0);
 		GL_BlitFramebufferFunc (0, 0, srcw, srch, srcx, srcy, srcx + dstw, srcy + dsth, GL_DEPTH_BUFFER_BIT, GL_NEAREST);
 	}
 
-	if (!msaa && !needwarpscale)
+	if (!resolved.msaa && !needwarpscale)
 	{
 		int dstw = force_blit_upscale ? r_refdef.vrect.width : srcw;
 		int dsth = force_blit_upscale ? r_refdef.vrect.height : srch;
-		GL_BindFramebufferFunc (GL_READ_FRAMEBUFFER, scene_fbo);
+		GL_BindFramebufferFunc (GL_READ_FRAMEBUFFER, resolved.scene_fbo);
 		glReadBuffer (GL_COLOR_ATTACHMENT0);
 		GL_BindFramebufferFunc (GL_DRAW_FRAMEBUFFER, fbodest);
 		if (fbodest)
@@ -6000,7 +6021,7 @@ void R_WarpScaleView (const RenderGraphResourceHandle *resources)
 
 	if (!needwarpscale)
 	{
-		if (fbodest == composite_fbo)
+		if (fbodest == resolved.composite_fbo)
 			framesetup.composite_ready = true;
 		return;
 	}
@@ -6034,15 +6055,15 @@ void R_WarpScaleView (const RenderGraphResourceHandle *resources)
 	GL_Uniform4fFunc (0, smax, tmax, water_warp ? 1.f / 256.f : 0.f, (float)t);
 	// View blends are applied after postprocess/UI to avoid AO/tone-map affecting overlays.
 	GL_Uniform4fFunc (1, 0.f, 0.f, 0.f, 0.f);
-	GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, msaa ? resolved_scene_color_tex : scene_color_tex);
-	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, water_warp && msaa ? GL_LINEAR : GL_NEAREST);
-	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, water_warp && msaa ? GL_LINEAR : GL_NEAREST);
+	GL_BindNative (GL_TEXTURE0, GL_TEXTURE_2D, resolved.msaa ? resolved.resolved_scene_color_tex : resolved.scene_color_tex);
+	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, water_warp && resolved.msaa ? GL_LINEAR : GL_NEAREST);
+	glTexParameteri (GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, water_warp && resolved.msaa ? GL_LINEAR : GL_NEAREST);
 
 	R_Backend_Draw (R_BACKEND_PRIMITIVE_TRIANGLES, 0, 3);
 
 	GL_EndGroup ();
 
-	if (fbodest == composite_fbo)
+	if (fbodest == resolved.composite_fbo)
 		framesetup.composite_ready = true;
 }
 

--- a/Quake/src/render/gl_rmisc.c
+++ b/Quake/src/render/gl_rmisc.c
@@ -469,6 +469,23 @@ float GL_WaterAlphaForTextureType (textype_t type)
 		return map_wateralpha;
 }
 
+typedef struct r_cvar_registration_s
+{
+	cvar_t *var;
+	void (*callback)(cvar_t *);
+} r_cvar_registration_t;
+
+static void R_RegisterCvarTable (const r_cvar_registration_t *table, size_t count)
+{
+	size_t i;
+	for (i = 0; i < count; ++i)
+	{
+		Cvar_RegisterVariable (table[i].var);
+		if (table[i].callback)
+			Cvar_SetCallback (table[i].var, table[i].callback);
+	}
+}
+
 /*
 ===============
 R_Init
@@ -485,25 +502,45 @@ void R_Init (void)
                 cmd->completion = R_ShowbboxesFilter_Completion_f;
         Cmd_AddCommand ("r_showbboxes_filter_clear", R_ShowbboxesFilterClear_f);
 
-        Lightgrid_Init ();
-        R_SkyVis_Init ();
-        Material_Init ();
+	Lightgrid_Init ();
+	R_SkyVis_Init ();
+	Material_Init ();
 	R_Backend_Init ();
 
-Cvar_RegisterVariable (&r_norefresh);
-Cvar_RegisterVariable (&r_lightmap);
-Cvar_RegisterVariable (&r_lightmap_linear);
-Cvar_SetCallback (&r_lightmap_linear, TexMgr_LightmapLinearCompat_f);
-Cvar_RegisterVariable (&r_lightmap_colorspace);
-Cvar_SetCallback (&r_lightmap_colorspace, TexMgr_LightmapColorspace_f);
-Cvar_RegisterVariable (&r_lightmap_colorspace_debug);
-Cvar_RegisterVariable (&r_lightmap_mipmaps);
-Cvar_RegisterVariable (&r_lightmap16f);
-Cvar_RegisterVariable (&r_lightingdir);
-Cvar_RegisterVariable (&r_rgblighting_enable);
-Cvar_RegisterVariable (&r_fullbright);
-Cvar_RegisterVariable (&r_drawentities);
-Cvar_RegisterVariable (&r_drawviewmodel);
+	{
+		static const r_cvar_registration_t base_cvars[] = {
+			{ &r_norefresh, NULL },
+			{ &r_lightmap, NULL },
+			{ &r_lightmap_linear, TexMgr_LightmapLinearCompat_f },
+			{ &r_lightmap_colorspace, TexMgr_LightmapColorspace_f },
+			{ &r_lightmap_colorspace_debug, NULL },
+			{ &r_lightmap_mipmaps, NULL },
+			{ &r_lightmap16f, NULL },
+			{ &r_lightingdir, NULL },
+			{ &r_rgblighting_enable, NULL },
+			{ &r_fullbright, NULL },
+			{ &r_drawentities, NULL },
+			{ &r_drawviewmodel, NULL }
+		};
+		static const r_cvar_registration_t water_cvars[] = {
+			{ &r_wateralpha, R_SetWateralpha_f },
+			{ &r_litwater, NULL }
+		};
+		static const r_cvar_registration_t color_pipeline_cvars[] = {
+			{ &r_srgb_textures, TexMgr_SRGBTextures_f },
+			{ &r_srgb_framebuffer, NULL },
+			{ &r_debug_colorspace, NULL },
+			{ &r_lighting_debug_view, NULL },
+			{ &r_color_midtone, NULL },
+			{ &r_color_contrast, NULL },
+			{ &r_color_saturation, NULL }
+		};
+
+		R_RegisterCvarTable (base_cvars, q_countof (base_cvars));
+		R_RegisterCvarTable (water_cvars, q_countof (water_cvars));
+		R_RegisterCvarTable (color_pipeline_cvars, q_countof (color_pipeline_cvars));
+	}
+
         Cvar_RegisterVariable (&r_debug_itemlight);
         Cvar_RegisterVariable (&r_minlight_models);
         Cvar_RegisterVariable (&r_model_lightgrid);
@@ -514,9 +551,6 @@ Cvar_RegisterVariable (&r_drawviewmodel);
         Cvar_RegisterVariable (&r_bmodel_relight);
         Cvar_RegisterVariable (&r_model_light_stats);
         Cvar_RegisterVariable (&r_model_light_samples_max);
-        Cvar_RegisterVariable (&r_wateralpha);
-        Cvar_SetCallback (&r_wateralpha, R_SetWateralpha_f);
-        Cvar_RegisterVariable (&r_litwater);
 	Cvar_RegisterVariable (&r_dynamic);
 	Cvar_RegisterVariable (&r_quality);
 	Cvar_RegisterVariable (&r_shadow);
@@ -593,14 +627,6 @@ Cvar_RegisterVariable (&r_exposure_lock);
 Cvar_RegisterVariable (&r_exposure_debug);
 Cvar_RegisterVariable (&r_tonemap_black_lift);
 Cvar_RegisterVariable (&r_tonemap_black_lift_strength);
-Cvar_RegisterVariable (&r_srgb_textures);
-Cvar_SetCallback (&r_srgb_textures, TexMgr_SRGBTextures_f);
-	Cvar_RegisterVariable (&r_srgb_framebuffer);
-	Cvar_RegisterVariable (&r_debug_colorspace);
-	Cvar_RegisterVariable (&r_lighting_debug_view);
-	Cvar_RegisterVariable (&r_color_midtone);
-	Cvar_RegisterVariable (&r_color_contrast);
-	Cvar_RegisterVariable (&r_color_saturation);
 	Cvar_RegisterVariable (&r_bloom);
 	Cvar_RegisterVariable (&r_bloom_threshold);
 	Cvar_RegisterVariable (&r_bloom_knee);

--- a/docs/cvar_ownership_matrix.md
+++ b/docs/cvar_ownership_matrix.md
@@ -1,0 +1,22 @@
+# Renderer CVar Ownership Matrix
+
+This matrix documents who owns registration, validation, and runtime consumption for renderer-facing CVars.
+
+## Ownership + registration tables
+
+| Subsystem | Canonical registration entry point | Validation hook style | Runtime consumers |
+|---|---|---|---|
+| Base render toggles (`r_norefresh`, lightmap switches, visibility toggles) | `R_Init()` in `gl_rmisc.c` via `base_cvars[]` table | per-CVar callback when needed | `gl_rmain.c`, draw passes, lightmap upload path |
+| Water/underwater controls (`r_wateralpha`, `r_litwater`) | `R_Init()` in `gl_rmisc.c` via `water_cvars[]` table | `R_SetWateralpha_f` callback | water/material alpha selection + warp decision path |
+| Color pipeline (`r_srgb_*`, tone controls) | `R_Init()` in `gl_rmisc.c` via `color_pipeline_cvars[]` table | texture callback (`TexMgr_SRGBTextures_f`) + runtime capability clamp | framebuffer output transform + texture upload |
+| PostFX core (`r_postfx*`) | `R_PostFX_RegisterCvars()` in `r_postfx.c` | internal clamp helpers in postfx tick/update | postfx graph and event stack |
+| SSAO (`r_ssao*`) | `R_SSAO_RegisterCvars()` in `r_ssao.c` | per-frame validity checks + disable fallback | SSAO generate/blur/composite passes |
+| Godrays (`r_godray*`, `r_godrays*`) | `R_Godrays_RegisterCvars()` in `r_godrays.c` | enable predicates + fallback texture path | godray source/mask/shaft passes |
+
+## Rules for adding renderer CVars
+
+1. Add the CVar declaration close to its owning subsystem implementation.
+2. Register in a table owned by the same subsystem (or subsystem-local `*_RegisterCvars` function).
+3. Attach callback validation only when value changes imply immediate resource/state rebuild.
+4. Keep hard capability fallbacks in runtime code paths (for example, no sRGB framebuffer support), not in registration.
+5. If a CVar crosses subsystem boundaries, document the single owner here before wiring additional consumers.

--- a/docs/todo_fixme_hotpath_triage.md
+++ b/docs/todo_fixme_hotpath_triage.md
@@ -1,0 +1,41 @@
+# TODO/FIXME Burn-down (hotpath-first)
+
+Snapshot date: 2026-04-20.
+
+Source scan used:
+
+```bash
+rg -n "TODO|FIXME" Quake/src
+```
+
+Current total in `Quake/src`: **90** markers (includes third-party code).
+
+## Hotpath priority buckets
+
+### 1) Performance-critical (do first)
+
+- `Quake/src/audio/snd_dma.c:1753` — callback-path blocking concern (`FIXME`), potential realtime audio jitter risk.
+- `Quake/src/render/gl_screen.c:2227` — render-loop call frequency note (`FIXME`), likely per-frame overhead.
+- `Quake/src/render/r_world.c:317` — water-surface cull strategy (`TODO`), broad scene traversal impact.
+- `Quake/src/core/cmd.c:131` — command buffer copy cost (`FIXME`), high-frequency command processing path.
+
+### 2) Correctness / stability
+
+- `Quake/src/server/sv_phys.c:897` and `:923` — entity push/link concerns (`FIXME`), gameplay/physics correctness.
+- `Quake/src/client/view.c:197` and `:1074` — noclip angle hack sync (`FIXME`), networked behavior divergence.
+- `Quake/src/server/sv_main.c:916` — protocol limits (`FIXME`), potential overflow/compat edge cases.
+- `Quake/src/render/gl_sky.c:574` — impossible-state handling (`FIXME`), robustness gap.
+
+### 3) Cleanup / maintainability
+
+- UI/UX polish notes in `Quake/src/ui/menu_common.c`.
+- Misc conversion/comment debt in `Quake/src/assets/*`, `Quake/src/core/common.c`, `Quake/src/gamecode/*`.
+- Third-party TODO/FIXME markers in `Quake/src/thirdparty/*` (track separately; avoid local churn unless upgrading vendor code).
+
+## Burn-down workflow
+
+1. **Track only first-party files for sprint debt metrics** (`Quake/src/thirdparty` excluded from rate).
+2. **Label each marker** as `perf`, `correctness`, or `cleanup` in issue tracker.
+3. **Budget each milestone**: at least 1 perf and 1 correctness marker removed before any cleanup-only work.
+4. **Require a micro-benchmark or smoke check** for perf-marker closures in render/audio/physics loops.
+5. **Keep marker count stable or lower**: no new TODO/FIXME in hotpath files without linked issue ID.


### PR DESCRIPTION
### Motivation

- Reduce duplicated, implicit fallback logic in the Warp/resolve/FBO code paths by resolving all frame-local framebuffer/texture choices in one place. 
- Make CVar registration and validation ownership explicit to contain CVar sprawl and simplify callback wiring. 
- Create an actionable baseline for addressing `TODO`/`FIXME` markers with hotpath-first priorities.

### Description

- Add a per-frame resource struct `r_warpscale_resources_t` and resolver `R_ResolveWarpScaleResources(...)` and refactor `R_WarpScaleView` to consume the resolved resources instead of re-running inline fallback checks (changes in `Quake/src/render/gl_rmain.c`).
- Introduce a small table-driven CVar registration helper (`r_cvar_registration_t` + `R_RegisterCvarTable(...)`) and migrate core renderer groups (`base_cvars`, `water_cvars`, `color_pipeline_cvars`) to that table model with callback hooks (changes in `Quake/src/render/gl_rmisc.c`).
- Add documentation: `docs/cvar_ownership_matrix.md` to record CVar ownership/registration rules and `docs/todo_fixme_hotpath_triage.md` to snapshot and triage `TODO`/`FIXME` markers with hotpath-first buckets.

### Testing

- Ran `git diff --check` and it completed with no new whitespace/patch errors reported. (passed)
- Verified presence of new symbols via `rg -n "R_RegisterCvarTable|R_ResolveWarpScaleResources"` against the modified sources and confirmed matches. (passed)
- Full Windows build/smoke (`MSBuild` / `C:\Quake\rerelease\ironwail.exe`) was not executed in this environment and remains to be validated on the target Windows build/release workflow. (not run)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e618fb6b98832e89a98f27b01d7430)