### PR TITLE
render: centralize GL framegraph resource slot registry

### DIFF
--- a/Quake/include/r_resources_gl.h
+++ b/Quake/include/r_resources_gl.h
@@ -1,0 +1,35 @@
+#ifndef R_RESOURCES_GL_H
+#define R_RESOURCES_GL_H
+
+#include "render_api.h"
+
+typedef enum gl_resource_size_class_e
+{
+	GL_RESOURCE_SIZE_NONE = 0,
+	GL_RESOURCE_SIZE_SCENE,
+	GL_RESOURCE_SIZE_NATIVE,
+	GL_RESOURCE_SIZE_SHADOW_SUN
+} gl_resource_size_class_t;
+
+typedef struct gl_resource_registry_entry_s
+{
+	const char *name;
+	const char *creator;
+	render_backend_resource_type_t type;
+	render_backend_resource_slot_t slot;
+	render_backend_resource_lifetime_t lifetime;
+	gl_resource_size_class_t size_class;
+	float width_scale;
+	float height_scale;
+} gl_resource_registry_entry_t;
+
+const gl_resource_registry_entry_t *GL_ResourceRegistry_FindEntry (render_backend_resource_slot_t slot);
+unsigned GL_ResourceRegistry_GetEntryCount (void);
+const gl_resource_registry_entry_t *GL_ResourceRegistry_GetEntryByIndex (unsigned index);
+
+void GL_ResourceRegistry_RegisterSlot (render_backend_resource_slot_t slot);
+void GL_ResourceRegistry_UnregisterSlot (render_backend_resource_slot_t slot);
+void GL_ResourceRegistry_RegisterFrameGraphSlots (void);
+void GL_ResourceRegistry_UnregisterFrameGraphSlots (void);
+
+#endif

--- a/Quake/src/render/gl_rmain.c
+++ b/Quake/src/render/gl_rmain.c
@@ -38,6 +38,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "gl_shadow_runtime.h"
 #include "gl_lightgrid.h"
 #include "gl_backend.h"
+#include "r_resources_gl.h"
 
 #ifdef RENDERER_PLUGIN_BUILD
 #define IW_PARSE_FSCANF fscanf_s
@@ -1418,40 +1419,15 @@ static qboolean GL_ValidateSimpleFramebuffer (GLuint fbo, const char* name)
 static qboolean GL_AutoExposurePBOAvailable (void);
 static void GL_AutoExposureDeletePBOs (void);
 static void GL_AutoExposureInitPBOs (void);
-static void GL_RegisterFrameGraphResourceSlots (void);
-static void GL_UnregisterFrameGraphResourceSlots (void);
 
 static void GL_RegisterFrameGraphResourceSlots (void)
 {
-	unsigned velocity_tex = (framebufs.scene.samples > 1) ? framebufs.resolved_scene.velocity_tex : framebufs.scene.velocity_tex;
-
-	GL_Backend_RegisterResource (R_BACKEND_RESOURCE_FRAMEBUFFER, R_BACKEND_RESOURCE_SLOT_SCENE_FBO, R_BACKEND_RESOURCE_LIFETIME_FRAME, framebufs.scene.fbo);
-	GL_Backend_RegisterResource (R_BACKEND_RESOURCE_TEXTURE, R_BACKEND_RESOURCE_SLOT_SCENE_COLOR, R_BACKEND_RESOURCE_LIFETIME_FRAME, framebufs.scene.color_tex);
-	GL_Backend_RegisterResource (R_BACKEND_RESOURCE_TEXTURE, R_BACKEND_RESOURCE_SLOT_SCENE_VELOCITY, R_BACKEND_RESOURCE_LIFETIME_FRAME, framebufs.scene.velocity_tex);
-	GL_Backend_RegisterResource (R_BACKEND_RESOURCE_TEXTURE, R_BACKEND_RESOURCE_SLOT_SCENE_DEPTH, R_BACKEND_RESOURCE_LIFETIME_FRAME, framebufs.scene.depth_stencil_tex);
-	GL_Backend_RegisterResource (R_BACKEND_RESOURCE_FRAMEBUFFER, R_BACKEND_RESOURCE_SLOT_RESOLVED_SCENE_FBO, R_BACKEND_RESOURCE_LIFETIME_FRAME, framebufs.resolved_scene.fbo);
-	GL_Backend_RegisterResource (R_BACKEND_RESOURCE_TEXTURE, R_BACKEND_RESOURCE_SLOT_RESOLVED_SCENE_COLOR, R_BACKEND_RESOURCE_LIFETIME_FRAME, framebufs.resolved_scene.color_tex);
-	GL_Backend_RegisterResource (R_BACKEND_RESOURCE_TEXTURE, R_BACKEND_RESOURCE_SLOT_RESOLVED_SCENE_VELOCITY, R_BACKEND_RESOURCE_LIFETIME_FRAME, framebufs.resolved_scene.velocity_tex);
-	GL_Backend_RegisterResource (R_BACKEND_RESOURCE_FRAMEBUFFER, R_BACKEND_RESOURCE_SLOT_COMPOSITE_FBO, R_BACKEND_RESOURCE_LIFETIME_FRAME, framebufs.composite.fbo);
-	GL_Backend_RegisterResource (R_BACKEND_RESOURCE_TEXTURE, R_BACKEND_RESOURCE_SLOT_COMPOSITE_COLOR, R_BACKEND_RESOURCE_LIFETIME_FRAME, framebufs.composite.color_tex);
-	GL_Backend_RegisterResource (R_BACKEND_RESOURCE_TEXTURE, R_BACKEND_RESOURCE_SLOT_COMPOSITE_DEPTH, R_BACKEND_RESOURCE_LIFETIME_FRAME, framebufs.composite.depth_stencil_tex);
-	GL_Backend_RegisterResource (R_BACKEND_RESOURCE_TEXTURE, R_BACKEND_RESOURCE_SLOT_VELOCITY, R_BACKEND_RESOURCE_LIFETIME_FRAME, velocity_tex);
+	GL_ResourceRegistry_RegisterFrameGraphSlots ();
 }
 
 static void GL_UnregisterFrameGraphResourceSlots (void)
 {
-	GL_Backend_UnregisterResourceBySlot (R_BACKEND_RESOURCE_SLOT_SCENE_FBO);
-	GL_Backend_UnregisterResourceBySlot (R_BACKEND_RESOURCE_SLOT_SCENE_COLOR);
-	GL_Backend_UnregisterResourceBySlot (R_BACKEND_RESOURCE_SLOT_SCENE_VELOCITY);
-	GL_Backend_UnregisterResourceBySlot (R_BACKEND_RESOURCE_SLOT_SCENE_DEPTH);
-	GL_Backend_UnregisterResourceBySlot (R_BACKEND_RESOURCE_SLOT_RESOLVED_SCENE_FBO);
-	GL_Backend_UnregisterResourceBySlot (R_BACKEND_RESOURCE_SLOT_RESOLVED_SCENE_COLOR);
-	GL_Backend_UnregisterResourceBySlot (R_BACKEND_RESOURCE_SLOT_RESOLVED_SCENE_VELOCITY);
-	GL_Backend_UnregisterResourceBySlot (R_BACKEND_RESOURCE_SLOT_COMPOSITE_FBO);
-	GL_Backend_UnregisterResourceBySlot (R_BACKEND_RESOURCE_SLOT_COMPOSITE_COLOR);
-	GL_Backend_UnregisterResourceBySlot (R_BACKEND_RESOURCE_SLOT_COMPOSITE_DEPTH);
-	GL_Backend_UnregisterResourceBySlot (R_BACKEND_RESOURCE_SLOT_SHADOW_SUN_DEPTH);
-	GL_Backend_UnregisterResourceBySlot (R_BACKEND_RESOURCE_SLOT_VELOCITY);
+	GL_ResourceRegistry_UnregisterFrameGraphSlots ();
 }
 
 /*

--- a/Quake/src/render/gl_shadow_runtime.c
+++ b/Quake/src/render/gl_shadow_runtime.c
@@ -1,10 +1,9 @@
 #include "quakedef.h"
 #include "glquake.h"
 #include "gl_backend.h"
-
-#include "gl_backend.h"
 #include "gl_shadow.h"
 #include "gl_shadow_runtime.h"
+#include "r_resources_gl.h"
 
 #include <float.h>
 #include <math.h>
@@ -593,7 +592,7 @@ void R_Shadow_CreateFrameBuffers (void)
 		GL_DeleteNativeTexture (framebufs.shadow.dlight_depth_tex);
 		framebufs.shadow.dlight_depth_tex = 0;
 		framebufs.shadow.available = true;
-		GL_Backend_RegisterResource (R_BACKEND_RESOURCE_TEXTURE, R_BACKEND_RESOURCE_SLOT_SHADOW_SUN_DEPTH, R_BACKEND_RESOURCE_LIFETIME_LEVEL, framebufs.shadow.sun_depth_tex);
+		GL_ResourceRegistry_RegisterSlot (R_BACKEND_RESOURCE_SLOT_SHADOW_SUN_DEPTH);
 		return;
 	}
 	if (r_shadow_log.value > 0.f)
@@ -601,7 +600,7 @@ void R_Shadow_CreateFrameBuffers (void)
 			dlight_size, dlight_size, SHADOW_DLIGHT_MAX * SHADOW_DLIGHT_FACES);
 
 	framebufs.shadow.available = true;
-	GL_Backend_RegisterResource (R_BACKEND_RESOURCE_TEXTURE, R_BACKEND_RESOURCE_SLOT_SHADOW_SUN_DEPTH, R_BACKEND_RESOURCE_LIFETIME_LEVEL, framebufs.shadow.sun_depth_tex);
+	GL_ResourceRegistry_RegisterSlot (R_BACKEND_RESOURCE_SLOT_SHADOW_SUN_DEPTH);
 }
 
 void R_Shadow_DeleteFrameBuffers (void)
@@ -615,7 +614,7 @@ void R_Shadow_DeleteFrameBuffers (void)
 	framebufs.shadow.dlight_depth_tex = 0;
 	framebufs.shadow.dlight_fbo = 0;
 	framebufs.shadow.available = false;
-	GL_Backend_UnregisterResourceBySlot (R_BACKEND_RESOURCE_SLOT_SHADOW_SUN_DEPTH);
+	GL_ResourceRegistry_UnregisterSlot (R_BACKEND_RESOURCE_SLOT_SHADOW_SUN_DEPTH);
 	r_shadow_draw_cache.valid = false;
 }
 

--- a/Quake/src/render/r_resources_gl.c
+++ b/Quake/src/render/r_resources_gl.c
@@ -1,0 +1,122 @@
+#include "quakedef.h"
+#include "glquake.h"
+#include "gl_backend.h"
+#include "r_resources_gl.h"
+
+static unsigned GL_ResourceRegistry_ResolveSceneVelocity (void)
+{
+	return (framebufs.scene.samples > 1) ? framebufs.resolved_scene.velocity_tex : framebufs.scene.velocity_tex;
+}
+
+static unsigned GL_ResourceRegistry_ResolveNativeResource (render_backend_resource_slot_t slot)
+{
+	switch (slot)
+	{
+	case R_BACKEND_RESOURCE_SLOT_SCENE_FBO:
+		return framebufs.scene.fbo;
+	case R_BACKEND_RESOURCE_SLOT_SCENE_COLOR:
+		return framebufs.scene.color_tex;
+	case R_BACKEND_RESOURCE_SLOT_SCENE_VELOCITY:
+		return framebufs.scene.velocity_tex;
+	case R_BACKEND_RESOURCE_SLOT_SCENE_DEPTH:
+		return framebufs.scene.depth_stencil_tex;
+	case R_BACKEND_RESOURCE_SLOT_RESOLVED_SCENE_FBO:
+		return framebufs.resolved_scene.fbo;
+	case R_BACKEND_RESOURCE_SLOT_RESOLVED_SCENE_COLOR:
+		return framebufs.resolved_scene.color_tex;
+	case R_BACKEND_RESOURCE_SLOT_RESOLVED_SCENE_VELOCITY:
+		return framebufs.resolved_scene.velocity_tex;
+	case R_BACKEND_RESOURCE_SLOT_COMPOSITE_FBO:
+		return framebufs.composite.fbo;
+	case R_BACKEND_RESOURCE_SLOT_COMPOSITE_COLOR:
+		return framebufs.composite.color_tex;
+	case R_BACKEND_RESOURCE_SLOT_COMPOSITE_DEPTH:
+		return framebufs.composite.depth_stencil_tex;
+	case R_BACKEND_RESOURCE_SLOT_SHADOW_SUN_DEPTH:
+		return framebufs.shadow.sun_depth_tex;
+	case R_BACKEND_RESOURCE_SLOT_VELOCITY:
+		return GL_ResourceRegistry_ResolveSceneVelocity ();
+	default:
+		break;
+	}
+
+	return 0;
+}
+
+static const gl_resource_registry_entry_t s_gl_resource_registry[] = {
+	{ "scene_fbo", "GL_CreateFrameBuffers", R_BACKEND_RESOURCE_FRAMEBUFFER, R_BACKEND_RESOURCE_SLOT_SCENE_FBO, R_BACKEND_RESOURCE_LIFETIME_FRAME, GL_RESOURCE_SIZE_SCENE, 1.f, 1.f },
+	{ "scene_color", "GL_CreateFrameBuffers", R_BACKEND_RESOURCE_TEXTURE, R_BACKEND_RESOURCE_SLOT_SCENE_COLOR, R_BACKEND_RESOURCE_LIFETIME_FRAME, GL_RESOURCE_SIZE_SCENE, 1.f, 1.f },
+	{ "scene_velocity", "GL_CreateFrameBuffers", R_BACKEND_RESOURCE_TEXTURE, R_BACKEND_RESOURCE_SLOT_SCENE_VELOCITY, R_BACKEND_RESOURCE_LIFETIME_FRAME, GL_RESOURCE_SIZE_SCENE, 1.f, 1.f },
+	{ "scene_depth", "GL_CreateFrameBuffers", R_BACKEND_RESOURCE_TEXTURE, R_BACKEND_RESOURCE_SLOT_SCENE_DEPTH, R_BACKEND_RESOURCE_LIFETIME_FRAME, GL_RESOURCE_SIZE_SCENE, 1.f, 1.f },
+	{ "resolved_scene_fbo", "GL_CreateFrameBuffers", R_BACKEND_RESOURCE_FRAMEBUFFER, R_BACKEND_RESOURCE_SLOT_RESOLVED_SCENE_FBO, R_BACKEND_RESOURCE_LIFETIME_FRAME, GL_RESOURCE_SIZE_SCENE, 1.f, 1.f },
+	{ "resolved_scene_color", "GL_CreateFrameBuffers", R_BACKEND_RESOURCE_TEXTURE, R_BACKEND_RESOURCE_SLOT_RESOLVED_SCENE_COLOR, R_BACKEND_RESOURCE_LIFETIME_FRAME, GL_RESOURCE_SIZE_SCENE, 1.f, 1.f },
+	{ "resolved_scene_velocity", "GL_CreateFrameBuffers", R_BACKEND_RESOURCE_TEXTURE, R_BACKEND_RESOURCE_SLOT_RESOLVED_SCENE_VELOCITY, R_BACKEND_RESOURCE_LIFETIME_FRAME, GL_RESOURCE_SIZE_SCENE, 1.f, 1.f },
+	{ "composite_fbo", "GL_CreateFrameBuffers", R_BACKEND_RESOURCE_FRAMEBUFFER, R_BACKEND_RESOURCE_SLOT_COMPOSITE_FBO, R_BACKEND_RESOURCE_LIFETIME_FRAME, GL_RESOURCE_SIZE_NATIVE, 1.f, 1.f },
+	{ "composite_color", "GL_CreateFrameBuffers", R_BACKEND_RESOURCE_TEXTURE, R_BACKEND_RESOURCE_SLOT_COMPOSITE_COLOR, R_BACKEND_RESOURCE_LIFETIME_FRAME, GL_RESOURCE_SIZE_NATIVE, 1.f, 1.f },
+	{ "composite_depth", "GL_CreateFrameBuffers", R_BACKEND_RESOURCE_TEXTURE, R_BACKEND_RESOURCE_SLOT_COMPOSITE_DEPTH, R_BACKEND_RESOURCE_LIFETIME_FRAME, GL_RESOURCE_SIZE_NATIVE, 1.f, 1.f },
+	{ "shadow_sun_depth", "R_Shadow_CreateFrameBuffers", R_BACKEND_RESOURCE_TEXTURE, R_BACKEND_RESOURCE_SLOT_SHADOW_SUN_DEPTH, R_BACKEND_RESOURCE_LIFETIME_LEVEL, GL_RESOURCE_SIZE_SHADOW_SUN, 1.f, 1.f },
+	{ "velocity", "GL_CreateFrameBuffers", R_BACKEND_RESOURCE_TEXTURE, R_BACKEND_RESOURCE_SLOT_VELOCITY, R_BACKEND_RESOURCE_LIFETIME_FRAME, GL_RESOURCE_SIZE_SCENE, 1.f, 1.f }
+};
+
+const gl_resource_registry_entry_t *GL_ResourceRegistry_FindEntry (render_backend_resource_slot_t slot)
+{
+	int i;
+
+	for (i = 0; i < (int)Q_COUNTOF (s_gl_resource_registry); ++i)
+	{
+		if (s_gl_resource_registry[i].slot == slot)
+			return &s_gl_resource_registry[i];
+	}
+
+	return NULL;
+}
+
+unsigned GL_ResourceRegistry_GetEntryCount (void)
+{
+	return (unsigned)Q_COUNTOF (s_gl_resource_registry);
+}
+
+const gl_resource_registry_entry_t *GL_ResourceRegistry_GetEntryByIndex (unsigned index)
+{
+	if (index >= (unsigned)Q_COUNTOF (s_gl_resource_registry))
+		return NULL;
+
+	return &s_gl_resource_registry[index];
+}
+
+void GL_ResourceRegistry_RegisterSlot (render_backend_resource_slot_t slot)
+{
+	const gl_resource_registry_entry_t *entry = GL_ResourceRegistry_FindEntry (slot);
+	unsigned native_id;
+
+	if (!entry)
+		return;
+
+	native_id = GL_ResourceRegistry_ResolveNativeResource (slot);
+	if (native_id == 0)
+		return;
+
+	GL_Backend_RegisterResource (entry->type, entry->slot, entry->lifetime, native_id);
+}
+
+void GL_ResourceRegistry_UnregisterSlot (render_backend_resource_slot_t slot)
+{
+	if (GL_ResourceRegistry_FindEntry (slot))
+		GL_Backend_UnregisterResourceBySlot (slot);
+}
+
+void GL_ResourceRegistry_RegisterFrameGraphSlots (void)
+{
+	unsigned i;
+
+	for (i = 0; i < (unsigned)Q_COUNTOF (s_gl_resource_registry); ++i)
+		GL_ResourceRegistry_RegisterSlot (s_gl_resource_registry[i].slot);
+}
+
+void GL_ResourceRegistry_UnregisterFrameGraphSlots (void)
+{
+	unsigned i;
+
+	for (i = 0; i < (unsigned)Q_COUNTOF (s_gl_resource_registry); ++i)
+		GL_ResourceRegistry_UnregisterSlot (s_gl_resource_registry[i].slot);
+}

--- a/Windows/VisualStudio/ironwail.vcxproj
+++ b/Windows/VisualStudio/ironwail.vcxproj
@@ -341,6 +341,7 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"
     <ClCompile Include="..\..\Quake\src\render\r_dlight_pool.c" />
     <ClCompile Include="..\..\Quake\src\render\r_backend.c" />
     <ClCompile Include="..\..\Quake\src\render\r_framegraph.c" />
+    <ClCompile Include="..\..\Quake\src\render\r_resources_gl.c" />
     <ClCompile Include="..\..\Quake\src\render\r_passes.c" />
     <ClCompile Include="..\..\Quake\src\render\r_quality.c" />
     <ClCompile Include="..\..\Quake\src\render\r_sanitize.c" />

--- a/Windows/VisualStudio/ironwail.vcxproj.filters
+++ b/Windows/VisualStudio/ironwail.vcxproj.filters
@@ -240,6 +240,9 @@
     <ClCompile Include="..\..\Quake\src\render\r_framegraph.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Quake\src\render\r_resources_gl.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\Quake\src\render\r_passes.c">
       <Filter>Source Files</Filter>
     </ClCompile>


### PR DESCRIPTION
### Motivation

- Reduce duplicated slot registration logic and centralize backend slot metadata for GL framegraph resources.  
- Make resource definitions data-driven by declaring producer, size/scale class, lifetime and backend slot in one place.  
- Avoid maintaining slot→native-id mapping in several locations (e.g. `gl_rmain.c` and shadow code).  

### Description

- Added a new registry API and table in `Quake/include/r_resources_gl.h` and `Quake/src/render/r_resources_gl.c` that defines per-resource entries (`creator`, `size_class`, `lifetime`, `slot`) and provides lookup and register/unregister helpers.  
- Replaced manual slot registrations in `Quake/src/render/gl_rmain.c` by calling `GL_ResourceRegistry_RegisterFrameGraphSlots()` and `GL_ResourceRegistry_UnregisterFrameGraphSlots()`.  
- Switched shadow runtime registration/unregistration in `Quake/src/render/gl_shadow_runtime.c` to use `GL_ResourceRegistry_RegisterSlot()` / `GL_ResourceRegistry_UnregisterSlot()` for `R_BACKEND_RESOURCE_SLOT_SHADOW_SUN_DEPTH`.  
- Updated Visual Studio project files so the new source `Quake/src/render/r_resources_gl.c` is compiled by the solution.  

### Testing

- Ran `git diff --check` to validate whitespace/issues, which reported no problems.  
- Attempted `cmake -S . -B build && cmake --build build -j2 --target ironwail`, which failed in the container due to missing system `SDL2` CMake package (environment issue).  
- Ran `python3 python/check_framegraph_pass_contracts.py`, which failed due to the script expecting a different filesystem layout in this checkout (path mismatch).  
- Performed a compile-syntax check (`cc -IQuake/include -fsyntax-only ...`) which failed in this environment because SDL headers (e.g. `SDL_endian.h`) are not available.  

If you want, I can (1) extend the registry table with additional slots, (2) add unit/verification helpers to cross-check registry vs framegraph mappings, or (3) adapt the build/test commands for your CI environment so we can run a full build here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e62fff32a0832eacd4b9715ddbf100)