### PR TITLE
Phase 3: Add PostFX LUT neutral texture-handle test (r_renderer_texture_handle_test)

### DIFF
--- a/Quake/src/render/gl_backend_resources.c
+++ b/Quake/src/render/gl_backend_resources.c
@@ -3,11 +3,239 @@
 #include "gl_backend.h"
 #include "r_framegraph.h"
 #include "r_resources_gl.h"
+#include "gl_texmgr.h"
 
 enum
 {
-	GL_BACKEND_MAX_RESOURCES = 128
+	GL_BACKEND_MAX_RESOURCES = 128,
+	GL_BACKEND_MAX_TEXTURE_HANDLES = 256
 };
+
+
+typedef enum gl_backend_texture_handle_kind_e
+{
+	GL_BACKEND_TEXTURE_HANDLE_NONE = 0,
+	GL_BACKEND_TEXTURE_HANDLE_LEGACY_GLTEXTURE,
+	GL_BACKEND_TEXTURE_HANDLE_NATIVE
+} gl_backend_texture_handle_kind_t;
+
+static struct gl_backend_texture_handle_table_s
+{
+	struct gl_backend_texture_handle_entry_s
+	{
+		render_texture_handle_t handle;
+		gl_backend_texture_handle_kind_t kind;
+		gltexture_t *legacy_texture;
+		unsigned native_id;
+		unsigned target;
+	} entries[GL_BACKEND_MAX_TEXTURE_HANDLES];
+	render_texture_handle_t next_handle;
+	unsigned short count;
+} s_gl_texture_handles = { { { 0 } }, 1u, 0u };
+
+#ifndef RENDERER_PLUGIN_BUILD
+extern cvar_t r_backend_debug;
+extern cvar_t r_renderer_migration_debug;
+#endif
+
+static qboolean GLBackend_TextureHandleDebugEnabled (void)
+{
+#ifdef RENDERER_PLUGIN_BUILD
+	return false;
+#else
+	return r_renderer_migration_debug.value != 0.f || r_backend_debug.value != 0.f;
+#endif
+}
+
+static render_texture_handle_t GLBackend_AllocTextureHandle (void)
+{
+	render_texture_handle_t handle = s_gl_texture_handles.next_handle++;
+	if (handle == RENDER_TEXTURE_HANDLE_INVALID)
+		handle = s_gl_texture_handles.next_handle++;
+	return handle;
+}
+
+static int GLBackend_FindTextureHandleIndex (render_texture_handle_t handle)
+{
+	unsigned i;
+
+	if (!R_TextureHandle_IsValid (handle))
+		return -1;
+
+	for (i = 0; i < s_gl_texture_handles.count; ++i)
+	{
+		if (s_gl_texture_handles.entries[i].handle == handle)
+			return (int)i;
+	}
+
+	return -1;
+}
+
+static int GLBackend_FindLegacyTextureHandleIndex (const gltexture_t *texture)
+{
+	unsigned i;
+
+	if (!texture)
+		return -1;
+
+	for (i = 0; i < s_gl_texture_handles.count; ++i)
+	{
+		const struct gl_backend_texture_handle_entry_s *entry = &s_gl_texture_handles.entries[i];
+		if (entry->kind == GL_BACKEND_TEXTURE_HANDLE_LEGACY_GLTEXTURE && entry->legacy_texture == texture)
+			return (int)i;
+	}
+
+	return -1;
+}
+
+static int GLBackend_FindNativeTextureHandleIndex (unsigned target, unsigned native_id)
+{
+	unsigned i;
+
+	if (target == 0u || native_id == 0u)
+		return -1;
+
+	for (i = 0; i < s_gl_texture_handles.count; ++i)
+	{
+		const struct gl_backend_texture_handle_entry_s *entry = &s_gl_texture_handles.entries[i];
+		if (entry->kind == GL_BACKEND_TEXTURE_HANDLE_NATIVE && entry->target == target && entry->native_id == native_id)
+			return (int)i;
+	}
+
+	return -1;
+}
+
+static struct gl_backend_texture_handle_entry_s *GLBackend_NewTextureHandleEntry (void)
+{
+	struct gl_backend_texture_handle_entry_s *entry;
+
+	if (s_gl_texture_handles.count >= GL_BACKEND_MAX_TEXTURE_HANDLES)
+		return NULL;
+
+	entry = &s_gl_texture_handles.entries[s_gl_texture_handles.count++];
+	memset (entry, 0, sizeof (*entry));
+	entry->handle = GLBackend_AllocTextureHandle ();
+	return entry;
+}
+
+render_texture_handle_t R_TextureHandle_FromLegacyGLTexture (gltexture_t *tex)
+{
+	struct gl_backend_texture_handle_entry_s *entry;
+	int index;
+
+	if (!tex)
+		return R_TextureHandle_Invalid ();
+
+	index = GLBackend_FindLegacyTextureHandleIndex (tex);
+	if (index >= 0)
+		return s_gl_texture_handles.entries[index].handle;
+
+	entry = GLBackend_NewTextureHandleEntry ();
+	if (!entry)
+	{
+		if (GLBackend_TextureHandleDebugEnabled ())
+			Con_DPrintf ("R_TextureHandle: legacy gltexture_t handle table full\n");
+		return R_TextureHandle_Invalid ();
+	}
+
+	entry->kind = GL_BACKEND_TEXTURE_HANDLE_LEGACY_GLTEXTURE;
+	entry->legacy_texture = tex;
+	entry->target = (unsigned)TexMgr_GetTarget (tex);
+	entry->native_id = (unsigned)TexMgr_GetNativeHandle (tex);
+	return entry->handle;
+}
+
+gltexture_t *R_TextureHandle_ResolveLegacyGLTexture (render_texture_handle_t h)
+{
+	int index = GLBackend_FindTextureHandleIndex (h);
+
+	if (index < 0 || s_gl_texture_handles.entries[index].kind != GL_BACKEND_TEXTURE_HANDLE_LEGACY_GLTEXTURE)
+		return NULL;
+
+	return s_gl_texture_handles.entries[index].legacy_texture;
+}
+
+render_texture_handle_t GL_Backend_TextureHandleFromNativeTexture (unsigned target, unsigned native_id)
+{
+	struct gl_backend_texture_handle_entry_s *entry;
+	int index;
+
+	if (target == 0u || native_id == 0u)
+		return R_TextureHandle_Invalid ();
+
+	index = GLBackend_FindNativeTextureHandleIndex (target, native_id);
+	if (index >= 0)
+		return s_gl_texture_handles.entries[index].handle;
+
+	entry = GLBackend_NewTextureHandleEntry ();
+	if (!entry)
+	{
+		if (GLBackend_TextureHandleDebugEnabled ())
+			Con_DPrintf ("R_TextureHandle: native texture handle table full\n");
+		return R_TextureHandle_Invalid ();
+	}
+
+	entry->kind = GL_BACKEND_TEXTURE_HANDLE_NATIVE;
+	entry->target = target;
+	entry->native_id = native_id;
+	return entry->handle;
+}
+
+qboolean GL_Backend_ResolveTextureHandleNative (render_texture_handle_t handle, unsigned *out_target, unsigned *out_native_id)
+{
+	const struct gl_backend_texture_handle_entry_s *entry;
+	int index = GLBackend_FindTextureHandleIndex (handle);
+
+	if (out_target)
+		*out_target = 0u;
+	if (out_native_id)
+		*out_native_id = 0u;
+	if (index < 0)
+		return false;
+
+	entry = &s_gl_texture_handles.entries[index];
+	if (entry->kind == GL_BACKEND_TEXTURE_HANDLE_LEGACY_GLTEXTURE)
+	{
+		if (!entry->legacy_texture)
+			return false;
+		if (out_target)
+			*out_target = (unsigned)TexMgr_GetTarget (entry->legacy_texture);
+		if (out_native_id)
+			*out_native_id = (unsigned)TexMgr_GetNativeHandle (entry->legacy_texture);
+		return out_native_id ? (*out_native_id != 0u) : true;
+	}
+	if (entry->kind == GL_BACKEND_TEXTURE_HANDLE_NATIVE)
+	{
+		if (out_target)
+			*out_target = entry->target;
+		if (out_native_id)
+			*out_native_id = entry->native_id;
+		return entry->target != 0u && entry->native_id != 0u;
+	}
+
+	return false;
+}
+
+qboolean GL_Backend_BindTextureHandle (unsigned texunit, render_texture_handle_t handle, unsigned expected_target)
+{
+	unsigned target = 0u;
+	unsigned native_id = 0u;
+
+	if (!GL_Backend_ResolveTextureHandleNative (handle, &target, &native_id))
+	{
+		if (GLBackend_TextureHandleDebugEnabled ())
+			Con_DPrintf ("R_TextureHandle: failed to resolve texture handle %u\n", (unsigned)handle);
+		return false;
+	}
+	if (expected_target != 0u && target != expected_target)
+	{
+		if (GLBackend_TextureHandleDebugEnabled ())
+			Con_DPrintf ("R_TextureHandle: target mismatch for handle %u: got %u expected %u\n", (unsigned)handle, target, expected_target);
+		return false;
+	}
+
+	return GL_BindNative ((GLenum)texunit, (GLenum)target, (GLuint)native_id);
+}
 
 static struct gl_backend_resource_table_s
 {
@@ -59,7 +287,9 @@ static int GLBackend_FindResourceIndexByKey (gl_backend_resource_key_t key)
 void GL_Backend_ResetResources (void)
 {
 	memset (&s_gl_resources, 0, sizeof (s_gl_resources));
+	memset (&s_gl_texture_handles, 0, sizeof (s_gl_texture_handles));
 	s_gl_resources.next_opaque_id = 1u;
+	s_gl_texture_handles.next_handle = 1u;
 	GL_Backend_ResetStateCache ();
 }
 

--- a/Quake/src/render/gl_rmain.c
+++ b/Quake/src/render/gl_rmain.c
@@ -26,6 +26,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "cl_postfx.h"
 #include "r_postfx.h"
 #include "r_framegraph.h"
+#include "r_backend.h"
 #include "r_godrays.h"
 #include "r_skyvis.h"
 #include "r_ssao.h"
@@ -45,6 +46,10 @@ extern cvar_t r_refgl_debug;
 extern cvar_t r_refgl_log_init;
 extern cvar_t r_refgl_log_passes;
 extern cvar_t r_refgl_log_resources;
+#ifndef RENDERER_PLUGIN_BUILD
+extern cvar_t r_backend_debug;
+extern cvar_t r_renderer_migration_debug;
+#endif
 extern cvar_t r_refgl_validate_fbo;
 extern cvar_t r_ref_enable_postfx;
 extern cvar_t r_ref_enable_fog;
@@ -759,6 +764,7 @@ cvar_t	r_postfx_lut = { "r_postfx_lut", "1", CVAR_ARCHIVE };
 cvar_t	r_postfx_lut_strength_powerup = { "r_postfx_lut_strength_powerup", "0.6", CVAR_ARCHIVE };
 cvar_t	r_postfx_lut_strength_underwater = { "r_postfx_lut_strength_underwater", "0.5", CVAR_ARCHIVE };
 cvar_t	r_postfx_lut_debug_id = { "r_postfx_lut_debug_id", "0", CVAR_NONE };
+cvar_t	r_renderer_texture_handle_test = { "r_renderer_texture_handle_test", "0", CVAR_NONE };
 cvar_t	r_postfx_debug = { "r_postfx_debug", "0", CVAR_NONE };
 cvar_t	r_film35_enable = { "r_film35_enable", "0", CVAR_ARCHIVE };
 cvar_t	r_film35_strength = { "r_film35_strength", "0.35", CVAR_ARCHIVE };
@@ -3354,6 +3360,16 @@ static qboolean GL_PostFXBloomBoostActive (void)
 	return state.bloom_boost > 0.f;
 }
 
+
+static qboolean GL_RendererMigrationDebugEnabled (void)
+{
+#ifdef RENDERER_PLUGIN_BUILD
+	return false;
+#else
+	return r_renderer_migration_debug.value != 0.f || r_backend_debug.value != 0.f;
+#endif
+}
+
 static GLuint R_ResolveCriticalResourceOrLegacyFallback (const RenderGraphResourceHandle *resources,
 	render_backend_resource_slot_t slot, const char *usage_tag, GLuint legacy_value, const char *legacy_label)
 {
@@ -3758,7 +3774,24 @@ void GL_PostProcess (const r_postprocess_input_t *input)
 	GL_BindNative (GL_TEXTURE6, GL_TEXTURE_2D, godrays_mask);
 	GL_BindNative (GL_TEXTURE7, GL_TEXTURE_2D, godrays_source);
 	GL_BindNative (GL_TEXTURE8, GL_TEXTURE_2D, ssao_texture);
-	GL_BindNative (GL_TEXTURE9, GL_TEXTURE_2D_ARRAY, R_PostFX_GetLUTTexture ());
+	if (r_renderer_texture_handle_test.value != 0.f)
+	{
+		render_texture_handle_t postfx_lut_handle = R_PostFX_GetLUTTextureHandle ();
+		if (!GL_Backend_BindTextureHandle ((unsigned)GL_TEXTURE9, postfx_lut_handle, (unsigned)GL_TEXTURE_2D_ARRAY))
+		{
+			if (GL_RendererMigrationDebugEnabled ())
+				Con_DPrintf ("R_Migration: PostFX LUT texture handle path failed; falling back to legacy GL texture id\n");
+			GL_BindNative (GL_TEXTURE9, GL_TEXTURE_2D_ARRAY, R_PostFX_GetLUTTexture ());
+		}
+		else if (GL_RendererMigrationDebugEnabled ())
+		{
+			Con_DPrintf ("R_Migration: PostFX LUT texture handle path bound handle %u\n", (unsigned)postfx_lut_handle);
+		}
+	}
+	else
+	{
+		GL_BindNative (GL_TEXTURE9, GL_TEXTURE_2D_ARRAY, R_PostFX_GetLUTTexture ());
+	}
 	GL_BindNative (GL_TEXTURE10, GL_TEXTURE_2D, 0);
 	GL_BindBufferRange (GL_SHADER_STORAGE_BUFFER, 0, gl_palette_buffer[palidx], 0, 256 * sizeof (GLuint));
 	{

--- a/Quake/src/render/r_backend.c
+++ b/Quake/src/render/r_backend.c
@@ -142,6 +142,7 @@ cvar_t r_backend_api = { "r_backend_api", "gl", CVAR_ARCHIVE };
 cvar_t r_backend_allow_builtin_gl = { "r_backend_allow_builtin_gl", "1", CVAR_ARCHIVE };
 cvar_t r_backend_debug = { "r_backend_debug", "0", CVAR_NONE };
 cvar_t r_renderer_migration_debug = { "r_renderer_migration_debug", "0", CVAR_NONE };
+extern cvar_t r_renderer_texture_handle_test;
 extern int r_framecount;
 extern cvar_t r_framegraph_debug;
 extern cvar_t r_refgl_debug;
@@ -194,13 +195,13 @@ static void R_Backend_WrapperAudit_f (void)
 ================
 R_Backend_MigrationAudit_f
 
-Text-only Phase 2 migration audit. Keep this conservative: it names known
+Text-only Phase 3 migration audit. Keep this conservative: it names known
 OpenGL coupling points without changing renderer selection or draw paths.
 ================
 */
 static void R_Backend_MigrationAudit_f (void)
 {
-	Con_Printf ("Renderer backend migration audit (Phase 2):\n");
+	Con_Printf ("Renderer backend migration audit (Phase 3):\n");
 	Con_Printf ("  Core/Header-Leaks:\n");
 	Con_Printf ("    - quakedef.h includes SDL_opengl.h.\n");
 	Con_Printf ("    - quakedef.h includes gl_model.h.\n");
@@ -234,15 +235,27 @@ static void R_Backend_MigrationAudit_f (void)
 	Con_Printf ("    - B Native GL access: direct target/texnum/internal_format/bindless_handle access remains concentrated in gl_texmgr.c, gl_rmain.c/r_postfx.c, r_world.c, and backend resource glue.\n");
 	Con_Printf ("    - C Upload/lifetime: TexMgr_NewTexture/TexMgr_LoadImage*/TexMgr_ReloadImage/TexMgr_FreeTexture and GL_DeleteTexture remain GL texture lifetime owners.\n");
 	Con_Printf ("    - D Material/model binding: world, alias skins, sprites, particles, decals, UI/HUD, and postfx still bind through gltexture_t.\n");
-	Con_Printf ("  First neutral texture-handle candidate:\n");
-	Con_Printf ("    - Preferred: PostFX LUT, then isolated UI/2D texture adapter.\n");
-	Con_Printf ("    - Avoid first: world textures, alias skins, shadows, and FBO attachments.\n");
+	Con_Printf ("  Phase 3 texture handle test:\n");
+	Con_Printf ("    - Phase 3 texture handle test available: yes\n");
+	Con_Printf ("    - selected candidate: PostFX LUT\n");
+	Con_Printf ("    - cvar: r_renderer_texture_handle_test\n");
+	Con_Printf ("    - default path: legacy\n");
+	Con_Printf ("    - fallback: enabled\n");
+	Con_Printf ("    - native GL ownership: GL resource/backend only\n");
+	Con_Printf ("    - migrated scope: exactly one isolated texture path\n");
+	Con_Printf ("    - Avoided: world textures, alias skins, shadows, and FBO attachments.\n");
+	Con_Printf ("  Known Phase-3 leaks left in place:\n");
+	Con_Printf ("    - quakedef.h GL leak.\n");
+	Con_Printf ("    - gltexture_t public bridge.\n");
+	Con_Printf ("    - gl_rmain.c legacy GL orchestration.\n");
+	Con_Printf ("    - glprogs_t GLuint programs.\n");
+	Con_Printf ("    - framegraph legacy pass execution.\n");
 	Con_Printf ("  Policy:\n");
 	Con_Printf ("    - r_backend=%s r_backend_api=%s r_backend_allow_builtin_gl=%s.\n",
 		r_backend.string ? r_backend.string : "<null>",
 		r_backend_api.string ? r_backend_api.string : "<null>",
 		r_backend_allow_builtin_gl.string ? r_backend_allow_builtin_gl.string : "<null>");
-	Con_Printf ("    - Vulkan/DX12 remain stub/blocklisted for activation in Phase 2.\n");
+	Con_Printf ("    - Vulkan/DX12 remain stub/blocklisted for activation in Phase 3.\n");
 }
 
 /*
@@ -2179,6 +2192,7 @@ void R_Backend_Init (void)
 	Cvar_RegisterVariable (&r_backend_allow_builtin_gl);
 	Cvar_RegisterVariable (&r_backend_debug);
 	Cvar_RegisterVariable (&r_renderer_migration_debug);
+	Cvar_RegisterVariable (&r_renderer_texture_handle_test);
 	Cvar_RegisterVariable (&r_refgl_debug);
 	Cvar_RegisterVariable (&r_refgl_log_init);
 	Cvar_RegisterVariable (&r_refgl_log_passes);

--- a/Quake/src/render/r_backend.h
+++ b/Quake/src/render/r_backend.h
@@ -39,6 +39,8 @@ typedef struct render_backend_milestones_s
 render_backend_runtime_status_t R_Backend_GetRuntimeStatusForName (const char *backend_name);
 const char *R_Backend_GetRuntimeStatusLabel (render_backend_runtime_status_t status);
 qboolean R_Backend_GetMilestonesForName (const char *backend_name, RenderBackendMilestones *out_milestones);
+extern cvar_t r_renderer_texture_handle_test;
+
 void R_Backend_QuerySurfaceInfo (RenderBackendSurfaceInfo *out_info);
 const char *R_Backend_ResourceSlotName (render_backend_resource_slot_t slot);
 qboolean R_Backend_GetFrameGraphResourceBinding (unsigned resource_bit, render_backend_resource_slot_t *out_slot, qboolean *out_requires_backend_resource);

--- a/Quake/src/render/r_postfx.c
+++ b/Quake/src/render/r_postfx.c
@@ -23,6 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "glquake.h"
 #include "gl_backend.h"
 #include "r_framegraph.h"
+#include "r_resources_gl.h"
 #include "r_postfx.h"
 #include "cl_postfx.h"
 #include "gl_texmgr.h"
@@ -32,6 +33,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  * Transitional native texture id exposed in this unit for LUT management.
  * Long-term target: opaque backend resource handle + resolve/upload service. */
 static GLuint r_postfx_lut_tex;
+static render_texture_handle_t r_postfx_lut_handle = RENDER_TEXTURE_HANDLE_INVALID;
 static int r_postfx_lut_size;
 
 static void R_PostFX_ReloadLUTs (void);
@@ -50,6 +52,10 @@ extern cvar_t r_postfx_debug;
 extern cvar_t r_refgl_debug;
 extern cvar_t r_refgl_log_resources;
 extern cvar_t r_refgl_validate_lifetime;
+#ifndef RENDERER_PLUGIN_BUILD
+extern cvar_t r_backend_debug;
+extern cvar_t r_renderer_migration_debug;
+#endif
 
 static const char *const postfx_lut_files[PFX_LUT_COUNT] =
 {
@@ -63,6 +69,15 @@ static const char *const postfx_lut_files[PFX_LUT_COUNT] =
 	"gfx/lut/quad"
 };
 
+static qboolean R_PostFX_TextureHandleDebugEnabled (void)
+{
+#ifdef RENDERER_PLUGIN_BUILD
+	return false;
+#else
+	return r_renderer_migration_debug.value != 0.f || r_backend_debug.value != 0.f;
+#endif
+}
+
 static void R_PostFX_DestroyLUTTexture (void)
 {
 	if (r_postfx_lut_tex)
@@ -72,6 +87,7 @@ static void R_PostFX_DestroyLUTTexture (void)
 		GL_DeleteNativeTexture (r_postfx_lut_tex);
 		r_postfx_lut_tex = 0;
 	}
+	r_postfx_lut_handle = R_TextureHandle_Invalid ();
 	r_postfx_lut_size = 0;
 }
 
@@ -181,6 +197,9 @@ static void R_PostFX_ReloadLUTs (void)
 	}
 	R_Backend_ConfigurePostFXLUTTexture (r_postfx_lut_tex);
 	GL_Backend_UploadPostFXLUTData (r_postfx_lut_tex, lut_storage, size * size, size, PFX_LUT_COUNT);
+	r_postfx_lut_handle = GL_Backend_TextureHandleFromNativeTexture ((unsigned)GL_TEXTURE_2D_ARRAY, (unsigned)r_postfx_lut_tex);
+	if (!R_TextureHandle_IsValid (r_postfx_lut_handle) && R_PostFX_TextureHandleDebugEnabled ())
+		Con_DPrintf ("R_TextureHandle: PostFX LUT native handle registration failed; legacy path remains available\n");
 
 	q_free(lut_storage);
 	r_postfx_lut_size = size;
@@ -223,6 +242,11 @@ void R_PostFX_GetState (postfx_state_t *out_state)
 unsigned R_PostFX_GetLUTTexture (void)
 {
 	return (unsigned)r_postfx_lut_tex;
+}
+
+render_texture_handle_t R_PostFX_GetLUTTextureHandle (void)
+{
+	return r_postfx_lut_handle;
 }
 
 int R_PostFX_GetLUTSize (void)

--- a/Quake/src/render/r_postfx.h
+++ b/Quake/src/render/r_postfx.h
@@ -22,11 +22,13 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define R_POSTFX_H
 
 #include "cl_postfx.h"
+#include "texture_handles.h"
 
 void R_PostFX_Init (void);
 void R_PostFX_RegisterCvars (void);
 void R_PostFX_GetState (postfx_state_t *out_state);
 unsigned R_PostFX_GetLUTTexture (void);
+render_texture_handle_t R_PostFX_GetLUTTextureHandle (void);
 int R_PostFX_GetLUTSize (void);
 qboolean R_PostFX_DoFEnabledEffective (void);
 qboolean R_PostFX_GodraysPreviewEnabledEffective (void);

--- a/Quake/src/render/r_resources_gl.h
+++ b/Quake/src/render/r_resources_gl.h
@@ -2,6 +2,7 @@
 #define R_RESOURCES_GL_H
 
 #include "render_api.h"
+#include "texture_handles.h"
 
 typedef enum gl_resource_size_class_e
 {
@@ -31,5 +32,9 @@ void GL_ResourceRegistry_RegisterSlot (render_backend_resource_slot_t slot);
 void GL_ResourceRegistry_UnregisterSlot (render_backend_resource_slot_t slot);
 void GL_ResourceRegistry_RegisterFrameGraphSlots (void);
 void GL_ResourceRegistry_UnregisterFrameGraphSlots (void);
+
+render_texture_handle_t GL_Backend_TextureHandleFromNativeTexture (unsigned target, unsigned native_id);
+qboolean GL_Backend_ResolveTextureHandleNative (render_texture_handle_t handle, unsigned *out_target, unsigned *out_native_id);
+qboolean GL_Backend_BindTextureHandle (unsigned texunit, render_texture_handle_t handle, unsigned expected_target);
 
 #endif

--- a/Quake/src/render/texture_handles.h
+++ b/Quake/src/render/texture_handles.h
@@ -31,4 +31,17 @@ typedef uintptr_t src_offset_t;
 struct gltexture_s;
 typedef struct gltexture_s gltexture_t;
 
+static inline qboolean R_TextureHandle_IsValid (render_texture_handle_t h)
+{
+	return h != RENDER_TEXTURE_HANDLE_INVALID;
+}
+
+static inline render_texture_handle_t R_TextureHandle_Invalid (void)
+{
+	return RENDER_TEXTURE_HANDLE_INVALID;
+}
+
+render_texture_handle_t R_TextureHandle_FromLegacyGLTexture (gltexture_t *tex);
+gltexture_t *R_TextureHandle_ResolveLegacyGLTexture (render_texture_handle_t h);
+
 #endif /* RENDER_TEXTURE_HANDLES_H */

--- a/docs/renderer_backend_migration_phase3.md
+++ b/docs/renderer_backend_migration_phase3.md
@@ -1,0 +1,133 @@
+# Renderer Backend Migration Phase 3
+
+## 1. Ziel
+
+Phase 3 introduces the first small renderer-neutral texture handle path without replacing `gltexture_t` or moving broad texture ownership. The test path is intentionally narrow: a `render_texture_handle_t` can be registered for one isolated texture and resolved by the GL backend/resource layer when the opt-in CVar is enabled.
+
+The default renderer path remains the legacy `gltexture_t`/native GL texture binding path.
+
+## 2. Nicht-Ziele
+
+Phase 3 deliberately does **not** do any of the following:
+
+- migrate world textures;
+- migrate alias skins;
+- migrate shadows or FBO attachments;
+- replace or hide `gltexture_t` globally;
+- clean up `quakedef.h`;
+- activate Vulkan or DX12;
+- change visible render output;
+- introduce descriptor sets, pipeline objects, or a full texture registry redesign.
+
+## 3. Gewählter Kandidat
+
+Selected candidate: **PostFX LUT**.
+
+UI/2D texture migration was reviewed as the fallback candidate, but it touches broader draw/HUD/console paths and is less isolated for a first handle test.
+
+## 4. Warum dieser Kandidat
+
+The PostFX LUT is the smallest safe Phase-3 candidate because:
+
+- it is a single texture-array binding used by the postprocess pass;
+- it has no shadow/depth semantics;
+- it is not an FBO attachment;
+- it does not participate in world or alias material binding;
+- it already has a clear native GL texture lifetime in the PostFX reload path;
+- the legacy native texture ID remains available for immediate fallback;
+- invalid handle or resolve failure can fall back before any visible output changes.
+
+## 5. Neuer CVar
+
+```text
+r_renderer_texture_handle_test "0"
+```
+
+Values:
+
+- `0`: use the legacy PostFX LUT GL texture ID binding path.
+- `1`: attempt the renderer-neutral `render_texture_handle_t` PostFX LUT binding path.
+
+The default is `0`, so the default path is unchanged.
+
+## 6. Legacy-Fallback
+
+When `r_renderer_texture_handle_test 1` is active, the postprocess pass attempts to bind the PostFX LUT through the texture handle adapter. If the handle is invalid, cannot be resolved, has the wrong target, or cannot bind, the code logs a debug-only `R_Migration:`/`R_TextureHandle:` message and immediately binds the existing legacy LUT texture ID instead.
+
+Debug output is gated behind either:
+
+```text
+r_renderer_migration_debug 1
+r_backend_debug 1
+```
+
+## 7. Welche Dateien geändert wurden
+
+- `Quake/src/render/texture_handles.h`: added neutral handle validity helpers and legacy GL texture adapter declarations.
+- `Quake/src/render/r_resources_gl.h`: declared the GL resource/backend texture-handle registration, resolve, and bind helpers.
+- `Quake/src/render/gl_backend_resources.c`: added the small GL-side texture-handle table and resolve/bind implementation for legacy `gltexture_t` and native GL textures.
+- `Quake/src/render/r_postfx.c`: records a PostFX LUT `render_texture_handle_t` alongside the existing legacy native texture ID.
+- `Quake/src/render/r_postfx.h`: exposes the PostFX LUT handle getter.
+- `Quake/src/render/gl_rmain.c`: adds the opt-in PostFX LUT handle binding attempt with legacy fallback.
+- `Quake/src/render/r_backend.c`: registers `r_renderer_texture_handle_test` and extends `r_backend_migration_audit` with Phase-3 status.
+- `Quake/src/render/r_backend.h`: exposes the CVar for render code.
+
+## 8. Welche GL-Leaks bewusst NICHT entfernt wurden
+
+The following known leaks remain intentionally unchanged for Phase 3:
+
+- `quakedef.h` GL leak;
+- public `gltexture_t` bridge;
+- `gl_rmain.c` legacy GL orchestration;
+- `glprogs_t` stores `GLuint` programs;
+- framegraph execution still calls legacy pass paths;
+- broad world/alias/sprite/UI texture binding still uses existing legacy paths.
+
+## 9. Testanleitung
+
+Default path:
+
+```text
+r_renderer_texture_handle_test 0
+```
+
+Expected result: exact old PostFX LUT binding path.
+
+Handle test path:
+
+```text
+r_renderer_texture_handle_test 1
+```
+
+Expected result: same image output. If handle registration/resolve/bind fails, the legacy PostFX LUT binding path is used automatically.
+
+Debug:
+
+```text
+r_renderer_migration_debug 1
+r_backend_debug 1
+```
+
+Useful audit command:
+
+```text
+r_backend_migration_audit
+```
+
+## 10. Go/No-Go für Phase 4
+
+GO for Phase 4 only if:
+
+1. Project compiles.
+2. Default path remains unchanged.
+3. New path is disabled by default via CVar.
+4. Legacy fallback works.
+5. No visible render change is observed.
+6. Only one isolated texture path was migrated.
+7. No world, alias, shadow, or FBO texture migration was included.
+8. Vulkan/DX12 remain blocked/stubbed.
+9. Audit command reports Phase-3 status.
+
+NO-GO if any of the above fails.
+
+Phase 4 should migrate a second small texture-handle path, likely an isolated UI/2D or decal texture path, while still avoiding world, alias, shadow, and FBO texture ownership.


### PR DESCRIPTION
### Motivation
- Introduce the first small renderer-neutral texture-handle path as a low-risk experiment to decouple one isolated texture binding from direct `gltexture_t`/native GL usage. 
- Choose a candidate that minimizes GL state, lifetime and material coupling so the default renderer behavior is unchanged and fallbacks are trivial.

### Description
- Add a narrow neutral handle API and helpers: `R_TextureHandle_IsValid`, `R_TextureHandle_Invalid`, `R_TextureHandle_FromLegacyGLTexture`, and `R_TextureHandle_ResolveLegacyGLTexture` in `Quake/src/render/texture_handles.h` so frontend code can refer to `render_texture_handle_t` for the test path.
- Implement a small GL-backend texture-handle table and adapter in `Quake/src/render/gl_backend_resources.c` with registration, resolve and bind helpers (`GL_Backend_TextureHandleFromNativeTexture`, `GL_Backend_ResolveTextureHandleNative`, `GL_Backend_BindTextureHandle`) that map `render_texture_handle_t` to either a legacy `gltexture_t` or a native GL id while keeping native fields GL-private.
- Record and expose a `render_texture_handle_t` for the PostFX LUT in `Quake/src/render/r_postfx.c`/`.h` in parallel with the existing legacy `GLuint` LUT id so the backend can attempt the neutral path and still fall back to the legacy id.
- Add opt-in binding in the postprocess pass (`Quake/src/render/gl_rmain.c`) guarded by the new CVar `r_renderer_texture_handle_test` which attempts `GL_Backend_BindTextureHandle` for the PostFX LUT and on failure logs a debug message and immediately falls back to `R_PostFX_GetLUTTexture()` (legacy path).
- Register the new CVar and update the migration audit text in `Quake/src/render/r_backend.c`/`.h` and declare the new backend helper functions in `Quake/src/render/r_resources_gl.h`.
- Add documentation `docs/renderer_backend_migration_phase3.md` describing goal, non-goals, chosen candidate (PostFX LUT), new CVar semantics, legacy fallback, changed files, test instructions and Phase-4 criteria.

### Testing
- Per-file syntax checks: ran compile-command-driven `-fsyntax-only` checks for the modified render units (`r_backend.c`, `gl_backend_resources.c`, `r_postfx.c`, `gl_rmain.c`) and they succeeded for the modified files. (succeeded)
- CMake full build: attempted `cmake --build` on a generated build tree to exercise integration, but the build stops on pre-existing, unrelated platform code in `Quake/src/core/quakelab_api.c` (`FIONBIO` / `ioctlsocket`) before a final link can complete, so an end-to-end binary was not produced in this environment. (failed, pre-existing unrelated failure)
- Makefile target: `make -C Quake -j2` was attempted but failed in this container due to environment/dependency and path issues (missing SDL config and other missing build inputs), so the classic Make build did not finish here. (failed, environment/dependency)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0326f0ee90832eaf0d0dc526ad34ee)