### PR TITLE
Phase 4: add opt-in render_texture_handle_t path for WinQuake menu background (`r_renderer_texture_handle_test2`)

### DIFF
--- a/Quake/src/render/gl_draw.c
+++ b/Quake/src/render/gl_draw.c
@@ -26,6 +26,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "quakedef.h"
 #include "render_dispatch.h"
 #include "glquake.h"
+#include "r_backend.h"
+#include "r_resources_gl.h"
 
 #if defined(IW_RENDERER_HOST_FRONTEND) && !defined(RENDERER_PLUGIN_BUILD)
 #define Draw_PicFromWad2 GL_Draw_PicFromWad2
@@ -163,6 +165,29 @@ static guivertex_t batchtri_verts[6 * MAX_BATCH_QUADS];
 static GLushort batchindices[6 * MAX_BATCH_QUADS];
 static qboolean draw_initialized = false;
 
+#ifndef RENDERER_PLUGIN_BUILD
+extern cvar_t r_backend_debug;
+extern cvar_t r_renderer_migration_debug;
+#endif
+
+static qboolean Draw_TextureHandleDebugEnabled (void)
+{
+#ifdef RENDERER_PLUGIN_BUILD
+	return false;
+#else
+	return r_renderer_migration_debug.value != 0.f || r_backend_debug.value != 0.f;
+#endif
+}
+
+static qboolean Draw_TextureHandleTest2Enabled (void)
+{
+#ifdef RENDERER_PLUGIN_BUILD
+	return false;
+#else
+	return r_renderer_texture_handle_test2.value != 0.f;
+#endif
+}
+
 glcanvas_t glcanvas;
 
 //==============================================================================
@@ -201,6 +226,7 @@ byte		scrap_texels[SCRAP_ATLAS_WIDTH*SCRAP_ATLAS_HEIGHT];
 qboolean	scrap_dirty;
 gltexture_t	*scrap_texture; //johnfitz
 gltexture_t	*winquakemenubg;
+static render_texture_handle_t winquakemenubg_handle = RENDER_TEXTURE_HANDLE_INVALID;
 
 
 /*
@@ -589,6 +615,9 @@ static void Draw_CreateWinQuakeMenuBgTex (void)
 		(byte*)winquakemenubg_pixels, "", (src_offset_t)winquakemenubg_pixels,
 		TEXPREF_ALPHA | TEXPREF_NEAREST | TEXPREF_PERSIST | TEXPREF_NOPICMIP
 	);
+	winquakemenubg_handle = R_TextureHandle_FromLegacyGLTexture (winquakemenubg);
+	if (!R_TextureHandle_IsValid (winquakemenubg_handle) && Draw_TextureHandleDebugEnabled ())
+		Con_DPrintf ("R_TextureHandle: WinQuake menu background handle registration failed; legacy path remains available\n");
 	TexMgr_Trace ("Draw_CreateWinQuakeMenuBgTex: end");
 }
 
@@ -698,7 +727,25 @@ void Draw_Flush (void)
 		R_Backend_SetDynamicState (&dynamic_state);
 	}
 	TexMgr_Trace ("Draw_Flush: before texture bind");
-	GL_Bind (GL_TEXTURE0, glcanvas.texture);
+	if (Draw_TextureHandleTest2Enabled () && glcanvas.texture == winquakemenubg)
+	{
+		if (!R_TextureHandle_IsValid (winquakemenubg_handle))
+		{
+			if (Draw_TextureHandleDebugEnabled ())
+				Con_DPrintf ("R_TextureHandle: WinQuake menu background handle invalid; falling back to legacy GL texture bind\n");
+			GL_Bind (GL_TEXTURE0, glcanvas.texture);
+		}
+		else if (!GL_Backend_BindTextureHandle ((unsigned)GL_TEXTURE0, winquakemenubg_handle, (unsigned)GL_TEXTURE_2D))
+		{
+			if (Draw_TextureHandleDebugEnabled ())
+				Con_DPrintf ("R_Migration: WinQuake menu background texture handle path failed; falling back to legacy GL texture bind\n");
+			GL_Bind (GL_TEXTURE0, glcanvas.texture);
+		}
+	}
+	else
+	{
+		GL_Bind (GL_TEXTURE0, glcanvas.texture);
+	}
 	TexMgr_Trace ("Draw_Flush: after texture bind");
 
 	for (int i = 0; i < numbatchquads; ++i)

--- a/Quake/src/render/gl_rmain.c
+++ b/Quake/src/render/gl_rmain.c
@@ -765,6 +765,7 @@ cvar_t	r_postfx_lut_strength_powerup = { "r_postfx_lut_strength_powerup", "0.6",
 cvar_t	r_postfx_lut_strength_underwater = { "r_postfx_lut_strength_underwater", "0.5", CVAR_ARCHIVE };
 cvar_t	r_postfx_lut_debug_id = { "r_postfx_lut_debug_id", "0", CVAR_NONE };
 cvar_t	r_renderer_texture_handle_test = { "r_renderer_texture_handle_test", "0", CVAR_NONE };
+cvar_t	r_renderer_texture_handle_test2 = { "r_renderer_texture_handle_test2", "0", CVAR_NONE };
 cvar_t	r_postfx_debug = { "r_postfx_debug", "0", CVAR_NONE };
 cvar_t	r_film35_enable = { "r_film35_enable", "0", CVAR_ARCHIVE };
 cvar_t	r_film35_strength = { "r_film35_strength", "0.35", CVAR_ARCHIVE };

--- a/Quake/src/render/r_backend.c
+++ b/Quake/src/render/r_backend.c
@@ -143,6 +143,7 @@ cvar_t r_backend_allow_builtin_gl = { "r_backend_allow_builtin_gl", "1", CVAR_AR
 cvar_t r_backend_debug = { "r_backend_debug", "0", CVAR_NONE };
 cvar_t r_renderer_migration_debug = { "r_renderer_migration_debug", "0", CVAR_NONE };
 extern cvar_t r_renderer_texture_handle_test;
+extern cvar_t r_renderer_texture_handle_test2;
 extern int r_framecount;
 extern cvar_t r_framegraph_debug;
 extern cvar_t r_refgl_debug;
@@ -244,7 +245,15 @@ static void R_Backend_MigrationAudit_f (void)
 	Con_Printf ("    - native GL ownership: GL resource/backend only\n");
 	Con_Printf ("    - migrated scope: exactly one isolated texture path\n");
 	Con_Printf ("    - Avoided: world textures, alias skins, shadows, and FBO attachments.\n");
-	Con_Printf ("  Known Phase-3 leaks left in place:\n");
+	Con_Printf ("  Phase 4 texture handle test:\n");
+	Con_Printf ("    - available: yes\n");
+	Con_Printf ("    - selected candidate: WinQuake menu background 2D texture\n");
+	Con_Printf ("    - cvar: r_renderer_texture_handle_test2\n");
+	Con_Printf ("    - default path: legacy\n");
+	Con_Printf ("    - fallback: enabled\n");
+	Con_Printf ("    - native GL ownership: GL resource/backend only\n");
+	Con_Printf ("    - migrated scope: exactly one second isolated texture path\n");
+	Con_Printf ("  Known Phase-3/4 leaks left in place:\n");
 	Con_Printf ("    - quakedef.h GL leak.\n");
 	Con_Printf ("    - gltexture_t public bridge.\n");
 	Con_Printf ("    - gl_rmain.c legacy GL orchestration.\n");
@@ -255,7 +264,7 @@ static void R_Backend_MigrationAudit_f (void)
 		r_backend.string ? r_backend.string : "<null>",
 		r_backend_api.string ? r_backend_api.string : "<null>",
 		r_backend_allow_builtin_gl.string ? r_backend_allow_builtin_gl.string : "<null>");
-	Con_Printf ("    - Vulkan/DX12 remain stub/blocklisted for activation in Phase 3.\n");
+	Con_Printf ("    - Vulkan/DX12 remain stub/blocklisted for activation in Phase 4.\n");
 }
 
 /*
@@ -2193,6 +2202,7 @@ void R_Backend_Init (void)
 	Cvar_RegisterVariable (&r_backend_debug);
 	Cvar_RegisterVariable (&r_renderer_migration_debug);
 	Cvar_RegisterVariable (&r_renderer_texture_handle_test);
+	Cvar_RegisterVariable (&r_renderer_texture_handle_test2);
 	Cvar_RegisterVariable (&r_refgl_debug);
 	Cvar_RegisterVariable (&r_refgl_log_init);
 	Cvar_RegisterVariable (&r_refgl_log_passes);

--- a/Quake/src/render/r_backend.h
+++ b/Quake/src/render/r_backend.h
@@ -40,6 +40,7 @@ render_backend_runtime_status_t R_Backend_GetRuntimeStatusForName (const char *b
 const char *R_Backend_GetRuntimeStatusLabel (render_backend_runtime_status_t status);
 qboolean R_Backend_GetMilestonesForName (const char *backend_name, RenderBackendMilestones *out_milestones);
 extern cvar_t r_renderer_texture_handle_test;
+extern cvar_t r_renderer_texture_handle_test2;
 
 void R_Backend_QuerySurfaceInfo (RenderBackendSurfaceInfo *out_info);
 const char *R_Backend_ResourceSlotName (render_backend_resource_slot_t slot);

--- a/docs/renderer_backend_migration_phase4.md
+++ b/docs/renderer_backend_migration_phase4.md
@@ -1,0 +1,128 @@
+# Renderer Backend Migration Phase 4
+
+## 1. Goal
+
+Phase 4 adds a second small, isolated renderer-neutral texture handle test path using `render_texture_handle_t`. Phase 3 remains scoped to the PostFX LUT and continues to use `r_renderer_texture_handle_test`; Phase 4 uses a separate CVar so each path can be enabled, disabled, and fallback-tested independently.
+
+## 2. Non-goals
+
+Phase 4 does not migrate world textures, alias skins, shadow maps, FBO attachments, lightmaps, sky textures, or the global particle texture path. It does not replace `gltexture_t`, clean up `quakedef.h`, split `gl_rmain.c`, introduce Vulkan/DX12 activation, descriptor sets, or a new pipeline system, and it must not change visible rendering in the default configuration.
+
+## 3. Selected candidate
+
+Selected candidate: **WinQuake menu background 2D texture** (`winquakemenubg`).
+
+## 4. Why this candidate
+
+The WinQuake menu background texture is a tiny UI/2D texture created from static CPU data, uploaded once during draw initialization, and bound through the existing GUI draw flush path only when the WinQuake menu background style is active. It has no FBO lifetime, no shadow/depth semantics, no world or alias material binding, and no texture-manager ownership changes are required. The new handle is created beside the legacy `gltexture_t *` and only used when `r_renderer_texture_handle_test2` is enabled.
+
+## 5. Why excluded candidates were not chosen
+
+- Console charset: isolated and UI-only, but it is used by most text rendering and therefore has a higher visible-regression surface than one menu-background texture.
+- Scrap atlas / cached pics / HUD pics: these are part of broader 2D batching and reload paths, so they are not as isolated.
+- Decal texture: decal rendering is gameplay-world facing and tied to decal batching/material choices, so it is riskier than a UI-only texture.
+- World textures, alias skins, shadows, FBO attachments, lightmaps, sky textures, and particle globals are explicitly out of scope for Phase 4.
+
+## 6. New CVar `r_renderer_texture_handle_test2`
+
+```text
+r_renderer_texture_handle_test2 "0"
+```
+
+- `0`: legacy path for the Phase-4 candidate.
+- `1`: attempt the neutral `render_texture_handle_t` binding path for the WinQuake menu background texture.
+
+The existing `r_renderer_texture_handle_test` remains dedicated to the Phase-3 PostFX LUT path.
+
+## 7. Legacy fallback
+
+The default path remains legacy. When `r_renderer_texture_handle_test2 1` is active, the GUI draw flush attempts to bind the WinQuake menu background through the GL resource/backend texture-handle helper. If the handle is invalid or the helper cannot resolve/bind it, debug-only `R_TextureHandle:` or `R_Migration:` messages are emitted and the code immediately falls back to the existing legacy `GL_Bind` path.
+
+Debug output is gated by either:
+
+```text
+r_renderer_migration_debug 1
+r_backend_debug 1
+```
+
+## 8. Changed files
+
+- `Quake/src/render/gl_draw.c`: stores the WinQuake menu background handle and uses it in the opt-in Phase-4 bind path.
+- `Quake/src/render/gl_rmain.c`: defines the new CVar.
+- `Quake/src/render/r_backend.h`: exposes the new CVar declaration.
+- `Quake/src/render/r_backend.c`: registers the CVar and extends `r_backend_migration_audit`.
+- `docs/renderer_backend_migration_phase4.md`: documents candidate choice, fallback, test matrix, and Phase-5 gate.
+
+## 9. GL leaks intentionally left in place
+
+The known migration blockers remain intentionally unchanged: `quakedef.h` still leaks GL-facing declarations into broad code, `gltexture_t` remains the public legacy bridge, `gl_rmain.c` still orchestrates legacy GL rendering, `glprogs_t` still stores `GLuint` shader program IDs, and framegraph pass execution still calls legacy/GL callbacks. Native GL texture IDs remain owned by GL resource/backend helpers for the new test path.
+
+## 10. Test instructions
+
+Default:
+
+```text
+r_renderer_texture_handle_test 0
+r_renderer_texture_handle_test2 0
+```
+
+Expectation: exact legacy behavior.
+
+Phase 3 only:
+
+```text
+r_renderer_texture_handle_test 1
+r_renderer_texture_handle_test2 0
+```
+
+Expectation: PostFX LUT handle path only; all other texture paths remain legacy.
+
+Phase 4 only:
+
+```text
+r_renderer_texture_handle_test 0
+r_renderer_texture_handle_test2 1
+```
+
+Expectation: WinQuake menu background handle path only; all other texture paths remain legacy.
+
+Both:
+
+```text
+r_renderer_texture_handle_test 1
+r_renderer_texture_handle_test2 1
+```
+
+Expectation: both isolated handle paths are active and their legacy fallbacks operate independently.
+
+Debug:
+
+```text
+r_renderer_migration_debug 1
+r_backend_debug 1
+```
+
+Build gate:
+
+```bash
+"/mnt/c/Program Files/Microsoft Visual Studio/18/Community/MSBuild/Current/Bin/MSBuild.exe" C:/projects/ironwail/Windows/VisualStudio/ironwail.sln /t:Build /p:Configuration=Release;Platform=x64 /m
+```
+
+Smoke from `C:\Quake\rerelease` with `-condebug -nosteamapi` when a Windows runtime is available.
+
+## 11. Go/No-Go for Phase 5
+
+GO only if:
+
+1. The project compiles.
+2. The default path remains unchanged.
+3. The Phase-3 PostFX LUT path does not regress.
+4. The Phase-4 path is disabled by default through `r_renderer_texture_handle_test2 0`.
+5. Legacy fallback works when the Phase-4 handle path cannot bind.
+6. Exactly one second isolated texture path was migrated.
+7. No world, alias, shadow, FBO, lightmap, sky, or particle-global texture path was migrated.
+8. No new GL leaks were added to core/neutral structures.
+9. Vulkan/DX12 remain blocked.
+10. `r_backend_migration_audit` shows both Phase-3 and Phase-4 status.
+
+Phase 5 recommendation: after Phase 3 and Phase 4 are stable, reduce public `gltexture_t` use by converting safe frontend references first, document a central legacy `gltexture_t` to `render_texture_handle_t` mapping policy, and avoid world, alias, shadow, and FBO paths until the small-handle paths have proven reliable.


### PR DESCRIPTION
### Motivation

- Continue the renderer-neutral texture-handle migration by adding a second, very small isolated test path that does not change default rendering.

### Description

- Introduce new CVar `r_renderer_texture_handle_test2` and expose/register it via `r_backend.h` / `r_backend.c` and define it in `gl_rmain.c` so the Phase‑4 path is opt-in and off by default. 
- Register a `render_texture_handle_t` for the WinQuake menu background (`winquakemenubg`) in `gl_draw.c` and keep the existing `gltexture_t *` legacy reference untouched. 
- At draw time the GUI flush uses the handle path only when `r_renderer_texture_handle_test2 == 1`, attempts `GL_Backend_BindTextureHandle`, and falls back immediately to the legacy `GL_Bind` on invalid handle or bind/resolve failure, emitting `R_TextureHandle:` / `R_Migration:` debug messages when debugging is enabled. 
- Extend `r_backend_migration_audit` and add `docs/renderer_backend_migration_phase4.md` documenting the candidate choice, non-goals, CVar semantics, fallback behavior, test matrix, and Phase‑5 go/no‑go criteria.

### Testing

- Ran a syntax-only check with `gcc -fsyntax-only` for the modified units (`gl_draw.c`, `r_backend.c`, `gl_rmain.c`), which reported no syntax errors. (succeeded)
- Ran `make` builds in the repository environment; compilation of renderer sources proceeded and many translation units were built, but a full link of the `ironwail` target could not be completed in this container due to an environment/repository layout issue (`menu.o` target / build layout) in one run, so a full release build was not produced here. (partial/succeeded for most compile steps, blocked at final link in this environment)
- Attempted the Windows MSBuild command described in the docs, but MSBuild is not available in this Linux container so that step could not be executed here. (blocked)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0330b8e360832e89d6d1a10b06a01e)