### PR TITLE
Make framegraph pass baselines explicit and deterministic

### DIFF
--- a/Quake/include/r_framegraph.h
+++ b/Quake/include/r_framegraph.h
@@ -57,7 +57,11 @@ typedef enum fg_pass_stage_e
 typedef enum fg_pass_baseline_bits_e
 {
 	FG_PASS_BASELINE_RESET_SCISSOR = 1u << 0,
-	FG_PASS_BASELINE_REQUIRE_AUTOBIND = 1u << 1
+	FG_PASS_BASELINE_REQUIRE_AUTOBIND = 1u << 1,
+	FG_PASS_BASELINE_RESET_BLEND = 1u << 2,
+	FG_PASS_BASELINE_RESET_DEPTH = 1u << 3,
+	FG_PASS_BASELINE_RESET_CULL = 1u << 4,
+	FG_PASS_BASELINE_RESET_PROGRAM_BINDINGS = 1u << 5
 } fg_pass_baseline_bits_t;
 
 typedef enum fg_pass_stats_channel_e
@@ -141,6 +145,7 @@ void R_Backend_SetViewport (int x, int y, int width, int height);
 void R_Backend_SetScissor (qboolean enabled, int x, int y, int width, int height);
 void R_Backend_ApplyLegacyPipelineState (unsigned state_bits);
 void R_Backend_SetPipelineState (unsigned state_bits);
+void R_Backend_ApplyFrameGraphBaseline (unsigned baseline_bits);
 void R_Backend_Draw (render_backend_primitive_t primitive, int first, int count);
 void R_Backend_DrawIndexed (render_backend_primitive_t primitive, render_backend_index_type_t index_type, int count, intptr_t index_offset_bytes);
 void R_Backend_DrawInstanced (render_backend_primitive_t primitive, int first, int count, int instance_count);

--- a/Quake/src/render/r_backend.c
+++ b/Quake/src/render/r_backend.c
@@ -1812,6 +1812,42 @@ void R_Backend_SetPipelineState (unsigned state_bits)
 	R_Backend_ApplyLegacyPipelineState (state_bits);
 }
 
+void R_Backend_ApplyFrameGraphBaseline (unsigned baseline_bits)
+{
+	unsigned state_bits = glstate;
+	qboolean apply_pipeline_state = false;
+
+	if ((baseline_bits & FG_PASS_BASELINE_RESET_BLEND) != 0u)
+	{
+		state_bits = (state_bits & ~GLS_MASK_BLEND) | GLS_BLEND_OPAQUE;
+		apply_pipeline_state = true;
+	}
+
+	if ((baseline_bits & FG_PASS_BASELINE_RESET_DEPTH) != 0u)
+	{
+		state_bits &= ~(GLS_NO_ZTEST | GLS_NO_ZWRITE);
+		apply_pipeline_state = true;
+	}
+
+	if ((baseline_bits & FG_PASS_BASELINE_RESET_CULL) != 0u)
+	{
+		state_bits = (state_bits & ~GLS_MASK_CULL) | GLS_CULL_BACK;
+		apply_pipeline_state = true;
+	}
+
+	if ((baseline_bits & FG_PASS_BASELINE_RESET_PROGRAM_BINDINGS) != 0u)
+	{
+		state_bits &= ~(GLS_MASK_ATTRIBS | GLS_MASK_INSTANCED_ATTRIBS);
+		apply_pipeline_state = true;
+	}
+
+	if (apply_pipeline_state)
+		R_Backend_SetPipelineState (state_bits);
+
+	if ((baseline_bits & FG_PASS_BASELINE_RESET_SCISSOR) != 0u)
+		R_Backend_SetScissor (false, 0, 0, 0, 0);
+}
+
 void R_Backend_Draw (render_backend_primitive_t primitive, int first, int count)
 {
 	const IRenderBackend *backend = R_GetRenderBackend ();

--- a/Quake/src/render/r_framegraph.c
+++ b/Quake/src/render/r_framegraph.c
@@ -812,8 +812,7 @@ static void FG_MaybePrintStats (void)
 
 static void FG_ApplyPassBaseline (const RenderPassDesc *pass, const RenderPassContext *ctx)
 {
-	const IRenderBackend *backend = ctx ? ctx->backend : NULL;
-	unsigned baseline_bits = FG_PASS_BASELINE_RESET_SCISSOR;
+	unsigned baseline_bits = 0u;
 
 	if (pass && pass->baseline_bits != 0u)
 		baseline_bits = pass->baseline_bits;
@@ -826,12 +825,8 @@ static void FG_ApplyPassBaseline (const RenderPassDesc *pass, const RenderPassCo
 		s_pass_baseline_autobind_warn_frame = r_framecount;
 	}
 
-	if ((baseline_bits & FG_PASS_BASELINE_RESET_SCISSOR) != 0u
-		&& backend
-		&& backend->set_scissor)
-	{
-		backend->set_scissor (false, 0, 0, 0, 0);
-	}
+	(void)ctx;
+	R_Backend_ApplyFrameGraphBaseline (baseline_bits);
 }
 
 static void FG_ApplyPassOutputBinding (const RenderPassDesc *pass, RenderPassContext *ctx)

--- a/Quake/src/render/r_passes.c
+++ b/Quake/src/render/r_passes.c
@@ -3,6 +3,13 @@
 #include "glquake.h"
 #include "r_framegraph.h"
 
+#define FG_PASS_BASELINE_DETERMINISTIC_STATE ( \
+	FG_PASS_BASELINE_RESET_SCISSOR | \
+	FG_PASS_BASELINE_RESET_BLEND | \
+	FG_PASS_BASELINE_RESET_DEPTH | \
+	FG_PASS_BASELINE_RESET_CULL | \
+	FG_PASS_BASELINE_RESET_PROGRAM_BINDINGS)
+
 static qboolean R_FG_PassWhenShadowEnabled (const RenderPassContext *ctx)
 {
 	return ctx && ctx->frame_plan
@@ -146,7 +153,7 @@ static const RenderPassDesc s_setup_view_framegraph_pass = {
 	.reads = RENDER_RES_NONE,
 	.writes = RENDER_RES_NONE,
 	.side_effects = 1u << 0,
-	.baseline_bits = FG_PASS_BASELINE_RESET_SCISSOR,
+	.baseline_bits = FG_PASS_BASELINE_DETERMINISTIC_STATE,
 	.output_target = FG_PASS_OUTPUT_KEEP,
 	.viewport_mode = FG_PASS_VIEWPORT_KEEP,
 	.enabled = NULL,
@@ -160,7 +167,7 @@ static const RenderPassDesc s_shadowmaps_framegraph_pass = {
 	.reads = RENDER_RES_NONE,
 	.writes = RENDER_RES_SHADOW_SUN_DEPTH,
 	.side_effects = 0,
-	.baseline_bits = FG_PASS_BASELINE_RESET_SCISSOR,
+	.baseline_bits = FG_PASS_BASELINE_DETERMINISTIC_STATE,
 	.output_target = FG_PASS_OUTPUT_KEEP,
 	.viewport_mode = FG_PASS_VIEWPORT_KEEP,
 	.enabled = R_FG_PassWhenShadowEnabled,
@@ -175,7 +182,7 @@ static const RenderPassDesc s_scene_framegraph_pass = {
 	.reads = RENDER_RES_DECALS | RENDER_RES_SHADOW_SUN_DEPTH,
 	.writes = RENDER_RES_SCENE_COLOR | RENDER_RES_SCENE_DEPTH | RENDER_RES_VELOCITY,
 	.side_effects = 0,
-	.baseline_bits = FG_PASS_BASELINE_RESET_SCISSOR | FG_PASS_BASELINE_REQUIRE_AUTOBIND,
+	.baseline_bits = FG_PASS_BASELINE_DETERMINISTIC_STATE | FG_PASS_BASELINE_REQUIRE_AUTOBIND,
 	.output_target = FG_PASS_OUTPUT_AUTO_SCENE,
 	.viewport_mode = FG_PASS_VIEWPORT_VIEW_RECT_SCALED,
 	.enabled = NULL,
@@ -192,7 +199,7 @@ static const RenderPassDesc s_warp_resolve_framegraph_pass = {
 	.reads = RENDER_RES_SCENE_COLOR | RENDER_RES_SCENE_DEPTH,
 	.writes = RENDER_RES_COMPOSITE_COLOR | RENDER_RES_COMPOSITE_DEPTH,
 	.side_effects = 1u << 0,
-	.baseline_bits = FG_PASS_BASELINE_RESET_SCISSOR | FG_PASS_BASELINE_REQUIRE_AUTOBIND,
+	.baseline_bits = FG_PASS_BASELINE_DETERMINISTIC_STATE | FG_PASS_BASELINE_REQUIRE_AUTOBIND,
 	.output_target = FG_PASS_OUTPUT_AUTO_WARP,
 	.viewport_mode = FG_PASS_VIEWPORT_VIEW_RECT,
 	.enabled = NULL,
@@ -209,7 +216,7 @@ static const RenderPassDesc s_ssao_fog_handoff_framegraph_pass = {
 	.reads = RENDER_RES_NONE,
 	.writes = RENDER_RES_SSAO_FOG_STATE,
 	.side_effects = 0,
-	.baseline_bits = FG_PASS_BASELINE_RESET_SCISSOR,
+	.baseline_bits = FG_PASS_BASELINE_DETERMINISTIC_STATE,
 	.output_target = FG_PASS_OUTPUT_KEEP,
 	.viewport_mode = FG_PASS_VIEWPORT_KEEP,
 	.enabled = NULL,
@@ -221,7 +228,7 @@ static const RenderPassDesc s_postprocess_framegraph_pass = {
 	.reads = RENDER_RES_COMPOSITE_COLOR | RENDER_RES_COMPOSITE_DEPTH | RENDER_RES_SSAO_FOG_STATE,
 	.writes = RENDER_RES_COMPOSITE_COLOR,
 	.side_effects = 1u << 0,
-	.baseline_bits = FG_PASS_BASELINE_RESET_SCISSOR | FG_PASS_BASELINE_REQUIRE_AUTOBIND,
+	.baseline_bits = FG_PASS_BASELINE_DETERMINISTIC_STATE | FG_PASS_BASELINE_REQUIRE_AUTOBIND,
 	.output_target = FG_PASS_OUTPUT_BACKBUFFER,
 	.viewport_mode = FG_PASS_VIEWPORT_FULL_WINDOW,
 	.enabled = R_FG_PassWhenPostprocessEnabled,
@@ -237,7 +244,7 @@ static const RenderPassDesc s_viewmodel_framegraph_pass = {
 	.reads = RENDER_RES_COMPOSITE_COLOR,
 	.writes = RENDER_RES_NONE,
 	.side_effects = 1u << 0,
-	.baseline_bits = FG_PASS_BASELINE_RESET_SCISSOR | FG_PASS_BASELINE_REQUIRE_AUTOBIND,
+	.baseline_bits = FG_PASS_BASELINE_DETERMINISTIC_STATE | FG_PASS_BASELINE_REQUIRE_AUTOBIND,
 	.output_target = FG_PASS_OUTPUT_BACKBUFFER,
 	.viewport_mode = FG_PASS_VIEWPORT_VIEW_RECT,
 	.enabled = R_FG_PassWhenViewmodelEnabled,
@@ -251,7 +258,7 @@ static const RenderPassDesc s_polyblend_framegraph_pass = {
 	.reads = RENDER_RES_COMPOSITE_COLOR,
 	.writes = RENDER_RES_NONE,
 	.side_effects = 1u << 0,
-	.baseline_bits = FG_PASS_BASELINE_RESET_SCISSOR | FG_PASS_BASELINE_REQUIRE_AUTOBIND,
+	.baseline_bits = FG_PASS_BASELINE_DETERMINISTIC_STATE | FG_PASS_BASELINE_REQUIRE_AUTOBIND,
 	.output_target = FG_PASS_OUTPUT_BACKBUFFER,
 	.viewport_mode = FG_PASS_VIEWPORT_VIEW_RECT,
 	.enabled = R_FG_PassWhenPolyblendEnabled,
@@ -265,7 +272,7 @@ static const RenderPassDesc s_storeprev_framegraph_pass = {
 	.reads = RENDER_RES_COMPOSITE_COLOR | RENDER_RES_SCENE_DEPTH,
 	.writes = RENDER_RES_NONE,
 	.side_effects = 1u << 0,
-	.baseline_bits = FG_PASS_BASELINE_RESET_SCISSOR,
+	.baseline_bits = FG_PASS_BASELINE_DETERMINISTIC_STATE,
 	.output_target = FG_PASS_OUTPUT_KEEP,
 	.viewport_mode = FG_PASS_VIEWPORT_KEEP,
 	.enabled = R_FG_PassWhenStorePrevEnabled,


### PR DESCRIPTION
### Motivation

- Reduce reliance on implicit GL state carried between framegraph passes by declaring and enforcing a deterministic minimum state per pass.
- Centralize baseline state changes through the backend API so resets use existing, auditable backend paths (`set_scissor` / pipeline-state helpers).

### Description

- Added new baseline bits in `r_framegraph.h`: `FG_PASS_BASELINE_RESET_BLEND`, `FG_PASS_BASELINE_RESET_DEPTH`, `FG_PASS_BASELINE_RESET_CULL`, and `FG_PASS_BASELINE_RESET_PROGRAM_BINDINGS`, and declared `R_Backend_ApplyFrameGraphBaseline(unsigned)`.
- Implemented `R_Backend_ApplyFrameGraphBaseline` in `r_backend.c` to reset blend/depth/cull/program-binding-related bits and to disable scissor using existing backend wrappers (`R_Backend_SetPipelineState` / `R_Backend_SetScissor`).
- Reworked `FG_ApplyPassBaseline` in `r_framegraph.c` to call `R_Backend_ApplyFrameGraphBaseline` instead of touching backend callbacks directly.
- Updated `r_passes.c` to explicitly mark each registered pass with a deterministic baseline via a new macro `FG_PASS_BASELINE_DETERMINISTIC_STATE` and preserved `FG_PASS_BASELINE_REQUIRE_AUTOBIND` only where needed.

### Testing

- Inspected updated call sites and references with ripgrep using `rg -n "R_Backend_ApplyFrameGraphBaseline|FG_PASS_BASELINE_RESET_PROGRAM_BINDINGS|FG_PASS_BASELINE_DETERMINISTIC_STATE"` and verified expected occurrences.
- Reviewed the produced diff with `git diff` and verified the four files changed (`r_framegraph.h`, `r_backend.c`, `r_framegraph.c`, `r_passes.c`) before committing.
- Did not run the Windows/MSBuild smoke test (`msbuild` step) in this Linux container environment, so runtime validation on target platforms remains outstanding.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e62b8fef88832eb3e8bc18bcdf997d)