### PR TITLE
Renderer Phase 2: audit output, legacy gltexture_t marking, model_types split-point and docs

### DIFF
--- a/Quake/src/core/model_types.h
+++ b/Quake/src/core/model_types.h
@@ -1,6 +1,34 @@
 /*
  * Transitional model type shim used by core-facing headers.
  * TODO_CORE_DECONTAMINATION: split truly neutral model types out of gl_model.h.
+ *
+ * Phase 2 split-point notes:
+ * - This header is the intended future home for renderer/backend-neutral model
+ *   declarations that core, client, server, physics, and tools can include
+ *   without importing GL model internals.
+ * - The include below deliberately remains in place during Phase 2. Moving
+ *   fields or changing structure ownership belongs to a later, separately
+ *   tested migration phase.
+ *
+ * TODO_MODEL_TYPES_NEUTRAL_BASE:
+ * - Define backend-neutral model_t base data here once ownership is clear.
+ * - Keep file identity, bounds, hull/clip data, visibility, and CPU-side
+ *   metadata separate from render-backend uploads.
+ *
+ * TODO_MODEL_TYPES_KIND_SPLIT:
+ * - Split mesh/brush/alias/sprite declarations into neutral CPU-facing
+ *   concepts before any backend resource handles are attached.
+ * - Preserve existing qmodel_t/model_t behavior until every call site has
+ *   an audited owner.
+ *
+ * TODO_MODEL_TYPES_CPU_GPU_SEPARATION:
+ * - Keep CPU-side model data in core/client-visible structs.
+ * - Move GPU/GL allocation state into the GL backend or a renderer resource
+ *   layer with explicit lifetime rules.
+ *
+ * TODO_MODEL_TYPES_NO_NATIVE_GL_FIELDS:
+ * - Future neutral model types must not contain GLuint, GLenum, gltexture_t,
+ *   or other API-native renderer fields.
  */
 
 #ifndef CORE_MODEL_TYPES_H

--- a/Quake/src/render/gl_texmgr.h
+++ b/Quake/src/render/gl_texmgr.h
@@ -23,6 +23,10 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define _GL_TEXMAN_H
 
 //gl_texmgr.h -- fitzquake's texture manager. manages opengl texture images
+// Phase 2: gltexture_t is a Legacy-GL-Bridge, not the final frontend texture API.
+// Long-term frontend code should see only render_texture_handle_t; native GL
+// target/texnum/bindless/internal_format data must stay in the GL backend or
+// a GL resource layer.
 
 typedef enum
 {
@@ -54,10 +58,10 @@ typedef struct gltexture_s {
 //managed by texture manager
 	/* LEGACY_GL_HANDLE / REF_GL_PRIVATE:
 	 * These native GL fields are intentionally still visible during migration.
-	 * Phase-3 goal is inventory + accessor candidates, not full opacity yet. */
-	GLenum			target;
-	GLuint			texnum;
-	GLuint64		bindless_handle;
+	 * Phase-2 goal is inventory + adapter candidates, not full opacity yet. */
+	GLenum			target;			// backend-specific GL texture target
+	GLuint			texnum;			// backend-specific GL texture object name
+	GLuint64		bindless_handle;	// backend-specific GL bindless handle
 	struct gltexture_s	*next;
 	qmodel_t		*owner;
 //managed by image loading
@@ -78,8 +82,13 @@ typedef struct gltexture_s {
 //used for rendering
 	int			visframe; //matches r_framecount if texture was bound this frame
 	int			mipmap; //number of mip levels uploaded (0 = unknown)
-	GLenum		internal_format; //GL internal format used for upload
+	GLenum		internal_format; //backend-specific GL internal format used for upload
 } gltexture_t;
+
+/* PHASE2_LEGACY_GL_BRIDGE:
+ * gltexture_t remains public only as a transitional bridge. Do not add new
+ * frontend dependencies on native GL fields; prefer render_texture_handle_t for
+ * new neutral paths and keep native GL data behind backend/resource adapters. */
 
 /* PHASE3_BOUNDARY_CANDIDATE:
  * Candidate accessor split for future opaque migration:

--- a/Quake/src/render/r_backend.c
+++ b/Quake/src/render/r_backend.c
@@ -194,37 +194,55 @@ static void R_Backend_WrapperAudit_f (void)
 ================
 R_Backend_MigrationAudit_f
 
-Text-only Phase 1 migration audit. Keep this conservative: it names known
+Text-only Phase 2 migration audit. Keep this conservative: it names known
 OpenGL coupling points without changing renderer selection or draw paths.
 ================
 */
 static void R_Backend_MigrationAudit_f (void)
 {
-	Con_Printf ("Renderer backend migration audit (Phase 1):\n");
-	Con_Printf ("  Core-Level:\n");
-	Con_Printf ("    - Quake/src/core/quakedef.h includes SDL_opengl.h.\n");
-	Con_Printf ("    - Quake/src/core/quakedef.h includes gl_model.h.\n");
-	Con_Printf ("    - Quake/src/core/quakedef.h includes gl_texmgr.h.\n");
-	Con_Printf ("    - Quake/src/core/model_types.h is currently a shim over gl_model.h.\n");
-	Con_Printf ("  Public GL Texture Leak:\n");
-	Con_Printf ("    - Quake/src/render/gl_texmgr.h exposes GLenum/GLuint/GLuint64 in gltexture_t.\n");
-	Con_Printf ("    - texture_handles.h exists, but gltexture_t remains the bridge type.\n");
-	Con_Printf ("  Legacy GL Orchestrator:\n");
-	Con_Printf ("    - Quake/src/render/gl_rmain.c owns R_RenderView, FBOs, PostFX, SSAO, Bloom, Godrays, and readbacks.\n");
-	Con_Printf ("  Framegraph/Legacy:\n");
-	Con_Printf ("    - Framegraph is declarative, but pass execution still calls legacy/GL callbacks.\n");
-	Con_Printf ("    - r_world/r_alias/r_part still rely on GL state baselines.\n");
-	Con_Printf ("  Shader Leak:\n");
+	Con_Printf ("Renderer backend migration audit (Phase 2):\n");
+	Con_Printf ("  Core/Header-Leaks:\n");
+	Con_Printf ("    - quakedef.h includes SDL_opengl.h.\n");
+	Con_Printf ("    - quakedef.h includes gl_model.h.\n");
+	Con_Printf ("    - quakedef.h includes gl_texmgr.h.\n");
+	Con_Printf ("    - model_types.h is currently only a shim to gl_model.h.\n");
+	Con_Printf ("    - render/frontend files still include glquake.h directly.\n");
+	Con_Printf ("  Frontend files with GL header dependency:\n");
+	Con_Printf ("    - r_world.c\n");
+	Con_Printf ("    - r_alias.c\n");
+	Con_Printf ("    - r_brush.c\n");
+	Con_Printf ("    - r_sprite.c\n");
+	Con_Printf ("    - r_part.c\n");
+	Con_Printf ("    - r_part_q3p.c\n");
+	Con_Printf ("    - r_decals.c\n");
+	Con_Printf ("    - r_postfx.c\n");
+	Con_Printf ("  Resource-Leaks:\n");
+	Con_Printf ("    - gltexture_t exposes GLenum target.\n");
+	Con_Printf ("    - gltexture_t exposes GLuint texnum.\n");
+	Con_Printf ("    - gltexture_t exposes GLuint64 bindless_handle.\n");
+	Con_Printf ("    - gltexture_t exposes GLenum internal_format.\n");
+	Con_Printf ("    - texture_handles.h exists but gltexture_t remains public bridge.\n");
+	Con_Printf ("  Shader-Leaks:\n");
 	Con_Printf ("    - glprogs_t stores GLuint program IDs.\n");
-	Con_Printf ("    - Shader metadata currently treats shader_id effectively as a GL program handle.\n");
-	Con_Printf ("  Resource Leak:\n");
-	Con_Printf ("    - Framegraph resource slots are still resolved to GL-native IDs.\n");
+	Con_Printf ("    - shader_id is still effectively GL program handle in GL backend.\n");
+	Con_Printf ("  Framegraph-Leaks:\n");
+	Con_Printf ("    - framegraph is declarative.\n");
+	Con_Printf ("    - pass execution still calls legacy/GL backend callbacks.\n");
+	Con_Printf ("    - FBO lifetime is not owned by generic framegraph yet.\n");
+	Con_Printf ("  gltexture_t usage inventory (static Phase 2 snapshot):\n");
+	Con_Printf ("    - A Safe frontend reference: pointer/reference-only use in r_alias.c, r_brush.c, r_sprite.c, r_part_q3p.c, r_decals.c, and portions of r_world.c.\n");
+	Con_Printf ("    - B Native GL access: direct target/texnum/internal_format/bindless_handle access remains concentrated in gl_texmgr.c, gl_rmain.c/r_postfx.c, r_world.c, and backend resource glue.\n");
+	Con_Printf ("    - C Upload/lifetime: TexMgr_NewTexture/TexMgr_LoadImage*/TexMgr_ReloadImage/TexMgr_FreeTexture and GL_DeleteTexture remain GL texture lifetime owners.\n");
+	Con_Printf ("    - D Material/model binding: world, alias skins, sprites, particles, decals, UI/HUD, and postfx still bind through gltexture_t.\n");
+	Con_Printf ("  First neutral texture-handle candidate:\n");
+	Con_Printf ("    - Preferred: PostFX LUT, then isolated UI/2D texture adapter.\n");
+	Con_Printf ("    - Avoid first: world textures, alias skins, shadows, and FBO attachments.\n");
 	Con_Printf ("  Policy:\n");
 	Con_Printf ("    - r_backend=%s r_backend_api=%s r_backend_allow_builtin_gl=%s.\n",
 		r_backend.string ? r_backend.string : "<null>",
 		r_backend_api.string ? r_backend_api.string : "<null>",
 		r_backend_allow_builtin_gl.string ? r_backend_allow_builtin_gl.string : "<null>");
-	Con_Printf ("    - Vulkan/DX12 remain stub/blocklisted for activation in Phase 1.\n");
+	Con_Printf ("    - Vulkan/DX12 remain stub/blocklisted for activation in Phase 2.\n");
 }
 
 /*

--- a/Quake/src/render/render_api.h
+++ b/Quake/src/render/render_api.h
@@ -335,14 +335,23 @@ typedef struct i_render_backend_s
 	void (*apply_framegraph_baseline)(unsigned baseline_bits);
 
 	/*
-	 * TODO Future API-neutral resource model:
-	 * - Texture
-	 * - Buffer
-	 * - Sampler
-	 * - ImageView
-	 * - RenderTarget
-	 * - Pipeline
-	 * - DescriptorSet
+	 * Phase 2 note: this interface still contains legacy bridge callbacks
+	 * above. They intentionally preserve the current GL-backed pass execution
+	 * while future API-neutral resource work is planned.
+	 *
+	 * Current shader_id/resource IDs may still map to native GL objects inside
+	 * the GL backend. Future backends must not expose native GLuint/GLenum (or
+	 * equivalent API-native object names) to frontend code.
+	 *
+	 * TODO Future API-neutral resource create/usage descriptions (comments only;
+	 * no ABI added in Phase 2):
+	 * - R_TextureCreateDesc: dimensions, format, usage, mip levels, array/cube.
+	 * - R_BufferCreateDesc: size, usage, memory/update policy.
+	 * - R_SamplerDesc: filter, wrap, anisotropy, compare mode.
+	 * - R_ImageViewDesc: resource, format override, subresource range.
+	 * - R_RenderTargetDesc: color/depth attachments, load/store, samples.
+	 * - R_PipelineDesc: shaders, vertex input, raster/depth/blend state.
+	 * - R_DescriptorSetDesc: resource bindings grouped by pipeline layout.
 	 */
 } IRenderBackend;
 

--- a/Quake/src/render/texture_handles.h
+++ b/Quake/src/render/texture_handles.h
@@ -1,6 +1,9 @@
 /*
  * Renderer-neutral texture handle declarations for core-facing headers.
  * Native GL texture IDs remain ref_gl-private.
+ * Phase 2 note: render_texture_handle_t is the intended destination for
+ * frontend-visible texture references, but gltexture_t has not been fully
+ * migrated and remains the public legacy bridge.
  */
 
 #ifndef RENDER_TEXTURE_HANDLES_H

--- a/docs/renderer_backend_migration_phase2.md
+++ b/docs/renderer_backend_migration_phase2.md
@@ -1,0 +1,158 @@
+# Renderer Backend Migration Phase 2
+
+## 1. Goal of Phase 2
+
+Phase 2 is a preparation-only phase for renderer core decontamination and later resource-handle migration. It makes the remaining OpenGL leaks measurable and documents the safest first texture-handle migration candidate without changing rendering behavior.
+
+The intended output is:
+
+- expanded `r_backend_migration_audit` diagnostics;
+- a clearer `model_types.h` future split point;
+- explicit public `gltexture_t` legacy-bridge labeling;
+- a static inventory of `gltexture_t` usage classes;
+- a ranked first neutral texture-handle migration candidate;
+- comments only for future API-neutral resource descriptors.
+
+## 2. Non-goals
+
+Phase 2 explicitly does **not**:
+
+- remove OpenGL;
+- hard-refactor `quakedef.h`;
+- replace `gltexture_t`;
+- split or dismantle `gl_rmain.c`;
+- enable Vulkan or DX12;
+- change renderer output;
+- change public renderer ABI or plugin structs;
+- migrate world, alias, shadow, or FBO attachment resources.
+
+## 3. Core GL leaks
+
+Known core/header contamination remains intentional and measurable:
+
+- `Quake/src/core/quakedef.h` includes `SDL_opengl.h`.
+- `Quake/src/core/quakedef.h` includes `gl_model.h`.
+- `Quake/src/core/quakedef.h` includes `gl_texmgr.h`.
+- `Quake/src/core/model_types.h` remains a shim over `gl_model.h`.
+- Render/frontend files still include `glquake.h` directly.
+
+These are not fixed in Phase 2. They are audit targets for later core decontamination.
+
+## 4. Public `gltexture_t` leak
+
+`gltexture_t` remains a public legacy OpenGL bridge. The native GL fields that leak backend implementation details are:
+
+- `target` (`GLenum`);
+- `texnum` (`GLuint`);
+- `bindless_handle` (`GLuint64`);
+- `internal_format` (`GLenum`).
+
+`texture_handles.h` already defines `render_texture_handle_t`, but current frontend and material/model paths still bridge through public `gltexture_t` pointers. Long-term frontend code should only see `render_texture_handle_t`; native GL data should move behind the GL backend or a GL resource layer.
+
+## 5. Header dependency hotspots
+
+Frontend/render files with direct GL-header dependency called out by the audit command:
+
+- `r_world.c`
+- `r_alias.c`
+- `r_brush.c`
+- `r_sprite.c`
+- `r_part.c`
+- `r_part_q3p.c`
+- `r_decals.c`
+- `r_postfx.c`
+
+These are hotspots, not migration targets for Phase 2.
+
+## 6. `gltexture_t` usage categories
+
+Static inventory snapshot gathered with `rg` during Phase 2:
+
+- `gltexture_t` references in `Quake/src`: 130 matching lines.
+- Direct `texnum` field references: 36 matching lines.
+- Direct `target` field references: 70 matching lines.
+- Direct `internal_format` field references: 19 matching lines.
+- Direct `bindless_handle` field references: 12 matching lines.
+
+### A. Safe frontend reference
+
+Code holds or forwards `gltexture_t *` without directly touching native GL fields in many call sites:
+
+- `r_alias.c` player/model texture arrays;
+- `r_brush.c` and sprite batching references;
+- `r_sprite.c` batch texture selection;
+- `r_part_q3p.c` material stage texture resolution;
+- portions of `r_decals.c` and `r_world.c` where textures are selected or passed onward.
+
+These are possible future adapter users, but they are not migrated in Phase 2.
+
+### B. Native GL access
+
+Direct backend-native access remains in GL-specific or tightly-coupled code:
+
+- `texnum` object IDs;
+- `target` bind targets;
+- `internal_format` upload formats;
+- `bindless_handle` world/material bindless paths.
+
+The heaviest native access is expected in `gl_texmgr.c`, with additional coupling in `r_world.c`, post-processing/FBO paths, and backend resource glue.
+
+### C. Upload/lifetime
+
+Texture lifetime remains owned by the existing texture manager path:
+
+- `TexMgr_NewTexture`
+- `TexMgr_LoadImage`
+- `TexMgr_LoadImageEx`
+- `TexMgr_ReloadImage`
+- `TexMgr_FreeTexture`
+- `GL_DeleteTexture` / native `glDeleteTextures`
+
+No ownership move occurs in Phase 2.
+
+### D. Material/model binding
+
+The following binding domains still depend on `gltexture_t`:
+
+- world textures;
+- alias model skins;
+- sprite textures;
+- particles;
+- decals;
+- UI/HUD/2D draw assets;
+- post-processing textures/LUTs;
+- lightmaps and other GL-managed renderer resources.
+
+## 7. Candidate ranking for first neutral texture-handle migration
+
+| Rank | Candidate | Assessment |
+| --- | --- | --- |
+| 1 | PostFX LUT | Best first adapter candidate: narrow scope, already conceptually a generated renderer resource, low material/model dependency, easier toggle/fallback. |
+| 2 | Isolated UI/2D texture | Good fallback candidate: visible but usually simple binding path; choose one isolated texture, not the whole UI atlas/scrap system. |
+| 3 | Decal texture | Medium risk: fewer dependencies than world/alias, but visible in scene and tied to material-style batching. |
+| 4 | Particle texture | Medium risk: potentially simple texture references, but high visual sensitivity and particle batching/state coupling. |
+| 5 | World texture | Do not start here: high dependency count, material stages, bindless, lightmaps, batching, and visible regression risk. |
+| 6 | Alias skin | Do not start here: model skin/fb skin paths, player translations, animation, and material binding increase risk. |
+| 7 | Shadow map | Do not start here: FBO/depth/sampler/compare-state coupling and high regression risk. |
+| 8 | FBO attachment | Do not start here: ownership belongs to future framegraph/render-target resource work, not texture-handle adapter smoke tests. |
+
+Recommendation: Phase 3 should start with the PostFX LUT. If that path proves too coupled, use a single isolated UI/2D texture as the backup candidate.
+
+## 8. Go/No-Go criteria for Phase 3
+
+Phase 2 is GO only if:
+
+- the project compiles in the target Windows/MSBuild environment;
+- no visible render path changed;
+- `quakedef.h` still contains the old GL includes;
+- `gl_texmgr.h` is functionally unchanged;
+- `gltexture_t` is not replaced;
+- Vulkan/DX12 remain blocked;
+- `r_backend_migration_audit` names all known GL leaks;
+- the first neutral texture-handle candidate is clearly recommended.
+
+Phase 3 preview only, not implemented here:
+
+- **Phase 3-A:** add a small texture-handle adapter for PostFX LUT or one isolated UI/2D texture; frontend sees `render_texture_handle_t`; GL backend keeps native `GLuint`.
+- **Phase 3-B:** do not migrate world/alias/shadows; keep the legacy `gltexture_t` fallback path.
+- **Phase 3-C:** use pixel equality or very tight visual tolerance; gate the new path behind a toggle/CVar; default to the legacy path first.


### PR DESCRIPTION
### Motivation
- Prepare the codebase for Core-Decontamination and Resource-Handle-Migration by making GL leaks and header dependencies visible without changing runtime behavior.
- Provide a safe, comment-only scaffold that identifies a first low-risk texture-handle migration candidate while keeping current GL-backed rendering intact.

### Description
- Expanded the migration audit output in `r_backend_migration_audit` to a Phase 2 report that lists Core/Header leaks, frontend files with GL header dependencies, resource/shader/framegraph leaks, and a static `gltexture_t` usage inventory (`Quake/src/render/r_backend.c`).
- Documented `model_types.h` as the intentional future split-point with TODOs and guidance while preserving the current `#include "gl_model.h"` shim (`Quake/src/core/model_types.h`).
- Marked `gltexture_t` as a legacy GL bridge and annotated native GL fields (`target`, `texnum`, `bindless_handle`, `internal_format`) as backend-specific, keeping struct layout unchanged and suggesting accessor candidates (`Quake/src/render/gl_texmgr.h`).
- Added Phase-2 notes that `render_texture_handle_t` is the intended frontend type while `gltexture_t` remains the public transitional bridge (`Quake/src/render/texture_handles.h`) and added comment-only future resource API sketches in `render_api.h` (no ABI changes).
- Added `docs/renderer_backend_migration_phase2.md` describing Phase 2 goals, non-goals, inventory snapshots, candidate ranking for first neutral texture-handle migration (PostFX LUT preferred), and explicit Go/No-Go criteria for Phase 3.

### Testing
- Per-file syntax checks: ran `cc -fsyntax-only` on `Quake/src/render/r_backend.c` and `Quake/src/core/quakedef.c`, which completed successfully for the modified units.
- Full CMake/Ninja Linux build: `cmake --build build --target ironwail` was attempted but the build stops on pre-existing portability issues in `Quake/src/core/quakelab_api.c` (conflicting `u_long` typedef and undefined `FIONBIO`/`ioctlsocket`), which are unrelated to the Phase 2 comment/audit changes.
- Windows/MSBuild: attempted Windows MSBuild invocation from container but the host MSBuild binary is not available here, so a Windows Release build was not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03231e9ba0832ea0c642505686a2c7)